### PR TITLE
Name loading phases in export / label-import / load-sort modals

### DIFF
--- a/docs/plans/brainstorm.md
+++ b/docs/plans/brainstorm.md
@@ -465,8 +465,16 @@ Voting calls `train_and_score()` synchronously in the request handler (`routes/s
 ### 13.3 Skip the demo-picker double round-trip ★★ XS
 Picking a demo today: open importer → pick Demo tab → pick demo card → fill embedder → submit → wait for download. Most users want the *recommended* setup. Add a one-click "Quick load" button on each demo card that uses the recommended embedder and skips the params form.
 
-### 13.4 Parallel-load multiple selected datasets ★★ S
-Selecting 3 datasets and clicking the bulk-load action loads them serially due to default concurrency of 1. The `_download_gate` already supports concurrent loads; bump the default (see §11.5) and most users immediately see 3x faster bulk loads.
+### 13.4 Parallel-load multiple selected datasets ★★ S — backend ready, frontend pending
+Original brief: *"Selecting 3 datasets and clicking the bulk-load action loads them serially due to default concurrency of 1. The `_download_gate` already supports concurrent loads; bump the default (see §11.5) and most users immediately see 3x faster bulk loads."*
+
+The "default concurrency of 1" premise is now stale: §11.5 shipped hardware-derived defaults, so `_download_gate` already lets `max(1, min(4, os.cpu_count() or 1))` loads run in parallel (typically 2–4 on user boxes) and `_embed_gate` already lets `min(2, torch.cuda.device_count())` loads embed in parallel on multi-GPU hosts. The gate also reads its limit fresh on every `acquire()` (`vtsearch/datasets/load_pipeline.py:31-32, 77-78`), so a user-bumped setting takes effect immediately for queued tasks. Test coverage at limit=1 and limit=2 lives in `tests/datasets/test_parallel_loading.py:587-918`.
+
+What's actually missing is the *bulk-load action*. The dashboard supports multi-select (`selectedDatasetIds: Set<string>` in `frontend/src/app/components/dashboard/dashboard.component.ts`) and renders side-action buttons for **Combine selected** and **Delete selected** (`dashboard.component.html:150-168`), but there is no **Load selected** counterpart — the only load path is the per-row `▶` button calling `loadDataset()` (`dashboard.component.ts:796-800` → `POST /api/datasets/registry/<id>/load`).
+
+**Open follow-ups:**
+- Add a "Load selected" side-action button next to Combine/Delete in `dashboard.component.html`, plus a `loadSelectedDatasets()` method that fires `loadRegistered(id)` for every entry of `selectedDatasetIds` in a tight loop (no need for a new bulk endpoint — the existing per-id endpoint plus `_download_gate` give the parallelism for free). Disable when `selectedDatasetIds.size === 0` or every selected dataset is already loaded.
+- No new backend tests needed; add a frontend spec asserting the new button calls `loadRegistered` once per selected id.
 
 ### 13.5 Don't block voting on labelset-source export ★★ XS
 `LabelsetSource.sync_to_labelset_source()` runs synchronously on every vote change to push to the external store. For slow targets (webhook, slow disk) this stalls the vote. Run it in a debounced background thread (200ms debounce coalesces rapid voting bursts).

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -236,7 +236,7 @@
             title="Send exported data to the selected destination"
           >
             @if (submitting) {
-              Exporting...
+              Exporting {{ filteredLabels.length | number }} labels to {{ activeTabExporter.display_name || activeTabExporter.name }}…
             } @else {
               {{ activeTabAction }}
             }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -361,7 +361,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   exportLabelsWith(exporter: ExporterEntry, fieldValues: Record<string, string>): void {
-    this.status = 'Exporting...';
+    const exporterLabel = exporter.display_name || exporter.name;
+    this.status = `Exporting ${this.filteredLabels.length.toLocaleString()} labels to ${exporterLabel}…`;
     this.error = '';
     this.submitting = true;
 

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -33,7 +33,7 @@
           (click)="triggerAddBad()"
           title="Upload a media file and add it to the Bad pile."
         >
-          {{ addingBad ? 'Adding...' : 'Add media to Bad' }}
+          {{ addingBad ? 'Adding to Bad pile…' : 'Add media to Bad' }}
         </button>
         <input
           #addGoodInput
@@ -47,7 +47,7 @@
           (click)="triggerAddGood()"
           title="Upload a media file and add it to the Good pile."
         >
-          {{ addingGood ? 'Adding...' : 'Add media to Good' }}
+          {{ addingGood ? 'Adding to Good pile…' : 'Add media to Good' }}
         </button>
       </div>
     </div>
@@ -165,7 +165,7 @@
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
           @if (submitting) {
-            Importing...
+            Importing labels from {{ selectedImporter.display_name || selectedImporter.name }}…
           } @else {
             Import
           }

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal title="Load Sort" [open]="true" (closed)="close()">
   @if (loading) {
-    <p class="empty-state">Loading...</p>
+    <p class="empty-state">Loading detectors…</p>
   } @else if (showMediaPicker) {
     <div class="media-picker">
       <button class="btn btn--secondary btn--sm back-btn" (click)="closeMediaPicker()" title="Return to sort options">&larr; Back</button>
@@ -9,7 +9,7 @@
       @if (mediaPickerView === 'sources') {
         <p class="picker-instructions">Choose a source to browse media from:</p>
         @if (browseLoading) {
-          <p class="empty-state">Loading sources...</p>
+          <p class="empty-state">Loading media sources…</p>
         } @else {
           <div class="source-list">
             @for (src of mediaSources; track src.name) {
@@ -28,7 +28,7 @@
       @if (mediaPickerView === 'browse-items') {
         <p class="picker-instructions">Select an item from <strong>{{ selectedSource?.display_name || selectedSource?.name }}</strong>:</p>
         @if (browseLoading) {
-          <p class="empty-state">Loading items...</p>
+          <p class="empty-state">Loading items from {{ selectedSource?.display_name || selectedSource?.name }}…</p>
         } @else if (browseItems.length > 0) {
           <div class="browse-list">
             @for (item of browseItems; track item.key) {


### PR DESCRIPTION
## Summary

Several spinners said bare "Loading…" / "Exporting…" / "Importing…" with no hint of the underlying operation. They now name the active phase, including counts and the selected importer/exporter where it's known.

### Export modal (`export-modal.component.html` + `.ts`)
- Submit button while exporting: `Exporting 142 labels to Server CSV File…`
- Matching `status` string in `exportLabelsWith()` uses the same shape

### Label importer modal (`label-importer-modal.component.html`)
- Submit button while importing: `Importing labels from Server CSV File…`
- "Add media to Bad/Good" buttons while uploading: `Adding to Bad pile…` / `Adding to Good pile…`

### Load Sort modal (the Find view's sort picker; `load-sort-modal.component.html`)
- Initial detector fetch: `Loading detectors…` (was bare `Loading...`)
- Media source picker: `Loading media sources…`
- Browse-items step: `Loading items from <Source>…`

Implementation note: the export button's `activeTabExporter?.x` was tripping Angular's NG8107 warning because the surrounding `@else if (activeTabExporter)` already narrows the type — switched to `activeTabExporter.x` to keep `npm run build:prod` warning-free (warnings are treated as failures by `run-tests.sh`).

## Test plan
- [x] `cd frontend && npm run build:prod` — clean, no warnings
- [ ] Open the export modal → confirm the submit button reads `Exporting <n> labels to <Exporter>…` while a real export is in flight
- [ ] Open the label importer modal → confirm `Importing labels from <Importer>…` and `Adding to <Good|Bad> pile…`
- [ ] Open the Load Sort modal from the Find view → confirm `Loading detectors…`, `Loading media sources…`, and `Loading items from <Source>…`

https://claude.ai/code/session_013UGrNjBqRgQUQzDrwXcVGN

---
_Generated by [Claude Code](https://claude.ai/code/session_013UGrNjBqRgQUQzDrwXcVGN)_