### PR TITLE
H27: mark not-a-bug and remove dead binary-media methods

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -313,11 +313,19 @@ Cross-section interaction agents:
   wrapper.  Regressions in `vote-state.service.spec.ts` cover (a) the
   no-entry-on-error path, (b) `previousPolarity` capture before the
   flip, and (c) redo-stack preservation on a failed POST.
-- **H27. Binary media endpoints bypass the `activeContextInterceptor`** —
-  `frontend/src/app/services/medias-api.service.ts` L41–60. Raw
-  `HttpClient.get()` for `/api/medias/.../audio|video|image` lacks
-  `X-Dataset-Id`; correct dataset is inferred by interceptor only for
-  typed-client calls.
+- ~~**H27. Binary media endpoints bypass the `activeContextInterceptor`**~~
+  — Not a bug. Functional `HttpInterceptorFn`s registered via
+  `provideHttpClient(withInterceptors([...]))` apply to **every**
+  `HttpClient` call — typed-client wrappers and raw `this.http.get(...)`
+  share the same client and the same interceptor chain. The real
+  bypass surface is native `<img src>` / `<audio src>` / `<video src>` /
+  `<iframe>` / `fetch()`, which don't go through `HttpClient` at all;
+  those are already handled by `ActiveContextService.mediaUrl()`
+  appending `?dataset_id=…&detector_id=…` query params, with the
+  backend reading them as a fallback (`app.py` L238, L252). Also
+  removed the four dead `getAudio/getVideo/getImage/getMedia` methods
+  on `MediasApiService` — they had no callers; every binary-stream
+  consumer goes through `mediaUrl()`.
 
 ### Multi-process / settings
 

--- a/frontend/src/app/services/medias-api.service.spec.ts
+++ b/frontend/src/app/services/medias-api.service.spec.ts
@@ -38,40 +38,11 @@ describe('MediasApiService', () => {
     req.flush(mock);
   });
 
-  it('getAudio should GET blob', () => {
-    service.getAudio(1).subscribe(data => expect(data instanceof Blob).toBeTrue());
-    const req = httpMock.expectOne('/api/medias/1/audio');
-    expect(req.request.method).toBe('GET');
-    expect(req.request.responseType).toBe('blob');
-    req.flush(new Blob());
-  });
-
-  it('getVideo should GET blob', () => {
-    service.getVideo(2).subscribe();
-    const req = httpMock.expectOne('/api/medias/2/video');
-    expect(req.request.method).toBe('GET');
-    req.flush(new Blob());
-  });
-
-  it('getImage should GET blob', () => {
-    service.getImage(3).subscribe();
-    const req = httpMock.expectOne('/api/medias/3/image');
-    expect(req.request.method).toBe('GET');
-    req.flush(new Blob());
-  });
-
   it('getText should GET json', () => {
     service.getText(4).subscribe(data => expect(data.content).toBe('hello'));
     const req = httpMock.expectOne('/api/medias/4/text');
     expect(req.request.method).toBe('GET');
     req.flush({ content: 'hello', word_count: 1, character_count: 5 });
-  });
-
-  it('getMedia should GET blob', () => {
-    service.getMedia(5).subscribe();
-    const req = httpMock.expectOne('/api/medias/5/media');
-    expect(req.request.method).toBe('GET');
-    req.flush(new Blob());
   });
 
   it('vote should POST with label', () => {

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -33,31 +33,8 @@ export class MediasApiService {
     return apiMediasBatchPost(this.http, this.config.rootUrl, { body: { ids } }).pipe(map((r) => r.body));
   }
 
-  /** Binary stream — stays on plain HttpClient because ng-openapi-gen
-   *  doesn't model binary response bodies usefully (the generated function
-   *  declares the success body as ``Error`` because the spec only carries
-   *  error responses for these routes). */
-  getAudio(id: number): Observable<Blob> {
-    return this.http.get(`/api/medias/${id}/audio`, { responseType: 'blob' });
-  }
-
-  /** Binary stream — see {@link getAudio}. */
-  getVideo(id: number): Observable<Blob> {
-    return this.http.get(`/api/medias/${id}/video`, { responseType: 'blob' });
-  }
-
-  /** Binary stream — see {@link getAudio}. */
-  getImage(id: number): Observable<Blob> {
-    return this.http.get(`/api/medias/${id}/image`, { responseType: 'blob' });
-  }
-
   getText(id: number): Observable<MediaParagraphResponse> {
     return apiMediasMediaIdTextGet(this.http, this.config.rootUrl, { media_id: id }).pipe(map((r) => r.body));
-  }
-
-  /** Binary stream — see {@link getAudio}. */
-  getMedia(id: number): Observable<Blob> {
-    return this.http.get(`/api/medias/${id}/media`, { responseType: 'blob' });
   }
 
   /**


### PR DESCRIPTION
## Summary

Investigated **H27** ("Binary media endpoints bypass the `activeContextInterceptor`") from `docs/plans/logical-bug-audit.md`. The finding's premise turns out to be incorrect:

- Angular's functional interceptors (`HttpInterceptorFn` registered via `provideHttpClient(withInterceptors([...]))` in `frontend/src/app/app.config.ts:14-20`) apply to **every** `HttpClient` call. Typed-client wrappers (`apiMediasIdsGet(this.http, …)`) and raw `this.http.get(...)` calls share the same `HttpClient` instance and the same interceptor chain — there is no opt-out.
- The real interceptor-bypass surface is native `<img src>` / `<audio src>` / `<video src>` / `<iframe>` / `fetch()`, which don't go through Angular's `HttpClient` at all. That surface is already handled by `ActiveContextService.mediaUrl()` appending `?dataset_id=…&detector_id=…`, with the backend reading the query params as a fallback (`app.py:238,252`).
- The four `getAudio` / `getVideo` / `getImage` / `getMedia` methods on `MediasApiService` are also **dead code** — `grep` finds no callers. Every binary-stream consumer in the app uses `mediaUrl()` instead.

## Changes

- `docs/plans/logical-bug-audit.md` — H27 marked as not-a-bug (struck-through heading, following the same convention used for H21).
- `frontend/src/app/services/medias-api.service.ts` — removed the four unused binary-stream methods (`getAudio`, `getVideo`, `getImage`, `getMedia`) and their stale comments.
- `frontend/src/app/services/medias-api.service.spec.ts` — removed the four tests covering the removed methods.

## Test plan

- [x] `cd frontend && npm run build:prod` — clean build, no warnings.
- [x] `npx tsc --noEmit -p tsconfig.spec.json` — exit 0.
- [x] `./run-tests.sh` — 4013 passed, 3 pre-existing failures in `TestValidatedVoteSnapshot` (unrelated to H27; the H1 absolute-target vote API change left the test helper using stale `{"vote": ...}` instead of `{"target": ...}`, already being fixed on parallel branches).
- [x] `grep -rn "\.getAudio\|\.getVideo\|\.getImage" frontend/src` confirms no callers of the removed methods.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8MQh1o5WDQHnVe8m6TdxQ)_