### PR TITLE
docs(vtscore): resolve Phase 0 open questions

### DIFF
--- a/docs/plans/extract-library.md
+++ b/docs/plans/extract-library.md
@@ -152,9 +152,11 @@ static/                    # built Angular output
 
 ## Risks and open questions
 
-- **Settings sources / labelset sources straddle the boundary.** `SettingsSource` is inherently a user-pref concern (app-side), but `LabelsetSource` is library-side (detector training writes labels). The shared `SyncSource[L,S]` ABC stays in the library; the settings-source registry stays app-side; the labelset-source registry moves to the library. Confirm before Phase 5.
-- **`medias.py` test-media generator** is used both at startup (app concern) and by `conftest.py`. Probably moves to `tests/fixtures/` rather than either distribution.
-- **`eval/visualisation.py`** likely pulls in matplotlib — keep as an optional extra (`vtscore[viz]`) to avoid forcing the dep on lean consumers.
+- **Settings sources / labelset sources straddle the boundary.** *Resolved (Phase 0 review):* `SettingsSource` is a user-pref concern and stays app-side. `LabelsetSource` ships in `vtscore.labels` — pulling labels in from external systems is a core library affordance, and the registry (`get_labelset_source` / `list_labelset_sources`) ships with it. The shared `SyncSource[L,S]` ABC remains in `vtscore.sync`.
+- **`medias.py` test-media generator** is used both at startup (app concern) and by `conftest.py`. The generator already moved to `tests/fixtures/medias.py` and is not part of the runtime app — no Phase action needed.
+- **`eval/visualisation.py`** *Resolved (Phase 0 review):* plotting (`plot_eval_results`, `plot_voting_iterations`) is presentation, not computation, and stays in `vtsearch/`. The library exports the data (`DatasetResult`, `QueryMetrics`, `LearnedSortMetrics`, `format_results_json`); the app renders it. No `vtscore[viz]` extra needed.
+- **`autorun_*` global state.** *Resolved (Phase 0 review):* the registry of which processors to autorun (`autorun_detectors`, `autorun_extractors`, `autorun_localizers` and their CRUD) is *policy* and stays app-side. The library keeps the `Processor` / `Detector` / `Localizer` / `Extractor` ABCs plus the code that applies them; the app passes in the resolved list. Phase 3 wires this as an explicit argument.
+- **Per-thread progress callback on `vtscore.media`.** *Resolved (Phase 0 review):* mirror `vtscore.concurrency.progress.set_thread_progress` — add `set_thread_progress_callback` that takes priority when set on the calling thread, keep `set_progress_callback` as the global default. Library consumers running multi-threaded ingestion won't have one thread clobber another's callback.
 - **Heavy ML deps** (torch/transformers/CLAP/CLIP) — declare as required for now; revisit extras (`vtscore[embedders]`) if a consumer asks for a leaner install.
 
 ## Order of operations recap

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -309,7 +309,17 @@ def all_type_ids() -> list[str]: ...
 def all_types_dict() -> list[dict]: ...
 def all_demo_datasets() -> dict[str, DemoDataset]: ...
 def normalize_type_id(type_id: str) -> str: ...
-def set_progress_callback(cb: ProgressCallback) -> None: ...
+def set_progress_callback(cb: ProgressCallback) -> None:
+    """Global default progress callback for media-registry operations.
+    A per-thread override via set_thread_progress_callback takes priority when set."""
+
+def set_thread_progress_callback(cb: ProgressCallback | None) -> None:
+    """Set a progress callback for the current thread only. Multi-threaded library
+    consumers (e.g. parallel evaluation harnesses) should use this to avoid one
+    thread clobbering another's callback. None clears the thread override and
+    falls back to the global. Mirrors vtscore.concurrency.progress.set_thread_progress."""
+
+def get_thread_progress_callback() -> ProgressCallback | None: ...
 ```
 
 ### Embedder registry
@@ -745,12 +755,6 @@ def run_eval(...) -> list[DatasetResult]:
 
 def format_results_json(results: list[DatasetResult]) -> str: ...
 
-def plot_eval_results(results: list[DatasetResult], out_dir: Path) -> None:
-    """Generate evaluation PNGs (mAP, AP, P@k, R@k, F1, metrics).
-    Requires `vtscore[viz]` extra (matplotlib)."""
-
-def plot_voting_iterations(results: list[dict], out_dir: Path) -> None: ...
-
 def simulate_voting_iterations(
     dataset: DatasetContext,
     *,
@@ -769,6 +773,12 @@ def run_voting_iterations_eval(
 
 def run_voting_iterations_eval_from_pickles(pickles: list[Path]) -> list[dict]: ...
 ```
+
+> `plot_eval_results` and `plot_voting_iterations` are **not** part of `vtscore`.
+> Plotting is presentation, not computation — those helpers move to `vtsearch/` and
+> import matplotlib app-side. The library exports the data (`DatasetResult`,
+> `QueryMetrics`, `LearnedSortMetrics`, `format_results_json`); rendering it is
+> the app's job.
 
 ---
 
@@ -886,8 +896,14 @@ The following names appear in `vtsearch.state` today but are app-side concerns a
   `dataset_display_name`, `safe_thresholds`, `calibrate_count`, `calibration_fraction`,
   `enrich_descriptions` — these are `_ProxyDict` / `_ProxyList` objects that read
   `flask.g`. They stay in the app as a thin shim that delegates to library contexts.
-- `autorun_detectors`, `autorun_extractors`, `autorun_localizers` — currently global
-  module state; Phase 3 moves them onto a context-or-config object the app owns.
+- `autorun_detectors`, `autorun_extractors`, `autorun_localizers` and their CRUD
+  (`add_autorun_extractor`, `remove_autorun_extractor`, `rename_autorun_extractor`,
+  `get_autorun_extractors`, `get_autorun_extractors_by_media`, and the matching
+  `_autorun_localizer` set) — *policy* about which processors to run automatically,
+  which is an app concern. The library keeps the `Processor` / `Detector` /
+  `Localizer` / `Extractor` ABCs and the code that applies them; the app keeps
+  the list of which ones to apply on load. Phase 3 wires the resolved list
+  through as an explicit argument to whichever library entry point needs it.
 - `get_inclusion`, `set_inclusion`, `get_calibrate_count`, `set_calibrate_count`,
   `get_calibration_fraction`, `set_calibration_fraction`, `get_safe_thresholds`,
   `set_safe_thresholds`, `get_dataset_display_name`, `set_dataset_display_name`,
@@ -1227,17 +1243,39 @@ Explicit non-goals — these are app concerns that stay in `vtsearch/`:
 - `vtsearch/achievements.py` — pure user-pref / gamification, no library consumer.
 - `vtsearch/schemas/` — flask-smorest marshmallow schemas for the HTTP API.
 
-## Open questions for Phase 1
+## Phase 1 decisions
 
-1. **`labelset_source` plugin family**: the plan's Phase 5 note says the labelset-source
-   registry moves to the library. Confirm before extracting — the alternative is to keep
-   both source registries app-side and have the library merely consume them.
-2. **`vtscore.eval.visualize` dependency on matplotlib**: ship as required, or as an
-   extra `vtscore[viz]`? Plan suggests extra; revisit if downstream prototypes need it
-   in the base install.
-3. **`autorun_*` global state**: today `autorun_detectors`, `autorun_extractors`,
-   `autorun_localizers` live in `vtsearch.state.__init__`. Phase 3 needs to decide
-   where they land — on `CoreConfig`, on a new context object, or app-side.
-4. **`set_progress_callback` on `vtscore.media`**: currently a global wire-up. Library
-   consumers using multiple threads will need a per-thread variant — the
-   `set_thread_progress` shape in `vtscore.concurrency.progress` is the precedent.
+The four open questions surfaced at Phase 0 review are settled. The principle
+that resolves them: **library = "the ability to do X"; app = "the policy that
+decides when X happens, what gets persisted, and where it shows up."**
+
+1. **`labelset_source` plugin family — ships in `vtscore.labels`.** Pulling labels
+   in from external systems is a core consumer affordance (you can't use the
+   library without it), so the ABC, the registry (`get_labelset_source` /
+   `list_labelset_sources`), and the discovery sentinel all live library-side.
+   The shared `SyncSource[L,S]` base in `vtscore.sync` is unchanged. Contrast
+   with `SettingsSource`, which is a user-pref concern and stays in `vtsearch/`.
+2. **Data visualization stays in the app.** Plotting eval results is presentation,
+   not computation — it belongs next to the routes that render charts, not in
+   the library that produces the numbers. `vtscore.eval` exports the dataclasses,
+   metric functions, and runners (`run_eval`, `eval_text_sort`, `eval_learned_sort`,
+   `simulate_voting_iterations`, `format_results_json`); the `plot_*` helpers move
+   to `vtsearch/` and import matplotlib there. This also drops the need for a
+   `vtscore[viz]` extra.
+3. **`autorun_*` lists are app-side; processor execution is library-side.** The
+   `Processor` / `Detector` / `Localizer` / `Extractor` ABCs and the code that
+   applies them to media stay in `vtscore` — the *ability* to run a processor is
+   a library concern. The registry of which processors to autorun
+   (`autorun_detectors`, `autorun_extractors`, `autorun_localizers`) plus its
+   CRUD (`add_autorun_extractor`, `remove_autorun_localizer`, etc.) is *policy*
+   the app owns; it stays in `vtsearch/`. The library accepts the resolved list
+   as an argument when a caller wants to run it.
+4. **Mirror the concurrency progress pattern on `vtscore.media`: per-thread override
+   plus global default.** Add `set_thread_progress_callback()` that takes priority
+   when set on the calling thread, and keep `set_progress_callback()` as the
+   global fallback for single-threaded consumers. Cost is ~10 lines
+   (`threading.local` or a `ContextVar`); benefit is that a library consumer
+   running multi-threaded ingestion (e.g. scoring two detectors in parallel)
+   doesn't have one thread clobber another's callback. The shape mirrors
+   `vtscore.concurrency.progress.set_thread_progress` so the two surfaces are
+   consistent.


### PR DESCRIPTION
## Summary

Resolves the four open questions surfaced at Phase 0 review of `docs/vtscore-api.md` (landed in #1478). The unifying principle: **library = "the ability to do X"; app = "the policy that decides when X happens and what gets persisted."**

1. **LabelsetSource → `vtscore.labels`** (ABC + registry). Pulling labels in from external systems is a core consumer affordance, so the discovery sentinel ships library-side. Contrast with `SettingsSource`, which is a user-pref concern and stays in `vtsearch/`.
2. **Eval visualization stays app-side.** Plotting is presentation, not computation — `plot_eval_results` and `plot_voting_iterations` move to `vtsearch/`. Library exports the data (`DatasetResult`, `format_results_json`); app renders it. Drops the `vtscore[viz]` extra.
3. **Autorun *registries* are app-side, processor *execution* is library-side.** `Processor`/`Detector`/`Localizer`/`Extractor` ABCs and the code that applies them stay in `vtscore`. The lists of which processors to autorun (`autorun_detectors`, `autorun_extractors`, `autorun_localizers`) plus their CRUD stay in `vtsearch/`. Phase 3 wires the resolved list through as an explicit argument.
4. **Per-thread + global progress callback on `vtscore.media`.** Mirrors `vtscore.concurrency.progress.set_thread_progress`: a `set_thread_progress_callback` override that takes priority when set on the calling thread, falling back to the existing global `set_progress_callback`. Multi-threaded library consumers (parallel eval harnesses, batch scoring) no longer clobber each other's callbacks.

Also updates the plan's "Risks and open questions" section to mark these resolved and drops the `vtscore[viz]` extra reference. No code changes — docs only.

Depends on #1478 (already merged).

## Test plan

- [ ] Skim the four updated sections of `docs/vtscore-api.md` (`Phase 1 decisions`, `vtscore.eval`, `vtscore.state` "what stays in the app", `vtscore.media`) for any policy/ability line that still looks blurry
- [ ] Confirm the four resolutions are what you want before Phase 1 work starts pulling on them

https://claude.ai/code/session_0173ZnSUKEuPjuWY2KrZMEmK

---
_Generated by [Claude Code](https://claude.ai/code/session_0173ZnSUKEuPjuWY2KrZMEmK)_