### PR TITLE
logical-bug-audit H3: thread embedder_name through train_detector_from_origins

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -104,13 +104,8 @@ Cross-section interaction agents:
   has no patch path (single-vector models) or the forward pass produces
   no output. Covered by `TestRegionAwareTrainingCrossDataset` in
   `tests/detectors/test_patch_embedder.py`.
-- **H3. Embedder drift on save → reload** —
-  `vtsearch/detectors/training.py` L449, L463.
-  `train_detector_from_origins()` calls
-  `embed_file(file_path, media_type)` with no `embedder_name`, so a
-  CLAP-trained detector re-trains with whatever the default audio
-  embedder is. CLAUDE.md's "re-derive with active embedder"
-  invariant becomes "re-derive with **wrong** embedder."
+- ~~**H3. Embedder drift on save → reload**~~ — shipped 2026-05-20.
+  See [Shipped](#shipped).
 - **H5. Detector embedder not revalidated on dataset switch** —
   `vtsearch/routes/detectors/scoring.py` + `dataset_sync.py`.
   `ensure_votes_match_active_dataset()` rehydrates votes but doesn't
@@ -620,6 +615,25 @@ and a one-line summary is recorded here.
   near 0 (all-bad) or 1 (all-good), not 0.5 — but the substantive
   "uninformative loss, no raise" claim was correct. Regression:
   `tests_lib/detectors/test_mlp_training.py::TestSingleClassGuard`.
+
+- **H3 — Embedder drift on save → reload** (2026-05-20).
+  `train_detector_from_origins()` in
+  `vtscore/detectors/training.py` now takes a required `embedder_name`
+  argument and threads it through to `embed_file(file_path, media_type,
+  embedder_name)` at both call sites. Callers must pass the embedder the
+  detector was originally trained with (typically
+  `detector_ctx.embedder`); the previous behaviour silently fell back to
+  `embedders_for_type(media_type)[0]` (the media type's default), so a
+  CLAP-trained detector could re-train on whatever the current default
+  audio embedder happens to be. VTSearch's own load path goes through
+  `vtscore/detectors/labelset_training.py` and was already correct, so
+  this fix primarily protects third-party `vtscore` consumers who follow
+  the documented integration path. Public docs updated in lockstep:
+  `vtscore/docs/packages/detectors.md`, `vtscore/docs/concepts.md`,
+  `vtscore/docs/quickstart.md`, `vtscore/docs/integration.md`,
+  `vtscore/docs/tutorials/train-and-score.md`, and
+  `docs/vtscore-api.md`. Regression:
+  `tests/detectors/test_training_pipeline.py::TestTrainDetectorFromOrigins::test_embedder_name_is_forwarded`.
 
 - **C12 — Orphaned dataset registry entry on activation failure**
   (2026-05-19). `_register_and_migrate` now returns

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -609,12 +609,21 @@ def collect_media_origins(medias: dict) -> list[tuple[int, Origin]]:
     votes to a detector JSON."""
 
 def train_detector_from_origins(
-    ctx: DetectorContext,
-    *,
-    config: CoreConfig | None = None,
-) -> None:
-    """Load-time retrainer: resolves every LabeledElement in ctx.labelset to a
-    file → embedding, builds (X, y), trains, stores the model on ctx."""
+    good_origins: list[dict],
+    bad_origins: list[dict],
+    inclusion: int,
+    media_type: str,
+    embedder_name: str,
+    calibrate_count: int = 2,
+    calibration_fraction: float = 0.5,
+) -> tuple[dict[str, list] | None, float]:
+    """Load-time retrainer: resolves each origin entry to a file, embeds it
+    with *embedder_name*, builds (X, y), and trains the MLP. Returns
+    (weights_dict, threshold), or (None, 0.5) on insufficient data.
+
+    embedder_name is required — pass the embedder the detector was
+    originally trained with so re-derived vectors don't drift onto the
+    media type's default."""
 ```
 
 ### Origin resolution

--- a/tests/detectors/test_training_pipeline.py
+++ b/tests/detectors/test_training_pipeline.py
@@ -225,6 +225,7 @@ class TestTrainDetectorFromOrigins:
             [],
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is None
         assert threshold == 0.5
@@ -235,6 +236,7 @@ class TestTrainDetectorFromOrigins:
             [],
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is None
         assert threshold == 0.5
@@ -245,6 +247,7 @@ class TestTrainDetectorFromOrigins:
             self._origins(["bad_1", "bad_2"]),
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is None
 
@@ -254,6 +257,7 @@ class TestTrainDetectorFromOrigins:
             self._origins(["bad_1", "bad_2", "bad_3"]),
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is not None
         # weights is a dict of {layer_name: nested_list_of_floats}.
@@ -277,6 +281,7 @@ class TestTrainDetectorFromOrigins:
             bad,
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is not None
 
@@ -296,6 +301,48 @@ class TestTrainDetectorFromOrigins:
             [{"origin": {"importer": "x", "params": {}}, "origin_name": "b", "md5": ""}],
             inclusion=0,
             media_type="audio",
+            embedder_name="clap",
         )
         assert weights is None
         assert threshold == 0.5
+
+    def test_embedder_name_is_forwarded(self, monkeypatch):
+        """The ``embedder_name`` argument must reach ``embed_file`` unchanged.
+
+        Regression test for H3 (embedder drift on save → reload): the load-
+        time retrainer used to call ``embed_file(file_path, media_type)``
+        with no embedder, so a CLAP-trained detector re-derived from saved
+        origins would silently re-embed audio with whatever the media
+        type's default embedder happened to be.
+        """
+        seen_embedders: list[str] = []
+
+        @contextmanager
+        def _fake_ctx(origin, origin_name="", filename=""):
+            yield ("PATH:" + origin_name) if origin_name else None
+
+        def _fake_embed(path, media_type, embedder_name=""):
+            seen_embedders.append(embedder_name)
+            if path is None:
+                return None
+            # One-hot-ish vector keyed by class so the MLP has something to learn.
+            base = np.full(8, 1.0 if "good" in path else -1.0, dtype=np.float32)
+            return base
+
+        import vtscore.detectors.resolver as resolver_mod
+
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
+        monkeypatch.setattr(resolver_mod, "embed_file", _fake_embed)
+
+        weights, _ = train_detector_from_origins(
+            self._origins(["good_1", "good_2", "good_3"]),
+            self._origins(["bad_1", "bad_2", "bad_3"]),
+            inclusion=0,
+            media_type="audio",
+            embedder_name="clap",
+        )
+        assert weights is not None
+        assert seen_embedders, "embed_file should have been called"
+        assert set(seen_embedders) == {"clap"}, (
+            f"every embed_file call must receive embedder_name='clap'; got {seen_embedders}"
+        )

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -408,6 +408,7 @@ def train_detector_from_origins(
     bad_origins: list[dict[str, Any]],
     inclusion: int,
     media_type: str,
+    embedder_name: str,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
 ) -> tuple[dict[str, list] | None, float]:
@@ -422,6 +423,13 @@ def train_detector_from_origins(
         bad_origins: Origin dicts for media labelled Bad.
         inclusion: The inclusion value to use for training.
         media_type: Media type string (e.g. ``"audio"``, ``"image"``).
+        embedder_name: Name of the embedder the detector was originally
+            trained with. Passed through to :func:`embed_file` so every
+            re-embedded media is encoded by the same model that produced
+            the saved vectors — otherwise the MLP trains on a mix of
+            embedder outputs and learns garbage. Pass ``""`` only when you
+            genuinely want the media type's default embedder (e.g. a
+            brand-new detector with no recorded embedder yet).
         calibrate_count: Number of k-fold calibration splits.
         calibration_fraction: Fraction reserved for calibration.
 
@@ -447,7 +455,7 @@ def train_detector_from_origins(
         ) as file_path:
             if file_path is None:
                 continue
-            emb = embed_file(file_path, media_type)
+            emb = embed_file(file_path, media_type, embedder_name)
         if emb is None:
             continue
         X_list.append(emb)
@@ -461,7 +469,7 @@ def train_detector_from_origins(
         ) as file_path:
             if file_path is None:
                 continue
-            emb = embed_file(file_path, media_type)
+            emb = embed_file(file_path, media_type, embedder_name)
         if emb is None:
             continue
         X_list.append(emb)

--- a/vtscore/docs/concepts.md
+++ b/vtscore/docs/concepts.md
@@ -222,7 +222,10 @@ Thresholding (`vtscore/training/thresholds.py`):
 The combined pipeline is `vtscore.detectors.training.train_and_threshold`:
 one call gives you `(model, threshold)` from `(X_list, y_list)`. The
 detector lifecycle (load labelset → re-derive embeddings → train) lives
-in `vtscore.detectors.training.train_detector_from_origins`.
+in `vtscore.detectors.training.train_detector_from_origins`; the caller
+must pass `embedder_name` so re-derivation uses the same embedder the
+detector was trained with, not whatever the media type's current default
+happens to be.
 
 ## 7. Context
 

--- a/vtscore/docs/integration.md
+++ b/vtscore/docs/integration.md
@@ -276,7 +276,17 @@ from vtscore.detectors.training import train_detector_from_origins
 def score_one(dataset_ctx: DatasetContext, detector_ctx: DetectorContext) -> dict:
     set_thread_dataset_context(dataset_ctx)
     set_thread_detector_context(detector_ctx)
-    train_detector_from_origins(detector_ctx)
+    # Re-derive the detector's MLP from its saved origins. Pass
+    # detector_ctx.embedder so the re-embedded vectors match the embedder
+    # the detector was originally trained with — never the media type's
+    # default, which may have changed since save.
+    good_origins, bad_origins = origins_from_labelset(detector_ctx.labelset)
+    train_detector_from_origins(
+        good_origins, bad_origins,
+        inclusion=0,
+        media_type=detector_ctx.media_type,
+        embedder_name=detector_ctx.embedder,
+    )
     # … score the dataset against the detector, return hits
     return {"detector_id": detector_ctx.detector_id, "n_hits": ...}
 

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -198,7 +198,7 @@ results, threshold, model = train_and_score(
 
 | Function                                                  | Behaviour                                                            |
 |-----------------------------------------------------------|----------------------------------------------------------------------|
-| `train_detector_from_origins(good_origins, bad_origins, inclusion, media_type, ...)` (line 405) | Resolve every entry to a file, embed, train. Returns `(weights_dict, threshold)` or `(None, 0.5)` on insufficient data. |
+| `train_detector_from_origins(good_origins, bad_origins, inclusion, media_type, embedder_name, ...)` (line 405) | Resolve every entry to a file, embed with the named embedder, train. `embedder_name` is required — pass the embedder the detector was originally trained with so re-derived vectors don't drift onto the media type's default. Returns `(weights_dict, threshold)` or `(None, 0.5)` on insufficient data. |
 | `collect_media_origins(media_ids, snap)` (line 373) | Extract `origin / origin_name / filename / md5` for every cid that appears in `snap`. |
 | `serialize_weights(model)` (line 111) | Pickle-safe `state_dict` dump via `tensor.tolist()`. Round-trips through `build_model_from_weights`. |
 | `validate_good_bad_split(y_list)` (line 24) | Precondition; raises `ValueError` when either class is empty. |

--- a/vtscore/docs/quickstart.md
+++ b/vtscore/docs/quickstart.md
@@ -231,8 +231,30 @@ save_detector("barks", labelset)
 ctx = DetectorContext(detector_id="barks", name="barks",
                       media_type="audio", embedder="audio_clap")
 register_detector_context(ctx)
-train_detector_from_origins(ctx)
-print(f"Restored detector with threshold {ctx.threshold:.3f}")
+
+# Build (good_origins, bad_origins) from the saved labelset's elements,
+# then re-derive embeddings + retrain. Pass the same embedder the detector
+# was trained with so the re-embedded vectors line up with the saved ones —
+# otherwise the MLP trains on a mix of embedder outputs.
+good_origins = [
+    {"origin": e.origin, "origin_name": e.origin_name,
+     "filename": e.filename, "md5": e.md5}
+    for e in labelset.labels if e.label == "good"
+]
+bad_origins = [
+    {"origin": e.origin, "origin_name": e.origin_name,
+     "filename": e.filename, "md5": e.md5}
+    for e in labelset.labels if e.label == "bad"
+]
+weights, threshold = train_detector_from_origins(
+    good_origins,
+    bad_origins,
+    inclusion=0,
+    media_type="audio",
+    embedder_name=ctx.embedder,
+)
+ctx.threshold = threshold
+print(f"Restored detector with threshold {threshold:.3f}")
 ```
 
 What's on disk after `save_detector`:

--- a/vtscore/docs/tutorials/train-and-score.md
+++ b/vtscore/docs/tutorials/train-and-score.md
@@ -269,13 +269,32 @@ ctx = DetectorContext(
 )
 register_detector_context(ctx)
 
-# This reads the JSON, resolves every origin to a file, embeds each file
-# with CLAP, builds (X, y), trains the MLP, and stores model + threshold
-# on the context.
-train_detector_from_origins(ctx)
+# Build (good_origins, bad_origins) from the saved JSON's labelset, then
+# resolve every origin to a file, embed each file *with the same embedder
+# the detector was trained with* (here: "audio_clap"), and train. Passing
+# ctx.embedder is critical — using "" would silently fall back to whatever
+# the media type's default embedder is, mixing model outputs.
+good_origins = [
+    {"origin": e.origin, "origin_name": e.origin_name,
+     "filename": e.filename, "md5": e.md5}
+    for e in saved_labelset.labels if e.label == "good"
+]
+bad_origins = [
+    {"origin": e.origin, "origin_name": e.origin_name,
+     "filename": e.filename, "md5": e.md5}
+    for e in saved_labelset.labels if e.label == "bad"
+]
+weights, threshold = train_detector_from_origins(
+    good_origins,
+    bad_origins,
+    inclusion=0,
+    media_type="audio",
+    embedder_name=ctx.embedder,
+)
+ctx.threshold = threshold
+# weights is a state_dict-shaped dict; load it onto a model and attach.
 
-print(f"Restored detector: threshold={ctx.threshold:.3f}, "
-      f"model layers={len(list(ctx.model.children()))}")
+print(f"Restored detector: threshold={ctx.threshold:.3f}")
 ```
 
 The library walked the origins, called the `server_folder`


### PR DESCRIPTION
## Summary

- Fixes **H3** from `docs/plans/logical-bug-audit.md` — `train_detector_from_origins()` in `vtscore/detectors/training.py` used to call `embed_file(file_path, media_type)` with no `embedder_name`, so re-derived vectors fell back to `embedders_for_type(media_type)[0]` (the media type's *default* embedder). A detector originally trained with a non-default embedder (e.g. CLAP audio when a different default is registered) could silently retrain on incompatible vectors.
- `train_detector_from_origins` now takes a required `embedder_name` parameter and forwards it to both `embed_file` call sites (L450, L464). Callers pass `detector_ctx.embedder` — the embedder the detector was originally trained with.
- Public `vtscore` docs updated in lockstep: `vtscore/docs/packages/detectors.md`, `vtscore/docs/concepts.md`, `vtscore/docs/quickstart.md`, `vtscore/docs/integration.md`, `vtscore/docs/tutorials/train-and-score.md`, plus `docs/vtscore-api.md`. Each example now threads `embedder_name=ctx.embedder` and the surrounding prose calls out the invariant.
- New regression test `tests/detectors/test_training_pipeline.py::TestTrainDetectorFromOrigins::test_embedder_name_is_forwarded` asserts every `embed_file` call receives the requested embedder.
- Audit plan: H3 collapsed to a struck-through heading, full summary added under Open follow-ups → Shipped.

### Scope clarification

VTSearch's own detector-load flow goes through `vtscore/detectors/labelset_training.py`, which already threads the embedder name correctly (`_embedder_for_active_dataset(snap)` + `_maybe_clear_cache_on_embedder_switch`). `train_detector_from_origins` is invoked only from the test suite within this repo, but it's advertised as a public `vtscore` library API in every tutorial and integration guide — so this fix primarily protects third-party `vtscore` consumers following the documented path.

## Test plan

- [x] `./run-tests.sh detectors` — 1056 passed
- [x] `./run-tests.sh` — 3960 passed, 1 skipped, 2 xpassed
- [x] `grep -rn "train_detector_from_origins("` — no remaining un-updated call sites

https://claude.ai/code/session_015NEkgauaUmMLFAyij7Gaqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015NEkgauaUmMLFAyij7Gaqq)_