### PR TITLE
audio embedders: add AST, CLAP-General-2024, Whisper-encoder

### DIFF
--- a/tests/detectors/test_new_embedders.py
+++ b/tests/detectors/test_new_embedders.py
@@ -189,6 +189,172 @@ class TestAudioClapMusicEmbedderProperties:
         assert CLAP_MUSIC_MODEL_ID == "laion/larger_clap_music_and_speech"
 
 
+class TestAudioClapGeneralEmbedderProperties:
+    """Verify AudioClapGeneralEmbedder class properties and registration."""
+
+    def test_name(self):
+        from vtsearch.media.audio.embedder_clap_general import AudioClapGeneralEmbedder
+
+        emb = AudioClapGeneralEmbedder()
+        assert emb.name == "clap_general"
+
+    def test_media_type_id(self):
+        from vtsearch.media.audio.embedder_clap_general import AudioClapGeneralEmbedder
+
+        emb = AudioClapGeneralEmbedder()
+        assert emb.media_type_id == "audio"
+
+    def test_description_wrappers_non_empty(self):
+        from vtsearch.media.audio.embedder_clap_general import AudioClapGeneralEmbedder
+
+        emb = AudioClapGeneralEmbedder()
+        wrappers = emb.description_wrappers
+        assert len(wrappers) > 0
+        assert all("{text}" in w for w in wrappers)
+
+    def test_registered_in_registry(self):
+        from vtsearch.media import get_embedder
+
+        emb = get_embedder("clap_general")
+        assert emb.name == "clap_general"
+        assert emb.media_type_id == "audio"
+
+    def test_to_dict(self):
+        from vtsearch.media.audio.embedder_clap_general import AudioClapGeneralEmbedder
+
+        emb = AudioClapGeneralEmbedder()
+        d = emb.to_dict()
+        assert d == {
+            "name": "clap_general",
+            "display_name": "CLAP (general 2024)",
+            "media_type_id": "audio",
+            "is_default": False,
+            "supports_text": True,
+            "supports_patch_regions": False,
+            "license_notice": None,
+        }
+
+    def test_uses_correct_model_id(self):
+        from vtsearch.config import CLAP_GENERAL_MODEL_ID
+
+        assert CLAP_GENERAL_MODEL_ID == "laion/larger_clap_general"
+
+
+class TestAudioASTEmbedderProperties:
+    """Verify AudioASTEmbedder class properties and registration."""
+
+    def test_name(self):
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+
+        emb = AudioASTEmbedder()
+        assert emb.name == "ast"
+
+    def test_media_type_id(self):
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+
+        emb = AudioASTEmbedder()
+        assert emb.media_type_id == "audio"
+
+    def test_supports_text_is_false(self):
+        """AST has no text encoder."""
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+
+        emb = AudioASTEmbedder()
+        assert emb.supports_text is False
+
+    def test_inherits_default_embed_text(self):
+        """Without a custom override, ``embed_text`` returns ``None``."""
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+
+        emb = AudioASTEmbedder()
+        assert emb.embed_text("any query") is None
+
+    def test_registered_in_registry(self):
+        from vtsearch.media import get_embedder
+
+        emb = get_embedder("ast")
+        assert emb.name == "ast"
+        assert emb.media_type_id == "audio"
+
+    def test_to_dict(self):
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+
+        emb = AudioASTEmbedder()
+        d = emb.to_dict()
+        assert d == {
+            "name": "ast",
+            "display_name": "AST (audio spectrogram)",
+            "media_type_id": "audio",
+            "is_default": False,
+            "supports_text": False,
+            "supports_patch_regions": False,
+            "license_notice": None,
+        }
+
+    def test_uses_correct_model_id(self):
+        from vtsearch.config import AST_MODEL_ID, AST_SAMPLE_RATE
+
+        assert AST_MODEL_ID == "MIT/ast-finetuned-audioset-10-10-0.4593"
+        assert AST_SAMPLE_RATE == 16000
+
+
+class TestAudioWhisperEncoderEmbedderProperties:
+    """Verify AudioWhisperEncoderEmbedder class properties and registration."""
+
+    def test_name(self):
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+
+        emb = AudioWhisperEncoderEmbedder()
+        assert emb.name == "whisper_encoder"
+
+    def test_media_type_id(self):
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+
+        emb = AudioWhisperEncoderEmbedder()
+        assert emb.media_type_id == "audio"
+
+    def test_supports_text_is_false(self):
+        """Whisper's decoder is text-OUT, not a text encoder; no shared space."""
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+
+        emb = AudioWhisperEncoderEmbedder()
+        assert emb.supports_text is False
+
+    def test_inherits_default_embed_text(self):
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+
+        emb = AudioWhisperEncoderEmbedder()
+        assert emb.embed_text("any query") is None
+
+    def test_registered_in_registry(self):
+        from vtsearch.media import get_embedder
+
+        emb = get_embedder("whisper_encoder")
+        assert emb.name == "whisper_encoder"
+        assert emb.media_type_id == "audio"
+
+    def test_to_dict(self):
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+
+        emb = AudioWhisperEncoderEmbedder()
+        d = emb.to_dict()
+        assert d == {
+            "name": "whisper_encoder",
+            "display_name": "Whisper encoder (speech)",
+            "media_type_id": "audio",
+            "is_default": False,
+            "supports_text": False,
+            "supports_patch_regions": False,
+            "license_notice": None,
+        }
+
+    def test_uses_correct_model_id(self):
+        from vtsearch.config import WHISPER_MODEL_ID, WHISPER_SAMPLE_RATE
+
+        assert WHISPER_MODEL_ID == "openai/whisper-base"
+        assert WHISPER_SAMPLE_RATE == 16000
+
+
 class TestTextBGEEmbedderProperties:
     """Verify TextBGEEmbedder class properties and registration."""
 
@@ -578,9 +744,10 @@ class TestAllEmbeddersRegistration:
 
         embedders = all_embedders()
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder + 1
-        # vision-only video embedder (videomae).
-        assert len(embedders) == 17
+        # variants for dinov2, dinov3, eupe) + 1 face embedder
+        # + 1 vision-only video embedder (videomae)
+        # + 3 audio embedders (ast, clap_general, whisper_encoder).
+        assert len(embedders) == 20
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -590,9 +757,9 @@ class TestAllEmbeddersRegistration:
         dicts = all_embedders_dict()
         by_name = {d["name"]: d for d in dicts}
         # Cross-modal embedders advertise text support.
-        for name in ("siglip", "siglip2", "clip", "clap", "xclip"):
+        for name in ("siglip", "siglip2", "clip", "clap", "clap_general", "xclip"):
             assert by_name[name]["supports_text"] is True, name
-        # Vision-only / patch-based embedders do not.
+        # Vision-only / patch-based and speech-only embedders do not.
         for name in (
             "dinov2_single",
             "dinov2_patch",
@@ -601,6 +768,8 @@ class TestAllEmbeddersRegistration:
             "eupe_single",
             "eupe_patch",
             "videomae",
+            "ast",
+            "whisper_encoder",
         ):
             assert by_name[name]["supports_text"] is False, name
 
@@ -611,6 +780,9 @@ class TestAllEmbeddersRegistration:
         expected = {
             "clap",
             "clap_music",
+            "clap_general",
+            "ast",
+            "whisper_encoder",
             "siglip",
             "siglip2",
             "clip",
@@ -633,7 +805,7 @@ class TestAllEmbeddersRegistration:
         from vtsearch.media import embedders_for_type
 
         names = {e.name for e in embedders_for_type("audio")}
-        assert names == {"clap", "clap_music"}
+        assert names == {"clap", "clap_music", "clap_general", "ast", "whisper_encoder"}
 
     def test_embedders_for_image(self):
         from vtsearch.media import embedders_for_type
@@ -679,9 +851,10 @@ class TestAllEmbeddersRegistration:
 
         dicts = all_embedders_dict()
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder + 1
-        # vision-only video embedder (videomae).
-        assert len(dicts) == 17
+        # variants for dinov2, dinov3, eupe) + 1 face embedder
+        # + 1 vision-only video embedder (videomae)
+        # + 3 audio embedders (ast, clap_general, whisper_encoder).
+        assert len(dicts) == 20
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d
@@ -700,8 +873,11 @@ class TestEmbedderSentinelDiscovery:
     """
 
     def test_every_builtin_embedder_module_has_sentinel(self):
+        from vtsearch.media.audio import embedder_ast
         from vtsearch.media.audio import embedder_clap
+        from vtsearch.media.audio import embedder_clap_general
         from vtsearch.media.audio import embedder_clap_music
+        from vtsearch.media.audio import embedder_whisper
         from vtsearch.media.image import embedder_siglip
         from vtsearch.media.text import embedder_bge
         from vtsearch.media.text import embedder_e5
@@ -712,8 +888,11 @@ class TestEmbedderSentinelDiscovery:
         from vtsearch.media.embedder import MediaEmbedder
 
         modules = [
+            embedder_ast,
             embedder_clap,
+            embedder_clap_general,
             embedder_clap_music,
+            embedder_whisper,
             embedder_siglip,
             embedder_bge,
             embedder_e5,
@@ -919,6 +1098,24 @@ class TestNewEmbeddersInheritance:
         from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
 
         assert issubclass(VideoVideoMAEEmbedder, MediaEmbedder)
+
+    def test_clap_general_is_media_embedder(self):
+        from vtsearch.media.audio.embedder_clap_general import AudioClapGeneralEmbedder
+        from vtsearch.media.embedder import MediaEmbedder
+
+        assert issubclass(AudioClapGeneralEmbedder, MediaEmbedder)
+
+    def test_ast_is_media_embedder(self):
+        from vtsearch.media.audio.embedder_ast import AudioASTEmbedder
+        from vtsearch.media.embedder import MediaEmbedder
+
+        assert issubclass(AudioASTEmbedder, MediaEmbedder)
+
+    def test_whisper_encoder_is_media_embedder(self):
+        from vtsearch.media.audio.embedder_whisper import AudioWhisperEncoderEmbedder
+        from vtsearch.media.embedder import MediaEmbedder
+
+        assert issubclass(AudioWhisperEncoderEmbedder, MediaEmbedder)
 
     def test_embed_text_enriched_works(self):
         """embed_text_enriched (inherited from base) should work with mocked embed_text."""

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -139,6 +139,11 @@ aliased to via a broken ``AutoModel.from_pretrained`` path (the PE-Core
 HF repo has no ``config.json`` so ``AutoModel`` could never load it).
 """
 CLAP_MUSIC_MODEL_ID = "laion/larger_clap_music_and_speech"
+CLAP_GENERAL_MODEL_ID = "laion/larger_clap_general"
+AST_MODEL_ID = "MIT/ast-finetuned-audioset-10-10-0.4593"
+AST_SAMPLE_RATE = 16000  # AST expects 16 kHz mono
+WHISPER_MODEL_ID = "openai/whisper-base"
+WHISPER_SAMPLE_RATE = 16000  # Whisper expects 16 kHz mono
 BGE_MODEL_ID = "BAAI/bge-base-en-v1.5"
 LANGUAGEBIND_VIDEO_MODEL_ID = "LanguageBind/LanguageBind_Video_V1.5_FT"
 VIDEOMAE_MODEL_ID = "OpenGVLab/VideoMAEv2-Base"

--- a/vtsearch/media/audio/embedder_ast.py
+++ b/vtsearch/media/audio/embedder_ast.py
@@ -1,0 +1,133 @@
+"""Audio embedder — AST (Audio Spectrogram Transformer).
+
+Wraps the AudioSet-finetuned ViT-style spectrogram transformer from MIT
+(``MIT/ast-finetuned-audioset-10-10-0.4593``).  AST is audio-only — there
+is no paired text encoder — so :attr:`supports_text` is ``False`` and the
+UI hides text-search affordances for datasets embedded with this model.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtsearch.config import AST_MODEL_ID, AST_SAMPLE_RATE
+from vtsearch.media.embedder import (
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
+
+
+class AudioASTEmbedder(MediaEmbedder):
+    """Embeds audio files using the Audio Spectrogram Transformer.
+
+    * Audio files → 768-dimensional vectors via AST's pooled hidden state.
+    * No text encoder; :meth:`embed_text` returns ``None``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._model: Any = None
+        self._processor: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "ast"
+
+    @property
+    def display_name(self) -> str:
+        return "AST (audio spectrogram)"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    @property
+    def supports_text(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import ASTFeatureExtractor, ASTModel  # noqa: PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+            import librosa  # noqa: F401, PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading AST model weights…")
+        with intercept_tqdm_progress(self._on_progress):
+            self._model = load_pretrained_local_first(
+                ASTModel.from_pretrained,
+                AST_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=False,
+            )
+        self._model = self._model.to("cpu")
+        self._model.eval()
+        self._on_progress("loading", "Loading AST feature extractor…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            self._processor = load_pretrained_local_first(
+                ASTFeatureExtractor.from_pretrained, AST_MODEL_ID, cache_dir=cache_dir, token=False
+            )
+
+        # Warmup: run a dummy forward pass so the first real embed_media
+        # call runs at steady-state speed.
+        self._on_progress("loading", "Warming up AST pipeline: preprocessing…", 1, 2)
+        dummy_audio = np.zeros(AST_SAMPLE_RATE, dtype=np.float32)
+        inputs = self._processor(dummy_audio, sampling_rate=AST_SAMPLE_RATE, return_tensors="pt")
+        self._on_progress("loading", "Warming up AST pipeline: running model…", 2, 2)
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            self._model(**inputs)
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        file_path = Path(media["media_path"])
+        try:
+            import librosa  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+
+            audio_data, _sr = librosa.load(file_path, sr=AST_SAMPLE_RATE, mono=True)
+            inputs = self._processor(audio_data, sampling_rate=AST_SAMPLE_RATE, return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                outputs = self._model(**inputs)
+                # AST returns ``BaseModelOutputWithPooling``; ``pooler_output``
+                # is the mean of patch tokens (768-dim for the base model).
+                embedding = outputs.pooler_output.detach().cpu().numpy()
+            return embedding[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            return None
+
+
+EMBEDDER = AudioASTEmbedder()

--- a/vtsearch/media/audio/embedder_clap_general.py
+++ b/vtsearch/media/audio/embedder_clap_general.py
@@ -1,0 +1,175 @@
+"""Audio embedder — CLAP General 2024 (laion/larger_clap_general)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtsearch.config import CLAP_GENERAL_MODEL_ID, CLAP_SAMPLE_RATE
+from vtsearch.media.embedder import (
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
+
+
+class AudioClapGeneralEmbedder(MediaEmbedder):
+    """Embeds audio files using the larger CLAP general checkpoint (laion/larger_clap_general).
+
+    * Audio files → 512-dimensional vectors via CLAP's audio encoder.
+    * Text queries → 512-dimensional vectors via CLAP's text encoder.
+
+    Compared to the original ``laion/clap-htsat-unfused`` baseline, this
+    larger general-purpose checkpoint is trained on a broader audio mix
+    and tends to give stronger zero-shot transfer for general sounds.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Typed ``Any``: transformers stubs miss several ``ClapProcessor.__call__``
+        # kwargs we pass at runtime; runtime ``None`` checks guard the calls.
+        self._model: Any = None
+        self._processor: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "clap_general"
+
+    @property
+    def display_name(self) -> str:
+        return "CLAP (general 2024)"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+            import librosa  # noqa: F401, PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP General model weights…")
+        with intercept_tqdm_progress(self._on_progress):
+            self._model = load_pretrained_local_first(
+                ClapModel.from_pretrained,
+                CLAP_GENERAL_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=False,
+            )
+        self._model = self._model.to("cpu")
+        self._on_progress("loading", "Loading CLAP General processor…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            self._processor = load_pretrained_local_first(
+                ClapProcessor.from_pretrained, CLAP_GENERAL_MODEL_ID, cache_dir=cache_dir, token=False
+            )
+
+        # Warmup: run a dummy forward pass
+        self._on_progress("loading", "Warming up CLAP General pipeline: preprocessing…", 1, 2)
+        dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
+        inputs = self._processor(
+            audio=dummy_audio,
+            sampling_rate=CLAP_SAMPLE_RATE,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=480000,
+            truncation=True,
+        )
+        self._on_progress("loading", "Warming up CLAP General pipeline: running model…", 2, 2)
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model.audio_model(**inputs)
+            self._model.audio_projection(outputs.pooler_output)
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "the sound of {text}",
+            "a recording of {text}",
+            "{text}",
+            "audio of {text}",
+            "the noise of {text}",
+        ]
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        file_path = Path(media["media_path"])
+        try:
+            import librosa  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+
+            audio_data, _sr = librosa.load(file_path, sr=CLAP_SAMPLE_RATE, mono=True)
+            inputs = self._processor(
+                audio=audio_data,
+                sampling_rate=CLAP_SAMPLE_RATE,
+                return_tensors="pt",
+                padding="max_length",
+                max_length=480000,
+                truncation=True,
+            )
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                outputs = self._model.audio_model(**inputs)
+                embedding = self._model.audio_projection(outputs.pooler_output).detach().cpu().numpy()
+            return embedding[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            return None
+
+    def embed_text(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            inputs = self._processor(text=[text], return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                outputs = self._model.text_model(**inputs)
+                text_vec = self._model.text_projection(outputs.pooler_output).detach().cpu().numpy()[0]
+            return text_vec
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding text query for audio (CLAP General)")
+            return None
+
+    # Internal helper used by loader.py bridge
+    def _get_model_and_processor(self):
+        if self._model is None:
+            self.load_models()
+        return self._model, self._processor
+
+
+EMBEDDER = AudioClapGeneralEmbedder()

--- a/vtsearch/media/audio/embedder_whisper.py
+++ b/vtsearch/media/audio/embedder_whisper.py
@@ -1,0 +1,144 @@
+"""Audio embedder — Whisper encoder (speech-rich datasets).
+
+Uses the encoder half of OpenAI's Whisper model (``openai/whisper-base``)
+and time-averages the last hidden states into a fixed-size vector.  The
+decoder (text generation) is never invoked — this is purely a speech-
+aware audio embedder, not a transcription pipeline.
+
+There is no paired text encoder in the same vector space, so
+:attr:`supports_text` is ``False`` and the UI hides text-search
+affordances for datasets embedded with this model.  For
+speech-keyword-style search, transcribe upstream and embed the
+transcript with a text embedder instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtsearch.config import WHISPER_MODEL_ID, WHISPER_SAMPLE_RATE
+from vtsearch.media.embedder import (
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
+
+
+class AudioWhisperEncoderEmbedder(MediaEmbedder):
+    """Embeds audio via Whisper's encoder, time-pooled to a single vector.
+
+    * Audio files → 512-dim vector (Whisper-base encoder hidden size).
+    * No text branch; :meth:`embed_text` returns ``None``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._model: Any = None
+        self._processor: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "whisper_encoder"
+
+    @property
+    def display_name(self) -> str:
+        return "Whisper encoder (speech)"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    @property
+    def supports_text(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import WhisperFeatureExtractor, WhisperModel  # noqa: PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+            import librosa  # noqa: F401, PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading Whisper encoder weights…")
+        with intercept_tqdm_progress(self._on_progress):
+            full_model = load_pretrained_local_first(
+                WhisperModel.from_pretrained,
+                WHISPER_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=False,
+            )
+        # Encoder only — drop the decoder so we don't keep ~half the
+        # weights in RSS for no benefit (we never invoke it).
+        full_model = full_model.to("cpu")
+        self._model = full_model.encoder
+        self._model.eval()
+
+        self._on_progress("loading", "Loading Whisper feature extractor…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            self._processor = load_pretrained_local_first(
+                WhisperFeatureExtractor.from_pretrained, WHISPER_MODEL_ID, cache_dir=cache_dir, token=False
+            )
+
+        # Warmup: run a dummy forward pass.
+        self._on_progress("loading", "Warming up Whisper pipeline: preprocessing…", 1, 2)
+        dummy_audio = np.zeros(WHISPER_SAMPLE_RATE, dtype=np.float32)
+        inputs = self._processor(dummy_audio, sampling_rate=WHISPER_SAMPLE_RATE, return_tensors="pt")
+        self._on_progress("loading", "Warming up Whisper pipeline: running encoder…", 2, 2)
+        device = next(self._model.parameters()).device
+        input_features = inputs.input_features.to(device)
+        with torch.no_grad():
+            self._model(input_features)
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        file_path = Path(media["media_path"])
+        try:
+            import librosa  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+
+            audio_data, _sr = librosa.load(file_path, sr=WHISPER_SAMPLE_RATE, mono=True)
+            inputs = self._processor(audio_data, sampling_rate=WHISPER_SAMPLE_RATE, return_tensors="pt")
+            device = next(self._model.parameters()).device
+            input_features = inputs.input_features.to(device)
+            with torch.no_grad():
+                # Whisper feature extractor zero-pads short clips to the
+                # full 30 s receptive field.  Mean-pooling over the time
+                # axis is the standard recipe for turning Whisper-encoder
+                # hidden states into a single utterance-level vector.
+                hidden = self._model(input_features).last_hidden_state
+                pooled = hidden.mean(dim=1).detach().cpu().numpy()
+            return pooled[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            return None
+
+
+EMBEDDER = AudioWhisperEncoderEmbedder()


### PR DESCRIPTION
## Summary

Three new audio embedders, auto-discovered via the `EMBEDDER` sentinel:

- **`ast`** — Audio Spectrogram Transformer (`MIT/ast-finetuned-audioset-10-10-0.4593`, 16 kHz, 768-dim from `pooler_output`). Audio-only, so `supports_text = False`.
- **`clap_general`** — newer LAION CLAP general checkpoint (`laion/larger_clap_general`, 48 kHz, 512-dim). Cross-modal like the existing CLAPs, so text search still works (`supports_text = True`).
- **`whisper_encoder`** — `openai/whisper-base` encoder, time-mean-pooled over the last hidden states (16 kHz, 512-dim). The decoder is dropped on load to save RSS; the decoder's text output is not in a shared embedding space, so `supports_text = False`.

Total registered embedders moves from 16 → 19. `embedders_for_type("audio")` now returns `{clap, clap_music, clap_general, ast, whisper_encoder}` with `clap` still the default (it carries `is_default = True`).

## Test plan

- [x] `./run-tests.sh` — 3816 passed, 1 skipped, 2 xpassed (the new embedders' registration + properties + sentinel-discovery tests are in `tests/detectors/test_new_embedders.py`).
- [x] `ruff check` / `ruff format --check` / `codespell` / `deptry` all pass.
- [x] Quick import smoke: `python -c` round-trip confirms all three sentinels load, register, and report the expected `name` / `media_type_id` / `supports_text` values.
- [ ] **Not exercised here:** real HuggingFace model downloads + forward passes. Tests stub `embed_media` / `load_models` per the conftest pattern, so the first time a user picks one of these embedders the model will download. The transformers classes (`ASTModel`, `ASTFeatureExtractor`, `WhisperModel`, `WhisperFeatureExtractor`, `ClapModel`/`ClapProcessor` for the new general checkpoint) are already available with the existing `transformers` dep.

## Notes

- `CLAP-General-2024` resolves to `laion/larger_clap_general` — LAION's newest general-purpose CLAP on the Hub.
- The Whisper embedder explicitly drops the decoder after `WhisperModel.from_pretrained` so we don't pay RSS for weights we never invoke.
- All three follow the same module/sentinel pattern as the existing `embedder_clap_music.py` — no edits to any `__init__.py` were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjHuPxBLVEautNJ3Vfr4pj)_