### PR TITLE
Add reusable vt-skeleton loader

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -14,7 +14,18 @@
       </div>
     </div>
 
-    @if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
+    @if (!registryLoaded && datasets.length === 0 && orphanLoadingTasks.length === 0) {
+      <ul class="dashboard-skeleton-list" aria-busy="true" aria-label="Loading datasets">
+        @for (_ of skeletonRows; track $index) {
+          <li class="dashboard-skeleton-row">
+            <vt-skeleton width="16px" height="16px" />
+            <vt-skeleton width="40%" height="14px" />
+            <vt-skeleton width="20%" height="12px" />
+            <vt-skeleton width="15%" height="12px" />
+          </li>
+        }
+      </ul>
+    } @else if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
       <div class="welcome-banner">
         <p class="welcome-banner-text">{{ welcomeBannerMessage }}</p>
         <button class="btn btn--primary btn--sm welcome-banner-cta"
@@ -161,7 +172,18 @@
       </div>
     </div>
 
-    @if (detectors.length === 0) {
+    @if (!registryLoaded && detectors.length === 0) {
+      <ul class="dashboard-skeleton-list" aria-busy="true" aria-label="Loading detectors">
+        @for (_ of skeletonRows; track $index) {
+          <li class="dashboard-skeleton-row">
+            <vt-skeleton width="16px" height="16px" />
+            <vt-skeleton width="40%" height="14px" />
+            <vt-skeleton width="20%" height="12px" />
+            <vt-skeleton width="15%" height="12px" />
+          </li>
+        }
+      </ul>
+    } @else if (detectors.length === 0) {
       <p class="empty-state">No detectors yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -248,6 +248,24 @@
   font-style: italic;
 }
 
+.dashboard-skeleton-list {
+  flex: 1 1 0;
+  min-height: 0;
+  list-style: none;
+  margin: 0;
+  padding: 4px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dashboard-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 4px;
+}
+
 .welcome-banner {
   flex: 1 1 0;
   min-height: 0;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -23,6 +23,7 @@ import {
   DetectorColumn,
 } from '../../services/dashboard-columns.service';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { SkeletonComponent } from '../skeleton/skeleton.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { DetectorCardComponent } from './detector-card/detector-card.component';
@@ -50,6 +51,7 @@ import { DiskUsageComponent, DiskUsageBytes } from './disk-usage/disk-usage.comp
     DatasetStatsModalComponent,
     IconComponent,
     DiskUsageComponent,
+    SkeletonComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -368,6 +370,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get loading(): boolean {
     return this.datasetState.loading;
   }
+
+  /** True once the registry's first fetch has resolved (success or empty). Used to
+   *  pick between skeleton rows and the welcome/empty state on initial render. */
+  get registryLoaded(): boolean {
+    return this.datasetState.loaded;
+  }
+
+  /** Iterable for *ngFor of N skeleton rows (a sized array of zeros). */
+  readonly skeletonRows = Array.from({ length: 4 });
 
   get progressMessage(): string {
     return this.datasetState.progressMessage;

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -14,7 +14,7 @@
   (keydown.space)="onClick()"
 >
   @if (isGrid) {
-    <div class="thumbnail-wrap">
+    <div class="thumbnail-wrap" [class.skeleton-bg]="thumbnailUrl">
       @if (thumbnailUrl) {
         <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
       } @else if (placeholderIcon) {
@@ -30,7 +30,7 @@
       @if (voteLabel === 'good') { &#x2713; } @else if (voteLabel === 'bad') { &#x2717; }
     </span>
     @if (thumbnailUrl) {
-      <span class="thumbnail-wrap thumbnail-wrap-list">
+      <span class="thumbnail-wrap thumbnail-wrap-list skeleton-bg">
         <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
         @if (bestRegionStyle) {
           <span class="best-region-outline" [ngStyle]="bestRegionStyle" aria-hidden="true" title="Region the embedder matched best"></span>

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -1,4 +1,25 @@
-@if (useVirtualScroll) {
+@if (showSkeletons) {
+  <div
+    class="media-list media-list-skeleton"
+    [class.grid-layout]="viewMode === 'grid'"
+    [style.--grid-goal-width]="gridGoalWidth + 'px'"
+    aria-busy="true"
+    aria-label="Loading media"
+  >
+    @for (_ of skeletonPlaceholders; track $index) {
+      @if (viewMode === 'grid') {
+        <div class="media-skeleton-card">
+          <vt-skeleton width="100%" height="100%" />
+        </div>
+      } @else {
+        <div class="media-skeleton-row">
+          <vt-skeleton width="28px" height="28px" borderRadius="var(--radius-sm)" />
+          <vt-skeleton width="60%" height="10px" />
+        </div>
+      }
+    }
+  </div>
+} @else if (useVirtualScroll) {
   <!-- Virtual scrolling for large datasets in list mode -->
   <cdk-virtual-scroll-viewport [itemSize]="listItemHeight" class="media-list virtual-scroll-viewport">
     <ng-container *cdkVirtualFor="let item of cachedOrderedItems; trackBy: trackByMediaId">

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -63,3 +63,34 @@
   font-style: italic;
   font-size: 0.85rem;
 }
+
+.media-list-skeleton {
+  // List-mode placeholder rows: each row holds a thumbnail-sized block + a
+  // text bar at the same dimensions as a real media-item, so swapping in
+  // real rows doesn't cause a layout shift.
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 8px;
+
+  &.grid-layout {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
+    gap: 4px;
+    padding: 4px;
+    align-content: start;
+    justify-content: start;
+  }
+}
+
+.media-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 28px;
+}
+
+.media-skeleton-card {
+  width: 100%;
+  aspect-ratio: 1;
+}

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MediaListComponent } from './media-list.component';
 import { Media } from '../../../models/api.models';
 
@@ -15,6 +17,7 @@ describe('MediaListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaListComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MediaListComponent);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -18,6 +18,8 @@ import { takeUntil } from 'rxjs/operators';
 import { MediaItemComponent } from '../media-item/media-item.component';
 import { Media } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
+import { MediaStateService } from '../../../services/media-state.service';
+import { SkeletonComponent } from '../../skeleton/skeleton.component';
 import { SortedItem } from '../left-panel.component';
 import { prefersReducedMotion } from '../../../utils/reduced-motion';
 
@@ -31,7 +33,7 @@ const PREFETCH_BUFFER = 50;
 @Component({
   selector: 'vt-media-list',
   standalone: true,
-  imports: [CommonModule, ScrollingModule, MediaItemComponent],
+  imports: [CommonModule, ScrollingModule, MediaItemComponent, SkeletonComponent],
   templateUrl: './media-list.component.html',
   styleUrl: './media-list.component.scss',
 })
@@ -63,7 +65,15 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   private readonly destroy$ = new Subject<void>();
   private scrollSubscribed = false;
 
-  constructor(private metadataCache: MediaMetadataCacheService) {}
+  /** Mirror of ``MediaStateService.loading``; drives the skeleton rows when the
+   *  list is empty during the initial /api/medias/ids fetch. */
+  loadingMedias = false;
+  readonly skeletonPlaceholders = Array.from({ length: 12 });
+
+  constructor(
+    private metadataCache: MediaMetadataCacheService,
+    private mediaState: MediaStateService,
+  ) {}
 
   ngOnInit(): void {
     // When the cache hydrates new items, re-enrich the displayed rows so
@@ -71,6 +81,13 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     this.metadataCache.version$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.rebuildOrderedItems());
+    this.mediaState.loading$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((loading) => (this.loadingMedias = loading));
+  }
+
+  get showSkeletons(): boolean {
+    return this.loadingMedias && this.cachedOrderedItems.length === 0;
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -18,7 +18,9 @@
         (keydown)="onEntryKeydown($event, entry.id)"
       >
         @if (hasThumbnailUrl(entry.id)) {
-          <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry.id))" />
+          <span class="vote-thumbnail-wrap skeleton-bg">
+            <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry.id))" />
+          </span>
         } @else if (placeholderIcon(entry.id)) {
           <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
         }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -87,18 +87,29 @@ h3 {
   border-radius: 3px;
 }
 
-.vote-thumbnail {
+.vote-thumbnail-wrap {
+  display: block;
   width: 28px;
   height: 28px;
-  object-fit: cover;
   border-radius: 3px;
-  background: var(--bg-surface);
   flex-shrink: 0;
 
   .vote-entry-grid & {
     width: 100%;
     height: auto;
     aspect-ratio: 1;
+  }
+}
+
+.vote-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 3px;
+  background: var(--bg-surface);
+  display: block;
+
+  .vote-entry-grid & {
     object-fit: contain;
   }
 }

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -18,7 +18,9 @@
         (keydown)="onEntryKeydown($event, entry)"
       >
         @if (hasThumbnailUrl(entry)) {
-          <img class="vote-thumbnail" [src]="thumbnailUrl(entry)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry))" />
+          <span class="vote-thumbnail-wrap skeleton-bg">
+            <img class="vote-thumbnail" [src]="thumbnailUrl(entry)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry))" />
+          </span>
         } @else if (placeholderIcon(entry)) {
           <span class="vote-placeholder">{{ placeholderIcon(entry) }}</span>
         }

--- a/frontend/src/app/components/skeleton/skeleton.component.html
+++ b/frontend/src/app/components/skeleton/skeleton.component.html
@@ -1,0 +1,1 @@
+<div class="skeleton" [ngStyle]="boxStyle" aria-hidden="true"></div>

--- a/frontend/src/app/components/skeleton/skeleton.component.scss
+++ b/frontend/src/app/components/skeleton/skeleton.component.scss
@@ -1,0 +1,32 @@
+.skeleton {
+  display: block;
+  background: var(--bg-subtle);
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      var(--skeleton-shimmer) 50%,
+      transparent 100%
+    );
+    transform: translateX(-100%);
+    animation: vt-skeleton-shimmer 1.4s ease-in-out infinite;
+  }
+}
+
+@keyframes vt-skeleton-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}

--- a/frontend/src/app/components/skeleton/skeleton.component.ts
+++ b/frontend/src/app/components/skeleton/skeleton.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import { NgStyle } from '@angular/common';
+
+@Component({
+  selector: 'vt-skeleton',
+  standalone: true,
+  imports: [NgStyle],
+  templateUrl: './skeleton.component.html',
+  styleUrl: './skeleton.component.scss',
+})
+export class SkeletonComponent {
+  @Input() width = '100%';
+  @Input() height = '12px';
+  @Input() borderRadius = 'var(--radius-sm)';
+
+  get boxStyle(): Record<string, string> {
+    return {
+      width: this.width,
+      height: this.height,
+      'border-radius': this.borderRadius,
+    };
+  }
+}

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import type { Media } from '../models/api.models';
 import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import { MediasApiService } from './medias-api.service';
@@ -20,10 +20,15 @@ import { MediaMetadataCacheService } from './media-metadata-cache.service';
 export class MediaStateService implements OnDestroy {
   private readonly mediasSubject = new BehaviorSubject<MediaIdsListResponse[]>([]);
   private readonly selectedIdSubject = new BehaviorSubject<number | null>(null);
+  /** True while ``/api/medias/ids`` is in flight. Drives skeleton loaders in
+   *  the media list/grid; flips back to ``false`` whether the request succeeds
+   *  or errors. */
+  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
   private readonly destroy$ = new Subject<void>();
 
   readonly medias$ = this.mediasSubject.asObservable();
   readonly selectedId$ = this.selectedIdSubject.asObservable();
+  readonly loading$ = this.loadingSubject.asObservable();
 
   constructor(
     private mediasApi: MediasApiService,
@@ -41,6 +46,10 @@ export class MediaStateService implements OnDestroy {
 
   get selectedId(): number | null {
     return this.selectedIdSubject.value;
+  }
+
+  get loading(): boolean {
+    return this.loadingSubject.value;
   }
 
   get selectedMedia(): Media | null {
@@ -66,9 +75,13 @@ export class MediaStateService implements OnDestroy {
   }
 
   loadMedias(): void {
+    this.loadingSubject.next(true);
     this.mediasApi
       .getMediaIds()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => this.loadingSubject.next(false)),
+      )
       .subscribe((stubs) => {
         this.mediasSubject.next(stubs);
       });
@@ -77,6 +90,7 @@ export class MediaStateService implements OnDestroy {
   clear(): void {
     this.mediasSubject.next([]);
     this.selectedIdSubject.next(null);
+    this.loadingSubject.next(false);
     this.metadataCache.clear();
   }
 }

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -266,6 +266,57 @@
   background: var(--scrollbar-thumb-hover);
 }
 
+// --- Skeleton shimmer background ---
+//
+// Apply to an element that contains a lazy-loaded <img>: a soft shimmer
+// shows behind the image until it paints, smoothing the "pop-in" you get
+// from native loading="lazy". Pairs with the <vt-skeleton> component, which
+// uses the same animation but renders a sized block on its own.
+.skeleton-bg {
+  position: relative;
+  // isolation: isolate scopes the pseudo-elements' negative z-index to
+  // this stacking context, so the base + shimmer sit behind the element's
+  // in-flow content without leaking behind the parent.
+  isolation: isolate;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--bg-subtle);
+    border-radius: inherit;
+    z-index: -1;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      var(--skeleton-shimmer) 50%,
+      transparent 100%
+    );
+    border-radius: inherit;
+    transform: translateX(-100%);
+    animation: vt-skeleton-shimmer 1.4s ease-in-out infinite;
+    z-index: -1;
+  }
+}
+
+@keyframes vt-skeleton-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-bg::after {
+    animation: none;
+  }
+}
+
 // --- Accessibility ---
 
 .sr-only {

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -87,6 +87,7 @@
   --badge-embedding: #e0a020;
   --btn-icon-hover-bg: rgba(255, 255, 255, 0.08);
   --text-warning: #e6a700;
+  --skeleton-shimmer: rgba(255, 255, 255, 0.06);
 
   // Aliases used by component SCSS files
   --border-color: var(--border);
@@ -159,6 +160,7 @@
   --badge-embedding: #c99000;
   --btn-icon-hover-bg: rgba(0, 0, 0, 0.07);
   --text-warning: #b87900;
+  --skeleton-shimmer: rgba(0, 0, 0, 0.05);
 
   // Aliases
   --border-color: var(--border);
@@ -231,6 +233,7 @@
   --badge-embedding: #ffff00;
   --btn-icon-hover-bg: rgba(255, 255, 255, 0.15);
   --text-warning: #ffff00;
+  --skeleton-shimmer: rgba(255, 255, 0, 0.2);
 
   // Aliases
   --border-color: var(--border);


### PR DESCRIPTION
## Summary

Adds a reusable `vt-skeleton` Angular component (a sized shimmer block) plus a sibling `.skeleton-bg` SCSS utility class (shimmer behind a lazy-loaded `<img>`). Swaps both into the loading states where the shape of the content is known in advance.

## The rule

- **List/grid of known-shape items → skeleton** (gives the user a wireframe of what's coming and avoids layout shift when real data lands).
- **Single operation with measurable percent-complete → keep the progress bar** (a real `value/max` is more informative than a wireframe).
- **Tiny inline "working..." hint → keep the spinner** (skeleton would be overkill).

## Where skeletons land

| Location | What loads | Treatment |
|---|---|---|
| Dashboard → datasets table | registry initial fetch | 4 skeleton rows while `!registryLoaded` |
| Dashboard → detectors table | registry initial fetch | 4 skeleton rows while `!registryLoaded` |
| Left panel → media list/grid | `/api/medias/ids` | 12 skeleton rows (list) or cards (grid) while `MediaStateService.loading$` is true and the list is empty |
| Media-item thumbnail | lazy-loaded thumbnail image | `.skeleton-bg` behind `<img>`; image paints over it on load |
| Right panel → label / labelset grids | lazy-loaded label thumbnails | `.skeleton-bg` behind each thumbnail |

## What stays as-is (per the rule)

- Dataset/detector load progress bars (per-row `vt-progress-bar` — measurable progress)
- Progress / autodetect / stats modal progress bars
- Audio-crop decode indicator
- Context-pulldown row spinner (inline busy hint)

## Implementation notes

- `MediaStateService` gained a `loading$` BehaviorSubject that flips during `loadMedias()`; `MediaListComponent` subscribes directly rather than threading another input through label-view → left-panel → media-list.
- `.skeleton-bg` uses `isolation: isolate` + `z-index: -1` on the pseudo-elements so the shimmer sits behind in-flow children without breaking absolutely-positioned siblings (e.g. `.best-region-outline` overlays).
- Shimmer color is a per-theme token (`--skeleton-shimmer`) defined in dark, light, and highviz themes.
- Animation is disabled under `prefers-reduced-motion: reduce`.

## Test plan

- [x] `./run-tests.sh core` (frontend `build:prod` + 507 backend tests) green
- [x] Manually verify the four templates compile (production bundle built clean, no warnings)
- [ ] Visual check: open dashboard cold, watch skeleton rows resolve into real rows
- [ ] Visual check: load a large dataset, watch media-list skeletons resolve into thumbnails
- [ ] Visual check: scroll through a labelset grid and confirm thumbnails shimmer briefly before paint
- [ ] Toggle through dark / light / highviz themes to confirm shimmer is visible in each


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRf4LM3JpvMDs8kP39rf1q)_