### PR TITLE
Lift test coverage on 8 under-tested modules (79% → 81% total)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,3 +15,4 @@
 # `pip-audit` clean in `run-tests.sh`). Drop the line if the version
 # pulled by requests/huggingface-hub already satisfies the constraint.
 urllib3>=2.7.0  # CVE-2026-44431, CVE-2026-44432
+idna>=3.15  # CVE-2026-45409

--- a/tests/cli/test_eval_cli.py
+++ b/tests/cli/test_eval_cli.py
@@ -1,0 +1,245 @@
+"""Tests for the eval CLI entry points.
+
+* ``python -m vtsearch.eval`` — :mod:`vtsearch.eval.__main__`
+* ``python -m vtsearch.eval.label_curve_main``
+
+The full ``run_eval`` / ``run_label_curve_eval`` calls download demo
+datasets and run real embedders, so we test argument parsing, ``--list``
+output, and the JSON / CSV serialisation paths with the heavy entry
+points stubbed.  This still exercises the argparse wiring and the
+result-printing branches that previously had 0% coverage.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from vtsearch.eval import label_curve_main as lc_main
+from vtsearch.eval import __main__ as eval_main
+from vtsearch.eval.metrics import DatasetResult, LearnedSortMetrics, QueryMetrics
+
+
+# ---------------------------------------------------------------------------
+# vtsearch.eval.__main__
+# ---------------------------------------------------------------------------
+
+
+class TestEvalMainList:
+    """``--list`` enumerates available eval datasets and exits 0."""
+
+    def test_list_exits_zero_and_prints_known_id(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["prog", "--list"])
+        with pytest.raises(SystemExit) as excinfo:
+            eval_main.main()
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert "Available eval datasets:" in out
+        # One of the canonical demo IDs must appear.
+        assert "esc50_s" in out
+
+
+class TestEvalMainRun:
+    """The body of ``main`` after argument parsing — printing, JSON write,
+    plot generation — exercised with ``run_eval`` stubbed."""
+
+    @pytest.fixture
+    def stub_run_eval(self, monkeypatch):
+        """Stub run_eval to return one populated DatasetResult."""
+
+        result = DatasetResult(dataset_id="esc50_s", media_type="audio")
+        result.text_sort = [
+            QueryMetrics(
+                query_text="a dog barking",
+                target_category="dog",
+                num_relevant=1,
+                num_total=10,
+                average_precision=0.5,
+                precision_at_k={5: 0.4, 10: 0.3},
+                recall_at_k={5: 0.2, 10: 0.4},
+                elapsed_seconds=0.1,
+            ),
+        ]
+        result.learned_sort = [
+            LearnedSortMetrics(
+                target_category="dog",
+                num_train=10,
+                num_test=5,
+                accuracy=0.8,
+                precision=0.7,
+                recall=0.6,
+                f1=0.65,
+                elapsed_seconds=0.2,
+            ),
+        ]
+
+        def _fake(**kwargs):
+            return [result]
+
+        monkeypatch.setattr(eval_main, "run_eval", _fake)
+        return result
+
+    def test_main_prints_summary(self, monkeypatch, capsys, stub_run_eval):
+        monkeypatch.setattr(sys, "argv", ["prog", "--datasets", "esc50_s"])
+        eval_main.main()
+        out = capsys.readouterr().out
+        assert "SUMMARY" in out
+        assert "esc50_s" in out
+        # text-sort surfaces the mAP line; learned-sort surfaces mean_F1.
+        assert "mAP=" in out
+        assert "mean_F1=" in out
+
+    def test_output_writes_json_file(self, monkeypatch, capsys, tmp_path, stub_run_eval):
+        out_path = tmp_path / "results.json"
+        monkeypatch.setattr(sys, "argv", ["prog", "--output", str(out_path)])
+        eval_main.main()
+        assert out_path.is_file()
+        # The CLI uses format_results_json which is JSON-valid.
+        data = json.loads(out_path.read_text())
+        assert isinstance(data, list)
+        assert data[0]["dataset_id"] == "esc50_s"
+
+    def test_plot_dir_invokes_plotter(self, monkeypatch, capsys, tmp_path, stub_run_eval):
+        from vtsearch.eval import visualize
+
+        calls = {}
+
+        def _fake_plot(results, output_dir):
+            calls["results"] = results
+            calls["output_dir"] = output_dir
+            return [tmp_path / "plot.png"]
+
+        monkeypatch.setattr(visualize, "plot_eval_results", _fake_plot)
+        monkeypatch.setattr(sys, "argv", ["prog", "--plot-dir", str(tmp_path)])
+        eval_main.main()
+        assert calls["output_dir"] == str(tmp_path)
+        out = capsys.readouterr().out
+        assert "Plots written" in out
+
+    def test_no_plot_flag_skips_plotter(self, monkeypatch, tmp_path, stub_run_eval):
+        from vtsearch.eval import visualize
+
+        called = {"yes": False}
+
+        def _fake_plot(results, output_dir):
+            called["yes"] = True
+            return []
+
+        monkeypatch.setattr(visualize, "plot_eval_results", _fake_plot)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["prog", "--plot-dir", str(tmp_path), "--no-plot"],
+        )
+        eval_main.main()
+        assert called["yes"] is False
+
+
+# ---------------------------------------------------------------------------
+# vtsearch.eval.label_curve_main
+# ---------------------------------------------------------------------------
+
+
+class TestLabelCurveMain:
+    @pytest.fixture
+    def stub_pipeline(self, monkeypatch):
+        """Stub the demo-dataset load and the eval to make ``main`` headless."""
+        import pandas as pd
+
+        monkeypatch.setattr(lc_main, "_load_dataset", lambda demo_id: {1: {"id": 1, "category": "x"}})
+
+        df = pd.DataFrame(
+            [
+                {
+                    "dataset": "esc50_s",
+                    "category": "dog",
+                    "trainer": "mlp",
+                    "n_labels": 10,
+                    "auroc_mean": 0.8,
+                    "auroc_std": 0.05,
+                    "average_precision_mean": 0.7,
+                    "average_precision_std": 0.04,
+                    "best_f1_mean": 0.6,
+                    "f1_at_xcal_mean": 0.55,
+                    "f1_at_xcal_std": 0.03,
+                    "train_seconds_mean": 0.1,
+                },
+            ]
+        )
+
+        monkeypatch.setattr(lc_main, "run_label_curve_eval", lambda **kw: df)
+
+        # summarise just returns the same df shape we built — pass through.
+        monkeypatch.setattr(lc_main, "summarise", lambda d: d)
+        return df
+
+    def test_main_smoke(self, capsys, stub_pipeline):
+        rc = lc_main.main(["--datasets", "esc50_s", "--label-counts", "10", "--seeds", "0"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Loading esc50_s" in out
+        assert "SUMMARY" in out
+        # The summary row is printed via _print_summary.
+        assert "esc50_s" in out
+        assert "mlp" in out
+
+    def test_main_csv_output(self, tmp_path, stub_pipeline):
+        out_path = tmp_path / "curve.csv"
+        rc = lc_main.main(
+            [
+                "--datasets",
+                "esc50_s",
+                "--label-counts",
+                "10",
+                "--seeds",
+                "0",
+                "--output",
+                str(out_path),
+            ]
+        )
+        assert rc == 0
+        assert out_path.is_file()
+        text = out_path.read_text()
+        assert "trainer" in text  # header row from to_csv
+
+    def test_main_json_output(self, tmp_path, stub_pipeline):
+        out_path = tmp_path / "curve.json"
+        rc = lc_main.main(
+            [
+                "--datasets",
+                "esc50_s",
+                "--label-counts",
+                "10",
+                "--seeds",
+                "0",
+                "--output",
+                str(out_path),
+            ]
+        )
+        assert rc == 0
+        # JSON output is well-formed.
+        data = json.loads(out_path.read_text())
+        assert isinstance(data, list)
+        assert data[0]["trainer"] == "mlp"
+
+    def test_main_no_datasets_loaded_returns_2(self, monkeypatch, capsys):
+        """If every dataset fails to load, exit code is 2."""
+
+        def _boom(demo_id):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(lc_main, "_load_dataset", _boom)
+        rc = lc_main.main(["--datasets", "esc50_s", "--label-counts", "10", "--seeds", "0"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "ERROR loading esc50_s" in err
+        assert "No datasets loaded" in err
+
+    def test_print_summary_empty_dataframe(self, capsys):
+        import pandas as pd
+
+        lc_main._print_summary(pd.DataFrame())
+        out = capsys.readouterr().out
+        assert "no rows" in out

--- a/tests/core/test_memory_budget.py
+++ b/tests/core/test_memory_budget.py
@@ -1,0 +1,110 @@
+"""Tests for ``vtsearch.concurrency.memory_budget.cap_workers_by_memory``.
+
+The function caps a requested worker count so that ``n_items * embed_dim *
+bytes_per_element`` per worker fits inside ``budget_fraction`` of currently-
+available memory.  Always returns at least 1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.concurrency import memory_budget
+from vtsearch.concurrency.memory_budget import cap_workers_by_memory
+
+
+@pytest.fixture
+def fixed_memory(monkeypatch):
+    """Pin ``_available_memory_bytes`` to a known value for deterministic math."""
+
+    def _set(bytes_available: int) -> None:
+        monkeypatch.setattr(memory_budget, "_available_memory_bytes", lambda: bytes_available)
+
+    return _set
+
+
+class TestEarlyReturns:
+    def test_single_worker_short_circuits(self, fixed_memory):
+        # Even with a tiny budget, max_workers=1 must return 1 without
+        # consulting the budget.
+        fixed_memory(0)
+        assert cap_workers_by_memory(1_000_000, 1024, max_workers=1) == 1
+
+    def test_zero_workers_returns_one(self, fixed_memory):
+        # Floor of 1 — never return 0.
+        fixed_memory(10 * 1024 * 1024 * 1024)
+        assert cap_workers_by_memory(100, 128, max_workers=0) == 1
+
+    def test_negative_workers_returns_one(self, fixed_memory):
+        fixed_memory(10 * 1024 * 1024 * 1024)
+        assert cap_workers_by_memory(100, 128, max_workers=-5) == 1
+
+    def test_zero_items_uses_requested_workers(self, fixed_memory):
+        # With no items, per-worker memory is 0 — return the request.
+        fixed_memory(0)
+        assert cap_workers_by_memory(0, 128, max_workers=8) == 8
+
+    def test_zero_embed_dim_uses_requested_workers(self, fixed_memory):
+        fixed_memory(0)
+        assert cap_workers_by_memory(1000, 0, max_workers=8) == 8
+
+
+class TestBudgetCapping:
+    def test_budget_allows_all_workers(self, fixed_memory):
+        # 8 GiB available, 25% budget = 2 GiB.  100 items * 128 dim * 4 B =
+        # ~50 KB per worker — plenty of room for 8 workers.
+        fixed_memory(8 * 1024 * 1024 * 1024)
+        assert cap_workers_by_memory(100, 128, max_workers=8) == 8
+
+    def test_budget_caps_below_requested(self, fixed_memory):
+        # 1 GiB available, 25% budget = 256 MiB.
+        # 100k items * 1152 dim * 4 B = ~439 MiB per worker → only 0 fit
+        # mathematically (256/439 = 0).  Floor enforces 1.
+        fixed_memory(1 * 1024 * 1024 * 1024)
+        assert cap_workers_by_memory(100_000, 1152, max_workers=8) == 1
+
+    def test_budget_allows_partial_workers(self, fixed_memory):
+        # Construct a case that divides exactly.  Budget = 4 * per_worker.
+        per_worker = 1000 * 100 * 4  # 400 KB
+        # budget = 4 * 400 KB = 1.6 MB, so available = 1.6 MB / 0.25 = 6.4 MB
+        fixed_memory(int(per_worker * 4 / 0.25))
+        assert cap_workers_by_memory(1000, 100, max_workers=16) == 4
+
+    def test_custom_budget_fraction(self, fixed_memory):
+        # 1 GiB available, 50% budget = 512 MiB.  Per-worker = 256 MiB →
+        # exactly 2 workers fit.
+        fixed_memory(1024 * 1024 * 1024)
+        per_worker = 256 * 1024 * 1024 // 4  # n*d*4 = 256 MiB
+        cap = cap_workers_by_memory(
+            per_worker,
+            1,
+            max_workers=8,
+            budget_fraction=0.5,
+        )
+        assert cap == 2
+
+    def test_custom_bytes_per_element(self, fixed_memory):
+        # 16 MiB available, 25% = 4 MiB.  Per element = 8 bytes (fp64).
+        # n=1024, d=128 → per worker = 1024*128*8 = 1 MiB → 4 fit.
+        fixed_memory(16 * 1024 * 1024)
+        cap = cap_workers_by_memory(1024, 128, max_workers=8, bytes_per_element=8)
+        assert cap == 4
+
+    def test_request_lower_than_budget_wins(self, fixed_memory):
+        # Budget would allow 10 workers but request is only 3 — return 3.
+        fixed_memory(10 * 1024 * 1024 * 1024)
+        assert cap_workers_by_memory(100, 128, max_workers=3) == 3
+
+
+class TestRealMemoryProbe:
+    """Sanity-check the real (un-monkeypatched) probe returns a sane value."""
+
+    def test_returns_positive_int(self):
+        avail = memory_budget._available_memory_bytes()
+        assert isinstance(avail, int)
+        assert avail > 0
+
+    def test_real_call_returns_floor_or_more(self):
+        # No monkeypatching: with a heavy per-worker estimate the cap should
+        # still be >= 1.
+        assert cap_workers_by_memory(10_000_000, 4096, max_workers=8) >= 1

--- a/tests/datasets/test_load_routes.py
+++ b/tests/datasets/test_load_routes.py
@@ -1,0 +1,131 @@
+"""Tests for the uncovered branches of ``vtsearch.routes.datasets.load``.
+
+Covers endpoints that had zero direct tests:
+
+* ``GET  /api/dataset/export`` — round-trips the current medias to a
+  pickle download.
+* ``POST /api/dataset/load-file`` — accepts a multipart pickle upload
+  (validates the no-file / empty-filename branches).
+* ``POST /api/dataset/load-source`` — the ``_load_from_origin``
+  pseudo-origin and unknown-importer branches.
+
+The tests do not exercise the background import thread itself; that
+lives in ``tests/datasets/test_parallel_loading.py`` and friends.
+"""
+
+from __future__ import annotations
+
+import io
+
+
+# ---------------------------------------------------------------------------
+# GET /api/dataset/export
+# ---------------------------------------------------------------------------
+
+
+class TestExportDataset:
+    def test_returns_pickle_for_loaded_dataset(self, client, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_pickle
+        from vtsearch.state import medias
+
+        # Default fixture medias are loaded; export should succeed.
+        resp = client.get("/api/dataset/export")
+        assert resp.status_code == 200
+        assert resp.content_type == "application/octet-stream"
+        assert resp.headers["Content-Disposition"].endswith(".pkl")
+
+        # The exported pickle round-trips back into a loadable dataset.
+        pkl_path = tmp_path / "roundtrip.pkl"
+        pkl_path.write_bytes(resp.data)
+        roundtrip: dict = {}
+        load_dataset_from_pickle(pkl_path, roundtrip)
+        assert len(roundtrip) == len(medias)
+
+    def test_returns_400_when_no_dataset(self, client):
+        from vtsearch.state import medias
+
+        saved = dict(medias)
+        medias.clear()
+        try:
+            resp = client.get("/api/dataset/export")
+            assert resp.status_code == 400
+            assert "No dataset loaded" in resp.get_json()["message"]
+        finally:
+            medias.update(saved)
+
+    def test_returns_500_when_export_raises(self, client, monkeypatch):
+        """Exporter exceptions are caught and surfaced as 500 + detail."""
+
+        def _boom(_snap):
+            raise RuntimeError("disk on fire")
+
+        import vtsearch.routes.datasets.load as load_mod
+
+        monkeypatch.setattr(load_mod, "export_dataset_to_file", _boom)
+        resp = client.get("/api/dataset/export")
+        assert resp.status_code == 500
+        body = resp.get_json()
+        assert "disk on fire" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/dataset/load-file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFile:
+    def test_missing_file_returns_400(self, client):
+        resp = client.post("/api/dataset/load-file")
+        assert resp.status_code == 400
+        assert "No file provided" in resp.get_json()["message"]
+
+    def test_empty_filename_returns_400(self, client):
+        """An uploaded file with no filename is rejected with 400."""
+        data = {"file": (io.BytesIO(b"junk"), "")}
+        resp = client.post("/api/dataset/load-file", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert "No file selected" in resp.get_json()["message"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/dataset/load-source
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSource:
+    def test_unknown_importer_returns_400(self, client):
+        resp = client.post(
+            "/api/dataset/load-source",
+            json={"source": {"importer": "not_a_real_importer", "params": {}}},
+        )
+        assert resp.status_code == 400
+        assert "Unknown importer" in resp.get_json()["message"]
+
+    def test_dupe_set_without_members_returns_400(self, client):
+        """The ``dupe_set`` pseudo-origin needs ``members`` — empty rejects."""
+        resp = client.post(
+            "/api/dataset/load-source",
+            json={"source": {"importer": "dupe_set", "members": []}},
+        )
+        assert resp.status_code == 400
+        assert "dupe_set" in resp.get_json()["message"]
+
+    def test_dupe_set_unwraps_to_inner_origin(self, client):
+        """``dupe_set`` recurses into the first member's origin — an inner
+        unknown-importer surface as the inner's 400, proving the unwrap ran."""
+        resp = client.post(
+            "/api/dataset/load-source",
+            json={
+                "source": {
+                    "importer": "dupe_set",
+                    "members": [{"origin": {"importer": "still_not_real", "params": {}}}],
+                }
+            },
+        )
+        assert resp.status_code == 400
+        assert "still_not_real" in resp.get_json()["message"]
+
+    def test_missing_source_field_returns_422(self, client):
+        """The flask-smorest schema gates the ``source`` field as required."""
+        resp = client.post("/api/dataset/load-source", json={})
+        assert resp.status_code == 422

--- a/tests/detectors/test_labels_routes.py
+++ b/tests/detectors/test_labels_routes.py
@@ -1,0 +1,333 @@
+"""Tests for the lower-covered branches of ``vtsearch.routes.detectors.labels``.
+
+The existing ``test_labelset_elements_api.py`` covers ``labels-detail``,
+``vote``, and ``thumbnail`` error paths.  This file fills in the
+remaining gaps:
+
+* ``POST /api/detectors/<name>/import-labels/<importer>`` — the entire
+  90-line method was at 0% coverage.
+* ``GET /api/detectors/<name>/labels/<element_id>/preview`` — file path
+  resolution, mimetype selection, text-mode JSON branch.
+
+Tests use a stub :class:`~vtsearch.labels.importers.LabelImporter` to
+avoid touching the real filesystem importer chain.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from vtsearch.detectors.store import _detector_path, _read_detector, _write_detector
+from vtsearch.settings import get_detectors_dir
+
+
+@pytest.fixture(autouse=True)
+def clean_detectors_dir():
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+    yield
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+
+
+def _write_seed_detector(name: str = "labels-target", media_type: str = "audio") -> str:
+    """Write a detector with an empty labelset and register it."""
+    from vtsearch.detectors.registry import register_detector, reset_for_tests
+
+    reset_for_tests()
+    _write_detector(
+        _detector_path(name),
+        {
+            "name": name,
+            "text_query": "",
+            "media_type": media_type,
+            "examples": [],
+            "labelset": {"labels": []},
+        },
+    )
+    entry = register_detector(name=name, media_type=media_type)
+    return entry["id"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/detectors/<name>/import-labels/<importer>
+# ---------------------------------------------------------------------------
+
+
+class TestImportLabelsRoute:
+    """Cover the previously-untested ``import_labels_into_detector`` route."""
+
+    def test_unknown_detector_returns_404(self, client):
+        res = client.post(
+            "/api/detectors/missing/import-labels/server_json_file",
+            json={"filepath": "/tmp/nope.json"},
+        )
+        assert res.status_code == 404
+
+    def test_unknown_importer_returns_404(self, client):
+        _write_seed_detector()
+        res = client.post(
+            "/api/detectors/labels-target/import-labels/not_a_real_importer",
+            json={"filepath": "/tmp/foo.json"},
+        )
+        assert res.status_code == 404
+        body = res.get_json()
+        assert "not_a_real_importer" in body["error"]
+
+    def test_missing_filepath_returns_422(self, client):
+        _write_seed_detector()
+        # server_json_file declares ``filepath`` as required.
+        res = client.post(
+            "/api/detectors/labels-target/import-labels/server_json_file",
+            json={},
+        )
+        assert res.status_code == 422
+
+    def test_invalid_filepath_returns_400(self, client):
+        _write_seed_detector()
+        # Path-traversal attempt — caught by validate_filepath_field.
+        res = client.post(
+            "/api/detectors/labels-target/import-labels/server_json_file",
+            json={"filepath": "/etc/passwd"},
+        )
+        assert res.status_code == 400
+
+    def test_importer_run_error_returns_400(self, client, tmp_path, monkeypatch):
+        """A ValueError from the importer surfaces as 400 with the message."""
+        _write_seed_detector()
+        # A file that doesn't exist → server_json_file raises ValueError.
+        from vtsearch.config import DATA_DIR
+
+        # Place the path under DATA_DIR so validate_filepath_field accepts it.
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        target = DATA_DIR / "does-not-exist.json"
+        if target.exists():
+            target.unlink()
+
+        res = client.post(
+            "/api/detectors/labels-target/import-labels/server_json_file",
+            json={"filepath": str(target)},
+        )
+        assert res.status_code == 400
+        assert "not found" in res.get_json()["error"].lower()
+
+    def test_happy_path_merges_labels(self, client, tmp_path, monkeypatch):
+        """Successful import writes the entries into the on-disk labelset."""
+        from vtsearch.config import DATA_DIR
+
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        labels_file = DATA_DIR / "import_happy.json"
+        labels_file.write_text(
+            '{"labels": ['
+            '{"md5": "a1b2", "label": "good", "origin_name": "x.wav"},'
+            '{"md5": "c3d4", "label": "bad", "origin_name": "y.wav"}'
+            "]}"
+        )
+        try:
+            _write_seed_detector()
+            res = client.post(
+                "/api/detectors/labels-target/import-labels/server_json_file",
+                json={"filepath": str(labels_file)},
+            )
+            assert res.status_code == 200, res.get_data(as_text=True)
+            body = res.get_json()
+            assert body["applied"] == 2
+            assert body["skipped"] == 0
+            assert body["num_labels"] == 2
+            assert "Added 2 label" in body["message"]
+
+            # On-disk labelset reflects the new entries.
+            data = _read_detector(_detector_path("labels-target"))
+            assert data is not None
+            labels = data["labelset"]["labels"]
+            assert len(labels) == 2
+            md5s = {lbl["md5"] for lbl in labels}
+            assert md5s == {"a1b2", "c3d4"}
+        finally:
+            if labels_file.exists():
+                labels_file.unlink()
+
+    def test_skips_invalid_label_values(self, client):
+        """Entries whose ``label`` isn't 'good'/'bad' are counted as skipped."""
+        from vtsearch.config import DATA_DIR
+
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        labels_file = DATA_DIR / "import_invalid.json"
+        labels_file.write_text(
+            '{"labels": ['
+            '{"md5": "aa", "label": "good"},'
+            '{"md5": "bb", "label": "maybe"},'  # invalid value
+            '{"md5": "cc"}'  # no label at all
+            "]}"
+        )
+        try:
+            _write_seed_detector()
+            res = client.post(
+                "/api/detectors/labels-target/import-labels/server_json_file",
+                json={"filepath": str(labels_file)},
+            )
+            assert res.status_code == 200
+            body = res.get_json()
+            assert body["applied"] == 1
+            assert body["skipped"] == 2
+        finally:
+            if labels_file.exists():
+                labels_file.unlink()
+
+    def test_dedups_existing_md5_label_pair(self, client):
+        """An entry whose (md5, label) pair is already present is skipped."""
+        from vtsearch.config import DATA_DIR
+
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        labels_file = DATA_DIR / "import_dupe.json"
+        labels_file.write_text('{"labels": [{"md5": "shared", "label": "good"},{"md5": "fresh", "label": "good"}]}')
+        try:
+            # Pre-seed the detector with a matching (md5, label) pair.
+            _write_seed_detector()
+            data = _read_detector(_detector_path("labels-target"))
+            assert data is not None
+            data["labelset"] = {"labels": [{"md5": "shared", "label": "good", "origin_name": "old.wav"}]}
+            _write_detector(_detector_path("labels-target"), data)
+
+            res = client.post(
+                "/api/detectors/labels-target/import-labels/server_json_file",
+                json={"filepath": str(labels_file)},
+            )
+            assert res.status_code == 200
+            body = res.get_json()
+            assert body["applied"] == 1, "only the fresh entry should land"
+            assert body["skipped"] == 1
+            assert body["num_labels"] == 2
+        finally:
+            if labels_file.exists():
+                labels_file.unlink()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/detectors/<name>/labels/<element_id>/preview
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewLabelRoute:
+    """Cover the file-streaming preview route, which had 0% coverage."""
+
+    def test_unknown_detector_returns_404(self, client):
+        res = client.get("/api/detectors/missing/labels/abc/preview")
+        assert res.status_code == 404
+
+    def test_unknown_element_returns_404(self, client):
+        _write_seed_detector()
+        res = client.get("/api/detectors/labels-target/labels/missing/preview")
+        assert res.status_code == 404
+
+    def test_unresolvable_file_returns_404(self, client):
+        """An element whose origin can't resolve to a file should 404 cleanly."""
+        _write_seed_detector()
+        # Inject a labelset with one element whose origin doesn't exist.
+        data = _read_detector(_detector_path("labels-target"))
+        assert data is not None
+        data["labelset"] = {
+            "labels": [
+                {
+                    "md5": "deadbeef",
+                    "label": "good",
+                    "origin": {"importer": "ghost", "params": {}},
+                    "origin_name": "ghost.wav",
+                    "filename": "ghost.wav",
+                }
+            ]
+        }
+        _write_detector(_detector_path("labels-target"), data)
+
+        detail = client.get("/api/detectors/labels-target/labels-detail").get_json()
+        elem_id = detail["good"][0]["id"]
+        res = client.get(f"/api/detectors/labels-target/labels/{elem_id}/preview")
+        assert res.status_code == 404
+
+    def test_text_media_returns_content_json(self, client, tmp_path, monkeypatch):
+        """For text media the route returns a JSON body, not raw bytes."""
+        from contextlib import contextmanager
+
+        text_path = tmp_path / "doc.txt"
+        text_path.write_text("hello world how are you")
+
+        @contextmanager
+        def _fake_resolve(origin, origin_name="", filename=""):
+            yield text_path
+
+        import vtsearch.detectors.labelset_elements as le_mod
+
+        monkeypatch.setattr(le_mod, "resolve_element_to_path", _fake_resolve)
+
+        _write_seed_detector(media_type="text")
+        data = _read_detector(_detector_path("labels-target"))
+        assert data is not None
+        data["labelset"] = {
+            "labels": [
+                {
+                    "md5": "deadbeef",
+                    "label": "good",
+                    "origin": {"importer": "ghost", "params": {}},
+                    "origin_name": "doc.txt",
+                    "filename": "doc.txt",
+                }
+            ]
+        }
+        _write_detector(_detector_path("labels-target"), data)
+
+        detail = client.get("/api/detectors/labels-target/labels-detail").get_json()
+        elem_id = detail["good"][0]["id"]
+        res = client.get(f"/api/detectors/labels-target/labels/{elem_id}/preview")
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body["content"] == "hello world how are you"
+        assert body["word_count"] == 5
+        assert body["character_count"] == 23
+
+    def test_binary_media_returns_file_bytes(self, client, tmp_path, monkeypatch):
+        """For non-text media the route streams the file bytes."""
+        from contextlib import contextmanager
+
+        img_path = tmp_path / "tiny.png"
+        # 1×1 PNG (valid header).
+        img_path.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+            b"\xff?\x00\x05\xfe\x02\xfe\xa3wW\x1d\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+        @contextmanager
+        def _fake_resolve(origin, origin_name="", filename=""):
+            yield img_path
+
+        import vtsearch.detectors.labelset_elements as le_mod
+
+        monkeypatch.setattr(le_mod, "resolve_element_to_path", _fake_resolve)
+
+        _write_seed_detector(media_type="image")
+        data = _read_detector(_detector_path("labels-target"))
+        assert data is not None
+        data["labelset"] = {
+            "labels": [
+                {
+                    "md5": "deadbeef",
+                    "label": "good",
+                    "origin": {"importer": "ghost", "params": {}},
+                    "origin_name": "tiny.png",
+                    "filename": "tiny.png",
+                }
+            ]
+        }
+        _write_detector(_detector_path("labels-target"), data)
+
+        detail = client.get("/api/detectors/labels-target/labels-detail").get_json()
+        elem_id = detail["good"][0]["id"]
+        res = client.get(f"/api/detectors/labels-target/labels/{elem_id}/preview")
+        assert res.status_code == 200
+        assert res.content_type == "image/png"
+        # PNG magic header survives the round-trip.
+        assert res.data[:8] == b"\x89PNG\r\n\x1a\n"

--- a/tests/detectors/test_processor_scoring.py
+++ b/tests/detectors/test_processor_scoring.py
@@ -1,0 +1,225 @@
+"""Happy-path tests for the processor scoring endpoints.
+
+The error paths (no medias, bad type, mismatched media type) live in
+``tests/detectors/test_extractors.py`` and
+``tests/integration/test_multi_media_coverage.py``.  This file exercises
+the *successful* execution branches in
+:mod:`vtsearch.routes.processors.scoring`:
+
+* ``/api/extract`` happy path — extractor produces hits, response has
+  the expected per-media shape.
+* ``/api/localize`` happy path — localizer produces bounding boxes.
+* ``/api/auto-extract`` and ``/api/auto-localize`` parallel runner
+  (``_auto_run_processors``) — uses the worker-cap path.
+
+A stub extractor / localizer is patched into the route module so the
+tests do not depend on YOLO weights.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vtsearch.autorun_processors import (
+    autorun_extractors,
+    autorun_localizers,
+)
+from vtsearch.media.processors import Extractor, Localizer
+from vtsearch.routes.processors import scoring as scoring_mod
+
+
+class StubAudioExtractor(Extractor):
+    """Audio extractor that yields one fake hit per media."""
+
+    def __init__(self, name: str, *, hits_per_media: int = 1):
+        self._name = name
+        self._hits_per_media = hits_per_media
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    def extract(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [{"confidence": 0.9, "label": "found", "idx": i} for i in range(self._hits_per_media)]
+
+
+class StubAudioLocalizer(Localizer):
+    """Audio localizer that yields one bounding-box per media."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    def localize(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [{"confidence": 0.8, "bbox": [0.0, 1.0]}]
+
+
+@pytest.fixture
+def stub_extractor_factory(monkeypatch):
+    """Make ``_build_extractor`` return a :class:`StubAudioExtractor`."""
+
+    def _factory(name: str, extractor_type: str, config: dict):
+        return StubAudioExtractor(name)
+
+    monkeypatch.setattr(scoring_mod, "_build_extractor", _factory)
+
+
+@pytest.fixture
+def stub_localizer_factory(monkeypatch):
+    """Make ``_build_localizer`` return a :class:`StubAudioLocalizer`."""
+
+    def _factory(name: str, localizer_type: str, config: dict):
+        return StubAudioLocalizer(name)
+
+    monkeypatch.setattr(scoring_mod, "_build_localizer", _factory)
+
+
+# ---------------------------------------------------------------------------
+# /api/extract
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHappyPath:
+    def test_runs_extractor_on_each_media(self, client, stub_extractor_factory):
+        from vtsearch.state import medias
+
+        resp = client.post(
+            "/api/extract",
+            json={"name": "stub-ext", "extractor_type": "any", "config": {}},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["extractor_name"] == "stub-ext"
+        assert body["media_type"] == "audio"
+        # Every media produces one hit → all medias appear in results.
+        assert body["total_medias_with_hits"] == len(medias)
+        assert len(body["results"]) == len(medias)
+
+    def test_result_dict_omits_heavyweight_keys(self, client, stub_extractor_factory):
+        resp = client.post(
+            "/api/extract",
+            json={"name": "stub-ext", "extractor_type": "any", "config": {}},
+        )
+        body = resp.get_json()
+        for result in body["results"]:
+            for heavy in ("embedding", "media_bytes", "media_string", "thumbnail_bytes"):
+                assert heavy not in result
+            assert "extractions" in result
+            assert result["extractions"][0]["label"] == "found"
+
+
+class TestLocalizeHappyPath:
+    def test_runs_localizer_on_each_media(self, client, stub_localizer_factory):
+        from vtsearch.state import medias
+
+        resp = client.post(
+            "/api/localize",
+            json={"name": "stub-loc", "localizer_type": "any", "config": {}},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["localizer_name"] == "stub-loc"
+        assert body["media_type"] == "audio"
+        assert body["total_medias_with_hits"] == len(medias)
+        for result in body["results"]:
+            assert "localizations" in result
+            assert result["localizations"][0]["confidence"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# /api/auto-extract  &  /api/auto-localize
+# ---------------------------------------------------------------------------
+
+
+class TestAutoExtractHappyPath:
+    def test_runs_registered_autorun_extractors(self, client, stub_extractor_factory):
+        # Register two autorun extractors for audio so the worker fan-out
+        # actually has multiple jobs to dispatch.
+        autorun_extractors["a"] = {
+            "name": "a",
+            "extractor_type": "any",
+            "media_type": "audio",
+            "config": {},
+            "created_at": 0,
+        }
+        autorun_extractors["b"] = {
+            "name": "b",
+            "extractor_type": "any",
+            "media_type": "audio",
+            "config": {},
+            "created_at": 0,
+        }
+
+        resp = client.post("/api/auto-extract")
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["media_type"] == "audio"
+        assert body["extractors_run"] == 2
+        assert set(body["results"].keys()) == {"a", "b"}
+        for entry in body["results"].values():
+            assert entry["total_medias_with_hits"] > 0
+            assert entry["results"]
+
+    def test_skips_extractors_whose_build_fails(self, client, monkeypatch):
+        """A failing factory call yields no entry for that extractor."""
+
+        def _flaky(name: str, extractor_type: str, config: dict):
+            if name == "broken":
+                raise RuntimeError("simulated config error")
+            return StubAudioExtractor(name)
+
+        monkeypatch.setattr(scoring_mod, "_build_extractor", _flaky)
+
+        autorun_extractors["ok"] = {
+            "name": "ok",
+            "extractor_type": "any",
+            "media_type": "audio",
+            "config": {},
+            "created_at": 0,
+        }
+        autorun_extractors["broken"] = {
+            "name": "broken",
+            "extractor_type": "any",
+            "media_type": "audio",
+            "config": {},
+            "created_at": 0,
+        }
+
+        resp = client.post("/api/auto-extract")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "ok" in body["results"]
+        assert "broken" not in body["results"]
+
+
+class TestAutoLocalizeHappyPath:
+    def test_runs_registered_autorun_localizers(self, client, stub_localizer_factory):
+        autorun_localizers["loc-x"] = {
+            "name": "loc-x",
+            "localizer_type": "any",
+            "media_type": "audio",
+            "config": {},
+            "created_at": 0,
+        }
+
+        resp = client.post("/api/auto-localize")
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["media_type"] == "audio"
+        assert body["localizers_run"] == 1
+        assert "loc-x" in body["results"]
+        entry = body["results"]["loc-x"]
+        assert entry["total_medias_with_hits"] > 0

--- a/tests/detectors/test_training_pipeline.py
+++ b/tests/detectors/test_training_pipeline.py
@@ -1,0 +1,301 @@
+"""Tests for :mod:`vtsearch.detectors.training`.
+
+The existing :mod:`tests/io/test_export_options.py` covers
+``train_and_threshold`` happy path indirectly.  This file fills in:
+
+* :func:`validate_good_bad_split` — the small ABC-level guard.
+* :func:`collect_media_origins` — origin extraction from a media snapshot.
+* :func:`train_detector_from_origins` — the load-time origin → file →
+  embedding → MLP pipeline, with file resolution and embedding stubbed.
+* :func:`train_and_score` — the empty-result and single-class branches
+  (the happy path is already exercised by the sort routes).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+from vtsearch.detectors.training import (
+    collect_media_origins,
+    train_and_score,
+    train_detector_from_origins,
+    validate_good_bad_split,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_good_bad_split
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGoodBadSplit:
+    def test_returns_counts_when_valid(self):
+        n_good, n_bad = validate_good_bad_split([1.0, 0.0, 1.0, 0.0, 1.0])
+        assert (n_good, n_bad) == (3, 2)
+
+    def test_zero_good_raises(self):
+        with pytest.raises(ValueError, match="at least one good and one bad"):
+            validate_good_bad_split([0.0, 0.0])
+
+    def test_zero_bad_raises(self):
+        with pytest.raises(ValueError, match="at least one good and one bad"):
+            validate_good_bad_split([1.0, 1.0])
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError):
+            validate_good_bad_split([])
+
+
+# ---------------------------------------------------------------------------
+# collect_media_origins
+# ---------------------------------------------------------------------------
+
+
+class TestCollectMediaOrigins:
+    def _snap(self):
+        return {
+            1: {
+                "id": 1,
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": "a.wav",
+                "filename": "a.wav",
+                "md5": "aa",
+            },
+            2: {
+                "id": 2,
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": "b.wav",
+                "filename": "b.wav",
+                "md5": "bb",
+            },
+        }
+
+    def test_collects_from_dict_keys(self):
+        # Vote dicts in the codebase are keyed by media id with None values.
+        origins = collect_media_origins({1: None, 2: None}, self._snap())
+        assert len(origins) == 2
+        assert {o["origin_name"] for o in origins} == {"a.wav", "b.wav"}
+
+    def test_collects_from_list(self):
+        origins = collect_media_origins([1, 2], self._snap())
+        assert len(origins) == 2
+
+    def test_skips_unknown_ids(self):
+        origins = collect_media_origins([1, 999], self._snap())
+        assert len(origins) == 1
+        assert origins[0]["origin_name"] == "a.wav"
+
+    def test_each_dict_has_full_origin_fields(self):
+        origins = collect_media_origins([1], self._snap())
+        assert origins[0] == {
+            "origin": {"importer": "test", "params": {}},
+            "origin_name": "a.wav",
+            "filename": "a.wav",
+            "md5": "aa",
+        }
+
+    def test_missing_fields_default_to_empty_string(self):
+        snap = {1: {"id": 1, "origin": None}}
+        origins = collect_media_origins([1], snap)
+        assert origins[0] == {
+            "origin": None,
+            "origin_name": "",
+            "filename": "",
+            "md5": "",
+        }
+
+
+# ---------------------------------------------------------------------------
+# train_and_score
+# ---------------------------------------------------------------------------
+
+
+class TestTrainAndScore:
+    def test_empty_votes_returns_empty(self):
+        clips = {1: {"id": 1, "embedding": np.ones(8, dtype=np.float32)}}
+        results, threshold, model = train_and_score(clips, {}, {})
+        assert results == []
+        assert threshold == 0.5
+        assert model is None
+
+    def test_only_good_returns_empty(self):
+        clips = {
+            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32)},
+            2: {"id": 2, "embedding": np.zeros(8, dtype=np.float32)},
+        }
+        results, threshold, model = train_and_score(clips, {1: None, 2: None}, {})
+        assert results == []
+        assert model is None
+
+    def test_only_bad_returns_empty(self):
+        clips = {
+            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32)},
+            2: {"id": 2, "embedding": np.zeros(8, dtype=np.float32)},
+        }
+        results, threshold, model = train_and_score(clips, {}, {1: None, 2: None})
+        assert results == []
+        assert model is None
+
+    def test_happy_path_trains_and_scores_all(self):
+        # Deterministic, well-separated embeddings so training is stable.
+        rng = np.random.default_rng(42)
+        clips = {}
+        for i in range(1, 11):
+            # Good cluster centered on +1, bad on -1.
+            center = 1.0 if i <= 5 else -1.0
+            clips[i] = {
+                "id": i,
+                "embedding": (center + rng.standard_normal(8) * 0.05).astype(np.float32),
+            }
+        good = {1: None, 2: None}
+        bad = {6: None, 7: None}
+        results, threshold, model = train_and_score(clips, good, bad)
+        assert model is not None
+        assert isinstance(threshold, float)
+        # Every clip in the snap shows up exactly once in the ranked results.
+        assert len(results) == len(clips)
+        assert {r["id"] for r in results} == set(clips)
+        # Results are sorted by score descending.
+        scores = [r["score"] for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# train_detector_from_origins
+# ---------------------------------------------------------------------------
+
+
+class TestTrainDetectorFromOrigins:
+    @pytest.fixture
+    def stubbed_resolver(self, monkeypatch):
+        """Replace ``resolve_file_context`` + ``embed_file`` so the tests
+        don't need real files or models.
+
+        Each origin maps deterministically to a vector keyed by its
+        ``origin_name`` so we can drive the train/threshold pipeline.
+        """
+        # vec table keyed by origin_name; defaults to a class-0 vec.
+        rng = np.random.default_rng(7)
+        vec_table: dict[str, np.ndarray] = {}
+
+        def _vec_for(name: str, klass: int) -> np.ndarray:
+            if name not in vec_table:
+                base = np.full(8, 1.0 if klass else -1.0, dtype=np.float32)
+                vec_table[name] = (base + rng.standard_normal(8) * 0.05).astype(np.float32)
+            return vec_table[name]
+
+        @contextmanager
+        def _fake_ctx(origin, origin_name="", filename=""):
+            # Yield a sentinel "path" — we only use it to drive embed_file.
+            yield ("PATH:" + origin_name) if origin_name else None
+
+        def _fake_embed(path, media_type, embedder_name=""):
+            if path is None:
+                return None
+            name = path.split(":", 1)[1] if isinstance(path, str) else ""
+            # Encode class in origin_name prefix: "good_X" or "bad_X".
+            if name.startswith("good_"):
+                return _vec_for(name, 1)
+            if name.startswith("bad_"):
+                return _vec_for(name, 0)
+            return None
+
+        import vtsearch.detectors.resolver as resolver_mod
+
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
+        monkeypatch.setattr(resolver_mod, "embed_file", _fake_embed)
+
+    def _origins(self, names: list[str]) -> list[dict]:
+        return [
+            {
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": n,
+                "filename": n,
+                "md5": "",
+            }
+            for n in names
+        ]
+
+    def test_too_few_labels_returns_none(self, stubbed_resolver):
+        weights, threshold = train_detector_from_origins(
+            self._origins(["good_1"]),
+            [],
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is None
+        assert threshold == 0.5
+
+    def test_only_good_returns_none(self, stubbed_resolver):
+        weights, threshold = train_detector_from_origins(
+            self._origins(["good_1", "good_2", "good_3"]),
+            [],
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is None
+        assert threshold == 0.5
+
+    def test_only_bad_returns_none(self, stubbed_resolver):
+        weights, threshold = train_detector_from_origins(
+            [],
+            self._origins(["bad_1", "bad_2"]),
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is None
+
+    def test_happy_path_returns_weights(self, stubbed_resolver):
+        weights, threshold = train_detector_from_origins(
+            self._origins(["good_1", "good_2", "good_3"]),
+            self._origins(["bad_1", "bad_2", "bad_3"]),
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is not None
+        # weights is a dict of {layer_name: nested_list_of_floats}.
+        assert isinstance(weights, dict)
+        assert len(weights) > 0
+        for key, layer in weights.items():
+            assert isinstance(key, str)
+            assert isinstance(layer, list)
+        assert isinstance(threshold, float)
+
+    def test_unresolvable_entries_are_skipped(self, stubbed_resolver):
+        """If an origin resolves to ``None``, the entry is skipped silently.
+
+        With three resolvable goods + three resolvable bads but two extra
+        garbage entries, the trainer still succeeds.
+        """
+        good = self._origins(["good_1", "good_2", "good_3", "junk_x"])
+        bad = self._origins(["bad_1", "bad_2", "bad_3", "junk_y"])
+        weights, _ = train_detector_from_origins(
+            good,
+            bad,
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is not None
+
+    def test_all_unresolvable_returns_none(self, monkeypatch):
+        """If every origin fails to resolve, no model is produced."""
+
+        @contextmanager
+        def _none_ctx(origin, origin_name="", filename=""):
+            yield None
+
+        import vtsearch.detectors.resolver as resolver_mod
+
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _none_ctx)
+
+        weights, threshold = train_detector_from_origins(
+            [{"origin": {"importer": "x", "params": {}}, "origin_name": "a", "md5": ""}],
+            [{"origin": {"importer": "x", "params": {}}, "origin_name": "b", "md5": ""}],
+            inclusion=0,
+            media_type="audio",
+        )
+        assert weights is None
+        assert threshold == 0.5

--- a/tests/detectors/test_workflow.py
+++ b/tests/detectors/test_workflow.py
@@ -1,0 +1,141 @@
+"""Tests for ``vtsearch.detectors.workflow.apply_and_retrain``.
+
+This is the Flask-aware retraining helper called from the
+``/api/detectors/<name>/import-labels/<importer>`` endpoint after label
+import.  It overrides the active detector context, resolves the new
+label entries against the loaded dataset, applies them, and retrains
+the MLP when both a good and a bad vote are present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.detectors.workflow import apply_and_retrain
+from vtsearch.state import medias
+from vtsearch.state.core import DetectorContext
+
+
+@pytest.fixture
+def det_ctx():
+    """A fresh DetectorContext that isn't tied to any registered detector.
+
+    The autouse ``reset_state`` fixture in ``conftest.py`` already wipes
+    the global registry, so spinning one up locally is safe.
+    """
+    return DetectorContext("test-det")
+
+
+def _audio_entry(media_id: int, label: str) -> dict:
+    """Build a label-import entry that matches an existing test audio media."""
+    media = medias[media_id]
+    return {
+        "label": label,
+        "origin": media["origin"],
+        "origin_name": media["origin_name"],
+        "filename": media.get("filename", ""),
+        "md5": media.get("md5", ""),
+    }
+
+
+class TestEmptySnapshot:
+    """When no dataset is loaded the workflow must return cleanly."""
+
+    def test_returns_zero_and_false_when_no_medias(self, det_ctx):
+        saved = dict(medias)
+        medias.clear()
+        try:
+            entries = [{"label": "good", "md5": "deadbeef"}]
+            resolved, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+            assert (resolved, trained) == (0, False)
+            # No model should have been built.
+            assert det_ctx.model is None
+        finally:
+            medias.update(saved)
+
+
+class TestLabelResolution:
+    def test_invalid_labels_are_skipped(self, det_ctx):
+        # ``maybe`` is not a recognised label — counts as 0 resolved.
+        entries = [_audio_entry(1, "maybe")]
+        resolved, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert resolved == 0
+        assert trained is False
+
+    def test_unresolvable_origin_does_not_count(self, det_ctx):
+        # An entry whose origin/md5 don't match anything in the dataset.
+        entries = [
+            {
+                "label": "good",
+                "origin": {"importer": "other", "params": {"x": 1}},
+                "origin_name": "ghost.wav",
+                "md5": "0" * 32,
+            }
+        ]
+        resolved, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert resolved == 0
+        assert trained is False
+
+    def test_resolvable_entry_counts_once(self, det_ctx):
+        entries = [_audio_entry(1, "good")]
+        resolved, _ = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert resolved == 1
+
+
+class TestTraining:
+    """The MLP is only retrained when at least one good AND one bad vote exist."""
+
+    def test_only_good_votes_does_not_train(self, det_ctx):
+        entries = [_audio_entry(1, "good"), _audio_entry(2, "good")]
+        _, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert trained is False
+        assert det_ctx.model is None
+
+    def test_only_bad_votes_does_not_train(self, det_ctx):
+        entries = [_audio_entry(1, "bad"), _audio_entry(2, "bad")]
+        _, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert trained is False
+        assert det_ctx.model is None
+
+    def test_one_good_one_bad_trains_mlp(self, det_ctx):
+        entries = [
+            _audio_entry(1, "good"),
+            _audio_entry(2, "bad"),
+        ]
+        resolved, trained = apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert resolved == 2
+        assert trained is True
+        assert det_ctx.model is not None
+        # The threshold should be a finite float in [0, 1].
+        assert isinstance(det_ctx.threshold, float)
+        assert 0.0 <= det_ctx.threshold <= 1.0
+        # training_medias cache should hold both voted media.
+        assert set(det_ctx.training_medias) >= {1, 2}
+        # embedder / media_type stamped from the snapshot.
+        assert det_ctx.embedder == "clap"
+        assert det_ctx.media_type == "audio"
+
+
+class TestVoteApplicationIsContextScoped:
+    """``apply_and_retrain`` swaps the active detector context inside its
+    body; the votes on the *passed* ctx must reflect the entries."""
+
+    def test_votes_are_applied_to_passed_context(self, det_ctx):
+        entries = [
+            _audio_entry(1, "good"),
+            _audio_entry(2, "bad"),
+        ]
+        apply_and_retrain("test-det", det_ctx, entries, "Test")
+        # The applied votes live on the supplied context.
+        assert 1 in det_ctx.good_votes
+        assert 2 in det_ctx.bad_votes
+
+    def test_unrelated_empty_context_is_not_polluted(self, det_ctx):
+        # Construct a second context, run the workflow on the first only,
+        # and confirm the second remains pristine.
+        other_ctx = DetectorContext("other-det")
+        entries = [_audio_entry(1, "good"), _audio_entry(2, "bad")]
+        apply_and_retrain("test-det", det_ctx, entries, "Test")
+        assert not other_ctx.good_votes
+        assert not other_ctx.bad_votes
+        assert other_ctx.model is None


### PR DESCRIPTION
## Summary

- Adds 79 new tests across 7 files to lift coverage on the lowest-covered modules outside of the GPU-stubbed embedders.
- Project line+branch coverage moves from **79% → 81%**; the targeted modules climb into the 72-95% band.
- Also bumps the `idna` transitive-dep pin to `>=3.15` in `requirements/base.txt` (CVE-2026-45409) following the existing `urllib3` precedent — `pip-audit` in `run-tests.sh` was failing on it for any branch since the CVE was filed upstream.

## Coverage lift (per-module)

| Module | Before | After |
|---|---|---|
| `detectors/workflow.py` | 5% | **95%** |
| `eval/__main__.py` | 0% | **95%** |
| `eval/label_curve_main.py` | 0% | **92%** |
| `routes/processors/scoring.py` | 49% | **93%** |
| `detectors/training.py` | 53% | **83%** |
| `routes/detectors/labels.py` | 38% | **72%** |
| `routes/datasets/load.py` | 65% | **77%** |
| `concurrency/memory_budget.py` | 24% | **61%** |

## What's covered, by file

- `tests/core/test_memory_budget.py` — `cap_workers_by_memory` edges (zero items / zero dim / negative request / custom byte sizes / budget capping).
- `tests/detectors/test_workflow.py` — `apply_and_retrain`: empty-snapshot, unresolvable-origin, invalid-label, only-good / only-bad / one-of-each (trains), and context-scoping (the passed `det_ctx` gets the votes; an unrelated ctx stays pristine).
- `tests/cli/test_eval_cli.py` — `python -m vtsearch.eval` `--list`, JSON `--output`, plot-dir success / `--no-plot` skip, and `label_curve_main` for `--output` (CSV & JSON), all-datasets-fail return code, and empty-summary printer.
- `tests/detectors/test_labels_routes.py` — `POST /api/detectors/<name>/import-labels/<importer>` (404 / 422 / 400 / happy-path merge / invalid-label skip / md5+label dedup) and `GET /api/detectors/<name>/labels/<element_id>/preview` (text mode JSON body, binary mode PNG bytes, unresolvable-file 404).
- `tests/detectors/test_processor_scoring.py` — `/api/extract`, `/api/localize`, `/api/auto-extract`, `/api/auto-localize` happy paths via stub `Extractor` / `Localizer` (avoids YOLO weight downloads), plus the "skip extractor whose build fails" branch.
- `tests/detectors/test_training_pipeline.py` — `validate_good_bad_split` (good case + each empty-side raise), `collect_media_origins` (dict / list / unknown ids / missing fields), `train_and_score` (empty / only-good / only-bad / happy-path), `train_detector_from_origins` (too-few-labels / only-one-class / unresolvable-skip / all-unresolvable / happy-path) — file resolution and embedding stubbed.
- `tests/datasets/test_load_routes.py` — `GET /api/dataset/export` (success + round-trip / no-dataset 400 / exporter-raises 500), `POST /api/dataset/load-file` (no-file / empty-filename 400s), `POST /api/dataset/load-source` (unknown importer / dupe_set without members / dupe_set unwraps to inner origin / missing-source-field 422).

## Test plan

- [x] `./run-tests.sh` — 3,939 passed, 1 skipped, 2 xpassed in ~85s.
- [x] `ruff check`, `ruff format --check`, `codespell`, `deptry`, `pip-audit`, frontend `build:prod` — all green via `run-tests.sh`.
- [x] Coverage rerun confirms the per-module lift above.

https://claude.ai/code/session_01Ttiy6ZYjkkuHB3aGQFvAFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ttiy6ZYjkkuHB3aGQFvAFG)_