### PR TITLE
Fix C6: zip-slip in HTTP archive importer (zip, tar, rar)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -106,18 +106,22 @@ Cross-section interaction agents:
   malicious client can wipe one detector's votes while the UI thinks
   it's labeling a different one.
 
-### C6. Zip-slip in HTTP archive importer (zip AND tar)
+### C6. Zip-slip in HTTP archive importer (zip AND tar) — SHIPPED 2026-05-19
 
-- **File:** `vtsearch/datasets/importers/http_archive/__init__.py`
-  ~L70–89
-- **Bug (zip):** `zf.extract(member, extract_dir)` is called *before*
-  the post-extraction path-traversal check, so a malicious member is
-  already written outside the directory by the time we reject it.
-- **Bug (tar):** `tf.extract(member, extract_dir, filter="data")` only
-  filters tar-specific attacks (symlink/hardlink), not traversal in
-  member names like `../../etc/x`.
-- **Fix sketch:** Validate every member name before extraction; use
-  `extractall(filter=...)` with explicit name validation.
+- **File:** `vtscore/datasets/importers/http_archive/__init__.py`
+- **What landed:** Added `_reject_traversal(extract_dir_resolved, member_name)`
+  helper that validates member names **before** any extract call.  It
+  rejects absolute paths (POSIX `/`, Windows `\\` and drive-letter form)
+  and any name that, once joined and `os.path.normpath`-normalised,
+  escapes the resolved extract dir (checked with `Path.is_relative_to`,
+  not the old prefix-buggy `str.startswith`).  Applied uniformly to the
+  zip, tar, and rar code paths — the tar branch previously had **no**
+  pre-extraction member validation and relied solely on
+  `filter="data"`; it now validates explicitly *in addition to* the
+  `filter="data"` defense.  Regression tests added in
+  `tests_lib/io/test_importers.py::TestExtractArchive` cover `../`
+  traversal, absolute paths, and the prefix-collision case that the old
+  `startswith` check accepted.
 
 ### C7. NaN/Infinity threshold leaks through safe-threshold blending
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -597,6 +597,67 @@ class TestExtractArchive:
         _extract_archive(zip_path, extract_dir)
         assert len(list(extract_dir.glob("*.wav"))) == 3
 
+    def test_zip_traversal_rejected_before_extraction(self, tmp_path):
+        """A zip member with ``..`` traversal must be rejected before any file lands on disk."""
+        from vtscore.datasets.importers.http_archive import _extract_archive
+
+        zip_path = tmp_path / "evil.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("../escape.wav", _make_wav_bytes())
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        with pytest.raises(ValueError, match="traversal"):
+            _extract_archive(zip_path, extract_dir)
+        # Neither the in-tree nor the escaped target should exist.
+        assert not (tmp_path / "escape.wav").exists()
+        assert not (extract_dir / "escape.wav").exists()
+
+    def test_zip_absolute_path_rejected(self, tmp_path):
+        """A zip member with an absolute path must be rejected."""
+        from vtscore.datasets.importers.http_archive import _extract_archive
+
+        zip_path = tmp_path / "abs.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("/etc/escape.wav", _make_wav_bytes())
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        with pytest.raises(ValueError, match="traversal"):
+            _extract_archive(zip_path, extract_dir)
+
+    def test_zip_prefix_collision_rejected(self, tmp_path):
+        """``extract_dir`` prefix collision must NOT pass the traversal check.
+
+        Regression: the previous string-prefix ``startswith`` check would
+        accept ``../out_evil/x`` when extracting into ``.../out`` because
+        ``str.startswith`` does not respect path separators.
+        """
+        from vtscore.datasets.importers.http_archive import _extract_archive
+
+        zip_path = tmp_path / "prefix.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("../out_evil/escape.wav", _make_wav_bytes())
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        with pytest.raises(ValueError, match="traversal"):
+            _extract_archive(zip_path, extract_dir)
+        assert not (tmp_path / "out_evil").exists()
+
+    def test_tar_traversal_rejected_before_extraction(self, tmp_path):
+        """A tar member with ``..`` traversal must be rejected before extraction."""
+        from vtscore.datasets.importers.http_archive import _extract_archive
+
+        tar_path = tmp_path / "evil.tar"
+        wav_data = _make_wav_bytes()
+        with tarfile.open(tar_path, "w") as tf:
+            info = tarfile.TarInfo(name="../escape.wav")
+            info.size = len(wav_data)
+            tf.addfile(info, io.BytesIO(wav_data))
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        with pytest.raises((ValueError, Exception), match="(?i)traversal|outside"):
+            _extract_archive(tar_path, extract_dir)
+        assert not (tmp_path / "escape.wav").exists()
+
 
 # ---------------------------------------------------------------------------
 # DatasetImporter bulk-record hooks (list_records / fetch_record /

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -21,6 +21,7 @@ The importer participates in the multi-media import flow.  Each
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tarfile
 import zipfile
@@ -48,6 +49,27 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
+def _reject_traversal(extract_dir_resolved: Path, member_name: str) -> None:
+    """Raise ValueError if *member_name* would extract outside extract_dir.
+
+    Validates before extraction so a malicious member is never written to disk.
+    Rejects absolute paths, ``..`` traversal, and any name that — once joined
+    and normalised — escapes the extraction root.
+    """
+    # Reject absolute member names outright; on Windows they'd also drop the
+    # root prefix when joined, but we want to fail loudly either way.
+    if member_name.startswith(("/", "\\")) or (len(member_name) > 1 and member_name[1] == ":"):
+        raise ValueError(f"Path traversal detected in archive: {member_name}")
+
+    # Use os.path.normpath-style joining without resolving symlinks: the
+    # extract_dir is freshly created and contains no symlinks yet, and we
+    # don't want a symlink planted by an earlier member in the same archive
+    # to mask a later traversal.
+    target = Path(os.path.normpath(extract_dir_resolved / member_name))
+    if target != extract_dir_resolved and not target.is_relative_to(extract_dir_resolved):
+        raise ValueError(f"Path traversal detected in archive: {member_name}")
+
+
 def _extract_archive(  # noqa: C901
     archive_path: Path,
     extract_dir: Path,
@@ -58,6 +80,7 @@ def _extract_archive(  # noqa: C901
         on_progress = _default_progress()
 
     name = archive_path.name.lower()
+    extract_dir_resolved = extract_dir.resolve()
 
     if name.endswith(".zip"):
         with zipfile.ZipFile(archive_path, "r") as zf:
@@ -70,9 +93,7 @@ def _extract_archive(  # noqa: C901
                     i,
                     total,
                 )
-                target = (extract_dir / member).resolve()
-                if not str(target).startswith(str(extract_dir.resolve())):
-                    raise ValueError(f"Path traversal detected in archive: {member}")
+                _reject_traversal(extract_dir_resolved, member)
                 zf.extract(member, extract_dir)
 
     elif tarfile.is_tarfile(archive_path):
@@ -86,6 +107,7 @@ def _extract_archive(  # noqa: C901
                     i,
                     total,
                 )
+                _reject_traversal(extract_dir_resolved, member.name)
                 tf.extract(member, extract_dir, filter="data")
 
     elif name.endswith(".rar"):
@@ -105,9 +127,7 @@ def _extract_archive(  # noqa: C901
                     i,
                     total,
                 )
-                target = (extract_dir / member).resolve()
-                if not str(target).startswith(str(extract_dir.resolve())):
-                    raise ValueError(f"Path traversal detected in archive: {member}")
+                _reject_traversal(extract_dir_resolved, member)
                 rf.extract(member, extract_dir)
 
     else:


### PR DESCRIPTION
## Summary

Fixes **C6** from `docs/plans/logical-bug-audit.md`: path-traversal flaws in the HTTP archive importer's `_extract_archive()` helper.

- Replaces the string-prefix `startswith` check with a shared `_reject_traversal()` helper that uses `Path.is_relative_to` on an `os.path.normpath`-normalised join (no `resolve()` — so an earlier malicious member can't plant a symlink that masks a later traversal).
- Rejects absolute member names (POSIX `/`, Windows `\`, drive-letter form) explicitly.
- Validates **before** every `extract()` call, so a malicious member never touches disk.
- Applies uniformly to zip, tar, and rar code paths. The tar branch previously had **no** explicit pre-extraction validation and relied solely on `filter="data"`; it now validates explicitly **in addition to** the `filter="data"` defense.

## Why the previous check was wrong

The old check was:
```python
target = (extract_dir / member).resolve()
if not str(target).startswith(str(extract_dir.resolve())):
    raise ValueError(...)
zf.extract(member, extract_dir)
```

Two problems:
1. **`str.startswith` doesn't respect path separators** — `/tmp/out` is a string prefix of `/tmp/out_evil/file`, so a member named `../out_evil/file` would slip past while extracting into `/tmp/out`.
2. **`resolve()` follows symlinks** — an earlier member in the same archive could plant a symlink that redirects a later resolve() back inside the extract dir, masking the actual escape target.

The tar branch additionally had no explicit pre-extraction check at all.

## Test plan
- [x] `python -m pytest tests_lib/io/test_importers.py::TestExtractArchive -v` — 11/11 pass (7 pre-existing happy-path + 4 new traversal-rejection tests).
- [x] `./run-tests.sh io` — 659/659 pass.
- [x] `./run-tests.sh` (full suite) — 3,943/3,943 pass.

New regression tests cover:
- `../escape.wav` in a zip archive (traversal via `..`).
- `/etc/escape.wav` in a zip archive (absolute path).
- `../out_evil/escape.wav` when extracting into `.../out` (prefix-collision case the old `startswith` accepted).
- `../escape.wav` in a tar archive (the case the audit flagged as having no pre-extraction validation).

https://claude.ai/code/session_01WBDobcsYdLjtT1xPM3ivTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBDobcsYdLjtT1xPM3ivTF)_