### PR TITLE
Plain-English tooltips for Smart/Stable/Diverse indicators (brainstorm 12.12)

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -431,8 +431,10 @@ Region voting requires holding `Shift`. When a patch-region embedder is detected
 ### 12.11 Cross-dataset scoring warning ★★ S
 When the user selects Dataset B + Detector trained on Dataset A and clicks Find/Train, today nothing flags this. Show a non-blocking note: *"This detector was trained on a different dataset (Dataset A). Scoring will still work but may be less accurate."*
 
-### 12.12 What "smart"/"stable" mean ★★ XS
+### 12.12 What "smart"/"stable" mean ★★ XS *(shipped)*
 The labeling status bar shows colored dots for `smart` and `stable`. Add a hover tooltip explaining each ("Smart: the model fits your votes consistently. Stable: predictions stopped shifting between retrains.").
+
+**Shipped:** `ProgressIndicatorsComponent` now exposes `smartTooltip`, `stableTooltip`, and `spanTooltip` getters that lead with the plain-English meaning, append live subtext (cost / flips / level) when present, and end with the green/yellow/red legend. Wired into the `[title]` attribute on each `.labeling-indicator` button.
 
 ---
 

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -16,7 +16,7 @@
       [attr.data-status]="smartStatus"
       (click)="onClick('smart')"
       aria-label="Smart indicator"
-      [title]="smartSubtext ? 'Smart: ' + smartSubtext + '. Tracks detector accuracy over labeling steps.' : 'Tracks detector accuracy over labeling steps. Green when error cost has leveled off (detector has converged). Yellow when still improving. Red when more votes are needed.'"
+      [title]="smartTooltip"
     >
       <span class="indicator-dot"></span>
       <span class="indicator-label">Smart</span>
@@ -27,7 +27,7 @@
       [attr.data-status]="stableStatus"
       (click)="onClick('stable')"
       aria-label="Stable indicator"
-      [title]="stableSubtext ? 'Stable: ' + stableSubtext + '. Tracks prediction stability.' : 'Tracks prediction stability. Green when predictions stop changing between labeling steps (detector is confident). Yellow when predictions are still shifting. Red when more votes are needed.'"
+      [title]="stableTooltip"
     >
       <span class="indicator-dot"></span>
       <span class="indicator-label">Stable</span>
@@ -38,7 +38,7 @@
       [attr.data-status]="spanStatus"
       (click)="onClick('span')"
       aria-label="Diverse indicator"
-      [title]="spanSubtext ? 'Diverse: ' + spanSubtext + '. Tracks dataset exploration coverage.' : 'Tracks how much of the dataset you have explored. Green when you have sampled from all major clusters. Yellow when some regions remain unexplored. Red when coverage data is unavailable.'"
+      [title]="spanTooltip"
     >
       <span class="indicator-dot"></span>
       <span class="indicator-label">Diverse</span>

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -115,6 +115,51 @@ describe('ProgressIndicatorsComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.labeling-indicator').length).toBe(3);
   });
 
+  it('should expose smart tooltip explaining the meaning', () => {
+    expect(component.smartTooltip).toContain('Smart: the model fits your votes consistently.');
+  });
+
+  it('should expose stable tooltip explaining the meaning', () => {
+    expect(component.stableTooltip).toContain('Stable: predictions stopped shifting between retrains.');
+  });
+
+  it('should expose diverse tooltip explaining the meaning', () => {
+    expect(component.spanTooltip).toContain('Diverse: your votes cover the dataset broadly.');
+  });
+
+  it('should include live subtext in smart tooltip when available', () => {
+    component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
+      smart: { status: 'yellow', cost: 0.456 },
+      stable: { status: '' },
+      span: { status: '' },
+    };
+    expect(component.smartTooltip).toContain('Cost: 0.456');
+    expect(component.smartTooltip).toContain('Smart: the model fits your votes consistently.');
+  });
+
+  it('should include live subtext in stable tooltip when available', () => {
+    component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
+      smart: { status: '' },
+      stable: { status: 'yellow', flips: 7 },
+      span: { status: '' },
+    };
+    expect(component.stableTooltip).toContain('Flips: 7');
+    expect(component.stableTooltip).toContain('Stable: predictions stopped shifting between retrains.');
+  });
+
+  it('should render tooltip text on the indicator buttons', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('.labeling-indicator');
+    expect(buttons[0].getAttribute('title')).toContain('Smart: the model fits your votes consistently.');
+    expect(buttons[1].getAttribute('title')).toContain('Stable: predictions stopped shifting between retrains.');
+    expect(buttons[2].getAttribute('title')).toContain('Diverse: your votes cover the dataset broadly.');
+  });
+
   it('should set data-status attribute on indicators', () => {
     component.labelingStatus = {
       good_count: 0,

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -58,6 +58,24 @@ export class ProgressIndicatorsComponent {
     return '';
   }
 
+  get smartTooltip(): string {
+    const meaning = 'Smart: the model fits your votes consistently.';
+    const legend = 'Green when error cost has leveled off, yellow when still improving, red when more votes are needed.';
+    return this.smartSubtext ? `${meaning} ${this.smartSubtext}. ${legend}` : `${meaning} ${legend}`;
+  }
+
+  get stableTooltip(): string {
+    const meaning = 'Stable: predictions stopped shifting between retrains.';
+    const legend = 'Green when predictions have settled, yellow when still shifting, red when more votes are needed.';
+    return this.stableSubtext ? `${meaning} ${this.stableSubtext}. ${legend}` : `${meaning} ${legend}`;
+  }
+
+  get spanTooltip(): string {
+    const meaning = 'Diverse: your votes cover the dataset broadly.';
+    const legend = 'Green when you have sampled from all major clusters, yellow when some regions remain unexplored, red when coverage data is unavailable.';
+    return this.spanSubtext ? `${meaning} Level ${this.spanSubtext}. ${legend}` : `${meaning} ${legend}`;
+  }
+
   onClick(name: string): void {
     this.indicatorClick.emit(name);
   }


### PR DESCRIPTION
## Summary

Implements brainstorm task 12.12 — give the labeling status bar's three colored dots tooltips that lead with what each metric *means*, not just how the colors decode.

- `ProgressIndicatorsComponent` now exposes `smartTooltip`, `stableTooltip`, and `spanTooltip` getters. Each leads with the plain-English meaning ("Smart: the model fits your votes consistently.", "Stable: predictions stopped shifting between retrains.", "Diverse: your votes cover the dataset broadly."), appends the live subtext (cost / flips / level) when available, and ends with the green/yellow/red legend.
- Template `[title]` bindings now use those getters, so the long inline strings are gone.
- Specs cover the new tooltips, including subtext interpolation and the rendered `title` attribute.
- Marked 12.12 as shipped in `docs/plans/brainstorm.md` with a short "Shipped" note.

## Test plan

- [x] `./run-tests.sh core` — 507 passed (includes ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot check, frontend TypeScript build, frontend audit, and the core pytest group)
- [ ] Manual smoke: hover the Smart, Stable, and Diverse dots in the left panel and confirm the new tooltip wording shows up


---
_Generated by [Claude Code](https://claude.ai/code/session_01XboQohxdz3oeDFFt5usdXV)_