### PR TITLE
Fix C3: pin in-flight DatasetContext to background load worker thread

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -107,6 +107,18 @@ Cross-section interaction agents:
 
 ### C3. Dataset background load tasks don't set thread-local dataset context
 
+- **Status:** Shipped 2026-05-19 — `_run_origin_load_in_background.task()`
+  now pins the freshly-created `DatasetContext` to its worker thread via
+  `set_thread_dataset_context(ctx)` immediately after creation, and
+  clears the thread-local in the task's `finally` (before
+  `loading_tasks.mark_finished`, so callers waiting on
+  `has_active_tasks() == False` see fully-cleaned-up worker state).
+  Regression covered by `TestBackgroundLoadThreadContext` in
+  `tests/datasets/test_parallel_loading.py`.
+  The warmup and staging spawn sites originally listed alongside the
+  importer site do not register a dataset context (warmup uses the
+  passed `media_dict` directly; staging writes to a temp dict via the
+  combine flow), so no `set_thread_dataset_context` call belongs there.
 - **File:** `vtsearch/datasets/load_pipeline.py` ~L822, ~L947, ~L1141
   (warmup, importer, staging spawn sites)
 - **Bug:** `task()` closures set thread user but never call
@@ -710,6 +722,16 @@ summary, and is also recorded here.
   `job.dataset_id` / `job.detector_id` before invoking the target, and
   clears all three thread-locals (user + dataset + detector) in a
   `finally`. Covered by `tests_lib/integration/test_async_jobs.py::TestThreadContextPropagation`.
+- **C3 — Dataset background load thread-local context** (2026-05-19).
+  `_run_origin_load_in_background.task()` in
+  `vtscore/datasets/load_pipeline.py` now pins the freshly-created
+  `DatasetContext` to its worker thread via
+  `set_thread_dataset_context(ctx)` immediately after creation, and
+  clears the thread-local in the task's `finally` (before
+  `loading_tasks.mark_finished`, so callers waiting on
+  `has_active_tasks() == False` see fully-cleaned-up worker state).
+  Regression in
+  `tests/datasets/test_parallel_loading.py::TestBackgroundLoadThreadContext`.
 - **C4 — embedding-matrix cache after clip/dedup** (2026-05-19).
   `_apply_clipper_stage`, `_collapse_duplicates_stage`, and the
   registry's reload-from-pickle dedup now all call
@@ -737,7 +759,7 @@ summary, and is also recorded here.
 
 ### Still open
 
-Every other finding (C3, C5, C7, C10, C12 and the High / Medium /
+Every other finding (C5, C7, C10, C12 and the High / Medium /
 Low tiers) remains as written. When the next fix lands, edit the
 finding above with **— shipped** and add a line here. When every
 critical and high is addressed, this doc can be retired into the

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -1015,7 +1015,9 @@ class TestBackgroundLoadThreadContext:
             get_thread_dataset_context,
         )
 
-        observed: dict[str, object] = {}
+        from vtscore.state.core import DatasetContext
+
+        observed: dict[str, DatasetContext | None] = {}
         ran = threading.Event()
 
         def capture_load(target_medias):
@@ -1045,13 +1047,11 @@ class TestBackgroundLoadThreadContext:
                 "Background task did not set a thread-local dataset context; "
                 "importer-level get_active_context() would land on the empty fallback."
             )
+            assert active_ctx is not None
             assert active_ctx is not _empty_dataset_context, (
-                "get_active_context() resolved to _empty_dataset_context inside the "
-                "background load — C3 regression."
+                "get_active_context() resolved to _empty_dataset_context inside the background load — C3 regression."
             )
-            assert thread_ctx is active_ctx, (
-                "Thread-local context and active context disagreed inside the load."
-            )
+            assert thread_ctx is active_ctx, "Thread-local context and active context disagreed inside the load."
             # Mutation through the active context proxy must have hit the
             # in-flight context, not the empty fallback.
             assert 1 in active_ctx.medias

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -998,3 +998,108 @@ class TestBuildDiversityTreeForContext:
         ctx = DatasetContext("test_empty")
         build_diversity_tree_for_context(ctx)
         assert ctx.diversity_tree is None
+
+
+class TestBackgroundLoadThreadContext:
+    """Regression for C3: background load tasks must pin the in-flight
+    DatasetContext to the worker thread so importer / clipper / dedup /
+    diversity-tree helpers that resolve via ``get_active_context()`` see
+    the dataset being built, not the empty fallback context.
+    """
+
+    def test_load_fn_sees_in_flight_dataset_context(self):
+        from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+        from vtscore.state.core import (
+            _empty_dataset_context,
+            get_active_context,
+            get_thread_dataset_context,
+        )
+
+        observed: dict[str, object] = {}
+        ran = threading.Event()
+
+        def capture_load(target_medias):
+            observed["thread_ctx"] = get_thread_dataset_context()
+            observed["active_ctx"] = get_active_context()
+            # Mutating the active context from the load_fn must land on
+            # the in-flight context, not on the empty fallback.
+            get_active_context().medias[1] = {"id": 1}
+            ran.set()
+
+        task_id = _run_origin_load_in_background(
+            capture_load,
+            {"importer": "ctx_probe", "params": {}},
+            name="ctx-probe",
+        )
+
+        try:
+            assert ran.wait(timeout=10), "load_fn never ran"
+            deadline = time.time() + 10
+            while loading_tasks.has_active_tasks() and time.time() < deadline:
+                time.sleep(0.05)
+
+            thread_ctx = observed["thread_ctx"]
+            active_ctx = observed["active_ctx"]
+
+            assert thread_ctx is not None, (
+                "Background task did not set a thread-local dataset context; "
+                "importer-level get_active_context() would land on the empty fallback."
+            )
+            assert active_ctx is not _empty_dataset_context, (
+                "get_active_context() resolved to _empty_dataset_context inside the "
+                "background load — C3 regression."
+            )
+            assert thread_ctx is active_ctx, (
+                "Thread-local context and active context disagreed inside the load."
+            )
+            # Mutation through the active context proxy must have hit the
+            # in-flight context, not the empty fallback.
+            assert 1 in active_ctx.medias
+            assert 1 not in _empty_dataset_context.medias
+        finally:
+            loading_tasks.remove_task(task_id)
+
+    def test_thread_context_cleared_after_task(self):
+        """The worker thread's dataset-context thread-local must be cleared
+        when the task finishes so a reused thread does not leak the prior
+        context to unrelated work.  Patch ``set_thread_dataset_context`` so
+        we can observe both the in-task pin and the post-task clear without
+        racing the daemon worker's thread-local from another thread.
+        """
+        import vtscore.state.core as state_core
+        from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+
+        original_setter = state_core.set_thread_dataset_context
+        calls: list[object] = []
+
+        def recording_setter(ctx):
+            calls.append(ctx)
+            original_setter(ctx)
+
+        ran = threading.Event()
+
+        def load_fn(target_medias):
+            ran.set()
+
+        with mock.patch.object(state_core, "set_thread_dataset_context", recording_setter):
+            task_id = _run_origin_load_in_background(
+                load_fn,
+                {"importer": "ctx_cleanup", "params": {}},
+                name="ctx-cleanup",
+            )
+            try:
+                assert ran.wait(timeout=10)
+                deadline = time.time() + 10
+                while loading_tasks.has_active_tasks() and time.time() < deadline:
+                    time.sleep(0.05)
+            finally:
+                loading_tasks.remove_task(task_id)
+
+        # The task should have both pinned a real context and cleared it.
+        non_none_pins = [c for c in calls if c is not None]
+        none_clears = [c for c in calls if c is None]
+        assert non_none_pins, "Background task never pinned a dataset context"
+        assert none_clears, (
+            "Background task never cleared its thread-local dataset context — "
+            "a reused worker thread would leak the prior dataset to unrelated work."
+        )

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -903,9 +903,17 @@ def _run_origin_load_in_background(
 
     def task():
         from vtsearch.auth import set_thread_user  # noqa: PLC0415
+        from vtscore.state.core import set_thread_dataset_context  # noqa: PLC0415
 
         set_thread_user(request_user)
         ctx = DatasetContext(task_id)
+        # Pin the in-flight context to this thread so importers, clippers,
+        # dedup, diversity-tree, and label-sync helpers that resolve via
+        # ``get_active_context()`` see the dataset being built — not the
+        # empty fallback context.  Without this, mutations addressed at
+        # the active context (e.g. label restoration, vote replay) land
+        # on ``_empty_dataset_context`` and are silently lost.
+        set_thread_dataset_context(ctx)
         context_id = task_id
         controller = _LoadGateController(tracker)
         stepped = _make_stepped_progress(controller, tracker)
@@ -954,10 +962,16 @@ def _run_origin_load_in_background(
         finally:
             controller.release()
             clear_thread_progress()
-            loading_tasks.mark_finished(task_id)
+            # Clear thread-locals *before* marking the task finished so
+            # callers waiting on ``has_active_tasks() == False`` see fully
+            # cleaned-up worker state.  Otherwise a daemon thread that is
+            # reused (or whose locals are scraped by a test) could still
+            # appear to hold the just-loaded dataset context.
+            set_thread_dataset_context(None)
             from vtsearch.auth import set_thread_user as _clear_thread_user  # noqa: PLC0415
 
             _clear_thread_user(None)
+            loading_tasks.mark_finished(task_id)
 
     threading.Thread(target=task, daemon=True).start()
     return task_id


### PR DESCRIPTION
## Summary

- **Fixes C3** from `docs/plans/logical-bug-audit.md`: the background dataset-load task in `_run_origin_load_in_background` set the thread-local user but never the dataset context, so any importer / clipper / dedup / diversity-tree / label-sync helper that resolved the active context via `get_active_context()` landed on `_empty_dataset_context` and silently dropped mutations addressed at the in-flight dataset.
- Pins the freshly-created `DatasetContext` to the worker thread immediately after `ctx = DatasetContext(task_id)`, and clears the thread-local in the task's `finally` — before `loading_tasks.mark_finished` so callers waiting on `has_active_tasks() == False` observe fully cleaned-up worker state.
- Adds a regression test (`TestBackgroundLoadThreadContext` in `tests/datasets/test_parallel_loading.py`) covering both the in-task pin (mutation through the active proxy lands on the in-flight ctx, not the empty fallback) and the post-task clear.
- Updates `docs/plans/logical-bug-audit.md`: marks C3 with a `Status: Shipped` line, adds a "Shipped" section under "Open follow-ups", and clarifies that the warmup and staging spawn sites originally listed alongside C3 do not register a dataset context (warmup uses the passed `media_dict` directly; staging writes to a temp dict for the combine flow), so no `set_thread_dataset_context` call belongs at those sites.

## Test plan

- [x] `./run-tests.sh datasets` — 506 passed, 2 skipped
- [x] `./run-tests.sh` (full suite) — 3941 passed, 1 skipped, 2 xpassed
- [x] New `TestBackgroundLoadThreadContext::test_load_fn_sees_in_flight_dataset_context` proves a load_fn run inside the background task sees the in-flight context (not `_empty_dataset_context`) via `get_active_context()`
- [x] New `TestBackgroundLoadThreadContext::test_thread_context_cleared_after_task` proves the worker thread's dataset-context thread-local is cleared on task exit


---
_Generated by [Claude Code](https://claude.ai/code/session_01JsauxVJfTxQDzSS85UYMwq)_