### PR TITLE
Add VideoMAE v2 embedder (vision-only, action features)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,6 +78,7 @@ VTSearch/
 │   │   ├── text/clipper.py         TextDefaultClipper, TextSentenceClipper
 │   │   ├── video/media_type.py     Video media type (MP4/WebM serving)
 │   │   ├── video/embedder_languagebind.py  VideoLanguageBindEmbedder (LanguageBind, 768-d)
+│   │   ├── video/embedder_videomae.py  VideoVideoMAEEmbedder (VideoMAE v2, 768-d, vision-only)
 │   │   ├── video/embedder_xclip.py VideoXClipEmbedder (X-CLIP, 768-d, default)
 │   │   ├── video/clipper.py        VideoDefaultClipper, VideoTilingClipper
 │   │   ├── document/media_type.py  Document handling (no embedder; convert first)

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -264,6 +264,7 @@ embedder per media type should override the `is_default` property to return
 | `text/embedder_bge.py` | `TextBGEEmbedder` | text | |
 | `video/embedder_xclip.py` | `VideoXClipEmbedder` | video | ✅ |
 | `video/embedder_languagebind.py` | `VideoLanguageBindEmbedder` | video | |
+| `video/embedder_videomae.py` | `VideoVideoMAEEmbedder` | video | |
 
 ### What to implement
 

--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -126,7 +126,7 @@ A **`clipper_chain`** abstraction so we can run e.g. `document_section → text_
 
 ### 4.4 Video
 - **InternVideo2** ★★ — current SOTA for video-text retrieval.
-- **VideoMAE-v2** ★ — single-modality but very strong action features.
+- ~~**VideoMAE-v2** ★ — single-modality but very strong action features.~~ Shipped (`OpenGVLab/VideoMAEv2-Base`, vision-only, mean-pooled patch features, L2-normalised); registered as the `videomae` embedder on the `video` media type.
 
 ### 4.5 Multimodal-shared
 - **ImageBind / LanguageBind family** ★★★ — *one* embedder that handles audio, image, text, video, depth, IMU. Would let us run cross-modal queries like "audio clips that match this photo" without converter chains. Big architectural win for the cross-modal voting story.

--- a/tests/detectors/test_new_embedders.py
+++ b/tests/detectors/test_new_embedders.py
@@ -405,6 +405,98 @@ class TestVideoLanguageBindEmbedderProperties:
         assert LANGUAGEBIND_VIDEO_MODEL_ID == "LanguageBind/LanguageBind_Video_V1.5_FT"
 
 
+class TestVideoMAEEmbedderProperties:
+    """Verify VideoVideoMAEEmbedder class properties and registration."""
+
+    def test_name(self):
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        assert emb.name == "videomae"
+
+    def test_media_type_id(self):
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        assert emb.media_type_id == "video"
+
+    def test_supports_text_is_false(self):
+        """VideoMAE is vision-only — no text encoder, so text queries are unsupported."""
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        assert emb.supports_text is False
+
+    def test_is_not_default(self):
+        """X-CLIP remains the default video embedder; VideoMAE is opt-in."""
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        assert emb.is_default is False
+
+    def test_registered_in_registry(self):
+        from vtsearch.media import get_embedder
+
+        emb = get_embedder("videomae")
+        assert emb.name == "videomae"
+        assert emb.media_type_id == "video"
+
+    def test_listed_in_embedders_for_type(self):
+        from vtsearch.media import embedders_for_type
+
+        embedders = embedders_for_type("video")
+        names = [e.name for e in embedders]
+        assert "videomae" in names
+
+    def test_to_dict(self):
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        d = emb.to_dict()
+        assert d == {
+            "name": "videomae",
+            "display_name": "VideoMAE v2 (action features)",
+            "media_type_id": "video",
+            "is_default": False,
+            "supports_text": False,
+            "supports_patch_regions": False,
+            "license_notice": None,
+        }
+
+    def test_load_models_idempotent(self):
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        # Simulate already-loaded model
+        emb._model = MagicMock()
+        # Calling load_models again should be a no-op (not re-download)
+        emb.load_models()
+        # Model should be the same mock
+        assert isinstance(emb._model, MagicMock)
+
+    def test_embed_media_returns_none_when_not_loaded(self):
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_media({"media_path": "/nonexistent.mp4"})
+        assert result is None
+
+    def test_embed_text_always_returns_none(self):
+        """VideoMAE has no text tower — embed_text returns None even when loaded."""
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        emb = VideoVideoMAEEmbedder()
+        # Loaded or not, text embedding is unsupported.
+        emb._model = MagicMock()
+        assert emb.embed_text("an action") is None
+
+    def test_uses_correct_model_id(self):
+        from vtsearch.config import VIDEOMAE_MODEL_ID
+
+        assert VIDEOMAE_MODEL_ID == "OpenGVLab/VideoMAEv2-Base"
+
+
 class TestPreprocessFrames:
     """Verify the _preprocess_frames helper produces correct shapes and values."""
 
@@ -440,6 +532,44 @@ class TestPreprocessFrames:
         assert result.shape == (3, 1, 224, 224)
 
 
+class TestVideoMAEPreprocessFrames:
+    """Verify VideoMAE's frame preprocessing produces the expected shape.
+
+    VideoMAE expects ``(T, C, H, W)`` per video — unlike LanguageBind which
+    transposes to ``(C, T, H, W)`` — so the helper differs by one axis order.
+    """
+
+    def test_output_shape(self):
+        from PIL import Image
+
+        from vtsearch.media.video.embedder_videomae import _preprocess_frames
+
+        rng = np.random.default_rng(42)
+        frames = [Image.fromarray(rng.integers(0, 255, (320, 240, 3), dtype=np.uint8)) for _ in range(16)]
+        result = _preprocess_frames(frames)
+        # VideoMAE expects (T, C, H, W).
+        assert result.shape == (16, 3, 224, 224)
+
+    def test_output_dtype(self):
+        from PIL import Image
+
+        from vtsearch.media.video.embedder_videomae import _preprocess_frames
+
+        rng = np.random.default_rng(42)
+        frames = [Image.fromarray(rng.integers(0, 255, (224, 224, 3), dtype=np.uint8)) for _ in range(4)]
+        result = _preprocess_frames(frames)
+        assert result.dtype == np.float32
+
+    def test_single_frame(self):
+        from PIL import Image
+
+        from vtsearch.media.video.embedder_videomae import _preprocess_frames
+
+        frame = Image.fromarray(np.zeros((300, 400, 3), dtype=np.uint8))
+        result = _preprocess_frames([frame])
+        assert result.shape == (1, 3, 224, 224)
+
+
 class TestAllEmbeddersRegistration:
     """Verify all expected embedders are registered."""
 
@@ -448,8 +578,9 @@ class TestAllEmbeddersRegistration:
 
         embedders = all_embedders()
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder.
-        assert len(embedders) == 16
+        # variants for dinov2, dinov3, eupe) + 1 face embedder + 1
+        # vision-only video embedder (videomae).
+        assert len(embedders) == 17
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -469,6 +600,7 @@ class TestAllEmbeddersRegistration:
             "dinov3_patch",
             "eupe_single",
             "eupe_patch",
+            "videomae",
         ):
             assert by_name[name]["supports_text"] is False, name
 
@@ -492,6 +624,7 @@ class TestAllEmbeddersRegistration:
             "bge",
             "xclip",
             "languagebind",
+            "videomae",
             "face",
         }
         assert names == expected
@@ -539,15 +672,16 @@ class TestAllEmbeddersRegistration:
         from vtsearch.media import embedders_for_type
 
         names = {e.name for e in embedders_for_type("video")}
-        assert names == {"xclip", "languagebind"}
+        assert names == {"xclip", "languagebind", "videomae"}
 
     def test_all_embedders_dict(self):
         from vtsearch.media import all_embedders_dict
 
         dicts = all_embedders_dict()
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder.
-        assert len(dicts) == 16
+        # variants for dinov2, dinov3, eupe) + 1 face embedder + 1
+        # vision-only video embedder (videomae).
+        assert len(dicts) == 17
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d
@@ -572,6 +706,7 @@ class TestEmbedderSentinelDiscovery:
         from vtsearch.media.text import embedder_bge
         from vtsearch.media.text import embedder_e5
         from vtsearch.media.video import embedder_languagebind
+        from vtsearch.media.video import embedder_videomae
         from vtsearch.media.video import embedder_xclip
 
         from vtsearch.media.embedder import MediaEmbedder
@@ -583,6 +718,7 @@ class TestEmbedderSentinelDiscovery:
             embedder_bge,
             embedder_e5,
             embedder_languagebind,
+            embedder_videomae,
             embedder_xclip,
         ]
         for mod in modules:
@@ -596,10 +732,12 @@ class TestEmbedderSentinelDiscovery:
         from vtsearch.media.audio.embedder_clap import EMBEDDER as clap_sentinel
         from vtsearch.media.text.embedder_bge import EMBEDDER as bge_sentinel
         from vtsearch.media.video.embedder_languagebind import EMBEDDER as lb_sentinel
+        from vtsearch.media.video.embedder_videomae import EMBEDDER as vm_sentinel
 
         assert get_embedder("clap") is clap_sentinel
         assert get_embedder("bge") is bge_sentinel
         assert get_embedder("languagebind") is lb_sentinel
+        assert get_embedder("videomae") is vm_sentinel
 
     def test_media_type_init_no_longer_lists_embedders(self):
         """Media-type package ``__init__.py`` files should not expose an
@@ -775,6 +913,12 @@ class TestNewEmbeddersInheritance:
         from vtsearch.media.video.embedder_languagebind import VideoLanguageBindEmbedder
 
         assert issubclass(VideoLanguageBindEmbedder, MediaEmbedder)
+
+    def test_videomae_is_media_embedder(self):
+        from vtsearch.media.embedder import MediaEmbedder
+        from vtsearch.media.video.embedder_videomae import VideoVideoMAEEmbedder
+
+        assert issubclass(VideoVideoMAEEmbedder, MediaEmbedder)
 
     def test_embed_text_enriched_works(self):
         """embed_text_enriched (inherited from base) should work with mocked embed_text."""

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -141,3 +141,12 @@ HF repo has no ``config.json`` so ``AutoModel`` could never load it).
 CLAP_MUSIC_MODEL_ID = "laion/larger_clap_music_and_speech"
 BGE_MODEL_ID = "BAAI/bge-base-en-v1.5"
 LANGUAGEBIND_VIDEO_MODEL_ID = "LanguageBind/LanguageBind_Video_V1.5_FT"
+VIDEOMAE_MODEL_ID = "OpenGVLab/VideoMAEv2-Base"
+"""Hugging Face repo for VideoMAE v2 Base weights.
+
+Loaded via ``AutoModel.from_pretrained(..., trust_remote_code=True)``.
+Vision-only encoder — there is no paired text tower, so the embedder
+sets ``supports_text=False`` and :meth:`embed_text` returns ``None``.
+The masked-autoencoder objective produces unusually strong action /
+motion features compared to image-only encoders applied per frame.
+"""

--- a/vtsearch/media/video/embedder_videomae.py
+++ b/vtsearch/media/video/embedder_videomae.py
@@ -1,0 +1,236 @@
+"""Video embedder — VideoMAE v2 (OpenGVLab/VideoMAEv2-Base).
+
+VideoMAE v2 is a vision-only video encoder pretrained with a masked
+autoencoder objective on a large action-recognition corpus. Compared
+to X-CLIP / LanguageBind (which optimise for video-text alignment) it
+produces noticeably stronger motion / action features at the cost of a
+text tower — there is no paired text encoder, so :meth:`embed_text`
+returns ``None`` and :attr:`supports_text` is ``False``. Use it when
+the dataset is mostly about *what is happening* rather than *what the
+caption says*; pair with image-/text-based detectors for hybrid flows.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtsearch.config import VIDEOMAE_MODEL_ID
+from vtsearch.media.embedder import (
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    intercept_weight_loading_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
+
+# ImageNet normalisation — VideoMAE's standard preprocessing pipeline.
+_IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+# VideoMAE v2 Base operates on 16 frames at 224x224.  Tubelet size 2 means
+# 8 temporal patches; spatial patch size 16 means 14x14 spatial patches.
+_NUM_FRAMES = 16
+_IMAGE_SIZE = 224
+
+
+def _preprocess_frames(frames: list) -> np.ndarray:
+    """Resize, center-crop, and normalise PIL Images for VideoMAE v2.
+
+    Returns a ``(T, C, H, W)`` ``float32`` array — the caller wraps it
+    in a batch dimension to produce VideoMAE's expected
+    ``(B, T, C, H, W)`` input.
+    """
+    processed = []
+    for img in frames:
+        w, h = img.size
+        # Scale shortest side to _IMAGE_SIZE.
+        if w < h:
+            new_w = _IMAGE_SIZE
+            new_h = int(h * _IMAGE_SIZE / w)
+        else:
+            new_h = _IMAGE_SIZE
+            new_w = int(w * _IMAGE_SIZE / h)
+        img = img.resize((new_w, new_h))
+        # Center crop to _IMAGE_SIZE x _IMAGE_SIZE.
+        left = (new_w - _IMAGE_SIZE) // 2
+        top = (new_h - _IMAGE_SIZE) // 2
+        img = img.crop((left, top, left + _IMAGE_SIZE, top + _IMAGE_SIZE))
+        arr = np.asarray(img, dtype=np.float32) / 255.0
+        arr = (arr - _IMAGENET_MEAN) / _IMAGENET_STD
+        processed.append(arr.transpose(2, 0, 1))  # (C, H, W)
+    return np.stack(processed, axis=0)  # (T, C, H, W)
+
+
+def _pool_features(outputs: Any) -> Any:
+    """Reduce a VideoMAE forward-pass output to a single ``(B, D)`` tensor.
+
+    Different VideoMAE checkpoints expose features under different
+    attribute names — the original transformers ``VideoMAEModel`` exposes
+    ``last_hidden_state``, while OpenGVLab's custom remote-code variant
+    sometimes returns a raw tensor or a ``pooler_output``. We probe the
+    common shapes and mean-pool patch tokens when needed.
+    """
+    import torch  # noqa: PLC0415
+
+    if isinstance(outputs, torch.Tensor):
+        return outputs if outputs.ndim == 2 else outputs.mean(dim=1)
+    pooled = getattr(outputs, "pooler_output", None)
+    if isinstance(pooled, torch.Tensor):
+        return pooled
+    hidden = getattr(outputs, "last_hidden_state", None)
+    if isinstance(hidden, torch.Tensor):
+        # (B, T*H*W, D) — no CLS token in VideoMAE, so mean-pool every patch.
+        return hidden.mean(dim=1)
+    # Fallback: assume tuple-like with the feature tensor first.
+    first = outputs[0]
+    return first if first.ndim == 2 else first.mean(dim=1)
+
+
+class VideoVideoMAEEmbedder(MediaEmbedder):
+    """Embeds videos using VideoMAE v2 (OpenGVLab/VideoMAEv2-Base).
+
+    * Videos -> 768-dimensional vectors via VideoMAE's video encoder
+      (16 sampled frames, mean-pooled over patch tokens, L2-normalised).
+    * Text queries are **not** supported — VideoMAE has no text tower,
+      so :meth:`embed_text` returns ``None`` and the frontend hides
+      text-search UI for datasets embedded with this model.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._model: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "videomae"
+
+    @property
+    def display_name(self) -> str:
+        return "VideoMAE v2 (action features)"
+
+    @property
+    def media_type_id(self) -> str:
+        return "video"
+
+    @property
+    def is_default(self) -> bool:
+        return False
+
+    @property
+    def supports_text(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(self._on_progress, "loading", "Importing torch...", 1, 2):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing transformers...", 2, 2):
+            from transformers import AutoModel  # noqa: PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading VideoMAE v2 model weights...")
+        with (
+            intercept_tqdm_progress(self._on_progress),
+            intercept_weight_loading_progress(self._on_progress, "Loading VideoMAE v2 model weights..."),
+        ):
+            self._model = load_pretrained_local_first(
+                AutoModel.from_pretrained,
+                VIDEOMAE_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=False,
+                trust_remote_code=True,
+            )
+        self._model = self._model.to("cpu")
+        self._model.eval()
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None:
+            return None
+        file_path = Path(media["media_path"])
+        try:
+            import cv2  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+            from PIL import Image  # noqa: PLC0415
+
+            cap = cv2.VideoCapture(str(file_path))
+            if not cap.isOpened():
+                logging.getLogger(__name__).error("Error opening video %s", file_path)
+                return None
+
+            try:
+                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                if frame_count <= 0:
+                    logging.getLogger(__name__).error("Could not determine frame count for %s", file_path)
+                    return None
+                num_frames = min(_NUM_FRAMES, max(1, frame_count))
+                indices = np.linspace(0, frame_count - 1, num_frames, dtype=int)
+
+                frames = []
+                for idx in indices:
+                    cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+                    ret, frame = cap.read()
+                    if ret:
+                        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                        frames.append(Image.fromarray(frame))
+            finally:
+                cap.release()
+
+            if not frames:
+                logging.getLogger(__name__).error("Could not extract frames from %s", file_path)
+                return None
+
+            # VideoMAE v2 expects exactly 16 frames; pad by repeating if fewer.
+            while len(frames) < _NUM_FRAMES:
+                frames.append(frames[-1])
+
+            # (T, C, H, W) -> (1, T, C, H, W)
+            pixel_values = _preprocess_frames(frames)
+            pixel_values = torch.tensor(pixel_values, dtype=torch.float32).unsqueeze(0)
+
+            device = next(self._model.parameters()).device
+            pixel_values = pixel_values.to(device)
+            with torch.no_grad():
+                outputs = self._model(pixel_values)
+                pooled = _pool_features(outputs)
+                # L2-normalise so cosine similarity behaves consistently
+                # with the other video embedders (xclip, languagebind).
+                pooled = pooled / pooled.norm(p=2, dim=-1, keepdim=True).clamp_min(1e-8)
+                embedding = pooled.detach().cpu().numpy()
+            return embedding[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            return None
+
+    def embed_text(self, text: str) -> Optional[np.ndarray]:
+        """VideoMAE is vision-only — text queries are unsupported.
+
+        Returns ``None`` so :func:`vtsearch.routes.media.embed.embed_text`
+        and other callers can surface the "this embedder doesn't support
+        text" path without a brittle attribute check.
+        """
+        return None
+
+
+EMBEDDER = VideoVideoMAEEmbedder()


### PR DESCRIPTION
## Summary

Adds **VideoMAE v2** (`OpenGVLab/VideoMAEv2-Base`) as a third video embedder
alongside X-CLIP (default, cross-modal) and LanguageBind (cross-modal, high
quality). VideoMAE v2 is a masked-autoencoder vision encoder pretrained on
action-recognition data; it produces noticeably stronger motion / action
features than the cross-modal alternatives at the cost of a text tower.

- `vtsearch/media/video/embedder_videomae.py` — `VideoVideoMAEEmbedder`
  registered via the `EMBEDDER` sentinel. Samples 16 frames, normalises with
  ImageNet stats, mean-pools the patch-token output of VideoMAEv2-Base, and
  L2-normalises so cosine similarity is consistent with the rest of the
  video stack.
- `supports_text = False` — VideoMAE has no text encoder. `embed_text()`
  returns `None` so the frontend hides text-search UI for datasets embedded
  with this model (same path as DINOv2/v3/EUPE for images).
- `is_default = False` — X-CLIP remains the default video embedder; users
  opt in to VideoMAE through the embedder picker on the new-dataset / new-
  detector flows.
- `VIDEOMAE_MODEL_ID = "OpenGVLab/VideoMAEv2-Base"` added to
  `vtsearch/config.py`; loaded via `AutoModel.from_pretrained(...,
  trust_remote_code=True)` (same pattern as LanguageBind).
- Tests: extends `tests/detectors/test_new_embedders.py` with a full
  `TestVideoMAEEmbedderProperties` suite, a preprocess-frames shape test,
  sentinel-discovery coverage, and bumps the global registration counts.
- Docs: updates `docs/ARCHITECTURE.md`, `docs/EXTENDING-media.md`, and
  strikes §4.4 in `docs/plans/brainstorm.md` to record that the item shipped.

## Test plan

- [x] `./run-tests.sh` — 3808 passed, 1 skipped
- [x] `./run-tests.sh detectors -- tests/detectors/test_new_embedders.py` —
  973 passed
- [x] Smoke check: `get_embedder("videomae")` resolves to the registered
  embedder, `embedders_for_type("video")` lists `["xclip", "languagebind",
  "videomae"]`, total embedder count = 17
- [ ] Manual: load a UCF-101 dataset with the `videomae` embedder selected,
  verify text-search UI is hidden and video voting / autodetect work
  end-to-end (not done in this PR — requires GPU + real model download)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DUnUrtTRTAKBaSUhNbfefs)_