### PR TITLE
Fix H2: honor region_box on cross-dataset label resolution

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -102,11 +102,15 @@ Cross-section interaction agents:
 
 ### Detector / training
 
-- **H2. Cross-dataset region-box loss** —
-  `vtsearch/detectors/labelset_training.py` L122–124. When an element
-  has `region_box` but the file isn't in the active dataset, fallback
-  `_embed_one` embeds the full file. Region-level training intent
-  silently downgrades to image-level.
+- ~~**H2. Cross-dataset region-box loss**~~ — fixed in
+  `vtscore/detectors/labelset_training.py`. `_embed_one` now resolves the
+  origin, runs `patch_forward` on the file when the active embedder
+  supports patch regions, and pools the box via `box_to_vote_vector` so a
+  region vote's training intent survives a dataset switch. Logs a
+  warning and falls back to a full-file embedding only when the embedder
+  has no patch path (single-vector models) or the forward pass produces
+  no output. Covered by `TestRegionAwareTrainingCrossDataset` in
+  `tests/detectors/test_patch_embedder.py`.
 - **H3. Embedder drift on save → reload** —
   `vtsearch/detectors/training.py` L449, L463.
   `train_detector_from_origins()` calls

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -521,11 +521,15 @@ voting" above; closeout summary below.
      `vtsearch/models/labelset_training.py::populate_label_embeddings`
      pool the training vector on-the-fly from `media["patch_grid"]`
      via `box_to_vote_vector` when `region_box` is set, falling back
-     to `media["embedding"]` for legacy datasets, single-vector
-     embedders, and cross-dataset elements resolved via origin.
-     Region-voted labelset elements re-pool every training pass so
-     `region_box` edits propagate without explicit cache
-     invalidation; the image-level cache fast path is unchanged.
+     to `media["embedding"]` for legacy datasets and single-vector
+     embedders.  Cross-dataset elements whose file isn't in the
+     active snap rebuild a patch grid via `patch_forward` on the
+     resolved file and pool the box from it (bug H2 fix); only when
+     the embedder has no patch path do they fall back to a full-file
+     embedding (with a logged warning).  Region-voted labelset
+     elements re-pool every training pass so `region_box` edits
+     propagate without explicit cache invalidation; the image-level
+     cache fast path is unchanged.
    - `LabelSet.from_clips_and_votes` accepts an optional
      `vote_region_boxes` map.  All four call sites
      (`/api/labels/export`, `POST /api/detectors/<name>/labels`,

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1386,3 +1386,273 @@ class TestRegionAwareTraining:
         det_ctx.label_embeddings[eid] = sentinel
         populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
         np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
+
+
+class TestRegionAwareTrainingCrossDataset:
+    """Cross-dataset region-vote path: when a labelset element carries a
+    ``region_box`` and its source file is not in the active dataset's snap,
+    ``_embed_one`` should resolve the file, run ``patch_forward`` on it,
+    and pool the box via :func:`box_to_vote_vector` — so the user's region
+    intent isn't silently downgraded to a full-image embedding (bug H2).
+
+    Falls back (with a warning) to the image-level embedding only when the
+    chosen embedder can't produce a patch grid.
+    """
+
+    def _make_grid(self, h: int = 4, w: int = 4, d: int = 16) -> np.ndarray:
+        """Axis-aligned unit-vector grid: cell (r, c) holds e_{r*w + c}.
+
+        Lets the test assert exactly which cells got pooled by inspecting
+        the resulting vector's argmax pattern.
+        """
+        n = h * w
+        flat = np.zeros((n, d), dtype=np.float32)
+        for i in range(n):
+            flat[i, i] = 1.0
+        return flat.reshape(h, w, d)
+
+    def _patch_capable_stub(self, grid: np.ndarray):
+        """A stub embedder whose ``patch_forward`` returns *grid*."""
+        from vtscore.media.patch_embed import PatchEmbedOutput
+
+        cls = np.zeros(grid.shape[-1], dtype=np.float32)
+        cls[-1] = 1.0  # arbitrary unit vector, distinct from any cell
+
+        class _PatchStub:
+            name = "patch-stub"
+            supports_patch_regions = True
+
+            def patch_forward(self, _media):
+                saliency = np.ones(grid.shape[:2], dtype=np.float32)
+                saliency /= saliency.sum()
+                return PatchEmbedOutput(cls_vec=cls, patch_grid=grid, patch_saliency=saliency)
+
+        return _PatchStub(), cls
+
+    def _single_vector_stub(self, dim: int = 16):
+        """Stub embedder that does NOT support patch regions; ``embed_media``
+        returns a sentinel vector so the fallback can be detected."""
+        sentinel = np.zeros(dim, dtype=np.float32)
+        sentinel[0] = 1.0
+
+        class _SingleStub:
+            name = "single-stub"
+            supports_patch_regions = False
+
+            def embed_media(self, _media):
+                return sentinel
+
+        return _SingleStub(), sentinel
+
+    def _wire_resolution(
+        self,
+        monkeypatch,
+        tmp_path,
+        embedder,
+        filename: str = "missing.png",
+    ):
+        """Make ``resolve_file_context`` yield a real-looking path and route
+        ``get_embedder`` / ``embedders_for_type`` / ``embed_file`` to *embedder*.
+
+        Returns the resolved path so the test can assert it was used.
+        """
+        from contextlib import contextmanager
+        from pathlib import Path
+
+        import vtscore.detectors.resolver as resolver_mod
+        import vtscore.media as media_mod
+
+        fake = Path(tmp_path) / filename
+        fake.write_bytes(b"")  # exists on disk so resolvers don't second-guess
+
+        @contextmanager
+        def _fake_ctx(_origin, _origin_name="", _filename=""):
+            yield fake
+
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
+        monkeypatch.setattr(media_mod, "get_embedder", lambda _name: embedder)
+        monkeypatch.setattr(media_mod, "embedders_for_type", lambda _mt: [embedder])
+
+        # Image-level fallback inside ``embed_file`` re-looks-up the
+        # embedder; stub it directly so the fallback path produces the
+        # single-stub sentinel rather than a real model load.
+        def _fake_embed_file(_path, _media_type, _embedder_name=""):
+            return embedder.embed_media({"media_path": str(fake)})
+
+        monkeypatch.setattr(resolver_mod, "embed_file", _fake_embed_file)
+        return fake
+
+    def _cross_dataset_elem(self, *, region_box, md5="ff" * 16, origin_name="missing.png"):
+        """Build an element whose md5 won't match any active media so the
+        in-dataset path skips and we hit ``_embed_one``."""
+        from vtscore.datasets.labelset import LabeledElement
+
+        return LabeledElement(
+            md5=md5,
+            label="good",
+            origin={"importer": "server_folder", "params": {"folder": "/nowhere"}},
+            origin_name=origin_name,
+            filename=origin_name,
+            region_box=region_box,
+        )
+
+    def test_cross_dataset_region_vote_uses_pooled_vector_when_embedder_supports_patches(
+        self, monkeypatch, tmp_path
+    ):
+        """An element with ``region_box`` whose file isn't in the active
+        snap pools via ``patch_forward`` + ``box_to_vote_vector`` instead of
+        falling back to the full-image embedding."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.media.patch_embed import box_to_vote_vector
+        from vtscore.state.core import DetectorContext
+
+        grid = self._make_grid()
+        stub, _cls = self._patch_capable_stub(grid)
+        self._wire_resolution(monkeypatch, tmp_path, stub)
+
+        box = (0.0, 0.0, 0.5, 0.5)
+        elem = self._cross_dataset_elem(region_box=box)
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        # Empty snap → in-dataset path skipped; ``_embed_one`` is invoked.
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+
+        eid = stable_element_id(elem)
+        assert eid in det_ctx.label_embeddings
+        expected = box_to_vote_vector(grid, box)
+        np.testing.assert_allclose(det_ctx.label_embeddings[eid], expected, atol=1e-6)
+
+    def test_cross_dataset_region_vote_box_change_reflects_in_pooled_vector(
+        self, monkeypatch, tmp_path
+    ):
+        """Two boxes selecting disjoint quadrants of the same patch grid
+        must produce two visibly different cached vectors — proves the
+        region intent really threads through the cross-dataset path."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.media.patch_embed import box_to_vote_vector
+        from vtscore.state.core import DetectorContext
+
+        grid = self._make_grid()
+        stub, _ = self._patch_capable_stub(grid)
+        self._wire_resolution(monkeypatch, tmp_path, stub)
+
+        top_left = (0.0, 0.0, 0.5, 0.5)
+        bot_right = (0.5, 0.5, 1.0, 1.0)
+
+        elem = self._cross_dataset_elem(region_box=top_left)
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+        eid = stable_element_id(elem)
+        first = np.array(det_ctx.label_embeddings[eid], copy=True)
+
+        elem.region_box = bot_right
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+        second = det_ctx.label_embeddings[eid]
+
+        np.testing.assert_allclose(second, box_to_vote_vector(grid, bot_right), atol=1e-6)
+        assert not np.allclose(first, second), "Region edit must repool, not reuse the cached vector"
+
+    def test_cross_dataset_region_vote_falls_back_with_warning_for_single_vector_embedder(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Legacy single-vector embedders can't produce a patch grid.  The
+        element still trains (we don't drop the vote), but the cached
+        embedding is the full-image vector and a warning surfaces the
+        silent downgrade."""
+        import logging
+
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.state.core import DetectorContext
+
+        stub, sentinel = self._single_vector_stub()
+        self._wire_resolution(monkeypatch, tmp_path, stub)
+
+        elem = self._cross_dataset_elem(region_box=(0.0, 0.0, 0.5, 0.5))
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+
+        with caplog.at_level(logging.WARNING, logger="vtscore.detectors.labelset_training"):
+            populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+
+        eid = stable_element_id(elem)
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
+        assert any(
+            "region_box" in r.message and "patch regions" in r.message for r in caplog.records
+        ), f"Expected a region-downgrade warning; got: {[r.message for r in caplog.records]}"
+
+    def test_cross_dataset_region_vote_returns_none_when_embedder_patch_forward_fails(
+        self, monkeypatch, tmp_path
+    ):
+        """``patch_forward`` returning ``None`` (failed decode, etc.)
+        downgrades to the image-level fallback rather than skipping the
+        element entirely — keeping the vote in the training set."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.state.core import DetectorContext
+
+        sentinel = np.zeros(16, dtype=np.float32)
+        sentinel[5] = 1.0
+
+        class _FlakyPatchStub:
+            name = "flaky-patch-stub"
+            supports_patch_regions = True
+
+            def patch_forward(self, _media):
+                return None  # simulates a failed forward pass
+
+            def embed_media(self, _media):
+                return sentinel
+
+        self._wire_resolution(monkeypatch, tmp_path, _FlakyPatchStub())
+
+        elem = self._cross_dataset_elem(region_box=(0.0, 0.0, 0.5, 0.5))
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+
+        eid = stable_element_id(elem)
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
+
+    def test_cross_dataset_no_region_box_unchanged(self, monkeypatch, tmp_path):
+        """Image-level cross-dataset elements (no ``region_box``) must hit
+        the existing ``embed_file`` path — patch_forward should not even
+        be called.  Guards against the new path firing spuriously."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.state.core import DetectorContext
+
+        sentinel = np.zeros(16, dtype=np.float32)
+        sentinel[7] = 1.0
+        patch_calls = []
+
+        class _ObservingPatchStub:
+            name = "observing-patch-stub"
+            supports_patch_regions = True
+
+            def patch_forward(self, media):
+                patch_calls.append(media)
+                raise AssertionError("patch_forward must not be called for image-level votes")
+
+            def embed_media(self, _media):
+                return sentinel
+
+        self._wire_resolution(monkeypatch, tmp_path, _ObservingPatchStub())
+
+        elem = self._cross_dataset_elem(region_box=None)
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap={})
+
+        eid = stable_element_id(elem)
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
+        assert patch_calls == []

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1496,9 +1496,7 @@ class TestRegionAwareTrainingCrossDataset:
             region_box=region_box,
         )
 
-    def test_cross_dataset_region_vote_uses_pooled_vector_when_embedder_supports_patches(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cross_dataset_region_vote_uses_pooled_vector_when_embedder_supports_patches(self, monkeypatch, tmp_path):
         """An element with ``region_box`` whose file isn't in the active
         snap pools via ``patch_forward`` + ``box_to_vote_vector`` instead of
         falling back to the full-image embedding."""
@@ -1524,9 +1522,7 @@ class TestRegionAwareTrainingCrossDataset:
         expected = box_to_vote_vector(grid, box)
         np.testing.assert_allclose(det_ctx.label_embeddings[eid], expected, atol=1e-6)
 
-    def test_cross_dataset_region_vote_box_change_reflects_in_pooled_vector(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cross_dataset_region_vote_box_change_reflects_in_pooled_vector(self, monkeypatch, tmp_path):
         """Two boxes selecting disjoint quadrants of the same patch grid
         must produce two visibly different cached vectors — proves the
         region intent really threads through the cross-dataset path."""
@@ -1584,13 +1580,11 @@ class TestRegionAwareTrainingCrossDataset:
 
         eid = stable_element_id(elem)
         np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
-        assert any(
-            "region_box" in r.message and "patch regions" in r.message for r in caplog.records
-        ), f"Expected a region-downgrade warning; got: {[r.message for r in caplog.records]}"
+        assert any("region_box" in r.message and "patch regions" in r.message for r in caplog.records), (
+            f"Expected a region-downgrade warning; got: {[r.message for r in caplog.records]}"
+        )
 
-    def test_cross_dataset_region_vote_returns_none_when_embedder_patch_forward_fails(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cross_dataset_region_vote_returns_none_when_embedder_patch_forward_fails(self, monkeypatch, tmp_path):
         """``patch_forward`` returning ``None`` (failed decode, etc.)
         downgrades to the image-level fallback rather than skipping the
         element entirely — keeping the vote in the training set."""

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -81,8 +81,7 @@ def _patch_pooled_from_file(
         output = embedder.patch_forward(media_from_path(file_path))
     except Exception:
         log.warning(
-            "labelset_training: patch_forward(%s) raised; region vote will fall "
-            "back to image-level embedding",
+            "labelset_training: patch_forward(%s) raised; region vote will fall back to image-level embedding",
             file_path,
             exc_info=True,
         )

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -15,12 +15,16 @@ This module is the single place that knows how to (re-)build the
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any, Callable
 
 import numpy as np
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet
 
+
+log = logging.getLogger(__name__)
 
 ProgressCallback = Callable[[str, int, int], None]
 
@@ -37,8 +41,69 @@ def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     return first.get("embedder", "") or ""
 
 
+def _patch_pooled_from_file(
+    file_path: Path,
+    *,
+    media_type: str,
+    embedder_name: str,
+    region_box: tuple[float, float, float, float],
+) -> np.ndarray | None:
+    """Run ``patch_forward`` on *file_path* and pool *region_box* into one vector.
+
+    Mirrors the in-dataset region path (``_pool_box_from_media`` →
+    :func:`box_to_vote_vector`) for the cross-dataset case: resolve the
+    origin to a file, rebuild a patch grid via
+    :meth:`MediaEmbedder.patch_forward`, and pool the user-drawn box.
+    Returns ``None`` when the chosen embedder doesn't support patch
+    regions or the forward pass produces no output, so the caller can
+    fall back to an image-level embedding.
+    """
+    from vtscore.media import embedders_for_type, get_embedder
+    from vtscore.media.embedder import media_from_path
+    from vtscore.media.patch_embed import box_to_vote_vector
+
+    embedder = None
+    if embedder_name:
+        try:
+            embedder = get_embedder(embedder_name)
+        except (KeyError, ValueError):
+            embedder = None
+    if embedder is None:
+        avail = embedders_for_type(media_type)
+        if not avail:
+            return None
+        embedder = avail[0]
+
+    if not getattr(embedder, "supports_patch_regions", False):
+        return None
+
+    try:
+        output = embedder.patch_forward(media_from_path(file_path))
+    except Exception:
+        log.warning(
+            "labelset_training: patch_forward(%s) raised; region vote will fall "
+            "back to image-level embedding",
+            file_path,
+            exc_info=True,
+        )
+        return None
+    if output is None:
+        return None
+    return box_to_vote_vector(np.asarray(output.patch_grid), region_box)
+
+
 def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> np.ndarray | None:
-    """Resolve *elem*'s origin file and embed it.  Returns ``None`` on failure."""
+    """Resolve *elem*'s origin file and embed it.  Returns ``None`` on failure.
+
+    When *elem* carries a ``region_box`` and the active embedder supports
+    patch regions, the resolved file is patch-forwarded and the box is
+    pooled via :func:`box_to_vote_vector` so the user's region-level
+    training intent survives a dataset switch.  Logs a warning and falls
+    back to a full-file embedding when the patch path is unavailable —
+    legacy single-vector embedders, an origin carrying a clipper we'd
+    have to replay against an unknown patch grid, or a failed forward
+    pass.
+    """
     from vtscore.detectors.resolver import (
         _apply_clip_and_embed,
         embed_file,
@@ -50,8 +115,34 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
             return None
 
         origin = elem.origin or {}
-        params = origin.get("params", {})
-        if isinstance(params, dict) and params.get("clipper"):
+        params = origin.get("params", {}) if isinstance(origin, dict) else {}
+        has_clipper = isinstance(params, dict) and bool(params.get("clipper"))
+
+        if elem.region_box is not None and not has_clipper:
+            pooled = _patch_pooled_from_file(
+                file_path,
+                media_type=media_type,
+                embedder_name=embedder_name,
+                region_box=elem.region_box,
+            )
+            if pooled is not None:
+                return pooled
+            log.warning(
+                "labelset_training: region_box on %r cannot be honored cross-dataset "
+                "(embedder=%r does not support patch regions or patch_forward "
+                "produced no output); falling back to image-level embedding",
+                elem.origin_name or elem.filename or "<unknown>",
+                embedder_name or "<default>",
+            )
+        elif elem.region_box is not None and has_clipper:
+            log.warning(
+                "labelset_training: region_box on %r cannot be honored cross-dataset "
+                "because the origin carries a clipper; falling back to image-level "
+                "embedding",
+                elem.origin_name or elem.filename or "<unknown>",
+            )
+
+        if has_clipper:
             return _apply_clip_and_embed(file_path, media_type, origin, embedder_name)
         return embed_file(file_path, media_type, embedder_name)
 
@@ -118,8 +209,13 @@ def _resolve_uncached_embedding(
             if emb is not None:
                 return np.asarray(emb)
 
-    # Cross-dataset path: no patch_grid is available, so a stashed
-    # ``region_box`` falls back to the image-level embedding.
+    # Cross-dataset path: ``_embed_one`` rebuilds a patch grid on the
+    # resolved file when ``elem.region_box`` is set and the embedder
+    # supports patch regions, then pools via ``box_to_vote_vector`` so
+    # region votes survive a dataset switch.  When the patch path isn't
+    # available (legacy single-vector embedder, clipper-bearing origin,
+    # failed forward pass) it logs a warning and returns the image-level
+    # embedding — the only signal we have left to offer training.
     emb = _embed_one(elem, media_type=media_type, embedder_name=embedder_name)
     return np.asarray(emb) if emb is not None else None
 


### PR DESCRIPTION
## Summary

Fixes bug **H2** from `docs/plans/logical-bug-audit.md`: when a region-voted Good `LabeledElement` (one carrying a `region_box`) resolved to a file outside the active dataset's snap, `_embed_one` previously embedded the whole file — silently downgrading the user's region-level training intent to image-level. The cached vector then stuck around until the embedder changed, so a region vote's contribution to the MLP depended on which dataset happened to be loaded when training fired.

`_embed_one` now resolves the origin, runs `patch_forward` on the file when the active embedder supports patch regions, and pools the box via `box_to_vote_vector` — mirroring the in-dataset path (`_pool_box_from_media`). When the embedder has no patch path (single-vector models) or `patch_forward` produces no output, it logs a warning and falls back to a full-file embedding so the vote still contributes, just without the region precision. Origins that carry a clipper also warn + fall back, since replaying an arbitrary clipper chain through `patch_forward` is out of scope.

## Test plan

- [x] New `TestRegionAwareTrainingCrossDataset` class in `tests/detectors/test_patch_embedder.py` covers:
  - pooled vector equals `box_to_vote_vector(patch_grid, region_box)` for a patch-capable embedder;
  - region-box edits repool (top-left vs. bottom-right quadrants produce different cached vectors);
  - single-vector embedder → fallback + a warning that mentions `region_box` and `patch regions`;
  - `patch_forward` returning `None` → fallback to `embed_file`;
  - no `region_box` → `patch_forward` is *not* called (guards against the new path firing spuriously).
- [x] `./run-tests.sh detectors` — 1060 passed.
- [x] `./run-tests.sh` (full suite) — 3964 passed, 1 skipped, 2 xpassed.
- [x] `ruff check`, `ruff format --check`, `codespell`, `deptry`, `pip-audit`, `pyright`, OpenAPI snapshot — all clean.

## Notes

- Updated `docs/plans/logical-bug-audit.md` to strike H2 with a pointer to the fix + test class.
- Updated `docs/plans/patch-embedder.md` step-4 note: the patch-embedder plan previously called the cross-dataset image-level fallback intentional; now it correctly describes the rebuild-via-`patch_forward` path with single-vector embedders as the only remaining fallback.
- Performance: region-voted elements re-resolve on every training pass (existing invariant — region edits propagate without explicit cache invalidation). For cross-dataset region votes this now means one `patch_forward` per pass. If that becomes hot, a process-scoped `patch_grid` cache on `DetectorContext` would lift it — flagged as a potential follow-up but not done here (would land as audit issue #3 from the investigation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWcRw8kyFUVT4FwKWEHhNL)_