### PR TITLE
Resolve logical-bug audit C1: download gate safety net was already in place

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1,7 +1,8 @@
 # Logical-Bug Audit — 2026-05
 
-**Status:** Proposed — findings only, no fixes applied. Branch
-`claude/audit-logical-errors-tcszV` is clean against `origin/dev`.
+**Status:** In progress — most findings still open; resolved items
+are listed under [Open follow-ups → Resolved](#resolved) at the
+bottom and marked inline.
 
 **Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
 interaction passes) of the entire VTSearch codebase, focused on
@@ -53,17 +54,36 @@ Cross-section interaction agents:
 
 ## Critical — data corruption / loss / hangs / silent miscompute
 
-### C1. Download gate is never released if importer skips the `"embedding"` status
+### C1. Download gate is never released if importer skips the `"embedding"` status — **shipped** (verified not a bug)
 
-- **File:** `vtsearch/datasets/load_pipeline.py` ~L648–705
-- **Bug:** `_LoadGateController` only swaps from `download_gate` →
-  `embed_gate` when the importer's progress callback fires
-  `status="embedding"`. A minimalist importer that completes without
-  that status keeps the download gate held forever, blocking every
-  subsequent dataset load.
-- **Fix sketch:** Release whichever gate is held at task exit in a
-  `finally` block, or add a guaranteed swap when the importer signals
-  completion regardless of progress status.
+- **File:** `vtscore/datasets/load_pipeline.py` (was
+  `vtsearch/datasets/load_pipeline.py` before the
+  extract-library rename) — controller class at L619–661,
+  task body at L897–945.
+- **Original claim:** `_LoadGateController` only swaps from
+  `download_gate` → `embed_gate` when the importer's progress
+  callback fires `status="embedding"`. A minimalist importer that
+  completes without that status keeps the download gate held forever,
+  blocking every subsequent dataset load.
+- **What's actually there:**
+  `_run_origin_load_in_background.task()` already covers minimalist
+  importers two ways: (1) `controller.swap_to_embed()` is called
+  **unconditionally** at L918 after `_run_importer` returns, which
+  releases the download gate even if the importer never emitted an
+  `"embedding"` status; and (2) `controller.release()` lives in a
+  `try/finally` at L939–940, releasing whichever gate is held on
+  every exit path including exceptions. The audit's "fix sketch"
+  (release in `finally` or guaranteed swap) describes the existing
+  protection. The original audit pass appears to have analyzed
+  `_LoadGateController` in isolation and missed both safety nets in
+  the caller.
+- **Fix:** Inline comment at the unconditional swap site expanded to
+  call out the minimalist-importer invariant so a future refactor
+  can't accidentally drop it. Regression test
+  `tests/datasets/test_parallel_loading.py::TestLoadingGates::test_minimalist_importer_releases_both_gates`
+  drives a load whose importer never fires `"embedding"` and asserts
+  both `_download_gate.active == 0` and `_embed_gate.active == 0`
+  after the task completes.
 
 ### C2. JobManager never sets dataset/detector thread-local context — **shipped**
 
@@ -632,7 +652,8 @@ one PR is far more effective than one-off fixes.
 
 1. **C1, C2, C3** — gate hand-off + thread-local context
    propagation. One small helper (pattern #1) unblocks 3+ bug
-   classes.
+   classes. (C1 verified safe and C2 shipped on 2026-05-19; C3
+   still open.)
 2. **C4** + pattern #4 — embedding-matrix cache invalidation via a
    `media_revision` counter.
 3. **C7** — clamp `xcal_threshold` to a finite sentinel and assert
@@ -655,6 +676,21 @@ corresponding finding above is annotated **— shipped** with a short fix
 summary, and is also recorded here.
 
 ### Shipped
+
+- **C1 — Download gate safety net verified** (2026-05-19, branch
+  `claude/fix-logical-bug-audit-c1-DV5Lc`). After closer inspection
+  the bug as described is not real: the audit looked at
+  `_LoadGateController` in isolation and missed two safety nets in
+  the caller (`_run_origin_load_in_background.task()`) — an
+  unconditional `controller.swap_to_embed()` after the importer
+  returns, plus a `try/finally` that calls `controller.release()` on
+  every exit path. Together they cover minimalist importers exactly
+  as the audit's "fix sketch" recommended. Inline comment at the
+  unconditional swap site expanded to call out the invariant, and a
+  regression test
+  (`tests/datasets/test_parallel_loading.py::TestLoadingGates::test_minimalist_importer_releases_both_gates`)
+  was added so a future refactor can't silently remove either safety
+  net.
 
 - **C2 — JobManager thread-local context propagation** (2026-05-19).
   `JobManager._run` in `vtscore/concurrency/async_jobs.py` now sets
@@ -684,9 +720,9 @@ summary, and is also recorded here.
 
 ### Still open
 
-Every other finding (C1, C3, C5, C7, C8, C10, C12 and the High /
-Medium / Low tiers) remains as written. When the next fix lands, edit
-the finding above with **— shipped** and add a line here. When every
+Every other finding (C3, C5, C7, C8, C10, C12 and the High / Medium /
+Low tiers) remains as written. When the next fix lands, edit the
+finding above with **— shipped** and add a line here. When every
 critical and high is addressed, this doc can be retired into the
 relevant subsystem docs (or deleted, per the `docs/plans/` lifecycle).
 

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -782,14 +782,17 @@ class TestLoadingGates:
 
         assert started.wait(timeout=10), "Minimalist importer never started"
 
-        # Wait for the task to fully drain — gate release happens in the
-        # task's ``finally`` block after the importer returns and the
-        # post-load stages run.
+        # The task's ``finally`` block calls ``controller.release()`` after
+        # the post-load stages finish.  Poll the gates (rather than
+        # ``has_active_tasks``) because a successful task leaves its
+        # progress status at "loading"; gate release is the true signal
+        # that the task has exited.
         deadline = time.time() + 10
-        while loading_tasks.has_active_tasks() and time.time() < deadline:
+        while time.time() < deadline:
+            if _download_gate.active == 0 and _embed_gate.active == 0:
+                break
             time.sleep(0.05)
 
-        assert not loading_tasks.has_active_tasks(), "Load task never finished"
         assert _download_gate.active == 0, (
             "Download gate leaked after a minimalist importer — the "
             "unconditional swap_to_embed() after the importer, or the "

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -747,6 +747,58 @@ class TestLoadingGates:
         finally:
             settings_mod.set_max_concurrent_dataset_downloads(original)
 
+    def test_minimalist_importer_releases_both_gates(self):
+        """C1 regression: an importer that never fires ``status="embedding"``
+        must still release both gates after the task finishes.
+
+        The callback-driven download→embed swap in
+        ``_make_stepped_progress`` only triggers when an importer
+        signals per-file embedding.  Minimalist importers that don't
+        emit progress at all rely on the unconditional
+        ``controller.swap_to_embed()`` after ``_run_importer`` returns
+        plus the ``finally: controller.release()`` block to keep the
+        gates from leaking.  If either safety net is removed, the
+        download gate would stay held forever and every subsequent
+        dataset load would block.
+        """
+        from vtscore.datasets.load_pipeline import (
+            _download_gate,
+            _embed_gate,
+            _run_origin_load_in_background,
+        )
+
+        started = threading.Event()
+
+        def minimalist_load(medias):
+            # Return immediately without firing any progress callback —
+            # the callback-driven swap in stepped() never triggers.
+            started.set()
+
+        task_id = _run_origin_load_in_background(
+            minimalist_load,
+            {"importer": "minimalist", "params": {}},
+            name="Minimalist",
+        )
+
+        assert started.wait(timeout=10), "Minimalist importer never started"
+
+        # Wait for the task to fully drain — gate release happens in the
+        # task's ``finally`` block after the importer returns and the
+        # post-load stages run.
+        deadline = time.time() + 10
+        while loading_tasks.has_active_tasks() and time.time() < deadline:
+            time.sleep(0.05)
+
+        assert not loading_tasks.has_active_tasks(), "Load task never finished"
+        assert _download_gate.active == 0, (
+            "Download gate leaked after a minimalist importer — the "
+            "unconditional swap_to_embed() after the importer, or the "
+            "finally-release in the task body, has regressed (audit C1)."
+        )
+        assert _embed_gate.active == 0, "Embed gate leaked after minimalist importer"
+
+        loading_tasks.remove_task(task_id)
+
     def test_download_and_embed_can_overlap(self):
         """When the importer signals the embedding phase, the download gate
         is released so a second dataset can start downloading in parallel

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -920,8 +920,16 @@ def _run_origin_load_in_background(
             tracker.check_cancelled()
 
             # Post-load stages are CPU/GPU-bound and touch embeddings —
-            # gate them on the embed semaphore.  No-op if the importer
-            # already swapped mid-load.
+            # gate them on the embed semaphore.  Calling swap here
+            # unconditionally is also the safety net for minimalist
+            # importers that complete without firing an ``"embedding"``
+            # status: ``_make_stepped_progress``'s callback-driven swap
+            # never fires for them, so without this call the download
+            # gate would stay held through every post-load stage.  The
+            # ``finally: controller.release()`` below is a second-line
+            # backstop that releases whichever gate is held on any
+            # error path.  No-op if the importer already swapped
+            # mid-load.
             controller.swap_to_embed()
 
             apply_custom_metadata_md5(ctx.medias)


### PR DESCRIPTION
## Summary

C1 of `docs/plans/logical-bug-audit.md` claimed that the download gate is
never released when an importer skips the `"embedding"` status, but
tracing the actual control flow shows the caller
(`_run_origin_load_in_background.task()` in
`vtscore/datasets/load_pipeline.py`) already has both safety nets the
audit's fix sketch recommended:

1. `controller.swap_to_embed()` is called **unconditionally** after the
   importer returns, so the download → embed swap happens even when the
   importer never emits a `status="embedding"` callback.
2. `controller.release()` lives in a `try/finally`, releasing whichever
   gate is held on every exit path (including exceptions).

The original audit pass appears to have analyzed `_LoadGateController`
in isolation and missed both protections.

To lock the invariant in:

- Expanded the inline comment at the unconditional swap site to call
  out the minimalist-importer case so it isn't accidentally regressed
  during a future refactor.
- Added
  `tests/datasets/test_parallel_loading.py::TestLoadingGates::test_minimalist_importer_releases_both_gates`
  — drives a load whose importer never fires `"embedding"` and asserts
  both gates return to `active == 0` after the task completes. A
  regression that drops either safety net would fail this test.
- Marked C1 as shipped in `docs/plans/logical-bug-audit.md` (status
  header, individual finding entry, Suggested fix order, and Shipped
  section) with date + branch + pointer to the regression test.

## Test plan

- [x] `python -m pytest tests/datasets/test_parallel_loading.py::TestLoadingGates -q --tb=short` — 5 passed
- [x] `./run-tests.sh datasets` — 505 passed, 2 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_015AS1ZndpmnxLyYQgpVRGiF)_