### PR TITLE
extract-library Phase 3: drop proxy view from library code

### DIFF
--- a/docs/plans/extract-library.md
+++ b/docs/plans/extract-library.md
@@ -1,6 +1,6 @@
 # Extract `vtscore` Library Plan
 
-Status: **Phases 0–2 functionally shipped** — public API surface captured in [`docs/vtscore-api.md`](../vtscore-api.md). Every library-candidate package is Flask-free *and* settings-free, including `vtsearch/config.py` itself: Phase 8's bridge relocation moved the body of `CoreConfig.from_settings()` into `vtsearch/shim/` (`build_core_config()`), wired via a new `register_core_config_builder()` hook. The classmethod is preserved as the public entry point for library-candidate callers. Phase 3 (global-state seam) is next. Phase 5's entry-point hook landed ahead of the split.
+Status: **Phases 0–3 functionally shipped** — public API surface captured in [`docs/vtscore-api.md`](../vtscore-api.md). Every library-candidate package is Flask-free, settings-free, *and* proxy-free: the module-level proxy view (`medias`, `good_votes`, etc.) now lives in `vtsearch/shim/state_proxies.py` and is re-exported by `vtsearch.state.__init__` for app callers. Library code resolves the active `DatasetContext` / `DetectorContext` explicitly via `get_active_*_context()`. Phase 8's bridge relocation moved the body of `CoreConfig.from_settings()` into `vtsearch/shim/` (`build_core_config()`), wired via `register_core_config_builder()`. Phase 4 (filesystem seam) is next. Phase 5's entry-point hook landed ahead of the split.
 
 Goal: split VTSearch into two distributions in one repo:
 
@@ -71,11 +71,11 @@ Approach:
 
 Currently `medias`, `good_votes`, `label_history`, etc. are module-level proxies. Library consumers should be able to pass `DatasetContext`/`DetectorContext` explicitly.
 
-- [ ] Audit every public library function and ensure it accepts a context object as a parameter (most already do via the proxy delegation; some implicitly read globals — make those explicit).
-- [ ] Keep the proxy module in the *app* layer, not the library. The library exports the context classes; the app exports the proxies that delegate to them via Flask `g` / thread-local.
+- [x] Audit every public library function and ensure it accepts a context object as a parameter. The state submodules (`vtsearch/state/votes.py`, `clicks.py`, `media_lookup.py`, `diversity.py`) and `vtsearch/labels/sync.py` now resolve the active context internally via `get_active_*_context()` and operate on `ctx.attr` instead of importing the module-level proxy names — the dependency on "the active context" is explicit in each function body.
+- [x] Keep the proxy module in the *app* layer, not the library. The proxy classes (`_ProxyDict`, `_ProxyList`) and module-level instances (`medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `vote_region_boxes`, `last_learned_scores`, `textsort_suggestions`) now live in `vtsearch/shim/state_proxies.py`. `vtsearch/state/__init__.py` re-exports them so `from vtsearch.state import medias` still works for routes/tests; the library subpackage submodules never import them.
 - [x] Move `autorun_extractors`, `autorun_localizers` off the library-candidate `vtsearch/state/` package onto an app-side singleton (`vtsearch/autorun_processors.py`). The dicts + CRUD now live in a single file outside `state/`; `state/processors.py` is gone, and `state/__init__.py` no longer re-exports any autorun names. Route + test imports were updated to point at the new module. `autorun_detectors` is already an app-side server-tier setting in `vtsearch/settings.py`, so the relocation is complete.
 
-**Exit criteria**: `grep -n "^medias\|^good_votes" vtscore-candidate-paths/` returns zero hits — those names exist only in the app shim.
+**Exit criteria** ✅ — `grep -rn "^medias\|^good_votes\|^_ProxyDict\|^_ProxyList" vtsearch/{datasets,detectors,embedding,training,media,converters,exporters,labels,eval,plugins,concurrency,state,sync,utils,security}` returns zero hits as of this commit. The only file that defines or instantiates the proxy names is `vtsearch/shim/state_proxies.py` (app-side).
 
 ## Phase 4 — Cut the filesystem seam
 
@@ -117,7 +117,7 @@ Once Phases 1–7 are green and behaviour-identical:
 
 1. Create `vtscore/` directory at repo root.
 2. `git mv` library subpackages into it: `datasets/`, `embedding/`, `detectors/`, `training/`, `media/`, `converters/`, `exporters/`, `labels/`, `eval/`, `plugins/`, `concurrency/`, `state/`, `sync/`, `security/`, plus `cli.py`, `cli_pipeline.py`, `cli_progress.py`, `config.py`, and the relevant `utils/` modules. (`processors/` does not exist as a top-level package today — processor *plugins* are reached via `vtsearch.media.processors` and per-route handlers; verify the move target before Phase 8.)
-3. Search-and-replace `vtsearch.datasets` → `vtscore.datasets` etc., across the codebase.
+3. Search-and-replace `vtsearch.datasets` → `vtscore.datasets` etc., across the codebase. Note: the existing `vtsearch/state/__init__.py` is **app-tier** (it re-exports the proxy view from `vtsearch.shim.state_proxies` and hosts the settings-persistence hooks). When `state/` moves to `vtscore/state/`, leave the library submodules (`core.py`, `votes.py`, `clicks.py`, `media_lookup.py`, `diversity.py`, `diversity_tree.py`) under `vtscore/state/` and keep a thin `vtsearch/state/__init__.py` shim that re-exports the library names alongside the proxies — that file becomes pure app-tier glue.
 4. Add `vtscore/pyproject.toml` and `pyproject.toml` workspace config so both distributions build.
 5. App imports become `from vtscore.X import ...`.
 6. Run full suite. Fix straggler imports.
@@ -199,12 +199,12 @@ Phases 1 → 4 are independent and can land in parallel PRs. Phase 5 depends on 
 
 ## Open follow-ups (what's left)
 
-Phase 2 is functionally done. Picking up from here, ordered smallest-first:
+Phase 3 is functionally done. Picking up from here, ordered smallest-first:
 
 1. ~~Phase 0 inventory doc, Phase 1 (Flask seam), Phase 2 (settings seam).~~ **All shipped.** See the per-phase status blocks above.
 2. ~~**Phase 3, easy bit: relocate `autorun_extractors` / `autorun_localizers`.**~~ **Shipped.** Moved to the new app-side singleton `vtsearch/autorun_processors.py` (dicts + CRUD); `state/processors.py` deleted; `state/core.py` and `state/__init__.py` no longer reference the autorun names. Route + test imports updated.
-3. **Phase 3, audit: explicit context parameters.** Walk every public library function. The ones that read `medias` / `good_votes` / etc. via the proxies need to accept `DatasetContext` / `DetectorContext` as a parameter (or pull it from a passed-in context). Most already do via the proxy delegation; the goal is to make the dependency *explicit* so the library doesn't depend on the magic module-level names.
-4. **Phase 3, finish: move the proxies to the app layer.** Once #2 and #3 are done, the proxies (`medias`, `good_votes`, the dict/list facades) move out of `vtsearch.state.core` into a new app-side module (e.g. `vtsearch/state_proxies.py` or part of `vtsearch/shim/`) and re-export under the existing `vtsearch.state` names. The library exports the `*Context` classes; the app stitches them into the proxy view route code expects.
+3. ~~**Phase 3, audit: explicit context parameters.**~~ **Shipped.** The state submodules (`vtsearch/state/votes.py`, `clicks.py`, `media_lookup.py`, `diversity.py`) and `vtsearch/labels/sync.py` now resolve the active context internally via `get_active_*_context()` and operate on `ctx.attr` directly — no library-candidate code imports the module-level proxy names anymore.
+4. ~~**Phase 3, finish: move the proxies to the app layer.**~~ **Shipped.** Proxy classes (`_ProxyDict`, `_ProxyList`) and instances (`medias`, `good_votes`, …) moved out of `vtsearch/state/core.py` into `vtsearch/shim/state_proxies.py`. `vtsearch/state/__init__.py` re-exports them so app-tier imports (`from vtsearch.state import medias`) keep working. Test imports that reached into `state.core` for proxies were updated to use `vtsearch.state` or `vtsearch.shim.state_proxies`.
 5. **Phase 4, filesystem seam.** All `data/` references move through `CoreConfig.data_dir`. Most are already there via `vtsearch.config.DATA_DIR`; the audit is small (`grep -rn '"data/' vtsearch/`).
 6. ~~**Phase 8 bridge relocation.**~~ **Shipped.** The body of `CoreConfig.from_settings()` moved out of `vtsearch/config.py` into `vtsearch/shim/__init__.py:build_core_config()`. The classmethod is now a thin wrapper that delegates to whatever the app installed via `vtsearch.config.register_core_config_builder()`; `vtsearch/shim/register_app_config_builder()` is the app-side wiring (called from `app.py` startup alongside the other shim hooks). Library-only consumers without an app skip `from_settings()` entirely and construct `CoreConfig` directly — they get a clear `RuntimeError` if they try otherwise. `vtsearch/config.py` no longer imports `vtsearch.settings`.
 

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -7,10 +7,10 @@ import numpy as np
 
 from tests import load_detector_and_wait as _load_detector_and_wait
 
+from vtsearch.shim.state_proxies import _ProxyDict
 from vtsearch.state.core import (
     DatasetContext,
     DetectorContext,
-    _ProxyDict,
     get_context,
     get_thread_dataset_context,
     list_loaded_dataset_ids,
@@ -110,7 +110,7 @@ class TestProxyDict:
     """_ProxyDict delegates to the active context."""
 
     def test_proxy_dict_reflects_active_context(self):
-        from vtsearch.state.core import medias
+        from vtsearch.state import medias
 
         # The reset_state fixture creates _test_default with test medias.
         # Create a second context and switch.
@@ -129,7 +129,7 @@ class TestProxyDict:
         assert len(medias) > 0  # test medias
 
     def test_proxy_dict_clear(self):
-        from vtsearch.state.core import good_votes
+        from vtsearch.state import good_votes
 
         good_votes[1] = None
         assert 1 in good_votes
@@ -137,21 +137,21 @@ class TestProxyDict:
         assert len(good_votes) == 0
 
     def test_proxy_dict_pop(self):
-        from vtsearch.state.core import bad_votes
+        from vtsearch.state import bad_votes
 
         bad_votes[5] = None
         assert bad_votes.pop(5, "missing") is None
         assert bad_votes.pop(5, "missing") == "missing"
 
     def test_proxy_dict_update(self):
-        from vtsearch.state.core import last_learned_scores
+        from vtsearch.state import last_learned_scores
 
         last_learned_scores.update({1: 0.5, 2: 0.8})
         assert last_learned_scores[1] == 0.5
         assert last_learned_scores[2] == 0.8
 
     def test_proxy_dict_copy(self):
-        from vtsearch.state.core import good_votes
+        from vtsearch.state import good_votes
 
         good_votes[10] = None
         c = good_votes.copy()
@@ -160,7 +160,7 @@ class TestProxyDict:
         assert 10 in c
 
     def test_proxy_dict_items_values_keys(self):
-        from vtsearch.state.core import good_votes
+        from vtsearch.state import good_votes
 
         good_votes[1] = None
         good_votes[2] = None
@@ -169,12 +169,12 @@ class TestProxyDict:
         assert set(dict(good_votes.items()).keys()) == {1, 2}
 
     def test_proxy_dict_is_dict_instance(self):
-        from vtsearch.state.core import medias
+        from vtsearch.state import medias
 
         assert isinstance(medias, dict)
 
     def test_proxy_dict_bool(self):
-        from vtsearch.state.core import last_learned_scores
+        from vtsearch.state import last_learned_scores
 
         last_learned_scores.clear()
         assert not last_learned_scores
@@ -186,7 +186,7 @@ class TestProxyList:
     """_ProxyList delegates to the active context."""
 
     def test_proxy_list_append_and_iter(self):
-        from vtsearch.state.core import textsort_suggestions
+        from vtsearch.state import textsort_suggestions
 
         textsort_suggestions.clear()
         textsort_suggestions.append("hello")
@@ -194,7 +194,7 @@ class TestProxyList:
         assert list(textsort_suggestions) == ["hello", "world"]
 
     def test_proxy_list_clear(self):
-        from vtsearch.state.core import label_history
+        from vtsearch.state import label_history
 
         label_history.append((1, "good", 0.0))
         assert len(label_history) > 0
@@ -202,12 +202,12 @@ class TestProxyList:
         assert len(label_history) == 0
 
     def test_proxy_list_is_list_instance(self):
-        from vtsearch.state.core import label_history
+        from vtsearch.state import label_history
 
         assert isinstance(label_history, list)
 
     def test_proxy_list_remove(self):
-        from vtsearch.state.core import textsort_suggestions
+        from vtsearch.state import textsort_suggestions
 
         textsort_suggestions.clear()
         textsort_suggestions.append("a")
@@ -566,14 +566,14 @@ class TestEmptyContextFallback:
     """When no context is active, proxies behave as empty containers."""
 
     def test_empty_medias_when_no_dataset(self):
-        from vtsearch.state.core import medias
+        from vtsearch.state import medias
 
         set_thread_dataset_context(None)
         assert len(medias) == 0
         assert list(medias.keys()) == []
 
     def test_empty_votes_when_no_detector(self):
-        from vtsearch.state.core import good_votes, bad_votes
+        from vtsearch.state import good_votes, bad_votes
 
         set_thread_detector_context(None)
         assert len(good_votes) == 0

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -7,6 +7,7 @@ dataset/model a request operates on, without mutating global "active" state.
 
 import numpy as np
 
+from vtsearch.state import bad_votes, good_votes, medias
 from vtsearch.state.core import (
     DatasetContext,
     DetectorContext,
@@ -19,9 +20,6 @@ from vtsearch.state.core import (
     register_detector_context,
     set_thread_dataset_context,
     set_thread_detector_context,
-    medias,
-    good_votes,
-    bad_votes,
 )
 
 

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1299,7 +1299,7 @@ class TestRegionAwareTraining:
         succeed by md5.  Conftest's ``reset_state`` wipes this between
         tests so there's no cross-test bleed.
         """
-        from vtsearch.state.core import medias
+        from vtsearch.state import medias
 
         media = self._media_with_patch_grid(grid_value, cid=cid)
         medias[cid] = media

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -627,7 +627,7 @@ class TestLabelsetSync:
             set_thread_detector_context,
             unregister_detector_context,
         )
-        from vtsearch.state.core import medias, good_votes
+        from vtsearch.state import medias, good_votes
 
         # Create and register a detector context with a labelset source
         ctx = DetectorContext("test_sync", name="test_sync")
@@ -671,7 +671,7 @@ class TestLabelsetSync:
             set_thread_detector_context,
             unregister_detector_context,
         )
-        from vtsearch.state.core import medias, good_votes
+        from vtsearch.state import medias, good_votes
 
         # Create a labels file with an md5 that matches a test media
         # Get an existing media's md5
@@ -715,7 +715,7 @@ class TestLabelsetSync:
             set_thread_detector_context,
             unregister_detector_context,
         )
-        from vtsearch.state.core import medias, good_votes
+        from vtsearch.state import medias, good_votes
 
         det_name = "meta_export"
         det_path = _detector_path(det_name)
@@ -778,7 +778,7 @@ class TestLabelsetSync:
             set_thread_detector_context,
             unregister_detector_context,
         )
-        from vtsearch.state.core import medias, good_votes
+        from vtsearch.state import medias, good_votes
 
         det_name = "meta_no_model"
         det_path = _detector_path(det_name)

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -53,7 +53,7 @@ def sync_to_labelset_source() -> None:
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.detectors.input_spec import build_detector_meta
     from vtsearch.detectors.store import _detector_path, _read_detector
-    from vtsearch.state.core import good_votes, bad_votes, medias, vote_region_boxes
+    from vtsearch.state.core import get_active_context
 
     # Read the detector JSON so the exported labelset can carry its
     # input_spec / media_type alongside the in-memory threshold.  Anything
@@ -69,11 +69,12 @@ def sync_to_labelset_source() -> None:
         if _syncing:
             return
         try:
+            ds_ctx = get_active_context()
             labelset = LabelSet.from_clips_and_votes(
-                dict(medias),
-                dict(good_votes),
-                dict(bad_votes),
-                vote_region_boxes=dict(vote_region_boxes),
+                dict(ds_ctx.medias),
+                dict(ctx.good_votes),
+                dict(ctx.bad_votes),
+                vote_region_boxes=dict(ctx.vote_region_boxes),
                 detector_meta=detector_meta or None,
             )
             source.save(labelset, field_values)
@@ -151,8 +152,10 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
     with _sync_lock:
         _syncing = True
         try:
+            from vtsearch.state.core import get_active_context
             from vtsearch.state.votes import apply_label
 
+            ds_medias = get_active_context().medias
             for entry in labels:
                 label = entry.get("label")
                 md5 = entry.get("md5")
@@ -160,9 +163,7 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
                     continue
 
                 # Find media by md5
-                from vtsearch.state.core import medias
-
-                for mid, media in medias.items():
+                for mid, media in ds_medias.items():
                     if media.get("md5") == md5:
                         apply_label(mid, label)
                         applied_any = True

--- a/vtsearch/shim/state_proxies.py
+++ b/vtsearch/shim/state_proxies.py
@@ -1,0 +1,264 @@
+"""App-side proxy view over the library's ``DatasetContext`` / ``DetectorContext``.
+
+Many app-layer call sites (Flask routes, app-tier tests) like to import
+``medias``, ``good_votes``, etc. as module-level dict/list names and treat
+them as the "current" container.  The library does not depend on those
+names — its functions resolve the active context explicitly — but the app
+keeps them as a convenience facade so existing code reads naturally.
+
+These proxies live on the app side of the future ``vtscore`` / ``vtsearch``
+split (see Phase 3 of ``docs/plans/extract-library.md``).  ``vtsearch.state``
+re-exports them under their original names so ``from vtsearch.state import
+medias`` keeps working; the library subpackage ``vtsearch.state`` itself
+never imports the proxy classes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from vtsearch.state.core import get_active_context, get_active_detector_context
+
+
+class _ProxyDict(dict):
+    """Dict-like proxy that forwards all operations to a target dict.
+
+    The *target_attr* names the attribute on the active context that holds
+    the real dict.  The *context_fn* is called to find that context.
+    Every method fetches the target lazily so switching contexts is instant.
+
+    Inherits from ``dict`` so that ``isinstance(medias, dict)`` is ``True``
+    and existing code that type-checks works.
+    """
+
+    def __init__(self, target_attr: str, context_fn: Callable[[], Any] | None = None) -> None:
+        # Do NOT call super().__init__() with data — we are a proxy, not a
+        # real container.  The empty super().__init__() satisfies the dict
+        # constructor without storing anything in our own hash table.
+        super().__init__()
+        object.__setattr__(self, "_target_attr", target_attr)
+        object.__setattr__(self, "_context_fn", context_fn or get_active_context)
+
+    def _target(self) -> dict:
+        ctx_fn = object.__getattribute__(self, "_context_fn")
+        return getattr(ctx_fn(), object.__getattribute__(self, "_target_attr"))
+
+    # -- Core dict methods, all forwarded -----------------------------------
+
+    def __getitem__(self, key):
+        return self._target().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        self._target().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self._target().__delitem__(key)
+
+    def __contains__(self, key):
+        return self._target().__contains__(key)
+
+    def __iter__(self):
+        # Snapshot keys so `for k in proxy` is safe against concurrent
+        # mutation of the underlying dict by another thread.
+        return iter(list(self._target()))
+
+    def __len__(self):
+        return self._target().__len__()
+
+    def __repr__(self):
+        return f"_ProxyDict({object.__getattribute__(self, '_target_attr')!r}, {self._target()!r})"
+
+    def __eq__(self, other):
+        return self._target().__eq__(other)
+
+    def __ne__(self, other):
+        return self._target().__ne__(other)
+
+    def __bool__(self):
+        return bool(self._target())
+
+    def get(self, key, default=None):
+        return self._target().get(key, default)
+
+    def keys(self):
+        return self._target().keys()
+
+    def values(self):
+        return self._target().values()
+
+    def items(self):
+        return self._target().items()
+
+    def pop(self, *args):
+        return self._target().pop(*args)
+
+    def setdefault(self, key, default=None):
+        return self._target().setdefault(key, default)
+
+    def update(self, *args, **kwargs):
+        return self._target().update(*args, **kwargs)
+
+    def clear(self):
+        return self._target().clear()
+
+    def copy(self):
+        return self._target().copy()
+
+    def __or__(self, other):
+        return self._target().__or__(other)
+
+    def __ior__(self, other):
+        target = self._target()
+        target.__ior__(other)
+        return self
+
+    def __reversed__(self):
+        # Snapshot to avoid RuntimeError under concurrent mutation.
+        return reversed(list(self._target()))
+
+
+class _ProxyList(list):
+    """List-like proxy forwarding to the active context's list attribute."""
+
+    def __init__(self, target_attr: str, context_fn: Callable[[], Any] | None = None) -> None:
+        super().__init__()
+        object.__setattr__(self, "_target_attr", target_attr)
+        object.__setattr__(self, "_context_fn", context_fn or get_active_context)
+
+    def _target(self) -> list:
+        ctx_fn = object.__getattribute__(self, "_context_fn")
+        return getattr(ctx_fn(), object.__getattribute__(self, "_target_attr"))
+
+    def __getitem__(self, index):
+        return self._target().__getitem__(index)
+
+    def __setitem__(self, index, value):
+        self._target().__setitem__(index, value)
+
+    def __delitem__(self, index):
+        self._target().__delitem__(index)
+
+    def __contains__(self, item):
+        return self._target().__contains__(item)
+
+    def __iter__(self):
+        # Snapshot elements so iteration is safe against concurrent mutation.
+        return iter(list(self._target()))
+
+    def __len__(self):
+        return self._target().__len__()
+
+    def __repr__(self):
+        return f"_ProxyList({object.__getattribute__(self, '_target_attr')!r}, {self._target()!r})"
+
+    def __eq__(self, other):
+        return self._target().__eq__(other)
+
+    def __bool__(self):
+        return bool(self._target())
+
+    def __add__(self, other):
+        return self._target().__add__(other)
+
+    def __iadd__(self, other):
+        target = self._target()
+        target.__iadd__(other)
+        return self
+
+    def append(self, item):
+        return self._target().append(item)
+
+    def extend(self, items):
+        return self._target().extend(items)
+
+    def insert(self, index, item):
+        return self._target().insert(index, item)
+
+    def remove(self, item):
+        return self._target().remove(item)
+
+    def pop(self, *args):
+        return self._target().pop(*args)
+
+    def clear(self):
+        return self._target().clear()
+
+    def copy(self):
+        return self._target().copy()
+
+    def index(self, value, *args):
+        return self._target().index(value, *args)
+
+    def count(self, value):
+        return self._target().count(value)
+
+    def sort(self, **kwargs):
+        return self._target().sort(**kwargs)
+
+    def reverse(self):
+        return self._target().reverse()
+
+
+# ---------------------------------------------------------------------------
+# Module-level proxy instances — re-exported by ``vtsearch.state`` so app
+# call sites can write ``from vtsearch.state import medias`` and treat
+# ``medias`` like a normal dict that always points at the current request's
+# active dataset.
+#
+# ``medias`` delegates to the active DatasetContext (dataset-intrinsic).
+# All vote/label proxies delegate to the active DetectorContext.
+# ---------------------------------------------------------------------------
+
+# Clips storage: id -> {id, type, duration, file_size, embedding, media_bytes, ...}
+medias: dict[int, dict[str, Any]] = _ProxyDict("medias")  # type: ignore[assignment]
+
+# Voting storage (OrderedDict behavior via dict in Python 3.7+)
+good_votes: dict[int, None] = _ProxyDict("good_votes", get_active_detector_context)  # type: ignore[assignment]
+bad_votes: dict[int, None] = _ProxyDict("bad_votes", get_active_detector_context)  # type: ignore[assignment]
+
+# Combined label history: [(media_id, label, timestamp), ...]
+label_history: list[tuple[int, str, float]] = _ProxyList(  # type: ignore[assignment]
+    "label_history",
+    get_active_detector_context,
+)
+
+# Click-time tracking: media_id -> click order (1-indexed).
+vote_click_times: dict[int, int] = _ProxyDict(  # type: ignore[assignment]
+    "vote_click_times",
+    get_active_detector_context,
+)
+
+# Per-good-vote region boxes: media_id -> (x0, y0, x1, y1) in normalised image
+# coords.  Only populated when the user drew a region as part of a yes-vote;
+# absent for image-level yes-votes and for every no-vote.  Patch-embedder v2.
+vote_region_boxes: dict[int, tuple[float, float, float, float]] = _ProxyDict(  # type: ignore[assignment]
+    "vote_region_boxes",
+    get_active_detector_context,
+)
+
+# Last learned-sort scores: media_id -> score (float in [0, 1]).
+last_learned_scores: dict[int, float] = _ProxyDict(  # type: ignore[assignment]
+    "last_learned_scores",
+    get_active_detector_context,
+)
+
+# Text-sort suggestions: text queries that received a Good vote, most recent last.
+textsort_suggestions: list[str] = _ProxyList(  # type: ignore[assignment]
+    "textsort_suggestions",
+    get_active_detector_context,
+)
+
+
+__all__ = [
+    "_ProxyDict",
+    "_ProxyList",
+    "bad_votes",
+    "good_votes",
+    "label_history",
+    "last_learned_scores",
+    "medias",
+    "textsort_suggestions",
+    "vote_click_times",
+    "vote_region_boxes",
+]

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -1,12 +1,15 @@
 """Global state management for medias and votes.
 
-This module is a re-export facade.  The actual state variables live in
-``state_core``, and the functions are split across ``state_votes``,
-``state_clicks``, ``state_diversity``, and ``state_media_lookup``.
-Remaining functions (clear_medias, clear_all, settings wrappers) live here.
+This module is a re-export facade.  The actual context classes and
+resolvers live in :mod:`vtsearch.state.core`, helper functions are split
+across the other ``state.*`` submodules, and the app-tier proxy
+instances (``medias``, ``good_votes``, …) live in
+:mod:`vtsearch.shim.state_proxies` — they are re-exported here so
+``from vtsearch.state import medias`` continues to work for the app
+layer.  See Phase 3 of ``docs/plans/extract-library.md``.
 
-All public names are importable from ``vtsearch.state`` exactly
-as before, so no call-sites need to change.
+All public names are importable from ``vtsearch.state`` exactly as
+before, so no call-sites need to change.
 """
 
 from __future__ import annotations
@@ -15,9 +18,10 @@ import gc
 from collections.abc import Callable
 from typing import Any
 
-# Re-export all state variables from state_core --------------------------
-from vtsearch.state.core import (  # noqa: F401
-    _state_lock,
+# Re-export the lock + per-context proxy instances.  The lock is library
+# code; the proxies are app-tier glue that lives in ``vtsearch.shim``.
+from vtsearch.state.core import _state_lock  # noqa: F401
+from vtsearch.shim.state_proxies import (  # noqa: F401
     bad_votes,
     good_votes,
     label_history,
@@ -112,7 +116,7 @@ from vtsearch.state.media_lookup import (  # noqa: F401
 
 
 def snapshot_medias() -> dict[int, dict[str, Any]]:
-    """Return a shallow copy of the medias dict, safe for iteration.
+    """Return a shallow copy of the active dataset's medias dict.
 
     Use this instead of accessing ``medias`` directly when you need to
     iterate over medias or access multiple entries.  The snapshot is
@@ -121,38 +125,38 @@ def snapshot_medias() -> dict[int, dict[str, Any]]:
     and ``medias[cid]``).
     """
     with _state_lock:
-        return dict(medias)
+        return dict(_core.get_active_context().medias)
 
 
 def get_media(media_id: int) -> dict[str, Any] | None:
-    """Return a single media entry by ID, or ``None`` if not loaded.
+    """Return a single media entry by ID from the active dataset, or ``None``.
 
     Thread-safe: holds ``_state_lock`` for the duration of the lookup.
     """
     with _state_lock:
-        return medias.get(media_id)
+        return _core.get_active_context().medias.get(media_id)
 
 
 def clear_medias() -> None:
-    """Clear all loaded medias from memory.
+    """Clear all loaded medias from the active dataset's context.
 
-    Removes all entries from the ``medias`` dict in place. Does not affect
-    votes or label history. Also clears the progress model cache since
-    cached models reference media embeddings.  Also clears the diversity tree
-    and the dataset display name override.
+    Removes all entries from the active dataset's medias dict in place.
+    Does not affect votes or label history. Also clears the progress model
+    cache since cached models reference media embeddings.  Also clears the
+    diversity tree and the dataset display name override.
     """
     from vtsearch.detectors.labeling_progress import clear_progress_cache
 
     with _state_lock:
-        medias.clear()
+        ctx = _core.get_active_context()
+        ctx.medias.clear()
         # Drop the cached embedding matrix so its RAM is released along with
         # the medias dict.  Lazy rebuild on next access would also handle it,
         # but releasing now is the friendly thing to do.
-        ctx = _core.get_active_context()
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
-        _core._set_diversity_tree(None)
-        _core._set_dataset_display_name(None)
+        ctx.diversity_tree = None
+        ctx.dataset_display_name = None
         clear_progress_cache()
     gc.collect()
 

--- a/vtsearch/state/clicks.py
+++ b/vtsearch/state/clicks.py
@@ -1,33 +1,35 @@
-"""Click-time tracking for vote ordering."""
+"""Click-time tracking for vote ordering.
+
+Operates on the active :class:`DetectorContext` (resolved per call) so the
+library has no implicit dependency on the app-side proxy view.  See Phase 3
+of ``docs/plans/extract-library.md``.
+"""
 
 from __future__ import annotations
 
-from vtsearch.state.core import _state_lock, vote_click_times
-
-# Import context-aware accessors for scalar state.
-from vtsearch.state.core import _get_click_counter, _set_click_counter
+from vtsearch.state.core import _state_lock, get_active_detector_context
 
 
 def assign_click_time(media_id: int) -> int:
     """Assign the next click-time ordinal to a media and return it.
 
-    Each call increments the global counter so click-times are unique and
-    monotonically increasing.
+    Each call increments the active detector's counter so click-times are
+    unique and monotonically increasing within that detector's session.
     """
     with _state_lock:
-        new_val = _get_click_counter() + 1
-        _set_click_counter(new_val)
-        vote_click_times[media_id] = new_val
-        return new_val
+        ctx = get_active_detector_context()
+        ctx.click_counter += 1
+        ctx.vote_click_times[media_id] = ctx.click_counter
+        return ctx.click_counter
 
 
 def remove_click_time(media_id: int) -> None:
     """Remove the click-time entry for a media (e.g. when unlabelling)."""
     with _state_lock:
-        vote_click_times.pop(media_id, None)
+        get_active_detector_context().vote_click_times.pop(media_id, None)
 
 
 def get_vote_click_times() -> dict[int, int]:
     """Return a copy of the click-time mapping."""
     with _state_lock:
-        return vote_click_times.copy()
+        return get_active_detector_context().vote_click_times.copy()

--- a/vtsearch/state/core.py
+++ b/vtsearch/state/core.py
@@ -1,23 +1,25 @@
-"""Core state variables and lock shared by all state submodules.
+"""Core state types and lock shared by all state submodules.
 
-This module defines the mutable global state and the reentrant lock that
-protects it.  All other ``state_*.py`` submodules import variables from
-here rather than defining their own.
+Defines the per-dataset and per-detector context classes
+(:class:`DatasetContext`, :class:`DetectorContext`), the resolution
+functions that find the "active" context for the current request /
+thread, and the reentrant lock that protects all mutable state.
 
 Multi-dataset support
 ---------------------
-Per-dataset state is bundled in ``DatasetContext`` objects.  A context store
-(``_contexts``) maps dataset IDs to their contexts, and ``_active_dataset_id``
-tracks which one the UI is currently interacting with.
+Per-dataset state is bundled in :class:`DatasetContext` objects.  Per-
+detector state lives in :class:`DetectorContext`.  Context stores map
+each ID to its context, and per-request / thread-local resolvers determine
+which one library helpers operate on.
 
-The module-level names ``medias``, ``good_votes``, ``bad_votes``, etc. are
-**proxy objects** that transparently delegate to the active context's
-underlying data structure.  This means all existing code that imports
-these names continues to work without modification — reads and writes go
-through to the active dataset's state.
-
-When no context is active the proxies behave as empty containers (reads
-return nothing, writes are silently discarded or raise where appropriate).
+The app-side facade
+-------------------
+Module-level convenience names (``medias``, ``good_votes``, …) used to
+live here as proxy objects, but they belong to the app layer — the
+library never imports them.  They now live in
+:mod:`vtsearch.shim.state_proxies` and are re-exported from
+:mod:`vtsearch.state` so existing app-tier imports continue to work.
+See Phase 3 of ``docs/plans/extract-library.md``.
 """
 
 from __future__ import annotations
@@ -433,234 +435,13 @@ def clear_all_detector_contexts() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Proxy classes — delegate to the active context's underlying container
-# ---------------------------------------------------------------------------
-
-
-class _ProxyDict(dict):
-    """Dict-like proxy that forwards all operations to a target dict.
-
-    The *target_attr* names the attribute on the active context that holds
-    the real dict.  The *context_fn* is called to find that context.
-    Every method fetches the target lazily so switching contexts is instant.
-
-    Inherits from ``dict`` so that ``isinstance(medias, dict)`` is ``True``
-    and existing code that type-checks works.
-    """
-
-    def __init__(self, target_attr: str, context_fn=None) -> None:
-        # Do NOT call super().__init__() with data — we are a proxy, not a
-        # real container.  The empty super().__init__() satisfies the dict
-        # constructor without storing anything in our own hash table.
-        super().__init__()
-        object.__setattr__(self, "_target_attr", target_attr)
-        object.__setattr__(self, "_context_fn", context_fn or get_active_context)
-
-    def _target(self) -> dict:
-        ctx_fn = object.__getattribute__(self, "_context_fn")
-        return getattr(ctx_fn(), object.__getattribute__(self, "_target_attr"))
-
-    # -- Core dict methods, all forwarded -----------------------------------
-
-    def __getitem__(self, key):
-        return self._target().__getitem__(key)
-
-    def __setitem__(self, key, value):
-        self._target().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        self._target().__delitem__(key)
-
-    def __contains__(self, key):
-        return self._target().__contains__(key)
-
-    def __iter__(self):
-        # Snapshot keys so `for k in proxy` is safe against concurrent
-        # mutation of the underlying dict by another thread.
-        return iter(list(self._target()))
-
-    def __len__(self):
-        return self._target().__len__()
-
-    def __repr__(self):
-        return f"_ProxyDict({object.__getattribute__(self, '_target_attr')!r}, {self._target()!r})"
-
-    def __eq__(self, other):
-        return self._target().__eq__(other)
-
-    def __ne__(self, other):
-        return self._target().__ne__(other)
-
-    def __bool__(self):
-        return bool(self._target())
-
-    def get(self, key, default=None):
-        return self._target().get(key, default)
-
-    def keys(self):
-        return self._target().keys()
-
-    def values(self):
-        return self._target().values()
-
-    def items(self):
-        return self._target().items()
-
-    def pop(self, *args):
-        return self._target().pop(*args)
-
-    def setdefault(self, key, default=None):
-        return self._target().setdefault(key, default)
-
-    def update(self, *args, **kwargs):
-        return self._target().update(*args, **kwargs)
-
-    def clear(self):
-        return self._target().clear()
-
-    def copy(self):
-        return self._target().copy()
-
-    def __or__(self, other):
-        return self._target().__or__(other)
-
-    def __ior__(self, other):
-        target = self._target()
-        target.__ior__(other)
-        return self
-
-    def __reversed__(self):
-        # Snapshot to avoid RuntimeError under concurrent mutation.
-        return reversed(list(self._target()))
-
-
-class _ProxyList(list):
-    """List-like proxy forwarding to the active context's list attribute."""
-
-    def __init__(self, target_attr: str, context_fn=None) -> None:
-        super().__init__()
-        object.__setattr__(self, "_target_attr", target_attr)
-        object.__setattr__(self, "_context_fn", context_fn or get_active_context)
-
-    def _target(self) -> list:
-        ctx_fn = object.__getattribute__(self, "_context_fn")
-        return getattr(ctx_fn(), object.__getattribute__(self, "_target_attr"))
-
-    def __getitem__(self, index):
-        return self._target().__getitem__(index)
-
-    def __setitem__(self, index, value):
-        self._target().__setitem__(index, value)
-
-    def __delitem__(self, index):
-        self._target().__delitem__(index)
-
-    def __contains__(self, item):
-        return self._target().__contains__(item)
-
-    def __iter__(self):
-        # Snapshot elements so iteration is safe against concurrent mutation.
-        return iter(list(self._target()))
-
-    def __len__(self):
-        return self._target().__len__()
-
-    def __repr__(self):
-        return f"_ProxyList({object.__getattribute__(self, '_target_attr')!r}, {self._target()!r})"
-
-    def __eq__(self, other):
-        return self._target().__eq__(other)
-
-    def __bool__(self):
-        return bool(self._target())
-
-    def __add__(self, other):
-        return self._target().__add__(other)
-
-    def __iadd__(self, other):
-        target = self._target()
-        target.__iadd__(other)
-        return self
-
-    def append(self, item):
-        return self._target().append(item)
-
-    def extend(self, items):
-        return self._target().extend(items)
-
-    def insert(self, index, item):
-        return self._target().insert(index, item)
-
-    def remove(self, item):
-        return self._target().remove(item)
-
-    def pop(self, *args):
-        return self._target().pop(*args)
-
-    def clear(self):
-        return self._target().clear()
-
-    def copy(self):
-        return self._target().copy()
-
-    def index(self, value, *args):
-        return self._target().index(value, *args)
-
-    def count(self, value):
-        return self._target().count(value)
-
-    def sort(self, **kwargs):
-        return self._target().sort(**kwargs)
-
-    def reverse(self):
-        return self._target().reverse()
-
-
-# ---------------------------------------------------------------------------
-# Module-level proxy instances — these ARE the public names that all other
-# modules import.  They look and behave like plain dicts/lists but delegate
-# to the appropriate active context.
-#
-# ``medias`` delegates to the active **DatasetContext** (dataset-intrinsic).
-# All vote/label proxies delegate to the active **DetectorContext**.
-# ---------------------------------------------------------------------------
-
-# Clips storage: id -> {id, type, duration, file_size, embedding, media_bytes, media_string, ...}
-medias: dict[int, dict[str, Any]] = _ProxyDict("medias")  # type: ignore[assignment]
-
-# Voting storage (OrderedDict behavior via dict in Python 3.7+)
-good_votes: dict[int, None] = _ProxyDict("good_votes", get_active_detector_context)  # type: ignore[assignment]
-bad_votes: dict[int, None] = _ProxyDict("bad_votes", get_active_detector_context)  # type: ignore[assignment]
-
-# Combined label history: [(media_id, label, timestamp), ...]
-label_history: list[tuple[int, str, float]] = _ProxyList("label_history", get_active_detector_context)  # type: ignore[assignment]
-
-# Click-time tracking: media_id -> click order (1-indexed).
-vote_click_times: dict[int, int] = _ProxyDict("vote_click_times", get_active_detector_context)  # type: ignore[assignment]
-
-# Per-good-vote region boxes: media_id -> (x0, y0, x1, y1) in normalised image
-# coords.  Only populated when the user drew a region as part of a yes-vote;
-# absent for image-level yes-votes and for every no-vote.  Patch-embedder v2.
-vote_region_boxes: dict[int, tuple[float, float, float, float]] = _ProxyDict(  # type: ignore[assignment]
-    "vote_region_boxes",
-    get_active_detector_context,
-)
-
-# Last learned-sort scores: media_id -> score (float in [0, 1]).
-last_learned_scores: dict[int, float] = _ProxyDict("last_learned_scores", get_active_detector_context)  # type: ignore[assignment]
-
-# Text-sort suggestions: text queries that received a Good vote, most recent last.
-textsort_suggestions: list[str] = _ProxyList("textsort_suggestions", get_active_detector_context)  # type: ignore[assignment]
-
-# Find-mode initial labels: media_id -> label assigned by the detector in find-label.
-_find_initial_labels: dict[int, str] = _ProxyDict("find_initial_labels", get_active_detector_context)  # type: ignore[assignment]
-
-
-# ---------------------------------------------------------------------------
 # Scalar state accessors
 # ---------------------------------------------------------------------------
+# These thin helpers wrap "give me the X of whatever context is currently
+# active" so callers that operate on the active context — but don't need
+# a full DatasetContext / DetectorContext reference — can stay one-liners.
 # Dataset-intrinsic scalars (diversity_tree, dataset_display_name) delegate
-# to the active DatasetContext.  Vote-related scalars (click_counter,
+# to the active DatasetContext.  Detector-related scalars (click_counter,
 # inclusion) delegate to the active DetectorContext.
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/state/diversity.py
+++ b/vtsearch/state/diversity.py
@@ -1,4 +1,10 @@
-"""Diversity tree management for diverse media sampling."""
+"""Diversity tree management for diverse media sampling.
+
+Operates on the active :class:`DatasetContext` (for the tree itself) and the
+active :class:`DetectorContext` (for the labels that get replayed into it).
+Functions resolve the contexts themselves — no module-level proxy names are
+imported.  See Phase 3 of ``docs/plans/extract-library.md``.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +13,9 @@ from typing import Any
 
 from vtsearch.state.core import (
     DatasetContext,
-    _get_diversity_tree,
-    _set_diversity_tree,
     _state_lock,
-    bad_votes,
-    good_votes,
-    medias,
+    get_active_context,
+    get_active_detector_context,
 )
 
 
@@ -20,11 +23,12 @@ def build_diversity_tree(
     media_dict: dict[int, dict[str, Any]] | None = None,
     on_progress: Callable[[int, int], None] | None = None,
 ) -> None:
-    """Build a 3-Diversity Tree from media embeddings.
+    """Build a 3-Diversity Tree from media embeddings on the active dataset context.
 
-    Uses the global ``medias`` dict by default, or an explicit *media_dict*
-    if provided.  Existing labels in ``good_votes`` and ``bad_votes`` are
-    replayed into the new tree so the seen state stays accurate.
+    Uses the active :class:`DatasetContext`'s medias by default, or an explicit
+    *media_dict* if provided.  Existing labels on the active detector context
+    (``good_votes`` and ``bad_votes``) are replayed into the new tree so the
+    seen state stays accurate.
 
     *on_progress*, when provided, is called as ``on_progress(current, total)``
     to report how many k-means clustering fits have been completed so far.
@@ -34,7 +38,8 @@ def build_diversity_tree(
     from vtsearch.state.diversity_tree import DiversityTree
 
     with _state_lock:
-        source = media_dict if media_dict is not None else medias
+        ds_ctx = get_active_context()
+        source = media_dict if media_dict is not None else ds_ctx.medias
         vectors: dict[int, np.ndarray] = {}
         for cid, media in source.items():
             emb = media.get("embedding")
@@ -42,17 +47,18 @@ def build_diversity_tree(
                 vectors[cid] = np.asarray(emb, dtype=np.float32)
 
         if not vectors:
-            _set_diversity_tree(None)
+            ds_ctx.diversity_tree = None
             return
 
         tree = DiversityTree(vectors, k=3, on_progress=on_progress)
-        _set_diversity_tree(tree)
+        ds_ctx.diversity_tree = tree
 
         # Replay existing labels so the tree reflects the current vote state.
-        for cid in good_votes:
+        det_ctx = get_active_detector_context()
+        for cid in det_ctx.good_votes:
             if cid in tree.vector_to_leaf:
                 tree.label(cid)
-        for cid in bad_votes:
+        for cid in det_ctx.bad_votes:
             if cid in tree.vector_to_leaf:
                 tree.label(cid)
 
@@ -87,9 +93,9 @@ def build_diversity_tree_for_context(
 
 
 def get_diversity_tree():
-    """Return the current DiversityTree instance, or ``None``."""
+    """Return the active dataset context's DiversityTree instance, or ``None``."""
     with _state_lock:
-        return _get_diversity_tree()
+        return get_active_context().diversity_tree
 
 
 def diversity_tree_next_sample(
@@ -104,23 +110,23 @@ def diversity_tree_next_sample(
     scored element otherwise.
     """
     with _state_lock:
-        tree = _get_diversity_tree()
+        tree = get_active_context().diversity_tree
         if tree is None:
             return None
         return tree.next_sample(scores=scores, threshold=threshold)
 
 
 def diversity_tree_label(media_id: int) -> None:
-    """Mark *media_id* as labeled in the diversity tree."""
+    """Mark *media_id* as labeled in the active dataset's diversity tree."""
     with _state_lock:
-        tree = _get_diversity_tree()
+        tree = get_active_context().diversity_tree
         if tree is not None and media_id in tree.vector_to_leaf:
             tree.label(media_id)
 
 
 def diversity_tree_unlabel(media_id: int) -> None:
-    """Remove *media_id*'s label from the diversity tree."""
+    """Remove *media_id*'s label from the active dataset's diversity tree."""
     with _state_lock:
-        tree = _get_diversity_tree()
+        tree = get_active_context().diversity_tree
         if tree is not None and media_id in tree.vector_to_leaf:
             tree.unlabel(media_id)

--- a/vtsearch/state/media_lookup.py
+++ b/vtsearch/state/media_lookup.py
@@ -1,11 +1,16 @@
-"""Media lookup helpers (origin+origin_name union with MD5) and duplicate collapsing."""
+"""Media lookup helpers (origin+origin_name union with MD5) and duplicate collapsing.
+
+Pure helpers operating on explicit media-dict arguments.  The only function
+that touches global state is :func:`get_dupe_count`, which falls back to the
+active :class:`DatasetContext` when the caller does not pass one in.
+"""
 
 from __future__ import annotations
 
 import json
 from typing import Any, Callable
 
-from vtsearch.state.core import _state_lock, medias
+from vtsearch.state.core import _state_lock, get_active_context
 
 
 def _origin_key(origin: dict[str, Any], origin_name: str) -> str:
@@ -199,10 +204,12 @@ def collapse_duplicates(
 def get_dupe_count(media_dict: dict[int, dict[str, Any]] | None = None) -> int:
     """Return the number of duplicate groups in the media dict.
 
-    Each media whose origin is ``"dupe_set"`` represents one group.
+    Each media whose origin is ``"dupe_set"`` represents one group.  When
+    *media_dict* is ``None`` the active :class:`DatasetContext`'s medias
+    are used.
     """
     with _state_lock:
-        source = media_dict if media_dict is not None else medias
+        source = media_dict if media_dict is not None else get_active_context().medias
         return sum(
             1
             for m in source.values()

--- a/vtsearch/state/votes.py
+++ b/vtsearch/state/votes.py
@@ -2,56 +2,52 @@
 
 Also contains compound vote operations (toggle_vote, apply_label) that
 coordinate across vote dicts, click tracking, and the diversity tree.
+
+All functions operate on the *active* :class:`DetectorContext` (and the
+active :class:`DatasetContext` for the diversity tree side-effects).  They
+resolve the context themselves via :func:`get_active_detector_context` /
+:func:`get_active_context` — no module-level proxy names are imported, so
+the library has no implicit dependency on the app-side proxy view.  See
+Phase 3 of ``docs/plans/extract-library.md``.
 """
 
 from __future__ import annotations
 
+from vtsearch.state.clicks import assign_click_time, remove_click_time
 from vtsearch.state.core import (
     _state_lock,
-    bad_votes,
-    good_votes,
-    label_history,
-    last_learned_scores,
-    textsort_suggestions,
-    vote_click_times,
-    vote_region_boxes,
+    get_active_context,
+    get_active_detector_context,
 )
-from vtsearch.state.core import (
-    _get_click_counter,
-    _get_diversity_tree,
-    _set_click_counter,
-)
-from vtsearch.state.clicks import assign_click_time, remove_click_time
 from vtsearch.state.diversity import diversity_tree_label, diversity_tree_unlabel
-
-from vtsearch.state.core import get_active_detector_context
 
 
 def clear_votes() -> None:
     """Clear all votes and the full label history.
 
     Removes all entries from ``good_votes``, ``bad_votes``, and
-    ``label_history`` in place. Does not affect the ``medias`` dict.
-    Also clears the progress model cache and click-time / score tracking.
+    ``label_history`` in place on the active detector context. Does not affect
+    any dataset's ``medias`` dict.  Also clears the progress model cache and
+    click-time / score tracking.
     """
     from vtsearch.detectors.labeling_progress import clear_progress_cache
 
     with _state_lock:
-        good_votes.clear()
-        bad_votes.clear()
-        label_history.clear()
-        textsort_suggestions.clear()
-        vote_click_times.clear()
-        vote_region_boxes.clear()
-        _set_click_counter(0)
-        last_learned_scores.clear()
         ctx = get_active_detector_context()
+        ctx.good_votes.clear()
+        ctx.bad_votes.clear()
+        ctx.label_history.clear()
+        ctx.textsort_suggestions.clear()
+        ctx.vote_click_times.clear()
+        ctx.vote_region_boxes.clear()
+        ctx.click_counter = 0
+        ctx.last_learned_scores.clear()
         ctx.find_initial_labels.clear()
         clear_progress_cache()
 
 
 def add_label_to_history(media_id: int, label: str) -> None:
-    """Append a labelling event to the global label history with a timestamp.
+    """Append a labelling event to the active detector's label history.
 
     Args:
         media_id: Integer ID of the media that was labelled.
@@ -60,7 +56,7 @@ def add_label_to_history(media_id: int, label: str) -> None:
     import time
 
     with _state_lock:
-        label_history.append((media_id, label, time.time()))
+        get_active_detector_context().label_history.append((media_id, label, time.time()))
 
 
 def add_textsort_suggestion(text: str) -> None:
@@ -72,23 +68,24 @@ def add_textsort_suggestion(text: str) -> None:
         text: The text-sort query string to store.
     """
     with _state_lock:
-        # Remove existing occurrence so it moves to the end
+        suggestions = get_active_detector_context().textsort_suggestions
         try:
-            textsort_suggestions.remove(text)
+            suggestions.remove(text)
         except ValueError:
             pass
-        textsort_suggestions.append(text)
+        suggestions.append(text)
 
 
 def get_textsort_suggestions() -> list[str]:
     """Return stored text-sort suggestions, most recent last."""
     with _state_lock:
-        return list(textsort_suggestions)
+        return list(get_active_detector_context().textsort_suggestions)
 
 
 def update_learned_scores(scores: dict[int, float]) -> None:
     """Replace the stored learned-sort scores with *scores*."""
     with _state_lock:
+        last_learned_scores = get_active_detector_context().last_learned_scores
         last_learned_scores.clear()
         last_learned_scores.update(scores)
 
@@ -96,7 +93,7 @@ def update_learned_scores(scores: dict[int, float]) -> None:
 def get_learned_scores() -> dict[int, float]:
     """Return a copy of the last learned-sort scores."""
     with _state_lock:
-        return last_learned_scores.copy()
+        return get_active_detector_context().last_learned_scores.copy()
 
 
 def set_find_initial_labels(labels: dict[int, str]) -> None:
@@ -157,6 +154,10 @@ def toggle_vote(
 
     added = False
     with _state_lock:
+        ctx = get_active_detector_context()
+        good_votes = ctx.good_votes
+        bad_votes = ctx.bad_votes
+        vote_region_boxes = ctx.vote_region_boxes
         if vote == "good":
             if media_id in good_votes:
                 good_votes.pop(media_id, None)
@@ -233,19 +234,20 @@ def apply_label(
             (no-votes are always image-level).  Patch-embedder v2.
     """
     with _state_lock:
+        ctx = get_active_detector_context()
         if label == "good":
-            bad_votes.pop(media_id, None)
-            good_votes[media_id] = None
+            ctx.bad_votes.pop(media_id, None)
+            ctx.good_votes[media_id] = None
             if region_box is not None:
-                vote_region_boxes[media_id] = region_box
+                ctx.vote_region_boxes[media_id] = region_box
             else:
-                vote_region_boxes.pop(media_id, None)
+                ctx.vote_region_boxes.pop(media_id, None)
             if not silent:
                 add_label_to_history(media_id, "good")
         else:
-            good_votes.pop(media_id, None)
-            vote_region_boxes.pop(media_id, None)
-            bad_votes[media_id] = None
+            ctx.good_votes.pop(media_id, None)
+            ctx.vote_region_boxes.pop(media_id, None)
+            ctx.bad_votes[media_id] = None
             if not silent:
                 add_label_to_history(media_id, "bad")
         if not silent:
@@ -263,15 +265,16 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
         label: ``"good"`` or ``"bad"``.
     """
     with _state_lock:
+        ctx = get_active_detector_context()
         if label == "good":
-            bad_votes.pop(media_id, None)
-            good_votes[media_id] = None
-            vote_region_boxes.pop(media_id, None)
+            ctx.bad_votes.pop(media_id, None)
+            ctx.good_votes[media_id] = None
+            ctx.vote_region_boxes.pop(media_id, None)
             add_label_to_history(media_id, "good")
         else:
-            good_votes.pop(media_id, None)
-            vote_region_boxes.pop(media_id, None)
-            bad_votes[media_id] = None
+            ctx.good_votes.pop(media_id, None)
+            ctx.vote_region_boxes.pop(media_id, None)
+            ctx.bad_votes[media_id] = None
             add_label_to_history(media_id, "bad")
         assign_click_time(media_id)
         diversity_tree_label(media_id)
@@ -293,9 +296,14 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
     import time as _time
 
     with _state_lock:
-        tree = _get_diversity_tree()
+        ctx = get_active_detector_context()
+        good_votes = ctx.good_votes
+        bad_votes = ctx.bad_votes
+        vote_click_times = ctx.vote_click_times
+        vote_region_boxes = ctx.vote_region_boxes
+        label_history = ctx.label_history
+        tree = get_active_context().diversity_tree
         if replace_all:
-            ctx = get_active_detector_context()
             kept = {mid for mid, _ in labels}
             for cid in [c for c in good_votes if c not in kept]:
                 good_votes.pop(cid, None)
@@ -317,8 +325,7 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
                 vote_region_boxes.pop(media_id, None)
                 bad_votes[media_id] = None
                 label_history.append((media_id, "bad", _time.time()))
-            new_val = _get_click_counter() + 1
-            _set_click_counter(new_val)
-            vote_click_times[media_id] = new_val
+            ctx.click_counter += 1
+            vote_click_times[media_id] = ctx.click_counter
             if tree is not None and media_id in tree.vector_to_leaf:
                 tree.label(media_id)


### PR DESCRIPTION
## Summary

Completes Phase 3 of `docs/plans/extract-library.md` (the global-state seam) by removing all library-candidate dependence on the module-level proxy view (`medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `vote_region_boxes`, `last_learned_scores`, `textsort_suggestions`) and relocating the proxy machinery itself to the app-side `vtsearch/shim/` package.

### Phase 3 audit — explicit context dependencies

- `vtsearch/state/votes.py`, `vtsearch/state/clicks.py`, `vtsearch/state/media_lookup.py`, `vtsearch/state/diversity.py`, and `vtsearch/labels/sync.py` now resolve the active `DetectorContext` / `DatasetContext` internally via `get_active_*_context()` and operate on `ctx.attr` directly.
- No library-candidate code imports the module-level proxy names anymore — the dependency on "the active context" is explicit in each function body.

### Phase 3 finish — proxy relocation

- `_ProxyDict`, `_ProxyList`, and the module-level proxy instances moved out of `vtsearch/state/core.py` into a new app-tier module `vtsearch/shim/state_proxies.py`.
- `vtsearch/state/__init__.py` re-exports the proxies from the shim so existing app-tier imports (`from vtsearch.state import medias`) keep working unchanged.
- `snapshot_medias` / `get_media` / `clear_medias` in `state/__init__.py` rewritten to operate on the active `DatasetContext` directly (they no longer go through the proxy view).
- Tests that reached into `state.core` for proxies were updated to import from `vtsearch.state` or `vtsearch.shim.state_proxies`.

### Plan doc updates

- Status header bumped to "Phases 0–3 functionally shipped".
- Phase 3 sub-items checked off with shipped notes.
- Phase 8 instructions updated to flag that `vtsearch/state/__init__.py` is app-tier glue (proxy re-exports + persistence hooks) — only the library submodules under `state/` move to `vtscore/state/` at Phase 8.

### Exit criteria

`grep -rn "^medias\|^good_votes\|^_ProxyDict\|^_ProxyList"` across `vtsearch/{datasets,detectors,embedding,training,media,converters,exporters,labels,eval,plugins,concurrency,state,sync,utils,security}` returns zero hits. The only file that defines or instantiates the proxy names is `vtsearch/shim/state_proxies.py` (app-side).

## Test plan

- [x] `./run-tests.sh` — full suite green (3846 passed, 1 skipped, 2 xpassed, 0 failures)
- [x] ruff check + format, codespell, deptry, pip-audit, pyright all clean
- [x] Verified library-candidate paths have no `medias`/`good_votes`/etc. definitions or imports left


---
_Generated by [Claude Code](https://claude.ai/code/session_015syF3QKqrCMhEdYx2U89Wj)_