### PR TITLE
H14: atomic VoteSnapshot for cross-dataset-safe label composition

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -148,10 +148,7 @@ Cross-section interaction agents:
   `vtsearch/routes/media/list.py` L524–563. Missing `X-Dataset-Id`
   falls back to whatever the context proxy resolves to; vote applies
   to wrong media.
-- **H14. `export_labels` leaks votes across datasets** —
-  `vtsearch/routes/labels/vote.py` L146–162. `good_votes` / `bad_votes`
-  are detector-scoped, not dataset-scoped. Re-using a detector across
-  datasets bleeds votes into the export of the wrong dataset.
+- ~~**H14. `export_labels` leaks votes across datasets**~~
 - **H15. File-browser symlink-traversal** — `vtsearch/routes/file_browser.py`
   L84–92. `target.resolve().relative_to(root.resolve())` succeeds for
   `/data/link → /etc`. If the configured root contains a symlink,

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -992,20 +992,28 @@ class TestValidatedVoteSnapshot:
         assert bad_cid in snap.medias
 
     def test_snapshot_unsafe_on_dataset_mismatch(self, client):
-        """votes_dataset_id != active dataset_id → safe=False with empty vote dicts."""
+        """votes_dataset_id != active dataset_id → safe=False with empty vote dicts.
+
+        Simulates the H14 race: another thread re-keyed the detector against
+        a different dataset between ``ensure_votes_match_active_dataset()``
+        and the snapshot copy.  Patches the rehydrate to a no-op so the
+        forced mismatch survives the snapshot's own rehydrate call.
+        """
+        from vtscore.detectors import dataset_sync as _ds_sync
         from vtscore.detectors.dataset_sync import validated_vote_snapshot
         from vtscore.state.core import get_active_detector_context
 
         self._setup_detector_with_votes(client)
 
-        # Simulate a concurrent rehydrate that re-keyed the detector against a
-        # different dataset between ``before_request`` and the route body —
-        # the detector context's ``votes_dataset_id`` no longer matches the
-        # active dataset's id.
         det_ctx = get_active_detector_context()
-        det_ctx.votes_dataset_id = "some_other_dataset_id"
+        original = _ds_sync.ensure_votes_match_active_dataset
+        _ds_sync.ensure_votes_match_active_dataset = lambda: None
+        try:
+            det_ctx.votes_dataset_id = "some_other_dataset_id"
+            snap = validated_vote_snapshot()
+        finally:
+            _ds_sync.ensure_votes_match_active_dataset = original
 
-        snap = validated_vote_snapshot()
         assert snap.safe is False
         assert snap.good_votes == {}
         assert snap.bad_votes == {}

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1071,7 +1071,7 @@ class TestValidatedVoteSnapshot:
         path = _detector_path(det_ctx.name)
         data = _read_detector(path)
         assert data is not None
-        labels_before = data.get("labelset", {}).get("elements", [])
+        labels_before = data.get("labelset", {}).get("labels", [])
         assert len(labels_before) >= 2
 
         # Simulate the race: votes_dataset_id mismatches active dataset, and
@@ -1089,7 +1089,7 @@ class TestValidatedVoteSnapshot:
 
         # The on-disk labelset must be unchanged.
         data_after = _read_detector(path)
-        labels_after = data_after.get("labelset", {}).get("elements", [])
+        labels_after = data_after.get("labelset", {}).get("labels", [])
         assert len(labels_after) == len(labels_before), (
             "sync should have bailed on safe=False, not erased on-disk labels"
         )

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -933,6 +933,160 @@ class TestLoadModelEndpoint:
         assert a_bad not in bad_votes, "bad cid from dataset A leaked into dataset B's id-space"
 
 
+class TestValidatedVoteSnapshot:
+    """``validated_vote_snapshot`` must atomically pair medias + votes (H14).
+
+    The H14 audit finding identified that ``good_votes`` / ``bad_votes`` are
+    detector-scoped while ``medias`` is dataset-scoped, and composing them
+    without an atomic snapshot allows a concurrent rehydrate on the same
+    detector against a different dataset to slip in between the
+    ``before_request`` rehydrate and the route body, leaking cross-dataset
+    cids into the export and corrupting on-disk writes.
+
+    The helper :func:`vtscore.detectors.dataset_sync.validated_vote_snapshot`
+    captures both contexts under a single ``_state_lock`` acquisition and
+    refuses to compose (``safe=False``) when ``votes_dataset_id`` doesn't
+    match the active dataset.
+    """
+
+    def _setup_detector_with_votes(self, client):
+        """Create a detector, load it, cast one good + one bad vote.
+
+        Returns ``(detector_id, good_cid, bad_cid)``.
+        """
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+        ids = list(medias.keys())
+        if len(ids) < 2:
+            pytest.skip("Need at least 2 medias")
+        good_cid, bad_cid = ids[0], ids[1]
+
+        client.post(
+            "/api/detectors",
+            json={"name": "SnapshotTest", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "SnapshotTest", "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, detector_id)
+
+        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        return detector_id, good_cid, bad_cid
+
+    def test_snapshot_safe_when_aligned(self, client):
+        """Happy path: votes_dataset_id matches active dataset → safe=True with full votes."""
+        from vtscore.detectors.dataset_sync import validated_vote_snapshot
+
+        _, good_cid, bad_cid = self._setup_detector_with_votes(client)
+
+        snap = validated_vote_snapshot()
+        assert snap.safe is True
+        assert good_cid in snap.good_votes
+        assert bad_cid in snap.bad_votes
+        assert good_cid in snap.medias
+        assert bad_cid in snap.medias
+
+    def test_snapshot_unsafe_on_dataset_mismatch(self, client):
+        """votes_dataset_id != active dataset_id → safe=False with empty vote dicts."""
+        from vtscore.detectors.dataset_sync import validated_vote_snapshot
+        from vtscore.state.core import get_active_detector_context
+
+        self._setup_detector_with_votes(client)
+
+        # Simulate a concurrent rehydrate that re-keyed the detector against a
+        # different dataset between ``before_request`` and the route body —
+        # the detector context's ``votes_dataset_id`` no longer matches the
+        # active dataset's id.
+        det_ctx = get_active_detector_context()
+        det_ctx.votes_dataset_id = "some_other_dataset_id"
+
+        snap = validated_vote_snapshot()
+        assert snap.safe is False
+        assert snap.good_votes == {}
+        assert snap.bad_votes == {}
+        assert snap.vote_region_boxes == {}
+        # ``medias`` is always populated from the live active dataset.
+        assert snap.medias, "medias should still be populated on safe=False"
+
+    def test_export_returns_empty_on_safe_false(self, client):
+        """/api/labels/export must not leak cross-dataset cids when snapshot is unsafe."""
+        from vtscore.state.core import get_active_detector_context
+
+        self._setup_detector_with_votes(client)
+
+        # Sanity: with aligned state we get the labels back.
+        resp = client.get("/api/labels/export")
+        assert resp.status_code == 200
+        assert len(resp.get_json()["labels"]) >= 2
+
+        # Now corrupt votes_dataset_id and re-export.  The route's
+        # ``ensure_votes_match_active_dataset`` will try to rehydrate but the
+        # detector file has been written to disk, so it'll match the active
+        # dataset again — verify by going around the rehydrate's mtime cache.
+        # Simplest: directly corrupt the detector's vote dicts to simulate a
+        # post-rehydrate mismatch (e.g. another thread re-flipped them).
+        det_ctx = get_active_detector_context()
+        # Force a state where votes_dataset_id can't match (the race outcome).
+        # We monkey-patch ensure_votes_match_active_dataset to be a no-op so
+        # the corruption survives the before_request hook.
+        from vtscore.detectors import dataset_sync as _ds_sync
+
+        original = _ds_sync.ensure_votes_match_active_dataset
+        _ds_sync.ensure_votes_match_active_dataset = lambda: None
+        try:
+            det_ctx.votes_dataset_id = "stale_dataset_id"
+            resp = client.get("/api/labels/export")
+            assert resp.status_code == 200
+            # safe=False degrades the vote dicts to empty, so no labels
+            # are composed — no cross-dataset cid leakage.
+            assert resp.get_json()["labels"] == []
+        finally:
+            _ds_sync.ensure_votes_match_active_dataset = original
+
+    def test_sync_labels_to_disk_skips_on_safe_false(self, client):
+        """``sync_labels_to_loaded_detector`` must not erase on-disk labels under race."""
+        from vtscore.detectors import dataset_sync as _ds_sync
+        from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
+        from vtscore.detectors.store import _detector_path, _read_detector
+        from vtscore.state.core import get_active_detector_context
+
+        _, good_cid, bad_cid = self._setup_detector_with_votes(client)
+
+        # After the votes were cast, the detector JSON on disk has 2 entries.
+        # Find the on-disk path and confirm.
+        det_ctx = get_active_detector_context()
+        path = _detector_path(det_ctx.name)
+        data = _read_detector(path)
+        assert data is not None
+        labels_before = data.get("labelset", {}).get("elements", [])
+        assert len(labels_before) >= 2
+
+        # Simulate the race: votes_dataset_id mismatches active dataset, and
+        # the rehydrate hook is bypassed (so the mismatch survives).  Without
+        # the safe=False guard, ``_merge_labelsets_across_datasets`` would
+        # drop the active dataset's existing entries and replace them with an
+        # empty composition — erasing labels from disk.
+        original = _ds_sync.ensure_votes_match_active_dataset
+        _ds_sync.ensure_votes_match_active_dataset = lambda: None
+        try:
+            det_ctx.votes_dataset_id = "stale_dataset_id"
+            sync_labels_to_loaded_detector()
+        finally:
+            _ds_sync.ensure_votes_match_active_dataset = original
+
+        # The on-disk labelset must be unchanged.
+        data_after = _read_detector(path)
+        labels_after = data_after.get("labelset", {}).get("elements", [])
+        assert len(labels_after) == len(labels_before), (
+            "sync should have bailed on safe=False, not erased on-disk labels"
+        )
+
+
 class TestVoteSyncsToLoadedModel:
     """Voting while a detector is loaded should auto-update the model's labelset."""
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1089,6 +1089,7 @@ class TestValidatedVoteSnapshot:
 
         # The on-disk labelset must be unchanged.
         data_after = _read_detector(path)
+        assert data_after is not None
         labels_after = data_after.get("labelset", {}).get("labels", [])
         assert len(labels_after) == len(labels_before), (
             "sync should have bailed on safe=False, not erased on-disk labels"

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -165,18 +165,24 @@ class VoteSnapshot(NamedTuple):
 def validated_vote_snapshot() -> VoteSnapshot:
     """Return an atomic, internally-consistent (dataset, detector) snapshot.
 
-    Runs :func:`ensure_votes_match_active_dataset` and then takes shallow
-    copies of medias + vote dicts under ``_state_lock`` so the returned vote
-    dicts are guaranteed to have been derived against the same dataset whose
-    medias are in the returned snap.  Callers should operate on the copies;
-    the live contexts can be mutated by other requests in the meantime.
+    Takes shallow copies of medias + vote dicts under a single ``_state_lock``
+    acquisition so the returned vote dicts are guaranteed to be derived
+    against the same dataset whose medias are in the returned snap.  Callers
+    should operate on the copies; the live contexts can be mutated by other
+    requests in the meantime.
+
+    The rehydrate that aligns ``votes_dataset_id`` with the active dataset
+    is the responsibility of :func:`ensure_votes_match_active_dataset` in
+    ``before_request`` — calling it again here would double-clear vote dicts
+    that test code or in-flight mutations have already populated.
 
     Refuses to compose when the snapshot cannot be made safe.  Returns
-    ``safe=False`` (with empty vote dicts) in any of these cases (all of
-    which would otherwise allow cross-dataset cid leakage):
+    ``safe=False`` (with empty vote dicts) when the detector's vote state is
+    stamped for a different dataset than the one whose medias the snapshot
+    is taken from:
 
     * A concurrent request on the same detector rehydrated against a
-      different dataset between our rehydrate call and this lock acquisition
+      different dataset between ``before_request`` and this lock acquisition
       (the H14 concurrency race).
     * The detector has no registry entry / on-disk file, so the rehydrate
       bailed early and left stale cids from a previous dataset in place.
@@ -186,9 +192,9 @@ def validated_vote_snapshot() -> VoteSnapshot:
 
     The ``medias`` field is always populated from whatever the active
     dataset context resolves to (empty when the header is missing).  When no
-    detector is loaded at all, the snapshot is considered safe (the empty
-    fallback detector has empty votes by construction, so there's nothing
-    to leak).
+    detector is loaded at all, or when ``votes_dataset_id`` is empty (no
+    rehydrate has ever stamped it — typical for a brand-new detector with
+    no votes), the snapshot is considered safe by construction.
     """
     from vtscore.state.core import (
         _state_lock,
@@ -196,17 +202,29 @@ def validated_vote_snapshot() -> VoteSnapshot:
         get_active_detector_context,
     )
 
-    ensure_votes_match_active_dataset()
     with _state_lock:
         ds_ctx = get_active_context()
         det_ctx = get_active_detector_context()
         snap = dict(ds_ctx.medias)
         # Compose votes only when we can prove they're keyed in the active
-        # dataset's cid space.  ``votes_dataset_id == ds_ctx.dataset_id`` is
-        # the post-rehydrate invariant; if it doesn't hold here, something
-        # bypassed or raced past the rehydrate and the cid dicts are not
-        # safe to pair with ``snap``.
-        if det_ctx.detector_id and det_ctx.votes_dataset_id != ds_ctx.dataset_id:
+        # dataset's cid space.  Two cases are safe to compose:
+        #   1. ``votes_dataset_id == ds_ctx.dataset_id`` — the post-rehydrate
+        #      invariant holds; the cid dicts are derived against the active
+        #      dataset.
+        #   2. ``votes_dataset_id == ""`` — the detector has never been
+        #      stamped against any dataset, which in production means no
+        #      votes have ever been cast (vote-casting goes through paths
+        #      that stamp the id).  Composing empty vote dicts is harmless,
+        #      and short-circuiting here lets save / sync endpoints work
+        #      against newly-created detectors that haven't been loaded.
+        # The remaining case — non-empty ``votes_dataset_id`` that doesn't
+        # match the active dataset — is the race / stale-state scenario and
+        # is the only one we refuse to compose for.
+        if (
+            det_ctx.detector_id
+            and det_ctx.votes_dataset_id
+            and det_ctx.votes_dataset_id != ds_ctx.dataset_id
+        ):
             return VoteSnapshot(snap, {}, {}, {}, safe=False)
         return VoteSnapshot(
             snap,

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -12,9 +12,18 @@ silently writes corrupt entries back to the on-disk labelset.
 The on-disk labelset is the canonical source of truth (dataset-agnostic — its
 elements are keyed by origin / md5).  This module re-derives the cid dicts
 from that labelset whenever the active dataset has changed.
+
+The companion helper :func:`validated_vote_snapshot` extends that defense to
+read/write paths: it runs the rehydrate and then atomically copies the active
+dataset's medias and the active detector's vote dicts under a single
+``_state_lock`` acquisition, so a concurrent rehydrate on the same detector
+against a different dataset can't slip in between the rehydrate and the
+composition.
 """
 
 from __future__ import annotations
+
+from typing import Any, NamedTuple
 
 
 def _detector_file_mtime(path) -> float:
@@ -126,3 +135,83 @@ def ensure_votes_match_active_dataset() -> None:
         det_ctx.cached_labelset = LabelSet.from_dict(data.get("labelset") or {})
         det_ctx.cached_labelset_mtime = refreshed_mtime
         det_ctx.cached_labelset_media_type = data.get("media_type", "") or ""
+
+
+class VoteSnapshot(NamedTuple):
+    """Atomic, internally-consistent (dataset, detector) state snapshot.
+
+    Holds shallow copies of the active dataset's ``medias`` and the active
+    detector's cid-keyed vote dicts, all captured under a single
+    ``_state_lock`` acquisition.  Composing the four fields is safe because
+    they were taken together — subsequent mutations to the live contexts
+    cannot leak into a held snapshot.
+
+    ``safe`` reports whether the vote dicts could be proved to be keyed in
+    the snapshot's medias' cid space.  When ``safe`` is False, ``good_votes``
+    / ``bad_votes`` / ``vote_region_boxes`` are returned empty (so read paths
+    that just compose with ``medias`` degrade to an empty result instead of
+    leaking cross-dataset cids).  Write paths that would replace on-disk
+    state must check ``safe`` and skip the write — otherwise an empty
+    composition would erase legitimate labels for the active dataset.
+    """
+
+    medias: dict[int, dict[str, Any]]
+    good_votes: dict[int, None]
+    bad_votes: dict[int, None]
+    vote_region_boxes: dict[int, tuple[float, float, float, float]]
+    safe: bool
+
+
+def validated_vote_snapshot() -> VoteSnapshot:
+    """Return an atomic, internally-consistent (dataset, detector) snapshot.
+
+    Runs :func:`ensure_votes_match_active_dataset` and then takes shallow
+    copies of medias + vote dicts under ``_state_lock`` so the returned vote
+    dicts are guaranteed to have been derived against the same dataset whose
+    medias are in the returned snap.  Callers should operate on the copies;
+    the live contexts can be mutated by other requests in the meantime.
+
+    Refuses to compose when the snapshot cannot be made safe.  Returns
+    ``safe=False`` (with empty vote dicts) in any of these cases (all of
+    which would otherwise allow cross-dataset cid leakage):
+
+    * A concurrent request on the same detector rehydrated against a
+      different dataset between our rehydrate call and this lock acquisition
+      (the H14 concurrency race).
+    * The detector has no registry entry / on-disk file, so the rehydrate
+      bailed early and left stale cids from a previous dataset in place.
+    * The active dataset has empty id (no ``X-Dataset-Id`` header on the
+      request, or an id that refers to an unloaded dataset) while the
+      detector's vote state was previously stamped for a real dataset.
+
+    The ``medias`` field is always populated from whatever the active
+    dataset context resolves to (empty when the header is missing).  When no
+    detector is loaded at all, the snapshot is considered safe (the empty
+    fallback detector has empty votes by construction, so there's nothing
+    to leak).
+    """
+    from vtscore.state.core import (
+        _state_lock,
+        get_active_context,
+        get_active_detector_context,
+    )
+
+    ensure_votes_match_active_dataset()
+    with _state_lock:
+        ds_ctx = get_active_context()
+        det_ctx = get_active_detector_context()
+        snap = dict(ds_ctx.medias)
+        # Compose votes only when we can prove they're keyed in the active
+        # dataset's cid space.  ``votes_dataset_id == ds_ctx.dataset_id`` is
+        # the post-rehydrate invariant; if it doesn't hold here, something
+        # bypassed or raced past the rehydrate and the cid dicts are not
+        # safe to pair with ``snap``.
+        if det_ctx.detector_id and det_ctx.votes_dataset_id != ds_ctx.dataset_id:
+            return VoteSnapshot(snap, {}, {}, {}, safe=False)
+        return VoteSnapshot(
+            snap,
+            dict(det_ctx.good_votes),
+            dict(det_ctx.bad_votes),
+            dict(det_ctx.vote_region_boxes),
+            safe=True,
+        )

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -14,11 +14,10 @@ elements are keyed by origin / md5).  This module re-derives the cid dicts
 from that labelset whenever the active dataset has changed.
 
 The companion helper :func:`validated_vote_snapshot` extends that defense to
-read/write paths: it runs the rehydrate and then atomically copies the active
-dataset's medias and the active detector's vote dicts under a single
-``_state_lock`` acquisition, so a concurrent rehydrate on the same detector
-against a different dataset can't slip in between the rehydrate and the
-composition.
+read/write paths: it atomically copies the active dataset's medias and the
+active detector's vote dicts under a single ``_state_lock`` acquisition, so
+a concurrent rehydrate on the same detector against a different dataset
+can't slip in between the (request-boundary) rehydrate and the composition.
 """
 
 from __future__ import annotations
@@ -220,11 +219,7 @@ def validated_vote_snapshot() -> VoteSnapshot:
         # The remaining case — non-empty ``votes_dataset_id`` that doesn't
         # match the active dataset — is the race / stale-state scenario and
         # is the only one we refuse to compose for.
-        if (
-            det_ctx.detector_id
-            and det_ctx.votes_dataset_id
-            and det_ctx.votes_dataset_id != ds_ctx.dataset_id
-        ):
+        if det_ctx.detector_id and det_ctx.votes_dataset_id and det_ctx.votes_dataset_id != ds_ctx.dataset_id:
             return VoteSnapshot(snap, {}, {}, {}, safe=False)
         return VoteSnapshot(
             snap,

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -123,17 +123,26 @@ def sync_labels_to_loaded_detector() -> None:
     entry, path, data, det_ctx = state
 
     from vtscore.datasets.labelset import media_element_key
+    from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.registry import update_detector
     from vtscore.detectors.store import _write_detector
-    from vtsearch.state import bad_votes, good_votes, snapshot_medias, vote_region_boxes
 
-    snap = snapshot_medias()
+    vote_snap = validated_vote_snapshot()
+    if not vote_snap.safe:
+        # Vote dicts can't be proved keyed in the active dataset's cid space
+        # (concurrent dataset switch on the same detector, missing
+        # ``X-Dataset-Id`` header, or no registry entry).  Writing now with
+        # an empty composition would erase the active dataset's on-disk
+        # labels — drop this sync; the next vote will trigger another that
+        # runs against a consistent snapshot.
+        return
+    snap = vote_snap.medias
     current_ls = LabelSet.from_clips_and_votes(
         snap,
-        good_votes,
-        bad_votes,
+        vote_snap.good_votes,
+        vote_snap.bad_votes,
         expand_dupes=False,
-        vote_region_boxes=dict(vote_region_boxes),
+        vote_region_boxes=vote_snap.vote_region_boxes,
     )
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 

--- a/vtscore/labels/sync.py
+++ b/vtscore/labels/sync.py
@@ -222,9 +222,9 @@ def _push_to_labelset_source() -> None:
     field_values = cfg.get("field_values", {})
 
     from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.input_spec import build_detector_meta
     from vtscore.detectors.store import _detector_path, _read_detector
-    from vtscore.state.core import get_active_context
 
     # Read the detector JSON so the exported labelset can carry its
     # input_spec / media_type alongside the in-memory threshold.  Anything
@@ -240,12 +240,21 @@ def _push_to_labelset_source() -> None:
         if _syncing:
             return
         try:
-            ds_ctx = get_active_context()
+            # Atomic snapshot so the votes we serialise are guaranteed to be
+            # keyed in the same dataset's cid space as the medias they're
+            # composed with — even under concurrent dataset-switch requests
+            # on the same detector.  ``safe=False`` means we couldn't prove
+            # consistency; pushing an empty labelset would clobber whatever
+            # the external source has, so we skip this push and let the next
+            # vote re-trigger the debounced timer.
+            vote_snap = validated_vote_snapshot()
+            if not vote_snap.safe:
+                return
             labelset = LabelSet.from_clips_and_votes(
-                dict(ds_ctx.medias),
-                dict(ctx.good_votes),
-                dict(ctx.bad_votes),
-                vote_region_boxes=dict(ctx.vote_region_boxes),
+                vote_snap.medias,
+                vote_snap.good_votes,
+                vote_snap.bad_votes,
+                vote_region_boxes=vote_snap.vote_region_boxes,
                 detector_meta=detector_meta or None,
             )
             source.save(labelset, field_values)

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -106,6 +106,9 @@ _DEFAULT_MIMETYPE_BY_TYPE = {
 @detectors_labels_bp.route("/api/detectors/<name>/labels", methods=["POST"])
 @detectors_labels_bp.response(200, DetectorSaveLabelsResponseSchema)
 @detectors_labels_bp.alt_response(404, description="Detector not found.")
+@detectors_labels_bp.alt_response(
+    409, description="Detector vote state is not aligned with the active dataset."
+)
 def save_detector_labels(name: str):
     """Save the current votes as the detector's labelset.
 
@@ -118,21 +121,23 @@ def save_detector_labels(name: str):
         abort(404, message=f"Detector '{name}' not found")
 
     from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtsearch.state import (
-        bad_votes,
-        good_votes,
-        snapshot_medias,
-        vote_region_boxes,
-    )
 
-    medias_snap = snapshot_medias()
+    snap = validated_vote_snapshot()
+    if not snap.safe:
+        # Refuse to overwrite the on-disk labelset with an empty composition
+        # when the (dataset, detector) state can't be proved consistent.
+        # Surfacing 409 lets the frontend retry on a stable request instead
+        # of silently destroying labels.
+        abort(409, message="Cannot save labels: detector vote state is not aligned with the active dataset")
+    medias_snap = snap.medias
     labelset = LabelSet.from_clips_and_votes(
         medias_snap,
-        good_votes,
-        bad_votes,
+        snap.good_votes,
+        snap.bad_votes,
         expand_dupes=False,
-        vote_region_boxes=dict(vote_region_boxes),
+        vote_region_boxes=snap.vote_region_boxes,
     )
     data["labelset"] = labelset.to_dict()
 

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -106,9 +106,7 @@ _DEFAULT_MIMETYPE_BY_TYPE = {
 @detectors_labels_bp.route("/api/detectors/<name>/labels", methods=["POST"])
 @detectors_labels_bp.response(200, DetectorSaveLabelsResponseSchema)
 @detectors_labels_bp.alt_response(404, description="Detector not found.")
-@detectors_labels_bp.alt_response(
-    409, description="Detector vote state is not aligned with the active dataset."
-)
+@detectors_labels_bp.alt_response(409, description="Detector vote state is not aligned with the active dataset.")
 def save_detector_labels(name: str):
     """Save the current votes as the detector's labelset.
 

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -18,16 +18,13 @@ from vtsearch.schemas.labels import (
     LabelsImportRequestSchema,
     LabelsImportResponseSchema,
 )
+from vtscore.detectors.dataset_sync import validated_vote_snapshot
 from vtsearch.state import (
     apply_label,
     apply_label_with_click_time,
-    bad_votes,
     build_media_lookup,
-    get_media,
-    good_votes,
     resolve_media_ids,
     snapshot_medias,
-    vote_region_boxes,
 )
 from vtscore.utils.hits import build_media_hit
 
@@ -40,12 +37,22 @@ labels_bp = Blueprint(
 )
 
 
-def _select_vote_pools(label_filter: str, goods_only: bool) -> tuple[dict, dict]:
+def _select_vote_pools(
+    label_filter: str,
+    goods_only: bool,
+    good_votes: dict[int, None],
+    bad_votes: dict[int, None],
+) -> tuple[dict, dict]:
     """Pick the (goods, bads) dicts to feed into ``LabelSet.from_clips_and_votes``.
 
     ``label_filter == "corrections"`` returns both pools — the corrections
     filtering step happens after annotation, since "correction" depends on
     the find-initial labels, not on good vs bad.
+
+    Takes the vote dicts as parameters (rather than reading the module-level
+    proxies) so the caller can pass an atomic snapshot from
+    :func:`validated_vote_snapshot`, guaranteed to be keyed in the same
+    dataset's cid space as the medias being composed with.
     """
     if label_filter == "good":
         return good_votes, {}
@@ -147,14 +154,19 @@ def export_labels(query: dict):
     from vtscore.datasets.labelset import LabelSet
 
     label_filter = query["label_filter"]
-    goods, bads = _select_vote_pools(label_filter, query["goods_only"])
+    # Atomic (medias, good_votes, bad_votes, vote_region_boxes) snapshot so
+    # the votes we compose with ``all_medias`` are guaranteed to be keyed in
+    # the same dataset's cid space — even if a concurrent request rehydrates
+    # the detector against a different dataset before this route finishes.
+    snap = validated_vote_snapshot()
+    goods, bads = _select_vote_pools(label_filter, query["goods_only"], snap.good_votes, snap.bad_votes)
 
-    all_medias = snapshot_medias()
+    all_medias = snap.medias
     labelset = LabelSet.from_clips_and_votes(
         all_medias,
         goods,
         bads,
-        vote_region_boxes=dict(vote_region_boxes),
+        vote_region_boxes=snap.vote_region_boxes,
     )
     result: dict = labelset.to_dict()
 
@@ -228,6 +240,15 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
     sides = body["sides"]
     confirm = body["confirm"]
 
+    # Atomic snapshot so the membership checks below use the same dataset's
+    # cid space as the medias dict — a concurrent rehydrate on the detector
+    # against a different dataset can't make us think an A-cid is "already
+    # voted" when in fact we're scoring against B's medias.
+    vote_snap = validated_vote_snapshot()
+    snap_good = vote_snap.good_votes
+    snap_bad = vote_snap.bad_votes
+    snap_medias = vote_snap.medias
+
     # Find unlabeled medias above/below threshold
     good_candidates = []
     bad_candidates = []
@@ -238,9 +259,9 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
             continue
         if not isinstance(score, (int, float)):
             continue
-        if cid in good_votes or cid in bad_votes:
+        if cid in snap_good or cid in snap_bad:
             continue
-        if get_media(cid) is None:
+        if cid not in snap_medias:
             continue
         if score >= thresh:
             good_candidates.append({"id": cid, "score": float(score)})
@@ -286,13 +307,18 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
     except Exception:
         logger.exception("fill_labels_from_sort: labelset source scheduling failed")
 
-    # Build a results dict compatible with exporters
-    snap = snapshot_medias()
-    good_hits = [build_media_hit(e["id"], snap.get(e["id"], {}), e["score"], label="good") for e in good_candidates]
-    bad_hits = [build_media_hit(e["id"], snap.get(e["id"], {}), e["score"], label="bad") for e in bad_candidates]
+    # Build a results dict compatible with exporters.  Reuse the snapshot
+    # taken at the top so the hit dicts reference the same dataset's media
+    # entries we used for membership checks.
+    good_hits = [
+        build_media_hit(e["id"], snap_medias.get(e["id"], {}), e["score"], label="good") for e in good_candidates
+    ]
+    bad_hits = [
+        build_media_hit(e["id"], snap_medias.get(e["id"], {}), e["score"], label="bad") for e in bad_candidates
+    ]
 
     media_type = "unknown"
-    for media in snap.values():
+    for media in snap_medias.values():
         media_type = media.get("type", "unknown")
         break
 

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -313,9 +313,7 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
     good_hits = [
         build_media_hit(e["id"], snap_medias.get(e["id"], {}), e["score"], label="good") for e in good_candidates
     ]
-    bad_hits = [
-        build_media_hit(e["id"], snap_medias.get(e["id"], {}), e["score"], label="bad") for e in bad_candidates
-    ]
+    bad_hits = [build_media_hit(e["id"], snap_medias.get(e["id"], {}), e["score"], label="bad") for e in bad_candidates]
 
     media_type = "unknown"
     for media in snap_medias.values():


### PR DESCRIPTION
## Summary

Fixes audit finding **H14** plus the same architectural pattern in three sibling sites.

The root cause: `good_votes` / `bad_votes` / `vote_region_boxes` live on `DetectorContext`, while `medias` lives on `DatasetContext`. Routes that compose them (export labels, save labels, sync to detector JSON, sync to external labelset source) rely on `before_request → ensure_votes_match_active_dataset` to keep the two in sync — but the rehydrate releases `_state_lock` before the route body runs, so a concurrent request on the same detector against a different dataset can re-flip `votes_dataset_id` between the rehydrate and the composition. Symptom: cross-dataset cid leakage in `/api/labels/export`, and on-disk corruption (or outright erasure) of the detector JSON + external labelset source.

## Fix

New helper `vtscore/detectors/dataset_sync.py::validated_vote_snapshot()` returns a `VoteSnapshot` NamedTuple with `medias` + `good_votes` + `bad_votes` + `vote_region_boxes` + `safe`, all copied under a single `_state_lock` acquisition. `safe=False` triggers when `det_ctx.votes_dataset_id` is set but doesn't match `ds_ctx.dataset_id` (race, missing header, unloaded dataset) — vote dicts come back empty so read paths degrade to empty results and write paths bail before clobbering disk state.

Ported four composition sites:

- `vtsearch/routes/labels/vote.py` — `export_labels` and `fill_labels_from_sort` read the snapshot; `safe=False` produces an empty export instead of leaked cids.
- `vtsearch/routes/detectors/labels.py` — `save_detector_labels` returns 409 on `safe=False` rather than overwriting the on-disk labelset with an empty composition.
- `vtscore/detectors/label_sync.py` — `sync_labels_to_loaded_detector` skips the write on `safe=False`; the next vote re-triggers a fresh sync.
- `vtscore/labels/sync.py` — `_push_to_labelset_source` skips the external push on `safe=False`; the debounced timer re-fires on the next vote.

The rehydrate itself stays at the request boundary (`before_request`) so test code and in-flight mutations that populate vote dicts outside the rehydrate machinery still work as expected — the lock + dataset-id check is the actual correctness guarantee.

Marked H14 as shipped in `docs/plans/logical-bug-audit.md`.

## Test plan

- [x] `tests/detectors/test_detectors.py::TestValidatedVoteSnapshot` — 4 new tests:
  - Happy-path snapshot returns `safe=True` with full votes
  - Forced `votes_dataset_id` mismatch (with rehydrate patched out) → `safe=False` + empty vote dicts
  - `/api/labels/export` returns empty (not leaked cids) when snapshot is unsafe
  - `sync_labels_to_loaded_detector` does not erase on-disk labels under simulated race
- [x] All 3870 non-frontend tests pass; ruff, codespell, deptry, pyright all clean.
- [x] Frontend tests (104) pass after Angular build.
- [ ] pip-audit reports 10 pre-existing CVEs in `joblib` / `pyjwt` / `transformers` — present on `origin/dev`, out of scope for this fix.

https://claude.ai/code/session_018y8YN634AQDrdS7iaa3uPt

---
_Generated by [Claude Code](https://claude.ai/code/session_018y8YN634AQDrdS7iaa3uPt)_