### PR TITLE
Fix C11: surface fill_labels_from_sort sync failures via 500

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -178,7 +178,7 @@ Cross-section interaction agents:
   filename / md5 / custom_metadata for dataset B's id=1.
 - **Fix sketch:** Key the cache by `${datasetId}:${mediaId}`.
 
-### C11. `fill_labels_from_sort` silently swallows sync failures
+### C11. `fill_labels_from_sort` silently swallows sync failures — **SHIPPED 2026-05-19**
 
 - **File:** `vtsearch/routes/labels/vote.py` ~L259–301
 - **Bug:** After applying labels, the endpoint calls
@@ -186,6 +186,28 @@ Cross-section interaction agents:
   outside any try-block. The HTTP response is built before those
   calls' results are known; a failure logs but returns "success" —
   labels appear committed in the UI but never reach disk.
+- **Fix:** Both sync calls now run **before** the response is built
+  and are wrapped in `try/except`. A failure from
+  `sync_labels_to_loaded_detector()` (disk write, detector-registry
+  update, etc.) is logged and re-raised as a 500 with the underlying
+  error message so the frontend can react instead of treating the
+  labels as persisted. `sync_to_labelset_source()` is fire-and-forget
+  by design (debounced background timer) — its synchronous portion is
+  also wrapped defensively, but a failure there does **not** fail the
+  request because disk state is already consistent. Regression test:
+  `tests/io/test_export_options.py::TestFillFromSortConfirm::test_disk_sync_failure_surfaces_as_500`.
+- **Known limitation / follow-up:** When the disk sync fails, the
+  in-memory labels are *not* rolled back — they remain applied until
+  the next successful sync writes them through (any subsequent vote
+  or fill-from-sort run will reconcile). Full transactional rollback
+  (pattern #8) is deferred; this fix only stops the silent-success
+  failure mode that lets the UI diverge from disk indefinitely. The
+  same untrapped sync pattern still exists in
+  `vtsearch/routes/labels/vote.py::import_labels`,
+  `vtsearch/routes/sorting.py`, `vtsearch/routes/media/list.py`,
+  `vtsearch/routes/labels/importers.py`, and
+  `vtsearch/routes/detectors/{registry,scoring}.py`; each is its own
+  audit item under pattern #8 and out of scope for C11.
 
 ### C12. Orphaned dataset registry entry on activation failure
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -256,6 +256,38 @@ class TestFillFromSortConfirm:
         assert data["good_applied"] == 0
         assert len(app_module.good_votes) == 0
 
+    def test_disk_sync_failure_surfaces_as_500(self, client, monkeypatch):
+        """C11 regression: a sync failure must not be silently swallowed.
+
+        Before the fix the route logged the failure and still returned 200 —
+        the UI then treated the labels as committed while the detector JSON
+        on disk had never been updated. After the fix the request fails
+        with a 5xx so the client can react.
+        """
+        from vtscore.detectors import label_sync
+
+        def _boom() -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(label_sync, "sync_labels_to_loaded_detector", _boom)
+
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "good",
+                "confirm": True,
+            },
+        )
+        assert resp.status_code == 500
+        data = resp.get_json() or {}
+        # flask_smorest places the error text in ``message`` (or ``errors``);
+        # accept either to stay schema-tolerant.
+        blob = json.dumps(data)
+        assert "disk full" in blob or "persist labels" in blob
+
 
 # ---------------------------------------------------------------------------
 # CLI _score_medias_with_detectors negative_hits

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -6,7 +6,9 @@ Migrated to ``flask_smorest`` so the routes are described in
 
 from __future__ import annotations
 
-from flask_smorest import Blueprint
+import logging
+
+from flask_smorest import Blueprint, abort
 
 from vtsearch.schemas.labels import (
     FillFromSortRequestSchema,
@@ -28,6 +30,8 @@ from vtsearch.state import (
     vote_region_boxes,
 )
 from vtscore.utils.hits import build_media_hit
+
+logger = logging.getLogger(__name__)
 
 labels_bp = Blueprint(
     "labels",
@@ -262,6 +266,26 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
     for entry in bad_candidates:
         apply_label_with_click_time(entry["id"], "bad")
 
+    # Persist labels to disk BEFORE building the response.  Letting a
+    # silent disk-write failure here fall through to ``return {...}`` is
+    # the C11 bug — the UI would treat the labels as committed while
+    # ``detectors/<name>.json`` never received them.  ``sync_to_labelset_source``
+    # is fire-and-forget by design (debounced background timer), so we
+    # only guard against the unlikely synchronous scheduling failure.
+    from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
+    from vtscore.labels.sync import sync_to_labelset_source
+
+    try:
+        sync_labels_to_loaded_detector()
+    except Exception as exc:
+        logger.exception("fill_labels_from_sort: detector label sync failed")
+        abort(500, message=f"Failed to persist labels to detector store: {exc}")
+
+    try:
+        sync_to_labelset_source()
+    except Exception:
+        logger.exception("fill_labels_from_sort: labelset source scheduling failed")
+
     # Build a results dict compatible with exporters
     snap = snapshot_medias()
     good_hits = [build_media_hit(e["id"], snap.get(e["id"], {}), e["score"], label="good") for e in good_candidates]
@@ -285,14 +309,6 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
             },
         },
     }
-
-    from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
-
-    sync_labels_to_loaded_detector()
-
-    from vtscore.labels.sync import sync_to_labelset_source
-
-    sync_to_labelset_source()
 
     return {
         "good_applied": len(good_candidates),


### PR DESCRIPTION
## Summary

Fixes **C11** from `docs/plans/logical-bug-audit.md` — `/api/labels/fill-from-sort` previously called `sync_labels_to_loaded_detector()` and `sync_to_labelset_source()` outside any try-block, after the response payload was already shaped. A disk write failure logged but still returned `200`, leaving the UI showing labels as committed while the detector JSON on disk never received them.

- Both sync calls now run **before** the response is built and are wrapped in `try/except`.
- `sync_labels_to_loaded_detector()` failures (disk write, detector-registry update) are logged and re-raised as a `500` with the underlying error so the frontend can react instead of treating the labels as persisted.
- `sync_to_labelset_source()` is fire-and-forget by design (debounced background timer). Its synchronous portion is wrapped defensively, but a failure there does **not** fail the request — the disk state is already consistent.

### Known limitation / follow-up

When the disk sync fails, the in-memory labels are *not* rolled back — they remain applied until the next successful sync writes them through (any subsequent vote or fill-from-sort run reconciles). Full transactional rollback (audit pattern #8) is deferred. The same untrapped sync pattern still exists in several other routes (`import_labels`, `sorting.py`, `media/list.py`, `labels/importers.py`, `detectors/{registry,scoring}.py`) — each is its own audit item and out of scope here. Notes recorded under C11's "Open follow-up" in the audit doc.

## Test plan

- [x] `./run-tests.sh io` — 656 passed (includes new regression test)
- [x] `./run-tests.sh api core` — 957 passed
- [x] `./run-tests.sh` (full suite) — 3940 passed, 1 skipped, 2 xpassed
- [x] New regression test: `tests/io/test_export_options.py::TestFillFromSortConfirm::test_disk_sync_failure_surfaces_as_500` — monkeypatches the disk-sync helper to raise and asserts the route returns `500` with the failure surfaced in the body.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QDV8dVigSMK2Xq1TheCWG7)_