### PR TITLE
Add loading-state context header + subtitle to progress UI

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -413,8 +413,12 @@ Add a `?` icon next to the embedder dropdown in every importer that exposes one.
 - CSV label importer: show the expected column schema (`md5,label`) with a sample.
 - JSON label importer: show a 3-line sample of the expected structure.
 
-### 12.6 Loading-state context in the progress modal ★★ S
-Today the dataset loading modal shows step numbers like "[Step 3/4] Loading embedding model…". The user has no model for what step 3 means. Add a header `Loading dataset · embedding model` and a subtitle with a one-liner like "Downloading SigLIP weights (~860 MB). First-time only — cached afterwards."
+### 12.6 Loading-state context in the progress modal ★★ S — shipped
+Was: dashboard loading rows showed cryptic step numbers like "[Step 3/4] Loading embedding model…" with no plain-English context for what step 3 actually meant.
+
+**What shipped:** `frontend/src/app/utils/format-progress.ts` gained `formatProgressHeader(progress, kind, embedder?)`, which returns a `{ header, subtitle, detail }` triple derived from the event's `status` + `message` (+ optional `embedder` woven into model-load / embedding-files / embedding-labels subtitles). The dataset card, detector card, and orphan-task row in `dashboard.component.html` were restructured to render the header line ("Loading dataset · embedding model") and a one-line subtitle ("Loading SigLIP weights. First-time only — cached on disk afterwards.") above the existing progress bar; the `[Step S/T]` prefix is stripped from the detail because the header now conveys the phase. Phase vocabulary covers the dataset-load flow (downloading source / unpacking archive / embedding model / warming text encoder / embedding files / slicing clips / embedding clips / converting media / removing duplicates / building diversity index / saving to registry) and the detector-load flow (restoring labels / seeding examples / embedding labels). Embedder names are pretty-printed via a small lookup table (`siglip → SigLIP`, `clap → LAION-CLAP`, `xclip → X-CLIP`, etc.) so the subtitle matches user-facing terminology.
+
+**Open follow-ups:** byte-rate / ETA on the first-run model download (§14.2) and per-file embedding progress (§14.1) remain — the header is now in place but the bar itself still shows a single indeterminate spinner inside `embedding model` and `embedding files`. Folding those in will make the subtitle's "First-time only — cached on disk afterwards." reassurance land harder.
 
 ### 12.7 Inclusion slider tick labels ★★ XS
 The slider is `[-10, +10]` with no anchors. Add tick labels: `-10 strict` / `0 default` / `+10 lenient`, plus a one-line caption "Trades off precision (left) vs recall (right)."

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -96,14 +96,25 @@
                       <button class="btn btn--cancel btn--sm" (click)="dismissLoadingTask(task.task_id)" title="Dismiss this error">Dismiss</button>
                     </div>
                   } @else {
+                    @let info = taskProgressInfo(task);
                     <div class="loading-task-progress">
-                      <span class="progress-msg">{{ taskProgressMessage(task) }}</span>
-                      <vt-progress-bar
-                        [value]="task.current"
-                        [max]="task.total"
-                        [indeterminate]="taskIsIndeterminate(task)"
-                      />
-                      <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
+                      <div class="progress-context">
+                        <div class="progress-header">{{ info.header }}</div>
+                        @if (info.subtitle) {
+                          <div class="progress-subtitle">{{ info.subtitle }}</div>
+                        }
+                      </div>
+                      <div class="progress-row">
+                        @if (info.detail) {
+                          <span class="progress-msg">{{ info.detail }}</span>
+                        }
+                        <vt-progress-bar
+                          [value]="task.current"
+                          [max]="task.total"
+                          [indeterminate]="taskIsIndeterminate(task)"
+                        />
+                        <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
+                      </div>
                     </div>
                   }
                 </td>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -161,6 +161,44 @@
   }
 }
 
+// When the loading-task-progress carries the new header + subtitle context,
+// stack the text rows above the bar instead of laying everything on one line.
+.loading-task-progress:has(.progress-context) {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+
+  .progress-context {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .progress-header {
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .progress-subtitle {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .progress-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .progress-msg {
+    font-size: 0.75rem;
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 .dashboard-progress {
   flex: 1;
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -16,7 +16,12 @@ import { TopBarStateService } from '../../services/top-bar-state.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { AchievementsService } from '../../services/achievements.service';
 import { AutoDetectResultsData, DatasetRegistryEntry, DemoDataset, LoadingTask, DetectorRegistryEntry, ImporterInfo, ProgressEvent } from '../../models/api.models';
-import { formatProgressMessage, isProgressIndeterminate } from '../../utils/format-progress';
+import {
+  ProgressHeader,
+  formatProgressHeader,
+  formatProgressMessage,
+  isProgressIndeterminate,
+} from '../../utils/format-progress';
 import {
   DashboardColumnsService,
   DatasetColumn,
@@ -1414,8 +1419,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Loading task helpers ---
 
-  taskProgressMessage(task: LoadingTask): string {
-    return formatProgressMessage(task, 'Loading...');
+  taskProgressInfo(task: LoadingTask): ProgressHeader {
+    return formatProgressHeader(task, 'dataset', task.embedder);
   }
 
   taskIsIndeterminate(task: LoadingTask): boolean {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -35,13 +35,23 @@
   <!-- Inline progress: replace remaining columns (middle + actions) with a progress bar -->
   <td [attr.colspan]="columnOrder.length + 1">
     <div class="inline-loading-progress">
-      <span class="progress-msg">{{ taskProgressMessage }}</span>
-      <vt-progress-bar
-        [value]="loadingTask.current"
-        [max]="loadingTask.total"
-        [indeterminate]="taskIsIndeterminate"
-      />
-      <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel this dataset load">Cancel</button>
+      <div class="progress-context">
+        <div class="progress-header">{{ taskProgressInfo.header }}</div>
+        @if (taskProgressInfo.subtitle) {
+          <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
+        }
+      </div>
+      <div class="progress-row">
+        @if (taskProgressInfo.detail) {
+          <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
+        }
+        <vt-progress-bar
+          [value]="loadingTask.current"
+          [max]="loadingTask.total"
+          [indeterminate]="taskIsIndeterminate"
+        />
+        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel this dataset load">Cancel</button>
+      </div>
     </div>
   </td>
 } @else if (loadingTask && loadingTask.error) {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -252,15 +252,39 @@ td.select-col {
 // Inline loading progress (replaces data columns while loading)
 .inline-loading-progress {
   display: flex;
-  align-items: center;
-  gap: var(--space-md);
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+
+  .progress-context {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .progress-header {
+    font-size: var(--font-sm);
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .progress-subtitle {
+    font-size: var(--font-xs);
+    color: var(--text-muted);
+  }
+
+  .progress-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+  }
 
   .progress-msg {
-    font-size: var(--font-sm);
+    font-size: var(--font-xs);
     color: var(--text-muted);
     white-space: nowrap;
     flex-shrink: 0;
-    max-width: 300px;
+    max-width: 240px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -286,6 +310,9 @@ td.select-col {
   }
 
   &.inline-loading-failed {
+    flex-direction: row;
+    align-items: center;
+
     .error-msg {
       flex: 1;
       font-size: var(--font-sm);

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -3,7 +3,11 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
-import { formatProgressMessage, isProgressIndeterminate } from '../../../utils/format-progress';
+import {
+  ProgressHeader,
+  formatProgressHeader,
+  isProgressIndeterminate,
+} from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 
 @Component({
@@ -145,10 +149,10 @@ export class DatasetCardComponent implements OnChanges {
     return type.charAt(0).toUpperCase() + type.slice(1);
   }
 
-  get taskProgressMessage(): string {
+  get taskProgressInfo(): ProgressHeader {
     const task = this.loadingTask;
-    if (!task) return '';
-    return formatProgressMessage(task, 'Loading...');
+    if (!task) return { header: '', subtitle: '', detail: '' };
+    return formatProgressHeader(task, 'dataset', task.embedder);
   }
 
   get taskIsIndeterminate(): boolean {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -34,13 +34,23 @@
 @if (loadingTask && !loadingTask.error) {
   <td [attr.colspan]="columnOrder.length + 1">
     <div class="loading-task-progress">
-      <span class="progress-msg">{{ taskProgressMessage }}</span>
-      <vt-progress-bar
-        [value]="loadingTask.current"
-        [max]="loadingTask.total"
-        [indeterminate]="taskIsIndeterminate()"
-      />
-      <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel loading">Cancel</button>
+      <div class="progress-context">
+        <div class="progress-header">{{ taskProgressInfo.header }}</div>
+        @if (taskProgressInfo.subtitle) {
+          <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
+        }
+      </div>
+      <div class="progress-row">
+        @if (taskProgressInfo.detail) {
+          <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
+        }
+        <vt-progress-bar
+          [value]="loadingTask.current"
+          [max]="loadingTask.total"
+          [indeterminate]="taskIsIndeterminate()"
+        />
+        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel loading">Cancel</button>
+      </div>
     </div>
   </td>
 } @else if (loadingTask?.error) {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -147,6 +147,91 @@ td.actions-col {
   font-size: 0.75rem;
 }
 
+// Inline loading progress (replaces data columns while loading). Mirrors the
+// stack layout used by the dataset card's `.inline-loading-progress` so the
+// dashboard's loading rows have a consistent shape.
+.loading-task-progress {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+
+  .progress-context {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .progress-header {
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .progress-subtitle {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .progress-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .progress-msg {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  vt-progress-bar {
+    flex: 1;
+  }
+
+  .btn--cancel {
+    flex-shrink: 0;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+    }
+  }
+
+  &.loading-task-failed {
+    flex-direction: row;
+    align-items: center;
+
+    .error-msg {
+      flex: 1;
+      font-size: 0.85rem;
+      color: var(--error-text);
+    }
+
+    .btn--cancel {
+      background: transparent;
+      color: var(--error-text);
+      border: 1px solid var(--error-border);
+
+      &:hover {
+        background: var(--error-border);
+        color: var(--btn-filled-text);
+      }
+    }
+  }
+}
+
 .add-labels-btn {
   background: none;
   border: none;

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -4,7 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { DetectorSwatchComponent } from '../../detector-swatch/detector-swatch.component';
-import { formatProgressMessage, isProgressIndeterminate } from '../../../utils/format-progress';
+import {
+  ProgressHeader,
+  formatProgressHeader,
+  isProgressIndeterminate,
+} from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 import { detectorHue } from '../../../utils/detector-color';
 
@@ -179,7 +183,9 @@ export class DetectorCardComponent implements OnChanges {
     return isProgressIndeterminate(t);
   }
 
-  get taskProgressMessage(): string {
-    return this.loadingTask ? formatProgressMessage(this.loadingTask, 'Loading...') : '';
+  get taskProgressInfo(): ProgressHeader {
+    const task = this.loadingTask;
+    if (!task) return { header: '', subtitle: '', detail: '' };
+    return formatProgressHeader(task, 'detector', task.embedder);
   }
 }

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -65,3 +65,142 @@ export function isProgressIndeterminate(
   const prog = progress ?? {};
   return !(prog.current != null && prog.total != null && prog.total > 0);
 }
+
+/**
+ * A three-tier breakdown of a progress event for header-style UIs. The bare
+ * ``[Step 3/4] Loading embedding model…`` is uninformative to users who have
+ * no mental model of the load steps. ``formatProgressHeader`` instead returns:
+ *
+ *   - ``header``: ``"<what> · <phase>"``, e.g. ``"Loading dataset · embedding model"``.
+ *   - ``subtitle``: a plain-English one-liner explaining what the phase actually does.
+ *   - ``detail``: the original message + ``(current/total)`` counts, with the
+ *     redundant ``[Step S/T]`` prefix stripped (the header conveys the phase).
+ */
+export interface ProgressHeader {
+  header: string;
+  subtitle: string;
+  detail: string;
+}
+
+/** Which load flow this progress event belongs to. */
+export type ProgressKind = 'dataset' | 'detector';
+
+const EMBEDDER_PRETTY: Record<string, string> = {
+  siglip: 'SigLIP',
+  siglip2: 'SigLIP 2',
+  clip: 'CLIP',
+  dinov2: 'DINOv2',
+  dinov2_patch: 'DINOv2',
+  dinov3: 'DINOv3',
+  dinov3_patch: 'DINOv3',
+  dinov3_single: 'DINOv3',
+  clap: 'LAION-CLAP',
+  clap_general: 'LAION-CLAP (general)',
+  clap_music: 'LAION-CLAP (music)',
+  xclip: 'X-CLIP',
+  'x-clip': 'X-CLIP',
+  whisper: 'Whisper',
+  ast: 'AST',
+  e5: 'E5',
+  bge: 'BGE',
+  languagebind: 'LanguageBind',
+};
+
+function prettifyEmbedder(name: string | undefined): string {
+  if (!name) return '';
+  const key = name.toLowerCase().replace(/-/g, '_');
+  return EMBEDDER_PRETTY[key] ?? name;
+}
+
+function stripStepPrefix(msg: string): string {
+  return msg.replace(/^\[Step \d+\/\d+\]\s*/, '');
+}
+
+/**
+ * Resolve a ``ProgressEvent`` to a header / subtitle / detail triple for UIs
+ * that want richer loading-state context than a single line of text. See the
+ * ``ProgressHeader`` interface for the meaning of each field. ``kind`` selects
+ * between the dataset-load and detector-load phase vocabularies; ``embedder``
+ * is woven into the subtitle when the phase mentions one ("Loading SigLIP
+ * weights. First-time only — cached on disk afterwards.").
+ */
+export function formatProgressHeader(
+  progress: ProgressEvent | null | undefined,
+  kind: ProgressKind,
+  embedder?: string,
+): ProgressHeader {
+  const prog = progress ?? {};
+  const status = (prog.status ?? '').toLowerCase();
+  const message = prog.message ?? '';
+  const what = kind === 'detector' ? 'Loading detector' : 'Loading dataset';
+
+  let phase = '';
+  let subtitle = '';
+
+  if (status === 'downloading') {
+    if (/extract/i.test(message)) {
+      phase = 'unpacking archive';
+      subtitle = 'Extracting the downloaded archive into the dataset cache.';
+    } else {
+      phase = 'downloading source';
+      subtitle = 'Fetching the dataset archive. Cached on disk for next time.';
+    }
+  } else if (status === 'embedding') {
+    phase = 'embedding files';
+    const pretty = prettifyEmbedder(embedder);
+    subtitle = pretty
+      ? `Computing one ${pretty} vector per file. Time depends on dataset size and hardware.`
+      : 'Computing one vector per file. Time depends on dataset size and hardware.';
+  } else if (status === 'loading' && /embedding model/i.test(message)) {
+    phase = 'embedding model';
+    const pretty = prettifyEmbedder(embedder);
+    subtitle = pretty
+      ? `Loading ${pretty} weights. First-time only — cached on disk afterwards.`
+      : 'Loading model weights. First-time only — cached on disk afterwards.';
+  } else if (status === 'loading' && /text encoder|warming/i.test(message)) {
+    phase = 'warming text encoder';
+    subtitle = 'One-time warm-up so the first text search returns instantly.';
+  } else if (/duplicates/i.test(message)) {
+    phase = 'removing duplicates';
+    subtitle = 'Collapsing media that share the same content fingerprint.';
+  } else if (/diversity/i.test(message)) {
+    phase = 'building diversity index';
+    subtitle = 'Indexing for fast diverse browsing and autopilot guidance.';
+  } else if (/saving to registry/i.test(message)) {
+    phase = 'saving to registry';
+    subtitle = 'Persisting the dataset so it survives a restart.';
+  } else if (/clipping/i.test(message)) {
+    phase = 'slicing clips';
+    subtitle = 'Cutting media into clips for finer-grained search.';
+  } else if (/embedding clips/i.test(message)) {
+    phase = 'embedding clips';
+    subtitle = 'Computing a vector for each clip.';
+  } else if (/converting/i.test(message)) {
+    phase = 'converting media';
+    subtitle = 'Running the converter on each input file.';
+  } else if (kind === 'detector' && /restoring labels/i.test(message)) {
+    phase = 'restoring labels';
+    subtitle = 'Reading the saved labelset for this detector.';
+  } else if (kind === 'detector' && /seeding examples/i.test(message)) {
+    phase = 'seeding examples';
+    subtitle = 'Pulling label examples back into the active dataset.';
+  } else if (
+    kind === 'detector' &&
+    /embedding labels|re-?resolving labels|re-?embedding/i.test(message)
+  ) {
+    phase = 'embedding labels';
+    const pretty = prettifyEmbedder(embedder);
+    subtitle = pretty
+      ? `Re-resolving label media into ${pretty} space so MLP training mixes only same-space vectors.`
+      : 'Re-resolving label media so MLP training mixes only same-space vectors.';
+  } else if (status === 'loading' && /preparing|scanning|importing/i.test(message)) {
+    phase = 'preparing';
+    subtitle = /scanning/i.test(message)
+      ? 'Walking the source folder to enumerate media files.'
+      : 'Setting up the load pipeline.';
+  }
+
+  const header = phase ? `${what} · ${phase}` : what;
+  const detail = stripStepPrefix(formatProgressMessage(progress));
+  return { header, subtitle, detail };
+}


### PR DESCRIPTION
## Summary

Brainstorm §12.6. The dashboard's inline loading rows showed cryptic step numbers like `[Step 3/4] Loading embedding model…` with no plain-English context for what step 3 actually meant.

`formatProgressHeader(progress, kind, embedder?)` (in `frontend/src/app/utils/format-progress.ts`) now returns a `{ header, subtitle, detail }` triple derived from the event's `status` + `message` (+ optional `embedder` pretty-printed in model-load / embedding subtitles). The dataset card, detector card, and orphan-task row in `dashboard.component.html` render two new lines above the existing progress bar:

- **Header**: `Loading dataset · embedding model` (kind + phase)
- **Subtitle**: e.g. `Loading SigLIP weights. First-time only — cached on disk afterwards.`

The redundant `[Step S/T]` prefix is stripped from the detail line because the header now conveys the phase.

Phase vocabulary covers the dataset-load flow (downloading source / unpacking archive / embedding model / warming text encoder / embedding files / slicing clips / embedding clips / converting media / removing duplicates / building diversity index / saving to registry) and the detector-load flow (restoring labels / seeding examples / embedding labels). Embedder names are pretty-printed via a small lookup table so subtitles match user-facing terminology (`siglip → SigLIP`, `clap → LAION-CLAP`, `xclip → X-CLIP`, etc.).

## Test plan

- [x] `./run-tests.sh` — 3842 passed, 1 skipped (full suite, including frontend `npm run build:prod` which compiled cleanly with no warnings).
- [ ] Manual: load a dataset on the dashboard and verify each phase shows the header + subtitle (download → embedding model → embedding files → finalising).
- [ ] Manual: load a detector and verify "Loading detector · restoring labels / seeding examples / embedding labels" headers.
- [ ] Manual: failure state still renders horizontally with the `Failed: …` message and `Dismiss` button.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZY6NPSfqfUWA4LJXk2hbQ)_