### PR TITLE
logical-bug-audit C10: dataset-qualify media-metadata cache keys

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -249,14 +249,18 @@ Cross-section interaction agents:
   `validate_server_filepath()` a required step in
   `SyncSource._resolve_filepath()`.
 
-### C10. MD5 / metadata cache collision returns wrong-dataset media on switch
+### C10. MD5 / metadata cache collision returns wrong-dataset media on switch — **SHIPPED 2026-05-19**
 
 - **File:** `frontend/src/app/services/media-metadata-cache.service.ts`
   ~L31
 - **Bug:** Cache key is `media_id` only. Media IDs are per-dataset, so
   after the user switches datasets the cache returns dataset A's
   filename / md5 / custom_metadata for dataset B's id=1.
-- **Fix sketch:** Key the cache by `${datasetId}:${mediaId}`.
+- **Fix:** Cache entries are keyed by `${datasetId}:${mediaId}` and
+  pending IDs are bucketed by the dataset they were queued under, so
+  each batch fetch runs while its dataset is active and the
+  `X-Dataset-Id` interceptor header matches what the response will be
+  cached against.
 
 ### C11. `fill_labels_from_sort` silently swallows sync failures — **SHIPPED 2026-05-19**
 
@@ -754,12 +758,20 @@ summary, and is also recorded here.
   `../labels/{detector_name}.json` is rejected at `load` / `load_full` /
   `save` time before any file handle is opened. Regression tests live in
   `tests/io/test_sync_sources.py`.
+- **C10 — MediaMetadataCacheService dataset-qualified keys** (2026-05-19).
+  Cache entries in
+  `frontend/src/app/services/media-metadata-cache.service.ts` now key on
+  `${datasetId}:${mediaId}` (snapshotted from `ActiveContextService`),
+  and pending IDs are bucketed by the dataset they were queued under so
+  each batch fetch dispatches only while its dataset is active and the
+  `X-Dataset-Id` interceptor header matches what the response will be
+  cached against.
 - **C11 — `fill_labels_from_sort` sync-failure surfacing** (2026-05-19).
   See the finding above for the full landed shape.
 
 ### Still open
 
-Every other finding (C5, C7, C10, C12 and the High / Medium /
+Every other finding (C5, C7, C12 and the High / Medium /
 Low tiers) remains as written. When the next fix lands, edit the
 finding above with **— shipped** and add a line here. When every
 critical and high is addressed, this doc can be retired into the

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -2,6 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+import { ActiveContextService } from './active-context.service';
 import { MediasApiService } from './medias-api.service';
 
 /**
@@ -25,11 +26,16 @@ const BATCH_SIZE = 200;
  *      `get(id)` to read a single cached item.
  *   3. `toMediaItems(ids)` returns MediaBatchResponse[] for already-cached
  *      IDs (skips unknown ones so the template can render immediately).
+ *
+ * Media IDs are per-dataset, so every cache entry is keyed by
+ * `${datasetId}:${mediaId}` and pending IDs are bucketed by the dataset
+ * they were queued under — otherwise a switch from dataset A to dataset B
+ * returns A's filename / md5 / metadata for B's id.
  */
 @Injectable({ providedIn: 'root' })
 export class MediaMetadataCacheService implements OnDestroy {
-  private readonly cache = new Map<number, MediaBatchResponse>();
-  private readonly pendingIds = new Set<number>();
+  private readonly cache = new Map<string, MediaBatchResponse>();
+  private readonly pendingByDataset = new Map<string, Set<number>>();
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly destroy$ = new Subject<void>();
 
@@ -37,7 +43,10 @@ export class MediaMetadataCacheService implements OnDestroy {
   private readonly versionSubject = new BehaviorSubject<number>(0);
   readonly version$ = this.versionSubject.asObservable();
 
-  constructor(private mediasApi: MediasApiService) {}
+  constructor(
+    private mediasApi: MediasApiService,
+    private activeContext: ActiveContextService,
+  ) {}
 
   ngOnDestroy(): void {
     this.destroy$.next();
@@ -47,12 +56,12 @@ export class MediaMetadataCacheService implements OnDestroy {
 
   /** Return a cached metadata entry or undefined if not yet fetched. */
   get(id: number): MediaBatchResponse | undefined {
-    return this.cache.get(id);
+    return this.cache.get(this.activeKey(id));
   }
 
   /** Whether the cache has metadata for this id. */
   has(id: number): boolean {
-    return this.cache.has(id);
+    return this.cache.has(this.activeKey(id));
   }
 
   /** Current cache size. */
@@ -63,7 +72,7 @@ export class MediaMetadataCacheService implements OnDestroy {
   /** Clear all cached metadata. */
   clear(): void {
     this.cache.clear();
-    this.pendingIds.clear();
+    this.pendingByDataset.clear();
     this.versionSubject.next(0);
   }
 
@@ -73,14 +82,14 @@ export class MediaMetadataCacheService implements OnDestroy {
    * request that fires on a microtask (so rapid consecutive calls are merged).
    */
   ensureLoaded(ids: number[]): void {
-    const needed: number[] = [];
+    const datasetId = this.activeContext.datasetId;
+    const pending = this.getOrCreatePending(datasetId);
     for (const id of ids) {
-      if (!this.cache.has(id) && !this.pendingIds.has(id)) {
-        needed.push(id);
-        this.pendingIds.add(id);
+      if (!this.cache.has(this.keyFor(datasetId, id))) {
+        pending.add(id);
       }
     }
-    if (needed.length === 0) return;
+    if (pending.size === 0) return;
     this.scheduleBatchFetch();
   }
 
@@ -90,8 +99,9 @@ export class MediaMetadataCacheService implements OnDestroy {
    */
   toMediaItems(ids: number[]): MediaBatchResponse[] {
     const result: MediaBatchResponse[] = [];
+    const datasetId = this.activeContext.datasetId;
     for (const id of ids) {
-      const item = this.cache.get(id);
+      const item = this.cache.get(this.keyFor(datasetId, id));
       if (item) result.push(item);
     }
     return result;
@@ -100,6 +110,23 @@ export class MediaMetadataCacheService implements OnDestroy {
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------
+
+  private keyFor(datasetId: string, id: number): string {
+    return `${datasetId}:${id}`;
+  }
+
+  private activeKey(id: number): string {
+    return this.keyFor(this.activeContext.datasetId, id);
+  }
+
+  private getOrCreatePending(datasetId: string): Set<number> {
+    let pending = this.pendingByDataset.get(datasetId);
+    if (!pending) {
+      pending = new Set<number>();
+      this.pendingByDataset.set(datasetId, pending);
+    }
+    return pending;
+  }
 
   private scheduleBatchFetch(): void {
     if (this.batchTimer) return; // already scheduled
@@ -110,9 +137,16 @@ export class MediaMetadataCacheService implements OnDestroy {
   }
 
   private flushPending(): void {
-    const ids = Array.from(this.pendingIds);
-    this.pendingIds.clear();
-    if (ids.length === 0) return;
+    // The batch request's X-Dataset-Id header is set from
+    // `ActiveContextService` at dispatch time, so we can only drain
+    // entries queued under the currently-active dataset. Entries for
+    // inactive datasets stay queued; the next `ensureLoaded()` after a
+    // switch re-schedules a flush for that dataset's bucket.
+    const datasetId = this.activeContext.datasetId;
+    const pending = this.pendingByDataset.get(datasetId);
+    if (!pending || pending.size === 0) return;
+    const ids = Array.from(pending);
+    pending.clear();
 
     // Split into chunks to keep individual requests bounded.
     for (let i = 0; i < ids.length; i += BATCH_SIZE) {
@@ -123,15 +157,17 @@ export class MediaMetadataCacheService implements OnDestroy {
         .subscribe({
           next: (items) => {
             for (const item of items) {
-              this.cache.set(item.id, item);
+              this.cache.set(this.keyFor(datasetId, item.id), item);
             }
             this.versionSubject.next(this.versionSubject.value + 1);
           },
           error: () => {
-            // Re-queue failed IDs so they can be retried on the next request.
+            // Re-queue failed IDs under the dataset that issued the
+            // request so they can be retried on the next request.
+            const bucket = this.getOrCreatePending(datasetId);
             for (const id of chunk) {
-              if (!this.cache.has(id)) {
-                this.pendingIds.add(id);
+              if (!this.cache.has(this.keyFor(datasetId, id))) {
+                bucket.add(id);
               }
             }
           },


### PR DESCRIPTION
## Summary

Fixes **C10** from `docs/plans/logical-bug-audit.md`: `MediaMetadataCacheService` keyed batch responses by raw `media_id`, but media IDs are per-dataset — after a dataset switch the cache returned dataset A's filename / md5 / custom_metadata for dataset B's id.

- Cache entries in `frontend/src/app/services/media-metadata-cache.service.ts` now key on `${datasetId}:${mediaId}` (snapshotted from `ActiveContextService`).
- Pending IDs are bucketed by the dataset that queued them, and `flushPending()` only dispatches the bucket for the currently-active dataset — so the `X-Dataset-Id` header attached by `activeContextInterceptor` always matches the dataset the response will be cached against. Entries for inactive datasets stay queued and drain on the next `ensureLoaded()` after a switch back.
- Audit plan updated to mark C10 shipped and add the corresponding entry under Open follow-ups → Shipped.

## Test plan

- [x] `./run-tests.sh` (3959 passed, 1 skipped) post-rebase onto current `origin/dev`.
- [x] `cd frontend && npm run build:prod` clean, no warnings.

https://claude.ai/code/session_01WNfhjTb3yPua72FCZEKXm2