### PR TITLE
Add inline format hints to importer path/URL fields

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -299,6 +299,10 @@
                 (change)="onFormFieldChanged(field.key)"
               />
             }
+
+            @if (field.hint) {
+              <p class="form-hint">{{ field.hint }}</p>
+            }
           </div>
         }
       } @else {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -144,6 +144,10 @@
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
               />
             }
+
+            @if (field.hint) {
+              <p class="form-hint">{{ field.hint }}</p>
+            }
           </div>
         }
       } @else {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -145,6 +145,12 @@ export interface ImporterField {
   default?: string;
   required?: boolean;
   placeholder?: string;
+  /** Inline format-hint text rendered as a visible chip below the input.
+   *  Distinct from ``description`` (which feeds the placeholder): the hint
+   *  stays visible after the user starts typing, so it's the right place
+   *  for accepted file extensions, expected schemas, or a short sample of
+   *  the file layout. */
+  hint?: string;
   /** When true, ``options`` is computed at runtime by calling
    *  ``POST /api/dataset/import/<importer>/options`` with the current
    *  field values.  The frontend re-fetches whenever any field listed in

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -204,6 +204,19 @@
   gap: var(--space-xs);
 }
 
+// Inline format-hint chip rendered below an importer form field when the
+// PluginField declares a `hint` (separate from `description`, which feeds
+// the placeholder).  Stays visible after the user starts typing — used for
+// accepted extensions, expected column schemas, JSON/CSV sample snippets.
+.form-hint {
+  margin: 2px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text-muted, #666);
+  white-space: pre-wrap;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+}
+
 .required {
   color: var(--color-bad);
 }

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -230,10 +230,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 "Symlinks are followed; directory entries are scanned recursively "
                 "for media files."
             ),
-            hint=(
-                "Accepts .txt, .list, or .npz. One path per line, or a NumPy "
-                "archive of pre-computed vectors."
-            ),
+            hint=("Accepts .txt, .list, or .npz. One path per line, or a NumPy archive of pre-computed vectors."),
             accept=".txt,.list,.npz",
         ),
         ImporterField(

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -230,6 +230,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 "Symlinks are followed; directory entries are scanned recursively "
                 "for media files."
             ),
+            hint=(
+                "Accepts .txt, .list, or .npz. One path per line, or a NumPy "
+                "archive of pre-computed vectors."
+            ),
             accept=".txt,.list,.npz",
         ),
         ImporterField(

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -42,6 +42,13 @@ class ServerCsvLabelImporter(LabelImporter):
                 "Absolute or relative path to a CSV file with md5 and label columns on the server filesystem."
             ),
             placeholder="data/labels/my_labels.csv",
+            hint=(
+                "Expects columns: md5,label\n"
+                "Example:\n"
+                "  md5,label\n"
+                "  d41d8cd98f00b204e9800998ecf8427e,good\n"
+                "  e2fc714c4727ee9395f324cd2e7f331f,bad"
+            ),
         ),
     ]
 

--- a/vtsearch/labels/importers/server_json_file/__init__.py
+++ b/vtsearch/labels/importers/server_json_file/__init__.py
@@ -40,6 +40,13 @@ class ServerJsonLabelImporter(LabelImporter):
             field_type="server_path",
             description=("Absolute or relative path to a VTSearch labels JSON file on the server filesystem."),
             placeholder="data/labels/my_labels.json",
+            hint=(
+                "Example structure:\n"
+                '  {"labels": [\n'
+                '    {"md5": "d41d8cd98f00b204e9800998ecf8427e", "label": "good"},\n'
+                '    {"md5": "e2fc714c4727ee9395f324cd2e7f331f", "label": "bad"}\n'
+                "  ]}"
+            ),
         ),
     ]
 

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -120,6 +120,14 @@ class PluginField:
     required: bool = True
     #: Hint shown as placeholder text inside the input widget.
     placeholder: str = ""
+    #: Inline format-hint text rendered as a visible chip below the input,
+    #: separate from :attr:`description` (which feeds the placeholder).  Use
+    #: this for format / schema hints the user needs to see at a glance even
+    #: after they start typing (e.g. accepted file extensions, expected
+    #: column schema, a short sample of the file layout).  Newlines and
+    #: leading-space indented lines render verbatim, so multi-line samples
+    #: are fine.
+    hint: str = ""
     #: When ``True``, :attr:`options` is computed at runtime by the plugin's
     #: ``get_field_options(field_key, current_values)`` method.  Static
     #: :attr:`options` (if any) are still served as the initial list.
@@ -149,6 +157,7 @@ class PluginField:
             "default": self.default,
             "required": self.required,
             "placeholder": self.placeholder,
+            "hint": self.hint,
             "dynamic_options": self.dynamic_options,
             "depends_on": list(self.depends_on),
             "min": self.min,


### PR DESCRIPTION
## Summary

Adds visible inline format-hint chips below path/URL fields in the importer forms so users see expected file formats and schemas at a glance — even after they start typing.

Previously, `PluginField.description` served double-duty as the placeholder; it disappeared as soon as the user typed anything and got truncated on narrow inputs. This change introduces a separate `hint` attribute that renders as a small monospace chip below the input.

**Backend** — new optional `hint: str = ""` on `PluginField`, serialized via `to_dict()`.

**Frontend** — new `hint?: string` on `ImporterField`; both the dataset importer modal (`dataset-importer-modal`) and label importer modal (`label-importer-modal`) render `<p class="form-hint">` below each field when set. `.form-hint` styling lives in `frontend/src/scss/_components.scss` (subtle muted text, monospace, `white-space: pre-wrap` so multi-line samples render verbatim).

**Hints added:**
- `server_files` `paths_file`: `Accepts .txt, .list, or .npz. One path per line, or a NumPy archive of pre-computed vectors.`
- `server_csv_file` `filepath`: expected `md5,label` column schema with a 2-row example.
- `server_json_file` `filepath`: 3-line sample of the expected `{"labels": [...]}` structure.

## Test plan

- [x] `./run-tests.sh io` — 650 passed (covers label importers)
- [x] `./run-tests.sh core` — 507 passed (covers frontend Angular build with the new template + SCSS)
- [x] `./run-tests.sh datasets` — 493 passed (covers `server_files` importer)
- [x] `ruff format` clean
- [ ] **Not visually verified in a browser** — the cloud container has no Chrome/Chromium. The Angular build compiles cleanly, but I cannot confirm the chip spacing/color look right in practice.

---
_Generated by [Claude Code](https://claude.ai/code/session_014qWBThNJiF397zsdMv1Wye)_