### PR TITLE
docs: mark §21.10 Model evaluation card as won't do

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -806,8 +806,8 @@ Domain-adapt the embedder on the user's unlabeled corpus (MAE/BYOL style). Heavy
 ### 21.9 Distillation ★ M
 Train a tiny CNN/MLP to mimic SigLIP scores on user's data. Useful for edge deployment / latency-sensitive batch scoring.
 
-### 21.10 Model evaluation card ★★ S
-Per-detector dashboard: precision/recall/F1 from a held-out vote split, calibration plot, confusion matrix, top-K errors. Currently you have to leave the app to get this.
+### 21.10 Model evaluation card ★★ S — **Won't do**
+~~Per-detector dashboard: precision/recall/F1 from a held-out vote split, calibration plot, confusion matrix, top-K errors. Currently you have to leave the app to get this.~~ Declined 2026-05-19: not pursuing an in-app evaluation dashboard; users who need these metrics can keep computing them out-of-app from the existing label export.
 
 ### 21.11 Vote-noise robustness ★★ experiment
 Add synthetic label noise, measure detector quality degradation. Inform UI for "warn user when their vote disagrees with a confident model prediction" feature.


### PR DESCRIPTION
## Summary

Marks brainstorm item §21.10 ("Model evaluation card") as **Won't do**. The original entry proposed an in-app per-detector dashboard (precision/recall/F1 on a held-out vote split, calibration plot, confusion matrix, top-K errors). We are not pursuing it — users who need these metrics can keep computing them out-of-app from the existing label export.

The entry is left in the backlog with a strike-through and a dated decline note so it doesn't get re-proposed.

## Test plan
- [x] Docs-only change; no code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbn1acn9ic45MgNRaRLhgr)_