### PR TITLE
text: add TextParagraphClipper (split on blank lines)

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -82,7 +82,7 @@ The base converter ships; the deferred improvements:
 - **`image_object` follow-ups** — experiment with SAM2 boxes for the same UI; consider a per-class confidence threshold instead of one global value if users ask for it.
 
 ### 3.3 Text
-- **`text_paragraph`** ★★ XS — split on `\n\n`. Free wins on prose.
+- ~~**`text_paragraph`** ★★ XS — split on `\n\n`. Free wins on prose.~~ **Shipped** — `TextParagraphClipper` in `vtsearch/media/text/clipper.py`.
 - **`text_token_window`** ★★ S — token-aware windows (tiktoken) with overlap.
 - **`text_semantic`** ★★ M — embedding-similarity-based chunking (sentence groups whose adjacent cosine drops below threshold).
 - **`text_heading`** ★ S — split on Markdown/HTML headings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,4 +229,4 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # slope formulas, medias as the global state proxy, goup as a TS method),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable).
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te"
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser"

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -1325,6 +1325,110 @@ class TestTextDefaultClipper:
 
 
 # ---------------------------------------------------------------------------
+# TextParagraphClipper
+# ---------------------------------------------------------------------------
+
+
+class TestTextParagraphClipper:
+    def test_identity(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        c = TextParagraphClipper()
+        assert c.name == "text_paragraph"
+        assert c.media_type == "text"
+        assert isinstance(c, MediaClipper)
+
+    def test_single_paragraph_unchanged(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        media = {"id": 1, "type": "text", "media_string": "Just one paragraph here."}
+        result = TextParagraphClipper().clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_splits_multiple_paragraphs(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird one."
+        media = {"id": 1, "type": "text", "media_string": text, "word_count": 6, "character_count": len(text)}
+        result = TextParagraphClipper().clip(media)
+        assert len(result) == 3
+        assert result[0]["media_string"] == "First paragraph."
+        assert result[1]["media_string"] == "Second paragraph."
+        assert result[2]["media_string"] == "Third one."
+        for idx, tile in enumerate(result):
+            assert tile["clip_index"] == idx
+            assert tile["word_count"] == len(tile["media_string"].split())
+            assert tile["character_count"] == len(tile["media_string"])
+
+    def test_multiline_paragraphs_preserved(self):
+        """A paragraph that internally contains single newlines stays intact."""
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        text = "Line one.\nLine two of the same para.\n\nSecond paragraph here."
+        media = {"id": 1, "type": "text", "media_string": text}
+        result = TextParagraphClipper().clip(media)
+        assert len(result) == 2
+        assert result[0]["media_string"] == "Line one.\nLine two of the same para."
+        assert result[1]["media_string"] == "Second paragraph here."
+
+    def test_collapses_runs_of_blank_lines(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        text = "Alpha.\n\n\n\nBeta.\n\n\nGamma."
+        media = {"id": 1, "type": "text", "media_string": text}
+        result = TextParagraphClipper().clip(media)
+        assert [t["media_string"] for t in result] == ["Alpha.", "Beta.", "Gamma."]
+
+    def test_handles_windows_line_endings(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        text = "Para one.\r\n\r\nPara two.\r\n\r\nPara three."
+        media = {"id": 1, "type": "text", "media_string": text}
+        result = TextParagraphClipper().clip(media)
+        assert [t["media_string"] for t in result] == ["Para one.", "Para two.", "Para three."]
+
+    def test_blank_line_with_whitespace_still_splits(self):
+        """A blank line that contains spaces/tabs still counts as a separator."""
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        text = "First.\n   \nSecond."
+        media = {"id": 1, "type": "text", "media_string": text}
+        result = TextParagraphClipper().clip(media)
+        assert [t["media_string"] for t in result] == ["First.", "Second."]
+
+    def test_empty_string_returns_unchanged(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        media = {"id": 1, "type": "text", "media_string": ""}
+        result = TextParagraphClipper().clip(media)
+        assert result == [media]
+
+    def test_no_media_string_returns_unchanged(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        media = {"id": 1, "type": "text"}
+        result = TextParagraphClipper().clip(media)
+        assert result == [media]
+
+    def test_registered_for_text_type(self):
+        """The paragraph clipper is auto-discovered for the text media type."""
+        from vtsearch.media import clippers_for_type
+
+        names = {c.name for c in clippers_for_type("text")}
+        assert "text_paragraph" in names
+
+    def test_to_dict_shape(self):
+        from vtsearch.media.text.clipper import TextParagraphClipper
+
+        d = TextParagraphClipper().to_dict()
+        assert d["name"] == "text_paragraph"
+        assert d["media_type"] == "text"
+        assert d["display_name"] == "Paragraph"
+        assert "blank lines" in d["description"]
+
+
+# ---------------------------------------------------------------------------
 # TextSentenceClipper
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/media/text/__init__.py
+++ b/vtsearch/media/text/__init__.py
@@ -1,5 +1,5 @@
-from vtsearch.media.text.clipper import TextDefaultClipper, TextSentenceClipper
+from vtsearch.media.text.clipper import TextDefaultClipper, TextParagraphClipper, TextSentenceClipper
 from vtsearch.media.text.media_type import TextMediaType
 
 MEDIA_TYPE = TextMediaType()
-CLIPPERS = [TextDefaultClipper(), TextSentenceClipper()]
+CLIPPERS = [TextDefaultClipper(), TextParagraphClipper(), TextSentenceClipper()]

--- a/vtsearch/media/text/clipper.py
+++ b/vtsearch/media/text/clipper.py
@@ -1,4 +1,4 @@
-"""Text clippers — split into sentences or pass-through text media."""
+"""Text clippers — split into paragraphs or sentences, or pass-through text media."""
 
 from __future__ import annotations
 
@@ -25,6 +25,52 @@ class TextDefaultClipper(MediaClipper):
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
+
+
+class TextParagraphClipper(MediaClipper):
+    """Split a text media into one media per paragraph.
+
+    Paragraphs are delimited by one or more blank lines (``\\n\\n``,
+    tolerating Windows ``\\r\\n\\r\\n`` and blank lines containing only
+    whitespace).  If the text contains no paragraph breaks, it is returned
+    unchanged.
+    """
+
+    # Match a blank line: a newline, any whitespace (which includes \r and
+    # additional newlines), then another newline.  Greedy \s* collapses
+    # runs of blank lines into a single split boundary.
+    _PARAGRAPH_RE = re.compile(r"\n\s*\n")
+
+    @property
+    def name(self) -> str:
+        return "text_paragraph"
+
+    @property
+    def media_type(self) -> str:
+        return "text"
+
+    @property
+    def description(self) -> str:
+        return "Split each text entry into paragraphs separated by blank lines."
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        text = media.get("media_string") or ""
+        if not text:
+            return [media]
+
+        paragraphs = [p.strip() for p in self._PARAGRAPH_RE.split(text) if p.strip()]
+        if len(paragraphs) <= 1:
+            return [media]
+
+        results: list[dict[str, Any]] = []
+        for idx, para in enumerate(paragraphs):
+            tile = dict(media)
+            tile["media_string"] = para
+            tile["word_count"] = len(para.split())
+            tile["character_count"] = len(para)
+            tile["clip_index"] = idx
+            results.append(tile)
+        return results
 
 
 class TextSentenceClipper(MediaClipper):


### PR DESCRIPTION
## Summary

- New `TextParagraphClipper` in `vtsearch/media/text/clipper.py` — splits text media on blank lines (`\n\n`, also tolerating `\r\n\r\n` and blank lines that contain only whitespace). Single-paragraph and empty inputs return unchanged, matching the `TextSentenceClipper` convention.
- Registered in `vtsearch/media/text/__init__.py` so it's auto-discovered for the `text` media type and appears in the clipper chooser between `text_default` and `text_sentence`.
- Marked as shipped in `docs/plans/brainstorm.md` §3.3 (was `★★ XS`).
- Drive-by: added `ser` to `[tool.codespell] ignore-words-list` in `pyproject.toml` — `docs/vtscore-api.md` uses "JSON ser/de" as shorthand for serialize/deserialize, and codespell was flagging it as a typo for "set" (blocking `./run-tests.sh`).

## Test plan

- [x] `./run-tests.sh detectors` — 969 passed (includes new `TestTextParagraphClipper` cases: identity, single-paragraph passthrough, multi-paragraph split, multiline paragraphs preserved, blank-line runs collapsed, Windows line endings, whitespace-only blank lines, empty string, missing `media_string`, plugin auto-discovery, `to_dict` shape)
- [x] `./run-tests.sh core` — 507 passed (ruff + ruff format + codespell + deptry + frontend `npm run build:prod`)
- [x] `./run-tests.sh` (full suite) — 3804 passed, 1 skipped, 2 xpassed


---
_Generated by [Claude Code](https://claude.ai/code/session_0133KkjUehHYcwjNbFhe1omn)_