### PR TITLE
Flip remaining 6 importers to multi_media=True (unblock shim removal)

### DIFF
--- a/docs/plans/multi-media-import.md
+++ b/docs/plans/multi-media-import.md
@@ -1,6 +1,8 @@
 # Multi-media importing
 
-Status: in progress (prototype landing alongside this doc).
+Status: every in-tree importer now sets `multi_media=True`.  Shim
+removal is the next step but is **blocked on external extensions** (see
+"Open follow-ups" at the bottom).
 
 ## The problem
 
@@ -258,36 +260,68 @@ When migrating an importer to `multi_media=True`:
 - Tests covering the new code path, the shim, and the `multi_media`
   flag on all migrated importers.
 
-Still on the legacy shim (will migrate in followups):
+## What shipped (latest round)
 
-- `pickle`, `combine_datasets`, `synthetic`, `http_archive`, `recaller`,
-  `demo`. Each is mechanical — flip the flag and rewrite `run()` to
-  iterate. ReCaller specifically waits on a working API client (see
-  `plans/RCDatasetImporter.md`).
-- **Update all EXTENSIONS.** Outside-developed importers are the real
-  bottleneck here, not the in-tree six. Any third-party `DatasetImporter`
-  subclass that ships outside this repo still works today via the
-  `multi_media=False` shim, but it cannot expose the new Include-rows UI,
-  cannot accept user-tunable converter params, and pins us to keeping the
-  legacy `converters` field and `media_type`-as-scan-filter semantics
-  alive. Shim removal is gated on those extension maintainers flipping
-  their importers — we cannot just delete the legacy path on our own
-  schedule without breaking them. Concrete asks per extension:
+Flipped `multi_media = True` on the last six in-tree importers so the
+in-tree set is uniformly off the legacy shim:
+
+- `http_archive`: real migration.  `run()` / `run_chunked()` iterate
+  `effective_source_specs()`; converter rows go through a thin
+  `_run_converter_specs()` wrapper around the typed
+  `run_converters_on_folder(converter_specs=...)` entry point.
+  `build_origin()` / `build_cli_args()` serialise `source_specs` JSON
+  instead of the legacy CSV `converters` field.
+- `synthetic`, `recaller`: have a `media_type` field but only ever pull
+  one source type per import, so `run()` keeps reading
+  `field_values["media_type"]` directly.  Label updated to "Output
+  Media Type".  No spec iteration added — there are no converter rows
+  for these flows.
+- `pickle`, `combine_datasets`, `demo`: no `media_type` field, no
+  `converters` field, no spec iteration in `run()`.  The flag flip is
+  purely to take them off the legacy shim — their custom / file-upload
+  UI modes mean the multi-media editor never renders anyway, and
+  `effective_source_specs()` is never called on them.
+
+Tests: each migrated importer now asserts `multi_media=True`.  The
+legacy synthesis branch of `effective_source_specs()` is still
+exercised via a `_LegacyTestImporter` stand-in (a tiny in-test
+`DatasetImporter` subclass with `multi_media=False`) so the shim stays
+covered for external importers until removal.
+
+## Open follow-ups
+
+- **Update all EXTENSIONS.** Outside-developed importers are the only
+  remaining users of the legacy path now that every in-tree importer
+  has flipped.  Any third-party `DatasetImporter` subclass still works
+  via the `multi_media=False` shim but cannot expose the Include-rows
+  UI, cannot accept user-tunable converter params, and pins us to the
+  legacy `converters` field and `media_type`-as-scan-filter semantics.
+  Shim removal is gated on those extension maintainers flipping their
+  importers — we cannot just delete the legacy path on our own schedule
+  without breaking them.  Concrete asks per extension:
   1. Set `multi_media = True`.
-  2. Replace the `converters` field handling in `run()` with a loop over
-     `self.effective_source_specs(field_values)`.
+  2. Replace the `converters` field handling in `run()` with a loop
+     over `self.effective_source_specs(field_values)`.
   3. If the importer is service-style (fetches from an API, not a
      folder), add a `list_records_for_source(source_type, ...)` (or
      equivalent) so each spec drives its own upstream fetch.
   4. Update `build_origin()` to record `source_specs` instead of the
      legacy `media_type` / `converters` pair.
 
-  Until every known external importer has flipped, the followup below
-  (delete the shim) stays blocked. Track known extensions and their
-  migration status here as they are surveyed.
+  Track known extensions and their migration status here as they are
+  surveyed.
+- **Delete the shim.** Once every known external importer has flipped,
+  delete:
+  - the `multi_media` flag on `DatasetImporter` (always implicit
+    `True`);
+  - the legacy branch of `effective_source_specs()` that synthesises a
+    spec list from `media_type` + CSV `converters`;
+  - the legacy `converters` form-field handling and the
+    `converters` extra-key pass-through in routes (`load.py`,
+    `staging.py`);
+  - `_LegacyTestImporter` in
+    `tests/converters/test_converter_selection.py`.
 
-Followups (not in this PR):
-
-- Once everything in-tree **and every known extension** is migrated,
-  delete the shim and the legacy `converters` form field, and rename
-  `media_type` → `output_type`.
+  Optionally rename `media_type` → `output_type` (per the original
+  plan) — note this is a user-visible field rename, not just an
+  internal cleanup.

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -261,29 +261,39 @@ class TestFolderImporterConverterFields:
 
 
 class TestHttpArchiveImporterConverterFields:
-    def test_build_cli_args_with_converters(self):
+    def test_build_cli_args_with_source_specs(self):
+        import json
+
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
+        specs = [
+            {"source_type": "image", "converter": None, "params": {}},
+            {"source_type": "video", "converter": "video2image", "params": {"n_clips": "8"}},
+        ]
         args = IMPORTER.build_cli_args(
             {
                 "url": "https://example.com/a.zip",
                 "media_type": "image",
-                "converters": "video2image",
+                "source_specs": specs,
             }
         )
-        assert "--converters video2image" in args
+        assert "--source-specs" in args
+        assert json.dumps(specs) in args
 
-    def test_build_origin_with_converters(self):
+    def test_build_origin_with_source_specs(self):
+        import json
+
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
+        specs = [{"source_type": "document", "converter": "document2image", "params": {}}]
         origin = IMPORTER.build_origin(
             {
                 "url": "https://example.com/a.zip",
                 "media_type": "image",
-                "converters": "document2image",
+                "source_specs": specs,
             }
         )
-        assert origin["params"]["converters"] == "document2image"
+        assert origin["params"]["source_specs"] == json.dumps(specs)
 
 
 # ===========================================================================
@@ -809,29 +819,57 @@ class TestSourceSpecParsing:
         assert spec.converter is None
 
 
+class _LegacyTestImporter:
+    """Stand-in for an external ``multi_media=False`` importer.
+
+    Every in-tree importer now sets ``multi_media=True``, so the legacy
+    synthesis branch of :meth:`DatasetImporter.effective_source_specs`
+    is exercised only by extension code.  We instantiate one explicitly
+    here to keep that branch under test until the shim is deleted.
+    """
+
+    @staticmethod
+    def make():
+        from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+        class _Legacy(DatasetImporter):
+            name = "_legacy_test"
+            display_name = "Legacy"
+            description = ""
+            multi_media = False
+            fields = [
+                ImporterField(key="media_type", label="Type", field_type="select", default="image"),
+            ]
+
+            def run(self, field_values, medias, thin=False):  # pragma: no cover
+                raise NotImplementedError
+
+        return _Legacy()
+
+
 class TestLegacyEffectiveSourceSpecs:
     """Legacy (multi_media=False) importers synthesise specs from
     media_type + comma-separated converters."""
 
     def test_legacy_single_media_type_only(self):
-        from vtsearch.datasets.importers.http_archive import IMPORTER
+        imp = _LegacyTestImporter.make()
 
-        specs = IMPORTER.effective_source_specs({"media_type": "image"})
+        specs = imp.effective_source_specs({"media_type": "image"})
         assert len(specs) == 1
         assert specs[0].source_type == "image"
         assert specs[0].converter is None
 
     def test_legacy_with_converters_csv(self):
-        from vtsearch.datasets.importers.http_archive import IMPORTER
+        imp = _LegacyTestImporter.make()
 
-        specs = IMPORTER.effective_source_specs({"media_type": "image", "converters": "video2image,document2image"})
+        specs = imp.effective_source_specs({"media_type": "image", "converters": "video2image,document2image"})
         assert [s.converter for s in specs] == [None, "video2image", "document2image"]
         assert [s.source_type for s in specs] == ["image", "video", "document"]
 
     def test_legacy_unknown_converter_is_skipped(self):
-        from vtsearch.datasets.importers.http_archive import IMPORTER
+        imp = _LegacyTestImporter.make()
 
-        specs = IMPORTER.effective_source_specs({"media_type": "image", "converters": "video2image,bogus"})
+        specs = imp.effective_source_specs({"media_type": "image", "converters": "video2image,bogus"})
         assert [s.converter for s in specs] == [None, "video2image"]
 
 
@@ -936,11 +974,36 @@ class TestImporterMultiMediaFlagInToDict:
         d = IMPORTER.to_dict()
         assert d.get("multi_media") is True
 
-    def test_http_archive_does_not_advertise_multi_media(self):
+    def test_http_archive_advertises_multi_media(self):
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
         d = IMPORTER.to_dict()
-        assert d.get("multi_media") is False
+        assert d.get("multi_media") is True
+
+    def test_pickle_advertises_multi_media(self):
+        from vtsearch.datasets.importers.pickle import IMPORTER
+
+        assert IMPORTER.to_dict().get("multi_media") is True
+
+    def test_combine_datasets_advertises_multi_media(self):
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        assert IMPORTER.to_dict().get("multi_media") is True
+
+    def test_synthetic_advertises_multi_media(self):
+        from vtsearch.datasets.importers.synthetic import IMPORTER
+
+        assert IMPORTER.to_dict().get("multi_media") is True
+
+    def test_recaller_advertises_multi_media(self):
+        from vtsearch.datasets.importers.recaller import IMPORTER
+
+        assert IMPORTER.to_dict().get("multi_media") is True
+
+    def test_demo_advertises_multi_media(self):
+        from vtsearch.datasets.importers.demo import IMPORTER
+
+        assert IMPORTER.to_dict().get("multi_media") is True
 
 
 class TestConverterFieldsInToDict:

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -46,6 +46,10 @@ class CombineDatasetsImporter(DatasetImporter):
     icon = "\U0001f500"  # twisted rightwards arrows
     ui_mode = "custom"
     hidden_from_picker = True
+    # The combined output type is determined by the source pickles, not
+    # by a user-chosen ``media_type``.  Flag set to keep the in-tree
+    # importer set uniformly off the legacy shim.
+    multi_media = True
     fields = [
         ImporterField(
             key="datasets",

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -35,6 +35,11 @@ class DemoDatasetImporter(DatasetImporter):
     ui_mode = "custom"
     picker_view = "demo"
     category = "demo"
+    # Demo datasets have a fixed media type baked into the demo entry —
+    # there is no user-chosen output type and no converter rows in the
+    # picker UI.  Flag set to keep the in-tree importer set uniformly
+    # off the legacy shim.
+    multi_media = True
 
     fields = [
         ImporterField(

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -7,14 +7,20 @@ Requires only ``requests``, which is already a core dependency.
 
 Converter support
 -----------------
-When the ``converters`` field value is set (a comma-separated list of
-converter names), the importer also scans the extracted archive for source
-files matching each converter's input type, converts them to the target
-media type, and appends them to the dataset.
+The importer participates in the multi-media import flow.  Each
+:class:`~vtsearch.datasets.importers.base.SourceSpec` row in
+``source_specs`` is applied to the extracted archive:
+
+* a direct row (``converter is None``) embeds files of the spec's
+  source type with the target embedder, and
+* a converter row scans the extracted archive for files of the
+  converter's source type and runs the converter (with per-row params)
+  to produce media of the chosen output type.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
 import tarfile
 import zipfile
@@ -24,7 +30,7 @@ from uuid import uuid4
 
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets.downloader import download_file_with_progress
-from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtsearch.datasets.loader import load_dataset_from_folder
 from vtsearch.security.url_validation import validate_url
 
@@ -111,19 +117,17 @@ def _extract_archive(  # noqa: C901
         )
 
 
-def _run_selected_converters(
+def _run_converter_specs(
     folder: Path,
     media_type: str,
     field_values: dict,
+    converter_specs: list[SourceSpec],
     medias: dict,
     thin: bool = False,
 ) -> None:
-    """Run any user-selected converters from *field_values*."""
-    converters_str = field_values.get("converters", "")
-    if not converters_str:
-        return
-    converter_names = [c.strip() for c in converters_str.split(",") if c.strip()]
-    if not converter_names:
+    """Hand the converter rows of a multi-media spec to the runner."""
+    runnable = [s for s in converter_specs if s.converter is not None]
+    if not runnable:
         return
 
     from vtsearch.converters.runner import run_converters_on_folder  # noqa: PLC0415
@@ -137,7 +141,7 @@ def _run_selected_converters(
     }
     run_converters_on_folder(
         folder_path=folder,
-        converter_names=converter_names,
+        converter_specs=runnable,
         target_media_type=media_type,
         medias=medias,
         thin=thin,
@@ -157,9 +161,11 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     Supported archive formats: ``.zip``, ``.tar``, ``.tar.gz``,
     ``.tar.bz2``, ``.tar.xz``, ``.rar`` (requires ``rarfile`` package).
 
-    When converters are selected (via the ``converters`` field value), files
-    matching each converter's source type are also scanned, converted, and
-    added to the dataset.
+    Multi-media imports work the same as in
+    :class:`~vtsearch.datasets.importers.server_folder.ServerFolderDatasetImporter`:
+    each :class:`SourceSpec` row either embeds files of its source type
+    directly or runs a converter to produce media of the chosen output
+    media type.
     """
 
     name = "http_archive"
@@ -167,6 +173,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     description = "Download an archive (.zip, .tar, .rar) from a web URL and embed the media files inside"
     icon = "\U0001f310"
     hidden_from_picker = True
+    multi_media = True
     fields = [
         ImporterField(
             key="url",
@@ -176,7 +183,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         ),
         ImporterField(
             key="media_type",
-            label="Media Type",
+            label="Output Media Type",
             field_type="select",
             description="Type of media files contained in the archive.",
             default="audio",
@@ -210,6 +217,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         url = field_values["url"]
         validate_url(url)
         media_type = field_values.get("media_type", "audio")
+        specs = self.effective_source_specs(field_values)
 
         DATA_DIR.mkdir(exist_ok=True)
 
@@ -245,8 +253,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,
             )
-            # Run any user-selected converters on the extracted folder.
-            _run_selected_converters(extract_dir, media_type, field_values, medias, thin=thin)
+            _run_converter_specs(extract_dir, media_type, field_values, specs, medias, thin=thin)
         finally:
             shutil.rmtree(extract_dir, ignore_errors=True)
 
@@ -299,6 +306,8 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         extract_dir = self._download_and_extract(field_values)
         media_type = field_values.get("media_type", "audio")
+        specs = self.effective_source_specs(field_values)
+        converter_specs = [s for s in specs if s.converter is not None]
         emb_name = field_values.get("embedder", "")
         skip_emb = bool(field_values.get("skip_embedding"))
         try:
@@ -313,11 +322,11 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,
             )
-            # Run converters on the extracted folder and yield as a chunk.
-            converters_str = field_values.get("converters", "")
-            if converters_str:
+            if converter_specs:
                 converter_chunk: dict[int, dict[str, Any]] = {}
-                _run_selected_converters(extract_dir, media_type, field_values, converter_chunk, thin=thin)
+                _run_converter_specs(
+                    extract_dir, media_type, field_values, converter_specs, converter_chunk, thin=thin,
+                )
                 if converter_chunk:
                     yield converter_chunk
         finally:
@@ -336,9 +345,11 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
     def build_cli_args(self, field_values: dict[str, Any]) -> str:
         base = super().build_cli_args(field_values)
-        converters = field_values.get("converters", "")
-        if converters:
-            base += f" --converters {converters}"
+        specs = field_values.get("source_specs")
+        if specs:
+            if not isinstance(specs, str):
+                specs = json.dumps(specs)
+            base += f" --source-specs '{specs}'"
         return base
 
     def default_display_name(self, field_values: dict[str, Any]) -> str:
@@ -356,9 +367,11 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         origin = super().build_origin(field_values)
-        converters = field_values.get("converters", "")
-        if converters:
-            origin["params"]["converters"] = converters
+        specs = field_values.get("source_specs")
+        if specs:
+            if not isinstance(specs, str):
+                specs = json.dumps(specs)
+            origin["params"]["source_specs"] = specs
         return origin
 
     def resolve_file(

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -325,7 +325,12 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             if converter_specs:
                 converter_chunk: dict[int, dict[str, Any]] = {}
                 _run_converter_specs(
-                    extract_dir, media_type, field_values, converter_specs, converter_chunk, thin=thin,
+                    extract_dir,
+                    media_type,
+                    field_values,
+                    converter_specs,
+                    converter_chunk,
+                    thin=thin,
                 )
                 if converter_chunk:
                     yield converter_chunk

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -35,6 +35,12 @@ class PickleDatasetImporter(DatasetImporter):
     icon = "\U0001f4e4"
     ui_mode = "file_upload"
     hidden_from_picker = True
+    # Pickle imports carry a single embedded media type from the .pkl
+    # itself — there is no user-chosen output type and no converter rows.
+    # The flag is set so the in-tree importer set is uniformly off the
+    # legacy ``effective_source_specs()`` shim, not because the upload
+    # flow has anything multi-media about it.
+    multi_media = True
     fields = [
         ImporterField(
             key="file",

--- a/vtsearch/datasets/importers/recaller/__init__.py
+++ b/vtsearch/datasets/importers/recaller/__init__.py
@@ -166,10 +166,16 @@ class ReCallerDatasetImporter(DatasetImporter):
     icon = "\U0001f50d"  # magnifying glass
     hidden_from_picker = True  # flip to False once API clients are implemented
     category = "services"
+    # ReCaller queries return a single ``media_type`` selected by the
+    # user — the import flow does not pull in additional source types
+    # via converters.  Flag set to keep the in-tree importer set
+    # uniformly off the legacy shim; the existing ``list_records``
+    # implementation reads ``field_values["media_type"]`` directly.
+    multi_media = True
     fields = [
         ImporterField(
             key="media_type",
-            label="Media Type",
+            label="Output Media Type",
             field_type="select",
             options=all_folder_names(),
             default="audio",

--- a/vtsearch/datasets/importers/synthetic/__init__.py
+++ b/vtsearch/datasets/importers/synthetic/__init__.py
@@ -40,11 +40,17 @@ class SyntheticDatasetImporter(DatasetImporter):
     # frontend/src/app/components/icon/icon.component.ts).
     icon = "\U0001f3ed"
     category = "demo"
+    # The generator only ever produces one media type per import
+    # (image | audio | video), so the "Include rows" editor only ever
+    # shows the auto-populated direct row — there are no converters
+    # for synthetic sources.  Flag set to keep the in-tree importer set
+    # uniformly off the legacy shim.
+    multi_media = True
 
     fields = [
         ImporterField(
             key="media_type",
-            label="Media Type",
+            label="Output Media Type",
             field_type="select",
             description="What kind of media to generate.",
             options=_SUPPORTED_MEDIA_TYPES,


### PR DESCRIPTION
## Summary

Migrates the last six in-tree importers (`pickle`, `combine_datasets`, `synthetic`, `http_archive`, `recaller`, `demo`) off the legacy `effective_source_specs()` / CSV-`converters` shim, so the in-tree set is uniformly on the multi-media import flow.  Shim deletion is the next step but stays blocked on external extensions — see the updated "Open follow-ups" in `docs/plans/multi-media-import.md`.

- `http_archive` is the only real migration: `run()` and `run_chunked()` now iterate `effective_source_specs()` and hand converter rows to a thin `_run_converter_specs()` wrapper around the typed `run_converters_on_folder(converter_specs=...)` entry point.  `build_origin()` / `build_cli_args()` serialise `source_specs` JSON instead of the legacy CSV.
- `synthetic` and `recaller` only ever pull one source type per import, so `run()` keeps reading `field_values["media_type"]` directly — the flag flip is cosmetic but consistent.  Label updated to "Output Media Type".
- `pickle`, `combine_datasets`, `demo` have no `media_type` field, no converters, and use custom / file-upload UI modes that don't render the multi-media editor — flag flip only.

Tests: each migrated importer now asserts `multi_media=True`.  The legacy synthesis branch of `effective_source_specs()` is still exercised via a small `_LegacyTestImporter` stand-in so the shim stays covered for external importers until removal.

## Test plan

- [x] `./run-tests.sh` — all 3793 tests pass.

https://claude.ai/code/session_0174KsMfH5cXVCdRgVEDcazX

---
_Generated by [Claude Code](https://claude.ai/code/session_0174KsMfH5cXVCdRgVEDcazX)_