### PR TITLE
Show phase intent on hover over Autopilot dots/labels

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -425,8 +425,10 @@ Was: dashboard loading rows showed cryptic step numbers like "[Step 3/4] Loading
 ### 12.7 Inclusion slider tick labels ★★ XS
 The slider is `[-10, +10]` with no anchors. Add tick labels: `-10 strict` / `0 default` / `+10 lenient`, plus a one-line caption "Trades off precision (left) vs recall (right)."
 
-### 12.8 Autopilot phase intent ★★ S
+### 12.8 Autopilot phase intent ★★ S — shipped
 The collapsed Autopilot bar shows four dots. Hovering should reveal phase intent: *"Phase 3: Boundary refinement — votes on uncertain items train the model fastest."* Already exists in long-form docs, but not in UI.
+
+**What shipped:** `AutopilotPanelComponent` now computes a `phaseIntent(phase, stepNumber)` string of the form *"Phase N: <short name> — <why this phase matters>"* for each of the four phases (plus a "done" variant), and binds it as the `title` tooltip on every collapsed-mode dot and every expanded-view step label. The active dot/label tooltip leads with the same intent and appends *"Click to reselect recommendation."* so the existing affordance is preserved. Spec coverage added for both the collapsed dots and the expanded labels.
 
 ### 12.9 Keyboard shortcut discoverability ★★ XS
 The keyboard help modal exists but is only reachable via a button most users never click. Show shortcuts inline as tooltips on the Good/Bad buttons (`Good (→)`, `Bad (←)`), and surface "press `?` for keyboard help" as a one-time toast after the third labeling session.

--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -439,10 +439,12 @@ Region voting requires holding `Shift`. When a patch-region embedder is detected
 ### 12.11 Cross-dataset scoring warning ★★ S
 When the user selects Dataset B + Detector trained on Dataset A and clicks Find/Train, today nothing flags this. Show a non-blocking note: *"This detector was trained on a different dataset (Dataset A). Scoring will still work but may be less accurate."*
 
-### 12.12 What "smart"/"stable" mean ★★ XS *(shipped)*
+### 12.12 What "smart"/"stable" mean ★★ XS — shipped
 The labeling status bar shows colored dots for `smart` and `stable`. Add a hover tooltip explaining each ("Smart: the model fits your votes consistently. Stable: predictions stopped shifting between retrains.").
 
-**Shipped:** `ProgressIndicatorsComponent` now exposes `smartTooltip`, `stableTooltip`, and `spanTooltip` getters that lead with the plain-English meaning, append live subtext (cost / flips / level) when present, and end with the green/yellow/red legend. Wired into the `[title]` attribute on each `.labeling-indicator` button.
+**What shipped:** plain-English `title` tooltips on every Smart/Stable/Diverse indicator the user sees:
+- *Labeling status bar.* `ProgressIndicatorsComponent` exposes `smartTooltip`, `stableTooltip`, and `spanTooltip` getters that lead with the plain-English meaning, append live subtext (cost / flips / level) when present, and end with the green/yellow/red legend. Wired into the `[title]` attribute on each `.labeling-indicator` button.
+- *Autopilot mini-icons.* The matching mini-icons (`.ap-status-icon`) shown next to the active step's detail during the boundary/diversity phases previously bound `title` to the bare ariaLabel (`Smart: green`). The `StatusIcon` shape now carries a richer `title` field populated by `phaseStatusIcons()` with the same explanatory text style, and the template binds it. Spec coverage extended to assert the explanation is present.
 
 ---
 

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -9,7 +9,7 @@
           [class.active]="step.state === 'active'"
           [class.future]="step.state === 'future'"
           [class.clickable]="step.state === 'active'"
-          [title]="step.state === 'active' ? 'Click to reselect recommendation' : step.label"
+          [title]="step.state === 'active' ? step.intent + ' Click to reselect recommendation.' : step.intent"
           (click)="step.state === 'active' && refocus.emit()"
         >
           @if (step.state === 'active') {
@@ -45,7 +45,7 @@
               }
             </div>
             <div class="ap-step-content">
-              <span class="ap-step-label" [title]="step.state === 'active' ? 'Click to reselect recommendation' : step.helpText">
+              <span class="ap-step-label" [title]="step.state === 'active' ? step.intent + ' Click to reselect recommendation.' : step.intent">
                 {{ step.label }}
               </span>
               @if (step.detail || step.statusIcons.length) {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -56,7 +56,7 @@
                       class="ap-status-icon"
                       [attr.data-color]="icon.color"
                       [attr.aria-label]="icon.ariaLabel"
-                      [title]="icon.ariaLabel"
+                      [title]="icon.title"
                       role="img"
                     ></span>
                   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -172,6 +172,11 @@ describe('AutopilotPanelComponent', () => {
     expect(newStep!.statusIcons.length).toBe(2);
     expect(newStep!.statusIcons[0].color).toBe('green');
     expect(newStep!.statusIcons[1].color).toBe('green');
+    // Tooltips explain each indicator, not just its raw colour
+    expect(newStep!.statusIcons[0].title).toContain('Smart');
+    expect(newStep!.statusIcons[0].title).toContain('detector accuracy');
+    expect(newStep!.statusIcons[1].title).toContain('Stable');
+    expect(newStep!.statusIcons[1].title).toContain('prediction stability');
   });
 
   it('should deactivate autopilot', () => {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -227,9 +227,28 @@ describe('AutopilotPanelComponent', () => {
   it('should show tooltip on each step label via title attribute', () => {
     const stepLabels = fixture.nativeElement.querySelectorAll('.ap-step-label');
     expect(stepLabels.length).toBe(5);
-    // Active step shows reselect hint; future steps show help text
+    // Active step (phase 1) leads with phase intent and ends with reselect hint
+    expect(stepLabels[0].title).toContain('Phase 1');
+    expect(stepLabels[0].title).toContain('Find initial goods');
     expect(stepLabels[0].title).toContain('reselect');
-    expect(stepLabels[1].title).toContain('not what you want');
+    // Future steps show phase intent only
+    expect(stepLabels[1].title).toContain('Phase 2');
+    expect(stepLabels[1].title).toContain('Find initial bads');
+    expect(stepLabels[2].title).toContain('Boundary refinement');
+    expect(stepLabels[3].title).toContain('Diversity exploration');
+  });
+
+  it('should show phase intent tooltip on each collapsed-step dot', () => {
+    fixture.componentRef.setInput('collapsed', true);
+    fixture.detectChanges();
+    const dots = fixture.nativeElement.querySelectorAll('.collapsed-step');
+    expect(dots.length).toBe(5);
+    expect(dots[0].title).toContain('Phase 1');
+    expect(dots[0].title).toContain('Find initial goods');
+    expect(dots[0].title).toContain('reselect');
+    expect(dots[2].title).toContain('Phase 3');
+    expect(dots[2].title).toContain('Boundary refinement');
+    expect(dots[2].title).toContain('uncertain items');
   });
 
   it('should emit refocus when clicking the active step', () => {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -24,6 +24,7 @@ export interface StepDisplay {
   detail: string;
   statusIcons: StatusIcon[];
   helpText: string;
+  intent: string;
 }
 
 @Component({
@@ -86,6 +87,7 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
         detail: stateStr === 'active' ? this.phaseDetail(phase) : '',
         statusIcons: stateStr === 'active' ? this.phaseStatusIcons(phase) : [],
         helpText: this.phaseHelpText(phase),
+        intent: this.phaseIntent(phase, i + 1),
       };
     });
   }
@@ -174,6 +176,29 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       case 'new': return 'Explore diverse items the system is less certain about, ensuring nothing important is missed.';
       case 'done': return 'All quality indicators are green. You can continue labeling or export your results.';
       default: return '';
+    }
+  }
+
+  /**
+   * Headline phase intent shown as a hover tooltip on the collapsed dots
+   * (where the only visible affordance is a number/letter) and as a richer
+   * tooltip on the expanded step label. Format: "Phase N: Short name —
+   * what the user is doing and why."
+   */
+  private phaseIntent(phase: AutopilotPhase, stepNumber: number): string {
+    switch (phase) {
+      case 'good':
+        return `Phase ${stepNumber}: Find initial goods — label a few positives so the detector knows what "good" looks like.`;
+      case 'bad':
+        return `Phase ${stepNumber}: Find initial bads — label a few negatives so the detector has both sides of the boundary.`;
+      case 'hard':
+        return `Phase ${stepNumber}: Boundary refinement — votes on uncertain items train the model fastest.`;
+      case 'new':
+        return `Phase ${stepNumber}: Diversity exploration — items from unseen parts of the dataset catch edge cases the boundary phase missed.`;
+      case 'done':
+        return 'Done — all quality indicators are green. Keep labeling for more accuracy, or export your results.';
+      default:
+        return '';
     }
   }
 

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -13,6 +13,7 @@ export type { AutopilotPhase, AutopilotState };
 interface StatusIcon {
   color: 'green' | 'yellow';
   ariaLabel: string;
+  title: string;
 }
 
 export interface StepDisplay {
@@ -162,9 +163,19 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   private phaseStatusIcons(phase: AutopilotPhase): StatusIcon[] {
     if (phase !== 'hard' && phase !== 'new') return [];
     const st = this.state;
+    const smartState = st.smartStatus === 'green' ? 'green' : 'pending';
+    const stableState = st.stableStatus === 'green' ? 'green' : 'pending';
     return [
-      { color: st.smartStatus === 'green' ? 'green' : 'yellow', ariaLabel: `Smart: ${st.smartStatus === 'green' ? 'green' : 'pending'}` },
-      { color: st.stableStatus === 'green' ? 'green' : 'yellow', ariaLabel: `Stable: ${st.stableStatus === 'green' ? 'green' : 'pending'}` },
+      {
+        color: st.smartStatus === 'green' ? 'green' : 'yellow',
+        ariaLabel: `Smart: ${smartState}`,
+        title: `Smart: ${smartState}. Tracks detector accuracy over labeling steps. Green when error cost has leveled off (detector has converged). Yellow when still improving.`,
+      },
+      {
+        color: st.stableStatus === 'green' ? 'green' : 'yellow',
+        ariaLabel: `Stable: ${stableState}`,
+        title: `Stable: ${stableState}. Tracks prediction stability. Green when predictions stop changing between labeling steps (detector is confident). Yellow when predictions are still shifting.`,
+      },
     ];
   }
 


### PR DESCRIPTION
## Summary

Surfaces the long-form Autopilot phase intent — currently only in `USER_GUIDE.md` — as a hover tooltip on the four phase dots in the collapsed Autopilot bar (and on the step labels in the expanded view).

Implements brainstorm §12.8.

## What changed

- `AutopilotPanelComponent` gains a `phaseIntent(phase, stepNumber)` method that returns strings of the form *"Phase N: &lt;short name&gt; — &lt;why this phase matters&gt;"*:
  - Phase 1: Find initial goods — label a few positives so the detector knows what "good" looks like.
  - Phase 2: Find initial bads — label a few negatives so the detector has both sides of the boundary.
  - Phase 3: Boundary refinement — votes on uncertain items train the model fastest.
  - Phase 4: Diversity exploration — items from unseen parts of the dataset catch edge cases the boundary phase missed.
  - Done — all quality indicators are green. Keep labeling for more accuracy, or export your results.
- `StepDisplay` gets a new `intent: string` field, populated for every phase.
- Template: collapsed-dot `[title]` and expanded `.ap-step-label` `[title]` now bind to `step.intent`. The active dot/label still ends with *"Click to reselect recommendation."* so the existing click affordance is preserved.
- Spec coverage added for both collapsed-dot and expanded-label tooltips; existing `should show tooltip on each step label` assertion updated to match the richer text.
- `docs/plans/brainstorm.md` §12.8 marked shipped with a "What shipped" note.

## Test plan

- [x] `npm run build:prod` — clean, no warnings.
- [x] `tsc --noEmit -p tsconfig.spec.json` — passes.
- [ ] Manual: hover each of the four dots in the collapsed bar and verify the tooltip reads e.g. "Phase 3: Boundary refinement — …" The active dot's tooltip should end with "Click to reselect recommendation."

https://claude.ai/code/session_0163KG4PvKdXrLacrNHgSMbm

---
_Generated by [Claude Code](https://claude.ai/code/session_0163KG4PvKdXrLacrNHgSMbm)_