### PR TITLE
Refactor four highest McCabe-complexity functions

### DIFF
--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -101,6 +101,88 @@ class SourceSpec:
         )
 
 
+def _parse_multi_media_specs(raw: Any, output_type: str) -> list[SourceSpec]:
+    """Parse and validate the explicit ``source_specs`` form value.
+
+    Used by importers with ``multi_media=True``.  Falls back to a single
+    pass-through spec when no value is submitted so a flipped importer
+    still loads cleanly before the frontend ships the new UI.
+    """
+    from vtsearch.converters import get_converter  # noqa: PLC0415
+    from vtsearch.media import get_by_folder_name  # noqa: PLC0415
+
+    specs_raw: list[dict[str, Any]]
+    if raw is None or raw == "":
+        specs_raw = [{"source_type": output_type, "converter": None, "params": {}}]
+    elif isinstance(raw, str):
+        try:
+            specs_raw = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid source_specs JSON: {exc}") from exc
+    else:
+        specs_raw = list(raw)
+
+    if not output_type:
+        raise ValueError("multi_media import requires a 'media_type' (output) field")
+
+    specs: list[SourceSpec] = []
+    for item in specs_raw:
+        if not isinstance(item, dict):
+            raise ValueError(f"source_specs entries must be objects, got {type(item).__name__}")
+        spec = SourceSpec.from_dict(item)
+        try:
+            spec.source_type = get_by_folder_name(spec.source_type).type_id
+        except (KeyError, AttributeError) as exc:
+            raise ValueError(f"Unknown source_type: {spec.source_type!r}") from exc
+        _validate_spec_converter(spec, output_type, get_converter)
+        specs.append(spec)
+    return specs
+
+
+def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) -> None:
+    """Validate that *spec*'s converter (if any) bridges source→output."""
+    if spec.converter is None:
+        if spec.source_type != output_type:
+            raise ValueError(
+                f"Direct (no-converter) source_type {spec.source_type!r} "
+                f"does not match output media_type {output_type!r}",
+            )
+        return
+    converter = get_converter(spec.converter)
+    if converter is None:
+        raise ValueError(f"Unknown converter: {spec.converter!r}")
+    if converter.source_type != spec.source_type:
+        raise ValueError(
+            f"Converter {spec.converter!r} expects source_type {converter.source_type!r}, not {spec.source_type!r}",
+        )
+    if converter.target_type != output_type:
+        raise ValueError(
+            f"Converter {spec.converter!r} produces "
+            f"{converter.target_type!r}, but output media_type is {output_type!r}",
+        )
+
+
+def _parse_legacy_specs(raw_converters: Any, output_type: str) -> list[SourceSpec]:
+    """Synthesise specs from the legacy ``media_type`` + comma-separated ``converters`` fields."""
+    from vtsearch.converters import get_converter  # noqa: PLC0415
+
+    legacy_specs: list[SourceSpec] = []
+    if output_type:
+        legacy_specs.append(SourceSpec(source_type=output_type, converter=None, params={}))
+    raw = raw_converters or ""
+    if isinstance(raw, list):
+        names = [str(n).strip() for n in raw if str(n).strip()]
+    else:
+        names = [n.strip() for n in str(raw).split(",") if n.strip()]
+    for name in names:
+        converter = get_converter(name)
+        if converter is None:
+            # Match the runner's behaviour: silently skip unknown converters.
+            continue
+        legacy_specs.append(SourceSpec(source_type=converter.source_type, converter=name, params={}))
+    return legacy_specs
+
+
 PickerView = str  # one of: "form", "demo", "server_folder", "local_folder"
 
 
@@ -580,7 +662,7 @@ class DatasetImporter(PluginBase):
     # Source specs (multi-media import)
     # ------------------------------------------------------------------
 
-    def effective_source_specs(self, field_values: dict[str, Any]) -> list[SourceSpec]:  # noqa: C901
+    def effective_source_specs(self, field_values: dict[str, Any]) -> list[SourceSpec]:
         """Resolve *field_values* into a flat list of :class:`SourceSpec`.
 
         For importers with :attr:`multi_media` ``= True``, the user submits
@@ -611,7 +693,6 @@ class DatasetImporter(PluginBase):
                 ``multi_media=True`` import is missing a ``media_type``
                 output declaration.
         """
-        from vtsearch.converters import get_converter  # noqa: PLC0415
         from vtsearch.media import get_by_folder_name  # noqa: PLC0415
 
         output_type_raw = field_values.get("media_type", "") or ""
@@ -621,75 +702,8 @@ class DatasetImporter(PluginBase):
             output_type = str(output_type_raw)
 
         if self.multi_media:
-            raw = field_values.get("source_specs")
-            specs_raw: list[dict[str, Any]]
-            if raw is None or raw == "":
-                # No specs declared: fall through to the legacy
-                # "include directly" single-row default so a flipped
-                # importer still loads cleanly when the frontend hasn't
-                # caught up with the new UI yet.
-                specs_raw = [{"source_type": output_type, "converter": None, "params": {}}]
-            elif isinstance(raw, str):
-                try:
-                    specs_raw = json.loads(raw)
-                except (TypeError, ValueError) as exc:
-                    raise ValueError(f"Invalid source_specs JSON: {exc}") from exc
-            else:
-                specs_raw = list(raw)
-
-            if not output_type:
-                raise ValueError("multi_media import requires a 'media_type' (output) field")
-
-            specs: list[SourceSpec] = []
-            for item in specs_raw:
-                if not isinstance(item, dict):
-                    raise ValueError(f"source_specs entries must be objects, got {type(item).__name__}")
-                spec = SourceSpec.from_dict(item)
-                # Normalise source_type (allow folder_import_name).
-                try:
-                    spec.source_type = get_by_folder_name(spec.source_type).type_id
-                except (KeyError, AttributeError) as exc:
-                    raise ValueError(f"Unknown source_type: {spec.source_type!r}") from exc
-                if spec.converter is None:
-                    if spec.source_type != output_type:
-                        raise ValueError(
-                            f"Direct (no-converter) source_type {spec.source_type!r} "
-                            f"does not match output media_type {output_type!r}",
-                        )
-                else:
-                    converter = get_converter(spec.converter)
-                    if converter is None:
-                        raise ValueError(f"Unknown converter: {spec.converter!r}")
-                    if converter.source_type != spec.source_type:
-                        raise ValueError(
-                            f"Converter {spec.converter!r} expects source_type "
-                            f"{converter.source_type!r}, not {spec.source_type!r}",
-                        )
-                    if converter.target_type != output_type:
-                        raise ValueError(
-                            f"Converter {spec.converter!r} produces "
-                            f"{converter.target_type!r}, but output media_type is {output_type!r}",
-                        )
-                specs.append(spec)
-            return specs
-
-        # Legacy: synthesise from media_type + comma-separated converters.
-        legacy_specs: list[SourceSpec] = []
-        if output_type:
-            legacy_specs.append(SourceSpec(source_type=output_type, converter=None, params={}))
-        raw_converters = field_values.get("converters", "") or ""
-        if isinstance(raw_converters, list):
-            names = [str(n).strip() for n in raw_converters if str(n).strip()]
-        else:
-            names = [n.strip() for n in str(raw_converters).split(",") if n.strip()]
-        for name in names:
-            converter = get_converter(name)
-            if converter is None:
-                # Match the runner's behaviour: silently skip unknown
-                # converters rather than crashing the legacy path.
-                continue
-            legacy_specs.append(SourceSpec(source_type=converter.source_type, converter=name, params={}))
-        return legacy_specs
+            return _parse_multi_media_specs(field_values.get("source_specs"), output_type)
+        return _parse_legacy_specs(field_values.get("converters", ""), output_type)
 
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         """Build an origin dict for elements imported by this importer.

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -669,7 +669,215 @@ def _auto_register_dataset(
 # ---------------------------------------------------------------------------
 
 
-def _run_origin_load_in_background(  # noqa: C901
+class _LoadGateController:
+    """Tracks which load-pipeline gate (download / embed) is currently held.
+
+    Splits gate-acquisition concerns out of the task body: the importer
+    runs under the download gate (bandwidth-bound), and we swap to the
+    embed gate as soon as the importer signals it's started embedding so
+    another dataset can begin downloading in parallel.
+    """
+
+    def __init__(self, tracker) -> None:
+        self._tracker = tracker
+        self._held: str | None = None
+
+    @property
+    def held(self) -> str | None:
+        return self._held
+
+    def acquire(self, gate: ConcurrencyGate, name: str, wait_msg: str) -> None:
+        if gate.acquire(blocking=False):
+            self._held = name
+            return
+        self._tracker.update("loading", wait_msg, 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
+        while not gate.acquire(timeout=0.5):
+            self._tracker.check_cancelled()
+        self._held = name
+
+    def acquire_download(self) -> None:
+        self.acquire(_download_gate, "download", "Waiting for other datasets to finish downloading…")
+
+    def swap_to_embed(self) -> None:
+        if self._held == "embed":
+            return
+        if self._held == "download":
+            _download_gate.release()
+            self._held = None
+        self.acquire(_embed_gate, "embed", "Waiting for other datasets to finish embedding…")
+
+    def release(self) -> None:
+        if self._held == "download":
+            _download_gate.release()
+        elif self._held == "embed":
+            _embed_gate.release()
+        self._held = None
+
+
+def _make_stepped_progress(controller: _LoadGateController, tracker):
+    """Build the importer-side progress callback.
+
+    Routes status updates into *tracker* with the right step number, and
+    triggers the download→embed gate swap on the first ``"embedding"``
+    status so a queued download can start.
+    """
+
+    def stepped(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        tracker.check_cancelled()
+        if status == "idle":
+            return
+        if status == "embedding" and controller.held != "embed":
+            controller.swap_to_embed()
+        step = _STATUS_TO_STEP.get(status)
+        tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+
+    return stepped
+
+
+def _run_importer(load_fn, ctx: DatasetContext, stepped) -> None:
+    """Invoke *load_fn* under thread-local progress, populating ctx.medias."""
+    import inspect  # noqa: PLC0415
+
+    set_thread_progress(stepped)
+    try:
+        sig = inspect.signature(load_fn)
+        if sig.parameters:
+            load_fn(ctx.medias)
+        else:
+            load_fn()
+    finally:
+        clear_thread_progress()
+
+
+def _tag_origins(media_dict: dict, origin: dict) -> None:
+    """Stamp *origin* onto medias that don't already carry one."""
+    for media in media_dict.values():
+        if media.get("origin") is None:
+            media["origin"] = origin
+        if not media.get("origin_name"):
+            media["origin_name"] = media.get("filename", "")
+
+
+def _apply_clipper_stage(
+    ctx: DatasetContext, tracker, clipper: str, clipper_params: dict | None, chain_steps: list[dict] | None
+) -> None:
+    """Run the clipper / chain stage with tracker-routed progress."""
+    if not (clipper or chain_steps):
+        return
+
+    def _clipper_progress(current: int, total: int, phase: str) -> None:
+        tracker.check_cancelled()
+        if phase == "clipping":
+            msg = "Clipping media…"
+        elif phase == "converting":
+            msg = "Converting media…"
+        else:
+            msg = "Embedding clips…"
+        tracker.update(
+            "loading", msg, current=current, total=total, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
+        )
+
+    _clipper_progress(0, 0, "clipping")
+    _apply_clipper(ctx.medias, clipper, clipper_params, on_progress=_clipper_progress, chain_steps=chain_steps)
+
+
+def _collapse_duplicates_stage(ctx: DatasetContext, tracker) -> None:
+    def _progress(current: int, total: int) -> None:
+        tracker.check_cancelled()
+        tracker.update(
+            "loading",
+            "Removing duplicates…",
+            current=current,
+            total=total,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
+
+    _progress(0, 0)
+    collapse_duplicates(ctx.medias, on_progress=_progress)
+
+
+def _build_diversity_tree_stage(ctx: DatasetContext, tracker) -> None:
+    def _progress(current: int, total: int) -> None:
+        tracker.check_cancelled()
+        tracker.update(
+            "loading",
+            "Building diversity index…",
+            current=current,
+            total=total,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
+
+    _progress(0, 0)
+    build_diversity_tree_for_context(ctx, on_progress=_progress)
+
+
+def _register_and_migrate(
+    ctx: DatasetContext,
+    tracker,
+    task_id: str,
+    origin: dict,
+    name: str,
+    clipper: str,
+    embedder: str,
+    created_by: str,
+    ingest_started_at: float,
+) -> str:
+    """Save to registry, migrate the context from task_id to its real id.
+
+    Returns the (possibly migrated) context_id.
+    """
+    tracker.update("loading", "Saving to registry…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
+    entry = _auto_register_dataset(
+        ctx.medias,
+        name=name,
+        origin_str=_origin_to_str(origin),
+        source=origin,
+        clipper=clipper,
+        embedder=embedder,
+        created_by=created_by,
+        display_name=name,
+        ingest_started_at=ingest_started_at,
+    )
+    if entry is None:
+        return task_id
+    _migrate_context_id(task_id, entry["id"])
+    ctx.dataset_display_name = entry.get("name", name)
+    # Associate the loading task with the real dataset ID so the frontend
+    # can show embedder-warmup progress inline on the dataset row.
+    loading_tasks.set_dataset_id(task_id, entry["id"])
+    return entry["id"]
+
+
+def _warmup_embedder_stage(ctx: DatasetContext, tracker) -> None:
+    def _task_progress(status, message="", current=0, total=0, **kw):
+        tracker.update(status, message, current, total, **kw)
+
+    _load_embedder_with_progress(ctx.medias, _task_progress)
+
+
+def _handle_load_failure(exc: BaseException, context_id: str, tracker) -> None:
+    """Unregister the context and write the failure into *tracker*."""
+    from vtsearch.state.core import unregister_context  # noqa: PLC0415
+
+    if isinstance(exc, CancelledError):
+        error = "Cancelled"
+    elif isinstance(exc, ImportError):
+        traceback.print_exc()
+        error = f"Missing dependency: {exc}. Install all required packages with: pip install -e '.[cpu,dev]'"
+    elif isinstance(exc, MemoryError):
+        error = "Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM."
+    else:
+        traceback.print_exc()
+        error = str(exc) or repr(exc) or "Unknown error during dataset loading"
+
+    unregister_context(context_id)
+    gc.collect()
+    tracker.update("idle", "", 0, 0, error=error, step=None, total_steps=None)
+
+
+def _run_origin_load_in_background(
     load_fn,
     origin: dict,
     *,
@@ -694,11 +902,10 @@ def _run_origin_load_in_background(  # noqa: C901
 
     Returns the task_id that can be used to poll progress or cancel.
     """
-
     # Reset the legacy cancellation flag so a previous cancel does not
-    # immediately abort this new operation — but only when no other
-    # parallel loads are running (otherwise we would clear cancellation
-    # that might still be intended for those in-flight tasks).
+    # immediately abort this new operation — but only when no other parallel
+    # loads are running (otherwise we would clear cancellation that might
+    # still be intended for those in-flight tasks).
     if not loading_tasks.has_active_tasks():
         dataset_progress.reset_cancel()
 
@@ -711,253 +918,61 @@ def _run_origin_load_in_background(  # noqa: C901
         except Exception:
             pass
 
-    import time as _time
-
     task_id = f"_loading_{uuid4().hex[:8]}"
-    ingest_started_at = _time.time()
+    ingest_started_at = time.time()
     tracker = loading_tasks.create_task(
         task_id, name or _origin_to_str(origin), media_type=media_type, embedder=embedder
     )
-
-    # Set initial progress synchronously so the first poll sees it.
     tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
 
     # Snapshot the user that triggered the load so background per-user
     # state (settings writes, settings_source sync) resolves correctly.
-    _request_user = created_by or get_current_user()
+    request_user = created_by or get_current_user()
 
-    def task():  # noqa: C901
-        from vtsearch.auth import set_thread_user
+    def task():
+        from vtsearch.auth import set_thread_user  # noqa: PLC0415
 
-        set_thread_user(_request_user)
+        set_thread_user(request_user)
         ctx = DatasetContext(task_id)
-        context_id = task_id  # tracks the current context key (may change after migration)
-
-        # Tracks which gate (if any) we currently hold.  The download gate
-        # covers the import/download phase; the embed gate covers all
-        # CPU/GPU-bound embedding work (importer-side embedding plus the
-        # post-load clipper, dedup, diversity-tree, and embedder warm-up).
-        # We swap from download → embed when the importer first signals an
-        # "embedding" status, freeing the download slot so another dataset
-        # can start downloading in parallel.
-        held_gate: dict[str, str | None] = {"name": None}
-
-        def _acquire(gate: ConcurrencyGate, name: str, wait_msg: str) -> None:
-            if gate.acquire(blocking=False):
-                held_gate["name"] = name
-                return
-            tracker.update("loading", wait_msg, 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
-            while not gate.acquire(timeout=0.5):
-                tracker.check_cancelled()
-            held_gate["name"] = name
-
-        def _swap_to_embed() -> None:
-            if held_gate["name"] == "embed":
-                return
-            if held_gate["name"] == "download":
-                _download_gate.release()
-                held_gate["name"] = None
-            _acquire(_embed_gate, "embed", "Waiting for other datasets to finish embedding…")
-
-        def stepped(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-            tracker.check_cancelled()
-            if status == "idle":
-                return
-            # Importer transitioned into per-file embedding — swap gates so
-            # another download can start while we do the GPU-bound work.
-            if status == "embedding" and held_gate["name"] != "embed":
-                _swap_to_embed()
-            step = _STATUS_TO_STEP.get(status)
-            tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+        context_id = task_id
+        controller = _LoadGateController(tracker)
+        stepped = _make_stepped_progress(controller, tracker)
 
         try:
-            # Acquire the download gate up front: every load starts with the
-            # importer's download/import phase.  The task is already visible
-            # in the UI, so the user sees the wait message while queued.
-            _acquire(
-                _download_gate,
-                "download",
-                "Waiting for other datasets to finish downloading…",
-            )
-
+            controller.acquire_download()
             tracker.update("loading", "Preparing new dataset…", 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
             register_context(ctx)
             gc.collect()
 
-            # Set thread-local progress so that loader/downloader callbacks
-            # route to this task's tracker instead of the global singleton.
-            set_thread_progress(stepped)
-            try:
-                import inspect
-
-                sig = inspect.signature(load_fn)
-                if sig.parameters:
-                    load_fn(ctx.medias)
-                else:
-                    load_fn()
-            finally:
-                clear_thread_progress()
-
+            _run_importer(load_fn, ctx, stepped)
             tracker.check_cancelled()
 
-            # Post-load steps (apply_md5, clipping, dedup, diversity tree,
-            # registry save, embedder warm-up) are all CPU/GPU-bound and
-            # touch embeddings — gate them on the embed semaphore.  This is
-            # a no-op if the importer already swapped mid-load.
-            _swap_to_embed()
+            # Post-load stages are CPU/GPU-bound and touch embeddings —
+            # gate them on the embed semaphore.  No-op if the importer
+            # already swapped mid-load.
+            controller.swap_to_embed()
 
             apply_custom_metadata_md5(ctx.medias)
-
-            # Tag medias that don't already have an origin.
-            for media in ctx.medias.values():
-                if media.get("origin") is None:
-                    media["origin"] = origin
-                if not media.get("origin_name"):
-                    media["origin_name"] = media.get("filename", "")
-
-            if clipper or chain_steps:
-
-                def _clipper_progress(current: int, total: int, phase: str) -> None:
-                    tracker.check_cancelled()
-                    if phase == "clipping":
-                        msg = "Clipping media…"
-                    elif phase == "converting":
-                        msg = "Converting media…"
-                    else:
-                        msg = "Embedding clips…"
-                    tracker.update(
-                        "loading",
-                        msg,
-                        current=current,
-                        total=total,
-                        step=_TOTAL_LOAD_STEPS,
-                        total_steps=_TOTAL_LOAD_STEPS,
-                    )
-
-                _clipper_progress(0, 0, "clipping")
-                _apply_clipper(
-                    ctx.medias,
-                    clipper,
-                    clipper_params,
-                    on_progress=_clipper_progress,
-                    chain_steps=chain_steps,
-                )
-
-            def _dedup_progress(current: int, total: int) -> None:
-                tracker.check_cancelled()
-                tracker.update(
-                    "loading",
-                    "Removing duplicates…",
-                    current=current,
-                    total=total,
-                    step=_TOTAL_LOAD_STEPS,
-                    total_steps=_TOTAL_LOAD_STEPS,
-                )
-
-            _dedup_progress(0, 0)
-            collapse_duplicates(ctx.medias, on_progress=_dedup_progress)
-
-            def _diversity_progress(current: int, total: int) -> None:
-                tracker.check_cancelled()
-                tracker.update(
-                    "loading",
-                    "Building diversity index…",
-                    current=current,
-                    total=total,
-                    step=_TOTAL_LOAD_STEPS,
-                    total_steps=_TOTAL_LOAD_STEPS,
-                )
-
-            _diversity_progress(0, 0)
-            build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
+            _tag_origins(ctx.medias, origin)
+            _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
+            _collapse_duplicates_stage(ctx, tracker)
+            _build_diversity_tree_stage(ctx, tracker)
             tracker.check_cancelled()
-            tracker.update("loading", "Saving to registry…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
-            origin_str = _origin_to_str(origin)
-            entry = _auto_register_dataset(
-                ctx.medias,
-                name=name,
-                origin_str=origin_str,
-                source=origin,
-                clipper=clipper,
-                embedder=embedder,
-                created_by=created_by,
-                display_name=name,
-                ingest_started_at=ingest_started_at,
+            context_id = _register_and_migrate(
+                ctx, tracker, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
             )
+            _warmup_embedder_stage(ctx, tracker)
 
-            # Migrate the context from the temp task_id to the real registry ID.
-            if entry is not None:
-                _migrate_context_id(task_id, entry["id"])
-                context_id = entry["id"]
-                ctx.dataset_display_name = entry.get("name", name)
-                # Associate the loading task with the real dataset ID so the
-                # frontend can show the embedder-warmup progress inline on the
-                # dataset row instead of as an orphan loading task.
-                loading_tasks.set_dataset_id(task_id, entry["id"])
-
-            # Warm up the embedder.  Use a progress wrapper that updates the
-            # task tracker, not the global singleton.
-            def _task_progress(status, message="", current=0, total=0, **kw):
-                tracker.update(status, message, current, total, **kw)
-
-            _load_embedder_with_progress(ctx.medias, _task_progress)
-
-            # Achievement: dataset load succeeded (demos/synthetic excluded).
-            from vtsearch.achievements import record_dataset_load
+            from vtsearch.achievements import record_dataset_load  # noqa: PLC0415
 
             record_dataset_load(str(origin.get("importer", "")))
-        except CancelledError:
-            from vtsearch.state.core import unregister_context
-
-            unregister_context(context_id)
-            gc.collect()
-            tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
-        except ImportError as e:
-            traceback.print_exc()
-            from vtsearch.state.core import unregister_context
-
-            unregister_context(context_id)
-            gc.collect()
-            tracker.update(
-                "idle",
-                "",
-                0,
-                0,
-                error=(f"Missing dependency: {e}. Install all required packages with: pip install -e '.[cpu,dev]'"),
-                step=None,
-                total_steps=None,
-            )
-        except MemoryError:
-            from vtsearch.state.core import unregister_context
-
-            unregister_context(context_id)
-            gc.collect()
-            tracker.update(
-                "idle",
-                "",
-                0,
-                0,
-                error="Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM.",
-                step=None,
-                total_steps=None,
-            )
-        except Exception as e:
-            traceback.print_exc()
-            from vtsearch.state.core import unregister_context
-
-            unregister_context(context_id)
-            gc.collect()
-            error_msg = str(e) or repr(e) or "Unknown error during dataset loading"
-            tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
+        except Exception as exc:
+            _handle_load_failure(exc, context_id, tracker)
         finally:
-            if held_gate["name"] == "download":
-                _download_gate.release()
-            elif held_gate["name"] == "embed":
-                _embed_gate.release()
-            held_gate["name"] = None
+            controller.release()
             clear_thread_progress()
             loading_tasks.mark_finished(task_id)
-            from vtsearch.auth import set_thread_user as _clear_thread_user
+            from vtsearch.auth import set_thread_user as _clear_thread_user  # noqa: PLC0415
 
             _clear_thread_user(None)
 

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -281,8 +281,101 @@ def intercept_tqdm_progress(callback: ProgressCallback) -> Any:  # noqa: C901
         tqdm.std.tqdm.close = _orig_close  # type: ignore[assignment]
 
 
+def _patch_safetensors_load_file(counter: list[int], total: list[int], report) -> tuple | None:
+    """Wrap ``safetensors.torch.load_file`` to count returned tensors."""
+    try:
+        import safetensors.torch as _st  # noqa: PLC0415
+    except ImportError:
+        return None
+    orig = _st.load_file
+
+    def tracked(*a: Any, **kw: Any) -> Any:
+        r = orig(*a, **kw)
+        total[0] += len(r)
+        return r
+
+    _st.load_file = tracked
+    return (_st, "load_file", orig)
+
+
+def _patch_torch_load(counter: list[int], total: list[int], report) -> tuple | None:
+    """Wrap ``torch.load`` to count tensors in returned state dicts (.bin weights)."""
+    try:
+        import torch as _torch  # noqa: PLC0415
+    except ImportError:
+        return None
+    orig = _torch.load
+
+    def tracked(*a: Any, **kw: Any) -> Any:
+        r = orig(*a, **kw)
+        if isinstance(r, dict) and r:
+            sample = next(iter(r.values()))
+            if isinstance(sample, _torch.Tensor):
+                total[0] += len(r)
+        return r
+
+    _torch.load = tracked
+    return (_torch, "load", orig)
+
+
+def _patch_set_module_tensor_to_device(counter: list[int], total: list[int], report) -> tuple | None:
+    """Wrap ``set_module_tensor_to_device`` (HF low_cpu_mem_usage path)."""
+    try:
+        import transformers.modeling_utils as _tm  # noqa: PLC0415
+
+        # pyright: ignore[reportAttributeAccessIssue] — set_module_tensor_to_device
+        # is re-exported from accelerate at runtime but isn't in the transformers
+        # stubs. The AttributeError catch handles missing-attribute drift.
+        orig = _tm.set_module_tensor_to_device  # pyright: ignore[reportAttributeAccessIssue]
+    except (ImportError, AttributeError):
+        return None
+
+    def tracked(*a: Any, **kw: Any) -> Any:
+        r = orig(*a, **kw)
+        counter[0] += 1
+        report()
+        return r
+
+    _tm.set_module_tensor_to_device = tracked  # pyright: ignore[reportAttributeAccessIssue]
+    return (_tm, "set_module_tensor_to_device", orig)
+
+
+def _patch_load_state_dict(counter: list[int], total: list[int], report) -> tuple | None:
+    """Wrap ``nn.Module.load_state_dict`` (PyTorch / SentenceTransformers path)."""
+    try:
+        import torch.nn as _nn  # noqa: PLC0415
+    except ImportError:
+        return None
+    orig = _nn.Module.load_state_dict
+
+    class _CountingStateDict(dict):
+        """Dict wrapper that counts unique key accesses for progress."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._seen: set = set()
+
+        def __getitem__(self, key: Any) -> Any:
+            val = super().__getitem__(key)
+            if key not in self._seen:
+                self._seen.add(key)
+                counter[0] += 1
+                report()
+            return val
+
+    def tracked(self_model: Any, state_dict: Any, *a: Any, **kw: Any) -> Any:
+        if isinstance(state_dict, dict) and not isinstance(state_dict, _CountingStateDict):
+            if total[0] == 0:
+                total[0] = len(state_dict)
+            state_dict = _CountingStateDict(state_dict)
+        return orig(self_model, state_dict, *a, **kw)
+
+    _nn.Module.load_state_dict = tracked  # type: ignore[assignment]
+    return (_nn.Module, "load_state_dict", orig)
+
+
 @contextlib.contextmanager
-def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "Loading model weights…") -> Any:  # noqa: C901
+def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "Loading model weights…") -> Any:
     """Track tensor-level progress during model weight loading.
 
     HuggingFace ``transformers`` with ``low_cpu_mem_usage=True`` dispatches
@@ -295,106 +388,28 @@ def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "
     discovered by also intercepting ``safetensors.torch.load_file`` and
     ``torch.load`` to count keys in loaded state dicts.
     """
-    _counter = [0]
-    _total = [0]
-    _patches: list[tuple] = []
+    counter = [0]
+    total = [0]
 
-    def _report() -> None:
-        if _total[0] > 0:
-            callback("loading", label, min(_counter[0], _total[0]), _total[0])
+    def report() -> None:
+        if total[0] > 0:
+            callback("loading", label, min(counter[0], total[0]), total[0])
 
-    # --- Intercept safetensors.torch.load_file to learn total tensor count ---
-    try:
-        import safetensors.torch as _st  # noqa: PLC0415
-
-        _orig_lf = _st.load_file
-
-        def _tracked_lf(*a: Any, **kw: Any) -> Any:
-            r = _orig_lf(*a, **kw)
-            _total[0] += len(r)
-            return r
-
-        _st.load_file = _tracked_lf
-        _patches.append((_st, "load_file", _orig_lf))
-    except ImportError:
-        pass
-
-    # --- Intercept torch.load for .bin weight files ---
-    try:
-        import torch as _torch  # noqa: PLC0415
-
-        _orig_tl = _torch.load
-
-        def _tracked_tl(*a: Any, **kw: Any) -> Any:
-            r = _orig_tl(*a, **kw)
-            if isinstance(r, dict) and r:
-                sample = next(iter(r.values()))
-                if isinstance(sample, _torch.Tensor):
-                    _total[0] += len(r)
-            return r
-
-        _torch.load = _tracked_tl
-        _patches.append((_torch, "load", _orig_tl))
-    except ImportError:
-        pass
-
-    # --- Intercept set_module_tensor_to_device (HF with low_cpu_mem_usage) ---
-    try:
-        import transformers.modeling_utils as _tm  # noqa: PLC0415
-
-        # pyright: ignore[reportAttributeAccessIssue] — set_module_tensor_to_device
-        # is re-exported from accelerate at runtime but isn't in the transformers
-        # stubs. The AttributeError catch below handles missing-attribute drift.
-        _orig_smttd = _tm.set_module_tensor_to_device  # pyright: ignore[reportAttributeAccessIssue]
-
-        def _tracked_smttd(*a: Any, **kw: Any) -> Any:
-            r = _orig_smttd(*a, **kw)
-            _counter[0] += 1
-            _report()
-            return r
-
-        _tm.set_module_tensor_to_device = _tracked_smttd  # pyright: ignore[reportAttributeAccessIssue]
-        _patches.append((_tm, "set_module_tensor_to_device", _orig_smttd))
-    except (ImportError, AttributeError):
-        pass
-
-    # --- Intercept Module.load_state_dict (PyTorch / SentenceTransformers) ---
-    try:
-        import torch.nn as _nn  # noqa: PLC0415
-
-        _orig_lsd = _nn.Module.load_state_dict
-
-        class _CountingStateDict(dict):
-            """Dict wrapper that counts unique key accesses for progress."""
-
-            def __init__(self, *args: Any, **kwargs: Any) -> None:
-                super().__init__(*args, **kwargs)
-                self._seen: set = set()
-
-            def __getitem__(self, key: Any) -> Any:
-                val = super().__getitem__(key)
-                if key not in self._seen:
-                    self._seen.add(key)
-                    _counter[0] += 1
-                    _report()
-                return val
-
-        def _tracked_lsd(self_model: Any, state_dict: Any, *a: Any, **kw: Any) -> Any:
-            if isinstance(state_dict, dict) and not isinstance(state_dict, _CountingStateDict):
-                if _total[0] == 0:
-                    _total[0] = len(state_dict)
-                state_dict = _CountingStateDict(state_dict)
-            return _orig_lsd(self_model, state_dict, *a, **kw)
-
-        _nn.Module.load_state_dict = _tracked_lsd  # type: ignore[assignment]
-        _patches.append((_nn.Module, "load_state_dict", _orig_lsd))
-    except ImportError:
-        pass
+    patches: list[tuple] = []
+    for installer in (
+        _patch_safetensors_load_file,
+        _patch_torch_load,
+        _patch_set_module_tensor_to_device,
+        _patch_load_state_dict,
+    ):
+        result = installer(counter, total, report)
+        if result is not None:
+            patches.append(result)
 
     try:
         yield
     finally:
-        for obj, attr, orig in _patches:
+        for obj, attr, orig in patches:
             setattr(obj, attr, orig)
 
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -364,53 +364,34 @@ def find_label(body: dict):  # noqa: C901
     }
 
 
-@detector_scoring_bp.route("/api/auto-detect", methods=["POST"])
-@detector_scoring_bp.arguments(AutoDetectRequestSchema)
-@detector_scoring_bp.response(200, AutoDetectResponseSchema)
-@detector_scoring_bp.alt_response(
-    400,
-    description="No medias loaded, or no autorun detectors match the active media type.",
-)
-@detector_scoring_bp.alt_response(404, description="Named detector is not flagged for autorun.")
-def auto_detect(body: dict):  # noqa: C901
-    """Score the active dataset with every detector flagged for autorun.
+def _resolve_autorun_names(body: dict, media_type: str) -> list[str]:
+    """Return the autorun detector names to consider for this request.
 
-    Iterates :func:`~vtsearch.settings.get_autorun_detectors` and trains each
-    one's MLP on demand from its on-disk labelset.  Returns one result column
-    per detector. Pass ``detector_name`` to run a single autorun detector.
+    Aborts with 404 when ``detector_name`` is given but not in the autorun
+    list, and with 400 when no autorun detectors are configured at all.
     """
-    import torch  # noqa: PLC0415
-
-    from vtsearch.detectors.registry import (
-        find_by_name,
-        list_detectors,
-    )
-    from vtsearch.detectors.store import _detector_path, _read_detector
-    from vtsearch.settings import get_autorun_detectors
-
-    snap = snapshot_medias()
-    if not snap:
-        abort(400, message="No medias loaded")
-
-    media_type = next(iter(snap.values())).get("type", "audio")
+    from vtsearch.settings import get_autorun_detectors  # noqa: PLC0415
 
     autorun_names = get_autorun_detectors()
     single_name = body.get("detector_name") or ""
     if single_name:
         if single_name not in autorun_names:
             abort(404, message=f"Detector '{single_name}' not flagged for autorun")
-        autorun_names = [single_name]
-
+        return [single_name]
     if not autorun_names:
         abort(400, message=f"No autorun detectors found for media type: {media_type}")
+    return autorun_names
 
-    # Build per-name (det_data, registry entry) pairs, filtered by media type.
-    detectors_to_run: list[tuple[str, dict, dict | None]] = []
+
+def _collect_detectors_for_media_type(autorun_names: list[str], media_type: str) -> list[tuple[str, dict, dict | None]]:
+    """Load detector data + registry entry for each autorun name matching *media_type*."""
+    from vtsearch.detectors.registry import find_by_name, list_detectors  # noqa: PLC0415
+    from vtsearch.detectors.store import _detector_path, _read_detector  # noqa: PLC0415
+
+    detectors: list[tuple[str, dict, dict | None]] = []
     for name in autorun_names:
         det_data = _read_detector(_detector_path(name))
-        if det_data is None:
-            continue
-        if det_data.get("media_type", "") != media_type:
+        if det_data is None or det_data.get("media_type", "") != media_type:
             continue
         reg_entry = find_by_name(name)
         if reg_entry is None:
@@ -419,57 +400,96 @@ def auto_detect(body: dict):  # noqa: C901
                 if entry.get("name") == name:
                     reg_entry = entry
                     break
-        detectors_to_run.append((name, det_data, reg_entry))
+        detectors.append((name, det_data, reg_entry))
+    return detectors
 
+
+def _score_detector_for_auto_detect(
+    name: str,
+    det_data: dict,
+    reg_entry: dict | None,
+    media_type: str,
+    snap: dict,
+    all_ids: list[int],
+    X_all: Any,
+) -> tuple[str, dict] | None:
+    """Train (or reuse) one detector and score every media in *snap*."""
+    import torch  # noqa: PLC0415
+
+    try:
+        detector_id = reg_entry["id"] if reg_entry else name
+        mlp, threshold, _diag = _resolve_or_train_detector(
+            detector_id,
+            det_data,
+            media_type,
+            snap,
+            progress_step=1,
+            progress_total_steps=1,
+        )
+        if mlp is None:
+            return None
+
+        with torch.no_grad():
+            X_in = X_all.to(next(mlp.parameters()).device)
+            scores = torch.sigmoid(mlp(X_in)).squeeze(1).cpu().tolist()
+
+        positive_hits = []
+        negative_hits = []
+        for cid, score in zip(all_ids, scores):
+            clip_info = _media_info_for_response(snap[cid])
+            clip_info["score"] = round(score, 4)
+            if score >= threshold:
+                positive_hits.append(clip_info)
+            else:
+                negative_hits.append(clip_info)
+
+        positive_hits.sort(key=lambda x: x["score"], reverse=True)
+        negative_hits.sort(key=lambda x: x["score"], reverse=True)
+
+        return name, {
+            "detector_name": name,
+            "threshold": round(threshold, 4),
+            "total_hits": len(positive_hits),
+            "hits": positive_hits,
+            "negative_hits": negative_hits,
+        }
+    except Exception:
+        logger.exception("Auto-detect failed for detector %s", name)
+        return None
+
+
+@detector_scoring_bp.route("/api/auto-detect", methods=["POST"])
+@detector_scoring_bp.arguments(AutoDetectRequestSchema)
+@detector_scoring_bp.response(200, AutoDetectResponseSchema)
+@detector_scoring_bp.alt_response(
+    400,
+    description="No medias loaded, or no autorun detectors match the active media type.",
+)
+@detector_scoring_bp.alt_response(404, description="Named detector is not flagged for autorun.")
+def auto_detect(body: dict):
+    """Score the active dataset with every detector flagged for autorun.
+
+    Iterates :func:`~vtsearch.settings.get_autorun_detectors` and trains each
+    one's MLP on demand from its on-disk labelset.  Returns one result column
+    per detector. Pass ``detector_name`` to run a single autorun detector.
+    """
+    import torch  # noqa: PLC0415
+
+    snap = snapshot_medias()
+    if not snap:
+        abort(400, message="No medias loaded")
+
+    media_type = next(iter(snap.values())).get("type", "audio")
+
+    autorun_names = _resolve_autorun_names(body, media_type)
+    detectors_to_run = _collect_detectors_for_media_type(autorun_names, media_type)
     if not detectors_to_run:
         abort(400, message=f"No autorun detectors found for media type: {media_type}")
 
-    from vtsearch.embedding.matrix import get_embedding_matrix_for_snap
+    from vtsearch.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
 
     all_ids, all_embs = get_embedding_matrix_for_snap(snap)
     X_all = torch.from_numpy(all_embs)
-
-    def _run_single(name: str, det_data: dict, reg_entry: dict | None):
-        try:
-            detector_id = reg_entry["id"] if reg_entry else name
-            mlp, threshold, _diag = _resolve_or_train_detector(
-                detector_id,
-                det_data,
-                media_type,
-                snap,
-                progress_step=1,
-                progress_total_steps=1,
-            )
-            if mlp is None:
-                return None
-
-            with torch.no_grad():
-                X_in = X_all.to(next(mlp.parameters()).device)
-                scores = torch.sigmoid(mlp(X_in)).squeeze(1).cpu().tolist()
-
-            positive_hits = []
-            negative_hits = []
-            for cid, score in zip(all_ids, scores):
-                clip_info = _media_info_for_response(snap[cid])
-                clip_info["score"] = round(score, 4)
-                if score >= threshold:
-                    positive_hits.append(clip_info)
-                else:
-                    negative_hits.append(clip_info)
-
-            positive_hits.sort(key=lambda x: x["score"], reverse=True)
-            negative_hits.sort(key=lambda x: x["score"], reverse=True)
-
-            return name, {
-                "detector_name": name,
-                "threshold": round(threshold, 4),
-                "total_hits": len(positive_hits),
-                "hits": positive_hits,
-                "negative_hits": negative_hits,
-            }
-        except Exception:
-            logger.exception("Auto-detect failed for detector %s", name)
-            return None
 
     embed_dim = int(all_embs.shape[1]) if all_embs.ndim > 1 else 0
     worker_cap = cap_workers_by_memory(
@@ -479,7 +499,10 @@ def auto_detect(body: dict):  # noqa: C901
     )
     results: dict[str, dict] = {}
     with ThreadPoolExecutor(max_workers=worker_cap) as pool:
-        futures = [pool.submit(_run_single, name, data, entry) for name, data, entry in detectors_to_run]
+        futures = [
+            pool.submit(_score_detector_for_auto_detect, name, data, entry, media_type, snap, all_ids, X_all)
+            for name, data, entry in detectors_to_run
+        ]
         for future in futures:
             outcome = future.result()
             if outcome is not None:
@@ -487,7 +510,7 @@ def auto_detect(body: dict):  # noqa: C901
                 results[name] = result
 
     if results:
-        from vtsearch.achievements import record_find
+        from vtsearch.achievements import record_find  # noqa: PLC0415
 
         record_find(len(all_ids) * len(results))
 


### PR DESCRIPTION
## Summary

Drops the four highest McCabe-complexity hotspots in the codebase under the C901 threshold by splitting each into focused helpers. No behavior changes; the full test suite (3846 tests) still passes.

Surveyed with `ruff check --select=C901 --ignore-noqa --config 'lint.mccabe.max-complexity=0'` to see actual numbers (the 60 existing `# noqa: C901` exemptions hide real complexity from a default ruff run). Picked the targets that combined high score with a clean split:

| Function | Before | After | Approach |
|---|---|---|---|
| `_run_origin_load_in_background` (`datasets/load_pipeline.py`) | 32 | 6 | Outer fn becomes a thin coordinator |
| nested `task()` inside it | 28 | (folded into helpers) | Stages extracted, exception arms unified |
| `effective_source_specs` (`datasets/importers/base.py`) | 19 | 3 | Split multi_media vs legacy paths |
| `intercept_weight_loading_progress` (`media/embedder.py`) | 19 | 6 | One installer fn per monkey-patched library |
| `auto_detect` (`routes/detectors/scoring.py`) | 20 | 6 | Lift `_run_single`, extract discovery helpers |

### `datasets/load_pipeline.py`

The inner `task()` did gate management, importer execution, six post-load stages, and four separate exception arms. Extracted:

- `_LoadGateController` — encapsulates `acquire_download` / `swap_to_embed` / `release` plus the held-gate bookkeeping that used to be a dict mutated by three nested closures.
- `_make_stepped_progress`, `_run_importer`, `_tag_origins`, `_apply_clipper_stage`, `_collapse_duplicates_stage`, `_build_diversity_tree_stage`, `_register_and_migrate`, `_warmup_embedder_stage` — one helper per phase, each with its own progress callback inlined.
- `_handle_load_failure` — type-dispatches on `CancelledError` / `ImportError` / `MemoryError` / `Exception` into a single exit path. `CancelledError` already subclasses `Exception`, so a single catch is equivalent.

### `datasets/importers/base.py`

`effective_source_specs` had two disjoint branches (`if self.multi_media`). Split into `_parse_multi_media_specs` + `_parse_legacy_specs`, with a small `_validate_spec_converter` helper for the per-spec converter checks. The public method is now four lines.

### `media/embedder.py`

`intercept_weight_loading_progress` monkey-patched four independent libraries (safetensors, torch.load, accelerate, torch.nn.Module) in one context manager. Each patch is now its own `_patch_*` installer that returns the `(obj, attr, orig)` restore tuple or `None`. The context manager iterates the installers and composes the restore list.

### `routes/detectors/scoring.py`

`auto_detect` had a nested `_run_single` closure doing all the heavy lifting. Lifted to module scope as `_score_detector_for_auto_detect` (closes over nothing — gets `X_all`, `all_ids`, `snap`, `media_type` as args). Discovery split into `_resolve_autorun_names` (handles the body filter + 404/400 aborts) and `_collect_detectors_for_media_type`.

## Test plan

- [x] `./run-tests.sh` — 3846 passed, 1 skipped, 2 xpassed; ruff/codespell/deptry pass.
- [x] Verified each refactored function now scores ≤ 8 under `ruff --select=C901 --ignore-noqa`.
- [x] Manually traced the load-pipeline gate handoff (download → embed swap on first `"embedding"` status, single release in `finally`) to confirm behavioral parity.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw93yMWbJD5Au9Z74Q2TLq)_