### PR TITLE
H26: gate the undo-stack push on the vote POST's success

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -296,10 +296,20 @@ Cross-section interaction agents:
   `setActivePair()` runs before the load is verified; interceptor
   immediately tags subsequent requests with a context that may not
   be loaded → cascade of 404s.
-- **H26. `recordVote` runs before the HTTP vote returns** —
-  `frontend/src/app/components/center-panel/center-panel.component.ts`
-  L249–251. Undo stack contains a vote that may have never reached
-  the server; Cmd-Z then posts a "reversal" of nothing.
+- ~~**H26. `recordVote` runs before the HTTP vote returns**~~ — fixed
+  by gating the undo-stack push on the POST's success.  A new
+  `VoteStateService.submitToggleVoteAndRecord(id, vote, mediaName,
+  regionBox?)` captures `previousPolarity` synchronously (before the
+  optimistic flip), then calls `submitToggleVote(...)` and pushes the
+  undo entry inside the resulting Observable's `tap` — so an entry
+  only lands on `past` after the server confirms.  On error the `tap`
+  doesn't run, leaving the undo / redo stacks untouched.  The three
+  callers (`center-panel`, `find-view`, `label-view`) were migrated to
+  the new helper; `recordVote` stays public as a low-level primitive
+  (used by the spec) with a docstring pointing future callers at the
+  wrapper.  Regressions in `vote-state.service.spec.ts` cover (a) the
+  no-entry-on-error path, (b) `previousPolarity` capture before the
+  flip, and (c) redo-stack preservation on a failed POST.
 - **H27. Binary media endpoints bypass the `activeContextInterceptor`** —
   `frontend/src/app/services/medias-api.service.ts` L41–60. Raw
   `HttpClient.get()` for `/api/medias/.../audio|video|image` lacks

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -246,29 +246,30 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     const regionBox = vote === 'good' ? this.currentRegionBox : null;
     this.pendingBadConfirm = false;
     this.isVoting = true;
-    this.voteState.recordVote(this.media.id, vote, this.mediaDisplayName(this.media));
 
-    this.voteState.submitToggleVote(this.media.id, vote, regionBox).subscribe({
-      next: () => {
-        const animate = this.swipeAnimation && !!this.media && !prefersReducedMotion();
-        if (animate) {
-          this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
-          this.spinningVote = vote;
-          if (this.spinTimer) clearTimeout(this.spinTimer);
-          this.spinTimer = setTimeout(() => (this.spinningVote = null), 300);
-          setTimeout(() => {
+    this.voteState
+      .submitToggleVoteAndRecord(this.media.id, vote, this.mediaDisplayName(this.media), regionBox)
+      .subscribe({
+        next: () => {
+          const animate = this.swipeAnimation && !!this.media && !prefersReducedMotion();
+          if (animate) {
+            this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
+            this.spinningVote = vote;
+            if (this.spinTimer) clearTimeout(this.spinTimer);
+            this.spinTimer = setTimeout(() => (this.spinningVote = null), 300);
+            setTimeout(() => {
+              this.mediaVoted.emit({ id: this.media!.id, vote });
+              this.isVoting = false;
+            }, 180);
+          } else {
             this.mediaVoted.emit({ id: this.media!.id, vote });
             this.isVoting = false;
-          }, 180);
-        } else {
-          this.mediaVoted.emit({ id: this.media!.id, vote });
+          }
+        },
+        error: () => {
           this.isVoting = false;
-        }
-      },
-      error: () => {
-        this.isVoting = false;
-      },
-    });
+        },
+      });
   }
 
   onRegionBoxChange(box: RegionBox | null): void {

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -373,9 +373,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.sortState.sortBusy) return;
     const m = this.mediaState.getMedia(event.id);
     const name = m?.filename || m?.origin_name || `#${event.id}`;
-    this.voteState.recordVote(event.id, event.vote, name);
     this.voteState
-      .submitToggleVote(event.id, event.vote)
+      .submitToggleVoteAndRecord(event.id, event.vote, name)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -870,9 +870,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
-    this.voteState.recordVote(event.id, event.vote, this.mediaDisplayName(event.id));
     this.voteState
-      .submitToggleVote(event.id, event.vote)
+      .submitToggleVoteAndRecord(event.id, event.vote, this.mediaDisplayName(event.id))
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -372,6 +372,90 @@ describe('VoteStateService', () => {
     });
   });
 
+  describe('submitToggleVoteAndRecord (the H26 fix surface)', () => {
+    it('records the undo entry only after the POST succeeds', () => {
+      service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe();
+      // Undo stack must be empty while the POST is in flight.
+      expect(service.canUndo()).toBeFalse();
+
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+
+      // After confirmation, the entry should be on the stack.
+      expect(service.canUndo()).toBeTrue();
+    });
+
+    it('does NOT record an undo entry when the POST errors', () => {
+      service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe({
+        next: () => {},
+        error: () => {},
+      });
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      req.flush(null, { status: 500, statusText: 'Server Error' });
+
+      // The failed POST must not leave a phantom undo entry — Cmd-Z next
+      // would otherwise post a "reversal" of a vote that never happened.
+      expect(service.canUndo()).toBeFalse();
+    });
+
+    it('captures previousPolarity before the optimistic flip', () => {
+      // Media starts as "good"; user clicks bad (a flip).
+      service.applyOptimisticState(5, 'good');
+
+      service.submitToggleVoteAndRecord(5, 'bad', 'foo.wav').subscribe();
+      // submitToggleVote inside has already optimistically flipped 5 to bad.
+      expect(service.badVotes.has(5)).toBeTrue();
+
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      req.flush({ ok: true, state: 'bad', click_time: 2 });
+
+      // Undo should now POST target='good' (the previousPolarity before
+      // the click, NOT the polarity that the optimistic flip put us in).
+      service.undo();
+      const undoReq = httpMock.expectOne('/api/medias/5/vote');
+      expect(undoReq.request.body).toEqual({ target: 'good' });
+      undoReq.flush({ ok: true, state: 'good', click_time: 3 });
+    });
+
+    it('clears the redo stack only when the POST succeeds', () => {
+      // Set up a redo entry the normal way.
+      service.recordVote(1, 'good', 'a');
+      service.applyOptimisticState(1, 'good');
+      service.undo();
+      httpMock
+        .expectOne('/api/medias/1/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
+      expect(service.canRedo()).toBeTrue();
+
+      // A new vote whose POST fails must NOT wipe the redo stack — the
+      // vote never happened, so the redo entry is still legitimate.
+      service.submitToggleVoteAndRecord(2, 'bad', 'b').subscribe({
+        next: () => {},
+        error: () => {},
+      });
+      httpMock
+        .expectOne('/api/medias/2/vote')
+        .flush(null, { status: 500, statusText: 'Server Error' });
+      expect(service.canRedo()).toBeTrue();
+
+      // A new vote whose POST succeeds wipes the redo stack as expected.
+      service.submitToggleVoteAndRecord(3, 'good', 'c').subscribe();
+      httpMock
+        .expectOne('/api/medias/3/vote')
+        .flush({ ok: true, state: 'good', click_time: 5 });
+      expect(service.canRedo()).toBeFalse();
+    });
+
+    it('honours regionBox on a good vote', () => {
+      service
+        .submitToggleVoteAndRecord(5, 'good', 'foo.wav', [0.1, 0.2, 0.3, 0.4])
+        .subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+    });
+  });
+
   it('goodVotes$ should emit on load', (done: DoneFn) => {
     const emissions: Set<number>[] = [];
     service.goodVotes$.subscribe((v) => emissions.push(v));

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -154,6 +154,41 @@ export class VoteStateService implements OnDestroy {
   }
 
   /**
+   * Like {@link submitToggleVote}, but also records an undo entry on the
+   * past stack — **only after the server confirms the vote**.  Production
+   * callers (centre / find / label views) should use this rather than
+   * pairing {@link submitToggleVote} with a separate {@link recordVote},
+   * because the latter ordering racks an undo entry that may not be
+   * reflected on the server (audit bug H26): a failed POST left a phantom
+   * entry on the stack, and a subsequent Cmd-Z then issued a "reversal" of
+   * a vote that never happened.
+   *
+   * `previousPolarity` is captured here, synchronously, **before** the
+   * optimistic flip — that snapshot is the only piece of state that has to
+   * exist pre-POST.  The undo entry itself is only pushed if the POST
+   * resolves successfully.
+   */
+  submitToggleVoteAndRecord(
+    id: number,
+    clickedDirection: 'good' | 'bad',
+    mediaName: string,
+    regionBox?: readonly number[] | null,
+  ): Observable<MediaVoteResponse> {
+    const previousPolarity: 'good' | 'bad' | null = this.goodVotesSubject.value.has(id)
+      ? 'good'
+      : this.badVotesSubject.value.has(id)
+        ? 'bad'
+        : null;
+    return this.submitToggleVote(id, clickedDirection, regionBox).pipe(
+      tap(() => {
+        this.past.push({ mediaId: id, clickedDirection, previousPolarity, mediaName });
+        if (this.past.length > UNDO_STACK_MAX) this.past.shift();
+        this.future = [];
+      }),
+    );
+  }
+
+  /**
    * Optimistically apply an absolute target state without going through the
    * toggle rule.  Used by {@link submitToggleVote} (above) and by the
    * Cmd-Z undo / redo flow, where the desired post-call state is known
@@ -257,7 +292,12 @@ export class VoteStateService implements OnDestroy {
 
   /**
    * Snapshot the polarity *before* a vote click and push it onto the undo
-   * stack.  Must be called BEFORE {@link submitToggleVote} (otherwise the
+   * stack.  Low-level primitive: pushes unconditionally, with no link to a
+   * POST result.  Production code should call {@link submitToggleVoteAndRecord}
+   * instead, which only records the entry once the server confirms the vote
+   * (audit bug H26).
+   *
+   * Must be called BEFORE the corresponding optimistic flip (otherwise the
    * snapshot would already reflect the toggle).  Any pending redo entries
    * are dropped, matching standard editor undo semantics.
    */

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -974,8 +974,8 @@ class TestValidatedVoteSnapshot:
         detector_id = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, detector_id)
 
-        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
         return detector_id, good_cid, bad_cid
 
     def test_snapshot_safe_when_aligned(self, client):


### PR DESCRIPTION
## Summary

Fixes audit bug **H26** (`docs/plans/logical-bug-audit.md`): the three vote-casting components (`center-panel`, `find-view`, `label-view`) pushed onto the undo stack synchronously, before `POST /api/medias/<id>/vote` returned. A failed POST left a phantom entry on `past`, and a later Cmd-Z would then POST a "reversal" of a vote that never reached the server.

The fix adds `VoteStateService.submitToggleVoteAndRecord(id, vote, mediaName, regionBox?)` which:

- captures `previousPolarity` synchronously, before the optimistic flip mutates the BehaviorSubjects;
- calls `submitToggleVote(...)` and chains a `tap` that pushes the undo entry **only after** the server confirms;
- leaves the undo / redo stacks untouched on POST error (the `tap` doesn't fire).

The three callers are migrated to the new helper. `recordVote` stays public — the spec exercises it directly as a primitive — but its docstring now points production callers at the wrapper.

While running the suite I also fixed three pre-existing failures in `TestValidatedVoteSnapshot` (stale `{"vote": "..."}` request bodies left over from the H1 contract rename — the test helper now posts `{"target": "..."}`).

## Test plan

- [x] `./run-tests.sh core` — frontend TypeScript build clean, 561 passed
- [x] `./run-tests.sh` — full suite, 4016 passed, 1 skipped, 0 failed
- [x] New regressions in `vote-state.service.spec.ts` cover:
  - undo entry only lands after a successful POST
  - failed POST does NOT push an entry (the H26 scenario)
  - `previousPolarity` is captured before the optimistic flip (verified via a flip-and-undo round-trip)
  - redo-stack is preserved when a vote's POST fails
  - `regionBox` passes through on a good vote

https://claude.ai/code/session_017N6X3XdXtzpNfhyarsTt7R

---
_Generated by [Claude Code](https://claude.ai/code/session_017N6X3XdXtzpNfhyarsTt7R)_