### PR TITLE
H28: cross-process RMW for per-user settings writes

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -310,13 +310,46 @@ Cross-section interaction agents:
 
 ### Multi-process / settings
 
-- **H28. Per-user cache is process-local; concurrent worker writes lose
-  updates** — `vtsearch/settings.py` `_user_caches` + `_synced_users`.
-  Two gunicorn workers each sync independently, then race the
-  per-user write.
+- ~~**H28. Per-user cache is process-local; concurrent worker writes lose
+  updates**~~ — fixed in `vtsearch/settings.py`. Every per-user (and
+  server-tier) write now goes through `_mutate_*_locked`, which holds a
+  cross-process `fcntl.flock` on a sibling `.lock` file, re-reads the
+  on-disk JSON, applies the mutator in place, and atomic-writes with
+  a per-writer `<file>.<pid>.<uuid>.tmp` name. The legacy "mutate cache
+  then save whole dict" pattern was removed (including from
+  `vtsearch/achievements.py`, which now uses the new public
+  `settings.mutate_user(mutator)` RMW helper for nested-dict updates).
+  Canonical lock order is `file_lock → settings_lock` everywhere — the
+  outer `with _settings_lock:` was removed from setter wrappers and
+  from read paths that previously held it across `_ensure_user_loaded`
+  (which can transitively trigger setter writes via sync-from-source).
+  Covered by `TestConcurrentWrites` in `tests/core/test_settings.py`
+  (RMW key-preservation, unique tmp filename pattern, two-thread
+  no-deadlock, `mutate_user` nested-dict RMW, `add_autorun_detector`
+  cross-process merge).
+
+  **Open follow-ups:**
+  - `_synced_users` is still process-local, so on a fresh container
+    every worker independently runs sync-from-source for each user
+    once. With the RMW fix this is no longer corrupting (just
+    duplicate I/O against the source) but worth de-duplicating with
+    an mtime-marker if it shows up in profiles.
+  - The legacy-settings migration in `_maybe_migrate_legacy_settings_locked`
+    still calls `_atomic_write` without the cross-process lock. It is a
+    one-shot startup step so the race window is small, but for full
+    correctness it should also use `_mutate_server_locked`.
+  - Windows has no `fcntl`, so the cross-process lock silently degrades
+    to the in-process lock only. Not a regression (the codebase ships
+    Linux-only Docker images), but worth a note if a contributor ever
+    wants to test on Windows.
 - **H29. `_save_user` holds `_settings_lock` across sync I/O** —
   `vtsearch/settings.py` ~L331–338. Slow source (NFS, webhook) blocks
-  all other settings reads/writes globally.
+  all other settings reads/writes globally. (Per-user side is
+  incidentally addressed by H28's fix — `_sync_to_source` now runs
+  outside the file lock and outside `_settings_lock`. Server-tier
+  paths through `_atomic_write` no longer hold `_settings_lock` across
+  file I/O either, but a dedicated audit of every remaining sink is
+  still warranted.)
 
 ### Error flow
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -669,3 +669,158 @@ class TestSettingsModule:
         settings_mod.set_last_embedder_for_media_type("image", "siglip")
         settings_mod.reset()
         assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"
+
+
+class TestConcurrentWrites:
+    """Cross-process safety for per-user settings writes.
+
+    H28 fix: each setter does a read-modify-write under a cross-process
+    file lock, so a stale in-process cache can no longer clobber
+    concurrent updates to other top-level keys.
+    """
+
+    def test_concurrent_write_preserves_other_processes_key(self, isolated_settings):
+        # Populate our cache with a known value.
+        settings_mod.set_volume(0.5)
+
+        # Simulate another process writing a DIFFERENT key directly to
+        # disk after our cache was populated.
+        user_path = isolated_settings._user
+        existing = json.loads(user_path.read_text())
+        existing["theme"] = "dark"
+        user_path.write_text(json.dumps(existing))
+
+        # Our next write should re-read disk first and merge.
+        settings_mod.set_inclusion(3)
+
+        raw = json.loads(user_path.read_text())
+        assert raw["volume"] == 0.5
+        assert raw["theme"] == "dark"  # would be lost without the RMW fix
+        assert raw["inclusion"] == 3
+
+    def test_atomic_write_uses_unique_tmp_filenames(self, isolated_settings):
+        """Tmp files must include PID + uuid so two writers can't truncate
+        each other's in-flight temp file."""
+        import re
+
+        settings_mod.set_volume(0.5)
+        # ``_atomic_write`` removes the tmp via rename, but the filename
+        # shape is what we care about. Confirm by inspecting the helper.
+        from vtsearch.settings import _atomic_write
+
+        # Drive it once and check the tmp name pattern used by inspecting
+        # the directory contents during a captured write.
+        captured: list[str] = []
+        real_replace = __import__("os").replace
+
+        def spy_replace(src, dst):
+            captured.append(str(src))
+            real_replace(src, dst)
+
+        import os as _os
+
+        _os.replace = spy_replace
+        try:
+            _atomic_write(isolated_settings._user, {"volume": 0.5})
+        finally:
+            _os.replace = real_replace
+
+        assert captured, "expected at least one tmp file rename"
+        tmp_name = captured[-1].rsplit("/", 1)[-1]
+        # user_settings.json.<pid>.<uuid32>.tmp
+        assert re.match(r"^user_settings\.json\.\d+\.[0-9a-f]{32}\.tmp$", tmp_name), tmp_name
+
+    def test_concurrent_threads_no_deadlock(self, isolated_settings):
+        """Two threads concurrently setting different keys must both complete.
+
+        Catches lock-ordering regressions (settings_lock vs file_lock).
+        """
+        import threading
+
+        errors: list[Exception] = []
+        ready = threading.Event()
+        ready_count = [0]
+        ready_lock = threading.Lock()
+
+        def writer(fn, value):
+            try:
+                with ready_lock:
+                    ready_count[0] += 1
+                    if ready_count[0] == 2:
+                        ready.set()
+                ready.wait(timeout=5)
+                fn(value)
+            except Exception as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=(settings_mod.set_volume, 0.5)),
+            threading.Thread(target=writer, args=(settings_mod.set_inclusion, 3)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"writers raised: {errors}"
+        for t in threads:
+            assert not t.is_alive(), "thread hung (likely deadlock)"
+
+        assert settings_mod.get_volume() == pytest.approx(0.5)
+        assert settings_mod.get_inclusion() == 3
+
+    def test_mutate_user_rmw_preserves_concurrent_writes(self, isolated_settings):
+        """``mutate_user`` re-reads disk before applying its mutator, so
+        nested-dict updates (e.g. achievement counters) merge with
+        whatever a sibling process wrote since our cache was populated."""
+        from vtsearch.settings import mutate_user
+
+        # Seed.
+        mutate_user(
+            lambda c: c.update(
+                {"theme": "light", "achievement_state": {"counters": {"votes_cast": 0}}}
+            )
+        )
+
+        # Simulate another process bumping votes_cast and changing theme
+        # on disk while we hold a stale in-memory cache.
+        user_path = isolated_settings._user
+        disk = json.loads(user_path.read_text())
+        disk["theme"] = "dark"
+        disk["achievement_state"]["counters"]["votes_cast"] = 100
+        user_path.write_text(json.dumps(disk))
+
+        # Our increment should read the disk value (100), bump to 101,
+        # and preserve the disk's theme update.
+        def _bump(cache):
+            cache["achievement_state"]["counters"]["votes_cast"] += 1
+
+        mutate_user(_bump)
+
+        final = json.loads(user_path.read_text())
+        assert final["theme"] == "dark"
+        assert final["achievement_state"]["counters"]["votes_cast"] == 101
+
+    def test_add_autorun_detector_rmw(self, isolated_settings):
+        """Concurrent ``add_autorun_detector`` calls must not lose entries.
+
+        Simulates the cross-process race: our cache says ``[]`` but disk
+        has ``["other-detector"]`` because a sibling process added it.
+        """
+        # Force-load the server cache (so add_autorun_detector below
+        # doesn't trigger a fresh load).
+        settings_mod.add_autorun_detector("ours-pre")
+
+        # Sibling process directly adds an entry on disk.
+        server_path = isolated_settings._server
+        disk = json.loads(server_path.read_text())
+        disk["autorun_detectors"] = list(disk.get("autorun_detectors", [])) + ["sibling"]
+        server_path.write_text(json.dumps(disk))
+
+        # We add another — should merge with disk, not clobber.
+        settings_mod.add_autorun_detector("ours-post")
+
+        final = json.loads(server_path.read_text())
+        assert "sibling" in final["autorun_detectors"]
+        assert "ours-pre" in final["autorun_detectors"]
+        assert "ours-post" in final["autorun_detectors"]

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -776,11 +776,7 @@ class TestConcurrentWrites:
         from vtsearch.settings import mutate_user
 
         # Seed.
-        mutate_user(
-            lambda c: c.update(
-                {"theme": "light", "achievement_state": {"counters": {"votes_cast": 0}}}
-            )
-        )
+        mutate_user(lambda c: c.update({"theme": "light", "achievement_state": {"counters": {"votes_cast": 0}}}))
 
         # Simulate another process bumping votes_cast and changing theme
         # on disk while we hold a stale in-memory cache.

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -22,17 +22,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from vtsearch.auth import get_current_user
-from vtsearch.settings import _ensure_user_loaded, _save_user, _settings_lock
-
-
-def _load_state_dict() -> dict[str, Any]:
-    """Return the current user's settings cache dict (lock held by caller)."""
-    return _ensure_user_loaded(get_current_user())
-
-
-def _persist_state() -> None:
-    """Persist the current user's settings cache (lock held by caller)."""
-    _save_user(get_current_user())
+from vtsearch.settings import _ensure_user_loaded, _settings_lock, mutate_user
 
 
 logger = logging.getLogger(__name__)
@@ -189,8 +179,9 @@ _DOC_BY_ID: dict[str, dict[str, str]] = {d["id"]: d for d in DOCS}
 def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
     """Return the mutable ``achievement_state`` sub-dict inside *settings*.
 
-    Initializes missing keys in place so callers don't have to.  Must be
-    called while holding ``_settings_lock``.
+    Initializes missing keys in place so callers don't have to. Must be
+    called from inside a ``mutate_user`` mutator so the mutations are
+    written back to disk under the cross-process settings lock.
     """
     state = settings.get("achievement_state")
     if not isinstance(state, dict):
@@ -260,9 +251,8 @@ def record_vote(
     date_str = dt.strftime("%Y-%m-%d")
     hour = dt.hour
 
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+    def _apply(cache: dict[str, Any]) -> None:
+        state = _ensure_state(cache)
         counters = state["counters"]
 
         counters["votes_cast"] += 1
@@ -299,44 +289,47 @@ def record_vote(
         if current > counters["vote_streak"]:
             counters["vote_streak"] = current
 
-        _persist_state()
+    mutate_user(_apply)
 
 
 def record_dataset_load(importer_name: str) -> None:
     """Record one dataset load (skipping demos/synthetic)."""
     if importer_name in EXCLUDED_DATASET_IMPORTERS:
         return
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+
+    def _apply(cache: dict[str, Any]) -> None:
+        state = _ensure_state(cache)
         state["counters"]["datasets_loaded"] += 1
-        _persist_state()
+
+    mutate_user(_apply)
 
 
 def record_detector_import(detector_id: str) -> None:
     """Record one detector receiving imported labels.  Dedupes by detector_id."""
     if not detector_id:
         return
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+
+    def _apply(cache: dict[str, Any]) -> None:
+        state = _ensure_state(cache)
         imported = state["imported_detector_ids"]
         if detector_id in imported:
             return
         imported.append(detector_id)
         state["counters"]["detectors_imported"] += 1
-        _persist_state()
+
+    mutate_user(_apply)
 
 
 def record_find(n_scored: int) -> None:
     """Record *n_scored* media items processed by a Find operation."""
     if n_scored <= 0:
         return
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+
+    def _apply(cache: dict[str, Any]) -> None:
+        state = _ensure_state(cache)
         state["counters"]["find_media"] += int(n_scored)
-        _persist_state()
+
+    mutate_user(_apply)
 
 
 def record_doc_phrase(phrase: str) -> dict[str, Any]:
@@ -364,26 +357,25 @@ def record_doc_phrase(phrase: str) -> dict[str, Any]:
         return {"matched": False, "doc_id": None, "doc_name": None, "already_read": False}
 
     doc = _DOC_BY_ID[matched_id]
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+    already_read = False
+
+    def _apply(cache: dict[str, Any]) -> None:
+        nonlocal already_read
+        state = _ensure_state(cache)
         read_ids = state["docs_read_ids"]
         if matched_id in read_ids:
-            return {
-                "matched": True,
-                "doc_id": matched_id,
-                "doc_name": doc["name"],
-                "already_read": True,
-            }
+            already_read = True
+            return
         read_ids.append(matched_id)
         state["counters"]["docs_read"] = len(read_ids)
-        _persist_state()
+
+    mutate_user(_apply)
 
     return {
         "matched": True,
         "doc_id": matched_id,
         "doc_name": doc["name"],
-        "already_read": False,
+        "already_read": already_read,
     }
 
 
@@ -425,8 +417,15 @@ def get_full_state() -> dict[str, Any]:
             ],
         }
     """
+    username = get_current_user()
+    _ensure_user_loaded(username)
     with _settings_lock:
-        s = _load_state_dict()
+        # Snapshot the cache once so the read-side view is consistent
+        # while we walk the achievement table. We don't mutate here, so
+        # there's no need to take the cross-process file lock.
+        from vtsearch.settings import _user_caches
+
+        s = dict(_user_caches.get(username, {}))
         state = _ensure_state(s)
         achievements: list[dict[str, Any]] = []
         pending: list[dict[str, Any]] = []
@@ -478,12 +477,17 @@ def acknowledge(category_id: str, tier_idx: int) -> bool:
         return False
     if tier_idx < 0 or tier_idx >= len(TIER_NAMES):
         return False
-    with _settings_lock:
-        s = _load_state_dict()
-        state = _ensure_state(s)
+
+    advanced = False
+
+    def _apply(cache: dict[str, Any]) -> None:
+        nonlocal advanced
+        state = _ensure_state(cache)
         prev = int(state["announced"].get(category_id, -1))
         if tier_idx <= prev:
-            return False
+            return
         state["announced"][category_id] = tier_idx
-        _persist_state()
-        return True
+        advanced = True
+
+    mutate_user(_apply)
+    return advanced

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -32,12 +32,9 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 try:
-    import fcntl  # POSIX-only; falls back to in-process locking on Windows.
-
-    _HAS_FCNTL = True
+    import fcntl as _fcntl  # POSIX-only; falls back to in-process locking on Windows.
 except ImportError:  # pragma: no cover - Windows
-    fcntl = None  # type: ignore[assignment]
-    _HAS_FCNTL = False
+    _fcntl = None
 
 from vtscore.config import DATA_DIR
 from vtsearch.settings_models import (
@@ -295,11 +292,12 @@ def _file_lock(path: Path):
     in_proc = _path_lock_for(path)
     in_proc.acquire()
     fd: int | None = None
-    if _HAS_FCNTL:
+    fcntl_mod = _fcntl  # snapshot so the narrowed binding survives the yield
+    if fcntl_mod is not None:
         lock_path = path.with_name(path.name + ".lock")
         try:
             fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            fcntl_mod.flock(fd, fcntl_mod.LOCK_EX)
         except OSError as exc:
             logger.warning("Could not acquire file lock on %s: %s", lock_path, exc)
             if fd is not None:
@@ -309,9 +307,9 @@ def _file_lock(path: Path):
     try:
         yield
     finally:
-        if fd is not None:
+        if fd is not None and fcntl_mod is not None:
             try:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                fcntl_mod.flock(fd, fcntl_mod.LOCK_UN)
             finally:
                 with contextlib.suppress(OSError):
                     os.close(fd)

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -20,14 +20,24 @@ the sync source is per-user and triggers only on per-user writes.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import threading
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
+
+try:
+    import fcntl  # POSIX-only; falls back to in-process locking on Windows.
+
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+    _HAS_FCNTL = False
 
 from vtscore.config import DATA_DIR
 from vtsearch.settings_models import (
@@ -222,14 +232,90 @@ def _load_path(path: Path) -> dict[str, Any]:
 
 
 def _atomic_write(path: Path, data: dict[str, Any]) -> None:
-    """Write *data* to *path* via a temp-file + rename."""
+    """Write *data* to *path* via a per-writer temp file + rename.
+
+    The temp filename embeds PID + a UUID so two processes writing to the
+    same target can't truncate each other's in-flight temp file. The
+    final ``os.replace`` is atomic on POSIX, so a concurrent reader
+    always sees either the pre- or post-write content, never a partial
+    write.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    with open(tmp, "w", encoding="utf-8") as f:
-        f.write(json.dumps(data, indent=2) + "\n")
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, path)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
+        raise
+
+
+# Per-path in-process locks. Used in two ways:
+# 1. As a fallback when ``fcntl`` is unavailable (Windows).
+# 2. Held in addition to the cross-process flock so that, within a single
+#    process, multiple threads serialise on the same path without
+#    repeatedly re-entering the kernel.
+_path_locks: dict[str, threading.Lock] = {}
+_path_locks_guard = threading.Lock()
+
+
+def _path_lock_for(path: Path) -> threading.Lock:
+    key = str(path.resolve()) if path.exists() else str(path)
+    with _path_locks_guard:
+        lock = _path_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def _file_lock(path: Path):
+    """Acquire an exclusive cross-process lock for *path*.
+
+    The lock is taken on a sibling ``<path>.lock`` file rather than on
+    the data file itself, because ``_atomic_write`` replaces the data
+    file's inode via ``os.replace`` — any fd held against the old inode
+    would be useless. The sibling lock file's inode is stable.
+
+    The lock is released automatically if the process exits (POSIX
+    flock semantics), so there are no zombie locks after crashes.
+
+    On Windows (``fcntl`` unavailable) the in-process lock alone is
+    used; cross-process protection degrades silently. VTSearch is
+    deployed on Linux containers, so this only affects the rare
+    Windows-dev case where multiple processes shouldn't be writing
+    the same settings file anyway.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    in_proc = _path_lock_for(path)
+    in_proc.acquire()
+    fd: int | None = None
+    if _HAS_FCNTL:
+        lock_path = path.with_name(path.name + ".lock")
+        try:
+            fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            logger.warning("Could not acquire file lock on %s: %s", lock_path, exc)
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                fd = None
+    try:
+        yield
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        in_proc.release()
 
 
 # ---------------------------------------------------------------------------
@@ -248,7 +334,15 @@ def _ensure_server_loaded() -> dict[str, Any]:
 
 
 def _ensure_user_loaded(username: str) -> dict[str, Any]:
-    """Load *username*'s per-user cache on first access."""
+    """Load *username*'s per-user cache on first access.
+
+    Sync-from-source is triggered the first time a user's cache is
+    populated each process lifetime — but **outside** the in-process
+    settings lock, because the setters it invokes acquire
+    ``_file_lock`` first and would otherwise invert the canonical lock
+    order with another thread that's reading the same user's cache.
+    """
+    needs_sync = False
     with _settings_lock:
         cache = _user_caches.get(username)
         if cache is None:
@@ -260,9 +354,14 @@ def _ensure_user_loaded(username: str) -> dict[str, Any]:
             if cache is None:
                 cache = _load_path(_user_settings_path(username))
                 _user_caches[username] = cache
-            # Lazy sync-from-source on first load for this user this process.
-            _maybe_sync_from_source_locked(username)
-        return _user_caches[username]
+        if username not in _synced_users:
+            _synced_users.add(username)
+            needs_sync = True
+
+    if needs_sync:
+        _maybe_sync_from_source(username)
+
+    return _user_caches[username]
 
 
 def _maybe_migrate_legacy_settings_locked() -> None:
@@ -322,20 +421,71 @@ def _maybe_migrate_legacy_settings_locked() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _save_server() -> None:
-    """Write the server-tier cache to disk."""
-    assert _server_cache is not None
-    _atomic_write(_server_settings_path(), _server_cache)
+def _mutate_server_locked(mutator) -> None:
+    """Apply *mutator* to a fresh-from-disk server cache, atomically.
+
+    Acquires the cross-process file lock, re-reads ``data/settings.json``
+    so any changes a sibling process made since this process loaded are
+    picked up, runs ``mutator(cache)`` to mutate the dict in place, then
+    atomically writes the result back. This is the only correct way to
+    mutate a multi-writer settings file from a Python process.
+
+    The legacy migration is left to ``_ensure_server_loaded`` and never
+    fires from inside the lock — by the time any setter runs the cache
+    has been loaded at least once.
+    """
+    global _server_cache
+    path = _server_settings_path()
+    with _file_lock(path):
+        with _settings_lock:
+            fresh = _load_path(path)
+            mutator(fresh)
+            _server_cache = fresh
+            _atomic_write(path, fresh)
 
 
-def _save_user(username: str) -> None:
-    """Write *username*'s cache to disk and (if configured) sync to source."""
-    cache = _user_caches.get(username)
-    if cache is None:
-        return
-    _atomic_write(_user_settings_path(username), cache)
-    if username not in _syncing:
-        _sync_to_source(username, cache)
+def _mutate_user_locked(username: str, mutator) -> dict[str, Any] | None:
+    """Apply *mutator* to a fresh-from-disk per-user cache, atomically.
+
+    Returns a snapshot of the cache after the mutation, intended for
+    ``_sync_to_source`` which is invoked **outside** the file lock so a
+    slow sync target (NFS, webhook) can't block other settings writes.
+    Returns ``None`` if the cache should not be synced (i.e. we are
+    currently importing from the source).
+    """
+    path = _user_settings_path(username)
+    with _file_lock(path):
+        with _settings_lock:
+            fresh = _load_path(path)
+            mutator(fresh)
+            _user_caches[username] = fresh
+            _atomic_write(path, fresh)
+            if username in _syncing:
+                return None
+            return dict(fresh)
+
+
+def mutate_user(mutator) -> None:
+    """Atomically read-modify-write the current user's settings file.
+
+    The on-disk file is locked across processes, re-read fresh,
+    *mutator(cache)* runs to mutate the loaded dict in place, and the
+    result is written back atomically. Use this whenever you need to
+    update a nested structure (counters, list appends, dict merges) —
+    a plain ``set_*`` call only round-trips the top-level key correctly
+    if you replace it wholesale, but ``mutate_user`` is correct for
+    any in-place change.
+
+    Triggers ``_sync_to_source`` after the lock is released (so a slow
+    sync target can't block other settings writes).
+    """
+    from vtsearch.auth import get_current_user
+
+    username = get_current_user()
+    _ensure_user_loaded(username)
+    sync_data = _mutate_user_locked(username, mutator)
+    if sync_data is not None:
+        _sync_to_source(username, sync_data)
 
 
 # ---------------------------------------------------------------------------
@@ -358,18 +508,25 @@ def _read_value(key: str) -> Any:
 
 
 def _write_value(key: str, value: Any) -> None:
-    """Persist *value* for *key*, routing to the correct tier."""
+    """Persist *value* for *key*, routing to the correct tier.
+
+    Each call is a single read-modify-write under the cross-process
+    file lock: the on-disk file is re-read, *key* is replaced, the
+    merged dict is written back, then the in-memory cache is refreshed
+    to match. This means two processes setting *different* keys on the
+    same user no longer clobber each other.
+    """
     if key in _SERVER_KEYS:
-        cache = _ensure_server_loaded()
-        cache[key] = value
-        _save_server()
+        _ensure_server_loaded()  # one-shot legacy migration
+        _mutate_server_locked(lambda c: c.__setitem__(key, value))
         return
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
-    cache = _ensure_user_loaded(username)
-    cache[key] = value
-    _save_user(username)
+    _ensure_user_loaded(username)  # one-shot lazy sync-from-source
+    sync_data = _mutate_user_locked(username, lambda c: c.__setitem__(key, value))
+    if sync_data is not None:
+        _sync_to_source(username, sync_data)
 
 
 # ---------------------------------------------------------------------------
@@ -403,19 +560,25 @@ def get_user_settings() -> dict[str, Any]:
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
+    # ``_ensure_user_loaded`` may trigger sync-from-source which calls
+    # setters that acquire ``_file_lock``. Calling it outside
+    # ``_settings_lock`` keeps the canonical lock order
+    # (file_lock → settings_lock) and avoids an AB-BA deadlock with
+    # concurrent writers.
+    _ensure_user_loaded(username)
     with _settings_lock:
-        user = _ensure_user_loaded(username)
-        result = dict(_USER_DEFAULTS)
-        result.update(user)
-        result["view_mode_left"] = get_view_mode_left()
-        result["view_mode_right"] = get_view_mode_right()
-        result["grid_icon_size_left"] = get_grid_icon_size_left()
-        result["grid_icon_size_right"] = get_grid_icon_size_right()
-        result["focus_mode_left"] = get_focus_mode_left()
-        result["focus_mode_right"] = get_focus_mode_right()
-        result["panel_pct_left"] = get_panel_pct_left()
-        result["panel_pct_right"] = get_panel_pct_right()
-        return result
+        user_copy = dict(_user_caches.get(username, {}))
+    result = dict(_USER_DEFAULTS)
+    result.update(user_copy)
+    result["view_mode_left"] = get_view_mode_left()
+    result["view_mode_right"] = get_view_mode_right()
+    result["grid_icon_size_left"] = get_grid_icon_size_left()
+    result["grid_icon_size_right"] = get_grid_icon_size_right()
+    result["focus_mode_left"] = get_focus_mode_left()
+    result["focus_mode_right"] = get_focus_mode_right()
+    result["panel_pct_left"] = get_panel_pct_left()
+    result["panel_pct_right"] = get_panel_pct_right()
+    return result
 
 
 def get_all() -> dict[str, Any]:
@@ -428,22 +591,24 @@ def get_all() -> dict[str, Any]:
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
+    _ensure_server_loaded()
+    _ensure_user_loaded(username)
     with _settings_lock:
-        server = _ensure_server_loaded()
-        user = _ensure_user_loaded(username)
-        result = dict(_DEFAULTS)
-        result.update(server)
-        result.update(user)
-        # Always return expanded per-media-type view/focus/panel dicts.
-        result["view_mode_left"] = get_view_mode_left()
-        result["view_mode_right"] = get_view_mode_right()
-        result["grid_icon_size_left"] = get_grid_icon_size_left()
-        result["grid_icon_size_right"] = get_grid_icon_size_right()
-        result["focus_mode_left"] = get_focus_mode_left()
-        result["focus_mode_right"] = get_focus_mode_right()
-        result["panel_pct_left"] = get_panel_pct_left()
-        result["panel_pct_right"] = get_panel_pct_right()
-        return result
+        server_copy = dict(_server_cache or {})
+        user_copy = dict(_user_caches.get(username, {}))
+    result = dict(_DEFAULTS)
+    result.update(server_copy)
+    result.update(user_copy)
+    # Always return expanded per-media-type view/focus/panel dicts.
+    result["view_mode_left"] = get_view_mode_left()
+    result["view_mode_right"] = get_view_mode_right()
+    result["grid_icon_size_left"] = get_grid_icon_size_left()
+    result["grid_icon_size_right"] = get_grid_icon_size_right()
+    result["focus_mode_left"] = get_focus_mode_left()
+    result["focus_mode_right"] = get_focus_mode_right()
+    result["panel_pct_left"] = get_panel_pct_left()
+    result["panel_pct_right"] = get_panel_pct_right()
+    return result
 
 
 # -------------------------------------------------------------------
@@ -485,9 +650,13 @@ def _make_scalar_accessors(model: type, key: str):
             return model.model_fields[key].get_default(call_default_factory=True)
 
     def setter(value):
+        # Lock acquisition is delegated to ``_write_value`` →
+        # ``_mutate_*_locked``, which takes ``_file_lock`` first and
+        # then ``_settings_lock``. Acquiring ``_settings_lock`` here
+        # would invert the order and risk an AB-BA deadlock with paths
+        # that enter ``_mutate_*_locked`` directly.
         coerced = _validate_field(model, key, value)
-        with _settings_lock:
-            _write_value(key, coerced)
+        _write_value(key, coerced)
 
     getter.__name__ = f"get_{key}"
     setter.__name__ = f"set_{key}"
@@ -631,8 +800,9 @@ def _make_per_side_setting(  # noqa: C901
                 raise ValueError(f"Invalid media type: {tid!r}")
             coerced[tid] = _validate_entry(v, key, tid)
 
-        with _settings_lock:
-            _write_value(key, coerced)
+        # Locks are taken inside ``_write_value`` in the canonical
+        # order (file_lock → settings_lock); see ``_make_scalar_accessors.setter``.
+        _write_value(key, coerced)
 
     def get_left():
         return _get_dict(f"{key_base}_left")
@@ -721,30 +891,44 @@ def get_autorun_detectors() -> list[str]:
 
 def set_autorun_detectors(value: list[str]) -> None:
     """Set and persist the full list of autorun detector names."""
-    with _settings_lock:
-        cache = _ensure_server_loaded()
-        cache["autorun_detectors"] = list(dict.fromkeys(value))  # dedupe, preserve order
-        _save_server()
+    _ensure_server_loaded()
+    deduped = list(dict.fromkeys(value))  # dedupe, preserve order
+    _mutate_server_locked(lambda c: c.__setitem__("autorun_detectors", deduped))
 
 
 def add_autorun_detector(name: str) -> None:
-    """Add a detector name to the autorun list (idempotent)."""
-    with _settings_lock:
-        current = get_autorun_detectors()
+    """Add a detector name to the autorun list (idempotent).
+
+    Single read-modify-write under the file lock: two processes adding
+    different names concurrently can no longer clobber each other's
+    addition.
+    """
+    _ensure_server_loaded()
+
+    def _add(cache: dict[str, Any]) -> None:
+        current = list(cache.get("autorun_detectors", []))
         if name not in current:
             current.append(name)
-            set_autorun_detectors(current)
+            cache["autorun_detectors"] = current
+
+    _mutate_server_locked(_add)
 
 
 def remove_autorun_detector(name: str) -> bool:
     """Remove a detector name from the autorun list. Returns True if found."""
-    with _settings_lock:
-        current = get_autorun_detectors()
+    _ensure_server_loaded()
+    found = False
+
+    def _remove(cache: dict[str, Any]) -> None:
+        nonlocal found
+        current = list(cache.get("autorun_detectors", []))
         if name in current:
             current.remove(name)
-            set_autorun_detectors(current)
-            return True
-        return False
+            cache["autorun_detectors"] = current
+            found = True
+
+    _mutate_server_locked(_remove)
+    return found
 
 
 def is_autorun_detector(name: str) -> bool:
@@ -766,10 +950,9 @@ def _get_dir(key: str) -> Path:
 
 def _set_dir(key: str, value: str | Path) -> None:
     """Persist a server-tier directory path setting."""
-    with _settings_lock:
-        cache = _ensure_server_loaded()
-        cache[key] = str(value)
-        _save_server()
+    _ensure_server_loaded()
+    coerced = str(value)
+    _mutate_server_locked(lambda c: c.__setitem__(key, coerced))
 
 
 def get_saved_datasets_dir() -> Path:
@@ -846,8 +1029,10 @@ def get_settings_source_config() -> dict[str, Any] | None:
     """
     from vtsearch.auth import get_current_user
 
+    username = get_current_user()
+    _ensure_user_loaded(username)
     with _settings_lock:
-        cache = _ensure_user_loaded(get_current_user())
+        cache = _user_caches.get(username, {})
         cfg = cache.get("settings_source")
     if isinstance(cfg, dict) and cfg.get("source_name"):
         return cfg
@@ -859,13 +1044,17 @@ def set_settings_source_config(config: dict[str, Any] | None) -> None:
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
-    with _settings_lock:
-        cache = _ensure_user_loaded(username)
+    _ensure_user_loaded(username)
+
+    def _apply(cache: dict[str, Any]) -> None:
         if config is None:
             cache.pop("settings_source", None)
         else:
             cache["settings_source"] = config
-        _save_user(username)
+
+    sync_data = _mutate_user_locked(username, _apply)
+    if sync_data is not None:
+        _sync_to_source(username, sync_data)
 
 
 # Map of setting key → setter function (generated dynamically).
@@ -912,7 +1101,7 @@ def sync_from_settings_source() -> dict[str, Any] | None:
     Triggered:
 
     - Lazily on first per-user cache load each process lifetime (see
-      :func:`_maybe_sync_from_source_locked`).
+      :func:`_maybe_sync_from_source`).
     - Manually via ``POST /api/settings-sources/sync``.
     """
     cfg = get_settings_source_config()
@@ -938,30 +1127,32 @@ def sync_from_settings_source() -> dict[str, Any] | None:
         return None
 
     username = get_current_user()
+    # The setters invoked by ``_apply_settings`` acquire ``_file_lock``
+    # and then ``_settings_lock``. Holding ``_settings_lock`` here would
+    # invert the canonical order — take the lock only to mutate
+    # ``_syncing``, then drop it for the actual apply.
     with _settings_lock:
         _syncing.add(username)
-        try:
-            _apply_settings(imported)
-        finally:
+    try:
+        _apply_settings(imported)
+    finally:
+        with _settings_lock:
             _syncing.discard(username)
 
     return imported
 
 
-def _maybe_sync_from_source_locked(username: str) -> None:
-    """Once-per-process lazy sync-from-source for *username*.
+def _maybe_sync_from_source(username: str) -> None:
+    """Lazy sync-from-source for *username*.
 
-    Called from :func:`_ensure_user_loaded` with the settings lock held.
-    Safe to call repeatedly: noops after the first successful run for the
-    user. Errors are logged and swallowed so a misconfigured source never
-    blocks ordinary settings access.
+    Called once per process per username from :func:`_ensure_user_loaded`
+    **after** releasing ``_settings_lock``; the caller is responsible
+    for the ``_synced_users.add`` claim. Errors are logged and swallowed
+    so a misconfigured source never blocks ordinary settings access.
     """
-    if username in _synced_users:
-        return
-    _synced_users.add(username)
-
-    cache = _user_caches.get(username) or {}
-    cfg = cache.get("settings_source")
+    with _settings_lock:
+        cache_snapshot = dict(_user_caches.get(username) or {})
+    cfg = cache_snapshot.get("settings_source")
     if not isinstance(cfg, dict) or not cfg.get("source_name"):
         return
 
@@ -981,17 +1172,21 @@ def _maybe_sync_from_source_locked(username: str) -> None:
     if not imported:
         return
 
-    _syncing.add(username)
+    with _settings_lock:
+        _syncing.add(username)
     try:
         _apply_settings(imported)
     finally:
-        _syncing.discard(username)
+        with _settings_lock:
+            _syncing.discard(username)
 
 
 def _sync_to_source(username: str, data: dict[str, Any]) -> None:
     """Push *username*'s current settings to their active source (if any).
 
-    Called from :func:`_save_user` after the per-user file is written.
+    Called from :func:`_write_value` / :func:`mutate_user` after the
+    per-user file is written, **outside** the cross-process file lock
+    so a slow sync target can't block other settings writes.
     Strips the ``settings_source`` key itself to avoid circular config.
     """
     cfg = data.get("settings_source")


### PR DESCRIPTION
## Summary

Fix H28 from `docs/plans/logical-bug-audit.md`: the per-user settings cache was process-local, so two gunicorn workers (or any sibling process — CLI, second `python app.py`) silently lost each other's writes. The atomic-write tmp filename was also fixed (`path.with_suffix(".tmp")`) so concurrent writers shared the same in-flight tmp file.

- Cross-process `fcntl.flock` on a sibling `<file>.lock` (stable inode under `os.replace`); degrades to in-process lock on Windows.
- `_atomic_write` now uses `<file>.<pid>.<uuid>.tmp`, so two writers can't truncate each other's in-flight temp.
- Every write — autogen setter, `set_autorun_detectors` / `add` / `remove`, `_set_dir`, `set_settings_source_config` — routes through `_mutate_*_locked`: acquire file lock, re-read disk fresh, apply mutator in place, atomic-write back.
- Canonical lock order is **file_lock → settings_lock** everywhere. Removed the redundant outer `with _settings_lock:` from setter wrappers and from read paths (`get_user_settings`, `get_all`, `get_settings_source_config`) that previously held it across `_ensure_user_loaded` — which can transitively trigger setter writes via sync-from-source.
- `_sync_to_source` / sync-from-source now run **outside** the file lock and outside `_settings_lock`, so a slow source target can't block other writes (incidental partial fix for H29 on the user tier).
- New public `settings.mutate_user(mutator)` RMW helper. `vtsearch/achievements.py` is migrated to use it — the previous "mutate cache then call `_save_user`" pattern silently clobbered concurrent counter increments because the legacy save shim shallow-copied the cache and `c.update(pending)` replaced nested dicts wholesale.

H28 is marked done in `docs/plans/logical-bug-audit.md`, with open follow-ups recorded there (process-local `_synced_users` dedup, legacy-migration RMW, Windows degradation note).

## Test plan

- [x] `./run-tests.sh` — 4018 pass, 1 skipped, 2 xpassed. The 3 `TestValidatedVoteSnapshot` failures in `tests/detectors/test_detectors.py` are pre-existing on `origin/dev` (verified by checking out `vtsearch/settings.py` + `vtsearch/achievements.py` at `dev` and reproducing the same 3 failures) and are unrelated to settings/achievements — they're in vote-snapshot dataset-id validation.
- [x] New `TestConcurrentWrites` class in `tests/core/test_settings.py` covers: RMW key preservation (simulates a sibling process writing a different key while our cache is stale), unique tmp filename pattern (regex on `<name>.<pid>.<uuid>.tmp`), two-thread no-deadlock (catches lock-ordering regressions), `mutate_user` nested-dict RMW (achievement-counter merge case), `add_autorun_detector` cross-process merge.
- [x] All 303 settings + per-user-settings + settings-API + settings-IO + achievements tests pass with the fix.
- [x] ruff check, ruff format, codespell, deptry, pip-audit, pyright all clean.

https://claude.ai/code/session_01MK6dgaNFTBkXUUzHu4TFyY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK6dgaNFTBkXUUzHu4TFyY)_