### PR TITLE
H23: mark withdrawn in logical-bug-audit (duplicate of shipped C9)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -279,10 +279,18 @@ Cross-section interaction agents:
 
 ### Security / sync
 
-- **H23. Settings-source filepath template not path-validated** —
-  `vtsearch/settings.py` L939–946 + the source plugins above. Even
-  with `sanitize_template_value()`, the template itself can contain
-  `../`, and the substituted path is never re-validated.
+- ~~**H23. Settings-source filepath template not path-validated**~~ —
+  duplicate of C9 (already struck through above); shipped in commit
+  `988dca3b` ("logical-bug-audit C9 — validate resolved sync-source
+  paths"). Both sync sources now call
+  `validate_server_filepath(resolved, base_dir=get_file_access_base_dir())`
+  at the end of `_resolve_filepath()`
+  (`vtsearch/settings_io/sources/server_json_file/__init__.py:89`,
+  `vtscore/labels/sources/server_json_file/__init__.py:121`/L150), so
+  the background sync site at `vtsearch/settings.py:932` is covered
+  alongside route handlers. Regression tests:
+  `tests/io/test_sync_sources.py::test_resolved_template_path_outside_base_dir_rejected`
+  (one per source).
 
 ### Frontend
 


### PR DESCRIPTION
## Summary

H23 in the logical-bug-audit High section described the same gap as
C9 (already struck through in the Critical section): sync-source
filepath templates substituted user values via
`sanitize_template_value()` but never re-validated the *resolved* path,
so a template containing `../` could escape the file-access base
directory on the background-sync code path that bypasses route-layer
validation.

Commit `988dca3b` ("logical-bug-audit C9 — validate resolved sync-source
paths") shipped the fix by adding a
`validate_server_filepath(resolved, base_dir=get_file_access_base_dir())`
call at the end of `_resolve_filepath()` in both server-JSON sync
sources (settings + labelset), plus the labelset source's
`resolve_filepath_for()` helper used by the rename flow:

- `vtsearch/settings_io/sources/server_json_file/__init__.py:89`
- `vtscore/labels/sources/server_json_file/__init__.py:121` / `:150`

`tests/io/test_sync_sources.py` covers both sources with
`test_resolved_template_path_outside_base_dir_rejected` regressions
that exercise `../`-prefixed templates against `_resolve_filepath`,
`load` / `load_full`, and `save`.

This PR strikes H23 through to match C9's treatment and adds a short
note pointing readers at the shipping commit and tests, so a future
audit scan does not re-open the same bug.

## Test plan

- [x] No code changes — docs only.
- [x] Confirmed both sync sources call `validate_server_filepath()` on
  the resolved path in current `dev`.
- [x] Confirmed regression tests exist at
  `tests/io/test_sync_sources.py:245` (settings source) and `:355`
  (labelset source).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXPNetWTSX3MDz9by4UtU4)_