### PR TITLE
docs: withdraw H19 from logical-bug audit (false positive)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -219,9 +219,23 @@ Cross-section interaction agents:
   importer returned the original strings byte-for-byte
   (`.strip().lower()` on the label only trims leading/trailing
   whitespace — interior newlines pass through).
-- **H19. Required select fields silently accept empty string** —
-  `vtsearch/plugins/schema.py` L119. `required` + `load_default=""`
-  lets empty value through marshmallow.
+- ~~**H19. Required select fields silently accept empty string**~~ —
+  investigation closed (2026-05-20): not a real bug. The audit's
+  framing assumes `_presence_kwargs()` in `vtscore/plugins/schema.py`
+  produces `{"required": True, "load_default": ""}` for a required
+  select, but the function is a mutually-exclusive 3-way branch that
+  never emits both keys (required-with-no-default → `{"required":
+  True}` only; default present → `{"load_default": <default>}`
+  only). More importantly, `_build_select` adds
+  `_non_empty_after_strip` to the validator list for every required
+  select (schema.py:116-117) — empty strings and whitespace-only
+  strings are rejected with `"Field may not be empty."`, and the
+  OneOf at L119 excludes `""` from its allowed set for required
+  fields too (double defence). Empirical check via
+  `schema.load({"choice": ""})` confirms a 422 for required selects
+  with static options, dynamic options, and with a non-empty default
+  alike. The parallel text-field case is already covered by
+  `tests_lib/core/test_plugin_schema.py::test_required_text_rejects_whitespace_only`.
 - ~~**H20. `audio2image` has no upper bound on `n_mels`**~~ — fixed
   systemically in `vtscore/plugins/schema.py:_build_number()`, which
   now attaches `validate.Range` whenever a `PluginField` declares


### PR DESCRIPTION
## Summary

- Investigation of H19 ("Required select fields silently accept empty string", `vtscore/plugins/schema.py` L119) concludes it's a false positive.
- `_presence_kwargs()` is a mutually-exclusive 3-way branch and never emits `{"required": True, "load_default": ""}` together; `_build_select()` unconditionally adds `_non_empty_after_strip` for every required select, so `""` / whitespace-only inputs are rejected with `ValidationError("Field may not be empty.")`. The OneOf at L119 also excludes `""` from its allowed set when the field is required.
- Strike-through note added to `docs/plans/logical-bug-audit.md` following the H12 precedent so the ID stays referenceable.

## Test plan

- [x] Live-tested `schema.load({"choice": ""})` across required-static-options, required-dynamic-options, and required-with-non-empty-default — all raise `ValidationError`.
- [x] Existing `tests_lib/core/test_plugin_schema.py::test_required_text_rejects_whitespace_only` already covers the parallel text-field case; no code change shipped.

https://claude.ai/code/session_01R3imwzWcwcWGeawx7rmHos

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3imwzWcwcWGeawx7rmHos)_