### PR TITLE
H17: warn and skip duplicate plugin names in PluginRegistry

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -196,9 +196,7 @@ Cross-section interaction agents:
 
 ### Plugins / converters / exporters
 
-- **H17. Plugin scanner silently shadows duplicate names** —
-  `vtsearch/plugins/__init__.py` ~L466. Second plugin with the same
-  `name` overwrites the first; no warning, no error.
+- ~~**H17. Plugin scanner silently shadows duplicate names**~~
 - ~~**H18. CSV exporter doesn't escape embedded newlines**~~ —
   investigation closed (2026-05-20): not a real bug. The audit's
   path is also stale (exporters moved to `vtscore/exporters/`); the

--- a/tests_lib/core/test_plugin_registry_collisions.py
+++ b/tests_lib/core/test_plugin_registry_collisions.py
@@ -1,0 +1,139 @@
+"""Tests for name-collision handling in :class:`PluginRegistry`.
+
+When two sub-packages (or flat modules, with ``discover_modules=True``)
+under the scanned package each declare a sentinel with the same
+``.name``, the registry must warn and keep the first discovered plugin
+rather than silently overwriting it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+from vtscore.plugins import PluginRegistry
+
+
+class TestSubPackageNameCollision:
+    """Two sub-packages declaring the same ``.name`` should not silently
+    shadow each other."""
+
+    def test_collision_warns_and_keeps_first(self, tmp_path):
+        # Create two external importer packages that both claim the same
+        # plugin name. They land in the real importers directory via
+        # symlinks so PluginRegistry's directory scan picks them up.
+        importer_src = (
+            "from vtscore.datasets.importers.base import DatasetImporter\n"
+            "from vtscore.plugins import PluginField\n"
+            "\n"
+            "class _Imp(DatasetImporter):\n"
+            '    name = "collision_test_imp"\n'
+            "    display_name = {display!r}\n"
+            "    description = {desc!r}\n"
+            "    fields = [PluginField(key='path', label='Path', field_type='folder')]\n"
+            "    def run(self, field_values, medias): return []\n"
+            "\n"
+            "IMPORTER = _Imp()\n"
+        )
+
+        pkg_a = tmp_path / "collision_pkg_a"
+        pkg_a.mkdir()
+        (pkg_a / "__init__.py").write_text(
+            importer_src.format(display="First", desc="First registration")
+        )
+
+        pkg_b = tmp_path / "collision_pkg_b"
+        pkg_b.mkdir()
+        (pkg_b / "__init__.py").write_text(
+            importer_src.format(display="Second", desc="Should be skipped")
+        )
+
+        import importlib
+
+        parent = importlib.import_module("vtscore.datasets.importers")
+        assert parent.__file__ is not None
+        pkg_dir = os.path.dirname(parent.__file__)
+        # Names are deliberately ordered so the alphabetical scan visits
+        # zz_collision_a first, then zz_collision_b second.
+        link_a = os.path.join(pkg_dir, "zz_collision_a")
+        link_b = os.path.join(pkg_dir, "zz_collision_b")
+        os.symlink(str(pkg_a), link_a)
+        os.symlink(str(pkg_b), link_b)
+
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                reg = PluginRegistry(
+                    package="vtscore.datasets.importers",
+                    sentinel="IMPORTER",
+                    label="dataset importer",
+                )
+                plugin = reg.get("collision_test_imp")
+
+            # The first plugin discovered wins.
+            assert plugin is not None
+            assert plugin.display_name == "First"
+
+            # The second registration emits a collision warning that
+            # names the offending module.
+            collision_warnings = [
+                str(w.message)
+                for w in caught
+                if "already registered" in str(w.message)
+            ]
+            assert collision_warnings, "expected a collision warning"
+            assert any("zz_collision_b" in msg for msg in collision_warnings)
+        finally:
+            os.unlink(link_a)
+            os.unlink(link_b)
+            for key in list(sys.modules):
+                if "zz_collision_" in key:
+                    del sys.modules[key]
+
+
+class TestFlatModuleNameCollision:
+    """``discover_modules=True`` registries must also catch collisions
+    between flat ``.py`` modules."""
+
+    def test_collision_warns_and_keeps_first(self, tmp_path):
+        # Build a fresh package on disk so we can populate it with two
+        # flat modules whose sentinels share a name.
+        pkg_root = tmp_path / "_collision_flat_pkg"
+        pkg_root.mkdir()
+        (pkg_root / "__init__.py").write_text("")
+        (pkg_root / "alpha.py").write_text(
+            'class _S:\n    name = "shared_name"\n    label = "alpha"\n\nFAKE = _S()\n'
+        )
+        (pkg_root / "beta.py").write_text(
+            'class _S:\n    name = "shared_name"\n    label = "beta"\n\nFAKE = _S()\n'
+        )
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                reg = PluginRegistry(
+                    package="_collision_flat_pkg",
+                    sentinel="FAKE",
+                    label="test plugin",
+                    discover_modules=True,
+                )
+                plugin = reg.get("shared_name")
+
+            # Alphabetical scan visits alpha.py first, so it wins.
+            assert plugin is not None
+            assert plugin.label == "alpha"
+
+            collision_warnings = [
+                str(w.message)
+                for w in caught
+                if "already registered" in str(w.message)
+            ]
+            assert collision_warnings, "expected a collision warning"
+            assert any("beta" in msg for msg in collision_warnings)
+        finally:
+            sys.path.remove(str(tmp_path))
+            for key in list(sys.modules):
+                if key == "_collision_flat_pkg" or key.startswith("_collision_flat_pkg."):
+                    del sys.modules[key]

--- a/tests_lib/core/test_plugin_registry_collisions.py
+++ b/tests_lib/core/test_plugin_registry_collisions.py
@@ -39,15 +39,11 @@ class TestSubPackageNameCollision:
 
         pkg_a = tmp_path / "collision_pkg_a"
         pkg_a.mkdir()
-        (pkg_a / "__init__.py").write_text(
-            importer_src.format(display="First", desc="First registration")
-        )
+        (pkg_a / "__init__.py").write_text(importer_src.format(display="First", desc="First registration"))
 
         pkg_b = tmp_path / "collision_pkg_b"
         pkg_b.mkdir()
-        (pkg_b / "__init__.py").write_text(
-            importer_src.format(display="Second", desc="Should be skipped")
-        )
+        (pkg_b / "__init__.py").write_text(importer_src.format(display="Second", desc="Should be skipped"))
 
         import importlib
 
@@ -77,11 +73,7 @@ class TestSubPackageNameCollision:
 
             # The second registration emits a collision warning that
             # names the offending module.
-            collision_warnings = [
-                str(w.message)
-                for w in caught
-                if "already registered" in str(w.message)
-            ]
+            collision_warnings = [str(w.message) for w in caught if "already registered" in str(w.message)]
             assert collision_warnings, "expected a collision warning"
             assert any("zz_collision_b" in msg for msg in collision_warnings)
         finally:
@@ -102,12 +94,8 @@ class TestFlatModuleNameCollision:
         pkg_root = tmp_path / "_collision_flat_pkg"
         pkg_root.mkdir()
         (pkg_root / "__init__.py").write_text("")
-        (pkg_root / "alpha.py").write_text(
-            'class _S:\n    name = "shared_name"\n    label = "alpha"\n\nFAKE = _S()\n'
-        )
-        (pkg_root / "beta.py").write_text(
-            'class _S:\n    name = "shared_name"\n    label = "beta"\n\nFAKE = _S()\n'
-        )
+        (pkg_root / "alpha.py").write_text('class _S:\n    name = "shared_name"\n    label = "alpha"\n\nFAKE = _S()\n')
+        (pkg_root / "beta.py").write_text('class _S:\n    name = "shared_name"\n    label = "beta"\n\nFAKE = _S()\n')
 
         sys.path.insert(0, str(tmp_path))
         try:
@@ -125,11 +113,7 @@ class TestFlatModuleNameCollision:
             assert plugin is not None
             assert plugin.label == "alpha"
 
-            collision_warnings = [
-                str(w.message)
-                for w in caught
-                if "already registered" in str(w.message)
-            ]
+            collision_warnings = [str(w.message) for w in caught if "already registered" in str(w.message)]
             assert collision_warnings, "expected a collision warning"
             assert any("beta" in msg for msg in collision_warnings)
         finally:

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -463,6 +463,13 @@ class PluginRegistry(Generic[T]):
                 mod = importlib.import_module(full_name)
             plugin = getattr(mod, self._sentinel, None)
             if plugin is not None:
+                if plugin.name in self._items:
+                    warnings.warn(
+                        f"{self._label} module {module_name!r} declares name "
+                        f"{plugin.name!r} which is already registered; skipped",
+                        stacklevel=2,
+                    )
+                    return
                 self._items[plugin.name] = plugin
         except Exception as exc:  # pragma: no cover
             # Clean up partially-registered module on failure.


### PR DESCRIPTION
## Summary

Fixes **H17** from `docs/plans/logical-bug-audit.md` — the directory-scan path in `PluginRegistry._try_load` (`vtscore/plugins/__init__.py:466`) silently overwrote `self._items[plugin.name]` when two sub-packages or flat modules declared a sentinel with the same `.name`. The entry-point loader on the same class already had a clash check that warned + skipped; this PR mirrors that check inside `_try_load`.

After the fix:
- The first plugin discovered wins (alphabetical filename order, same as before).
- Subsequent collisions emit `warnings.warn(f"{label} module {module_name!r} declares name {plugin.name!r} which is already registered; skipped", ...)` and are dropped.
- No silent shadowing for built-in vs built-in collisions (built-in vs entry-point was already covered).

Affects every plugin family using `PluginRegistry`: dataset importers, exporters, label importers, labelset sources, settings importers/exporters/sources, converters, media sources, processor importers.

## Test plan

- [x] New `tests_lib/core/test_plugin_registry_collisions.py` covering both the sub-package path (symlinked into `vtscore.datasets.importers`) and the `discover_modules=True` flat-module path.
- [x] `pytest tests_lib/core/test_plugin_registry_collisions.py` — 2 passed.
- [x] `pytest tests/core/test_plugin_entry_points.py tests_lib/io/test_importer_symlinks.py tests/integration/test_thread_safety.py` — 57 passed (no regressions in related plugin-registry suites).
- [ ] `./run-tests.sh core` — blocked at the `pip-audit` gate on `dev` as well; CVEs are in pre-existing `transformers` / `pyjwt` / `joblib` versions, unrelated to this change.

https://claude.ai/code/session_01GRCfPcP4jBz8Siv33M9Uep

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRCfPcP4jBz8Siv33M9Uep)_