### PR TITLE
H20: enforce PluginField numeric ranges at schema-load time

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -205,9 +205,22 @@ Cross-section interaction agents:
 - **H19. Required select fields silently accept empty string** —
   `vtsearch/plugins/schema.py` L119. `required` + `load_default=""`
   lets empty value through marshmallow.
-- **H20. `audio2image` has no upper bound on `n_mels`** —
-  `vtsearch/converters/audio2image.py` L201. `max(8, n_mels)` only
-  sets the floor; absurdly large user input → OOM/DoS.
+- ~~**H20. `audio2image` has no upper bound on `n_mels`**~~ — fixed
+  systemically in `vtscore/plugins/schema.py:_build_number()`, which
+  now attaches `validate.Range` whenever a `PluginField` declares
+  numeric `min` / `max` (so every plugin family that goes through
+  `validate_plugin_args` benefits). Converters bypass that route-layer
+  schema because their `params` ride inside `source_specs` /
+  `clipper_chain` pass-through dicts, so they got their own entry
+  point: `MediaConverter.validate_params()` runs the params through
+  the converter's own plugin schema, and the two upstream parsers
+  (`_parse_multi_media_specs` and `clipper_chain.validate_chain`) call
+  it before any expensive work runs. The `audio2image` declared range
+  is now actually enforced — `n_mels=10_000_000` is rejected at
+  request time instead of building a ~41 GB mel filter bank inside
+  librosa. Audited every numeric `PluginField` in the codebase; no
+  declared `max` was tighter than real usage, so attaching `Range`
+  everywhere was safe.
 
 ### CLI / app entry
 

--- a/tests/converters/test_audio2image_and_image2text.py
+++ b/tests/converters/test_audio2image_and_image2text.py
@@ -192,6 +192,44 @@ class TestAudio2ImageMediaConverter:
         assert len(results) == 1
         assert results[0]["filename"].endswith("_spec_mel.png")
 
+    def test_validate_params_rejects_out_of_range_n_mels(self):
+        """Regression for H20: a huge ``n_mels`` would build a multi-GB mel
+        filter bank inside librosa.  ``validate_params`` must reject it
+        before the converter is even invoked."""
+        from marshmallow import ValidationError
+
+        from vtscore.converters.audio2image import Audio2ImageMediaConverter
+
+        c = Audio2ImageMediaConverter()
+        with pytest.raises(ValidationError) as exc:
+            c.validate_params({"n_mels": 10_000_000})
+        assert "n_mels" in exc.value.messages
+        # Below the declared floor is also rejected.
+        with pytest.raises(ValidationError):
+            c.validate_params({"n_mels": 1})
+        # In-range values are accepted and the schema returns the coerced
+        # dict (with defaults for unspecified fields).
+        loaded = c.validate_params({"n_mels": 128})
+        assert loaded["n_mels"] == 128
+
+    def test_source_spec_parser_rejects_oversized_n_mels(self):
+        """End-to-end: the multi-media source-spec parser must reject a
+        converter ``params`` dict that violates the converter's declared
+        :class:`PluginField` range."""
+        from vtscore.datasets.importers.base import _parse_multi_media_specs
+
+        raw = [
+            {
+                "source_type": "audio",
+                "converter": "audio2image",
+                "params": {"n_mels": 99_999_999},
+            }
+        ]
+        with pytest.raises(ValueError) as exc:
+            _parse_multi_media_specs(raw, output_type="image")
+        assert "audio2image" in str(exc.value)
+        assert "n_mels" in str(exc.value)
+
 
 # ===========================================================================
 # Image2TextMediaConverter

--- a/tests_lib/core/test_plugin_schema.py
+++ b/tests_lib/core/test_plugin_schema.py
@@ -102,6 +102,49 @@ class TestSchemaBuilder:
         schema = make_plugin_arg_schema(plugin)()
         assert schema.load({"x": 2.5}) == {"x": 2.5}
 
+    def test_number_integer_range_enforced(self):
+        plugin = _FakePlugin(
+            [PluginField(key="n", label="N", field_type="number", default="128", step="1", min="8", max="512")]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        # In-range values pass.
+        assert schema.load({"n": 8}) == {"n": 8}
+        assert schema.load({"n": 512}) == {"n": 512}
+        # Below min and above max are both rejected.
+        with pytest.raises(ValidationError) as exc:
+            schema.load({"n": 7})
+        assert "n" in exc.value.messages
+        with pytest.raises(ValidationError) as exc:
+            schema.load({"n": 10_000_000})
+        assert "n" in exc.value.messages
+
+    def test_number_float_range_enforced(self):
+        plugin = _FakePlugin(
+            [PluginField(key="t", label="T", field_type="number", default="0.5", step="0.05", min="0", max="1")]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"t": 0.0}) == {"t": 0.0}
+        assert schema.load({"t": 1.0}) == {"t": 1.0}
+        with pytest.raises(ValidationError):
+            schema.load({"t": -0.1})
+        with pytest.raises(ValidationError):
+            schema.load({"t": 1.5})
+
+    def test_number_min_only_allows_arbitrary_upper(self):
+        # synthetic.size, video2audio.ffmpeg_timeout etc. declare only a floor.
+        plugin = _FakePlugin([PluginField(key="n", label="N", field_type="number", default="100", min="1", step="1")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"n": 1_000_000}) == {"n": 1_000_000}
+        with pytest.raises(ValidationError):
+            schema.load({"n": 0})
+
+    def test_number_no_range_when_unset(self):
+        # No min / no max → no Range validator attached.
+        plugin = _FakePlugin([PluginField(key="n", label="N", field_type="number", default="1", step="1")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"n": -999_999}) == {"n": -999_999}
+        assert schema.load({"n": 999_999_999}) == {"n": 999_999_999}
+
     def test_checkbox_accepts_string_true_false(self):
         plugin = _FakePlugin([PluginField(key="flag", label="Flag", field_type="checkbox", default="false")])
         schema = make_plugin_arg_schema(plugin)()

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -198,7 +198,10 @@ class Audio2ImageMediaConverter(MediaConverter):
             n_mels = int(self.get_param(params, "n_mels") or 128)
         except (TypeError, ValueError):
             n_mels = 128
-        n_mels = max(8, n_mels)
+        # Defensive clamp to the declared PluginField range — the upstream
+        # plugin schema enforces this for any API-supplied params, but direct
+        # callers of convert() (tests, ad-hoc scripts) skip that path.
+        n_mels = max(8, min(512, n_mels))
 
         try:
             time_window_s = float(self.get_param(params, "time_window_s") or 0)

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -108,7 +108,12 @@ class MediaConverter(PluginBase, ABC):
         from vtscore.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
 
         schema = get_plugin_arg_schema(self)
-        return schema.load(params or {})
+        loaded = schema.load(params or {})
+        # ``Schema.load(<dict>)`` returns a dict (the ``many=True`` overload
+        # returns a list); marshmallow's typing is too permissive to narrow
+        # this automatically.
+        assert isinstance(loaded, dict)
+        return loaded
 
     def get_param(self, params: dict[str, Any] | None, key: str) -> Any:
         """Return the value for *key* from *params*, falling back to the

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -92,6 +92,24 @@ class MediaConverter(PluginBase, ABC):
     # Param helpers
     # ------------------------------------------------------------------
 
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any]:
+        """Validate *params* against this converter's :attr:`fields` schema.
+
+        Converters are usually invoked from ``source_specs`` /
+        ``clipper_chain`` dicts that flow through the API as pass-through
+        payloads — they don't go through :func:`validate_plugin_args`
+        like importer/exporter form bodies do.  Call this from any entry
+        point that accepts user-supplied params to enforce declared
+        :class:`PluginField` constraints (in particular numeric
+        :attr:`min` / :attr:`max` ranges) before the params reach the
+        expensive :meth:`convert` body.  Raises
+        :class:`marshmallow.ValidationError` on a bad value.
+        """
+        from vtscore.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
+
+        schema = get_plugin_arg_schema(self)
+        return schema.load(params or {})
+
     def get_param(self, params: dict[str, Any] | None, key: str) -> Any:
         """Return the value for *key* from *params*, falling back to the
         declared :attr:`PluginField.default` for that key.

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -24,6 +24,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable
 
+from marshmallow import ValidationError
+
 ChainStep = dict[str, Any]
 
 
@@ -87,6 +89,10 @@ def validate_chain(steps: list[ChainStep], source_media_type: str) -> str:
             conv = get_converter(name)
             if conv is None:
                 raise ValueError(f"chain step {i}: unknown converter {name!r}")
+            try:
+                conv.validate_params(step.get("params") or {})
+            except ValidationError as e:
+                raise ValueError(f"chain step {i} (converter {name!r}): invalid params: {e.messages}") from e
             in_type = conv.source_type
             out_type = conv.target_type
         if in_type != current:

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -140,7 +140,14 @@ def _parse_multi_media_specs(raw: Any, output_type: str) -> list[SourceSpec]:
 
 
 def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) -> None:
-    """Validate that *spec*'s converter (if any) bridges source→output."""
+    """Validate that *spec*'s converter (if any) bridges source→output.
+
+    Also validates ``spec.params`` against the converter's own
+    :class:`PluginField` schema, so declared ``min`` / ``max`` ranges
+    are enforced before the params reach :meth:`MediaConverter.convert`.
+    """
+    from marshmallow import ValidationError  # noqa: PLC0415
+
     if spec.converter is None:
         if spec.source_type != output_type:
             raise ValueError(
@@ -160,6 +167,10 @@ def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) 
             f"Converter {spec.converter!r} produces "
             f"{converter.target_type!r}, but output media_type is {output_type!r}",
         )
+    try:
+        converter.validate_params(spec.params)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid params for converter {spec.converter!r}: {exc.messages}") from exc
 
 
 def _parse_legacy_specs(raw_converters: Any, output_type: str) -> list[SourceSpec]:

--- a/vtscore/plugins/schema.py
+++ b/vtscore/plugins/schema.py
@@ -23,7 +23,10 @@ password     :class:`fields.String`
 folder       :class:`fields.String`
 server_path  :class:`fields.String`
 number       :class:`fields.Integer` (integer-looking)
-             / :class:`fields.Float`
+             / :class:`fields.Float`, with :class:`validate.Range`
+             attached when :attr:`PluginField.min` / :attr:`max`
+             are declared (out-of-range values are rejected at
+             schema-load time, not silently coerced)
 select       :class:`fields.String` + :class:`validate.OneOf`
              (static options); plain :class:`fields.String` for
              dynamic-options fields
@@ -100,12 +103,28 @@ def _build_checkbox(pf: PluginField, kwargs: dict) -> fields.Field:
 
 def _build_number(pf: PluginField, kwargs: dict) -> fields.Field:
     kwargs.pop("load_default", None)
+    cast = int if pf.is_integer_number() else float
     if pf.default:
         try:
-            kwargs["load_default"] = int(pf.default) if pf.is_integer_number() else float(pf.default)
+            kwargs["load_default"] = cast(pf.default)
         except (TypeError, ValueError):
             # Bad default — let marshmallow raise on missing input.
             kwargs.pop("load_default", None)
+
+    range_kwargs: dict = {}
+    if pf.min:
+        try:
+            range_kwargs["min"] = cast(pf.min)
+        except (TypeError, ValueError):
+            pass
+    if pf.max:
+        try:
+            range_kwargs["max"] = cast(pf.max)
+        except (TypeError, ValueError):
+            pass
+    if range_kwargs:
+        kwargs["validate"] = validate.Range(**range_kwargs)
+
     if pf.is_integer_number():
         return fields.Integer(**kwargs)
     return fields.Float(**kwargs)


### PR DESCRIPTION
## Summary

- Closes **H20** from `docs/plans/logical-bug-audit.md`. The audio2image converter's `_coerce_params` only enforced a floor on `n_mels` (`max(8, n_mels)`), so a user-supplied value like `10_000_000` would sail through and feed `librosa.feature.melspectrogram(..., n_mels=...)`, which allocates an `(n_mels, 1+n_fft//2)` float32 mel filter bank — ~41 GB at that input. Audit doc said `vtsearch/converters/audio2image.py L201`; the file actually lives under `vtscore/converters/`, line 201 was correct.
- Picked the **systemic fix**: `vtscore/plugins/schema.py:_build_number()` now attaches `validate.Range(min=..., max=...)` whenever a `PluginField` declares numeric bounds. Out-of-range values are rejected at schema-load time across every plugin family that flows through `validate_plugin_args` (importers, exporters, source plugins, label importers), not silently coerced.
- Converters don't go through that route-layer schema today — their `params` ride inside `source_specs` / `clipper_chain` pass-through dicts and are handed straight to `convert()`. Added `MediaConverter.validate_params()` (runs `params` through the converter's own plugin schema) and wired it into the two upstream parsers (`_parse_multi_media_specs` and `clipper_chain.validate_chain`) so range violations are caught before `convert()` runs.
- Tightened the local `audio2image` clamp from `max(8, n_mels)` to `max(8, min(512, n_mels))` as a defensive backstop for any direct callers of `convert()` that bypass schema validation (tests, scripts).
- Audited every numeric `PluginField` in the codebase first; no declared `max` is tighter than real usage, so the range attachment is safe to apply systemically.

## Test plan

- [x] New schema tests in `tests_lib/core/test_plugin_schema.py` cover integer + float ranges, min-only declarations, and unset ranges.
- [x] New converter tests in `tests/converters/test_audio2image_and_image2text.py` cover both `MediaConverter.validate_params()` and the end-to-end `_parse_multi_media_specs` rejection path for `n_mels=99_999_999`.
- [x] `python -m pytest tests/ tests_lib/ -q -m 'not gpu and not slow'` → **3982 passed, 1 skipped, 2 xpassed**.
- [x] `ruff check`, `ruff format --check`, `codespell`, `deptry`, OpenAPI snapshot, `pyright`, and the frontend `npm run build:prod` all clean.
- [ ] **pip-audit** flags 10 CVEs (joblib · pyjwt · transformers) — verified identical on bare `origin/dev`, environmental from the PyPI advisory DB, unrelated to this change.

https://claude.ai/code/session_01REWeQYFEcbZNuJfhco6XPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01REWeQYFEcbZNuJfhco6XPd)_