### PR TITLE
Fix H16: 409 instead of silent fallback when header names unloaded dataset/detector

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from flask import Flask, g
 from werkzeug.exceptions import MethodNotAllowed, NotFound
 
 # Import refactored modules
+from vtscore.state.core import DatasetNotLoadedError, DetectorNotLoadedError  # noqa: E402
 from vtsearch.auth import get_login_provider  # noqa: E402
 from vtscore.embedding import initialize_models, preload_predicted_embedders  # noqa: E402
 from vtsearch.routes import (  # noqa: E402
@@ -214,8 +215,12 @@ def _set_request_context():
     (``medias``, ``good_votes``, etc.) resolve to it for the duration of
     this request — without mutating global "active" state.
 
-    When the headers are absent the proxies fall back to the global active
-    pointers, preserving backward compatibility.
+    When a header is absent the proxies fall back to the thread-local /
+    empty context. When a header is **present but names an unloaded id**,
+    the unloaded id is stashed on ``g`` so the resolver raises
+    ``DatasetNotLoadedError`` / ``DetectorNotLoadedError`` on proxy
+    access (mapped to 409). Routes that never touch the proxies still
+    respond normally — see logical-bug-audit H16.
 
     Any failure here must not 500 every subsequent request — fall back to
     the default (empty) context.
@@ -235,12 +240,22 @@ def _set_request_context():
             ctx = get_context(ds_id)
             if ctx is not None:
                 g._dataset_context = ctx
+            else:
+                # Header refers to a dataset that isn't loaded.  Stash the id
+                # so the resolver raises DatasetNotLoadedError at proxy
+                # access — silent fallback to the empty context hid stale
+                # results from the client (logical-bug-audit H16).  Routes
+                # that never touch the dataset proxies (registry listings,
+                # auth, file browser, etc.) still respond normally.
+                g._unloaded_dataset_id = ds_id
 
         detector_id = request.headers.get("X-Detector-Id") or request.args.get("detector_id")
         if detector_id:
             det_ctx = get_detector_context(detector_id)
             if det_ctx is not None:
                 g._detector_context = det_ctx
+            else:
+                g._unloaded_detector_id = detector_id
     except Exception:
         logging.getLogger(__name__).exception("Request context resolution failed")
 
@@ -253,6 +268,10 @@ def _set_request_context():
         from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
 
         ensure_votes_match_active_dataset()
+    except (DatasetNotLoadedError, DetectorNotLoadedError):
+        # The route handler will hit the same error when it touches the
+        # proxies; the global error handler turns it into a clean 409.
+        pass
     except Exception:
         logging.getLogger(__name__).exception("Vote rehydrate failed")
 
@@ -323,6 +342,40 @@ def _handle_405(exc):
     if not _req.path.startswith("/api/"):
         return exc
     return error_response(exc.name, 405)
+
+
+@app.errorhandler(DatasetNotLoadedError)
+def _handle_dataset_not_loaded(exc):
+    """Return a JSON 409 when ``X-Dataset-Id`` names an unloaded dataset.
+
+    Raised by the Flask resolver when a route handler touches the
+    dataset proxies and the header doesn't resolve to a loaded context.
+    Replaces the silent fallback to the empty context that returned 200
+    with stale data (logical-bug-audit H16). The frontend can
+    distinguish 409 + ``code="dataset_not_loaded"`` from a generic 500
+    and offer a load action.
+    """
+    from vtsearch.routes._shared import error_response
+
+    return error_response(
+        "Dataset is not loaded",
+        409,
+        dataset_id=exc.dataset_id,
+        code="dataset_not_loaded",
+    )
+
+
+@app.errorhandler(DetectorNotLoadedError)
+def _handle_detector_not_loaded(exc):
+    """Detector counterpart of :func:`_handle_dataset_not_loaded` (H16/H34)."""
+    from vtsearch.routes._shared import error_response
+
+    return error_response(
+        "Detector is not loaded",
+        409,
+        detector_id=exc.detector_id,
+        code="detector_not_loaded",
+    )
 
 
 @app.errorhandler(Exception)

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -156,11 +156,10 @@ Cross-section interaction agents:
   L84–92. `target.resolve().relative_to(root.resolve())` succeeds for
   `/data/link → /etc`. If the configured root contains a symlink,
   listings escape.
-- **H16. Header refers to unloaded dataset → silent fallback** —
-  `app.py` `before_request`. `ctx = get_context("nonexistent_id")`
-  returns None, `g._dataset_context` is never set, the proxy silently
-  resolves to the empty context. Client sees stale data with no
-  error.
+- ~~**H16. Header refers to unloaded dataset → silent fallback**~~ —
+  also closes the "header points to an unloaded id" half of H34 by the
+  same mechanism. The "header absent → thread-local leak" half of H34
+  remains open.
 - **H32. `add_media_to_pile` TOCTOU between md5 check and insertion** —
   `vtsearch/routes/media/list.py` L607–608 vs. L687–690. The md5
   lookup (`snap = snapshot_medias()` + `build_media_lookup(snap)`)
@@ -186,7 +185,9 @@ Cross-section interaction agents:
 - **H34. Missing `X-Detector-Id` → silent detector fallback** —
   `vtscore/state/core.py` `get_active_detector_context()` falls
   through to the thread-local (then `_empty_detector_context`) when
-  `g._detector_context` is unset. Any route that mutates votes
+  `g._detector_context` is unset. The H16 fix closed the sub-case
+  where the header is *present* but names an unloaded id (now 409);
+  the *header-absent* case remains open. Any route that mutates votes
   without requiring the header — `add_media_to_pile`, `vote_media`,
   bulk-label endpoints — silently writes to whatever the thread-local
   resolves to, which on a Flask threaded-server worker can be the

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -83,8 +83,18 @@ class TestRequestScopedDataset:
         ctx_a = get_thread_dataset_context()
         assert ctx_a is not None and ctx_a.dataset_id == "req_ds_a"
 
-    def test_header_with_unloaded_id_falls_back_to_active(self, client):
-        """If X-Dataset-Id refers to a dataset not in memory, fall back to global active."""
+    def test_header_with_unloaded_id_raises_at_proxy_access(self, client):
+        """If X-Dataset-Id names an unloaded dataset, proxy access raises (H16).
+
+        Previously this fell back silently to the thread-local / empty
+        context, returning stale data with HTTP 200. Now the resolver
+        raises ``DatasetNotLoadedError`` (mapped to 409) the moment a
+        handler touches the dataset proxies.
+        """
+        import pytest
+
+        from vtscore.state.core import DatasetNotLoadedError
+
         _make_dataset("req_fallback", [300])
         set_thread_dataset_context(get_context("req_fallback"))
 
@@ -92,10 +102,34 @@ class TestRequestScopedDataset:
 
         with app.test_request_context(headers={"X-Dataset-Id": "nonexistent"}):
             app.preprocess_request()
-            # Falls back to global active
-            ctx = get_active_context()
-            assert ctx.dataset_id == "req_fallback"
-            assert 300 in medias
+            with pytest.raises(DatasetNotLoadedError) as excinfo:
+                get_active_context()
+            assert excinfo.value.dataset_id == "nonexistent"
+            # Proxy access through the module-level name also raises.
+            with pytest.raises(DatasetNotLoadedError):
+                _ = 300 in medias
+
+    def test_header_with_unloaded_id_returns_409(self, client):
+        """End-to-end: a request with an unloaded X-Dataset-Id gets 409."""
+        _make_dataset("req_e2e_loaded", [400])
+
+        # A route that touches the medias proxy via snapshot_medias().
+        resp = client.get("/api/medias/ids", headers={"X-Dataset-Id": "nope"})
+        assert resp.status_code == 409
+        body = resp.get_json()
+        assert body["code"] == "dataset_not_loaded"
+        assert body["dataset_id"] == "nope"
+
+    def test_unloaded_header_does_not_block_routes_that_skip_proxies(self, client):
+        """Routes that don't touch the dataset proxies still respond 200.
+
+        The registry-listing endpoint operates on the global context store,
+        not on the active ``medias``, so an unloaded ``X-Dataset-Id``
+        header must not break it — clients need this endpoint precisely
+        to discover which datasets *are* loaded.
+        """
+        resp = client.get("/api/datasets/registry", headers={"X-Dataset-Id": "nope"})
+        assert resp.status_code == 200
 
     def test_no_header_uses_global_active(self, client):
         """Without the header, behaviour is identical to before (global active)."""
@@ -149,8 +183,14 @@ class TestRequestScopedModel:
         det_a = get_thread_detector_context()
         assert det_a is not None and det_a.detector_id == "req_det_a"
 
-    def test_model_header_with_unloaded_id_falls_back(self, client):
-        """If X-Detector-Id refers to a detector not in memory, fall back to global."""
+    def test_model_header_with_unloaded_id_returns_409(self, client):
+        """If X-Detector-Id names an unloaded detector, the route returns 409 (H34).
+
+        Previously this fell back to the thread-local detector and the
+        client saw votes from a different (or stale) detector under HTTP
+        200. Now the resolver raises ``DetectorNotLoadedError`` (mapped to
+        409) at proxy access.
+        """
         det = _make_detector("req_det_fb")
         det.good_votes[5] = None
         from vtscore.state.core import get_detector_context
@@ -158,9 +198,10 @@ class TestRequestScopedModel:
         set_thread_detector_context(get_detector_context("req_det_fb"))
 
         resp = client.get("/api/votes", headers={"X-Detector-Id": "nonexistent"})
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert 5 in set(data.get("good", []))
+        assert resp.status_code == 409
+        body = resp.get_json()
+        assert body["code"] == "detector_not_loaded"
+        assert body["detector_id"] == "nonexistent"
 
     def test_header_resolves_correct_detector_in_request(self, client):
         """Verify the proxy objects resolve correctly inside a request context."""

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -36,6 +36,34 @@ from typing import Any
 _state_lock = threading.RLock()
 
 
+class DatasetNotLoadedError(LookupError):
+    """The request explicitly named a dataset that is not loaded in memory.
+
+    Raised by the request-scoped dataset resolver (and propagated through
+    :func:`get_active_context`) when an ``X-Dataset-Id`` header (or
+    ``?dataset_id=`` query param) was sent but no matching
+    :class:`DatasetContext` is registered. Silent fallback to an empty
+    context produced stale results that the client could not detect —
+    see logical-bug-audit H16.
+    """
+
+    def __init__(self, dataset_id: str) -> None:
+        super().__init__(f"dataset {dataset_id!r} is not loaded")
+        self.dataset_id = dataset_id
+
+
+class DetectorNotLoadedError(LookupError):
+    """The request explicitly named a detector that is not loaded in memory.
+
+    Detector counterpart of :class:`DatasetNotLoadedError`. See
+    logical-bug-audit H16 / H34.
+    """
+
+    def __init__(self, detector_id: str) -> None:
+        super().__init__(f"detector {detector_id!r} is not loaded")
+        self.detector_id = detector_id
+
+
 # ---------------------------------------------------------------------------
 # Pluggable per-request context resolvers
 # ---------------------------------------------------------------------------

--- a/vtsearch/shim/__init__.py
+++ b/vtsearch/shim/__init__.py
@@ -22,21 +22,41 @@ def _flask_dataset_context_resolver() -> Any:
     Returns ``None`` outside a request context (background threads, CLI,
     library callers) so :func:`vtscore.state.core.get_active_context`
     can fall through to its thread-local / empty-context fallback.
+
+    Raises :class:`vtscore.state.core.DatasetNotLoadedError` if the
+    request explicitly named a dataset (``X-Dataset-Id`` header or
+    ``?dataset_id=`` query param) that is not loaded. Without this, the
+    proxy silently resolved to the empty context and the client saw
+    stale data — logical-bug-audit H16.
     """
     from flask import g, has_request_context
 
-    if has_request_context():
-        return getattr(g, "_dataset_context", None)
-    return None
+    if not has_request_context():
+        return None
+    ctx = getattr(g, "_dataset_context", None)
+    if ctx is None:
+        unloaded = getattr(g, "_unloaded_dataset_id", None)
+        if unloaded:
+            from vtscore.state.core import DatasetNotLoadedError
+
+            raise DatasetNotLoadedError(unloaded)
+    return ctx
 
 
 def _flask_detector_context_resolver() -> Any:
     """Counterpart of :func:`_flask_dataset_context_resolver` for detectors."""
     from flask import g, has_request_context
 
-    if has_request_context():
-        return getattr(g, "_detector_context", None)
-    return None
+    if not has_request_context():
+        return None
+    ctx = getattr(g, "_detector_context", None)
+    if ctx is None:
+        unloaded = getattr(g, "_unloaded_detector_id", None)
+        if unloaded:
+            from vtscore.state.core import DetectorNotLoadedError
+
+            raise DetectorNotLoadedError(unloaded)
+    return ctx
 
 
 def register_flask_context_resolvers() -> None:


### PR DESCRIPTION
## Summary

Closes **H16** in `docs/plans/logical-bug-audit.md` — and the
"header points to an unloaded id" half of **H34** by the same
mechanism.

### Before

`app.py`'s `_set_request_context` had this shape:

```python
if ds_id:
    ctx = get_context(ds_id)
    if ctx is not None:
        g._dataset_context = ctx
```

When the client sent `X-Dataset-Id: <unloaded_id>` (e.g. dataset
unloaded under their feet, or stale id from a prior session):

1. `get_context(unloaded_id)` returns `None`.
2. The `if ctx is not None` gate skipped, so `g._dataset_context` was
   never set.
3. `_flask_dataset_context_resolver` returned `None`.
4. `get_active_context()` fell through to the thread-local, then to
   `_empty_dataset_context`.
5. Handler returned **HTTP 200** with empty (or thread-local-leaked)
   data — no error, no warning, client had no way to detect the
   mismatch.

Same shape for `X-Detector-Id`. The existing test
`test_header_with_unloaded_id_falls_back_to_active` explicitly
asserted the broken behavior.

### After

- **`vtscore/state/core.py`**: new `DatasetNotLoadedError` /
  `DetectorNotLoadedError` exception classes (library tier — no Flask
  dependency).
- **`vtsearch/shim/__init__.py`**: the Flask resolvers now raise
  `DatasetNotLoadedError` / `DetectorNotLoadedError` when
  `g._unloaded_dataset_id` / `g._unloaded_detector_id` is set.
- **`app.py` `_set_request_context`**: when the header names an
  unloaded id, stash it on `g` (instead of silently dropping it). The
  in-line `ensure_votes_match_active_dataset()` call catches the new
  exceptions silently — the route handler will hit the same error
  when it touches the proxies and the global error handler will turn
  it into the 409.
- **`app.py` error handlers**: two new `@app.errorhandler`s map the
  exceptions to a JSON 409 with `code=dataset_not_loaded` /
  `detector_not_loaded` plus the offending id, so the frontend can
  distinguish "named the wrong id" from a generic 500 and offer a
  load action.

### Surgical, not blanket

The raise fires at proxy access. Routes that never touch the
`medias` / `good_votes` / `bad_votes` proxies — registry listings,
auth, file browser, settings, etc. — keep responding **200** even
with an unloaded `X-Dataset-Id` header. This matters because the
registry endpoint is exactly what the frontend uses to discover which
datasets are loaded; blanket-rejecting in `before_request` would have
created a deadlock for clients holding a stale id.

### What's left for H34

H34's other half — vote-mutating endpoints that don't require the
header at all, where the thread-local can leak a stale detector
across requests on the same worker thread — is a per-route concern
(reject the request when the header is absent) and stays open. The
audit doc has been updated to reflect the partial closure.

## Test plan

- [x] `python -m pytest tests/datasets/test_request_context.py -x`
  — 14/14 pass (replaced two silent-fallback assertions with 409
  assertions; added an end-to-end test through `/api/medias/ids` and a
  guard test that `/api/datasets/registry` keeps returning 200 with
  an unloaded `X-Dataset-Id`).
- [x] `python -m pytest tests/ tests_lib/ -q -m 'not gpu and not slow'`
  — 3978 passed, 1 skipped, 0 failed.
- [x] `./run-tests.sh vtscore-clean` — 940 passed (library tier still
  Flask-free).
- [x] `pyright` — 0 errors.
- [x] OpenAPI snapshot — no drift.
- [x] `cd frontend && npm run build:prod` — clean build, no warnings.

`pip-audit` blocks `./run-tests.sh` on three pre-existing CVEs in
`joblib` / `pyjwt` / `transformers` that are also present on `dev` —
unrelated to this change.

https://claude.ai/code/session_018WrMehAvP5sjweRabDrAdM

---
_Generated by [Claude Code](https://claude.ai/code/session_018WrMehAvP5sjweRabDrAdM)_