### PR TITLE
Fix H1: absolute-target vote API closes counter-inflation race

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -88,9 +88,27 @@ Cross-section interaction agents:
 ### State / concurrency
 
 - ~~**`record_vote()` called after releasing `_state_lock`**~~
-- **H1. Vote-progress invalidation / `record_vote` race** when the same
-  media is rapid-toggled across two tabs — counter inflates while
-  in-memory shows one vote.
+- ~~**H1. Vote-progress invalidation / `record_vote` race**~~ — fixed by
+  replacing the toggle contract on `POST /api/medias/<id>/vote` with an
+  absolute-target contract.  Body takes `target: "good" | "bad" | "none"`
+  instead of `vote: "good" | "bad"`; handler delegates to a new
+  `vtscore.state.votes.set_vote(media_id, target, region_box)` that
+  no-ops on idempotent re-applies (no `label_history` append, no
+  achievement credit, no click-time bump, no progress-cache churn), so
+  two stale-view tabs racing the same target collapse into a single
+  transition on the server instead of alternating ADD/REMOVE.  Progress
+  cache now invalidates on **any** training-set membership change for
+  the media (was: polarity flips only — left un-vote cached models
+  stale).  Response shape grew `state` + `click_time`; the Angular
+  `VoteStateService` was rewritten around a single `submitToggleVote()`
+  entry point that computes the target from local state and clears
+  `pendingOptimistic` deterministically on every POST return, closing
+  the persistent prediction-vs-server desync half of the bug.  Covered
+  by new regressions across `tests/core/test_votes.py`,
+  `tests/api/test_error_recovery.py`, `tests/core/test_achievements.py`,
+  `tests/api/test_api_contracts.py`, `tests/detectors/test_patch_embedder.py`,
+  and `frontend/src/app/services/vote-state.service.spec.ts`.  See
+  Open follow-ups for the parallel labelset-element vote endpoint.
 
 ### Detector / training
 
@@ -526,3 +544,20 @@ Cross-cutting open items that don't fit any single finding above:
   `medias` mutation (or a `MediasDict` subclass that does so
   transparently) would neutralise the whole category and let the
   matrix accessor compare a single int instead of two id lists.
+
+- **H1 follow-up: labelset element vote endpoint still toggles.**
+  `POST /api/detectors/<name>/labels/<element_id>/vote` (and the
+  underlying `apply_element_vote_in_data` in
+  `vtscore/detectors/labelset_elements.py`) still takes
+  `vote: "good" | "bad"` with toggle-on-same-direction semantics — a
+  stale-view tab voting against an already-good labelset element
+  removes the element from the on-disk labelset, same kind of
+  inflation race the media-vote H1 fix eliminated.  Migrating that
+  endpoint to absolute-target (`target: "good" | "bad" | "remove"`)
+  would let the in-memory `set_vote()` mirror run idempotently too,
+  closing the same class of race on the labelset side.  Deferred
+  because the labelset element CRUD is a separate user surface
+  (`vt-labels-list` modal, not the centre-pane click flow that H1
+  was scoped to).  The on-disk labelset write is idempotent already
+  via `_write_detector`; the race is on the in-memory mirror and
+  the `num_training` registry counter.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3207,36 +3207,53 @@
       "MediaVoteRequest": {
         "properties": {
           "region_box": {
-            "description": "Optional 4-element ``[x0, y0, x1, y1]`` in normalised image coordinates ``[0, 1]``. Only valid on good votes.",
+            "description": "Optional 4-element ``[x0, y0, x1, y1]`` in normalised image coordinates ``[0, 1]``. Only valid when ``target`` is ``good``.",
             "items": {
               "type": "number"
             },
             "nullable": true,
             "type": "array"
           },
-          "vote": {
-            "description": "``good`` or ``bad``.",
+          "target": {
+            "description": "Absolute target state: ``good``, ``bad``, or ``none`` (un-vote). Idempotent.",
             "enum": [
               "good",
-              "bad"
+              "bad",
+              "none"
             ],
             "type": "string"
           }
         },
         "required": [
-          "vote"
+          "target"
         ],
         "type": "object"
       },
       "MediaVoteResponse": {
         "additionalProperties": false,
         "properties": {
+          "click_time": {
+            "description": "Click-time ordinal of the new label, or ``null`` when the target is ``none`` or the call was a no-op.",
+            "nullable": true,
+            "type": "integer"
+          },
           "ok": {
             "type": "boolean"
+          },
+          "state": {
+            "description": "The media's vote state after the call.",
+            "enum": [
+              "good",
+              "bad",
+              "none"
+            ],
+            "type": "string"
           }
         },
         "required": [
-          "ok"
+          "click_time",
+          "ok",
+          "state"
         ],
         "type": "object"
       },
@@ -9403,7 +9420,7 @@
         }
       ],
       "post": {
-        "description": "Voting behaviour (toggle semantics):\n\n- If ``vote == \"good\"`` and the media is already in ``good_votes``, the\n  vote is *removed* (toggled off).\n- If ``vote == \"good\"`` and the media is not yet in ``good_votes``, it is\n  added to ``good_votes`` (removed from ``bad_votes`` if present) and the\n  event is appended to ``label_history``.\n- The same toggle logic applies symmetrically for ``vote == \"bad\"``.\n\nYes-votes may carry ``\"region_box\": [x0, y0, x1, y1]`` (normalised image\ncoords in ``[0, 1]``) to designate the good region. No-votes that\ninclude ``region_box`` are rejected \u2014 by design no-votes are\nimage-level always (patch-embedder v2).",
+        "description": "``target`` is one of:\n\n- ``\"good\"`` \u2014 set to good (overrides ``bad`` if present).\n- ``\"bad\"`` \u2014 set to bad (overrides ``good`` if present).\n- ``\"none\"`` \u2014 un-vote (remove any existing vote).\n\nBehaviour is **idempotent**: sending the current state is a no-op\nthat does not append to ``label_history``, does not credit\nachievements, and returns the existing click-time.  This is the\nfix for logical-bug-audit H1 \u2014 two stale-view tabs that race the\nsame media no longer alternate ADD/REMOVE on the server, so the\nachievement counter no longer inflates beyond the number of real\nlabeling decisions.\n\nYes-targets may carry ``\"region_box\": [x0, y0, x1, y1]`` (normalised\nimage coords in ``[0, 1]``) to designate the good region.\n``\"bad\"`` and ``\"none\"`` targets must not include ``region_box`` \u2014 by\ndesign no-votes are image-level always (patch-embedder v2).\n\nReturns ``{\"ok\": true, \"state\": <new state>, \"click_time\": <int|null>}``\nso the client can reconcile its optimistic view directly from the\nresponse.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9426,7 +9443,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "region_box is malformed, or a bad-vote carries a region_box."
+            "description": "region_box is malformed, or a non-good target carries a region_box."
           },
           "404": {
             "description": "Media not found."
@@ -9438,7 +9455,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Record or toggle a good/bad vote for a single media item.",
+        "summary": "Set a single media's vote to an **absolute target state**.",
         "tags": [
           "medias"
         ]

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -248,7 +248,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.isVoting = true;
     this.voteState.recordVote(this.media.id, vote, this.mediaDisplayName(this.media));
 
-    this.mediasApi.vote(this.media.id, vote, regionBox).subscribe({
+    this.voteState.submitToggleVote(this.media.id, vote, regionBox).subscribe({
       next: () => {
         const animate = this.swipeAnimation && !!this.media && !prefersReducedMotion();
         if (animate) {

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -374,17 +374,20 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const m = this.mediaState.getMedia(event.id);
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState.recordVote(event.id, event.vote, name);
-    this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.onMediaVoted(event);
-      },
-    });
+    this.voteState
+      .submitToggleVote(event.id, event.vote)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.onMediaVoted(event);
+        },
+      });
   }
 
   onMediaVoted(event: { id: number; vote: 'good' | 'bad' }): void {
-    // In find mode: update labels but do NOT re-train or re-sort.
-    // Just update the vote state so the right panel and left panel stripe update.
-    this.voteState.applyOptimisticVote(event.id, event.vote);
+    // In find mode: re-fetch labelset counters but skip a re-sort. The local
+    // vote state has already been reconciled from the POST response inside
+    // submitToggleVote, so a follow-up GET /api/votes only refreshes counts.
     this.voteState.loadVotes();
   }
 

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -551,13 +551,13 @@ describe('LabelViewComponent', () => {
     const voteState = TestBed.inject(VoteStateService);
 
     // Simulate leftover votes from a previous session (e.g. old detector)
-    voteState.applyOptimisticVote(1, 'good');
-    voteState.applyOptimisticVote(2, 'good');
-    voteState.applyOptimisticVote(3, 'good');
-    voteState.applyOptimisticVote(4, 'bad');
-    voteState.applyOptimisticVote(5, 'bad');
-    voteState.applyOptimisticVote(6, 'bad');
-    voteState.applyOptimisticVote(7, 'bad');
+    voteState.applyOptimisticState(1, 'good');
+    voteState.applyOptimisticState(2, 'good');
+    voteState.applyOptimisticState(3, 'good');
+    voteState.applyOptimisticState(4, 'bad');
+    voteState.applyOptimisticState(5, 'bad');
+    voteState.applyOptimisticState(6, 'bad');
+    voteState.applyOptimisticState(7, 'bad');
     expect(voteState.goodVotes.size).toBe(3);
     expect(voteState.badVotes.size).toBe(4);
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -871,11 +871,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     this.voteState.recordVote(event.id, event.vote, this.mediaDisplayName(event.id));
-    this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.onMediaVoted(event);
-      },
-    });
+    this.voteState
+      .submitToggleVote(event.id, event.vote)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.onMediaVoted(event);
+        },
+      });
   }
 
   private mediaDisplayName(id: number): string {
@@ -884,7 +887,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onMediaVoted(event: { id: number; vote: 'good' | 'bad' }): void {
-    this.voteState.applyOptimisticVote(event.id, event.vote);
+    // Local vote state is already reconciled from the POST response inside
+    // submitToggleVote; loadVotes() only refreshes derived counters.
     this.voteState.loadVotes();
     this.autoSelectNext(event.id);
     if (this.sortState.sortMode === 'learned' && this.voteState.learnedSortAvailable) {

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -60,12 +60,25 @@ export class MediasApiService {
     return this.http.get(`/api/medias/${id}/media`, { responseType: 'blob' });
   }
 
+  /**
+   * Set the absolute vote state for a media item.
+   *
+   * ``target`` is the post-call state, not a "click direction" — the server
+   * applies it idempotently (so concurrent stale-view tabs no longer race
+   * the achievement counter, logical-bug-audit H1).  Callers that want the
+   * old "click good toggles good off" behaviour should compute the toggle
+   * locally (e.g. {@link VoteStateService.vote}) before invoking this method.
+   *
+   * Returns the server-confirmed new state and click-time so the optimistic
+   * local view can be reconciled directly from the response without a
+   * follow-up ``GET /api/votes``.
+   */
   vote(
     id: number,
-    label: 'good' | 'bad',
+    target: 'good' | 'bad' | 'none',
     regionBox?: readonly number[] | null,
   ): Observable<MediaVoteResponse> {
-    const body: MediaVoteRequest = { vote: label };
+    const body: MediaVoteRequest = { target };
     if (regionBox && regionBox.length === 4) body.region_box = [...regionBox];
     return apiMediasMediaIdVotePost(this.http, this.config.rootUrl, { media_id: id, body }).pipe(
       map((r) => r.body),

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -88,146 +88,220 @@ describe('VoteStateService', () => {
     expect(service.learnedScores).toEqual({});
   });
 
-  it('applyOptimisticVote should add to good and set click time', () => {
-    service.applyOptimisticVote(5, 'good');
-    expect(service.goodVotes.has(5)).toBeTrue();
-    expect(service.badVotes.has(5)).toBeFalse();
-    expect(service.clickTimes['5']).toBe(1);
-  });
-
-  it('applyOptimisticVote should add to bad and set click time', () => {
-    service.applyOptimisticVote(5, 'bad');
-    expect(service.badVotes.has(5)).toBeTrue();
-    expect(service.goodVotes.has(5)).toBeFalse();
-    expect(service.clickTimes['5']).toBe(1);
-  });
-
-  it('applyOptimisticVote click time should exceed existing max', () => {
-    // Load votes with existing click times
-    service.loadVotes();
-    httpMock.expectOne('/api/votes').flush(mockVotes);
-    // mockVotes has click_times: { '1': 100, '2': 200 }
-
-    service.applyOptimisticVote(7, 'good');
-    expect(service.clickTimes['7']).toBe(201);
-  });
-
-  it('applyOptimisticVote toggle-off should not set click time', () => {
-    service.applyOptimisticVote(5, 'good');
-    const timeAfterAdd = service.clickTimes['5'];
-    expect(timeAfterAdd).toBe(1);
-
-    // Toggle off
-    service.applyOptimisticVote(5, 'good');
-    expect(service.goodVotes.has(5)).toBeFalse();
-    // Click time should remain unchanged (no new time set on removal)
-    expect(service.clickTimes['5']).toBe(1);
-  });
-
-  it('applyOptimisticVote should move from bad to good with new click time', () => {
-    service.applyOptimisticVote(5, 'bad');
-    expect(service.clickTimes['5']).toBe(1);
-
-    service.applyOptimisticVote(5, 'good');
-    expect(service.goodVotes.has(5)).toBeTrue();
-    expect(service.badVotes.has(5)).toBeFalse();
-    expect(service.clickTimes['5']).toBe(2);
-  });
-
-  it('applyVotes should preserve optimistic vote when server has not caught up', () => {
-    // Simulate optimistic vote
-    service.applyOptimisticVote(10, 'good');
-    expect(service.goodVotes.has(10)).toBeTrue();
-    expect(service.clickTimes['10']).toBe(1);
-
-    // Server response arrives WITHOUT the new vote (stale data)
-    service.loadVotes();
-    httpMock.expectOne('/api/votes').flush({
-      good: [1, 2],
-      bad: [3],
-      click_times: { '1': 100, '2': 200 },
-      learned_scores: {},
+  describe('toggleTargetFor (local toggle rule → absolute target)', () => {
+    it('returns clicked direction when media is unvoted', () => {
+      expect(service.toggleTargetFor(5, 'good')).toBe('good');
+      expect(service.toggleTargetFor(5, 'bad')).toBe('bad');
     });
 
-    // Optimistic vote should be preserved
-    expect(service.goodVotes.has(10)).toBeTrue();
-    expect(service.clickTimes['10']).toBe(1);
-    // Server data should also be present
-    expect(service.goodVotes.has(1)).toBeTrue();
-    expect(service.goodVotes.has(2)).toBeTrue();
-  });
-
-  it('applyVotes should clear optimistic tracking once server confirms', () => {
-    // Simulate optimistic vote
-    service.applyOptimisticVote(10, 'good');
-
-    // Server response now includes the voted item
-    service.loadVotes();
-    httpMock.expectOne('/api/votes').flush({
-      good: [1, 2, 10],
-      bad: [3],
-      click_times: { '1': 100, '2': 200, '10': 300 },
-      learned_scores: {},
+    it('returns none when clicked direction matches current polarity', () => {
+      service.applyOptimisticState(5, 'good');
+      expect(service.toggleTargetFor(5, 'good')).toBe('none');
+      service.applyOptimisticState(5, 'bad');
+      expect(service.toggleTargetFor(5, 'bad')).toBe('none');
     });
 
-    expect(service.goodVotes.has(10)).toBeTrue();
-    // Server's click time should be used now (not the optimistic one)
-    expect(service.clickTimes['10']).toBe(300);
+    it('returns clicked direction when polarities differ (flip)', () => {
+      service.applyOptimisticState(5, 'good');
+      expect(service.toggleTargetFor(5, 'bad')).toBe('bad');
+      service.applyOptimisticState(5, 'bad');
+      expect(service.toggleTargetFor(5, 'good')).toBe('good');
+    });
   });
 
-  it('stale polling should not remove optimistic bad vote', fakeAsync(() => {
-    service.startPolling(1000);
-    // Initial poll
-    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+  describe('applyOptimisticState (absolute target)', () => {
+    it('sets good and assigns a click time', () => {
+      service.applyOptimisticState(5, 'good');
+      expect(service.goodVotes.has(5)).toBeTrue();
+      expect(service.badVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBe(1);
+    });
 
-    // User votes bad optimistically
-    service.applyOptimisticVote(5, 'bad');
-    expect(service.badVotes.has(5)).toBeTrue();
+    it('sets bad and assigns a click time', () => {
+      service.applyOptimisticState(5, 'bad');
+      expect(service.badVotes.has(5)).toBeTrue();
+      expect(service.goodVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBe(1);
+    });
 
-    // Next poll arrives with stale data (no vote for 5)
-    tick(1000);
-    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+    it('target=none clears the vote and click time', () => {
+      service.applyOptimisticState(5, 'good');
+      service.applyOptimisticState(5, 'none');
+      expect(service.goodVotes.has(5)).toBeFalse();
+      expect(service.badVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBeUndefined();
+    });
 
-    // Optimistic bad vote should still be preserved
-    expect(service.badVotes.has(5)).toBeTrue();
-    expect(service.clickTimes['5']).toBe(1);
+    it('moves bad → good with a new click time', () => {
+      service.applyOptimisticState(5, 'bad');
+      expect(service.clickTimes['5']).toBe(1);
 
-    service.stopPolling();
-    discardPeriodicTasks();
-  }));
+      service.applyOptimisticState(5, 'good');
+      expect(service.goodVotes.has(5)).toBeTrue();
+      expect(service.badVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBe(2);
+    });
+
+    it('click time exceeds existing max', () => {
+      service.loadVotes();
+      httpMock.expectOne('/api/votes').flush(mockVotes);
+      // mockVotes has click_times: { '1': 100, '2': 200 }
+
+      service.applyOptimisticState(7, 'good');
+      expect(service.clickTimes['7']).toBe(201);
+    });
+  });
+
+  describe('submitToggleVote (the H1 fix surface)', () => {
+    it('posts absolute target=good when clicking good on an unvoted media', () => {
+      service.submitToggleVote(5, 'good').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good' });
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+      expect(service.goodVotes.has(5)).toBeTrue();
+    });
+
+    it('posts absolute target=none when clicking good on an already-good media (toggle off)', () => {
+      service.applyOptimisticState(5, 'good');
+      service.submitToggleVote(5, 'good').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'none' });
+      req.flush({ ok: true, state: 'none', click_time: null });
+      expect(service.goodVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBeUndefined();
+    });
+
+    it('posts absolute target=bad when flipping from good (polarity switch)', () => {
+      service.applyOptimisticState(5, 'good');
+      service.submitToggleVote(5, 'bad').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'bad' });
+      req.flush({ ok: true, state: 'bad', click_time: 2 });
+      expect(service.badVotes.has(5)).toBeTrue();
+      expect(service.goodVotes.has(5)).toBeFalse();
+    });
+
+    it('honours region_box only when the computed target is good', () => {
+      service.submitToggleVote(5, 'good', [0.1, 0.2, 0.3, 0.4]).subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+
+      // Click good again → target=none, region_box must be omitted.
+      service.submitToggleVote(5, 'good', [0.1, 0.2, 0.3, 0.4]).subscribe();
+      const req2 = httpMock.expectOne('/api/medias/5/vote');
+      expect(req2.request.body).toEqual({ target: 'none' });
+      req2.flush({ ok: true, state: 'none', click_time: null });
+    });
+
+    it('reconciles local state from the server response, even when the prediction was wrong', () => {
+      service.submitToggleVote(5, 'good').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      // Server says the state is actually "none" — e.g. another tab raced
+      // ahead of us. The optimistic 'good' must be overridden.
+      req.flush({ ok: true, state: 'none', click_time: null });
+
+      expect(service.goodVotes.has(5)).toBeFalse();
+      expect(service.badVotes.has(5)).toBeFalse();
+      expect(service.clickTimes['5']).toBeUndefined();
+    });
+  });
+
+  describe('polling interaction with optimistic state', () => {
+    it('preserves the optimistic state when a poll lands before the POST returns', () => {
+      service.submitToggleVote(10, 'good').subscribe();
+      // POST is in-flight; a poll arrives WITHOUT the new vote (stale data).
+      service.loadVotes();
+      httpMock.expectOne('/api/votes').flush({
+        good: [1, 2],
+        bad: [3],
+        click_times: { '1': 100, '2': 200 },
+        learned_scores: {},
+      });
+
+      // Optimistic vote should still be visible.
+      expect(service.goodVotes.has(10)).toBeTrue();
+      expect(service.goodVotes.has(1)).toBeTrue();
+      expect(service.goodVotes.has(2)).toBeTrue();
+
+      // Drain the POST so the test doesn't leave a pending request.
+      httpMock.expectOne('/api/medias/10/vote').flush({ ok: true, state: 'good', click_time: 1 });
+    });
+
+    it('clears pendingOptimistic deterministically when the POST resolves', () => {
+      service.submitToggleVote(10, 'good').subscribe();
+      httpMock
+        .expectOne('/api/medias/10/vote')
+        .flush({ ok: true, state: 'good', click_time: 300 });
+
+      // A subsequent stale poll (server reflects pre-vote state) must NOT
+      // re-introduce the optimistic ghost — pendingOptimistic was cleared
+      // by reconcileVoteResponse, so the poll's absence of the vote wins.
+      service.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+
+      expect(service.goodVotes.has(10)).toBeFalse();
+    });
+
+    it('does not get stuck in a predict-vs-server desync (H1 stuck-prediction scenario)', () => {
+      // Another tab voted X=good first; our tab still thinks X is unvoted.
+      // We click good → optimistic predicts good. Server (already good)
+      // returns state=good idempotently. Counters do not inflate; local
+      // state lines up with the server.
+      service.submitToggleVote(5, 'good').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good' });
+      req.flush({ ok: true, state: 'good', click_time: 42 });
+
+      expect(service.goodVotes.has(5)).toBeTrue();
+      expect(service.clickTimes['5']).toBe(42);
+    });
+  });
 
   describe('undo / redo stack', () => {
-    it('records the previous polarity at click time and POSTs the inverse on undo', () => {
-      service.applyOptimisticVote(5, 'good'); // pretend a vote landed
-      service.recordVote(5, 'good', 'foo.wav'); // capture state BEFORE another click
-      // We just recorded that previously (before next click) it was 'good'.
-      // Simulate the click that would follow: toggle off.
-      service.applyOptimisticVote(5, 'good');
+    it('records the previous polarity at click time and POSTs the inverse target on undo', () => {
+      // Pretend a vote landed: media 5 is now good.
+      service.applyOptimisticState(5, 'good');
+      // Capture state BEFORE the next click (which will toggle off).
+      service.recordVote(5, 'good', 'foo.wav');
+      // Simulate the click that follows: toggle off → state=none.
+      service.applyOptimisticState(5, 'none');
 
       service.undo();
-      // Inverse direction should be the *previous* polarity, restoring 'good'.
+      // The inverse target is the saved previousPolarity ('good').
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ vote: 'good' });
-      req.flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [5], bad: [], click_times: {}, learned_scores: {} });
+      expect(req.request.body).toEqual({ target: 'good' });
+      req.flush({ ok: true, state: 'good', click_time: 1 });
 
       expect(service.canRedo()).toBeTrue();
       expect(service.canUndo()).toBeFalse();
     });
 
-    it('redo replays the original clicked direction', () => {
-      service.recordVote(7, 'bad', 'bar.wav'); // previous = null
-      service.applyOptimisticVote(7, 'bad');
+    it('undo of a first-time vote posts target=none', () => {
+      service.recordVote(7, 'bad', 'bar.wav'); // previousPolarity = null
+      service.applyOptimisticState(7, 'bad');
 
       service.undo();
-      httpMock.expectOne('/api/medias/7/vote').flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      const req = httpMock.expectOne('/api/medias/7/vote');
+      expect(req.request.body).toEqual({ target: 'none' });
+      req.flush({ ok: true, state: 'none', click_time: null });
+    });
+
+    it('redo replays the original clicked direction as an absolute target', () => {
+      service.recordVote(7, 'bad', 'bar.wav'); // previousPolarity = null
+      service.applyOptimisticState(7, 'bad');
+
+      service.undo();
+      httpMock
+        .expectOne('/api/medias/7/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
 
       service.redo();
       const req = httpMock.expectOne('/api/medias/7/vote');
-      expect(req.request.body).toEqual({ vote: 'bad' });
-      req.flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [], bad: [7], click_times: {}, learned_scores: {} });
+      expect(req.request.body).toEqual({ target: 'bad' });
+      req.flush({ ok: true, state: 'bad', click_time: 2 });
 
       expect(service.canRedo()).toBeFalse();
       expect(service.canUndo()).toBeTrue();
@@ -235,10 +309,11 @@ describe('VoteStateService', () => {
 
     it('a new recordVote clears the redo stack', () => {
       service.recordVote(1, 'good', 'a');
-      service.applyOptimisticVote(1, 'good');
+      service.applyOptimisticState(1, 'good');
       service.undo();
-      httpMock.expectOne('/api/medias/1/vote').flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      httpMock
+        .expectOne('/api/medias/1/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
       expect(service.canRedo()).toBeTrue();
 
       service.recordVote(2, 'bad', 'b');
@@ -256,14 +331,16 @@ describe('VoteStateService', () => {
       service.toast$.subscribe((t) => toasts.push(t));
 
       service.recordVote(9, 'good', 'pic.png');
-      service.applyOptimisticVote(9, 'good');
+      service.applyOptimisticState(9, 'good');
       service.undo();
-      httpMock.expectOne('/api/medias/9/vote').flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      httpMock
+        .expectOne('/api/medias/9/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
 
       service.redo();
-      httpMock.expectOne('/api/medias/9/vote').flush({ ok: true });
-      httpMock.expectOne('/api/votes').flush({ good: [9], bad: [], click_times: {}, learned_scores: {} });
+      httpMock
+        .expectOne('/api/medias/9/vote')
+        .flush({ ok: true, state: 'good', click_time: 2 });
 
       expect(toasts).toEqual([
         { action: 'undo', mediaName: 'pic.png' },
@@ -275,13 +352,11 @@ describe('VoteStateService', () => {
       for (let i = 0; i < 25; i++) {
         service.recordVote(i, 'good', `m${i}`);
       }
-      // Undo as many times as the stack should hold. Each pops one and POSTs.
       let popped = 0;
       while (service.canUndo()) {
         service.undo();
         const req = httpMock.expectOne((r) => r.url.startsWith('/api/medias/') && r.url.endsWith('/vote'));
-        req.flush({ ok: true });
-        httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+        req.flush({ ok: true, state: 'none', click_time: null });
         popped++;
         if (popped > 30) throw new Error('runaway');
       }

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject, timer } from 'rxjs';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
+import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
 import { VotesResponse } from '../models/api.models';
 import { MediasApiService } from './medias-api.service';
 import { SortingApiService } from './sorting-api.service';
@@ -22,6 +23,8 @@ export interface UndoToast {
   mediaName: string;
 }
 
+type VoteState = 'good' | 'bad' | 'none';
+
 const UNDO_STACK_MAX = 20;
 
 @Injectable({ providedIn: 'root' })
@@ -35,8 +38,15 @@ export class VoteStateService implements OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly stopPolling$ = new Subject<void>();
   private polling = false;
-  /** Tracks optimistic votes not yet confirmed by the server. */
-  private pendingOptimistic = new Map<number, { vote: 'good' | 'bad'; clickTime: number }>();
+  /**
+   * Optimistic post-vote state per media, used to preserve the user's click
+   * across a polling response that raced ahead of the vote POST.  Cleared
+   * deterministically on every vote POST response — the server's reply IS
+   * the authoritative state, so there is no longer a "permanently stuck"
+   * desync if our prediction disagreed with the server (the persistent-desync
+   * half of logical-bug-audit H1).
+   */
+  private pendingOptimistic = new Map<number, { state: VoteState; clickTime: number | null }>();
 
   /** Past votes available to undo, most-recent last.  Capped at UNDO_STACK_MAX. */
   private past: UndoEntry[] = [];
@@ -103,48 +113,107 @@ export class VoteStateService implements OnDestroy {
     return this.labelsetGoodCount > 0 && this.labelsetBadCount > 0;
   }
 
+  /** Current local polarity for *id*, or ``'none'`` when not voted. */
+  private currentState(id: number): VoteState {
+    if (this.goodVotesSubject.value.has(id)) return 'good';
+    if (this.badVotesSubject.value.has(id)) return 'bad';
+    return 'none';
+  }
+
   /**
-   * Optimistically update local vote sets to reflect a toggle vote.
-   *
-   * This mirrors the backend toggle semantics so that callers checking
-   * vote state immediately after a vote see the updated counts without
-   * waiting for the async loadVotes() HTTP round-trip.
+   * Translate a clicked direction into an absolute target by the local
+   * toggle rule (clicking the current polarity un-votes; anything else sets
+   * to the clicked polarity).  Pure — does not mutate local state.
    */
-  applyOptimisticVote(id: number, vote: 'good' | 'bad'): void {
+  toggleTargetFor(id: number, clickedDirection: 'good' | 'bad'): VoteState {
+    return this.currentState(id) === clickedDirection ? 'none' : clickedDirection;
+  }
+
+  /**
+   * Submit a click on a media with the local-view toggle rule.
+   *
+   * Computes the target from current local state, optimistically applies
+   * it, POSTs ``target`` to ``/api/medias/<id>/vote``, and reconciles the
+   * local view from the server's response when it arrives.  All callers in
+   * the components (centre / right / find / label views) funnel through
+   * here so the toggle-to-target conversion lives in exactly one place.
+   *
+   * @param regionBox  Optional good-vote region.  Honoured only when the
+   *                   computed target is ``'good'``.
+   */
+  submitToggleVote(
+    id: number,
+    clickedDirection: 'good' | 'bad',
+    regionBox?: readonly number[] | null,
+  ): Observable<MediaVoteResponse> {
+    const target = this.toggleTargetFor(id, clickedDirection);
+    this.applyOptimisticState(id, target);
+    return this.mediasApi.vote(id, target, target === 'good' ? regionBox : null).pipe(
+      tap((resp) => this.reconcileVoteResponse(id, resp)),
+    );
+  }
+
+  /**
+   * Optimistically apply an absolute target state without going through the
+   * toggle rule.  Used by {@link submitToggleVote} (above) and by the
+   * Cmd-Z undo / redo flow, where the desired post-call state is known
+   * directly (a polarity to restore, or ``'none'`` to wipe the vote).
+   */
+  applyOptimisticState(id: number, target: VoteState): void {
     const good = new Set(this.goodVotesSubject.value);
     const bad = new Set(this.badVotesSubject.value);
-
-    const isAdd = vote === 'good' ? !good.has(id) : !bad.has(id);
-
-    if (vote === 'good') {
-      if (good.has(id)) {
-        good.delete(id);
-      } else {
-        good.add(id);
-        bad.delete(id);
-      }
-    } else {
-      if (bad.has(id)) {
-        bad.delete(id);
-      } else {
-        bad.add(id);
-        good.delete(id);
-      }
-    }
-
-    // Set an optimistic click time so the item sorts correctly immediately,
-    // rather than appearing with time=-1 and then jumping when the server responds.
     const times = { ...this.clickTimesSubject.value };
-    if (isAdd) {
-      const maxTime = Object.values(times).reduce((m, t) => Math.max(m, t), 0);
-      const optimisticTime = maxTime + 1;
-      times[String(id)] = optimisticTime;
-      this.pendingOptimistic.set(id, { vote, clickTime: optimisticTime });
-    } else {
-      this.pendingOptimistic.delete(id);
+
+    good.delete(id);
+    bad.delete(id);
+
+    let optimisticClickTime: number | null = null;
+    if (target === 'good') {
+      good.add(id);
+    } else if (target === 'bad') {
+      bad.add(id);
     }
+    if (target !== 'none') {
+      // Set an optimistic click time so the item sorts correctly immediately,
+      // rather than appearing with time=-1 and then jumping when the server responds.
+      const maxTime = Object.values(times).reduce((m, t) => Math.max(m, t), 0);
+      optimisticClickTime = maxTime + 1;
+      times[String(id)] = optimisticClickTime;
+    } else {
+      delete times[String(id)];
+    }
+
+    this.pendingOptimistic.set(id, { state: target, clickTime: optimisticClickTime });
 
     // Emit all changes together so Angular sees a single consistent state.
+    this.goodVotesSubject.next(good);
+    this.badVotesSubject.next(bad);
+    this.clickTimesSubject.next(times);
+  }
+
+  /**
+   * Apply the absolute state the server confirmed in its vote response,
+   * regardless of what the optimistic prediction was.  Pending optimism is
+   * cleared deterministically here — even if our prediction was wrong, the
+   * server's reply replaces it so the desync cannot persist.
+   */
+  reconcileVoteResponse(id: number, resp: MediaVoteResponse): void {
+    this.pendingOptimistic.delete(id);
+    const good = new Set(this.goodVotesSubject.value);
+    const bad = new Set(this.badVotesSubject.value);
+    const times = { ...this.clickTimesSubject.value };
+
+    good.delete(id);
+    bad.delete(id);
+    if (resp.state === 'good') good.add(id);
+    else if (resp.state === 'bad') bad.add(id);
+
+    if (resp.click_time != null) {
+      times[String(id)] = resp.click_time;
+    } else {
+      delete times[String(id)];
+    }
+
     this.goodVotesSubject.next(good);
     this.badVotesSubject.next(bad);
     this.clickTimesSubject.next(times);
@@ -188,9 +257,9 @@ export class VoteStateService implements OnDestroy {
 
   /**
    * Snapshot the polarity *before* a vote click and push it onto the undo
-   * stack.  Must be called BEFORE applyOptimisticVote (otherwise the snapshot
-   * would already reflect the toggle).  Any pending redo entries are dropped,
-   * matching standard editor undo semantics.
+   * stack.  Must be called BEFORE {@link submitToggleVote} (otherwise the
+   * snapshot would already reflect the toggle).  Any pending redo entries
+   * are dropped, matching standard editor undo semantics.
    */
   recordVote(mediaId: number, clickedDirection: 'good' | 'bad', mediaName: string): void {
     const previousPolarity: 'good' | 'bad' | null = this.goodVotesSubject.value.has(mediaId)
@@ -212,10 +281,10 @@ export class VoteStateService implements OnDestroy {
   }
 
   /**
-   * Reverse the most recent vote.  The inverse POST is:
-   *   - {@code previousPolarity} if non-null (restores prior state, including
-   *     polarity flips since /vote toggles mutual exclusion server-side), or
-   *   - {@code clickedDirection} if previousPolarity was null (toggles off).
+   * Reverse the most recent vote.  The inverse target is:
+   *   - the saved {@code previousPolarity} (restores prior state, including
+   *     polarity flips), or
+   *   - ``'none'`` when previousPolarity was null (un-votes).
    *
    * Side effects that aren't reversible (achievements, label_history append,
    * click_counter monotonicity) are accepted — the user really did make the
@@ -225,24 +294,29 @@ export class VoteStateService implements OnDestroy {
     const entry = this.past.pop();
     if (!entry) return;
     this.future.push(entry);
-    const direction: 'good' | 'bad' = entry.previousPolarity ?? entry.clickedDirection;
-    this.applyOptimisticVote(entry.mediaId, direction);
-    this.mediasApi.vote(entry.mediaId, direction).subscribe({
-      next: () => this.loadVotes(),
+    const target: VoteState = entry.previousPolarity ?? 'none';
+    this.applyOptimisticState(entry.mediaId, target);
+    this.mediasApi.vote(entry.mediaId, target).subscribe({
+      next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       error: () => this.loadVotes(),
     });
     this.toastSubject.next({ action: 'undo', mediaName: entry.mediaName });
   }
 
-  /** Re-apply the most recently undone vote — POST the original direction. */
+  /** Re-apply the most recently undone vote — POST the toggled-from-prior target. */
   redo(): void {
     const entry = this.future.pop();
     if (!entry) return;
     this.past.push(entry);
     if (this.past.length > UNDO_STACK_MAX) this.past.shift();
-    this.applyOptimisticVote(entry.mediaId, entry.clickedDirection);
-    this.mediasApi.vote(entry.mediaId, entry.clickedDirection).subscribe({
-      next: () => this.loadVotes(),
+    // The redo target is whichever polarity the original click landed on
+    // (clickedDirection unless previousPolarity matched, in which case the
+    // click was an un-vote).
+    const target: VoteState =
+      entry.previousPolarity === entry.clickedDirection ? 'none' : entry.clickedDirection;
+    this.applyOptimisticState(entry.mediaId, target);
+    this.mediasApi.vote(entry.mediaId, target).subscribe({
+      next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       error: () => this.loadVotes(),
     });
     this.toastSubject.next({ action: 'redo', mediaName: entry.mediaName });
@@ -253,25 +327,20 @@ export class VoteStateService implements OnDestroy {
     const bad = new Set(votes.bad);
     const times = { ...votes.click_times };
 
-    // Preserve optimistic votes that the server hasn't acknowledged yet.
-    // Without this, a stale polling response (or a loadVotes() response that
-    // raced ahead of the vote POST) would remove the item from the grid,
-    // causing it to disappear and reappear (flicker).
+    // Preserve optimistic votes whose POSTs haven't returned yet.  Once a
+    // POST resolves, reconcileVoteResponse() clears the pending entry and
+    // applies the server's authoritative state — so any preserved entry
+    // here is genuinely in-flight, not a permanent prediction-vs-server
+    // desync (the H1 stuck-prediction case is gone).
     for (const [id, opt] of this.pendingOptimistic) {
-      const serverHasIt = opt.vote === 'good' ? good.has(id) : bad.has(id);
-      if (serverHasIt) {
-        // Server caught up — stop preserving this optimistic vote.
-        this.pendingOptimistic.delete(id);
-      } else {
-        // Server hasn't processed the vote yet — keep optimistic state.
-        if (opt.vote === 'good') {
-          good.add(id);
-          bad.delete(id);
-        } else {
-          bad.add(id);
-          good.delete(id);
-        }
+      good.delete(id);
+      bad.delete(id);
+      if (opt.state === 'good') good.add(id);
+      else if (opt.state === 'bad') bad.add(id);
+      if (opt.clickTime != null) {
         times[String(id)] = opt.clickTime;
+      } else {
+        delete times[String(id)];
       }
     }
 

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -98,10 +98,30 @@ class TestVotesContract:
         assert isinstance(data["learned_scores"], dict)
 
     def test_vote_response_shape(self, client):
-        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["ok"] is True
+        # H1 contract: server returns the new absolute state and click-time
+        # so the client can reconcile its optimistic view directly.
+        assert data["state"] == "good"
+        assert isinstance(data["click_time"], int)
+
+    def test_vote_response_state_on_idempotent_call(self, client):
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        # Second call with the same target is idempotent — server still
+        # returns state="good" so the client knows it landed.
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
+        data = resp.get_json()
+        assert data["state"] == "good"
+        assert isinstance(data["click_time"], int)
+
+    def test_vote_response_state_on_unvote(self, client):
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        resp = client.post("/api/medias/1/vote", json={"target": "none"})
+        data = resp.get_json()
+        assert data["state"] == "none"
+        assert data["click_time"] is None
 
 
 class TestSortContract:
@@ -455,9 +475,9 @@ class TestLabelingStatusContract:
     def test_with_votes_returns_indicator_fields(self, client):
         """With sufficient votes, response should have labeling status indicators."""
         for i in range(1, 4):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "good"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "good"})
         for i in range(4, 7):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "bad"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "bad"})
         resp = client.get("/api/labeling-status")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -550,12 +570,11 @@ class TestErrorResponseFormat:
         assert "message" in data
 
     def test_400_vote_error_is_json(self, client):
-        # The media-vote blueprint now uses flask-smorest's standard
-        # error envelope: a ``vote`` value that fails the OneOf check
-        # surfaces as 422 with a per-field ``errors`` dict, not the
-        # legacy ``{"error": str}`` shape. Keeping the test name for
-        # grep continuity.
-        resp = client.post("/api/medias/1/vote", json={"vote": "invalid"})
+        # The media-vote blueprint uses flask-smorest's standard error
+        # envelope: a ``target`` value that fails the OneOf check surfaces
+        # as 422 with a per-field ``errors`` dict. (H1 renamed the field
+        # from ``vote`` to ``target`` to flag the absolute-state contract.)
+        resp = client.post("/api/medias/1/vote", json={"target": "invalid"})
         assert resp.status_code == 422
         data = resp.get_json()
         assert "errors" in data

--- a/tests/api/test_error_recovery.py
+++ b/tests/api/test_error_recovery.py
@@ -311,7 +311,7 @@ class TestNonexistentResources:
         assert resp.status_code == 404
 
     def test_vote_nonexistent_media(self, client):
-        resp = client.post("/api/medias/99999/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/99999/vote", json={"target": "good"})
         assert resp.status_code == 404
 
     def test_delete_nonexistent_model(self, client):
@@ -601,29 +601,31 @@ class TestVoteEdgeCases:
         """Extra fields in vote request should not cause errors."""
         resp = client.post(
             "/api/medias/1/vote",
-            json={
-                "vote": "good",
+            json={"target": "good",
                 "confidence": 0.95,
                 "note": "very relevant",
             },
         )
         assert resp.status_code == 200
 
-    def test_rapid_toggle_votes(self, client):
-        """Rapidly toggling a vote should leave consistent state."""
+    def test_rapid_idempotent_re_votes_are_no_ops(self, client):
+        """H1 regression: rapidly POSTing the same absolute target must not
+        flip-flop the vote (the pre-fix toggle semantics did exactly that)."""
         for _ in range(10):
-            client.post("/api/medias/1/vote", json={"vote": "good"})
-        # After 10 toggles (even number), vote should be off
+            resp = client.post("/api/medias/1/vote", json={"target": "good"})
+            assert resp.status_code == 200
+            assert resp.get_json()["state"] == "good"
         resp = client.get("/api/votes")
         data = resp.get_json()
-        assert 1 not in data["good"]
+        # Ten POSTs of target=good leave the media in good, not toggled off.
+        assert 1 in data["good"]
 
     def test_vote_all_medias(self, client):
         """Voting on every media should work without errors."""
         num = len(medias)
         for i in range(1, num + 1):
-            vote = "good" if i % 2 == 0 else "bad"
-            resp = client.post(f"/api/medias/{i}/vote", json={"vote": vote})
+            target = "good" if i % 2 == 0 else "bad"
+            resp = client.post(f"/api/medias/{i}/vote", json={"target": target})
             assert resp.status_code == 200
 
         resp = client.get("/api/votes")

--- a/tests/api/test_error_recovery.py
+++ b/tests/api/test_error_recovery.py
@@ -601,7 +601,8 @@ class TestVoteEdgeCases:
         """Extra fields in vote request should not cause errors."""
         resp = client.post(
             "/api/medias/1/vote",
-            json={"target": "good",
+            json={
+                "target": "good",
                 "confidence": 0.95,
                 "note": "very relevant",
             },

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -612,7 +612,7 @@ class TestActionHooks:
         # Find any media id from the test fixture.
         listing = client.get("/api/medias/ids").get_json()
         media_id = listing[0]["id"]
-        resp = client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
+        resp = client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
         assert resp.status_code == 200
         state = achievements.get_full_state()
         assert _by_id(state, "votes_cast")["counter"] == 1
@@ -620,7 +620,19 @@ class TestActionHooks:
     def test_unvote_does_not_decrement(self, client):
         listing = client.get("/api/medias/ids").get_json()
         media_id = listing[0]["id"]
-        client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})  # toggle off
+        client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{media_id}/vote", json={"target": "none"})  # un-vote
         # Counter should be 1: only the add counts, not the remove.
+        assert _by_id(achievements.get_full_state(), "votes_cast")["counter"] == 1
+
+    def test_idempotent_re_vote_does_not_increment(self, client):
+        """H1 fix: sending target=good on an already-good media is idempotent
+        and must not credit a second vote.  This is the achievement-counter
+        side of the inflation race — two stale-view tabs each POSTing the
+        same target collapse into one increment on the server."""
+        listing = client.get("/api/medias/ids").get_json()
+        media_id = listing[0]["id"]
+        client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
         assert _by_id(achievements.get_full_state(), "votes_cast")["counter"] == 1

--- a/tests/core/test_votes.py
+++ b/tests/core/test_votes.py
@@ -17,61 +17,93 @@ from vtsearch.state import (
 
 class TestVoteClip:
     def test_vote_good(self, client):
-        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert resp.get_json()["ok"] is True
         assert 1 in app_module.good_votes
 
     def test_vote_bad(self, client):
-        resp = client.post("/api/medias/1/vote", json={"vote": "bad"})
+        resp = client.post("/api/medias/1/vote", json={"target": "bad"})
         assert resp.status_code == 200
         assert 1 in app_module.bad_votes
 
-    def test_toggle_good_off(self, client):
-        """Voting good twice should toggle it off."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+    def test_unvote_good(self, client):
+        """target=none removes a good vote."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert 1 in app_module.good_votes
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert 1 not in app_module.good_votes
 
-    def test_toggle_bad_off(self, client):
-        """Voting bad twice should toggle it off."""
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+    def test_unvote_bad(self, client):
+        """target=none removes a bad vote."""
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert 1 in app_module.bad_votes
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert 1 not in app_module.bad_votes
 
+    def test_idempotent_re_vote_good(self, client):
+        """Re-sending target=good on a good media is a no-op (H1 fix).
+
+        Two stale-view tabs that both POST target=good no longer alternate
+        ADD/REMOVE on the server — the second call is idempotent.
+        """
+        r1 = client.post("/api/medias/1/vote", json={"target": "good"})
+        assert r1.status_code == 200
+        r2 = client.post("/api/medias/1/vote", json={"target": "good"})
+        assert r2.status_code == 200
+        assert 1 in app_module.good_votes
+        # Idempotent: a single label_history entry, not two.
+        from vtsearch.state import label_history
+        assert sum(1 for entry in label_history if entry[0] == 1) == 1
+
+    def test_idempotent_re_vote_bad(self, client):
+        r1 = client.post("/api/medias/1/vote", json={"target": "bad"})
+        assert r1.status_code == 200
+        r2 = client.post("/api/medias/1/vote", json={"target": "bad"})
+        assert r2.status_code == 200
+        assert 1 in app_module.bad_votes
+        from vtsearch.state import label_history
+        assert sum(1 for entry in label_history if entry[0] == 1) == 1
+
     def test_switch_from_good_to_bad(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert 1 not in app_module.good_votes
         assert 1 in app_module.bad_votes
 
     def test_switch_from_bad_to_good(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert 1 not in app_module.bad_votes
         assert 1 in app_module.good_votes
 
-    def test_invalid_vote_value(self, client):
-        # Marshmallow OneOf validator on ``vote`` rejects non-{good,bad}
+    def test_invalid_target_value(self, client):
+        # Marshmallow OneOf validator on ``target`` rejects non-{good,bad,none}
         # values with the flask-smorest 422 envelope.
-        resp = client.post("/api/medias/1/vote", json={"vote": "meh"})
+        resp = client.post("/api/medias/1/vote", json={"target": "meh"})
         assert resp.status_code == 422
-        assert "vote" in resp.get_json()["errors"]["json"]
+        assert "target" in resp.get_json()["errors"]["json"]
 
-    def test_missing_vote_field(self, client):
+    def test_missing_target_field(self, client):
         # Required-field validation runs in MediaVoteRequestSchema → 422.
         resp = client.post("/api/medias/1/vote", json={"wrong": "field"})
         assert resp.status_code == 422
 
+    def test_legacy_vote_field_rejected(self, client):
+        # The pre-H1 ``vote`` field is no longer accepted — the schema requires
+        # ``target`` with absolute-state semantics so the toggle race cannot
+        # be re-introduced by a client that hasn't been updated.
+        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert resp.status_code == 422
+        assert "target" in resp.get_json()["errors"]["json"]
+
     def test_vote_nonexistent_clip(self, client):
-        resp = client.post("/api/medias/9999/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/9999/vote", json={"target": "good"})
         assert resp.status_code == 404
 
     def test_multiple_clips_independent_votes(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         assert 1 in app_module.good_votes
         assert 2 in app_module.bad_votes
         assert 1 not in app_module.bad_votes
@@ -109,8 +141,8 @@ class TestGetVotes:
         assert data["bad"] == [2]
 
     def test_votes_after_voting_via_api(self, client):
-        client.post("/api/medias/3/vote", json={"vote": "good"})
-        client.post("/api/medias/5/vote", json={"vote": "bad"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/5/vote", json={"target": "bad"})
         resp = client.get("/api/votes")
         data = resp.get_json()
         assert 3 in data["good"]
@@ -120,8 +152,8 @@ class TestGetVotes:
 class TestClearVotes:
     def test_clear_votes_empties_good_and_bad(self, client):
         """POST /api/votes/clear should remove all votes."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         assert 1 in app_module.good_votes
         assert 2 in app_module.bad_votes
 
@@ -134,15 +166,15 @@ class TestClearVotes:
     def test_clear_votes_preserves_medias(self, client):
         """Clearing votes should not affect loaded medias."""
         num_before = len(medias)
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         resp = client.post("/api/votes/clear")
         assert resp.status_code == 200
         assert len(medias) == num_before
 
     def test_get_votes_empty_after_clear(self, client):
         """GET /api/votes should return empty lists after clear."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         client.post("/api/votes/clear")
         resp = client.get("/api/votes")
         data = resp.get_json()
@@ -152,37 +184,45 @@ class TestClearVotes:
 
 class TestLabelHistory:
     def test_vote_adds_history_entry(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert len(label_history) == 1
         assert label_history[0][0] == 1
         assert label_history[0][1] == "good"
 
-    def test_toggle_off_adds_unlabel_history(self, client):
-        """Toggling off a vote should record an 'unlabel' event."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+    def test_unvote_good_adds_unlabel_history(self, client):
+        """target=none on a good media should record an 'unlabel' event."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert len(label_history) == 2
         assert label_history[1][1] == "unlabel"
 
-    def test_toggle_off_bad_adds_unlabel_history(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+    def test_unvote_bad_adds_unlabel_history(self, client):
+        client.post("/api/medias/1/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert len(label_history) == 2
         assert label_history[1][1] == "unlabel"
+
+    def test_idempotent_re_vote_does_not_grow_history(self, client):
+        """Re-sending the current state appends nothing to label_history (H1)."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        assert len(label_history) == 1
+        assert label_history[0][1] == "good"
 
     def test_switch_vote_adds_new_label_history(self, client):
         """Switching good->bad should add a 'bad' entry, not 'unlabel'."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(label_history) == 2
         assert label_history[0][1] == "good"
         assert label_history[1][1] == "bad"
 
-    def test_toggle_off_then_revote(self, client):
-        """Toggle off then revote should produce 3 history entries."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})  # toggle off
-        client.post("/api/medias/1/vote", json={"vote": "bad"})  # revote bad
+    def test_unvote_then_revote(self, client):
+        """Un-vote then re-vote should produce 3 history entries."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "none"})  # un-vote
+        client.post("/api/medias/1/vote", json={"target": "bad"})  # revote bad
         assert len(label_history) == 3
         assert label_history[0][1] == "good"
         assert label_history[1][1] == "unlabel"
@@ -195,15 +235,15 @@ class TestProgressCacheWithLabelChanges:
     """Verify the progress cache stays consistent when labels are changed."""
 
     def test_cache_removes_clip_on_unlabel(self, client):
-        """After toggling off, the progress cache should not include the media."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        """After un-voting, the progress cache should not include the media."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert 1 in _cache_good_ids
         assert 2 in _cache_bad_ids
 
-        # Toggle off media 1
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        # Un-vote media 1
+        client.post("/api/medias/1/vote", json={"target": "none"})
         _ensure_cache(medias, label_history, 0)
         assert 1 not in _cache_good_ids
         assert 1 not in _cache_bad_ids
@@ -211,48 +251,48 @@ class TestProgressCacheWithLabelChanges:
 
     def test_cache_handles_switch_vote(self, client):
         """Switching good->bad should update cache running sets correctly."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert 1 in _cache_good_ids
 
         # Switch media 1 from good to bad
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert 1 not in _cache_good_ids
         assert 1 in _cache_bad_ids
 
-    def test_cache_toggle_off_then_revote(self, client):
-        """Toggle off then revote should leave cache in correct state."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
-        # Toggle off media 1
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+    def test_cache_unvote_then_revote(self, client):
+        """Un-vote then re-vote should leave cache in correct state."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
+        # Un-vote media 1
+        client.post("/api/medias/1/vote", json={"target": "none"})
         # Revote as bad
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert 1 in _cache_bad_ids
         assert 1 not in _cache_good_ids
 
-    def test_learned_sort_after_toggle_off(self, client):
-        """Learned sort should work after toggling off a vote."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+    def test_learned_sort_after_unvote(self, client):
+        """Learned sort should work after un-voting a media."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
-        # Toggle off good vote, add a different good vote
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/3/vote", json={"vote": "good"})
+        # Un-vote the existing good, add a different good vote
+        client.post("/api/medias/1/vote", json={"target": "none"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
-    def test_learned_sort_returns_400_after_toggling_all_good(self, client):
-        """If all good votes are toggled off, learned sort should return 400."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
-        # Toggle off the only good vote
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+    def test_learned_sort_returns_400_after_unvoting_all_good(self, client):
+        """If all good votes are removed, learned sort should return 400."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
+        # Un-vote the only good vote
+        client.post("/api/medias/1/vote", json={"target": "none"})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
@@ -260,16 +300,16 @@ class TestProgressCacheWithLabelChanges:
         """labeling-status endpoint should not crash after label changes."""
         # Vote enough medias to get past the minimum threshold
         for i in range(1, 6):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "good"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "good"})
         for i in range(6, 11):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "bad"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "bad"})
 
         resp = client.get("/api/labeling-status")
         assert resp.status_code == 200
 
-        # Now toggle off a good vote and switch a bad vote
-        client.post("/api/medias/1/vote", json={"vote": "good"})  # toggle off
-        client.post("/api/medias/6/vote", json={"vote": "good"})  # switch bad->good
+        # Now un-vote a good and switch a bad vote
+        client.post("/api/medias/1/vote", json={"target": "none"})  # un-vote
+        client.post("/api/medias/6/vote", json={"target": "good"})  # switch bad->good
 
         resp = client.get("/api/labeling-status")
         assert resp.status_code == 200
@@ -289,85 +329,101 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
         """Switching good→bad should keep steps before the media first appeared."""
         # Steps: 0=(3,good), 1=(4,bad), 2=(1,good), 3=(2,bad)
         # Media 1 first appears at step 2.
-        client.post("/api/medias/3/vote", json={"vote": "good"})
-        client.post("/api/medias/4/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/4/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 4
 
         # Switch media 1 from good to bad — steps 0-1 preserved, 2-3 discarded
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(_cached_steps) == 2, "Steps before media 1's first appearance should be kept"
 
     def test_bad_to_good_truncates_from_first_appearance(self, client):
         """Switching bad→good should keep steps before the media first appeared."""
-        client.post("/api/medias/3/vote", json={"vote": "good"})
-        client.post("/api/medias/4/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
-        client.post("/api/medias/2/vote", json={"vote": "good"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/4/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
+        client.post("/api/medias/2/vote", json={"target": "good"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 4
 
         # Switch media 1 from bad to good — steps 0-1 preserved, 2-3 discarded
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert len(_cached_steps) == 2, "Steps before media 1's first appearance should be kept"
 
     def test_first_vote_switch_clears_entire_cache(self, client):
         """If the switched media was in the very first step, full clear occurs."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 2
 
         # Switch media 1 (present from step 0) — full clear
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(_cached_steps) == 0, "Cache should be fully cleared when media was in step 0"
 
-    def test_toggle_off_does_not_clear_cache(self, client):
-        """Toggling a vote OFF (unlabeling) should NOT clear the progress cache."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+    def test_unvote_invalidates_cache_from_first_appearance(self, client):
+        """Un-voting (X→none) now invalidates the progress cache from the
+        media's first appearance — same rule as polarity flips (H1 cache-
+        invalidation fix).  Previously cache was retained, leaving cached
+        models trained against a label the user has since withdrawn.
+        """
+        # Steps: 0=(3,good), 1=(4,bad), 2=(1,good)
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/4/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 3
+
+        # Un-vote media 1 (first appears at step 2) — keep 2 earlier steps.
+        client.post("/api/medias/1/vote", json={"target": "none"})
+        assert len(_cached_steps) == 2
+
+    def test_unvote_clears_cache_when_media_was_in_first_step(self, client):
+        """If the un-voted media was in step 0, the full cache is cleared."""
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 2
 
-        # Toggle off media 1 (good→unlabel) — cache should NOT be cleared
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        assert len(_cached_steps) > 0, "Cache should not be cleared on simple toggle-off"
+        client.post("/api/medias/1/vote", json={"target": "none"})
+        assert len(_cached_steps) == 0, "Cache should be fully cleared when media was in step 0"
 
     def test_new_vote_does_not_clear_cache(self, client):
         """Adding a brand-new vote (no prior label) should NOT clear the cache."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 2
 
         # Add a new good vote on media 3 (no prior label)
-        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
         assert len(_cached_steps) == 2, "Cache should not be cleared when adding a new vote"
 
     def test_live_models_cleared_on_switch(self, client):
         """Live models from learned-sort should also be cleared on a vote switch."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         assert len(_live_models) > 0
 
         # Switch media 1 from good to bad — live models should be cleared
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(_live_models) == 0, "Live models should be cleared on vote switch"
 
     def test_running_ids_restored_after_truncation(self, client):
         """After partial truncation, _cache_good_ids/_cache_bad_ids match the last kept step."""
-        client.post("/api/medias/3/vote", json={"vote": "good"})
-        client.post("/api/medias/4/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/4/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
 
         # Switch media 1 — truncates to 2 steps (steps 0-1)
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(_cached_steps) == 2
         # Running ID sets should match step 1's state: good={3}, bad={4}
         assert 3 in _cache_good_ids
@@ -377,15 +433,15 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
 
     def test_cache_rebuilds_correctly_after_partial_truncation(self, client):
         """After partial invalidation, _ensure_cache replays from the truncation point."""
-        client.post("/api/medias/3/vote", json={"vote": "good"})
-        client.post("/api/medias/4/vote", json={"vote": "bad"})
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
+        client.post("/api/medias/4/vote", json={"target": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 4
 
         # Switch media 1 from good to bad — truncates to 2 steps
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert len(_cached_steps) == 2
 
         # Rebuild cache — should replay from step 2 onward
@@ -398,23 +454,23 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
     def test_labeling_progress_works_after_switch(self, client):
         """The /api/labeling-progress endpoint should work after a vote switch."""
         for i in range(1, 6):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "good"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "good"})
         for i in range(6, 11):
-            client.post(f"/api/medias/{i}/vote", json={"vote": "bad"})
+            client.post(f"/api/medias/{i}/vote", json={"target": "bad"})
 
         resp = client.post("/api/labeling-progress")
         assert resp.status_code == 200
 
         # Switch a vote
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
 
         resp = client.post("/api/labeling-progress")
         assert resp.status_code == 200
 
     def test_invalidate_noop_when_media_not_in_cache(self, client):
         """invalidate_progress_cache_from should be a no-op for unknown media."""
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 2
 

--- a/tests/core/test_votes.py
+++ b/tests/core/test_votes.py
@@ -54,6 +54,7 @@ class TestVoteClip:
         assert 1 in app_module.good_votes
         # Idempotent: a single label_history entry, not two.
         from vtsearch.state import label_history
+
         assert sum(1 for entry in label_history if entry[0] == 1) == 1
 
     def test_idempotent_re_vote_bad(self, client):
@@ -63,6 +64,7 @@ class TestVoteClip:
         assert r2.status_code == 200
         assert 1 in app_module.bad_votes
         from vtsearch.state import label_history
+
         assert sum(1 for entry in label_history if entry[0] == 1) == 1
 
     def test_switch_from_good_to_bad(self, client):

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -466,14 +466,14 @@ class TestSaveLabels:
 
         # Cast a good vote on the first media
         first_id = next(iter(medias))
-        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
 
         # Cast a bad vote on the second media
         media_ids = list(medias.keys())
         if len(media_ids) < 2:
             pytest.skip("Need at least 2 medias")
         second_id = media_ids[1]
-        client.post(f"/api/medias/{second_id}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{second_id}/vote", json={"target": "bad"})
 
         client.post(
             "/api/detectors",
@@ -598,7 +598,7 @@ class TestSaveLabels:
             ],
         }
         try:
-            client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+            client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
             client.post("/api/detectors", json={"name": "DupeTest", "media_type": "audio", "text_query": "test"})
 
             res = client.post("/api/detectors/DupeTest/labels")
@@ -638,8 +638,8 @@ class TestLabelVoteIsolation:
         client.post("/api/detectors", json={"name": "Model B", "media_type": "audio", "text_query": "b"})
 
         # Simulate labeling with Model A: vote on ids[0] and ids[1]
-        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"target": "bad"})
         client.post("/api/detectors/Model%20A/labels")  # save 2 labels
 
         # Now clear votes (as the Label button should do) and import Model B's labels
@@ -669,13 +669,13 @@ class TestLabelVoteIsolation:
 
         # Create model and label 2 items
         client.post("/api/detectors", json={"name": "Target", "media_type": "audio", "text_query": "t"})
-        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"target": "bad"})
         client.post("/api/detectors/Target/labels")
 
         # Add extra votes that DON'T belong to the model (simulating stale state)
-        client.post(f"/api/medias/{ids[2]}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{ids[3]}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{ids[2]}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{ids[3]}/vote", json={"target": "bad"})
         assert len(good_votes) == 2  # ids[0] + ids[2]
         assert len(bad_votes) == 2  # ids[1] + ids[3]
 
@@ -812,8 +812,8 @@ class TestLoadModelEndpoint:
 
         # Load model A and cast some votes.
         _load_detector_and_wait(client, mid_a)
-        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"target": "bad"})
         assert ids[0] in good_votes
         assert ids[1] in bad_votes
 
@@ -845,7 +845,7 @@ class TestLoadModelEndpoint:
         )
         mid = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, mid)
-        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"target": "good"})
         # Labels auto-sync on vote, so the detector file now has 1 label.
 
         # Unload to clear votes, then reload — label should be restored.
@@ -900,8 +900,8 @@ class TestLoadModelEndpoint:
 
         # Vote in dataset A.  Persists to good_votes/bad_votes and to the
         # detector's on-disk labelset via sync_labels_to_loaded_detector.
-        client.post(f"/api/medias/{a_good}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{a_bad}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{a_good}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{a_bad}/vote", json={"target": "bad"})
         assert a_good in good_votes
         assert a_bad in bad_votes
 
@@ -960,7 +960,7 @@ class TestVoteSyncsToLoadedModel:
 
         # Cast a vote
         first_id = next(iter(medias))
-        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
 
         # Check that the model's labelset was updated
         model_data = client.get("/api/detectors/AutoSync").get_json()
@@ -994,12 +994,12 @@ class TestVoteSyncsToLoadedModel:
 
         first_id = next(iter(medias))
         # Vote good
-        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
         model_data = client.get("/api/detectors/ToggleSync").get_json()
         assert len(model_data["labelset"]["labels"]) == 1
 
-        # Toggle off (vote good again)
-        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        # Un-vote (absolute target=none)
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "none"})
         model_data = client.get("/api/detectors/ToggleSync").get_json()
         assert len(model_data["labelset"]["labels"]) == 0
 
@@ -1016,7 +1016,7 @@ class TestVoteSyncsToLoadedModel:
         )
 
         first_id = next(iter(medias))
-        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
 
         # Model should still have empty labelset
         model_data = client.get("/api/detectors/NoSync").get_json()
@@ -1255,7 +1255,7 @@ class TestSeedVotesFromExamples:
         # Make sure we don't vote bad on the newly inserted item
         new_id = max(medias.keys())
         target_id = first_id if first_id != new_id else list(medias.keys())[1]
-        client.post(f"/api/medias/{target_id}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{target_id}/vote", json={"target": "bad"})
         assert len(bad_votes) >= 1
 
         # Learned sort should work — it accesses the embedding from the inserted media

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1121,21 +1121,43 @@ class TestVoteEndpointRegionBox:
         assert 1 in bad_votes
         assert 1 not in vote_region_boxes
 
-    def test_replacing_region_box_updates_value(self, client):
-        """Re-voting good with a different box after toggling off the
-        previous yes-vote stores the new box, not the previous one."""
+    def test_replacing_region_box_via_unvote_then_revote(self, client):
+        """Un-voting clears the region_box; re-voting good with a new box
+        stores the new value."""
         from vtsearch.state import vote_region_boxes
 
         client.post(
             "/api/medias/1/vote",
             json={"target": "good", "region_box": [0.1, 0.2, 0.4, 0.4]},
         )
-        # Toggle off, then vote good again with a different box.
-        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         client.post(
             "/api/medias/1/vote",
             json={"target": "good", "region_box": [0.3, 0.3, 0.9, 0.9]},
         )
+        assert vote_region_boxes[1] == (0.3, 0.3, 0.9, 0.9)
+
+    def test_idempotent_revote_with_new_region_box_replaces_in_place(self, client):
+        """Drawing a new box on an already-good media replaces the previous
+        annotation without going through un-vote, since the user explicitly
+        sent a new ``region_box``.  An idempotent re-vote *without* a
+        region_box leaves the existing one alone (so a stale-view tab can't
+        wipe a region a different tab just set — H1 idempotency)."""
+        from vtsearch.state import vote_region_boxes
+
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "region_box": [0.1, 0.2, 0.4, 0.4]},
+        )
+        # New box on an already-good media → replace in place.
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "region_box": [0.3, 0.3, 0.9, 0.9]},
+        )
+        assert vote_region_boxes[1] == (0.3, 0.3, 0.9, 0.9)
+
+        # Idempotent re-vote without a region_box → existing box preserved.
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert vote_region_boxes[1] == (0.3, 0.3, 0.9, 0.9)
 
 

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -995,7 +995,7 @@ class TestVoteEndpointRegionBox:
 
         resp = client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
         )
         assert resp.status_code == 200
         assert 1 in good_votes
@@ -1007,7 +1007,7 @@ class TestVoteEndpointRegionBox:
             vote_region_boxes,
         )
 
-        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert 1 in good_votes
         assert 1 not in vote_region_boxes
@@ -1023,7 +1023,7 @@ class TestVoteEndpointRegionBox:
 
         resp = client.post(
             "/api/medias/1/vote",
-            json={"vote": "bad", "region_box": [0.1, 0.2, 0.7, 0.8]},
+            json={"target": "bad", "region_box": [0.1, 0.2, 0.7, 0.8]},
         )
         assert resp.status_code == 400
         assert 1 not in bad_votes
@@ -1035,7 +1035,7 @@ class TestVoteEndpointRegionBox:
             vote_region_boxes,
         )
 
-        resp = client.post("/api/medias/1/vote", json={"vote": "bad"})
+        resp = client.post("/api/medias/1/vote", json={"target": "bad"})
         assert resp.status_code == 200
         assert 1 in bad_votes
         assert 1 not in vote_region_boxes
@@ -1047,7 +1047,7 @@ class TestVoteEndpointRegionBox:
         # rejected by the handler with a 400 + standard ``message`` envelope.
         resp = client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7]},
         )
         assert resp.status_code == 400
         assert "region_box" in resp.get_json()["message"]
@@ -1057,7 +1057,7 @@ class TestVoteEndpointRegionBox:
         # handler → 400 + standard ``message`` envelope.
         resp = client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 1.5]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 1.5]},
         )
         assert resp.status_code == 400
 
@@ -1066,14 +1066,13 @@ class TestVoteEndpointRegionBox:
         # schema-level 422 with the per-field ``errors`` envelope.
         resp = client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": ["a", "b", "c", "d"]},
+            json={"target": "good", "region_box": ["a", "b", "c", "d"]},
         )
         assert resp.status_code == 422
 
-    def test_toggle_good_off_clears_region_box(self, client):
-        """Voting good twice toggles off the vote; the region_box must go
-        with it so a subsequent fresh yes-vote isn't tagged with a stale
-        annotation."""
+    def test_unvote_clears_region_box(self, client):
+        """target=none removes the vote AND any region_box, so a subsequent
+        fresh yes-vote isn't tagged with a stale annotation."""
         from vtsearch.state import (
             good_votes,
             vote_region_boxes,
@@ -1081,12 +1080,27 @@ class TestVoteEndpointRegionBox:
 
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
         )
         assert 1 in vote_region_boxes
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert 1 not in good_votes
         assert 1 not in vote_region_boxes
+
+    def test_idempotent_re_vote_preserves_region_box(self, client):
+        """Re-sending target=good without region_box on an already-good media
+        is idempotent — region_box stays unchanged.  This is intentional: an
+        absent ``region_box`` on an idempotent call must not silently wipe a
+        previously-recorded one (H1 idempotency rule)."""
+        from vtsearch.state import vote_region_boxes
+
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        assert vote_region_boxes[1] == (0.1, 0.2, 0.7, 0.8)
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        assert vote_region_boxes[1] == (0.1, 0.2, 0.7, 0.8)
 
     def test_switch_good_to_bad_clears_region_box(self, client):
         """A region annotation belongs to a yes-vote; flipping the same
@@ -1099,10 +1113,10 @@ class TestVoteEndpointRegionBox:
 
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
         )
         assert 1 in vote_region_boxes
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert 1 not in good_votes
         assert 1 in bad_votes
         assert 1 not in vote_region_boxes
@@ -1114,13 +1128,13 @@ class TestVoteEndpointRegionBox:
 
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.4, 0.4]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.4, 0.4]},
         )
         # Toggle off, then vote good again with a different box.
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.3, 0.3, 0.9, 0.9]},
+            json={"target": "good", "region_box": [0.3, 0.3, 0.9, 0.9]},
         )
         assert vote_region_boxes[1] == (0.3, 0.3, 0.9, 0.9)
 
@@ -1134,7 +1148,7 @@ class TestLabelExportRegionBox:
     def test_export_emits_region_box_on_good_vote(self, client):
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
         )
         resp = client.get("/api/labels/export")
         assert resp.status_code == 200
@@ -1144,14 +1158,14 @@ class TestLabelExportRegionBox:
         assert labels[0]["region_box"] == [0.1, 0.2, 0.7, 0.8]
 
     def test_export_omits_region_box_on_plain_good_vote(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         resp = client.get("/api/labels/export")
         labels = resp.get_json()["labels"]
         assert len(labels) == 1
         assert "region_box" not in labels[0]
 
     def test_export_never_emits_region_box_on_bad_vote(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         resp = client.get("/api/labels/export")
         labels = resp.get_json()["labels"]
         assert len(labels) == 1
@@ -1162,10 +1176,10 @@ class TestLabelExportRegionBox:
         """Region-annotated good, plain good, and a bad in the same export."""
         client.post(
             "/api/medias/1/vote",
-            json={"vote": "good", "region_box": [0.1, 0.2, 0.3, 0.4]},
+            json={"target": "good", "region_box": [0.1, 0.2, 0.3, 0.4]},
         )
-        client.post("/api/medias/2/vote", json={"vote": "good"})
-        client.post("/api/medias/3/vote", json={"vote": "bad"})
+        client.post("/api/medias/2/vote", json={"target": "good"})
+        client.post("/api/medias/3/vote", json={"target": "bad"})
         resp = client.get("/api/labels/export")
         labels = resp.get_json()["labels"]
         by_md5 = {e["md5"]: e for e in labels}

--- a/tests/integration/test_multi_media_coverage.py
+++ b/tests/integration/test_multi_media_coverage.py
@@ -462,7 +462,7 @@ class TestVoteOnNonAudioMedia:
         try:
             for i in range(1, 6):
                 medias[i] = make_image_media(i)
-            resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+            resp = client.post("/api/medias/1/vote", json={"target": "good"})
             assert resp.status_code == 200
             resp = client.get("/api/votes")
             data = resp.get_json()
@@ -477,7 +477,7 @@ class TestVoteOnNonAudioMedia:
         try:
             for i in range(1, 6):
                 medias[i] = make_text_media(i)
-            resp = client.post("/api/medias/3/vote", json={"vote": "bad"})
+            resp = client.post("/api/medias/3/vote", json={"target": "bad"})
             assert resp.status_code == 200
             resp = client.get("/api/votes")
             data = resp.get_json()

--- a/tests/sorting/test_diversity_tree_integration.py
+++ b/tests/sorting/test_diversity_tree_integration.py
@@ -230,14 +230,14 @@ class TestVoteUpdatesTree:
     def test_good_vote_labels_tree(self, client):
         tree = _build_tree()
         cid = 1
-        resp = client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+        resp = client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert cid in tree.labeled_ids
 
     def test_bad_vote_labels_tree(self, client):
         tree = _build_tree()
         cid = 2
-        resp = client.post(f"/api/medias/{cid}/vote", json={"vote": "bad"})
+        resp = client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
         assert resp.status_code == 200
         assert cid in tree.labeled_ids
 
@@ -245,20 +245,20 @@ class TestVoteUpdatesTree:
         tree = _build_tree()
         cid = 1
         # Vote good
-        client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert cid in tree.labeled_ids
         # Toggle good off (unlabel)
-        client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert cid not in tree.labeled_ids
 
     def test_switch_vote_keeps_labeled(self, client):
         """Switching from good to bad should keep the media labeled."""
         tree = _build_tree()
         cid = 3
-        client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert cid in tree.labeled_ids
         # Switch to bad
-        client.post(f"/api/medias/{cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
         assert cid in tree.labeled_ids
 
 
@@ -318,7 +318,7 @@ class TestSpanLevelProgression:
             sample = diversity_tree_next_sample()
             if sample is None:
                 break
-            resp = client.post(f"/api/medias/{sample}/vote", json={"vote": "good"})
+            resp = client.post(f"/api/medias/{sample}/vote", json={"target": "good"})
             assert resp.status_code == 200
 
         # After voting on diverse medias, the level should have advanced past 1
@@ -444,9 +444,9 @@ class TestDiversityLevelOverTime:
         cids = sorted(tree.vector_to_leaf.keys())[:6]
         for i, cid in enumerate(cids):
             if i % 2 == 0:
-                client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+                client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
             else:
-                client.post(f"/api/medias/{cid}/vote", json={"vote": "bad"})
+                client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
 
         # Record the diversity level before the switch
         resp = client.post("/api/labeling-progress")
@@ -457,7 +457,7 @@ class TestDiversityLevelOverTime:
 
         # Switch the last bad vote to good (polarity switch triggers cache invalidation)
         switch_cid = cids[1]  # was voted bad
-        client.post(f"/api/medias/{switch_cid}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{switch_cid}/vote", json={"target": "good"})
 
         # Fetch diversity history again — no entry should be below the pre-switch peak
         resp = client.post("/api/labeling-progress")

--- a/tests/sorting/test_diversity_tree_integration.py
+++ b/tests/sorting/test_diversity_tree_integration.py
@@ -241,14 +241,14 @@ class TestVoteUpdatesTree:
         assert resp.status_code == 200
         assert cid in tree.labeled_ids
 
-    def test_toggle_unlabels_tree(self, client):
+    def test_unvote_unlabels_tree(self, client):
         tree = _build_tree()
         cid = 1
         # Vote good
         client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert cid in tree.labeled_ids
-        # Toggle good off (unlabel)
-        client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
+        # Un-vote (absolute target=none)
+        client.post(f"/api/medias/{cid}/vote", json={"target": "none"})
         assert cid not in tree.labeled_ids
 
     def test_switch_vote_keeps_labeled(self, client):

--- a/tests/sorting/test_label_sorting.py
+++ b/tests/sorting/test_label_sorting.py
@@ -21,40 +21,40 @@ class TestClickTimeTracking:
     """Verify that voting via the API assigns monotonically-increasing click times."""
 
     def test_vote_assigns_click_time(self, client):
-        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert 1 in vote_click_times
         assert vote_click_times[1] == 1
 
     def test_sequential_votes_increment(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
-        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
+        client.post("/api/medias/3/vote", json={"target": "good"})
         assert vote_click_times[1] == 1
         assert vote_click_times[2] == 2
         assert vote_click_times[3] == 3
 
     def test_unvote_removes_click_time(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert 1 in vote_click_times
-        # Toggle off
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        # Un-vote via absolute target=none
+        client.post("/api/medias/1/vote", json={"target": "none"})
         assert 1 not in vote_click_times
 
     def test_revote_gets_new_click_time(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert vote_click_times[1] == 1
-        # Toggle off (does not increment counter)
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        # Un-vote (does not increment counter)
+        client.post("/api/medias/1/vote", json={"target": "none"})
         # Vote again — should get a new, higher click time
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert vote_click_times[1] == 2
 
     def test_switch_vote_gets_new_click_time(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert vote_click_times[1] == 1
         # Switch from good to bad
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "bad"})
         assert vote_click_times[1] == 2
         assert 1 in app_module.bad_votes
         assert 1 not in app_module.good_votes
@@ -71,8 +71,8 @@ class TestVotesEndpointEnriched:
     """The /api/votes endpoint should include click_times and learned_scores."""
 
     def test_votes_response_includes_click_times(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "bad"})
         resp = client.get("/api/votes")
         data = resp.get_json()
         assert "click_times" in data
@@ -119,7 +119,7 @@ class TestClearVotesResetsState:
     """Clearing votes should also clear click times and learned scores."""
 
     def test_clear_votes_clears_click_times(self, client):
-        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/1/vote", json={"target": "good"})
         assert len(vote_click_times) == 1
         _state.clear_votes()
         assert len(vote_click_times) == 0

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -67,6 +67,7 @@ from vtscore.state.votes import (  # noqa: F401
     get_learned_scores,
     get_textsort_suggestions,
     set_find_initial_labels,
+    set_vote,
     toggle_vote,
     update_learned_scores,
 )

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -162,10 +162,18 @@ def _set_vote_locked(
     ctx = get_active_detector_context()
     old = _current_label_locked(ctx, media_id)
     if old == target:
-        # Idempotent — preserve everything (no history append, no cache churn,
-        # no achievement credit).  This is the key change that closes the H1
-        # counter-inflation race: concurrent tabs sending the same target on a
-        # media that's already in that state no longer increment counters.
+        # Idempotent — no history append, no cache churn, no achievement
+        # credit.  This is the key change that closes the H1 counter-inflation
+        # race: concurrent tabs sending the same target on a media that's
+        # already in that state no longer increment counters.  The one
+        # exception is an explicit ``region_box`` on a ``"good"`` re-vote,
+        # which lets the user replace the recorded annotation without first
+        # un-voting (drawing a new box on an already-good media is an
+        # intentional user action — the stale-tab race the idempotency rule
+        # closes was about counters, not region updates).  An absent
+        # ``region_box`` on an idempotent call leaves the existing one alone.
+        if target == "good" and region_box is not None:
+            ctx.vote_region_boxes[media_id] = region_box
         existing_click = ctx.vote_click_times.get(media_id) if target != "none" else None
         return (old, old, existing_click)
 

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -134,88 +134,158 @@ def _record_vote_locked() -> None:
     record_vote(det_ctx.detector_id, media_type=det_ctx.media_type)
 
 
+def _current_label_locked(ctx, media_id: int) -> str:
+    """Return ``"good"`` / ``"bad"`` / ``"none"`` for *media_id* (lock held)."""
+    if media_id in ctx.good_votes:
+        return "good"
+    if media_id in ctx.bad_votes:
+        return "bad"
+    return "none"
+
+
+def _set_vote_locked(
+    media_id: int,
+    target: str,
+    region_box: tuple[float, float, float, float] | None = None,
+) -> tuple[str, str, int | None]:
+    """Set *media_id*'s vote to *target* under an already-held ``_state_lock``.
+
+    Returns ``(old_label, new_label, click_time)`` where ``click_time`` is the
+    ordinal assigned to a newly-labeled media (or ``None`` when *target* is
+    ``"none"`` or the call was idempotent).
+    """
+    from vtscore.detectors.labeling_progress import invalidate_progress_cache_from
+
+    if target not in ("good", "bad", "none"):
+        raise ValueError(f"target must be 'good', 'bad', or 'none' (got {target!r})")
+
+    ctx = get_active_detector_context()
+    old = _current_label_locked(ctx, media_id)
+    if old == target:
+        # Idempotent — preserve everything (no history append, no cache churn,
+        # no achievement credit).  This is the key change that closes the H1
+        # counter-inflation race: concurrent tabs sending the same target on a
+        # media that's already in that state no longer increment counters.
+        existing_click = ctx.vote_click_times.get(media_id) if target != "none" else None
+        return (old, old, existing_click)
+
+    if target == "good":
+        ctx.bad_votes.pop(media_id, None)
+        ctx.good_votes[media_id] = None
+        if region_box is not None:
+            ctx.vote_region_boxes[media_id] = region_box
+        else:
+            ctx.vote_region_boxes.pop(media_id, None)
+        click_time = assign_click_time(media_id)
+        add_label_to_history(media_id, "good")
+        diversity_tree_label(media_id)
+    elif target == "bad":
+        ctx.good_votes.pop(media_id, None)
+        ctx.vote_region_boxes.pop(media_id, None)
+        ctx.bad_votes[media_id] = None
+        click_time = assign_click_time(media_id)
+        add_label_to_history(media_id, "bad")
+        diversity_tree_label(media_id)
+    else:  # target == "none"
+        ctx.good_votes.pop(media_id, None)
+        ctx.bad_votes.pop(media_id, None)
+        ctx.vote_region_boxes.pop(media_id, None)
+        remove_click_time(media_id)
+        add_label_to_history(media_id, "unlabel")
+        diversity_tree_unlabel(media_id)
+        click_time = None
+
+    # Invalidate the progress cache on ANY training-set membership change for
+    # this media.  The old `toggle_vote` only invalidated on polarity flips,
+    # leaving cached steps stale on good→none / bad→none.  Cached models that
+    # included this media are now wrong regardless of whether the new state is
+    # the opposite polarity or "none", so the rule is: invalidate iff the media
+    # was previously labeled.
+    if old != "none":
+        invalidate_progress_cache_from(media_id)
+
+    # Counter increments only on a transition that produces a labeled state.
+    # Un-vote (X→none) and idempotent re-apply (handled above) credit nothing.
+    if target != "none":
+        _record_vote_locked()
+
+    return (old, target, click_time)
+
+
+def set_vote(
+    media_id: int,
+    target: str,
+    region_box: tuple[float, float, float, float] | None = None,
+) -> tuple[str, str, int | None]:
+    """Atomically set a media's vote to an absolute target state.
+
+    *target* is one of ``"good"``, ``"bad"``, or ``"none"``.  Behaviour is
+    **idempotent**: setting the target equal to the current state is a no-op
+    that does not append to ``label_history``, does not increment achievement
+    counters, and does not assign a new click-time.  Achievement credit fires
+    exactly when the media moves from one state to a *different* labeled
+    state (none→good, none→bad, good→bad, bad→good); un-vote and idempotent
+    re-apply credit nothing.  The progress cache is invalidated for *media_id*
+    whenever its prior training-set membership changes (i.e. when ``old`` was
+    ``"good"`` or ``"bad"``).
+
+    Concurrent rapid-toggle from multiple tabs no longer inflates counters,
+    because each client sends an absolute target rather than a "toggle"
+    intent — stale-view duplicates collapse into idempotent no-ops on the
+    server (logical-bug-audit H1).
+
+    Args:
+        media_id: Integer ID of the media to vote on.
+        target: ``"good"``, ``"bad"``, or ``"none"``.
+        region_box: Optional normalised ``(x0, y0, x1, y1)`` good-vote region.
+            Only honoured when *target* is ``"good"`` (patch-embedder v2:
+            no-votes are always image-level).
+
+    Returns:
+        ``(old_label, new_label, click_time)``.  ``click_time`` is the
+        ordinal assigned to the new label, or ``None`` for ``"none"`` /
+        idempotent calls.
+    """
+    with _state_lock:
+        return _set_vote_locked(media_id, target, region_box=region_box)
+
+
 def toggle_vote(
     media_id: int,
     vote: str,
     region_box: tuple[float, float, float, float] | None = None,
 ) -> None:
-    """Atomically toggle a good/bad vote for a media item.
+    """Toggle a good/bad vote, computing the target from the current state.
 
-    Implements the same toggle semantics as the ``/api/medias/<id>/vote``
-    endpoint: if the media already has the requested vote it is removed
-    (unlabelled); otherwise the vote is applied (overriding any existing
-    opposite vote).
-
-    When a vote switches polarity (good->bad or bad->good), the progress
-    cache is partially invalidated: only cached steps from the point where
-    the media first appeared in the training data are discarded.  Earlier
-    steps (whose models never included this media) are preserved.
-
-    This function acquires ``_state_lock`` so that the entire check-then-modify
-    sequence is atomic with respect to concurrent requests.
+    Implemented as a thin wrapper over :func:`set_vote` so all the
+    correctness rules (idempotent semantics, cache invalidation on
+    membership change, achievement-credit gating) are shared.  Kept for
+    in-process callers that want the old "same vote toggles off" affordance
+    (the HTTP ``/api/medias/<id>/vote`` endpoint no longer uses it — see
+    :func:`set_vote`).
 
     Args:
         media_id: Integer ID of the media to vote on.
-        vote: ``"good"`` or ``"bad"``.
-        region_box: Optional normalised ``(x0, y0, x1, y1)`` box that the
-            user drew as part of a yes-vote.  Only honoured when *vote* is
-            ``"good"`` and the vote is being *added* (not toggled off);
-            stored in :attr:`DetectorContext.vote_region_boxes` so label
-            export / detector sync emit it on the resulting LabeledElement.
-            Ignored for no-votes (which are always image-level — see the
-            patch-embedder v2 design).  Patch-embedder v2.
+        vote: ``"good"`` or ``"bad"`` — the clicked direction.  Toggles off
+            when *media_id* is already in that polarity, otherwise sets to
+            *vote* (overriding any opposite vote).
+        region_box: Optional normalised good-vote region; honoured only when
+            the resulting target is ``"good"``.
     """
-    from vtscore.detectors.labeling_progress import invalidate_progress_cache_from
-
-    added = False
     with _state_lock:
         ctx = get_active_detector_context()
-        good_votes = ctx.good_votes
-        bad_votes = ctx.bad_votes
-        vote_region_boxes = ctx.vote_region_boxes
+        current = _current_label_locked(ctx, media_id)
         if vote == "good":
-            if media_id in good_votes:
-                good_votes.pop(media_id, None)
-                vote_region_boxes.pop(media_id, None)
-                remove_click_time(media_id)
-                add_label_to_history(media_id, "unlabel")
-                if media_id not in bad_votes:
-                    diversity_tree_unlabel(media_id)
-            else:
-                was_opposite = media_id in bad_votes
-                bad_votes.pop(media_id, None)
-                good_votes[media_id] = None
-                if region_box is not None:
-                    vote_region_boxes[media_id] = region_box
-                else:
-                    vote_region_boxes.pop(media_id, None)
-                assign_click_time(media_id)
-                add_label_to_history(media_id, "good")
-                diversity_tree_label(media_id)
-                if was_opposite:
-                    invalidate_progress_cache_from(media_id)
-                added = True
+            target = "none" if current == "good" else "good"
+        elif vote == "bad":
+            target = "none" if current == "bad" else "bad"
         else:
-            if media_id in bad_votes:
-                bad_votes.pop(media_id, None)
-                remove_click_time(media_id)
-                add_label_to_history(media_id, "unlabel")
-                if media_id not in good_votes:
-                    diversity_tree_unlabel(media_id)
-            else:
-                was_opposite = media_id in good_votes
-                good_votes.pop(media_id, None)
-                vote_region_boxes.pop(media_id, None)
-                bad_votes[media_id] = None
-                assign_click_time(media_id)
-                add_label_to_history(media_id, "bad")
-                diversity_tree_label(media_id)
-                if was_opposite:
-                    invalidate_progress_cache_from(media_id)
-                added = True
-
-        if added:
-            _record_vote_locked()
+            raise ValueError(f"vote must be 'good' or 'bad' (got {vote!r})")
+        _set_vote_locked(
+            media_id,
+            target,
+            region_box=region_box if target == "good" else None,
+        )
 
 
 def apply_label(

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -42,8 +42,8 @@ from vtsearch.state import (
     get_media,
     medias,
     next_media_id,
+    set_vote,
     snapshot_medias,
-    toggle_vote,
 )
 
 medias_bp = Blueprint(
@@ -519,38 +519,47 @@ def media_generic(media_id: int):
 @medias_bp.route("/api/medias/<int:media_id>/vote", methods=["POST"])
 @medias_bp.arguments(MediaVoteRequestSchema)
 @medias_bp.response(200, MediaVoteResponseSchema)
-@medias_bp.alt_response(400, description="region_box is malformed, or a bad-vote carries a region_box.")
+@medias_bp.alt_response(400, description="region_box is malformed, or a non-good target carries a region_box.")
 @medias_bp.alt_response(404, description="Media not found.")
 def vote_media(body: dict, media_id: int):
-    """Record or toggle a good/bad vote for a single media item.
+    """Set a single media's vote to an **absolute target state**.
 
-    Voting behaviour (toggle semantics):
+    ``target`` is one of:
 
-    - If ``vote == "good"`` and the media is already in ``good_votes``, the
-      vote is *removed* (toggled off).
-    - If ``vote == "good"`` and the media is not yet in ``good_votes``, it is
-      added to ``good_votes`` (removed from ``bad_votes`` if present) and the
-      event is appended to ``label_history``.
-    - The same toggle logic applies symmetrically for ``vote == "bad"``.
+    - ``"good"`` — set to good (overrides ``bad`` if present).
+    - ``"bad"`` — set to bad (overrides ``good`` if present).
+    - ``"none"`` — un-vote (remove any existing vote).
 
-    Yes-votes may carry ``"region_box": [x0, y0, x1, y1]`` (normalised image
-    coords in ``[0, 1]``) to designate the good region. No-votes that
-    include ``region_box`` are rejected — by design no-votes are
-    image-level always (patch-embedder v2).
+    Behaviour is **idempotent**: sending the current state is a no-op
+    that does not append to ``label_history``, does not credit
+    achievements, and returns the existing click-time.  This is the
+    fix for logical-bug-audit H1 — two stale-view tabs that race the
+    same media no longer alternate ADD/REMOVE on the server, so the
+    achievement counter no longer inflates beyond the number of real
+    labeling decisions.
+
+    Yes-targets may carry ``"region_box": [x0, y0, x1, y1]`` (normalised
+    image coords in ``[0, 1]``) to designate the good region.
+    ``"bad"`` and ``"none"`` targets must not include ``region_box`` — by
+    design no-votes are image-level always (patch-embedder v2).
+
+    Returns ``{"ok": true, "state": <new state>, "click_time": <int|null>}``
+    so the client can reconcile its optimistic view directly from the
+    response.
     """
     if get_media(media_id) is None:
         abort(404, message="not found")
 
-    vote = body["vote"]
+    target = body["target"]
 
     try:
         region_box = _parse_region_box(body.get("region_box"))
     except ValueError as exc:
         abort(400, message=str(exc))
-    if vote == "bad" and region_box is not None:
-        abort(400, message="no-votes cannot carry a region_box")
+    if target != "good" and region_box is not None:
+        abort(400, message="region_box is only valid on 'good' targets")
 
-    toggle_vote(media_id, vote, region_box=region_box)
+    _old, new_state, click_time = set_vote(media_id, target, region_box=region_box)
 
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
 
@@ -560,7 +569,7 @@ def vote_media(body: dict, media_id: int):
 
     sync_to_labelset_source()
 
-    return {"ok": True}
+    return {"ok": True, "state": new_state, "click_time": click_time}
 
 
 @medias_bp.route("/api/medias/add-to-pile", methods=["POST"])

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -130,20 +130,33 @@ class MediaBatchResponseSchema(_MediaBatchEntrySchema):
 class MediaVoteRequestSchema(Schema):
     """Body for ``POST /api/medias/<id>/vote``.
 
+    The endpoint uses **absolute-target** semantics: ``target`` is the
+    state the caller wants the media to be in after the call.  Repeats
+    are idempotent — sending ``target="good"`` on a media that's already
+    good does nothing, does not append to ``label_history``, and does
+    not credit achievements.  This closes the H1 counter-inflation race
+    where two stale-view tabs each thought they were toggling the same
+    media and the server alternated ADD/REMOVE on every click.
+
     ``region_box`` is a 4-tuple of normalised image coords (``[x0, y0,
     x1, y1]`` in ``[0, 1]``). Per the patch-embedder v2 design, only
-    good votes may carry a region; the handler rejects bad votes with a
-    region_box.
+    good votes may carry a region; the handler rejects ``"bad"`` /
+    ``"none"`` targets that carry a region_box.
 
     Unknown fields are silently dropped so the frontend can attach
     advisory keys (e.g. ``confidence``, ``note``) without breaking the
     schema check.
     """
 
-    vote = fields.String(
+    target = fields.String(
         required=True,
-        validate=validate.OneOf(["good", "bad"]),
-        metadata={"description": "``good`` or ``bad``."},
+        validate=validate.OneOf(["good", "bad", "none"]),
+        metadata={
+            "description": (
+                "Absolute target state: ``good``, ``bad``, or ``none`` "
+                "(un-vote). Idempotent."
+            ),
+        },
     )
     region_box = fields.List(
         fields.Float(),
@@ -151,7 +164,7 @@ class MediaVoteRequestSchema(Schema):
         metadata={
             "description": (
                 "Optional 4-element ``[x0, y0, x1, y1]`` in normalised image "
-                "coordinates ``[0, 1]``. Only valid on good votes."
+                "coordinates ``[0, 1]``. Only valid when ``target`` is ``good``."
             ),
         },
     )
@@ -161,9 +174,30 @@ class MediaVoteRequestSchema(Schema):
 
 
 class MediaVoteResponseSchema(Schema):
-    """Response for ``POST /api/medias/<id>/vote`` (success path)."""
+    """Response for ``POST /api/medias/<id>/vote`` (success path).
+
+    Returns the post-call state so the client can reconcile its optimistic
+    view without needing a follow-up ``GET /api/votes``.  ``click_time`` is
+    the ordinal assigned when the target is ``good``/``bad`` and the call
+    actually changed the state; ``null`` on un-vote and on idempotent calls.
+    """
 
     ok = fields.Boolean(required=True)
+    state = fields.String(
+        required=True,
+        validate=validate.OneOf(["good", "bad", "none"]),
+        metadata={"description": "The media's vote state after the call."},
+    )
+    click_time = fields.Integer(
+        required=True,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Click-time ordinal of the new label, or ``null`` when the "
+                "target is ``none`` or the call was a no-op."
+            ),
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -152,10 +152,7 @@ class MediaVoteRequestSchema(Schema):
         required=True,
         validate=validate.OneOf(["good", "bad", "none"]),
         metadata={
-            "description": (
-                "Absolute target state: ``good``, ``bad``, or ``none`` "
-                "(un-vote). Idempotent."
-            ),
+            "description": ("Absolute target state: ``good``, ``bad``, or ``none`` (un-vote). Idempotent."),
         },
     )
     region_box = fields.List(
@@ -193,8 +190,7 @@ class MediaVoteResponseSchema(Schema):
         allow_none=True,
         metadata={
             "description": (
-                "Click-time ordinal of the new label, or ``null`` when the "
-                "target is ``none`` or the call was a no-op."
+                "Click-time ordinal of the new label, or ``null`` when the target is ``none`` or the call was a no-op."
             ),
         },
     )

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -72,6 +72,7 @@ from vtscore.state import (  # noqa: F401
     set_safe_thresholds,
     set_thread_dataset_context,
     set_thread_detector_context,
+    set_vote,
     snapshot_medias,
     toggle_vote,
     unregister_context,


### PR DESCRIPTION
## Summary

Closes logical-bug-audit **H1** — "Vote-progress invalidation / `record_vote` race when the same media is rapid-toggled across two tabs; counter inflates while in-memory shows one vote."

The pre-existing `POST /api/medias/<id>/vote` decided ADD-vs-REMOVE from server-side state, so two stale-view tabs each thought they were toggling the same media and the server alternated ADD/REMOVE every click. Each ADD bumped `votes_cast` / `click_counter` / `vote_streak`; the user perceived a single vote while counters silently inflated. The frontend's `pendingOptimistic` preservation logic locked clients into a permanent prediction-vs-server desync whenever the prediction happened to disagree with the server.

This PR replaces the toggle contract with an **absolute-target** one:

- Request body becomes `target: "good" | "bad" | "none"` (breaking — the old `vote` field is rejected with 422).
- Server delegates to a new `vtscore.state.votes.set_vote(media_id, target, region_box)` that is **idempotent** when `target` equals the current state: no `label_history` append, no achievement credit, no click-time bump, no progress-cache churn. Concurrent stale-tab POSTs collapse into one transition per real state change.
- Progress cache is now invalidated on **any** training-set membership change for the affected media (was: polarity flips only — un-vote left stale cached models alive).
- Response shape grew `state` + `click_time` so the Angular client reconciles directly from the POST result.
- `VoteStateService` was rewritten around a single `submitToggleVote()` entry point that computes the target from current local state and clears `pendingOptimistic` deterministically on every POST return via `reconcileVoteResponse()`, dismantling the persistent-desync half of the bug.
- An idempotent good-revote with an explicit new `region_box` updates the region in place (drawing a new box is intentional); an idempotent revote *without* a region_box leaves the existing one alone (so a stale-view tab can't wipe a region another tab just set).

The detector-label vote endpoint (`POST /api/detectors/<name>/labels/<element_id>/vote`) still uses toggle semantics on the on-disk labelset element — converting that surface is recorded in `docs/plans/logical-bug-audit.md` under "Open follow-ups → H1 follow-up".

## Test plan

- [x] `python -m pytest tests/ tests_lib/ -q -m 'not gpu'` → **3981 passed, 1 skipped**
- [x] `cd frontend && npm run build:prod` → clean build, no Angular warnings
- [x] `ruff check . && ruff format --check .` → clean
- [x] `pyright` → 0 errors (one pre-existing warning in `vtscore/plugins/inventory.py` unrelated to this PR)
- [x] OpenAPI snapshot regenerated and verified drift-free against the committed `frontend/openapi.json`
- [x] New regression coverage:
  - `tests/core/test_votes.py::TestVoteClip::test_idempotent_re_vote_good` / `_bad`
  - `tests/core/test_votes.py::TestVoteClip::test_legacy_vote_field_rejected`
  - `tests/core/test_votes.py::TestLabelHistory::test_idempotent_re_vote_does_not_grow_history`
  - `tests/core/test_votes.py::TestProgressCacheInvalidatedOnVoteSwitch::test_unvote_invalidates_cache_from_first_appearance` / `_when_media_was_in_first_step`
  - `tests/api/test_error_recovery.py::test_rapid_idempotent_re_votes_are_no_ops`
  - `tests/core/test_achievements.py::test_idempotent_re_vote_does_not_increment`
  - `tests/api/test_api_contracts.py::TestVoteContract::test_vote_response_*`
  - `tests/detectors/test_patch_embedder.py::TestVoteEndpointRegionBox::test_idempotent_revote_with_new_region_box_replaces_in_place` / `test_replacing_region_box_via_unvote_then_revote`
  - `frontend/src/app/services/vote-state.service.spec.ts` (`submitToggleVote`, `polling interaction with optimistic state`, `undo / redo stack`)

## Out of scope (recorded as follow-ups)

The labelset element vote endpoint (`/api/detectors/<name>/labels/<element_id>/vote`) and `apply_element_vote_in_data` still toggle — they have the same kind of inflation race but on a separate user surface. Documented in `docs/plans/logical-bug-audit.md` under "Open follow-ups → H1 follow-up: labelset element vote endpoint still toggles."

https://claude.ai/code/session_017GtWMt87C2HZxsRMNbS3LP

---
_Generated by [Claude Code](https://claude.ai/code/session_016LxrEGefWxL5u2wpJo8tnv)_