### PR TITLE
Async embedder warm-up after import (brainstorm 13.8)

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -477,8 +477,10 @@ First time a user opens a new media type, the panel settings (`view_mode_*`, `gr
 ### 13.7 Skip diversity-tree rebuild on small updates ★ M
 When a few medias are added/removed (e.g. clip fix-up), today the whole diversity tree rebuilds. For incremental changes < 1% of dataset size, do an incremental insert/delete instead. Saves seconds on every clip-aware import.
 
-### 13.8 Async embedder warm-up after import ★ XS
+### 13.8 Async embedder warm-up after import ★ XS — shipped
 After a dataset loads, the "warming up text encoder…" step blocks task completion. Move it to fire-and-forget so the dataset is usable for grid-browsing immediately and Text sort just waits on first use.
+
+**What shipped:** the synchronous `_warmup_embedder_stage` was replaced with a fire-and-forget `_warmup_embedder_async(media_dict)` daemon thread (`vtsearch/datasets/load_pipeline.py:800`). Both load paths — the importer-driven `_run_origin_load_in_background` and the registry-driven `load_registered_dataset` (`vtsearch/routes/datasets/registry.py`) — now kick off the warm-up after `_register_and_migrate` / `_reg_add_loaded` and return immediately, so the dashboard row goes green the moment the dataset is in memory. `load_registered_dataset`'s `_LOAD_STEPS` dropped from 3 to 2 (read pickle + build diversity index). The warmup itself still calls `emb.load_models()` then `emb.embed_text("warmup")` on a daemon thread named `warmup-embedder`; if the user clicks Text Sort before warmup finishes, the existing `_embedder_load_lock` in `vtsearch/routes/sorting.py:107` serialises the wait behind the regular "Loading embedder…" sort-progress bar — no race, no double-load (`load_models` is idempotent via `_model_load_lock`, `vtsearch/media/embedder.py:551-555`). The now-orphaned `_load_embedder_with_progress` / `_load_embedder_for_clips` helpers in `vtsearch/datasets/load_pipeline.py` were deleted (the routes/sorting variant of the same name is a separate function).
 
 ---
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1361,6 +1361,7 @@ class TestLoadProgressRaceCondition:
 
         assert settings_mod.get_last_embedder_per_media_type() == {}
 
+
 class TestCancelIngest:
     """Tests for the POST /api/dataset/cancel endpoint."""
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -749,32 +749,73 @@ class TestImporterMetadata:
             assert ds_field["required"] is False
 
 
-class TestLoadEmbedderForClips:
-    """_load_embedder_for_clips should warm up the text encoder at dataset load time."""
+class TestWarmupEmbedderAsync:
+    """_warmup_embedder_async should warm up the text encoder in a daemon thread."""
+
+    def _wait_for_threads(self, name_prefix: str = "warmup-embedder", timeout: float = 5.0) -> None:
+        """Join all daemon threads whose name starts with *name_prefix*."""
+        import threading
+        import time
+
+        deadline = time.monotonic() + timeout
+        for t in list(threading.enumerate()):
+            if not t.name.startswith(name_prefix):
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            t.join(timeout=remaining)
 
     def test_warms_up_text_encoder(self):
         """embed_text('warmup') is called to prime the text encoder branch."""
         from unittest.mock import patch
 
         from vtsearch.media import embedders_for_type
-        from vtsearch.datasets.load_pipeline import _load_embedder_for_clips
+        from vtsearch.datasets.load_pipeline import _warmup_embedder_async
+        from vtsearch.state import snapshot_medias
 
         emb = embedders_for_type("audio")[0]
         with patch.object(emb, "embed_text", wraps=emb.embed_text) as mock_embed:
-            _load_embedder_for_clips()
+            _warmup_embedder_async(snapshot_medias())
+            self._wait_for_threads()
             mock_embed.assert_called_once_with("warmup")
 
     def test_text_encoder_produces_valid_embedding_after_load(self):
-        """After _load_embedder_for_clips, embed_text returns a real vector."""
+        """After _warmup_embedder_async finishes, embed_text returns a real vector."""
         from vtsearch.media import embedders_for_type
-        from vtsearch.datasets.load_pipeline import _load_embedder_for_clips
+        from vtsearch.datasets.load_pipeline import _warmup_embedder_async
+        from vtsearch.state import snapshot_medias
 
-        _load_embedder_for_clips()
+        _warmup_embedder_async(snapshot_medias())
+        self._wait_for_threads()
         emb = embedders_for_type("audio")[0]
         vec = emb.embed_text("a high-pitched beep")
         assert vec is not None
         assert len(vec.shape) == 1
         assert vec.shape[0] > 0
+
+    def test_does_not_block_caller(self):
+        """The warmup must run in a background thread, not synchronously."""
+        import threading
+        from unittest.mock import patch
+
+        from vtsearch.media import embedders_for_type
+        from vtsearch.datasets.load_pipeline import _warmup_embedder_async
+        from vtsearch.state import snapshot_medias
+
+        emb = embedders_for_type("audio")[0]
+        gate = threading.Event()
+        original_load = emb.load_models
+
+        def _blocking_load() -> None:
+            gate.wait(timeout=5.0)
+            original_load()
+
+        with patch.object(emb, "load_models", side_effect=_blocking_load):
+            _warmup_embedder_async(snapshot_medias())
+            # The call returned even though load_models hasn't completed.
+            gate.set()
+            self._wait_for_threads()
 
 
 class TestDemoCacheEmbedderMismatch:
@@ -1320,37 +1361,6 @@ class TestLoadProgressRaceCondition:
 
         assert settings_mod.get_last_embedder_per_media_type() == {}
 
-    def test_load_embedder_sets_initial_progress(self):
-        """_load_embedder_for_clips must set progress before loading starts.
-
-        The function should emit 'Loading embedding model…' so the frontend
-        knows the embedder warm-up phase has begun (rather than staying stuck
-        on the previous phase's message like 'Saving to registry…').
-        """
-        from unittest.mock import patch
-
-        from vtsearch.datasets.load_pipeline import _load_embedder_for_clips
-        from vtsearch.concurrency.progress import update_progress
-
-        # _load_embedder_for_clips inspects medias to find the embedder.
-        # The conftest-populated medias dict provides this automatically.
-        # Set a stale progress message from the previous phase.
-        update_progress("loading", "Saving to registry…", step=3, total_steps=4)
-
-        messages: list[str] = []
-
-        def _capture_update(status, message="", current=0, total=0, **kw):
-            messages.append(message)
-
-        with patch("vtsearch.datasets.load_pipeline.update_progress", side_effect=_capture_update):
-            _load_embedder_for_clips()
-
-        # Should have set "Loading embedding model…" before calling load_models
-        assert any("Loading embedding model" in m for m in messages), (
-            f"Expected 'Loading embedding model…' in progress messages, got: {messages}"
-        )
-
-
 class TestCancelIngest:
     """Tests for the POST /api/dataset/cancel endpoint."""
 
@@ -1440,7 +1450,7 @@ class TestCancelIngest:
             # Start a new load — should reset the flag
             from vtsearch.datasets.load_pipeline import _run_origin_load_in_background
 
-            with patch("vtsearch.datasets.load_pipeline._load_embedder_for_clips"):
+            with patch("vtsearch.datasets.load_pipeline._warmup_embedder_async"):
                 _run_origin_load_in_background(
                     lambda: None,
                     {"importer": "test", "params": {}},

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -117,7 +117,6 @@ from vtsearch.state import (
     clear_all,
     collapse_duplicates,
     register_context,
-    snapshot_medias,
 )
 from vtsearch.concurrency.progress import update_progress
 from vtsearch.concurrency.progress import (
@@ -160,58 +159,6 @@ def _get_embedder_for_medias(media_dict: dict):
     from vtsearch.routes._shared import get_embedder_for_medias as _impl
 
     return _impl(media_dict)
-
-
-def _get_embedder_for_clips():
-    """Return the embedder for the current dataset, or None."""
-    return _get_embedder_for_medias(snapshot_medias())
-
-
-def _load_embedder_with_progress(
-    media_dict: dict | None,
-    progress_fn,
-    step: int | None = None,
-    total_steps: int | None = None,
-) -> None:
-    """Eagerly load the embedder and warm up its text encoder.
-
-    *progress_fn* is called as ``progress_fn(status, message, current, total, **kw)``
-    to report progress.  When *media_dict* is passed it is used to determine
-    the embedder; otherwise falls back to the active dataset.
-    """
-    if step is None:
-        step = _TOTAL_LOAD_STEPS
-    if total_steps is None:
-        total_steps = _TOTAL_LOAD_STEPS
-
-    emb = _get_embedder_for_medias(media_dict) if media_dict else _get_embedder_for_clips()
-    if emb is None:
-        progress_fn("idle", "Ready", step=None, total_steps=None)
-        return
-
-    def _model_load_progress(status, message, current, total):
-        progress_fn(status, message, current, total, step=step, total_steps=total_steps)
-
-    progress_fn("loading", "Loading embedding model…", 0, 0, step=step, total_steps=total_steps)
-    original_cb = emb._on_progress
-    emb._on_progress = _model_load_progress
-    try:
-        emb.load_models()
-    finally:
-        emb._on_progress = original_cb
-
-    # Warm up the text encoder so the first text sort is instant.
-    progress_fn("loading", "Warming up text encoder…", 0, 0, step=step, total_steps=total_steps)
-    try:
-        emb.embed_text("warmup")
-    except Exception:
-        pass
-    progress_fn("idle", "Ready", step=None, total_steps=None)
-
-
-def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = None) -> None:
-    """Load embedder using the global progress tracker."""
-    _load_embedder_with_progress(None, update_progress, step=step, total_steps=total_steps)
 
 
 def _origin_to_str(origin: dict | None) -> str:
@@ -844,17 +791,35 @@ def _register_and_migrate(
         return task_id
     _migrate_context_id(task_id, entry["id"])
     ctx.dataset_display_name = entry.get("name", name)
-    # Associate the loading task with the real dataset ID so the frontend
-    # can show embedder-warmup progress inline on the dataset row.
+    # Associate the loading task with the real dataset ID so the
+    # finished-task tick is attributed to the right dashboard row.
     loading_tasks.set_dataset_id(task_id, entry["id"])
     return entry["id"]
 
 
-def _warmup_embedder_stage(ctx: DatasetContext, tracker) -> None:
-    def _task_progress(status, message="", current=0, total=0, **kw):
-        tracker.update(status, message, current, total, **kw)
+def _warmup_embedder_async(media_dict: dict) -> None:
+    """Warm up the embedder (model load + text-encoder prime) in a daemon thread.
 
-    _load_embedder_with_progress(ctx.medias, _task_progress)
+    Fire-and-forget: the caller doesn't wait, and there is no progress
+    surface — the dataset is usable for grid-browsing immediately, and
+    text sort waits behind its own ``_embedder_load_lock`` (see
+    ``vtsearch/routes/sorting.py:_load_embedder_with_progress``) on first
+    use.  ``MediaEmbedder.load_models`` is idempotent and serialised by
+    a per-class lock, so racing this thread against an on-demand sort
+    load is safe.
+    """
+
+    def _run() -> None:
+        emb = _get_embedder_for_medias(media_dict)
+        if emb is None:
+            return
+        try:
+            emb.load_models()
+            emb.embed_text("warmup")
+        except Exception:
+            pass
+
+    threading.Thread(target=_run, name="warmup-embedder", daemon=True).start()
 
 
 def _handle_load_failure(exc: BaseException, context_id: str, tracker) -> None:
@@ -961,7 +926,10 @@ def _run_origin_load_in_background(
             context_id = _register_and_migrate(
                 ctx, tracker, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
             )
-            _warmup_embedder_stage(ctx, tracker)
+            # Embedder warm-up is fire-and-forget so the dashboard row goes
+            # green immediately.  Text sort waits behind its own progress
+            # bar on first use if the model isn't ready yet.
+            _warmup_embedder_async(ctx.medias)
 
             from vtsearch.achievements import record_dataset_load  # noqa: PLC0415
 

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -31,9 +31,7 @@ from pathlib import Path
 
 from flask_smorest import Blueprint, abort
 
-from vtsearch.datasets.load_pipeline import (
-    _load_embedder_with_progress as _load_embedder_for_clips_with_progress,
-)
+from vtsearch.datasets.load_pipeline import _warmup_embedder_async
 from vtsearch.datasets.loader import load_dataset_from_pickle
 from vtsearch.datasets.registry import (
     add_loaded_id as _reg_add_loaded,
@@ -138,7 +136,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     if not pkl_path or not Path(pkl_path).is_file():
         abort(404, message=f"Saved dataset file not found: {pkl_path}")
 
-    _LOAD_STEPS = 3  # read pickle + process items, build diversity index, warm up embedder
+    _LOAD_STEPS = 2  # read pickle + process items, build diversity index
 
     # Create a per-task tracker for this load operation.
     task_id = f"_regload_{dataset_id[:8]}"
@@ -221,13 +219,10 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
             _reg_update(dataset_id, num_items=len(ctx.medias), num_dupes=num_dupes)
             ctx.dataset_display_name = entry.get("name", "")
 
-            # Warm up the embedder using the task tracker.
-            def _task_progress(status, message="", current=0, total=0, **kw):
-                tracker.update(status, message, current, total, **kw)
-
-            _load_embedder_for_clips_with_progress(
-                ctx.medias, _task_progress, step=_LOAD_STEPS, total_steps=_LOAD_STEPS
-            )
+            # Embedder warm-up runs fire-and-forget so the dashboard row
+            # goes green immediately; text sort waits behind its own
+            # progress bar on first use if the model isn't ready yet.
+            _warmup_embedder_async(ctx.medias)
         except CancelledError:
             unregister_context(dataset_id)
             _reg_remove_loaded(dataset_id)


### PR DESCRIPTION
## Summary

Implements brainstorm item **13.8 — Async embedder warm-up after import**. The "Warming up text encoder…" stage that ran as the final step of every dataset load now fires-and-forgets, so the dashboard row turns green the moment the dataset is in memory and the user can grid-browse immediately. Text sort waits behind the existing `_embedder_load_lock` on first use if the warm-up isn't done yet — `load_models()` is idempotent and serialised by `_model_load_lock`, so no race, no double-load.

- `vtsearch/datasets/load_pipeline.py`: replace `_warmup_embedder_stage` (sync, drives the loading-task tracker) with `_warmup_embedder_async(media_dict)` (daemon thread, no progress surface). Delete the now-orphaned `_load_embedder_with_progress` / `_load_embedder_for_clips` helpers.
- `vtsearch/routes/datasets/registry.py`: same swap on the saved-pkl reload path. `_LOAD_STEPS` shrinks from 3 → 2 (read pickle + build diversity index).
- `tests/datasets/test_datasets.py`: rename `TestLoadEmbedderForClips` → `TestWarmupEmbedderAsync`, join daemon threads to verify `embed_text("warmup")` still runs, add a non-blocking-caller test, drop the now-irrelevant progress-message assertion, and re-target the cancel-flag test patch.
- `docs/plans/brainstorm.md`: mark 13.8 shipped with a What-shipped note.

## Test plan

- [x] `./run-tests.sh datasets` — 495 passed, 2 skipped
- [x] `./run-tests.sh` (full default suite) — 3849 passed, 1 skipped, 2 xpassed
- [x] Ruff format / lint / pyright clean


---
_Generated by [Claude Code](https://claude.ai/code/session_013xx1zXbPMi97jYhanrMi6z)_