### PR TITLE
Add smoothed ETA to every progress bar (brainstorm §14.3)

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -492,8 +492,13 @@ The dataset-load progress reports step 1-4 ("downloading", "embedding", "dedupin
 ### 14.2 Bytes/sec for first-run model downloads ★★★ M
 First-run model downloads (CLAP ~1.1 GB, X-CLIP ~600 MB) currently show "Loading embedding model…" with no bar. HuggingFace's `tqdm`-style progress is available — pipe it through `update_progress()` to show `Downloading SigLIP (412 / 860 MB, 18 MB/s, ~25s left)`.
 
-### 14.3 ETA estimates on long bars ★★ S
-Every progress bar should show an ETA once we've seen >5s and have a current/total. ETA = `(elapsed / current) * (total - current)`, smoothed. Eliminates the "is this hung?" fear.
+### 14.3 ETA estimates on long bars ★★ S — shipped
+
+Every progress bar now shows a remaining-time estimate once it has been running long enough for the rate to mean something.
+
+**What shipped:** `ProgressTracker._compute_eta` in `vtsearch/concurrency/progress.py` records a per-phase start time, computes `raw = (elapsed / completed) * (total - current)` once `elapsed > 5s` with `current > 0` and a known `total`, and smooths it with an EMA (α = 0.3) against the previous sample. The phase clock resets whenever `status` or `total` changes, or when `current` decreases (a new bar starting), so phase transitions don't pollute the estimate with stale rate from the previous phase. The result lives in a new `eta_seconds` field added to `_PROGRESS_COMMON_EXTRAS`, so every singleton tracker (dataset / sort / eval / find) and every per-task tracker created by `LoadingTasksTracker` carries it for free.
+
+On the frontend, `ProgressEvent.eta_seconds` lands on `frontend/src/app/models/api.models.ts`, and `formatEta()` + a tail in `formatProgressMessage()` in `frontend/src/app/utils/format-progress.ts` render it as `· ~Hh Mm left` / `· ~Mm Ss left` / `· ~Ss left` appended to the existing `(current/total) message` detail line. Because the dashboard cards, find view, label view, and detector card all flow through `formatProgressMessage` / `formatProgressHeader.detail`, no per-component change is needed — the ETA chip appears automatically on every long-running bar that has a `current` and `total`. Short bars (≤5s) keep showing only `(C/T)` so they don't flash a meaningless estimate.
 
 ### 14.4 Per-detector progress during auto-detect ★★ S
 `/api/auto-detect` runs N detectors in parallel and reports a single aggregated bar. Switch to a list of mini-bars in `AutodetectResultsModalComponent` ("Detector A: ✓ done · Detector B: 47% · Detector C: queued"). The frontend already gets per-detector results; just expose progress per-id over SSE.

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -64,6 +64,12 @@ export interface ProgressEvent {
   total_steps?: number | null;
   /** Error message if the operation failed. */
   error?: string | null;
+  /**
+   * Smoothed remaining-seconds estimate filled in by
+   * ``ProgressTracker._compute_eta`` once the bar has been running long
+   * enough (>5s) with a known total. ``null`` means "no estimate yet".
+   */
+  eta_seconds?: number | null;
   /** Dataset-only: payload returned by combine-datasets staging. */
   staging_result?: unknown;
   [key: string]: unknown;

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -21,13 +21,35 @@ export function formatProgressFraction(current: number, total: number): string {
 }
 
 /**
+ * Format a remaining-seconds estimate into a compact ``~Hh Mm`` / ``~Mm Ss``
+ * / ``~Ss`` chip. Returns an empty string for ``null``, non-positive, or
+ * non-finite values so the caller can drop it from concatenation unconditionally.
+ */
+export function formatEta(seconds: number | null | undefined): string {
+  if (seconds == null || !isFinite(seconds) || seconds <= 0) return '';
+  const total = Math.round(seconds);
+  if (total < 60) return `~${total}s left`;
+  if (total < 3600) {
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return s > 0 ? `~${m}m ${s}s left` : `~${m}m left`;
+  }
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  return m > 0 ? `~${h}h ${m}m left` : `~${h}h left`;
+}
+
+/**
  * Format a `ProgressEvent` into the canonical
- * ``[Step S/T] (C/T) message`` string used by every progress consumer.
+ * ``[Step S/T] (C/T) message · ~ETA left`` string used by every progress consumer.
  *
  * Each piece is optional:
  *   - The ``[Step S/T]`` prefix appears only when ``total_steps > 1``.
  *   - The ``(C/T)`` fraction appears only when ``total > 0``.
- *   - When neither is present, returns the bare ``message`` (or
+ *   - The ``· ~Xs left`` tail appears only when ``eta_seconds > 0`` — the
+ *     backend gates this on at least 5s of elapsed work, so it stays hidden
+ *     for short bars.
+ *   - When none are present, returns the bare ``message`` (or
  *     ``defaultMessage`` if ``message`` is empty).
  */
 export function formatProgressMessage(
@@ -51,6 +73,10 @@ export function formatProgressMessage(
     } else {
       msg = msg ? `${fraction} ${msg}` : fraction;
     }
+  }
+  const eta = formatEta(prog.eta_seconds);
+  if (eta) {
+    msg = msg ? `${msg} · ${eta}` : eta;
   }
   return msg;
 }

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -76,6 +76,109 @@ class TestProgressTrackerSubscriptions:
         assert received[0]["step"] == 2
 
 
+class TestProgressTrackerEta:
+    """``ProgressTracker`` should fill in a smoothed ``eta_seconds`` once a
+    bar has been running >5s, reset its phase clock when the status or total
+    changes, and stay silent otherwise. We patch :func:`time.monotonic` for
+    determinism — the clock advance values matter, not wall time."""
+
+    def _make_tracker(self) -> ProgressTracker:
+        return ProgressTracker(extra_fields={"eta_seconds": None})
+
+    def test_eta_is_none_until_min_elapsed(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("loading", "", 0, 100)
+        assert tracker.get()["eta_seconds"] is None
+
+        now[0] += 2.0  # <5s elapsed
+        tracker.update("loading", "", 5, 100)
+        assert tracker.get()["eta_seconds"] is None
+
+    def test_eta_appears_after_min_elapsed(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("loading", "", 0, 100)
+        now[0] += 10.0
+        tracker.update("loading", "", 10, 100)
+        eta = tracker.get()["eta_seconds"]
+        # 10s elapsed for 10/100 done → 90 units remain at 1 unit/sec → 90s.
+        assert eta is not None
+        assert 89.0 <= eta <= 91.0
+
+    def test_eta_smoothed_via_ema(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("loading", "", 0, 100)
+        now[0] += 10.0
+        tracker.update("loading", "", 10, 100)
+        first = tracker.get()["eta_seconds"]
+        assert first is not None
+
+        # Pretend the rate suddenly doubles: 10 more units in just 1s.
+        now[0] += 1.0
+        tracker.update("loading", "", 20, 100)
+        smoothed = tracker.get()["eta_seconds"]
+        # Raw new ETA = (11 / 20) * 80 = 44s. Smoothed with alpha=0.3 against
+        # the previous ~90s sample sits well above 44 and below the old 90.
+        assert smoothed is not None
+        assert 44.0 < smoothed < first
+
+    def test_eta_resets_when_status_changes(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("downloading", "", 0, 100)
+        now[0] += 10.0
+        tracker.update("downloading", "", 50, 100)
+        assert tracker.get()["eta_seconds"] is not None
+
+        # New phase: clock should restart, ETA hidden until the next 5s elapse.
+        tracker.update("embedding", "", 0, 100)
+        assert tracker.get()["eta_seconds"] is None
+        now[0] += 1.0
+        tracker.update("embedding", "", 5, 100)
+        assert tracker.get()["eta_seconds"] is None
+
+    def test_eta_resets_when_total_changes(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("loading", "", 0, 100)
+        now[0] += 10.0
+        tracker.update("loading", "", 50, 100)
+        assert tracker.get()["eta_seconds"] is not None
+
+        # A new bar with a different total resets the phase clock.
+        tracker.update("loading", "", 0, 200)
+        assert tracker.get()["eta_seconds"] is None
+
+    def test_eta_none_for_indeterminate_bars(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr("vtsearch.concurrency.progress.time.monotonic", lambda: now[0])
+        tracker = self._make_tracker()
+
+        tracker.update("loading", "", 0, 0)
+        now[0] += 20.0
+        tracker.update("loading", "", 42, 0)
+        assert tracker.get()["eta_seconds"] is None
+
+    def test_eta_field_absent_when_extra_not_declared(self):
+        """Trackers created without an ``eta_seconds`` extra get no key —
+        the feature is opt-in via :data:`_PROGRESS_COMMON_EXTRAS`."""
+        tracker = ProgressTracker()
+        tracker.update("loading", "", 1, 2)
+        assert "eta_seconds" not in tracker.get()
+
+
 class TestLoadingTasksTrackerSubscriptions:
     def test_create_task_notifies(self):
         tracker = LoadingTasksTracker()

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -71,11 +71,7 @@ class ProgressTracker:
         """
         now = time.monotonic()
         phase_key = (status, total)
-        if (
-            self._phase_key != phase_key
-            or self._phase_start is None
-            or current < self._phase_current_start
-        ):
+        if self._phase_key != phase_key or self._phase_start is None or current < self._phase_current_start:
             self._phase_key = phase_key
             self._phase_start = now
             self._phase_current_start = current

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -34,6 +34,15 @@ class ProgressTracker:
             and are returned by :meth:`get`.
     """
 
+    #: Minimum elapsed time (seconds) before an ETA is computed. Below this we
+    #: don't have enough samples to extrapolate reliably and the number jitters
+    #: wildly, so the snapshot's ``eta_seconds`` stays ``None``.
+    _ETA_MIN_ELAPSED = 5.0
+
+    #: Smoothing factor for the EMA over the raw ETA. ``0.3`` weights the new
+    #: sample lightly enough to dampen noise while still tracking real slowdowns.
+    _ETA_SMOOTHING_ALPHA = 0.3
+
     def __init__(self, extra_fields: Optional[dict[str, Any]] = None) -> None:
         self._lock = threading.Lock()
         self._extra_defaults = dict(extra_fields) if extra_fields else {}
@@ -47,6 +56,47 @@ class ProgressTracker:
         }
         self._subscribers: list[Callable[[dict[str, Any]], None]] = []
         self._subscribers_lock = threading.Lock()
+        self._phase_key: tuple[str, int] | None = None
+        self._phase_start: float | None = None
+        self._phase_current_start: int = 0
+        self._smoothed_eta: float | None = None
+
+    def _compute_eta(self, status: str, current: int, total: int) -> Optional[float]:
+        """Compute the smoothed ETA in seconds for the current bar.
+
+        Resets the phase clock when ``status`` changes, ``total`` changes, or
+        ``current`` resets backwards (a new bar is starting). Returns ``None``
+        until at least :data:`_ETA_MIN_ELAPSED` seconds of work have elapsed
+        with a known total and ``current > 0``.
+        """
+        now = time.monotonic()
+        phase_key = (status, total)
+        if (
+            self._phase_key != phase_key
+            or self._phase_start is None
+            or current < self._phase_current_start
+        ):
+            self._phase_key = phase_key
+            self._phase_start = now
+            self._phase_current_start = current
+            self._smoothed_eta = None
+            return None
+
+        if total <= 0 or current <= 0 or current >= total:
+            return None
+        elapsed = now - self._phase_start
+        if elapsed < self._ETA_MIN_ELAPSED:
+            return None
+        completed = current - self._phase_current_start
+        if completed <= 0:
+            return None
+        raw_eta = (elapsed / completed) * (total - current)
+        if self._smoothed_eta is None:
+            self._smoothed_eta = raw_eta
+        else:
+            alpha = self._ETA_SMOOTHING_ALPHA
+            self._smoothed_eta = alpha * raw_eta + (1.0 - alpha) * self._smoothed_eta
+        return self._smoothed_eta
 
     def update(
         self,
@@ -74,6 +124,8 @@ class ProgressTracker:
             for key in self._extra_defaults:
                 if key in kwargs:
                     self._data[key] = kwargs[key]
+            if "eta_seconds" in self._extra_defaults:
+                self._data["eta_seconds"] = self._compute_eta(status, current, total)
             snapshot = dict(self._data)
         self._notify(snapshot)
 
@@ -178,11 +230,18 @@ def clear_thread_progress() -> None:
 # ---------------------------------------------------------------------------
 #: Extras shared by every long-running operation: an optional sub-step counter
 #: (``step``/``total_steps`` — used when a single operation has multiple phases
-#: like load→embed→stage) and an ``error`` string. Every singleton tracker —
-#: and every per-task tracker created by :class:`LoadingTasksTracker` — exposes
-#: these so the frontend can render any progress payload with the same
-#: ``ProgressEvent`` interface (see ``frontend/src/app/models/api.models.ts``).
-_PROGRESS_COMMON_EXTRAS: dict[str, Any] = {"step": None, "total_steps": None, "error": None}
+#: like load→embed→stage), an ``error`` string, and a smoothed ``eta_seconds``
+#: filled in automatically by :meth:`ProgressTracker._compute_eta`. Every
+#: singleton tracker — and every per-task tracker created by
+#: :class:`LoadingTasksTracker` — exposes these so the frontend can render any
+#: progress payload with the same ``ProgressEvent`` interface (see
+#: ``frontend/src/app/models/api.models.ts``).
+_PROGRESS_COMMON_EXTRAS: dict[str, Any] = {
+    "step": None,
+    "total_steps": None,
+    "error": None,
+    "eta_seconds": None,
+}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements brainstorm §14.3 — "ETA estimates on long bars". Every progress bar now shows a remaining-time estimate once it has been running long enough for the rate to be meaningful, eliminating the "is this hung?" fear on long dataset loads, embeddings, sorts, and find operations.

- **Backend.** `ProgressTracker._compute_eta` in `vtsearch/concurrency/progress.py` records a per-phase start time, then once `elapsed > 5s` with `current > 0` and a known `total` computes `(elapsed / completed) * (total - current)` and smooths it with an EMA (α = 0.3) against the previous sample. The phase clock resets when `status` or `total` changes, or when `current` decreases (a new bar starting), so phase transitions don't pollute the estimate with stale rate from the previous phase.
- **Single touch-point.** `eta_seconds` is added to `_PROGRESS_COMMON_EXTRAS`, so every singleton tracker (dataset / sort / eval / find) and every per-task tracker created by `LoadingTasksTracker` carries it automatically — no per-call-site changes.
- **Frontend.** `ProgressEvent.eta_seconds` lands on the shared model; `formatEta()` + a tail in `formatProgressMessage()` render it as `· ~Hh Mm left` / `· ~Mm Ss left` / `· ~Ss left`. Because the dashboard cards, find view, label view, and detector card all flow through `formatProgressMessage` / `formatProgressHeader.detail`, the chip appears automatically on every long-running bar that has a `current` and `total`. Short bars (≤5s) keep showing only `(C/T)` so they don't flash a meaningless estimate.
- **Tests.** New `TestProgressTrackerEta` class in `tests/api/test_events_sse.py` patches `time.monotonic` for determinism and covers: silent under 5s, appearance after 5s, EMA smoothing of a rate spike, reset on status change, reset on total change, indeterminate (`total=0`) stays silent, and the field is absent when the extra isn't declared.

## Test plan

- [x] `./run-tests.sh api core` (944 passed — covers new ETA tests + frontend build)
- [x] `./run-tests.sh cli` (135 passed)
- [x] `./run-tests.sh` (3856 passed, 1 skipped — full suite)
- [x] `ruff check` / `ruff format --check` / codespell / deptry / pyright / pip-audit / OpenAPI snapshot all clean (run as part of `./run-tests.sh`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LEBJj2EfSeQXASx39EBF43)_