### PR TITLE
Fix C4: invalidate embedding-matrix cache after clip/dedup

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -95,16 +95,23 @@ Cross-section interaction agents:
   `_empty_dataset_context` instead of the in-flight context. Mutations
   meant for the new dataset are silently lost.
 
-### C4. Embedding-matrix cache is not invalidated after clip/dedup
+### C4. Embedding-matrix cache is not invalidated after clip/dedup — **SHIPPED 2026-05-19**
 
-- **File:** `vtsearch/datasets/load_pipeline.py`
+- **File:** `vtscore/datasets/load_pipeline.py`
   (`_collapse_duplicates_stage`, `_apply_clipper_stage`) +
-  `vtsearch/embedding/matrix.py`
+  `vtsearch/routes/datasets/registry.py` (registry reload's dedup) +
+  `vtscore/embedding/matrix.py`
 - **Bug:** After media items are removed/renumbered,
   `DatasetContext._emb_matrix_ids` is left stale. The next
   `train_and_score()` reads a matrix whose row order no longer matches
   the live `medias` dict — training vectors and scored results are
   mapped to the wrong media IDs. Silent ranking corruption.
+- **Fix:** Both load-pipeline stages now call
+  `invalidate_embedding_matrix(ctx)` after mutating `ctx.medias`, and
+  the registry's reload-from-pickle path does the same after its own
+  `collapse_duplicates` call. Pattern #4 (a `media_revision` counter
+  hooked into every `medias` mutation) remains the durable fix for the
+  broader category — see the "Recurring patterns" section.
 
 ### C5. `find_label` allows body field to override the request's dataset context
 
@@ -603,11 +610,29 @@ summary, and is also recorded here.
   `job.dataset_id` / `job.detector_id` before invoking the target, and
   clears all three thread-locals (user + dataset + detector) in a
   `finally`. Covered by `tests_lib/integration/test_async_jobs.py::TestThreadContextPropagation`.
+- **C4 — embedding-matrix cache after clip/dedup** (2026-05-19).
+  `_apply_clipper_stage`, `_collapse_duplicates_stage`, and the
+  registry's reload-from-pickle dedup now all call
+  `invalidate_embedding_matrix(ctx)` after mutating the medias dict.
+  Regression coverage in `tests/datasets/test_load_stage_matrix_cache.py`.
+- **C6 — zip-slip in HTTP archive importer (zip, tar, rar)**
+  (2026-05-19). See the finding above for the full landed shape.
 
 ### Still open
 
-Every other finding (C1, C3–C12 and the High / Medium / Low tiers)
-remains as written. When the next fix lands, edit the finding above
-with **— shipped** and add a line here. When every critical and high is
-addressed, this doc can be retired into the relevant subsystem docs (or
-deleted, per the `docs/plans/` lifecycle).
+Every other finding (C1, C3, C5, C7–C12 and the High / Medium / Low
+tiers) remains as written. When the next fix lands, edit the finding
+above with **— shipped** and add a line here. When every critical and
+high is addressed, this doc can be retired into the relevant subsystem
+docs (or deleted, per the `docs/plans/` lifecycle).
+
+Specific open items called out by previously-shipped fixes:
+
+- **Pattern #4 (media_revision counter)** is still unimplemented.
+  The C4 stage-level invalidation closes the known clip/dedup hole,
+  but any future mutation site that changes embeddings without
+  changing the id set will reintroduce the same class of bug. A
+  `media_revision` counter on `DatasetContext` bumped from every
+  `medias` mutation (or a `MediasDict` subclass that does so
+  transparently) would neutralise the whole category and let the
+  matrix accessor compare a single int instead of two id lists.

--- a/tests/datasets/test_load_stage_matrix_cache.py
+++ b/tests/datasets/test_load_stage_matrix_cache.py
@@ -1,0 +1,108 @@
+"""Regression tests for C4: embedding-matrix cache must be invalidated
+after the clip and dedup stages of the dataset-load pipeline.
+
+Both ``_apply_clipper_stage`` and ``_collapse_duplicates_stage`` mutate
+``ctx.medias`` in ways the matrix cache's id-keyed check cannot detect:
+
+- ``_apply_clipper_stage`` (via ``clipper_chain.apply_chain_to_clips``)
+  renumbers media IDs starting at 1 while replacing embeddings in place.
+  A 1-to-1 chain produces the same id list as before clipping, so the
+  cached matrix's ``cached_ids == sorted_ids`` check fails to fire and
+  the next reader sees stale rows.
+
+- ``_collapse_duplicates_stage`` removes duplicate media items. The id
+  set changes, but only by removal — a cached matrix built before dedup
+  still holds rows for the deleted ids that no longer correspond to any
+  live media.
+
+Both stages must drop the cache so the next ``get_embedding_matrix``
+rebuilds against the live medias dict.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.concurrency.progress import LoadingTasksTracker
+from vtscore.datasets.load_pipeline import (
+    _apply_clipper_stage,
+    _collapse_duplicates_stage,
+)
+from vtscore.embedding.matrix import get_embedding_matrix
+from vtscore.state.core import DatasetContext
+
+
+def _populate_matrix(ctx: DatasetContext) -> np.ndarray:
+    """Force the matrix cache to be built; return the cached matrix."""
+    _, matrix = get_embedding_matrix(ctx)
+    assert ctx._emb_matrix is matrix
+    assert ctx._emb_matrix_ids == sorted(ctx.medias.keys())
+    return matrix
+
+
+def _make_tracker():
+    return LoadingTasksTracker().create_task("test_task", "test")
+
+
+class TestCollapseDuplicatesStageInvalidatesMatrix:
+    def test_cache_dropped_after_dedup(self):
+        ctx = DatasetContext("test_dedup_cache")
+        ctx.medias[1] = {"id": 1, "md5": "aaa", "embedding": np.ones(4, dtype=np.float32)}
+        ctx.medias[2] = {"id": 2, "md5": "aaa", "embedding": np.full(4, 2.0, dtype=np.float32)}
+        ctx.medias[3] = {"id": 3, "md5": "bbb", "embedding": np.full(4, 3.0, dtype=np.float32)}
+
+        _populate_matrix(ctx)
+
+        _collapse_duplicates_stage(ctx, _make_tracker())
+
+        assert ctx._emb_matrix_ids is None
+        assert ctx._emb_matrix is None
+
+        ids, matrix = get_embedding_matrix(ctx)
+        assert ids == sorted(ctx.medias.keys())
+        assert matrix.shape[0] == len(ctx.medias)
+
+
+class TestApplyClipperStageInvalidatesMatrix:
+    """A no-op clipper still re-stamps origins; once a real clipper renumbers
+    ids, the cache would silently survive. Use a default clipper (no
+    structural change) to exercise the stage's invalidation contract
+    without depending on heavy media bytes."""
+
+    def test_cache_dropped_after_clipper_stage(self):
+        ctx = DatasetContext("test_clipper_cache")
+        rng = np.random.default_rng(0)
+        for cid in (1, 2, 3):
+            ctx.medias[cid] = {
+                "id": cid,
+                "type": "audio",
+                "filename": f"a_{cid}.wav",
+                "md5": f"md5_{cid}",
+                "embedding": rng.standard_normal(4).astype(np.float32),
+                "origin": {"importer": "server_folder", "params": {"path": "/x"}},
+                "origin_name": f"a_{cid}.wav",
+            }
+
+        _populate_matrix(ctx)
+
+        # ``sound_default`` is a stamp-only clipper: no embedding rewrite,
+        # no id renumbering. The stage must still invalidate so that a
+        # real clip chain (which does rewrite embeddings in place) can't
+        # leave stale rows in the cache.
+        _apply_clipper_stage(ctx, _make_tracker(), "sound_default", None, None)
+
+        assert ctx._emb_matrix_ids is None
+        assert ctx._emb_matrix is None
+
+    def test_noop_when_no_clipper(self):
+        """No clipper, no chain: stage is a no-op and must not touch the cache."""
+        ctx = DatasetContext("test_noop_cache")
+        ctx.medias[1] = {"id": 1, "md5": "x", "embedding": np.ones(4, dtype=np.float32)}
+
+        _populate_matrix(ctx)
+        cached_matrix = ctx._emb_matrix
+
+        _apply_clipper_stage(ctx, _make_tracker(), "", None, None)
+
+        # No mutation happened; cache survives.
+        assert ctx._emb_matrix is cached_matrix

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -118,6 +118,7 @@ from vtsearch.state import (
     collapse_duplicates,
     register_context,
 )
+from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.concurrency.progress import update_progress
 from vtscore.concurrency.progress import (
     CancelledError,
@@ -726,6 +727,11 @@ def _apply_clipper_stage(
 
     _clipper_progress(0, 0, "clipping")
     _apply_clipper(ctx.medias, clipper, clipper_params, on_progress=_clipper_progress, chain_steps=chain_steps)
+    # Clipping reassigns media IDs starting from 1 and rewrites embeddings
+    # in place; the cached matrix's id list can collide with the new one
+    # while pointing at stale rows. Drop the cache so the next reader
+    # rebuilds against the live medias dict.
+    invalidate_embedding_matrix(ctx)
 
 
 def _collapse_duplicates_stage(ctx: DatasetContext, tracker) -> None:
@@ -742,6 +748,7 @@ def _collapse_duplicates_stage(ctx: DatasetContext, tracker) -> None:
 
     _progress(0, 0)
     collapse_duplicates(ctx.medias, on_progress=_progress)
+    invalidate_embedding_matrix(ctx)
 
 
 def _build_diversity_tree_stage(ctx: DatasetContext, tracker) -> None:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -66,6 +66,7 @@ from vtsearch.state import (
 )
 from vtscore.concurrency.progress import CancelledError
 from vtscore.concurrency.progress import loading_tasks as _loading_tasks
+from vtscore.embedding.matrix import invalidate_embedding_matrix
 
 datasets_registry_bp = Blueprint(
     "datasets_registry",
@@ -195,6 +196,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
 
             _dedup_progress(0, 0)
             collapse_duplicates(ctx.medias, on_progress=_dedup_progress)
+            invalidate_embedding_matrix(ctx)
 
             def _diversity_progress(current: int, total: int) -> None:
                 tracker.check_cancelled()


### PR DESCRIPTION
Fixes finding **C4** in `docs/plans/logical-bug-audit.md`.

## Summary

- `_apply_clipper_stage` and `_collapse_duplicates_stage` in `vtscore/datasets/load_pipeline.py` now call `invalidate_embedding_matrix(ctx)` after mutating `ctx.medias`. The clipper-chain path renumbers ids starting at 1 while rewriting embeddings in place, and a 1-to-1 chain produces the same id list as before — so the matrix cache's `cached_ids == sorted_ids` check would not fire and the next `train_and_score()` would read stale rows. Dedup removes ids that the cache still believes are present.
- `vtsearch/routes/datasets/registry.py`'s reload-from-pickle path also calls `invalidate_embedding_matrix(ctx)` after its own `collapse_duplicates` call, so any future cache populated during reload doesn't outlive the mutation.
- Audit doc updated: C4 marked **SHIPPED 2026-05-19** and a "What shipped" section added. Pattern #4 (a `media_revision` counter on every `medias` mutation) is called out as still open — the stage-level invalidation closes the known hole, but the durable category fix is still owed.

## Test plan

- [x] New regression coverage in `tests/datasets/test_load_stage_matrix_cache.py` (3 cases): dedup invalidates, clipper stage invalidates, no-op clipper does not touch the cache. Verified the two mutation cases fail without the fix and pass with it.
- [x] `./run-tests.sh datasets` — 507 passed.
- [x] `./run-tests.sh detectors` — 1054 passed.
- [x] `./run-tests.sh sorting` — 235 passed.
- [x] `./run-tests.sh` (full suite) — 3942 passed, 1 skipped, 2 xpassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VCwqqjJD15eZFS3PnvJvyb)_