### PR TITLE
Fix audit C8: credit achievements on bulk label paths

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -185,14 +185,25 @@ Cross-section interaction agents:
   blended value is finite before returning it. Regression tests cover
   `inf`/`NaN` xcal and the new sentinel.
 
-### C8. Bulk label paths skip achievement recording entirely
+### C8. Bulk label paths skip achievement recording entirely — **SHIPPED 2026-05-19**
 
-- **File:** `vtsearch/state/votes.py` — `apply_label_with_click_time()`
+- **File:** `vtscore/state/votes.py` — `apply_label_with_click_time()`
   (no `record_vote()` call) vs `toggle_vote()` (calls `record_vote()`).
 - **Bug:** `/api/labels/fill-from-sort`, label importers, and bulk
   find-label apply votes without crediting achievements. `votes_cast`,
   `days_active`, `vote_streak` are inert for any user who uses
   search-then-bulk-label flows.
+- **Fix:** Achievement recording is now centralised in
+  `vtscore/state/votes.py` via `_record_vote_locked()`. `toggle_vote`,
+  `apply_label`, `apply_label_with_click_time`, and
+  `apply_labels_bulk_with_click_time` all credit a vote inside
+  `_state_lock` (which also fixes the cross-section "record_vote after
+  releasing the lock" race noted in the High tier). `apply_label` gains
+  a `record_achievement: bool = True` opt-out, used by
+  `sync_from_labelset_source` and `seed_good_votes_from_examples` —
+  system-driven paths that aren't user vote actions.  Idempotent
+  re-applies (the media was already at that label) don't credit, so
+  re-importing the same labelset doesn't inflate `votes_cast`.
 
 ### C9. Path-template substitution missing post-resolution validation
 
@@ -284,7 +295,8 @@ Cross-section interaction agents:
 - **`record_vote()` called after releasing `_state_lock`** —
   `vtsearch/state/votes.py` ~L156–206. Detector context can change
   between unlock and credit; achievement is credited to the wrong
-  detector. Cross-section with C8.
+  detector. Cross-section with C8. **SHIPPED 2026-05-19 as part of
+  C8** — `_record_vote_locked()` runs inside the state lock now.
 - **Vote-progress invalidation / `record_vote` race** when the same
   media is rapid-toggled across two tabs — counter inflates while
   in-memory shows one vote.
@@ -705,6 +717,11 @@ summary, and is also recorded here.
   Regression coverage in `tests/datasets/test_load_stage_matrix_cache.py`.
 - **C6 — zip-slip in HTTP archive importer (zip, tar, rar)**
   (2026-05-19). See the finding above for the full landed shape.
+- **C8 — Bulk label paths skip achievement recording entirely**
+  (2026-05-19). Centralised achievement credit inside `_state_lock`
+  in `vtscore/state/votes.py`; also fixed the related High finding
+  ("`record_vote()` called after releasing `_state_lock`") in the
+  same change. See the C8 entry above for details.
 - **C9 — Path-template post-resolution validation** (2026-05-19).
   `_resolve_filepath()` in both
   `vtscore/labels/sources/server_json_file/__init__.py` and
@@ -720,7 +737,7 @@ summary, and is also recorded here.
 
 ### Still open
 
-Every other finding (C3, C5, C7, C8, C10, C12 and the High / Medium /
+Every other finding (C3, C5, C7, C10, C12 and the High / Medium /
 Low tiers) remains as written. When the next fix lands, edit the
 finding above with **— shipped** and add a line here. When every
 critical and high is addressed, this doc can be retired into the

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -73,8 +73,10 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
 
         if cids:
             # Example matches existing dataset media — just vote good.
+            # System-driven seeding from a detector's saved examples, not a
+            # user vote action, so don't credit achievement counters.
             for cid in cids:
-                apply_label(cid, "good")
+                apply_label(cid, "good", record_achievement=False)
             seeded += 1
         else:
             # Example is NOT in the dataset — embed and insert as new media.
@@ -118,7 +120,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
                     "origin_name": filename,
                 }
 
-            apply_label(new_id, "good")
+            apply_label(new_id, "good", record_achievement=False)
             seeded += 1
 
     return seeded

--- a/vtscore/labels/sync.py
+++ b/vtscore/labels/sync.py
@@ -336,7 +336,11 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
                 # Find media by md5
                 for mid, media in ds_medias.items():
                     if media.get("md5") == md5:
-                        apply_label(mid, label)
+                        # System-driven auto-import on detector load; the
+                        # ``record_detector_import`` call below covers the
+                        # achievement credit instead of crediting each
+                        # imported label as a user vote.
+                        apply_label(mid, label, record_achievement=False)
                         applied_any = True
                         break
         finally:

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -119,6 +119,21 @@ def get_find_initial_labels() -> dict[int, str]:
 # ---------------------------------------------------------------------------
 
 
+def _record_vote_locked() -> None:
+    """Credit one vote to the active detector's achievements.
+
+    Must be called while ``_state_lock`` is held so the detector context
+    cannot change between the vote landing in state and the achievement
+    being credited (otherwise a concurrent context switch would credit the
+    wrong detector).  Establishes the lock order ``_state_lock → _settings_lock``;
+    no code path takes the locks in the reverse order.
+    """
+    from vtsearch.achievements import record_vote  # noqa: PLC0415
+
+    det_ctx = get_active_detector_context()
+    record_vote(det_ctx.detector_id, media_type=det_ctx.media_type)
+
+
 def toggle_vote(
     media_id: int,
     vote: str,
@@ -199,11 +214,8 @@ def toggle_vote(
                     invalidate_progress_cache_from(media_id)
                 added = True
 
-    if added:
-        from vtsearch.achievements import record_vote
-
-        det_ctx = get_active_detector_context()
-        record_vote(det_ctx.detector_id, media_type=det_ctx.media_type)
+        if added:
+            _record_vote_locked()
 
 
 def apply_label(
@@ -212,6 +224,7 @@ def apply_label(
     *,
     silent: bool = False,
     region_box: tuple[float, float, float, float] | None = None,
+    record_achievement: bool = True,
 ) -> None:
     """Atomically apply a label to a media (for imports).
 
@@ -219,23 +232,31 @@ def apply_label(
     No click-time is assigned (imported labels have no click-time).
 
     When *silent* is True, the label is recorded in ``good_votes``/``bad_votes``
-    only — ``label_history`` is not appended and the diversity tree is not
-    marked.  This is used when restoring a detector's saved labels into a new
-    dataset: those labels are seeded so autopilot's good/bad-count gates are
-    satisfied, but they should not contaminate the per-session Smart/Stable
-    trends or pre-fill diversity coverage in the new dataset.
+    only — ``label_history`` is not appended, the diversity tree is not
+    marked, and achievement counters are not credited.  This is used when
+    restoring a detector's saved labels into a new dataset: those labels are
+    seeded so autopilot's good/bad-count gates are satisfied, but they should
+    not contaminate the per-session Smart/Stable trends or pre-fill diversity
+    coverage in the new dataset.
 
     Args:
         media_id: Integer ID of the media to label.
         label: ``"good"`` or ``"bad"``.
-        silent: If True, skip history append and diversity-tree marking.
+        silent: If True, skip history append, diversity-tree marking, and
+            achievement credit.
         region_box: Optional normalised ``(x0, y0, x1, y1)`` box from an
             imported labelset entry.  Only stored when *label* is ``"good"``
             (no-votes are always image-level).  Patch-embedder v2.
+        record_achievement: When True (the default), credit one vote in the
+            active detector's achievement counters.  Set to False for
+            system-driven label application that isn't a user vote action
+            (e.g. auto-import from a labelset source, example-media seeding
+            on detector load).
     """
     with _state_lock:
         ctx = get_active_detector_context()
         if label == "good":
+            already = media_id in ctx.good_votes
             ctx.bad_votes.pop(media_id, None)
             ctx.good_votes[media_id] = None
             if region_box is not None:
@@ -245,6 +266,7 @@ def apply_label(
             if not silent:
                 add_label_to_history(media_id, "good")
         else:
+            already = media_id in ctx.bad_votes
             ctx.good_votes.pop(media_id, None)
             ctx.vote_region_boxes.pop(media_id, None)
             ctx.bad_votes[media_id] = None
@@ -252,13 +274,18 @@ def apply_label(
                 add_label_to_history(media_id, "bad")
         if not silent:
             diversity_tree_label(media_id)
+            if record_achievement and not already:
+                _record_vote_locked()
 
 
 def apply_label_with_click_time(media_id: int, label: str) -> None:
     """Atomically apply a label with click-time assignment (for fill-from-sort).
 
     Same as :func:`apply_label` but also assigns a click-time ordinal so the
-    label appears in the frontend's click-time timeline.
+    label appears in the frontend's click-time timeline.  Credits one vote in
+    the active detector's achievement counters — bulk fill-from-sort flows
+    are user vote actions and must show up in ``votes_cast`` etc. (audit
+    finding C8).
 
     Args:
         media_id: Integer ID of the media to label.
@@ -278,6 +305,7 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
             add_label_to_history(media_id, "bad")
         assign_click_time(media_id)
         diversity_tree_label(media_id)
+        _record_vote_locked()
 
 
 def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all: bool = False) -> None:
@@ -285,7 +313,9 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
 
     Each entry is ``(media_id, label)`` where *label* is ``"good"`` or
     ``"bad"``.  All labels are applied atomically with click-time ordinals
-    assigned in order.
+    assigned in order.  Each entry credits one vote in the active detector's
+    achievement counters — bulk find-label flows are user vote actions and
+    must show up in ``votes_cast`` etc. (audit finding C8).
 
     When *replace_all* is True, any pre-existing votes/click-times for IDs
     outside *labels* are cleared first.  This is what ``/api/find-label``
@@ -316,11 +346,13 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
             ctx.find_initial_labels.clear()
         for media_id, label in labels:
             if label == "good":
+                already = media_id in good_votes
                 bad_votes.pop(media_id, None)
                 good_votes[media_id] = None
                 vote_region_boxes.pop(media_id, None)
                 label_history.append((media_id, "good", _time.time()))
             else:
+                already = media_id in bad_votes
                 good_votes.pop(media_id, None)
                 vote_region_boxes.pop(media_id, None)
                 bad_votes[media_id] = None
@@ -329,3 +361,5 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
             vote_click_times[media_id] = ctx.click_counter
             if tree is not None and media_id in tree.vector_to_leaf:
                 tree.label(media_id)
+            if not already:
+                _record_vote_locked()


### PR DESCRIPTION
## Summary

Fixes audit finding **C8** from `docs/plans/logical-bug-audit.md` — bulk label-application paths (`/api/labels/fill-from-sort`, `/api/labels/import`, `/api/find-label`, `/api/medias/add-to-pile`, `/api/detectors/<name>/labels`) applied votes without crediting achievements, leaving `votes_cast`, `days_active`, `vote_streak`, etc. inert for any user who used search-then-bulk-label flows.

Achievement crediting is now centralised in a single `_record_vote_locked()` helper in `vtscore/state/votes.py` that runs **inside** `_state_lock`. All four label-application primitives credit through it: `toggle_vote`, `apply_label`, `apply_label_with_click_time`, and `apply_labels_bulk_with_click_time`.

Moving the credit inside the lock also closes the related High-tier race ("`record_vote()` called after releasing `_state_lock`") — the detector context can no longer change between the vote landing and the credit being applied. This establishes the lock order `_state_lock → _settings_lock`; no other code path takes them in the reverse order.

`apply_label` gains a `record_achievement: bool = True` opt-out for system-driven paths that aren't user vote actions — `sync_from_labelset_source` (auto-import from a labelset source, already credited via `record_detector_import`) and `seed_good_votes_from_examples` (detector-load example seeding). Idempotent re-applies (the media was already at that label) don't credit, so re-importing the same labelset doesn't inflate `votes_cast`.

The audit doc is updated: C8 and the related High-tier finding are marked **SHIPPED 2026-05-19**, with entries in the `Open follow-ups` → `Shipped` section.

## Test plan

- [x] `./run-tests.sh` — full suite green (3946 passed, 1 skipped) on the rebased branch.
- [x] Existing `tests/core/test_achievements.py` and `tests/integration/test_thread_safety.py` continue to pass — no semantic regression on `toggle_vote` / `apply_label*` callers.
- [x] Lint/format/typecheck/audit (ruff, codespell, deptry, pip-audit, pyright, frontend build) all clean as part of `./run-tests.sh`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ldt2JLFuiHxWxqwTKuABBd)_