### PR TITLE
new-detector modal: mirror text seed into the name field

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -19,7 +19,8 @@
         <input
           id="detector-name"
           class="form-input"
-          [(ngModel)]="name"
+          [ngModel]="name"
+          (ngModelChange)="onNameInput($event)"
           name="name"
           placeholder="e.g. Dog Barks"
           title="A short name to identify this detector"
@@ -100,7 +101,8 @@
               <div class="text-input-row">
                 <input
                   class="form-input"
-                  [(ngModel)]="pendingText"
+                  [ngModel]="pendingText"
+                  (ngModelChange)="onPendingTextInput($event)"
                   name="pendingText"
                   placeholder="e.g. dog barking sounds"
                   title="A text description of what this detector should find"

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -152,6 +152,31 @@ describe('NewDetectorModalComponent', () => {
     component.unlockMediaType();
     expect(component.mediaTypeLocked).toBeFalse();
   });
+
+  it('pre-fills the name from the text seed while the name is untouched', () => {
+    component.onPendingTextInput('dog barking sounds');
+    expect(component.pendingText).toBe('dog barking sounds');
+    expect(component.name).toBe('dog barking sounds');
+  });
+
+  it('sanitises pasted whitespace when mirroring the seed into the name', () => {
+    component.onPendingTextInput('   dog   barking\n  sounds   ');
+    expect(component.pendingText).toBe('   dog   barking\n  sounds   ');
+    expect(component.name).toBe('dog barking sounds');
+  });
+
+  it('stops mirroring once the user edits the name', () => {
+    component.onPendingTextInput('dog');
+    expect(component.name).toBe('dog');
+
+    component.onNameInput('Dog Barks');
+    expect(component.name).toBe('Dog Barks');
+    expect(component.nameTouched).toBeTrue();
+
+    component.onPendingTextInput('cat meowing');
+    expect(component.pendingText).toBe('cat meowing');
+    expect(component.name).toBe('Dog Barks');
+  });
 });
 
 describe('NewDetectorModalComponent with defaultMediaType', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -59,6 +59,10 @@ export class NewDetectorModalComponent implements OnInit {
   view: ModalView = 'main';
   tab: ModalTab = 'blank';
   name = '';
+  /** True once the user has typed into the name field. While false, the
+   *  name auto-tracks ``pendingText`` (sanitised) so users don't have to
+   *  type the same string twice. */
+  nameTouched = false;
   mediaType = 'audio';
   pendingText = '';
   mediaTypes: string[] = [];
@@ -272,6 +276,24 @@ export class NewDetectorModalComponent implements OnInit {
 
   unlockMediaType(): void {
     this.mediaTypeLocked = false;
+  }
+
+  /** Trim and collapse internal whitespace so a pasted multi-line query
+   *  becomes a single-line name. */
+  private sanitizeName(text: string): string {
+    return text.trim().replace(/\s+/g, ' ');
+  }
+
+  onPendingTextInput(value: string): void {
+    this.pendingText = value;
+    if (!this.nameTouched) {
+      this.name = this.sanitizeName(value);
+    }
+  }
+
+  onNameInput(value: string): void {
+    this.nameTouched = true;
+    this.name = value;
   }
 
   toggleMediaTypeDropdown(): void {


### PR DESCRIPTION
## Summary
- Auto-fill the detector name from the text seed (`pendingText`) as the user types, sanitised by trimming and collapsing internal whitespace, so users no longer have to type the same string twice.
- Mirror stops the moment the user edits the name field; programmatic resets (media-picker selection, crop confirm, `clearExample`) bypass the handler and don't clobber the user's name.

## Test plan
- [x] `./run-tests.sh core` (includes the frontend production build — no new warnings)
- [x] `./run-tests.sh` full suite (3662 passed)
- [x] New unit tests cover: mirror-while-untouched, whitespace sanitisation, and stop-after-user-edit

Resolves task 11.10 (Detector name from query/seed).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Mh5VWXKgLKzXuTRYu6YCQ)_