### PR TITLE
Withdraw H4 from logical-bug audit (asymmetric pooling is by design)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -107,11 +107,6 @@ Cross-section interaction agents:
   CLAP-trained detector re-trains with whatever the default audio
   embedder is. CLAUDE.md's "re-derive with active embedder"
   invariant becomes "re-derive with **wrong** embedder."
-- **H4. Asymmetric region pooling between good/bad votes** —
-  `vtsearch/detectors/training.py` L171. Good votes use
-  `_training_vec_for_vote(..., region_boxes.get(cid))`; bad votes use
-  the raw embedding unconditionally. Mixed-modality MLP training on
-  the same detector when patch_grid is in play.
 - **H5. Detector embedder not revalidated on dataset switch** —
   `vtsearch/routes/detectors/scoring.py` + `dataset_sync.py`.
   `ensure_votes_match_active_dataset()` rehydrates votes but doesn't


### PR DESCRIPTION
## Summary

- H4 in `docs/plans/logical-bug-audit.md` claimed that `_build_vote_tensors` mixes modalities by region-pooling good votes while always using the CLS embedding for bad votes. On closer reading, this asymmetry is the intended encoding of the label semantics — *"this region is good"* vs *"this whole image is bad"* — and max-over-regions inference is the correct query for that intent.
- The CLS vector is itself one of the per-region scores at inference (`patch_regions[0]`), so there is no train/inference modality mismatch in practice; pushing down bad CLS vectors generalises to nearby patch pools by proximity in the encoder's embedding space, which is the desired behavior.
- H5–H31 are left at their existing IDs (the doc states IDs are stable and may be referenced from other docs/PRs).

## Test plan

- [ ] Visually confirm H4 is gone and H3/H5 still bracket the removal cleanly in `docs/plans/logical-bug-audit.md`.

https://claude.ai/code/session_01Y29tSJk1Cht43hAjdMBMJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y29tSJk1Cht43hAjdMBMJa)_