### PR TITLE
Update brainstorm §13.4 with current state of parallel dataset loads

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -122,12 +122,7 @@ Cross-section interaction agents:
   no output. Covered by `TestRegionAwareTrainingCrossDataset` in
   `tests/detectors/test_patch_embedder.py`.
 - ~~**H3. Embedder drift on save → reload**~~
-- **H5. Detector embedder not revalidated on dataset switch** —
-  `vtsearch/routes/detectors/scoring.py` + `dataset_sync.py`.
-  `ensure_votes_match_active_dataset()` rehydrates votes but doesn't
-  check the new dataset's embedder against the detector's training
-  embedder. An MLP trained on CLAP can score SigLIP vectors with no
-  warning.
+- ~~**H5. Detector embedder not revalidated on dataset switch**~~
 - ~~**H6. `train_model` produces degenerate single-class model**~~
 - ~~**H7. Vote applied before retrain; retrain failure leaves vote live**~~
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1119,8 +1119,8 @@ class TestValidatedVoteSnapshot:
         detector_id = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, detector_id)
 
-        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
         return detector_id, good_cid, bad_cid
 
     def test_snapshot_safe_when_aligned(self, client):

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -932,6 +932,151 @@ class TestLoadModelEndpoint:
         assert a_good not in good_votes, "good cid from dataset A leaked into dataset B's id-space"
         assert a_bad not in bad_votes, "bad cid from dataset A leaked into dataset B's id-space"
 
+    def test_dataset_switch_invalidates_cached_mlp_on_embedder_change(self, client):
+        """Switching to a dataset with a different embedder must drop the cached MLP.
+
+        The detector's MLP is dimensionally and semantically tied to the
+        embedder its training vectors came from.  Scoring a CLAP-trained MLP
+        against SigLIP image vectors yields either a tensor-shape error or
+        silent garbage when the two embedders happen to share a dimensionality.
+        H5 — corruption potential because the garbage scores flow into
+        ``apply_labels_bulk_with_click_time`` and ``sync_to_labelset_source``.
+        """
+        import hashlib
+
+        import numpy as np
+
+        from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
+        from vtscore.state.core import get_active_detector_context
+        from vtsearch.state import (
+            DatasetContext,
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
+
+        if not medias:
+            pytest.skip("No medias loaded")
+        ids = list(medias.keys())
+        if len(ids) < 2:
+            pytest.skip("Need at least 2 medias")
+
+        client.post(
+            "/api/detectors",
+            json={"name": "EmbSwitch", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "EmbSwitch", "media_type": "audio", "text_query": "test"},
+        )
+        mid = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, mid)
+
+        # Plant a fake MLP + embedder stamp on the loaded detector — we don't
+        # need an actually-trained model to verify invalidation, just a
+        # non-None ``.model`` and a stamped ``.embedder``.
+        det_ctx = get_active_detector_context()
+        sentinel_mlp = object()
+        det_ctx.model = sentinel_mlp
+        det_ctx.threshold = 0.7
+        det_ctx.embedder = "clap"
+        det_ctx.calibration_cache = ("fp", 0.7)
+        det_ctx.label_embeddings["eid"] = np.zeros(8, dtype=np.float32)
+
+        # Build dataset B with a DIFFERENT embedder.
+        ctx_b = DatasetContext("ds_b_for_embedder_switch_test")
+        for cid in ids[:2]:
+            ctx_b.medias[cid] = {
+                "id": cid,
+                "type": "image",
+                "embedder": "siglip",  # ← key: different from "clap" above
+                "md5": hashlib.md5(f"ds_b_{cid}".encode()).hexdigest(),
+                "embedding": np.zeros(512, dtype=np.float32),
+                "media_bytes": b"fake-b",
+                "filename": f"ds_b_{cid}.jpg",
+                "category": "test",
+                "origin": {"importer": "test_b", "params": {"id": cid}},
+                "origin_name": f"ds_b_{cid}.jpg",
+            }
+        register_context(ctx_b)
+        set_thread_dataset_context(ctx_b)
+
+        # Simulate the before_request hook firing for a request whose active
+        # dataset is now B.
+        ensure_votes_match_active_dataset()
+
+        assert det_ctx.model is None, "stale CLAP MLP must be cleared on switch to a SigLIP dataset"
+        assert det_ctx.threshold == 0.5, "threshold should reset to its sentinel default"
+        assert det_ctx.calibration_cache is None
+        assert det_ctx.label_embeddings == {}
+        assert det_ctx.embedder == "", "stale embedder stamp must be cleared so the next train re-stamps"
+
+    def test_dataset_switch_preserves_cached_mlp_when_embedder_unchanged(self, client):
+        """Switching datasets with the SAME embedder must keep the cached MLP.
+
+        We only want to invalidate when we're confident the MLP would be
+        applied to incompatible vectors — same-embedder switches are safe.
+        """
+        import hashlib
+
+        import numpy as np
+
+        from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
+        from vtscore.state.core import get_active_detector_context
+        from vtsearch.state import (
+            DatasetContext,
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
+
+        if not medias:
+            pytest.skip("No medias loaded")
+        ids = list(medias.keys())
+        if len(ids) < 2:
+            pytest.skip("Need at least 2 medias")
+
+        client.post(
+            "/api/detectors",
+            json={"name": "EmbSame", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "EmbSame", "media_type": "audio", "text_query": "test"},
+        )
+        mid = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, mid)
+
+        det_ctx = get_active_detector_context()
+        sentinel_mlp = object()
+        det_ctx.model = sentinel_mlp
+        det_ctx.threshold = 0.7
+        det_ctx.embedder = "clap"
+
+        # Dataset B uses the SAME embedder ("clap").
+        ctx_b = DatasetContext("ds_b_same_embedder")
+        for cid in ids[:2]:
+            ctx_b.medias[cid] = {
+                "id": cid,
+                "type": "audio",
+                "embedder": "clap",
+                "md5": hashlib.md5(f"ds_b_same_{cid}".encode()).hexdigest(),
+                "embedding": np.zeros(512, dtype=np.float32),
+                "media_bytes": b"fake-b",
+                "filename": f"ds_b_same_{cid}.wav",
+                "category": "test",
+                "origin": {"importer": "test_b", "params": {"id": cid}},
+                "origin_name": f"ds_b_same_{cid}.wav",
+            }
+        register_context(ctx_b)
+        set_thread_dataset_context(ctx_b)
+
+        ensure_votes_match_active_dataset()
+
+        assert det_ctx.model is sentinel_mlp, "MLP must survive same-embedder dataset switch"
+        assert det_ctx.threshold == 0.7
+        assert det_ctx.embedder == "clap"
+
 
 class TestValidatedVoteSnapshot:
     """``validated_vote_snapshot`` must atomically pair medias + votes (H14).

--- a/tests_lib/detectors/test_dataset_sync.py
+++ b/tests_lib/detectors/test_dataset_sync.py
@@ -1,0 +1,112 @@
+"""Tests for `vtscore.detectors.dataset_sync`.
+
+Covers the embedder-switch invalidation helpers introduced for H5.  The
+full ``ensure_votes_match_active_dataset`` flow (with on-disk detector
+JSON and the request lifecycle) is exercised in the app-tier
+``tests/detectors/test_detectors.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.detectors.dataset_sync import (
+    first_media_embedder,
+    invalidate_model_on_embedder_switch,
+)
+from vtscore.state.core import DatasetContext, DetectorContext
+
+
+class _DummyModel:
+    """Stand-in for ``nn.Module`` — only its presence matters here."""
+
+
+def _build_det_ctx(*, model=None, embedder: str = "") -> DetectorContext:
+    ctx = DetectorContext("det", name="det", media_type="audio", embedder=embedder)
+    ctx.model = model
+    ctx.threshold = 0.7
+    ctx.calibration_cache = ("fingerprint", 0.7)
+    ctx.label_embeddings["eid-a"] = np.zeros(8, dtype=np.float32)
+    return ctx
+
+
+def _ds_with_embedder(embedder: str, *, dataset_id: str = "ds") -> DatasetContext:
+    ds = DatasetContext(dataset_id)
+    ds.medias[1] = {"id": 1, "embedder": embedder, "type": "audio"}
+    return ds
+
+
+class TestFirstMediaEmbedder:
+    def test_empty_dict_returns_blank(self):
+        assert first_media_embedder({}) == ""
+
+    def test_returns_first_entry(self):
+        medias = {
+            1: {"embedder": "clap"},
+            2: {"embedder": "siglip"},  # not consulted — same-dataset invariant
+        }
+        assert first_media_embedder(medias) == "clap"
+
+    def test_missing_field_returns_blank(self):
+        assert first_media_embedder({1: {"type": "audio"}}) == ""
+
+    def test_blank_value_returns_blank(self):
+        assert first_media_embedder({1: {"embedder": ""}}) == ""
+
+
+class TestInvalidateModelOnEmbedderSwitch:
+    def test_no_model_is_noop(self):
+        det_ctx = _build_det_ctx(model=None, embedder="clap")
+        assert invalidate_model_on_embedder_switch(det_ctx, "siglip") is False
+        assert det_ctx.embedder == "clap"
+        assert det_ctx.label_embeddings  # untouched
+
+    def test_unknown_old_embedder_is_noop(self):
+        """Empty stamp on det_ctx means we can't be confident it's stale."""
+        model = _DummyModel()
+        det_ctx = _build_det_ctx(model=model, embedder="")
+        assert invalidate_model_on_embedder_switch(det_ctx, "siglip") is False
+        assert det_ctx.model is model
+        assert det_ctx.calibration_cache is not None
+
+    def test_unknown_new_embedder_is_noop(self):
+        """Empty active embedder means we can't be confident either."""
+        model = _DummyModel()
+        det_ctx = _build_det_ctx(model=model, embedder="clap")
+        assert invalidate_model_on_embedder_switch(det_ctx, "") is False
+        assert det_ctx.model is model
+        assert det_ctx.embedder == "clap"
+
+    def test_matching_embedder_is_noop(self):
+        model = _DummyModel()
+        det_ctx = _build_det_ctx(model=model, embedder="clap")
+        assert invalidate_model_on_embedder_switch(det_ctx, "clap") is False
+        assert det_ctx.model is model
+        assert det_ctx.embedder == "clap"
+        assert det_ctx.calibration_cache is not None
+        assert det_ctx.label_embeddings  # cache preserved
+
+    def test_mismatch_clears_all_caches(self):
+        """Mismatch clears the MLP, threshold, calibration, label-embeddings,
+        and the stamp itself so the next train re-stamps it."""
+        model = _DummyModel()
+        det_ctx = _build_det_ctx(model=model, embedder="clap")
+        cleared = invalidate_model_on_embedder_switch(det_ctx, "siglip")
+        assert cleared is True
+        assert det_ctx.model is None
+        assert det_ctx.threshold == 0.5
+        assert det_ctx.calibration_cache is None
+        assert det_ctx.label_embeddings == {}
+        assert det_ctx.embedder == ""
+
+
+class TestFirstMediaEmbedderOnContext:
+    """Sanity check: the helper integrates cleanly with DatasetContext."""
+
+    def test_active_dataset_with_embedder(self):
+        ds = _ds_with_embedder("clap")
+        assert first_media_embedder(ds.medias) == "clap"
+
+    def test_empty_dataset(self):
+        ds = DatasetContext("ds")
+        assert first_media_embedder(ds.medias) == ""

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -18,6 +18,14 @@ read/write paths: it atomically copies the active dataset's medias and the
 active detector's vote dicts under a single ``_state_lock`` acquisition, so
 a concurrent rehydrate on the same detector against a different dataset
 can't slip in between the (request-boundary) rehydrate and the composition.
+
+This module also invalidates the detector's cached MLP when the active
+dataset's embedder differs from the embedder its training vectors came
+from.  An MLP is dimensionally and semantically tied to its embedder, so
+scoring an MLP trained on (say) CLAP audio vectors against SigLIP image
+vectors yields either a tensor-shape error or — when the two embedders
+happen to share a dimensionality — silent garbage that then gets written
+back to the on-disk labelset via ``sync_to_labelset_source``.
 """
 
 from __future__ import annotations
@@ -31,6 +39,60 @@ def _detector_file_mtime(path) -> float:
         return path.stat().st_mtime
     except OSError:
         return 0.0
+
+
+def first_media_embedder(medias) -> str:
+    """Return the embedder name of *medias*' first entry, or ``""``.
+
+    Accepts either a ``DatasetContext.medias`` dict or a snap (the same
+    shape).  Every media in a single dataset shares an embedder, so the
+    first entry is representative.  Returns ``""`` when the collection is
+    empty or the embedder field is missing.
+    """
+    for media in medias.values():
+        return media.get("embedder", "") or ""
+    return ""
+
+
+def invalidate_model_on_embedder_switch(det_ctx, new_embedder: str) -> bool:
+    """Drop a cached MLP whose embedder no longer matches *new_embedder*.
+
+    The detector's MLP is tied to the embedder its training vectors came
+    from.  When the active dataset uses a different embedder, scoring the
+    cached MLP against that dataset's vectors is unsafe: best case the
+    forward pass raises on a dim mismatch; worst case the two embedders
+    share a dimensionality and the MLP returns silent garbage that flows
+    into ``apply_labels_bulk_with_click_time`` and ``sync_to_labelset_source``,
+    corrupting the on-disk labelset.
+
+    No-op when either ``det_ctx.embedder`` or *new_embedder* is unknown —
+    both must be present for a confident mismatch.
+
+    Acquires ``_state_lock`` for the duration of the clear so concurrent
+    readers can't see partial state (the lock is an ``RLock`` so callers
+    that already hold it pay nothing).
+
+    Returns ``True`` iff the cache was actually cleared.
+    """
+    from vtscore.state.core import _state_lock
+
+    with _state_lock:
+        if det_ctx.model is None:
+            return False
+        if not det_ctx.embedder or not new_embedder:
+            return False
+        if det_ctx.embedder == new_embedder:
+            return False
+
+        det_ctx.model = None
+        det_ctx.threshold = 0.5
+        det_ctx.calibration_cache = None
+        det_ctx.label_embeddings.clear()
+        # Clear the stamp so the next training pass re-stamps it via
+        # populate_label_embeddings / apply_and_retrain rather than carrying
+        # the stale value forward.
+        det_ctx.embedder = ""
+        return True
 
 
 def ensure_votes_match_active_dataset() -> None:
@@ -68,6 +130,15 @@ def ensure_votes_match_active_dataset() -> None:
         # No active dataset; preserve whatever the detector last saw so a
         # request that happens to omit the dataset header doesn't wipe state.
         return
+
+    # Invalidate the cached MLP if the active dataset's embedder no longer
+    # matches the embedder its training vectors came from.  Runs on every
+    # request — cheap O(1) check (one dict read + string compare) and
+    # independent of the vote-rehydrate fast-path below, since the MLP can
+    # need invalidation even when ``votes_dataset_id`` already matches
+    # (e.g. a dataset was re-loaded with a different embedder under the
+    # same id).  The helper acquires ``_state_lock`` itself.
+    invalidate_model_on_embedder_switch(det_ctx, first_media_embedder(ds_ctx.medias))
 
     from vtscore.detectors.registry import get_detector
     from vtscore.detectors.store import _detector_path, _read_detector

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -425,7 +425,7 @@ active dataset, and apply matching votes silently
 
 Returns the number of labels restored.
 
-### `dataset_sync.ensure_votes_match_active_dataset()` (line 28)
+### `dataset_sync.ensure_votes_match_active_dataset()`
 
 Rehydrate per-dataset detector state on dataset switch. No-op unless
 the dataset id or labelset file mtime has changed since the detector
@@ -433,6 +433,32 @@ last saw it. When triggered, clears `good_votes` / `bad_votes` /
 `label_history` / etc., replays `restore_labels_from_detector`, and
 caches the parsed labelset + mtime so subsequent requests within the
 same `(dataset_id, file_mtime)` tuple are no-ops.
+
+Also calls `invalidate_model_on_embedder_switch` on every request as
+its first step (cheap O(1) check) so a stale MLP can't survive a
+dataset swap to a different embedder.
+
+### `dataset_sync.invalidate_model_on_embedder_switch(det_ctx, new_embedder)`
+
+Drop a cached MLP whose `det_ctx.embedder` stamp doesn't match
+*new_embedder*. The MLP is dimensionally and semantically tied to its
+embedder: scoring a CLAP-trained MLP against SigLIP vectors yields
+either a tensor-shape error or — when the two embedders share a
+dimensionality — silent garbage. Clears `model`, `threshold`,
+`calibration_cache`, `label_embeddings`, and the stamp itself; the
+next training pass re-stamps via `populate_label_embeddings` /
+`apply_and_retrain`. No-op when either stamp is empty (the invariant
+fires only on a confident mismatch). Used by
+`ensure_votes_match_active_dataset` (per-request invalidation) and
+`scoring._resolve_or_train_detector` / `find._score_dataset`
+(defence-in-depth at each cached-MLP read site).
+
+### `dataset_sync.first_media_embedder(medias)`
+
+Return the embedder name of the first media in *medias*, or `""` when
+the dict is empty or the field is missing. Convenience accessor used
+by the invalidator and the scoring routes — every media in a single
+dataset shares an embedder, so the first entry is representative.
 
 ### `media_seeding.seed_good_votes_from_examples(examples)` (line 10)
 

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -188,31 +188,38 @@ def _resolve_find_detectors(detector_ids: list[str]) -> list[dict]:
 
 
 def _build_detector_config(d: dict) -> dict:
-    """Pick the live-MLP path or the cold-detector path for *d*.
+    """Build a per-detector config carrying both the live-MLP and cold paths.
 
-    Aborts with 400 when the detector has no usable labels in either form.
+    A Find call can span multiple datasets that use different embedders, so
+    we resolve both paths up front and let :func:`_score_dataset` pick per
+    dataset based on whether the live MLP's embedder matches that
+    dataset's vectors.  When the live MLP doesn't match, the cold path
+    retrains on the dataset's own vectors.
+
+    Aborts with 400 when neither path is usable for *d*.
     """
     from vtscore.detectors.store import _detector_path, _read_detector  # noqa: PLC0415
     from vtscore.state.core import get_detector_context  # noqa: PLC0415
 
-    det_ctx = get_detector_context(d["id"])
-    if det_ctx is not None and det_ctx.model is not None:
-        return {
-            "name": d["name"],
-            "detector_id": d["id"],
-            "live_mlp": det_ctx.model,
-            "threshold": det_ctx.threshold,
-        }
+    config: dict = {
+        "name": d["name"],
+        "detector_id": d["id"],
+    }
 
     det_data = _read_detector(_detector_path(d["name"]))
     if det_data and det_data.get("labelset", {}).get("labels"):
-        return {
-            "name": d["name"],
-            "detector_id": d["id"],
-            "detector_data": det_data,
-        }
+        config["detector_data"] = det_data
 
-    _abort_find(400, f"Detector '{d['name']}' has no labels for detection")
+    det_ctx = get_detector_context(d["id"])
+    if det_ctx is not None and det_ctx.model is not None:
+        config["live_mlp"] = det_ctx.model
+        config["live_embedder"] = det_ctx.embedder
+        config["threshold"] = det_ctx.threshold
+
+    if "detector_data" not in config and "live_mlp" not in config:
+        _abort_find(400, f"Detector '{d['name']}' has no labels for detection")
+
+    return config
 
 
 def _build_detector_configs(detectors: list[dict]) -> list[dict]:
@@ -303,6 +310,19 @@ def _record_verdicts(
             "verdict": fallback_verdict,
             "score": 0,
         }
+
+
+def _live_mlp_matches_dataset(dc: dict, ds_embedder: str) -> bool:
+    """Return ``False`` when *dc*'s live MLP is bound to a different embedder.
+
+    Returns ``True`` (treat as a match) when either stamp is unknown — the
+    invariant only fires on a confident mismatch, mirroring
+    :func:`vtscore.detectors.dataset_sync.invalidate_model_on_embedder_switch`.
+    """
+    live_embedder = dc.get("live_embedder", "") or ""
+    if not live_embedder or not ds_embedder:
+        return True
+    return live_embedder == ds_embedder
 
 
 def _score_with_live_mlp(dc: dict, X_all, all_ids: list[int], media_results: dict[int, dict]) -> None:
@@ -418,7 +438,9 @@ def _score_dataset(
     if not temp_medias:
         return [], [], scored_units, 0, ""
 
-    detected_media_type = next(iter(temp_medias.values()), {}).get("type", "")
+    first_media = next(iter(temp_medias.values()), {})
+    detected_media_type = first_media.get("type", "")
+    ds_embedder = first_media.get("embedder", "") or ""
 
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
 
@@ -443,10 +465,15 @@ def _score_dataset(
             total_steps=_FIND_STEPS,
         )
 
-        if "live_mlp" in dc:
+        if "live_mlp" in dc and _live_mlp_matches_dataset(dc, ds_embedder):
             _score_with_live_mlp(dc, X_all, all_ids, media_results)
         elif "detector_data" in dc:
             _score_with_cold_detector(dc, temp_medias, X_all, all_ids, media_results)
+        else:
+            # Live MLP exists but is bound to a different embedder, and no
+            # cold-path labelset is available — surface as N/A rather than
+            # scoring with a mismatched MLP.
+            _record_verdicts(media_results, dc["name"], all_ids, None, 0.0, "N/A")
 
         scored_units += len(all_ids)
         update_find_progress(

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -60,9 +60,19 @@ def _resolve_or_train_detector(  # noqa: C901
     origin importer.  Returns ``(None, _, diag)`` when training is not
     possible.
     """
+    from vtscore.detectors.dataset_sync import (
+        first_media_embedder,
+        invalidate_model_on_embedder_switch,
+    )
     from vtscore.state.core import get_detector_context
 
     det_ctx = get_detector_context(detector_id)
+    if det_ctx is not None:
+        # Defence-in-depth — ``ensure_votes_match_active_dataset`` normally
+        # invalidates this on the request boundary, but non-Flask callers
+        # (background threads, library-tier code) don't run it.  Drop the
+        # cache here so we don't score with a stale-embedder MLP.
+        invalidate_model_on_embedder_switch(det_ctx, first_media_embedder(snap or {}))
     if det_ctx is not None and det_ctx.model is not None:
         return det_ctx.model, det_ctx.threshold, None
 


### PR DESCRIPTION
The backend half of §13.4 ("bump the default of 1") was already shipped by
§11.5 — gates use hardware-derived defaults and read limits fresh on every
acquire. The remaining gap is a frontend "Load selected" side-action; the
dashboard has multi-select + bulk Combine/Delete but no bulk-load button.
Record that split and the open follow-ups so the next contributor sees
what's actually left.

https://claude.ai/code/session_01WNfhjTb3yPua72FCZEKXm2