### PR TITLE
logical-bug-audit H7: train-first apply_and_retrain

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -119,9 +119,8 @@ Cross-section interaction agents:
   warning.
 - ~~**H6. `train_model` produces degenerate single-class model**~~ —
   shipped 2026-05-20. See [Shipped](#shipped).
-- **H7. Vote applied before retrain; retrain failure leaves vote live** —
-  `vtsearch/detectors/workflow.py` L40–105. User sees the vote, model
-  is stale or absent.
+- ~~**H7. Vote applied before retrain; retrain failure leaves vote live**~~ —
+  shipped 2026-05-20. See [Shipped](#shipped).
 
 ### Datasets
 
@@ -633,6 +632,16 @@ and a one-line summary is recorded here.
   registry write itself fails, so the inverse orphan (pkl on disk,
   no entry) is also impossible. Regression:
   `tests/datasets/test_datasets.py::TestLoadFailureCleanup`.
+
+- **H7 — train-first `apply_and_retrain`** (2026-05-20).
+  `apply_and_retrain` in `vtscore/detectors/workflow.py` now resolves
+  entries into `(cid, label)` pairs, builds `proposed_good` /
+  `proposed_bad` dicts merged with the current votes, and runs
+  `train_and_score` on those *before* any `apply_label` /
+  `sync_labels_to_loaded_detector()` call. A failing retrain now
+  leaves `det_ctx.good_votes`, `det_ctx.bad_votes`, `det_ctx.model`,
+  and the persisted labelset all untouched. Regression in
+  `tests/detectors/test_workflow.py::TestTrainingFailureIsTransactional`.
 
 ### Still open
 

--- a/tests/detectors/test_workflow.py
+++ b/tests/detectors/test_workflow.py
@@ -139,3 +139,54 @@ class TestVoteApplicationIsContextScoped:
         assert not other_ctx.good_votes
         assert not other_ctx.bad_votes
         assert other_ctx.model is None
+
+
+class TestTrainingFailureIsTransactional:
+    """Audit H7: if ``train_and_score`` raises, no votes may be applied and
+    no labelset write may happen.  The detector must be left in its prior
+    consistent state so the user doesn't see a live vote pointing at a
+    stale (or absent) model.
+    """
+
+    def test_train_failure_does_not_apply_votes(self, det_ctx, monkeypatch):
+        boom = RuntimeError("simulated training failure")
+
+        def explode(*args, **kwargs):
+            raise boom
+
+        monkeypatch.setattr("vtscore.detectors.training.train_and_score", explode)
+
+        entries = [_audio_entry(1, "good"), _audio_entry(2, "bad")]
+        with pytest.raises(RuntimeError, match="simulated training failure"):
+            apply_and_retrain("test-det", det_ctx, entries, "Test")
+
+        # No vote should have been applied to the in-memory context,
+        # because training was attempted *before* the commit step.
+        assert not det_ctx.good_votes
+        assert not det_ctx.bad_votes
+        assert det_ctx.model is None
+        assert det_ctx.training_medias == {}
+
+    def test_train_failure_does_not_persist_labelset(self, det_ctx, monkeypatch):
+        # ``sync_labels_to_loaded_detector`` is the disk-write step.  A
+        # train-first workflow must never reach it when training raises.
+        calls = []
+
+        def fake_sync():
+            calls.append("called")
+
+        monkeypatch.setattr(
+            "vtscore.detectors.label_sync.sync_labels_to_loaded_detector",
+            fake_sync,
+        )
+
+        def explode(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("vtscore.detectors.training.train_and_score", explode)
+
+        entries = [_audio_entry(1, "good"), _audio_entry(2, "bad")]
+        with pytest.raises(RuntimeError):
+            apply_and_retrain("test-det", det_ctx, entries, "Test")
+
+        assert calls == []  # sync_labels_to_loaded_detector never ran

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -26,14 +26,24 @@ def apply_and_retrain(  # noqa: C901
     :func:`vtscore.state.core.override_detector_context`), regardless of
     whether the caller is inside a Flask request or a background thread.
 
+    Train-first ordering: the candidate vote set (existing votes + newly
+    resolved entries) is fed to :func:`train_and_score` *before* any vote is
+    written to ``det_ctx`` or persisted to disk.  If training raises, the
+    detector's in-memory votes, persisted labelset, and active model are all
+    left untouched — so a failed retrain can never leave a vote live with a
+    stale model behind it (audit finding H7).
+
     Returns ``(resolved_count, trained_bool)``.
     """
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
     from vtsearch.state import (
         apply_label,
+        bad_votes,
         build_media_lookup,
+        good_votes,
         resolve_media_ids,
         snapshot_medias,
+        vote_region_boxes,
     )
     from vtscore.state.core import override_detector_context
 
@@ -44,6 +54,9 @@ def apply_and_retrain(  # noqa: C901
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
 
+        # 1) Resolve every entry into concrete (cid, label) pairs without
+        #    touching any state yet.
+        resolved_pairs: list[tuple[int, str]] = []
         resolved = 0
         for entry in new_entries:
             label = entry.get("label", "")
@@ -51,23 +64,29 @@ def apply_and_retrain(  # noqa: C901
                 continue
             cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
             for cid in cids:
-                apply_label(cid, label)
+                resolved_pairs.append((cid, label))
             if cids:
                 resolved += 1
 
-        # Persist the updated votes back to the detector file so the
-        # labelset reflects any newly-resolved medias.
-        sync_labels_to_loaded_detector()
+        # 2) Build the *proposed* vote dicts (current + new resolutions)
+        #    for a dry-run training pass.  Same-side dedup is automatic
+        #    via dict; new opposite-side labels supersede the old ones.
+        proposed_good = dict(good_votes)
+        proposed_bad = dict(bad_votes)
+        for cid, label in resolved_pairs:
+            if label == "good":
+                proposed_bad.pop(cid, None)
+                proposed_good[cid] = None
+            else:
+                proposed_good.pop(cid, None)
+                proposed_bad[cid] = None
 
-        # Retrain MLP if we have at least one good and one bad vote.
-        from vtsearch.state import (
-            bad_votes,
-            good_votes,
-            vote_region_boxes,
-        )
-
-        trained = False
-        if good_votes and bad_votes:
+        # 3) Try retraining on the proposed votes first.  If this raises,
+        #    nothing has been mutated yet — the detector stays in its
+        #    prior consistent state and the exception propagates.
+        new_model = None
+        new_threshold = 0.5
+        if proposed_good and proposed_bad:
             from vtscore.detectors.training import train_and_score
             from vtsearch.state import (
                 get_calibrate_count,
@@ -76,10 +95,10 @@ def apply_and_retrain(  # noqa: C901
                 get_safe_thresholds,
             )
 
-            _, threshold, model = train_and_score(
+            _, new_threshold, new_model = train_and_score(
                 snap,
-                dict(good_votes),
-                dict(bad_votes),
+                proposed_good,
+                proposed_bad,
                 get_inclusion(),
                 safe_thresholds=get_safe_thresholds(),
                 calibrate_count=get_calibrate_count(),
@@ -87,19 +106,26 @@ def apply_and_retrain(  # noqa: C901
                 vote_region_boxes=dict(vote_region_boxes),
                 det_ctx=det_ctx,
             )
-            if model is not None:
-                det_ctx.model = model
-                det_ctx.threshold = threshold
-                # Cache voted media items with embeddings.
-                training = {}
-                for cid in list(good_votes) + list(bad_votes):
-                    if cid in snap:
-                        training[cid] = snap[cid]
-                det_ctx.training_medias = training
-                if snap:
-                    first = next(iter(snap.values()), {})
-                    det_ctx.embedder = first.get("embedder", "")
-                    det_ctx.media_type = first.get("type", "")
-                trained = True
+
+        # 4) Training succeeded (or was skipped because we don't yet
+        #    have both classes).  Commit the votes and persist.
+        for cid, label in resolved_pairs:
+            apply_label(cid, label)
+
+        sync_labels_to_loaded_detector()
+
+        trained = False
+        if new_model is not None:
+            det_ctx.model = new_model
+            det_ctx.threshold = new_threshold
+            training = {}
+            for cid in list(good_votes) + list(bad_votes):
+                if cid in snap:
+                    training[cid] = snap[cid]
+            det_ctx.training_medias = training
+            first = next(iter(snap.values()), {})
+            det_ctx.embedder = first.get("embedder", "")
+            det_ctx.media_type = first.get("type", "")
+            trained = True
 
         return resolved, trained


### PR DESCRIPTION
## Summary

Fixes audit finding **H7** ("Vote applied before retrain; retrain failure leaves vote live") in `vtscore/detectors/workflow.py`.

Before this change `apply_and_retrain` applied votes both in memory (`det_ctx.good_votes`/`bad_votes`) and on disk (via `sync_labels_to_loaded_detector()`), and **only then** called `train_and_score`. If training raised, the votes were left live with a stale (or absent) model — the detector's in-memory state, persisted labelset, and active MLP all drifted out of sync, and the HTTP caller got a 500 with no clean way to recover.

The fix reorders the workflow to train-first:

1. Resolve each entry to a concrete `(cid, label)` pair without mutating any state.
2. Build `proposed_good` / `proposed_bad` dicts by merging the current votes with the new resolutions.
3. Run `train_and_score` on the proposed votes.
4. Only on success: `apply_label` for each pair, `sync_labels_to_loaded_detector()`, and install the new model/threshold/training_medias on `det_ctx`.

If `train_and_score` raises, nothing has been mutated yet, so the exception propagates with the detector still in its prior consistent state.

`train_and_score` only forwards `det_ctx` to the threshold cache (it doesn't mutate `det_ctx.good_votes`/`bad_votes`/`model`), so running it before commit is safe.

## Test plan

- [x] `./run-tests.sh detectors` — 1057 passed.
- [x] `./run-tests.sh` (full CPU suite) — 3961 passed, 1 skipped, 2 xpassed.
- [x] New regression coverage in `tests/detectors/test_workflow.py::TestTrainingFailureIsTransactional`:
  - `test_train_failure_does_not_apply_votes` monkeypatches `train_and_score` to raise and asserts no vote lands on the context and `det_ctx.model` stays `None`.
  - `test_train_failure_does_not_persist_labelset` additionally asserts `sync_labels_to_loaded_detector` is never reached.
- [x] `docs/plans/logical-bug-audit.md` updated: H7 collapsed to a struck-through bullet, full fix summary added under **Open follow-ups → Shipped**.

https://claude.ai/code/session_01UkHPWbHyNfTCoa3J8zX5wE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkHPWbHyNfTCoa3J8zX5wE)_