### PR TITLE
Fix H25: split ActiveContextService into intent + active layers

### DIFF
--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -110,7 +110,12 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       this.maybeAutoSelectNewDataset();
     });
     this.datasetState.detectors$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
-    this.activeContext.pair$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
+    // Read intent (not active) so the pulldown highlight updates the
+    // moment the user picks a row, rather than waiting for any
+    // dataset/detector load to finish.
+    this.activeContext.intentPair$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.rebuildRows());
     this.datasetState.error$.pipe(takeUntil(this.destroy$)).subscribe((err) => {
       this.registryError = err;
     });
@@ -231,9 +236,9 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       return;
     }
     if (this.isDataset) {
-      this.contextSwitch.switchTo(row.id, this.activeContext.modelId);
+      this.contextSwitch.switchTo(row.id, this.activeContext.intentModelId);
     } else {
-      this.contextSwitch.switchTo(this.activeContext.datasetId, row.id);
+      this.contextSwitch.switchTo(this.activeContext.intentDatasetId, row.id);
     }
     this.close();
   }
@@ -246,8 +251,8 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       this.knownIdsAtAddStart = new Set(this.datasetState.datasets.map((d) => d.id));
       this.newThingFlows.openImporter();
     } else {
-      const other = this.activeContext.datasetId
-        ? this.datasetState.datasets.find((d) => d.id === this.activeContext.datasetId)
+      const other = this.activeContext.intentDatasetId
+        ? this.datasetState.datasets.find((d) => d.id === this.activeContext.intentDatasetId)
         : null;
       this.newThingFlows.openNewDetector({ defaultMediaType: other?.media_type || '' });
     }
@@ -367,7 +372,9 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   private findActiveIndex(): number {
-    const id = this.isDataset ? this.activeContext.datasetId : this.activeContext.modelId;
+    const id = this.isDataset
+      ? this.activeContext.intentDatasetId
+      : this.activeContext.intentModelId;
     return this.rows.findIndex((r) => r.id === id);
   }
 
@@ -393,17 +400,20 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
 
   private switchToNewItem(id: string): void {
     if (this.isDataset) {
-      this.contextSwitch.switchTo(id, this.activeContext.modelId);
+      this.contextSwitch.switchTo(id, this.activeContext.intentModelId);
     } else {
-      this.contextSwitch.switchTo(this.activeContext.datasetId, id);
+      this.contextSwitch.switchTo(this.activeContext.intentDatasetId, id);
     }
   }
 
   private rebuildRows(): void {
     const datasets = this.datasetState.datasets;
     const detectors = this.datasetState.detectors;
-    const activeDsId = this.activeContext.datasetId;
-    const activeDetId = this.activeContext.modelId;
+    // Highlight rows by intent (what the user picked), not by what's
+    // currently loaded — picking a row should feel instant even when
+    // a dataset/detector load is still running behind the scenes.
+    const activeDsId = this.activeContext.intentDatasetId;
+    const activeDetId = this.activeContext.intentModelId;
     const activeDataset = activeDsId ? datasets.find((d) => d.id === activeDsId) : null;
     const activeDetector = activeDetId ? detectors.find((d) => d.id === activeDetId) : null;
 

--- a/frontend/src/app/services/active-context.service.ts
+++ b/frontend/src/app/services/active-context.service.ts
@@ -5,27 +5,57 @@ import { distinctUntilChanged, map } from 'rxjs/operators';
 /**
  * Tracks which dataset and model the user is currently working with.
  *
- * The HTTP interceptor (`activeContextInterceptor`) reads from this
- * service and attaches `X-Dataset-Id` / `X-Detector-Id` headers to every
- * outgoing API request so the backend resolves the correct context
- * per-request — no server-side "active" state needed.
+ * Split into two layers to fix the H25 race where the HTTP interceptor
+ * would otherwise tag outgoing requests with an id the backend hadn't
+ * finished loading (cascade of 409 `dataset_not_loaded`):
+ *
+ *  - **intent** — what the user has selected (pulldown click, deep-link
+ *    URL).  Updates immediately so UI affordances like the pulldown
+ *    highlight reflect the selection without delay.
+ *  - **active** — the pair currently loaded into the backend, against
+ *    which API requests are dispatched.  The HTTP interceptor
+ *    (`activeContextInterceptor`) attaches `X-Dataset-Id` /
+ *    `X-Detector-Id` from this layer, so it lags `intent` until
+ *    `ContextSwitchService` has finished any required dataset / detector
+ *    load and explicitly promotes the pair via `setActive()`.
+ *
+ * `setActivePair()` writes BOTH layers — used by cleanup paths (the
+ * registry watcher, `clear()`) where there is nothing to wait for.  UI
+ * code that wants to *change* the pair should go through
+ * `ContextSwitchService.switchTo()` so loads run first.
  */
 @Injectable({ providedIn: 'root' })
 export class ActiveContextService {
+  // --- ACTIVE layer (what the HTTP interceptor reads) ---------------------
   private readonly datasetIdSubject = new BehaviorSubject<string>('');
   private readonly modelIdSubject = new BehaviorSubject<string>('');
   private readonly pairSubject = new BehaviorSubject<{ datasetId: string; modelId: string }>({
     datasetId: '',
     modelId: '',
   });
+
+  // --- INTENT layer (what the user picked) -------------------------------
+  private readonly intentDatasetIdSubject = new BehaviorSubject<string>('');
+  private readonly intentModelIdSubject = new BehaviorSubject<string>('');
+  private readonly intentPairSubject = new BehaviorSubject<{
+    datasetId: string;
+    modelId: string;
+  }>({
+    datasetId: '',
+    modelId: '',
+  });
+
   private requestCounter = 0;
 
   readonly datasetId$ = this.datasetIdSubject.asObservable();
   readonly modelId$ = this.modelIdSubject.asObservable();
+  readonly intentDatasetId$ = this.intentDatasetIdSubject.asObservable();
+  readonly intentModelId$ = this.intentModelIdSubject.asObservable();
 
   /**
-   * Emits whenever either half of the pair changes. Use this when a view
-   * needs to react to a swap — subscribing to the two halves separately
+   * Emits whenever either half of the *active* pair changes.  Use this
+   * when a view needs to react to the actually-loaded pair (e.g. media
+   * URLs, cache invalidation).  Subscribing to the two halves separately
    * would fire twice for an atomic `setActivePair()` call.
    */
   readonly pair$: Observable<{ datasetId: string; modelId: string }> = this.pairSubject.pipe(
@@ -33,10 +63,27 @@ export class ActiveContextService {
   );
 
   /**
-   * Emits whenever the (datasetId, modelId) tuple changes, as a joined key
-   * (`<datasetId>::<modelId>`). Useful as a `switchMap` trigger.
+   * Emits whenever either half of the user's *intent* changes — i.e.
+   * the moment a pulldown row is clicked, before any load has run.
+   * Use this for UI affordances that should reflect the user's pick
+   * without waiting (pulldown highlight, "you picked X" labels).
    */
+  readonly intentPair$: Observable<{ datasetId: string; modelId: string }> =
+    this.intentPairSubject.pipe(
+      distinctUntilChanged((a, b) => a.datasetId === b.datasetId && a.modelId === b.modelId),
+    );
+
+  /** Active-pair tuple as a joined key (`<datasetId>::<modelId>`). */
   readonly pairKey$: Observable<string> = combineLatest([this.datasetId$, this.modelId$]).pipe(
+    map(([d, m]) => `${d}::${m}`),
+    distinctUntilChanged(),
+  );
+
+  /** Intent-pair tuple as a joined key. */
+  readonly intentPairKey$: Observable<string> = combineLatest([
+    this.intentDatasetId$,
+    this.intentModelId$,
+  ]).pipe(
     map(([d, m]) => `${d}::${m}`),
     distinctUntilChanged(),
   );
@@ -49,23 +96,55 @@ export class ActiveContextService {
     return this.modelIdSubject.value;
   }
 
+  get intentDatasetId(): string {
+    return this.intentDatasetIdSubject.value;
+  }
+
+  get intentModelId(): string {
+    return this.intentModelIdSubject.value;
+  }
+
   /**
-   * Set both halves of the active pair in a single change.
-   *
-   * Phase 2 made the URL authoritative — call this only from the
-   * `activeContextGuard` (via `ContextSwitchService.applyActivePair`)
-   * or from internal recovery paths (e.g. `ActiveContextWatcherService`
-   * clearing a deleted half). UI code that wants to change the pair
-   * should `router.navigate(['/label', ds, det])` and let the guard
-   * write through here.
+   * Set the user's intent.  Called by `ContextSwitchService` the moment
+   * a switch begins so UI affordances (pulldown highlight) reflect the
+   * selection immediately, while the active pair stays pinned to the
+   * still-loaded backend state.  Active is promoted separately via
+   * `setActive()` once any required load finishes.
    */
-  setActivePair(datasetId: string, modelId: string): void {
+  setIntent(datasetId: string, modelId: string): void {
+    const dsChanged = this.intentDatasetIdSubject.value !== datasetId;
+    const mChanged = this.intentModelIdSubject.value !== modelId;
+    if (!dsChanged && !mChanged) return;
+    if (dsChanged) this.intentDatasetIdSubject.next(datasetId);
+    if (mChanged) this.intentModelIdSubject.next(modelId);
+    this.intentPairSubject.next({ datasetId, modelId });
+  }
+
+  /**
+   * Promote a pair to active — what the HTTP interceptor will tag onto
+   * outgoing requests.  Called by `ContextSwitchService` once required
+   * loads have finished (or by `setActivePair`/cleanup paths).
+   */
+  setActive(datasetId: string, modelId: string): void {
     const dsChanged = this.datasetIdSubject.value !== datasetId;
     const mChanged = this.modelIdSubject.value !== modelId;
     if (!dsChanged && !mChanged) return;
     if (dsChanged) this.datasetIdSubject.next(datasetId);
     if (mChanged) this.modelIdSubject.next(modelId);
     this.pairSubject.next({ datasetId, modelId });
+  }
+
+  /**
+   * Set both intent and active atomically.  Used by cleanup paths that
+   * are not gated on a load: the registry watcher when an active id
+   * disappears, the `clear()` shortcut, and tests.  Code that wants to
+   * *switch* to a new pair should go through
+   * `ContextSwitchService.switchTo()` instead so the dataset/detector
+   * load runs before active flips.
+   */
+  setActivePair(datasetId: string, modelId: string): void {
+    this.setIntent(datasetId, modelId);
+    this.setActive(datasetId, modelId);
   }
 
   clear(): void {
@@ -91,6 +170,10 @@ export class ActiveContextService {
   /**
    * Build a media URL with context query params so browser-native requests
    * (`<img src>`, `<audio src>`, `<video src>`) resolve the correct dataset.
+   *
+   * Uses the *active* pair so the id matches what the backend has
+   * loaded — falling back to intent would point at an in-flight,
+   * not-yet-resolved id.
    *
    * Angular HttpClient requests use the interceptor to send headers, but
    * native element `src` attributes bypass it entirely.

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -22,10 +22,17 @@ interface ActiveSwitch {
 }
 
 /**
- * Drives a pulldown-initiated active-pair change end-to-end: sets the
- * pair atomically on `ActiveContextService`, kicks off any dataset /
- * detector loads that are needed, and exposes a `switching$` observable
- * so view code (and the top-bar pulldowns) can render a loading state.
+ * Drives a pulldown-initiated active-pair change end-to-end: tags the
+ * user's intent on `ActiveContextService` immediately, kicks off any
+ * dataset / detector loads that are needed, and promotes the pair to
+ * *active* (what the HTTP interceptor reads) only once those loads have
+ * settled. Exposes a `switching$` observable so view code (and the
+ * top-bar pulldowns) can render a loading state.
+ *
+ * The intent/active split (see `ActiveContextService`) is what fixes
+ * H25: without it, the interceptor would tag outgoing requests with
+ * the new ids the moment the pulldown was clicked, causing a cascade
+ * of 409 `dataset_not_loaded` until the load finished.
  *
  * Cancel-and-replace semantics: rapidly clicking a different row tags
  * each invocation with a monotonic request id. When a prep step
@@ -86,11 +93,13 @@ export class ContextSwitchService {
   }
 
   /**
-   * Called by `activeContextGuard`. Atomically flips the active pair
-   * and kicks off any dataset / detector loads, returning an Observable
-   * that completes when all loads finish (or immediately if nothing was
-   * needed). The guard holds the route activation until this completes
-   * so the view doesn't render against half-loaded state.
+   * Called by `activeContextGuard`. Tags the user's intent, kicks off
+   * any dataset / detector loads, and returns an Observable that
+   * completes when all loads finish (or immediately if nothing was
+   * needed). At completion the pair is promoted to *active* so the HTTP
+   * interceptor starts tagging requests with the new ids. The guard
+   * holds the route activation until this completes so the view never
+   * renders against a half-loaded backend.
    */
   applyActivePair(datasetId: string, detectorId: string): Observable<void> {
     return this.flipAndLoad(datasetId, detectorId);
@@ -129,9 +138,13 @@ export class ContextSwitchService {
     };
     this.active = current;
 
-    // Flip the pair atomically so the HTTP interceptor immediately
-    // routes against the new ids.
-    this.activeContext.setActivePair(datasetId, detectorId);
+    // Tag the user's intent so UI affordances (pulldown highlight) update
+    // immediately. The active pair — what the HTTP interceptor reads —
+    // stays pinned to the currently-loaded backend state and is promoted
+    // in `finishIfCurrent` once any required load completes. This avoids
+    // the H25 race where the interceptor would otherwise tag requests
+    // with an id the backend hasn't loaded yet.
+    this.activeContext.setIntent(datasetId, detectorId);
 
     const datasets = this.datasetState.datasets;
     const detectors = this.datasetState.detectors;
@@ -278,6 +291,10 @@ export class ContextSwitchService {
   private finishIfCurrent(current: ActiveSwitch): void {
     if (this.active !== current || current.cancelled) return;
     if (current.requestId !== this.activeContext.currentRequestId) return;
+    // Loads have settled — promote intent to active now so the HTTP
+    // interceptor starts tagging requests with the new ids (and not
+    // before, per H25).
+    this.activeContext.setActive(current.datasetId, current.detectorId);
     this.switchingSubject.next(false);
     this.datasetState.setLoading(false);
     this.active = null;

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -974,8 +974,8 @@ class TestValidatedVoteSnapshot:
         detector_id = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, detector_id)
 
-        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
         return detector_id, good_cid, bad_cid
 
     def test_snapshot_safe_when_aligned(self, client):


### PR DESCRIPTION
## Summary

- H25: the HTTP interceptor was tagging outgoing requests with the new `X-Dataset-Id`/`X-Detector-Id` headers the moment `ContextSwitchService.flipAndLoad` ran, but the dataset/detector load runs asynchronously after that point. Any request fired during the load window (vote-state polling on the old view, embedded media URLs, the labelset poller) carried an id the backend hadn't loaded yet and came back as 409 `dataset_not_loaded` — and per H24 a single error tears down vote-state polling permanently.
- Split `ActiveContextService` into two layers:
  - **intent** — what the user just picked (pulldown row click, deep-link URL). Flips immediately so UI affordances update without waiting.
  - **active** — the pair currently loaded into the backend. The HTTP interceptor and `mediaUrl()` read this layer.
- `ContextSwitchService` now calls `setIntent()` on entry and only promotes to `setActive()` inside `finishIfCurrent()`, after any required dataset/detector load has settled. `setActivePair()` keeps its old semantics (writes both atomically) so the registry watcher and the existing watcher/guard tests don't change.
- The context pulldown component is repointed at the new `intent*` getters so the highlight and swap-composition reflect the user's pick instantly even when a load is running in the background.
- Drive-by: `TestValidatedVoteSnapshot._setup_detector_with_votes` was still posting `{"vote": "good"}`; H1's API migration to `{"target": "good"}` missed it, leaving 3 pre-existing failures on `dev`. Fixed in a separate commit.

## Test plan

- [x] `cd frontend && npm run build:prod` — clean build, no warnings.
- [x] `./run-tests.sh` — 4016 passed, 1 skipped, 0 failures.
- [ ] Manual: click a not-yet-loaded dataset in the pulldown from `/label/A/B`, confirm vote-state polling on the old view no longer 409s during the load window, confirm pulldown highlight updates immediately.
- [ ] Manual: rapidly click A→B→C in the pulldown, confirm active flips only when the last-clicked load completes (and intent passes through B briefly).

https://claude.ai/code/session_012koitf9b7Gd99ja8QvXczo

---
_Generated by [Claude Code](https://claude.ai/code/session_012koitf9b7Gd99ja8QvXczo)_