### PR TITLE
Fix C12: roll back orphaned dataset registry entry on load failure

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -80,14 +80,7 @@ Cross-section interaction agents:
 
 ### ~~C11. `fill_labels_from_sort` silently swallows sync failures~~
 
-### C12. Orphaned dataset registry entry on activation failure
-
-- **File:** `vtsearch/datasets/load_pipeline.py` ~L596–610, ~L825–842
-- **Bug:** If the importer/pickle save succeeds (registry entry
-  created) but a later stage (diversity tree, post-embed clip fix-up)
-  throws, the registry entry remains while the `DatasetContext` is
-  unregistered. The dataset shows up in the UI list but can't be
-  loaded — and the next "load" hits the half-built path again.
+### ~~C12. Orphaned dataset registry entry on activation failure~~
 
 ---
 
@@ -568,9 +561,22 @@ and a one-line summary is recorded here.
   back (full transactional rollback deferred to pattern #8).
   Regression: `tests/io/test_export_options.py::TestFillFromSortConfirm::test_disk_sync_failure_surfaces_as_500`.
 
+- **C12 — Orphaned dataset registry entry on activation failure**
+  (2026-05-19). `_register_and_migrate` now returns
+  `(context_id, registry_entry_id)` and self-rolls-back the entry if
+  its in-place context migration raises after the entry has been
+  written. `task()` in `_run_origin_load_in_background` threads
+  `registry_entry_id` into `_handle_load_failure`, which now also
+  calls `unregister_dataset` (deletes the pkl + clears
+  `_loaded_ids`). `_auto_register_dataset` wraps `register_dataset`
+  in `try/except` that deletes the freshly-written pkl when the
+  registry write itself fails, so the inverse orphan (pkl on disk,
+  no entry) is also impossible. Regression:
+  `tests/datasets/test_datasets.py::TestLoadFailureCleanup`.
+
 ### Still open
 
-Every other finding (C12 and the H / M / L tiers) remains as written.
+Every other finding (the H / M / L tiers) remains as written.
 When the next fix lands, collapse the finding above to a struck-through
 heading and add a line here. When every critical and high is addressed,
 this doc can be retired into the relevant subsystem docs (or deleted,

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1362,6 +1362,128 @@ class TestLoadProgressRaceCondition:
         assert settings_mod.get_last_embedder_per_media_type() == {}
 
 
+class TestLoadFailureCleanup:
+    """C12 — a failure anywhere in the load pipeline must not leave an
+    orphan registry entry behind.
+
+    Before the fix, ``_register_and_migrate`` wrote the registry entry +
+    pkl, and if any later step (the in-place context migration, the
+    achievement record, etc.) raised, ``_handle_load_failure`` only
+    unregistered the in-memory context — leaving a half-built dashboard
+    row pointing at a pkl with no in-memory context to back it.
+    """
+
+    @staticmethod
+    def _sync_thread_factory(captured):
+        from unittest import mock as _mock
+
+        def fake_thread(target, daemon=True, name=None):
+            captured["fn"] = target
+            t = _mock.MagicMock()
+            t.start = lambda: target()
+            return t
+
+        return fake_thread
+
+    @staticmethod
+    def _fake_load(target_medias):
+        import numpy as np
+
+        target_medias[1] = {
+            "id": 1,
+            "type": "audio",
+            "duration": 1.0,
+            "file_size": 100,
+            "md5": "test-md5-c12",
+            "embedder": "",
+            "embedding": np.zeros(8, dtype=np.float32),
+            "filename": "fake.wav",
+            "category": "unknown",
+            "origin": None,
+            "origin_name": "fake.wav",
+            "media_bytes": None,
+            "media_string": None,
+            "media_path": None,
+        }
+
+    def test_post_register_failure_rolls_back_registry_entry(self, isolated_settings):
+        """A failure after the registry entry is created must remove it."""
+        from unittest import mock
+
+        from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+        from vtscore.datasets.registry import list_datasets
+
+        captured: dict = {}
+        with (
+            mock.patch(
+                "vtscore.datasets.load_pipeline.threading.Thread",
+                side_effect=self._sync_thread_factory(captured),
+            ),
+            mock.patch(
+                "vtsearch.achievements.record_dataset_load",
+                side_effect=RuntimeError("simulated post-register failure"),
+            ),
+        ):
+            _run_origin_load_in_background(
+                self._fake_load,
+                {"importer": "test", "params": {}},
+            )
+
+        assert list_datasets() == [], (
+            "registry entry must be rolled back when a post-register step fails — "
+            "otherwise the dashboard shows a phantom dataset row backed by a half-built pkl"
+        )
+
+    def test_successful_load_keeps_registry_entry(self, isolated_settings):
+        """The cleanup must NOT fire on the happy path."""
+        from unittest import mock
+
+        from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+        from vtscore.datasets.registry import list_datasets, unregister_dataset
+
+        captured: dict = {}
+        with mock.patch(
+            "vtscore.datasets.load_pipeline.threading.Thread",
+            side_effect=self._sync_thread_factory(captured),
+        ):
+            _run_origin_load_in_background(
+                self._fake_load,
+                {"importer": "test", "params": {}},
+            )
+
+        entries = list_datasets()
+        try:
+            assert len(entries) == 1, "successful load should leave exactly one registry entry"
+        finally:
+            for e in entries:
+                unregister_dataset(e["id"])
+
+    def test_registry_write_failure_cleans_up_pkl(self, isolated_settings, tmp_path):
+        """If ``register_dataset`` itself raises after the pkl is written, the
+        orphaned pkl must be deleted rather than left on disk forever."""
+        from pathlib import Path
+        from unittest import mock
+
+        from vtsearch import settings as settings_mod
+        from vtscore.datasets.load_pipeline import _auto_register_dataset
+
+        ds_dir = tmp_path / "saved_for_c12"
+        settings_mod.set_saved_datasets_dir(str(ds_dir))
+
+        medias = {}
+        self._fake_load(medias)
+
+        with mock.patch(
+            "vtscore.datasets.load_pipeline._reg_register",
+            side_effect=RuntimeError("simulated registry write failure"),
+        ):
+            entry = _auto_register_dataset(medias, name="orphan-test")
+
+        assert entry is None
+        leftover = list(Path(ds_dir).glob("ds_*.pkl")) if ds_dir.exists() else []
+        assert leftover == [], f"pkl files must be cleaned up when registry write fails, found: {leftover}"
+
+
 class TestCancelIngest:
     """Tests for the POST /api/dataset/cancel endpoint."""
 

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -110,6 +110,7 @@ from vtscore.datasets.registry import (
     get_saved_datasets_dir,
     register_dataset as _reg_register,
     add_loaded_id as _reg_add_loaded,
+    unregister_dataset as _reg_unregister,
 )
 from vtsearch.state import (
     DatasetContext,
@@ -594,20 +595,27 @@ def _auto_register_dataset(
         traceback.print_exc()
         return None
 
-    entry = _reg_register(
-        name=name,
-        media_type=media_type,
-        num_items=num_items,
-        num_dupes=num_dupes,
-        pkl_path=pkl_path,
-        origin=origin_str,
-        source=source,
-        clipper=clipper,
-        embedder=embedder,
-        created_by=created_by,
-        file_type_counts=file_type_counts,
-        ingest_started_at=ingest_started_at,
-    )
+    try:
+        entry = _reg_register(
+            name=name,
+            media_type=media_type,
+            num_items=num_items,
+            num_dupes=num_dupes,
+            pkl_path=pkl_path,
+            origin=origin_str,
+            source=source,
+            clipper=clipper,
+            embedder=embedder,
+            created_by=created_by,
+            file_type_counts=file_type_counts,
+            ingest_started_at=ingest_started_at,
+        )
+    except Exception:
+        # Registry write failed — clean up the orphaned pkl so we don't
+        # leave a stale file behind with nothing pointing at it.
+        traceback.print_exc()
+        Path(pkl_path).unlink(missing_ok=True)
+        return None
     _reg_add_loaded(entry["id"])
     return entry
 
@@ -777,10 +785,18 @@ def _register_and_migrate(
     embedder: str,
     created_by: str,
     ingest_started_at: float,
-) -> str:
+) -> tuple[str, str | None]:
     """Save to registry, migrate the context from task_id to its real id.
 
-    Returns the (possibly migrated) context_id.
+    Returns ``(context_id, registry_entry_id)`` — *context_id* is the
+    (possibly migrated) context id, and *registry_entry_id* is the id of
+    the newly created registry entry (or ``None`` if registration was
+    skipped).  Callers should retain *registry_entry_id* so a later
+    failure in the surrounding pipeline can roll the entry back.
+
+    If the registry entry is created successfully but the subsequent
+    in-memory migration steps raise, the entry is rolled back before the
+    exception propagates so we never leave an orphan on disk.
     """
     tracker.update("loading", "Saving to registry…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
     entry = _auto_register_dataset(
@@ -795,13 +811,23 @@ def _register_and_migrate(
         ingest_started_at=ingest_started_at,
     )
     if entry is None:
-        return task_id
-    _migrate_context_id(task_id, entry["id"])
-    ctx.dataset_display_name = entry.get("name", name)
-    # Associate the loading task with the real dataset ID so the
-    # finished-task tick is attributed to the right dashboard row.
-    loading_tasks.set_dataset_id(task_id, entry["id"])
-    return entry["id"]
+        return task_id, None
+    entry_id = entry["id"]
+    try:
+        _migrate_context_id(task_id, entry_id)
+        ctx.dataset_display_name = entry.get("name", name)
+        # Associate the loading task with the real dataset ID so the
+        # finished-task tick is attributed to the right dashboard row.
+        loading_tasks.set_dataset_id(task_id, entry_id)
+    except Exception:
+        # Migration failed after the registry entry was written — roll
+        # it back so the dashboard doesn't show a half-built dataset.
+        try:
+            _reg_unregister(entry_id)
+        except Exception:
+            traceback.print_exc()
+        raise
+    return entry_id, entry_id
 
 
 def _warmup_embedder_async(media_dict: dict) -> None:
@@ -829,8 +855,19 @@ def _warmup_embedder_async(media_dict: dict) -> None:
     threading.Thread(target=_run, name="warmup-embedder", daemon=True).start()
 
 
-def _handle_load_failure(exc: BaseException, context_id: str, tracker) -> None:
-    """Unregister the context and write the failure into *tracker*."""
+def _handle_load_failure(
+    exc: BaseException,
+    context_id: str,
+    tracker,
+    registry_entry_id: str | None = None,
+) -> None:
+    """Unregister the context and write the failure into *tracker*.
+
+    If *registry_entry_id* is set, the on-disk registry entry (and its
+    backing pkl) is also removed — this prevents an orphaned dashboard
+    row when a load fails after :func:`_register_and_migrate` has
+    already written the entry.
+    """
     from vtscore.state.core import unregister_context  # noqa: PLC0415
 
     if isinstance(exc, CancelledError):
@@ -845,6 +882,11 @@ def _handle_load_failure(exc: BaseException, context_id: str, tracker) -> None:
         error = str(exc) or repr(exc) or "Unknown error during dataset loading"
 
     unregister_context(context_id)
+    if registry_entry_id:
+        try:
+            _reg_unregister(registry_entry_id)
+        except Exception:
+            traceback.print_exc()
     gc.collect()
     tracker.update("idle", "", 0, 0, error=error, step=None, total_steps=None)
 
@@ -915,6 +957,7 @@ def _run_origin_load_in_background(
         # on ``_empty_dataset_context`` and are silently lost.
         set_thread_dataset_context(ctx)
         context_id = task_id
+        registry_entry_id: str | None = None
         controller = _LoadGateController(tracker)
         stepped = _make_stepped_progress(controller, tracker)
 
@@ -946,7 +989,7 @@ def _run_origin_load_in_background(
             _collapse_duplicates_stage(ctx, tracker)
             _build_diversity_tree_stage(ctx, tracker)
             tracker.check_cancelled()
-            context_id = _register_and_migrate(
+            context_id, registry_entry_id = _register_and_migrate(
                 ctx, tracker, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
             )
             # Embedder warm-up is fire-and-forget so the dashboard row goes
@@ -958,7 +1001,7 @@ def _run_origin_load_in_background(
 
             record_dataset_load(str(origin.get("importer", "")))
         except Exception as exc:
-            _handle_load_failure(exc, context_id, tracker)
+            _handle_load_failure(exc, context_id, tracker, registry_entry_id=registry_entry_id)
         finally:
             controller.release()
             clear_thread_progress()


### PR DESCRIPTION
## Summary

Addresses **C12** from `docs/plans/logical-bug-audit.md`: if the dataset load pipeline failed *after* `_register_and_migrate` had already written the registry entry + pkl, `_handle_load_failure` only unregistered the in-memory `DatasetContext`. The on-disk entry stayed put, leaving a phantom dashboard row pointing at a half-built pkl — and the next "load" would hit the same broken state again.

- `_register_and_migrate` now returns `(context_id, registry_entry_id)` and self-rolls-back the entry if its own in-place migration steps raise.
- `task()` in `_run_origin_load_in_background` retains `registry_entry_id` and passes it to `_handle_load_failure`, which now also calls `unregister_dataset` (deletes the pkl + clears `_loaded_ids`).
- `_auto_register_dataset` wraps `register_dataset` in a try/except that deletes the just-written pkl if the registry write itself fails, so "pkl on disk, no entry" is also impossible.
- Audit doc updated: C12 marked **shipped** with a "Shipped" entry alongside C2 and C6.

## Test plan

- [x] `./run-tests.sh datasets` — 507 passed, 2 skipped
- [x] `./run-tests.sh` (full suite) — 3949 passed, 1 skipped, 2 xpassed
- [x] New `TestLoadFailureCleanup` class in `tests/datasets/test_datasets.py` covers:
  - post-register failure path (`record_dataset_load` raises → registry must be empty)
  - happy path (exactly one entry remains)
  - registry-write-failure pkl cleanup (`_reg_register` raises → no orphan pkl)

https://claude.ai/code/session_017tESK7gnwmXxY2Wj7isFLH

---
_Generated by [Claude Code](https://claude.ai/code/session_017tESK7gnwmXxY2Wj7isFLH)_