### PR TITLE
feat(detector-color): per-detector hue accent across detector surfaces

### DIFF
--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.html
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.html
@@ -9,6 +9,9 @@
   (keydown)="onKeydown($event)"
 >
   <strong class="trigger-label">{{ fieldLabel }}:</strong>
+  @if (!isDataset && activeRowExists) {
+    <vt-detector-swatch class="trigger-swatch" [name]="activeName"></vt-detector-swatch>
+  }
   <span class="trigger-value" [class.is-placeholder]="!activeRowExists">{{ activeRowExists ? activeName : placeholderLabel }}</span>
   <span class="trigger-caret" aria-hidden="true">▾</span>
 </button>
@@ -42,10 +45,14 @@
             [class.is-focused]="i === focusedIndex"
             [attr.aria-selected]="row.active"
             [attr.title]="row.incompatReason || null"
+            [style.--detector-hue]="hueFor(row)"
             (click)="pickRow(row)"
             (mouseenter)="focusedIndex = i"
           >
             <span class="row-glyph" [title]="glyphTitle(row)">{{ glyphFor(row) }}</span>
+            @if (!isDataset) {
+              <vt-detector-swatch [name]="row.name"></vt-detector-swatch>
+            }
             <span class="row-name">{{ row.name }}</span>
             <span class="row-type">· {{ row.mediaType }}</span>
             @if (row.busy) {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
@@ -33,6 +33,10 @@
     font-weight: 600;
   }
 
+  .trigger-swatch {
+    flex: 0 0 auto;
+  }
+
   .trigger-value {
     flex: 1 1 auto;
     min-width: 0;
@@ -143,6 +147,18 @@
     &.is-focused,
     &:hover {
       background: var(--accent-highlight-bg);
+    }
+  }
+
+  // Detector rows use the per-detector hue (`--detector-hue` is bound inline
+  // per row); dataset rows keep the global accent so the two pulldowns don't
+  // compete for the eye.
+  :host(.kind-detector) &.is-active {
+    background: var(--detector-accent-bg);
+
+    &.is-focused,
+    &:hover {
+      background: var(--detector-accent-bg);
     }
   }
 

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostBinding, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -12,6 +12,8 @@ import { RunningJobsService, pairKey } from '../../services/running-jobs.service
 import { SortState } from '../../utils/managed-columns';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.models';
 import { isPairCompatible } from '../../utils/context-compat';
+import { detectorHue } from '../../utils/detector-color';
+import { DetectorSwatchComponent } from '../detector-swatch/detector-swatch.component';
 
 type PulldownKind = 'dataset' | 'detector';
 
@@ -44,12 +46,17 @@ interface PulldownRow {
 @Component({
   selector: 'vt-context-pulldown',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, DetectorSwatchComponent],
   templateUrl: './context-pulldown.component.html',
   styleUrl: './context-pulldown.component.scss',
 })
 export class ContextPulldownComponent implements OnInit, OnDestroy {
   @Input() kind: PulldownKind = 'dataset';
+
+  @HostBinding('class.kind-detector')
+  get isDetectorKind(): boolean {
+    return this.kind === 'detector';
+  }
 
   @ViewChild('menuRef') menuRef?: ElementRef<HTMLDivElement>;
 
@@ -336,6 +343,12 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
 
   trackRow(_: number, row: PulldownRow): string {
     return row.id;
+  }
+
+  /** Hue (0-359) for a detector row, hashed from its name. Returns null for
+   *  dataset rows so the template binding becomes a no-op (no inline style). */
+  hueFor(row: PulldownRow): string | null {
+    return this.isDataset ? null : String(detectorHue(row.name));
   }
 
   /** Sort registry entries the same way the Dashboard's tables sort them

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.html
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.html
@@ -7,7 +7,7 @@
       <p class="explainer-title">No dataset selected.</p>
       <p class="explainer-detail">
         Pick a dataset compatible with detector
-        <strong>{{ detector?.name }}</strong>
+        <vt-detector-swatch [name]="detector?.name || ''"></vt-detector-swatch>&nbsp;<strong>{{ detector?.name }}</strong>
         (<em>{{ detector?.media_type }}</em>) from the top-bar pulldown,
         or go to the Dashboard.
       </p>
@@ -22,7 +22,7 @@
     } @else if (mediaTypeMismatch) {
       <p class="explainer-title">
         <strong>{{ dataset?.name }}</strong> and
-        <strong>{{ detector?.name }}</strong> are incompatible: they are
+        <vt-detector-swatch [name]="detector?.name || ''"></vt-detector-swatch>&nbsp;<strong>{{ detector?.name }}</strong> are incompatible: they are
         different media types (<em>{{ dataset?.media_type }}</em> vs.
         <em>{{ detector?.media_type }}</em>).
       </p>

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
@@ -7,6 +7,7 @@ import { DatasetStateService } from '../../services/dataset-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { PulldownControlService } from '../../services/pulldown-control.service';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.models';
+import { DetectorSwatchComponent } from '../detector-swatch/detector-swatch.component';
 
 /**
  * Renders in place of `/label` and `/find` content when the active
@@ -20,7 +21,7 @@ import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.mo
 @Component({
   selector: 'vt-incompatible-pair-explainer',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, DetectorSwatchComponent],
   templateUrl: './incompatible-pair-explainer.component.html',
   styleUrl: './incompatible-pair-explainer.component.scss',
 })

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -5,7 +5,7 @@
       <ul class="source-list">
         @for (row of rows; track row.name) {
           <li class="source-row">
-            <span class="source-name" [title]="row.name">{{ row.name }}</span>
+            <span class="source-name" [title]="row.name"><vt-detector-swatch [name]="row.name"></vt-detector-swatch> {{ row.name }}</span>
             <span class="source-meta">
               <span class="meta-pill" title="Number of labels in this source">{{ row.numLabels }} labels</span>
               @if (row.textQuery) {

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
+import { DetectorSwatchComponent } from '../../detector-swatch/detector-swatch.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import type { DetectorCombineResponse } from '../../../generated/api-client/models/detector-combine-response';
 import { DetectorRegistryEntry } from '../../../models/api.models';
@@ -15,7 +16,7 @@ interface SourceRow {
 @Component({
   selector: 'vt-combine-detectors-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, DetectorSwatchComponent],
   templateUrl: './combine-detectors-modal.component.html',
   styleUrl: './combine-detectors-modal.component.scss',
 })

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -26,6 +26,7 @@
     />
   } @else {
     <span class="name-cell">
+      <vt-detector-swatch [name]="detector.name"></vt-detector-swatch>
       {{ detector.name }}
     </span>
   }

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -8,7 +8,7 @@
   }
 
   &.selected {
-    background: var(--accent-highlight-bg);
+    background: var(--detector-accent-bg);
   }
 
   &.dimmed {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -3,13 +3,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { DetectorSwatchComponent } from '../../detector-swatch/detector-swatch.component';
 import { formatProgressMessage, isProgressIndeterminate } from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
+import { detectorHue } from '../../../utils/detector-color';
 
 @Component({
   selector: 'vt-detector-card',
   standalone: true,
-  imports: [CommonModule, FormsModule, ProgressBarComponent],
+  imports: [CommonModule, FormsModule, ProgressBarComponent, DetectorSwatchComponent],
   templateUrl: './detector-card.component.html',
   styleUrl: './detector-card.component.scss',
 })
@@ -19,6 +21,11 @@ export class DetectorCardComponent implements OnChanges {
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;
+
+  @HostBinding('style.--detector-hue')
+  get hueStyle(): string {
+    return String(detectorHue(this.detector?.name || ''));
+  }
 
   @HostBinding('class.loading-error')
   get hasLoadingError(): boolean {

--- a/frontend/src/app/components/detector-swatch/detector-swatch.component.scss
+++ b/frontend/src/app/components/detector-swatch/detector-swatch.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--detector-accent);
+  flex-shrink: 0;
+  vertical-align: middle;
+}

--- a/frontend/src/app/components/detector-swatch/detector-swatch.component.ts
+++ b/frontend/src/app/components/detector-swatch/detector-swatch.component.ts
@@ -1,0 +1,23 @@
+import { Component, HostBinding, Input } from '@angular/core';
+import { detectorHue } from '../../utils/detector-color';
+
+/**
+ * Small colored dot keyed to a detector's name hue. Rendered next to detector
+ * names across the app to give each detector a recognisable visual handle.
+ */
+@Component({
+  selector: 'vt-detector-swatch',
+  standalone: true,
+  template: '',
+  styleUrl: './detector-swatch.component.scss',
+})
+export class DetectorSwatchComponent {
+  @Input() name = '';
+
+  @HostBinding('attr.aria-hidden') readonly ariaHidden = 'true';
+
+  @HostBinding('style.--detector-hue')
+  get hueStyle(): string {
+    return String(detectorHue(this.name));
+  }
+}

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -67,7 +67,10 @@
           <div class="file-list">
             @for (model of registryModels; track model.id) {
               <button class="file-item" (click)="loadRegistryModel(model)" [title]="'Load detector: ' + model.name">
-                {{ model.name }}
+                <span class="file-item-name">
+                  <vt-detector-swatch [name]="model.name"></vt-detector-swatch>
+                  {{ model.name }}
+                </span>
                 @if (model.num_training) {
                   <span class="item-meta">{{ model.num_training | number }} labels</span>
                 }

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -50,6 +50,16 @@
   }
 }
 
+.file-item-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .item-meta {
   font-size: 0.7rem;
   color: var(--text-secondary);

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -17,6 +17,7 @@ import {
   MediaCropModalComponent,
   MediaCropResult,
 } from '../media-crop-modal/media-crop-modal.component';
+import { DetectorSwatchComponent } from '../../detector-swatch/detector-swatch.component';
 
 interface BrowseItem {
   key: string;
@@ -28,7 +29,7 @@ type MediaPickerView = 'sources' | 'browse-items' | 'file-browser';
 @Component({
   selector: 'vt-load-sort-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent, IconComponent, FolderBrowserComponent, MediaCropModalComponent],
+  imports: [CommonModule, ModalComponent, IconComponent, FolderBrowserComponent, MediaCropModalComponent, DetectorSwatchComponent],
   templateUrl: './load-sort-modal.component.html',
   styleUrl: './load-sort-modal.component.scss',
 })

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -4,7 +4,7 @@
       <div>
         <span class="train-context-label" title="The detector being trained on your good/bad votes in this session">Detector</span>
         @if (!editing) {
-          <span class="train-context-name">{{ detectorName }}</span>
+          <span class="train-context-name"><vt-detector-swatch [name]="detectorName"></vt-detector-swatch> {{ detectorName }}</span>
           <button
             class="btn-icon train-rename-btn"
             title="Rename detector"

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
@@ -1,7 +1,7 @@
 .train-context-bar {
   padding: 6px 10px;
   border-bottom: 1px solid var(--border);
-  background: var(--accent-highlight-bg);
+  background: var(--detector-accent-bg);
   flex-shrink: 0;
   overflow: hidden;
 }

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
@@ -1,11 +1,13 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostBinding, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { DetectorSwatchComponent } from '../../detector-swatch/detector-swatch.component';
+import { detectorHue } from '../../../utils/detector-color';
 
 @Component({
   selector: 'vt-detector-context-bar',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, DetectorSwatchComponent],
   templateUrl: './detector-context-bar.component.html',
   styleUrl: './detector-context-bar.component.scss',
 })
@@ -13,6 +15,11 @@ export class DetectorContextBarComponent {
   @Input() detectorName = '';
   @Input() visible = false;
   @Output() renamed = new EventEmitter<string>();
+
+  @HostBinding('style.--detector-hue')
+  get hueStyle(): string {
+    return String(detectorHue(this.detectorName));
+  }
 
   editing = false;
   editValue = '';

--- a/frontend/src/app/utils/detector-color.ts
+++ b/frontend/src/app/utils/detector-color.ts
@@ -1,0 +1,15 @@
+/**
+ * Deterministic hue for a detector, derived from its display name.
+ *
+ * The hue (0-359) feeds the `--detector-hue` CSS custom property; theme SCSS
+ * picks saturation/lightness so the color renders well in dark and light
+ * modes. Renaming a detector intentionally produces a new color — the hue
+ * tracks the user's mental label, not the opaque registry id.
+ */
+export function detectorHue(name: string): number {
+  let hash = 5381;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) + hash + name.charCodeAt(i)) | 0;
+  }
+  return ((hash % 360) + 360) % 360;
+}

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -94,6 +94,12 @@
   --bg-primary: var(--bg-panel);
   --accent-color: var(--accent);
   --color-accent: var(--accent);
+  // Per-detector accent. Components opt in by setting `--detector-hue: <0-359>`
+  // (typically via inline style bound to `detectorHue(detector.name)`); these
+  // vars resolve the hue against theme-specific saturation/lightness. The
+  // fallback hue keeps colors readable when `--detector-hue` is unset.
+  --detector-accent: hsl(var(--detector-hue, 230), 55%, 70%);
+  --detector-accent-bg: hsla(var(--detector-hue, 230), 60%, 60%, 0.22);
   --error: var(--color-bad);
   --error-text: var(--color-bad);
   --error-border: var(--border-secondary);
@@ -166,6 +172,8 @@
   --bg-primary: var(--bg-panel);
   --accent-color: var(--accent);
   --color-accent: var(--accent);
+  --detector-accent: hsl(var(--detector-hue, 230), 50%, 42%);
+  --detector-accent-bg: hsla(var(--detector-hue, 230), 55%, 50%, 0.18);
   --error: var(--color-bad);
   --error-text: var(--color-bad);
   --error-border: #e57373;
@@ -238,6 +246,10 @@
   --bg-primary: var(--bg-panel);
   --accent-color: var(--accent);
   --color-accent: var(--accent);
+  // Highviz: skip per-detector hues so the yellow accessibility accent is
+  // not diluted. All detector surfaces fall back to the global accent.
+  --detector-accent: var(--accent);
+  --detector-accent-bg: var(--accent-highlight-bg);
   --error: var(--color-bad);
   --error-text: var(--color-bad);
   --error-border: #ff4444;


### PR DESCRIPTION
## Summary

Each detector gets a deterministic color hue derived from its display name, so it has a recognizable visual handle wherever it appears in the app. Datasets intentionally stay neutral — this is per-detector only.

## How the hue works

- **Source:** djb2 hash of `detector.name` → `0..359`. Renaming a detector intentionally changes the color (it tracks the user's mental label, not the opaque registry id).
- **Theme-aware:** the hue feeds a `--detector-hue` CSS custom property; `--detector-accent` / `--detector-accent-bg` resolve it against theme-specific S/L so the color reads correctly in both dark and light modes.
- **Highviz:** falls back to the global yellow accent. The accessibility palette is not diluted; the swatch dot becomes uniform across detectors.

## Surfaces affected

- **Dashboard detector-card** — selected/hover row tint uses the per-detector bg; small swatch dot next to the detector name.
- **Detector context bar** (training view) — background and swatch use the active detector's hue.
- **Context pulldown** — detector rows show a swatch dot; active detector row uses `--detector-accent-bg`. Dataset rows untouched. Detector trigger button also shows the active swatch.
- **Incompatible-pair explainer**, **combine-detectors modal**, **load-sort modal**'s detector list — swatch beside the name.

## What's new

- `frontend/src/app/utils/detector-color.ts` — `detectorHue(name)` helper.
- `frontend/src/app/components/detector-swatch/` — `vt-detector-swatch` standalone component (8px dot).
- Theme variables `--detector-accent` and `--detector-accent-bg` added to dark/light/highviz blocks in `_variables.scss`.

## Test plan

- [x] `./run-tests.sh core` — frontend TypeScript build clean; all 507 core tests pass
- [x] `./run-tests.sh` — full suite (3788 passed, 1 skipped)
- [ ] Eyeball check in dark/light/highviz themes that the hues read well and don't conflict with the global accent
- [ ] Rename a detector and verify its color updates accordingly

https://claude.ai/code/session_01RLtt8bNiX3o7CrZGcMxdi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLtt8bNiX3o7CrZGcMxdi2)_