### PR TITLE
Fix H22: persist detector embedder for accurate preload

### DIFF
--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -974,8 +974,8 @@ class TestValidatedVoteSnapshot:
         detector_id = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, detector_id)
 
-        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
         return detector_id, good_cid, bad_cid
 
     def test_snapshot_safe_when_aligned(self, client):

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -230,6 +230,8 @@ class TestPredictEmbeddersToPreload:
             assert predict_embedders_to_preload() == ["clap", "siglip"]
 
     def test_detectors_contribute_default_embedder(self):
+        # Legacy detector entry without an ``embedder`` field falls back to
+        # the media type's default.
         fake_default = MagicMock()
         fake_default.name = "e5"
         with (
@@ -239,15 +241,51 @@ class TestPredictEmbeddersToPreload:
         ):
             assert predict_embedders_to_preload() == ["e5"]
 
-    def test_unregistered_embedder_name_filtered_out(self):
-        # entry["embedder"] = "ghost" is not in the embedder registry → dropped.
+    def test_detector_with_explicit_embedder_is_preloaded(self):
+        # Detector entries can record the embedder their labels are
+        # embedded against; preload should warm that one, not the media
+        # type's default.
+        with (
+            patch("vtscore.datasets.registry.list_datasets", return_value=[]),
+            patch(
+                "vtscore.detectors.registry.list_detectors",
+                return_value=[{"media_type": "image", "embedder": "face"}],
+            ),
+        ):
+            assert predict_embedders_to_preload() == ["face"]
+
+    def test_detector_with_unrecognised_embedder_falls_back_to_default(self):
+        # When the recorded embedder is no longer registered (renamed,
+        # removed, typo) fall back to the media type's default rather than
+        # silently skipping — losing the optimisation entirely is worse
+        # than warming the wrong embedder.
+        fake_default = MagicMock()
+        fake_default.name = "siglip"
+        with (
+            patch("vtscore.datasets.registry.list_datasets", return_value=[]),
+            patch(
+                "vtscore.detectors.registry.list_detectors",
+                return_value=[{"media_type": "image", "embedder": "ghost"}],
+            ),
+            patch("vtscore.media.embedders_for_type", return_value=[fake_default]),
+        ):
+            assert predict_embedders_to_preload() == ["siglip"]
+
+    def test_dataset_with_unrecognised_embedder_falls_back_to_default(self):
+        # Same hardening on the dataset side: a set-but-invalid embedder
+        # name (e.g. embedder removed between sessions) shouldn't silently
+        # drop the preload — fall back to the media type's default.
+        fake_default = MagicMock()
+        fake_default.name = "clap"
         with (
             patch(
-                "vtscore.datasets.registry.list_datasets", return_value=[{"media_type": "audio", "embedder": "ghost"}]
+                "vtscore.datasets.registry.list_datasets",
+                return_value=[{"media_type": "audio", "embedder": "ghost"}],
             ),
             patch("vtscore.detectors.registry.list_detectors", return_value=[]),
+            patch("vtscore.media.embedders_for_type", return_value=[fake_default]),
         ):
-            assert predict_embedders_to_preload() == []
+            assert predict_embedders_to_preload() == ["clap"]
 
 
 class TestInterceptWeightLoadingProgress:

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -271,9 +271,14 @@ def populate_label_embeddings(
             on_progress(elem.origin_name or elem.filename or eid, idx + 1, total)
 
     # Stamp the embedder the cache is now built against so the next call can
-    # detect a switch and invalidate.
+    # detect a switch and invalidate.  Also persist to the detector registry
+    # so the smart preload predictor warms the right model next session
+    # instead of the media type's default.
     if embedder_name:
         det_ctx.embedder = embedder_name
+        from vtscore.detectors.registry import record_detector_embedder
+
+        record_detector_embedder(det_ctx.detector_id, embedder_name)
     return cached
 
 

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -103,6 +103,7 @@ def register_detector(
     text_query: str = "",
     media_example: str = "",
     created_by: str = "default",
+    embedder: str = "",
 ) -> dict[str, Any]:
     """Add a new detector to the registry and persist.
 
@@ -114,6 +115,12 @@ def register_detector(
         text_query: Text-sort query associated with the detector.
         media_example: Optional path to an example media file.
         created_by: Username of the user who created this detector.
+        embedder: Name of the embedder used for this detector's labels.
+            Defaults to ``""`` for newly created detectors that haven't been
+            trained yet; stamped automatically the first time training runs
+            (see :func:`record_detector_embedder`).  Read by the smart
+            preload predictor so the right model is warmed at startup
+            instead of the media type's default.
 
     Returns:
         The newly created entry dict.
@@ -129,6 +136,7 @@ def register_detector(
         "media_example": media_example,
         "created_by": created_by,
         "created_at": time.time(),
+        "embedder": embedder,
     }
     with _lock:
         entries = _ensure_loaded()
@@ -172,6 +180,31 @@ def update_detector(detector_id: str, **fields: Any) -> bool:
                 _save(entries)
                 return True
     return False
+
+
+def record_detector_embedder(detector_id: str, embedder_name: str) -> None:
+    """Persist the embedder a detector's labels are currently embedded with.
+
+    Called from the training paths that stamp ``DetectorContext.embedder``
+    so the smart preload predictor knows which model to warm on the next
+    process start.  No-ops on empty inputs or unknown detector ids; swallows
+    registry write failures because losing the optimization is preferable
+    to crashing a training cycle.
+    """
+    if not detector_id or not embedder_name:
+        return
+    try:
+        with _lock:
+            entries = _ensure_loaded()
+            for entry in entries:
+                if entry["id"] == detector_id:
+                    if entry.get("embedder") == embedder_name:
+                        return
+                    entry["embedder"] = embedder_name
+                    _save(entries)
+                    return
+    except Exception as exc:
+        logger.warning("Failed to persist embedder for detector %s: %s", detector_id, exc)
 
 
 def find_by_name(name: str) -> dict[str, Any] | None:

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -126,6 +126,9 @@ def apply_and_retrain(  # noqa: C901
             first = next(iter(snap.values()), {})
             det_ctx.embedder = first.get("embedder", "")
             det_ctx.media_type = first.get("type", "")
+            from vtscore.detectors.registry import record_detector_embedder
+
+            record_detector_embedder(det_ctx.detector_id, det_ctx.embedder)
             trained = True
 
         return resolved, trained

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -134,13 +134,19 @@ def predict_embedders_to_preload() -> list[str]:
     Walks the dataset registry and detector registry and returns the unique
     list of embedder names the user is likely to need:
 
-    - For each registered dataset: ``entry["embedder"]`` if set, otherwise
-      the default embedder for ``entry["media_type"]``.
-    - For each registered detector: the default embedder for
-      ``entry["media_type"]``.
+    - For each registered dataset and detector: ``entry["embedder"]`` if set
+      and recognised, otherwise the default embedder for
+      ``entry["media_type"]``.  A set-but-unrecognised ``embedder`` (e.g.
+      the embedder was renamed or removed) also falls back to the media
+      type's default rather than being silently dropped — losing the
+      optimisation entirely on a typo is worse than warming the wrong
+      embedder, which the user can still override.
 
-    Names not matching a registered embedder are filtered out. Order
-    reflects discovery order (datasets first, then detectors), so the
+    Detector entries written before the ``embedder`` field existed have
+    ``entry["embedder"] == ""``, so they fall through to the media type's
+    default — matching the previous behaviour for unmigrated state.
+
+    Order reflects discovery order (datasets first, then detectors), so the
     output is stable across runs.
     """
     from vtscore.datasets.registry import list_datasets
@@ -162,12 +168,17 @@ def predict_embedders_to_preload() -> list[str]:
         opts = embedders_for_type(media_type)
         return opts[0].name if opts else ""
 
+    def _resolve(entry: dict) -> str:
+        emb = (entry.get("embedder") or "").strip()
+        if emb and emb in valid:
+            return emb
+        return _default_for(entry.get("media_type", "") or "")
+
     for entry in list_datasets():
-        emb = entry.get("embedder", "") or ""
-        _add(emb if emb else _default_for(entry.get("media_type", "")))
+        _add(_resolve(entry))
 
     for entry in list_detectors():
-        _add(_default_for(entry.get("media_type", "")))
+        _add(_resolve(entry))
 
     return predictions
 
@@ -235,7 +246,8 @@ def predict_embedder_for_dataset(dataset_id: str) -> str:
 
     Mirrors the per-dataset half of :func:`predict_embedders_to_preload`
     for a single registry entry: returns ``entry["embedder"]`` if set and
-    valid, otherwise the default embedder for ``entry["media_type"]``.
+    recognised, otherwise the default embedder for ``entry["media_type"]``
+    (also the fallback when ``embedder`` is set but unrecognised).
     Returns ``""`` when the dataset is unknown or has no resolvable
     embedder.
     """

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -95,13 +95,16 @@ def list_registered_detectors():
         entry["detector_loaded"] = did in loaded_ids
         # Expose the loaded detector's recorded embedder so the frontend
         # can detect a cross-embedder switch and trigger a label re-embed
-        # via /api/detectors/registry/load. Unloaded detectors have no
-        # embedder yet (it's inferred from the dataset on load).
+        # via /api/detectors/registry/load.  Loaded contexts always win
+        # because they reflect the live cache state; for unloaded
+        # detectors fall back to the registry's persisted embedder (which
+        # is stamped the first time training runs against a dataset).
         if entry["detector_loaded"]:
             ctx = get_detector_context(did)
-            entry["embedder"] = ctx.embedder if ctx is not None else ""
+            ctx_emb = ctx.embedder if ctx is not None else ""
+            entry["embedder"] = ctx_emb or entry.get("embedder", "") or ""
         else:
-            entry["embedder"] = ""
+            entry["embedder"] = entry.get("embedder", "") or ""
     return {"detectors": entries}
 
 

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -267,8 +267,11 @@ class DetectorRegistryEntrySchema(Schema):
     detector_loaded = fields.Boolean()
     autorun = fields.Boolean()
     last_trained_at = fields.Float(allow_none=True)
-    # Recorded only for loaded detectors. Empty for unloaded entries (the
-    # embedder is inferred from the active dataset at load time).
+    # Stamped the first time a detector trains against a dataset and
+    # persisted on the registry entry, so the smart preload predictor and
+    # the dashboard's cross-embedder check both see it without having to
+    # load the detector.  Loaded contexts override the persisted value
+    # when present.  Empty string for detectors that have never trained.
     embedder = fields.String()
 
     class Meta:


### PR DESCRIPTION
## Summary

Fixes logical-bug-audit **H22** — `predict_embedders_to_preload` was warming the wrong model for any detector trained against a non-default embedder, and silently dropping any dataset whose `embedder` field referenced a name that wasn't in the embedder registry.

- **Detector registry now persists `embedder`.** New `embedder` field on entries, stamped via a new `record_detector_embedder()` helper the moment `DetectorContext.embedder` is set during training (both the `populate_label_embeddings` cache-build and the `apply_and_retrain` workflow path). Legacy entries with no field fall back to the media type's default — the prior behaviour for unmigrated state.
- **Smart preload reads the persisted embedder for detectors.** `predict_embedders_to_preload` now uses `entry["embedder"]` for both datasets and detectors, with a unified `_resolve` helper.
- **Set-but-unrecognised embedder no longer silently dropped.** Both dataset and detector paths now fall back to `_default_for(media_type)` when the recorded name isn't in the registry (e.g. embedder renamed or removed). Losing the optimisation entirely on a typo is worse than warming the wrong embedder.
- **Dashboard surfaces the persisted embedder.** `GET /api/detectors/registry` reads the registry value for unloaded detectors (loaded contexts still win when present), so the cross-embedder warning UX doesn't have to wait for a load.

The fix is graceful: detectors that have never trained keep `embedder=""` and behave exactly as before; the field is populated automatically on first training run.

Also fixes a pre-existing failure: `TestValidatedVoteSnapshot._setup_detector_with_votes` still posted `{"vote": "good"}` after #1550 (H1) moved the endpoint to absolute-target `{"target": "good"}` semantics. Schema validation was silently rejecting it with 422, so no votes were being cast in the test.

## Test plan
- [x] `./run-tests.sh` — 4018 passed, 1 skipped, 2 xpassed
- [x] New preload-prediction tests cover detector-with-embedder, detector-with-unrecognised-embedder fallback, and dataset-with-unrecognised-embedder fallback
- [x] Pre-existing `TestValidatedVoteSnapshot` failures now pass

https://claude.ai/code/session_019AZ5muXdRP76ErhxAffy3z

---
_Generated by [Claude Code](https://claude.ai/code/session_019AZ5muXdRP76ErhxAffy3z)_