### PR TITLE
docs(audit): close H12 as not-a-real-race, add H32/H33/H34

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -150,10 +150,21 @@ Cross-section interaction agents:
 
 ### Routes / API
 
-- **H12. `add_media_to_pile` race** — `vtsearch/routes/media/list.py`
-  L611–615. Snapshot in dataset A, `apply_label` in
-  (concurrently-switched) dataset B. Labels applied to wrong
-  dataset.
+- ~~**H12. `add_media_to_pile` race**~~ — investigation closed
+  (2026-05-20): not a real race in the current architecture. The
+  audit's framing assumes a global "active dataset" pointer that
+  could be switched mid-handler between `snapshot_medias()` and
+  `apply_label()`, but `before_request` in `app.py` pins both
+  `g._dataset_context` and `g._detector_context` for the duration
+  of each request (resolver in `vtsearch/shim/__init__.py:19-39`),
+  and `flask.g` is request-local — so the two calls inside one
+  `add_media_to_pile` invocation always resolve to the same
+  contexts. Note also that `apply_label` writes to the *detector*
+  context's `good_votes` / `bad_votes`, not to a dataset, so the
+  audit's "labels applied to wrong dataset" framing is a category
+  error. The same line window (L600-694) does contain real bugs,
+  but they are different from the one H12 names — see H32 / H33 /
+  H34.
 - **H13. `vote_media` silent-mistarget on dropped header** —
   `vtsearch/routes/media/list.py` L524–563. Missing `X-Dataset-Id`
   falls back to whatever the context proxy resolves to; vote applies
@@ -171,6 +182,38 @@ Cross-section interaction agents:
   returns None, `g._dataset_context` is never set, the proxy silently
   resolves to the empty context. Client sees stale data with no
   error.
+- **H32. `add_media_to_pile` TOCTOU between md5 check and insertion** —
+  `vtsearch/routes/media/list.py` L607–608 vs. L687–690. The md5
+  lookup (`snap = snapshot_medias()` + `build_media_lookup(snap)`)
+  runs outside `_state_lock`; the new-media insertion happens under
+  the lock ~80 lines later. Two concurrent uploads of the same file
+  can both miss the existing-cid hit, both embed, and both insert,
+  producing duplicate medias with identical md5. Fix sketch:
+  re-check `md5_lookup` (or recompute it from `medias`) under
+  `_state_lock` immediately before assigning `new_id` and writing
+  `medias[new_id]`, and dispatch to the existing-cid branch if a
+  match appears in the recheck.
+- **H33. `add_media_to_pile` label not synced to disk** —
+  `vtsearch/routes/media/list.py` L614 and L692. `vote_media`
+  follows `toggle_vote` with `sync_labels_to_loaded_detector()` +
+  `sync_to_labelset_source()` (L555–561) so the change reaches the
+  detector's on-disk labelset and any configured `LabelsetSource`.
+  `add_media_to_pile` calls neither after `apply_label`. The
+  in-memory `good_votes` / `bad_votes` are updated, but the labelset
+  file is not — so the next time `ensure_votes_match_active_dataset`
+  rehydrates the detector from disk (e.g. on the next dataset /
+  detector switch handled by `before_request` in `app.py:247-257`),
+  the just-applied label silently disappears.
+- **H34. Missing `X-Detector-Id` → silent detector fallback** —
+  `vtscore/state/core.py` `get_active_detector_context()` falls
+  through to the thread-local (then `_empty_detector_context`) when
+  `g._detector_context` is unset. Any route that mutates votes
+  without requiring the header — `add_media_to_pile`, `vote_media`,
+  bulk-label endpoints — silently writes to whatever the thread-local
+  resolves to, which on a Flask threaded-server worker can be the
+  detector left over from a previous request on the same thread.
+  Detector-side analog of H13; the fix is the same shape (reject the
+  request when the header is absent for any vote-mutating endpoint).
 
 ### Plugins / converters / exporters
 


### PR DESCRIPTION
## Summary

Investigated H12 (`add_media_to_pile` race) from `docs/plans/logical-bug-audit.md` and closed it as a false positive in the current architecture. While reading the same line window I found three real bugs that the H12 wording was conflating; those are added as H32 / H33 / H34.

### Why H12 isn't a real race

The audit's framing assumes a global "active dataset" pointer that another request could switch mid-handler between `snapshot_medias()` (L607) and `apply_label()` (L614). That pointer no longer exists:

- `app.py` `before_request` (L208–243) pins `g._dataset_context` / `g._detector_context` for the request.
- The resolver in `vtsearch/shim/__init__.py` reads only `flask.g`, which is request-local.
- So both calls inside one `add_media_to_pile` invocation always resolve to the same dataset and detector context.

`apply_label` also writes to the *detector* context's `good_votes` / `bad_votes` — it never writes to a dataset — so "labels applied to wrong dataset" is a category error.

### New bugs found in the same handler

- **H32 — TOCTOU between md5 check and insertion.** The md5 lookup at L607–608 runs outside `_state_lock`; the new-media insertion under the lock is ~80 lines later (L687–690). Two concurrent uploads of the same file can both miss the existing-cid hit, both embed, and both insert duplicates.
- **H33 — Label not synced to disk.** `vote_media` follows `toggle_vote` with `sync_labels_to_loaded_detector()` + `sync_to_labelset_source()`. `add_media_to_pile` calls neither after `apply_label`, so the in-memory vote disappears the next time `ensure_votes_match_active_dataset` rehydrates the detector from disk.
- **H34 — Missing `X-Detector-Id` → silent thread-local fallback.** Any vote-mutating route that doesn't require the header silently writes to whatever `get_active_detector_context()` falls through to (thread-local, possibly stale from a previous request on the same threaded-server worker). Detector-side analog of H13.

## Test plan

- [x] Investigation only — no code changes, doc edit only.
- [x] `git diff --stat` shows only `docs/plans/logical-bug-audit.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PwmRE5t3Soaa1L1hsk3Ky)_