### PR TITLE
H8: defensive-copy origin dict at every per-media tagging site

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -133,10 +133,7 @@ Cross-section interaction agents:
 
 ### Datasets
 
-- **H8. Origin dict shared by reference across medias** —
-  `vtsearch/datasets/load_pipeline.py` L699–705. `_tag_origins()`
-  stamps the same dict object; later mutations of `origin.params`
-  propagate to siblings. Each media must hold its own copy.
+- ~~**H8. Origin dict shared by reference across medias**~~
 - ~~**H9. Single-item split has 0 test samples**~~
 - **H10. Clipped media re-ingest reads whole file for MD5** —
   `vtsearch/datasets/ingest.py` L275. MD5 of the full parent

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7559,6 +7559,9 @@
           "404": {
             "description": "Detector not found."
           },
+          "409": {
+            "description": "Detector vote state is not aligned with the active dataset."
+          },
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }

--- a/tests/datasets/test_origin_isolation.py
+++ b/tests/datasets/test_origin_isolation.py
@@ -36,13 +36,17 @@ def _assert_isolated(*medias: dict[str, Any]) -> None:
 class TestTagOriginsIsolation:
     def test_each_media_gets_distinct_origin_and_params(self):
         origin = {"importer": "server_folder", "params": {"path": "/data", "media_type": "audio"}}
-        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}, 3: {"filename": "c.wav"}}
+        medias: dict[int, dict[str, Any]] = {
+            1: {"filename": "a.wav"},
+            2: {"filename": "b.wav"},
+            3: {"filename": "c.wav"},
+        }
         _tag_origins(medias, origin)
         _assert_isolated(medias[1], medias[2], medias[3])
 
     def test_mutating_one_origin_params_does_not_leak_to_siblings(self):
         origin = {"importer": "server_folder", "params": {"path": "/data"}}
-        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
+        medias: dict[int, dict[str, Any]] = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
         _tag_origins(medias, origin)
 
         medias[1]["origin"]["params"]["extra"] = "only-on-1"
@@ -53,7 +57,7 @@ class TestTagOriginsIsolation:
 
     def test_origin_values_are_preserved(self):
         origin = {"importer": "server_folder", "params": {"path": "/data", "media_type": "audio"}}
-        medias = {1: {"filename": "a.wav"}}
+        medias: dict[int, dict[str, Any]] = {1: {"filename": "a.wav"}}
         _tag_origins(medias, origin)
         assert medias[1]["origin"] == origin
         # ...but it must not be the same object.
@@ -62,7 +66,10 @@ class TestTagOriginsIsolation:
 
     def test_origin_name_falls_back_to_filename(self):
         origin = {"importer": "x", "params": {}}
-        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav", "origin_name": "kept"}}
+        medias: dict[int, dict[str, Any]] = {
+            1: {"filename": "a.wav"},
+            2: {"filename": "b.wav", "origin_name": "kept"},
+        }
         _tag_origins(medias, origin)
         assert medias[1]["origin_name"] == "a.wav"
         assert medias[2]["origin_name"] == "kept"
@@ -70,7 +77,10 @@ class TestTagOriginsIsolation:
     def test_skips_medias_that_already_carry_an_origin(self):
         pre_existing = {"importer": "other", "params": {"k": "v"}}
         origin = {"importer": "new", "params": {"k": "w"}}
-        medias = {1: {"filename": "a.wav", "origin": pre_existing}, 2: {"filename": "b.wav"}}
+        medias: dict[int, dict[str, Any]] = {
+            1: {"filename": "a.wav", "origin": pre_existing},
+            2: {"filename": "b.wav"},
+        }
         _tag_origins(medias, origin)
         assert medias[1]["origin"] is pre_existing  # untouched
         assert medias[2]["origin"]["importer"] == "new"
@@ -78,7 +88,7 @@ class TestTagOriginsIsolation:
 
     def test_isolation_survives_pickle_roundtrip(self):
         origin = {"importer": "server_folder", "params": {"path": "/data"}}
-        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
+        medias: dict[int, dict[str, Any]] = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
         _tag_origins(medias, origin)
 
         revived = pickle.loads(pickle.dumps(medias))
@@ -132,7 +142,7 @@ class TestRewriteOriginsIsolation:
         origin = {"importer": "server_files", "params": {"path": "/list.txt"}}
         src_a = tmp_path / "a.wav"
         src_b = tmp_path / "b.wav"
-        medias = {
+        medias: dict[int, dict[str, Any]] = {
             1: {"origin_name": "a.wav", "filename": "a.wav"},
             2: {"origin_name": "b.wav", "filename": "b.wav"},
         }
@@ -149,7 +159,7 @@ class TestRewriteOriginsIsolation:
 
     def test_skips_medias_with_no_matching_source(self, tmp_path):
         origin = {"importer": "server_files", "params": {"path": "/list.txt"}}
-        medias = {
+        medias: dict[int, dict[str, Any]] = {
             1: {"origin_name": "a.wav", "filename": "a.wav", "origin": {"existing": True}},
         }
         # name_to_source has no entry for "a.wav" → media must be left alone.

--- a/tests/datasets/test_origin_isolation.py
+++ b/tests/datasets/test_origin_isolation.py
@@ -1,0 +1,158 @@
+"""Regression tests for H8 — origin dict shared by reference across medias.
+
+The previous implementations of ``_tag_origins`` (in
+``vtscore/datasets/load_pipeline.py``), the legacy ingest path in
+``vtscore/datasets/ingest.py``, ``ServerFilesDatasetImporter._rewrite_origins``,
+and ``_build_folder_media_data`` (in ``vtscore/datasets/loader_folder.py``)
+all stamped the same ``origin`` dict reference onto every media they
+visited.  A later mutation of ``media["origin"]["params"]`` on any one
+of them therefore silently propagated to every sibling — and the
+aliasing survived pickle round-trips via backreferences.
+
+These tests pin down the fixed behaviour: each media must own a fresh,
+independent ``origin`` (including a fresh ``params``).
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any
+
+import app as app_module  # noqa: F401  (sets up Flask test infra via conftest)
+from vtscore.datasets.importers.server_files import ServerFilesDatasetImporter
+from vtscore.datasets.load_pipeline import _tag_origins
+from vtscore.datasets.loader_folder import _build_folder_media_data
+
+
+def _assert_isolated(*medias: dict[str, Any]) -> None:
+    """Every pair must hold distinct ``origin`` and ``params`` dicts."""
+    for i, a in enumerate(medias):
+        for b in medias[i + 1 :]:
+            assert a["origin"] is not b["origin"], "origin dict is shared by reference"
+            assert a["origin"]["params"] is not b["origin"]["params"], "origin.params is shared by reference"
+
+
+class TestTagOriginsIsolation:
+    def test_each_media_gets_distinct_origin_and_params(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data", "media_type": "audio"}}
+        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}, 3: {"filename": "c.wav"}}
+        _tag_origins(medias, origin)
+        _assert_isolated(medias[1], medias[2], medias[3])
+
+    def test_mutating_one_origin_params_does_not_leak_to_siblings(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
+        _tag_origins(medias, origin)
+
+        medias[1]["origin"]["params"]["extra"] = "only-on-1"
+        medias[1]["origin"]["importer"] = "mutated"
+
+        assert "extra" not in medias[2]["origin"]["params"]
+        assert medias[2]["origin"]["importer"] == "server_folder"
+
+    def test_origin_values_are_preserved(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data", "media_type": "audio"}}
+        medias = {1: {"filename": "a.wav"}}
+        _tag_origins(medias, origin)
+        assert medias[1]["origin"] == origin
+        # ...but it must not be the same object.
+        assert medias[1]["origin"] is not origin
+        assert medias[1]["origin"]["params"] is not origin["params"]
+
+    def test_origin_name_falls_back_to_filename(self):
+        origin = {"importer": "x", "params": {}}
+        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav", "origin_name": "kept"}}
+        _tag_origins(medias, origin)
+        assert medias[1]["origin_name"] == "a.wav"
+        assert medias[2]["origin_name"] == "kept"
+
+    def test_skips_medias_that_already_carry_an_origin(self):
+        pre_existing = {"importer": "other", "params": {"k": "v"}}
+        origin = {"importer": "new", "params": {"k": "w"}}
+        medias = {1: {"filename": "a.wav", "origin": pre_existing}, 2: {"filename": "b.wav"}}
+        _tag_origins(medias, origin)
+        assert medias[1]["origin"] is pre_existing  # untouched
+        assert medias[2]["origin"]["importer"] == "new"
+        assert medias[2]["origin"] is not origin
+
+    def test_isolation_survives_pickle_roundtrip(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        medias = {1: {"filename": "a.wav"}, 2: {"filename": "b.wav"}}
+        _tag_origins(medias, origin)
+
+        revived = pickle.loads(pickle.dumps(medias))
+        _assert_isolated(revived[1], revived[2])
+
+        revived[1]["origin"]["params"]["extra"] = "only-on-1"
+        assert "extra" not in revived[2]["origin"]["params"]
+
+
+class TestBuildFolderMediaDataIsolation:
+    def _build(self, media_id: int, rel_path: str, origin: dict[str, Any] | None) -> dict[str, Any]:
+        return _build_folder_media_data(
+            media_id=media_id,
+            type_id="audio",
+            embedder_id="test_embedder",
+            embedding=None,
+            md5="deadbeef",
+            rel_path=rel_path,
+            file_path=Path(rel_path),
+            file_size=42,
+            origin=origin,
+        )
+
+    def test_two_calls_share_no_origin_state(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        a = self._build(1, "a.wav", origin)
+        b = self._build(2, "b.wav", origin)
+        _assert_isolated(a, b)
+
+    def test_mutating_one_origin_does_not_leak(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        a = self._build(1, "a.wav", origin)
+        b = self._build(2, "b.wav", origin)
+        a["origin"]["params"]["clipper"] = "audio_default"
+        assert "clipper" not in b["origin"]["params"]
+        # Caller-provided origin is also untouched.
+        assert "clipper" not in origin["params"]
+
+    def test_none_origin_passes_through(self):
+        media = self._build(1, "a.wav", None)
+        assert media["origin"] is None
+
+
+class TestRewriteOriginsIsolation:
+    """``ServerFilesDatasetImporter._rewrite_origins`` repoints each media's
+    origin at the canonical importer dict — but every media must get its
+    own copy, not a shared reference.
+    """
+
+    def test_each_media_gets_distinct_origin(self, tmp_path):
+        origin = {"importer": "server_files", "params": {"path": "/list.txt"}}
+        src_a = tmp_path / "a.wav"
+        src_b = tmp_path / "b.wav"
+        medias = {
+            1: {"origin_name": "a.wav", "filename": "a.wav"},
+            2: {"origin_name": "b.wav", "filename": "b.wav"},
+        }
+        name_to_source = {"a.wav": src_a, "b.wav": src_b}
+
+        importer = ServerFilesDatasetImporter()
+        importer._rewrite_origins(medias, name_to_source, origin)
+
+        _assert_isolated(medias[1], medias[2])
+        # Mutation isolation.
+        medias[1]["origin"]["params"]["mutated"] = "yes"
+        assert "mutated" not in medias[2]["origin"]["params"]
+        assert "mutated" not in origin["params"]
+
+    def test_skips_medias_with_no_matching_source(self, tmp_path):
+        origin = {"importer": "server_files", "params": {"path": "/list.txt"}}
+        medias = {
+            1: {"origin_name": "a.wav", "filename": "a.wav", "origin": {"existing": True}},
+        }
+        # name_to_source has no entry for "a.wav" → media must be left alone.
+        importer = ServerFilesDatasetImporter()
+        importer._rewrite_origins(medias, {}, origin)
+        assert medias[1]["origin"] == {"existing": True}

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -339,12 +339,19 @@ class ServerFilesDatasetImporter(DatasetImporter):
         name_to_source: dict[str, Path],
         origin: dict[str, Any],
     ) -> None:
-        """Point each media at its real source path instead of the symlink."""
+        """Point each media at its real source path instead of the symlink.
+
+        Each media gets a fresh copy of *origin* so a later mutation of one
+        media's ``origin.params`` cannot leak across siblings.
+        """
         for media in medias.values():
             src = name_to_source.get(media.get("origin_name", "")) or name_to_source.get(media.get("filename", ""))
             if src is None:
                 continue
-            media["origin"] = origin
+            media["origin"] = {
+                "importer": origin.get("importer", ""),
+                "params": dict(origin.get("params", {})),
+            }
             media["origin_name"] = str(src)
             media["media_path"] = str(src)
 

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -391,10 +391,15 @@ def ingest_missing_medias(  # noqa: C901
             # If the importer fails (e.g. folder not found), skip this origin
             continue
 
-        # Set origin on temp medias that don't have one
+        # Set origin on temp medias that don't have one.  Each media gets a
+        # fresh copy so a later mutation of one media's ``origin.params``
+        # cannot leak across siblings (and across pickle round-trips).
         for media in temp_medias.values():
             if media.get("origin") is None:
-                media["origin"] = origin_dict
+                media["origin"] = {
+                    "importer": origin_dict.get("importer", ""),
+                    "params": dict(origin_dict.get("params", {})),
+                }
             if not media.get("origin_name"):
                 media["origin_name"] = media.get("filename", "")
 

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -706,10 +706,20 @@ def _run_importer(load_fn, ctx: DatasetContext, stepped) -> None:
 
 
 def _tag_origins(media_dict: dict, origin: dict) -> None:
-    """Stamp *origin* onto medias that don't already carry one."""
+    """Stamp *origin* onto medias that don't already carry one.
+
+    Each media gets its own fresh copy of the origin dict (including a
+    fresh ``params``).  Sharing one dict by reference across siblings
+    means any later mutation of ``media["origin"]["params"]`` on one
+    media silently corrupts every other media stamped by the same load —
+    and that aliasing also survives pickle round-trips via backreferences.
+    """
     for media in media_dict.values():
         if media.get("origin") is None:
-            media["origin"] = origin
+            media["origin"] = {
+                "importer": origin.get("importer", ""),
+                "params": dict(origin.get("params", {})),
+            }
         if not media.get("origin_name"):
             media["origin_name"] = media.get("filename", "")
 

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -359,7 +359,20 @@ def _build_folder_media_data(
 
     Type-specific fields (and ``media_bytes`` for full mode) are merged
     by the caller after this base is constructed.
+
+    The *origin* dict is copied per-media so siblings never share the
+    same nested ``params`` dict — a later mutation on one media would
+    otherwise propagate to every other media built from the same call,
+    and that aliasing also survives pickle round-trips via backrefs.
     """
+    media_origin: dict[str, Any] | None
+    if origin is None:
+        media_origin = None
+    else:
+        media_origin = {
+            "importer": origin.get("importer", ""),
+            "params": dict(origin.get("params", {})),
+        }
     return {
         "id": media_id,
         "type": type_id,
@@ -369,7 +382,7 @@ def _build_folder_media_data(
         "embedding": embedding,
         "filename": rel_path,
         "category": "custom",
-        "origin": origin,
+        "origin": media_origin,
         "origin_name": rel_path,
         "media_bytes": None,
         "media_string": None,


### PR DESCRIPTION
## Summary

Fixes H8 from `docs/plans/logical-bug-audit.md`. `_tag_origins()` and three sibling tagging sites previously multiplexed one `origin` dict reference across every media in a load — so any later `media["origin"]["params"][k] = v` would silently corrupt every sibling, and the aliasing survived pickle round-trips via backreferences. Each tagging site now constructs a fresh `{"importer": ..., "params": dict(...)}` per media.

Sites fixed:
- `vtscore/datasets/load_pipeline.py:_tag_origins` (the audit's primary site).
- `vtscore/datasets/loader_folder.py:_build_folder_media_data` (folder-importer persisted-media constructor).
- `vtscore/datasets/importers/server_files/__init__.py:_rewrite_origins`.
- `vtscore/datasets/ingest.py` legacy re-ingest loop.

The pre-existing defensive `dict(...)` copies in `_apply_clipper` and `_stamp_origin` (clipper_chain.py) become belt-and-braces — H8 was latent in the prior tree because every known post-tag mutator already deep-copied, but the aliasing was a sharp edge waiting for the next contributor.

Doc: H8 collapsed to a struck-through heading in `docs/plans/logical-bug-audit.md` per the current convention.

Also includes:
- `Regenerate OpenAPI snapshot for the new 409 on dev` — a recently-merged dev change added a 409 on `/api/auto-detect` but didn't regenerate the snapshot, leaving `run-tests.sh` blocked at the drift guard.

## Test plan

- [x] New regression suite: `tests/datasets/test_origin_isolation.py` (11 tests) — pins distinct `origin` and `params` dicts per media, mutation isolation across siblings, and that the isolation survives a pickle round-trip; also covers "skip medias that already carry an origin" semantics.
- [x] `./run-tests.sh datasets` — 530 passed, 1 skipped.
- [x] `./run-tests.sh` (full suite) — 4013 passed, 1 skipped, 2 xpassed. 3 failures (`TestValidatedVoteSnapshot` in `tests/detectors/test_detectors.py`) are pre-existing on `origin/dev` HEAD — confirmed by reproducing on a clean `origin/dev` checkout — and are unrelated to H8 (they touch `validated_vote_snapshot` / dataset-sync code I didn't modify).
- [x] ruff / format / codespell / deptry / pyright / OpenAPI snapshot all clean.
