### PR TITLE
Fix C5: drop body dataset_id from /api/find-label

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -106,7 +106,7 @@ Cross-section interaction agents:
   the live `medias` dict — training vectors and scored results are
   mapped to the wrong media IDs. Silent ranking corruption.
 
-### C5. `find_label` allows body field to override the request's dataset context
+### C5. `find_label` allows body field to override the request's dataset context — **SHIPPED**
 
 - **File:** `vtsearch/routes/detectors/scoring.py` ~L207–214, ~L336
 - **Bug:** The endpoint mutates `g._dataset_context` from a `dataset_id`
@@ -114,6 +114,11 @@ Cross-section interaction agents:
   headers. Combined with `replace_all=True` further down, a confused or
   malicious client can wipe one detector's votes while the UI thinks
   it's labeling a different one.
+- **Fix shipped:** Removed the body override in `find_label`, dropped
+  `dataset_id` from `FindLabelRequestSchema`, and removed the redundant
+  body field from the frontend caller. The `X-Dataset-Id` header (set
+  by `activeContextInterceptor`) is now the only dataset selector for
+  `/api/find-label`, matching every other route.
 
 ### C6. Zip-slip in HTTP archive importer (zip AND tar) — SHIPPED 2026-05-19
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2446,10 +2446,6 @@
       "FindLabelRequest": {
         "additionalProperties": false,
         "properties": {
-          "dataset_id": {
-            "default": "",
-            "type": "string"
-          },
           "detector_id": {
             "minLength": 1,
             "type": "string"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -179,10 +179,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Start polling for progress concurrently
     this.startProgressPolling();
 
-    const datasetId = this.activeContext.datasetId;
     const modelName =
       this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
-    this.detectorsApi.findLabel({ detector_id: modelId, ...(datasetId ? { dataset_id: datasetId } : {}) })
+    this.detectorsApi.findLabel({ detector_id: modelId })
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => {

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -57,6 +57,31 @@ class TestFindLabel:
         finally:
             app_module.medias.update(saved)
 
+    def test_find_label_body_dataset_id_is_rejected(self, client):
+        """Regression for C5: the body must not carry a ``dataset_id`` field.
+
+        The dataset to score against comes exclusively from the
+        ``X-Dataset-Id`` header set by ``before_request``. An extra
+        ``dataset_id`` in the body must fail schema validation rather
+        than silently override ``g._dataset_context`` — which used to
+        let a confused client wipe one detector's votes while the UI
+        thought it was labeling a different dataset.
+        """
+        detector_id = setup_trainable_model_in_registry(
+            "c5-regression",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        resp = client.post(
+            "/api/find-label",
+            json={"detector_id": detector_id, "dataset_id": "spoofed"},
+        )
+        # ``additionalProperties: false`` on the request schema turns
+        # the unknown field into a 422 from flask-smorest.
+        assert resp.status_code == 422, resp.get_json()
+        assert "dataset_id" in resp.get_json()["errors"]["json"]
+
 
 class TestAutoDetect:
     """``POST /api/auto-detect`` iterates detectors flagged for autorun."""

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -202,17 +202,6 @@ def find_label(body: dict):  # noqa: C901
 
     detector_id = body["detector_id"]
 
-    # If the request body specifies a dataset_id, override the request-scoped
-    # context so scoring runs against the correct dataset.
-    dataset_id = body.get("dataset_id") or ""
-    if dataset_id:
-        from flask import g
-        from vtsearch.state import get_context
-
-        ctx = get_context(dataset_id)
-        if ctx is not None:
-            g._dataset_context = ctx
-
     # Clear a leftover cancel flag from a previously-cancelled run so
     # the new operation doesn't trip on it immediately.
     find_progress.reset_cancel()

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -420,13 +420,15 @@ class _FindLabelResultSchema(Schema):
 class FindLabelRequestSchema(Schema):
     """Body for ``POST /api/find-label``.
 
-    ``dataset_id`` is optional and overrides the request-scoped dataset
-    context when present, so a single Find run can target a dataset that
-    isn't the active one in the frontend.
+    The dataset to score against comes from the request-scoped context
+    set by ``before_request`` from the ``X-Dataset-Id`` header (or the
+    ``dataset_id`` query param for browser-native requests). The body
+    intentionally does not carry a dataset selector — letting the body
+    override the header allowed a confused client to score one dataset
+    while ``replace_all=True`` wiped a different detector's votes.
     """
 
     detector_id = fields.String(required=True, validate=validate.Length(min=1))
-    dataset_id = fields.String(load_default="")
 
 
 class FindLabelResponseSchema(Schema):


### PR DESCRIPTION
## Summary

Fixes finding **C5** from `docs/plans/logical-bug-audit.md`.

`/api/find-label` mutated `g._dataset_context` from an optional `dataset_id` field in the request body, *after* `before_request` had already resolved the dataset from the `X-Dataset-Id` header. Combined with the downstream `apply_labels_bulk_with_click_time(..., replace_all=True)`, a confused or malicious client could wipe one detector's votes by submitting a find-label run that scored a different dataset's media — votes for the original dataset's IDs were dropped because they fell outside the new bulk-apply set.

The header has been the canonical dataset selector since `activeContextInterceptor` landed; the body field was a leftover from the pre-header design. This PR removes the override entirely so the header is the only dataset selector for `/api/find-label`, matching every other route.

- Remove the body override block in `find_label` (`vtsearch/routes/detectors/scoring.py`).
- Drop `dataset_id` from `FindLabelRequestSchema`; regenerate `frontend/openapi.json`.
- Remove the redundant `dataset_id` field from the find-view caller (`frontend/src/app/components/find-view/find-view.component.ts`).
- Add a regression test asserting the body field is rejected (422) by marshmallow's unknown-field handling.
- Mark C5 as SHIPPED in `docs/plans/logical-bug-audit.md`.

## Test plan

- [x] `./run-tests.sh` — full suite, 3947 passed
- [x] `./run-tests.sh detectors` — 1055 passed (includes new C5 regression test)
- [x] OpenAPI snapshot regenerated and committed

https://claude.ai/code/session_01TfA6JhwACGdr1u9mwbJfX9

---
_Generated by [Claude Code](https://claude.ai/code/session_012cCP73LwMLfsaeDmcQCwAJ)_