### PR TITLE
Update brainstorm §13.4 with current state of parallel dataset loads

### DIFF
--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -689,8 +689,7 @@ class TestAddToPile:
 
         # Exactly one new media inserted (the regression: was 2 before fix).
         assert len(app_module.medias) == initial_count + 1, (
-            f"H32: duplicate insert — medias grew by "
-            f"{len(app_module.medias) - initial_count}, expected 1"
+            f"H32: duplicate insert — medias grew by {len(app_module.medias) - initial_count}, expected 1"
         )
 
         # Both requests succeed and report the same media id.
@@ -705,8 +704,5 @@ class TestAddToPile:
 
         # The single inserted media carries the uploaded bytes' md5.
         inserted_id = next(iter(media_ids))
-        assert (
-            app_module.medias[inserted_id]["md5"]
-            == hashlib.md5(wav_bytes).hexdigest()
-        )
+        assert app_module.medias[inserted_id]["md5"] == hashlib.md5(wav_bytes).hexdigest()
         assert inserted_id in app_module.good_votes

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -607,7 +607,7 @@ class TestAddToPile:
         finally:
             app_module.medias.update(saved)
 
-    def test_concurrent_uploads_same_md5_no_duplicate(self, client):
+    def test_concurrent_uploads_same_md5_no_duplicate(self):
         """H32 regression: two concurrent uploads of identical bytes must
         not produce duplicate medias.
 
@@ -659,11 +659,17 @@ class TestAddToPile:
             try:
                 set_thread_dataset_context(ds_ctx)
                 set_thread_detector_context(det_ctx)
-                r = client.post(
-                    "/api/medias/add-to-pile",
-                    data={"label": "good", "file": (io.BytesIO(wav_bytes), "race.wav")},
-                    content_type="multipart/form-data",
-                )
+                # Each worker thread uses its own test client. The fixture
+                # ``client`` is opened in the main thread, and Flask's test
+                # client preserves request contexts on its own ExitStack —
+                # invoking it from worker threads pushes contexts onto the
+                # workers' ContextVars and breaks the main-thread teardown.
+                with app_module.app.test_client() as c:
+                    r = c.post(
+                        "/api/medias/add-to-pile",
+                        data={"label": "good", "file": (io.BytesIO(wav_bytes), "race.wav")},
+                        content_type="multipart/form-data",
+                    )
                 with lock:
                     results.append((r.status_code, r.get_json()))
             except BaseException as exc:  # noqa: BLE001

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -606,3 +606,101 @@ class TestAddToPile:
             assert "No dataset" in resp.get_json()["message"]
         finally:
             app_module.medias.update(saved)
+
+    def test_concurrent_uploads_same_md5_no_duplicate(self, client):
+        """H32 regression: two concurrent uploads of identical bytes must
+        not produce duplicate medias.
+
+        The first MD5 lookup happens outside ``_state_lock`` and embedding
+        takes the full unlocked window with it. Without a re-check inside
+        the lock, two parallel requests both miss the existing-cid hit and
+        both insert — yielding two medias with identical md5/embedding.
+        The fix re-checks ``md5_lookup`` under ``_state_lock`` immediately
+        before the insert and routes the loser into the existing-cid
+        branch.
+        """
+        import threading
+        from unittest.mock import patch
+
+        from vtscore.media import embedders_for_type
+        from vtscore.state.core import (
+            get_active_context,
+            get_active_detector_context,
+            set_thread_dataset_context,
+            set_thread_detector_context,
+        )
+
+        audio_embedder = embedders_for_type("audio")[0]
+
+        wav_bytes = app_module.generate_wav(77777, 0.25)
+        initial_count = len(app_module.medias)
+
+        # Capture the test thread's contexts so the worker threads resolve
+        # the same DatasetContext/DetectorContext when ``before_request``
+        # falls through to the thread-local (no X-Dataset-Id header in
+        # these requests).
+        ds_ctx = get_active_context()
+        det_ctx = get_active_detector_context()
+
+        # Embedding must block both threads simultaneously inside the
+        # unlocked window so the race is reproduced deterministically.
+        barrier = threading.Barrier(2)
+        original_embed = audio_embedder.embed_media
+
+        def _blocking_embed(media_dict):
+            barrier.wait(timeout=5)
+            return original_embed(media_dict)
+
+        results: list[tuple[int, dict]] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def _do_post():
+            try:
+                set_thread_dataset_context(ds_ctx)
+                set_thread_detector_context(det_ctx)
+                r = client.post(
+                    "/api/medias/add-to-pile",
+                    data={"label": "good", "file": (io.BytesIO(wav_bytes), "race.wav")},
+                    content_type="multipart/form-data",
+                )
+                with lock:
+                    results.append((r.status_code, r.get_json()))
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+
+        with patch.object(audio_embedder, "embed_media", side_effect=_blocking_embed):
+            t1 = threading.Thread(target=_do_post)
+            t2 = threading.Thread(target=_do_post)
+            t1.start()
+            t2.start()
+            t1.join(timeout=15)
+            t2.join(timeout=15)
+
+        assert not errors, f"worker threads raised: {errors}"
+        assert len(results) == 2
+
+        # Exactly one new media inserted (the regression: was 2 before fix).
+        assert len(app_module.medias) == initial_count + 1, (
+            f"H32: duplicate insert — medias grew by "
+            f"{len(app_module.medias) - initial_count}, expected 1"
+        )
+
+        # Both requests succeed and report the same media id.
+        media_ids = {r[1]["media_id"] for r in results}
+        assert len(media_ids) == 1, f"requests reported different ids: {media_ids}"
+
+        # One winner (201, is_new=True), one loser (200, is_new=False).
+        statuses = sorted(r[0] for r in results)
+        assert statuses == [200, 201]
+        is_new_flags = sorted(r[1]["is_new"] for r in results)
+        assert is_new_flags == [False, True]
+
+        # The single inserted media carries the uploaded bytes' md5.
+        inserted_id = next(iter(media_ids))
+        assert (
+            app_module.medias[inserted_id]["md5"]
+            == hashlib.md5(wav_bytes).hexdigest()
+        )
+        assert inserted_id in app_module.good_votes

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -974,8 +974,8 @@ class TestValidatedVoteSnapshot:
         detector_id = res.get_json()["detector"]["id"]
         _load_detector_and_wait(client, detector_id)
 
-        client.post(f"/api/medias/{good_cid}/vote", json={"vote": "good"})
-        client.post(f"/api/medias/{bad_cid}/vote", json={"vote": "bad"})
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
         return detector_id, good_cid, bad_cid
 
     def test_snapshot_safe_when_aligned(self, client):

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -612,15 +612,19 @@ def add_media_to_pile():  # noqa: C901
 
     file_md5 = hashlib.md5(file_bytes).hexdigest()
 
-    # Check if a media with this MD5 already exists
+    # First-pass MD5 lookup (outside _state_lock). When this hits we can
+    # skip the expensive embedding step and vote the existing media right
+    # away. When it misses we still have to re-check under the lock just
+    # before insertion (see below) because embedding holds no lock and a
+    # concurrent upload of the same bytes could land between the two.
     snap = snapshot_medias()
     _, md5_lookup, _ = build_media_lookup(snap)
     existing_cids = md5_lookup.get(file_md5, [])
 
     if existing_cids:
-        # MD5 match — vote the existing media(s).
         for cid in existing_cids:
             apply_label(cid, label)
+        _sync_pile_label_to_storage()
         return {"ok": True, "media_id": existing_cids[0], "is_new": False}
 
     # No match — embed and insert as new media.
@@ -693,11 +697,48 @@ def add_media_to_pile():  # noqa: C901
     if thumb is not None:
         new_media["thumbnail_bytes"] = thumb
 
+    # Re-check the MD5 lookup under _state_lock immediately before inserting.
+    # Embedding above ran without the lock (it can take seconds), so a
+    # concurrent request uploading the same bytes may have inserted a media
+    # with this MD5 in the meantime. Without this re-check, both requests
+    # would each insert a fresh media — producing duplicates with identical
+    # md5/embedding/bytes. (logical-bug-audit.md H32.)
     with _state_lock:
-        new_id = next_media_id(medias)
-        new_media["id"] = new_id
-        medias[new_id] = new_media
+        _, md5_lookup_now, _ = build_media_lookup(medias)
+        collided_cids = md5_lookup_now.get(file_md5, [])
+        if collided_cids:
+            target_cids: list[int] = list(collided_cids)
+            target_id = collided_cids[0]
+            is_new = False
+        else:
+            target_id = next_media_id(medias)
+            new_media["id"] = target_id
+            medias[target_id] = new_media
+            target_cids = [target_id]
+            is_new = True
 
-    apply_label(new_id, label)
+    for cid in target_cids:
+        apply_label(cid, label)
+    _sync_pile_label_to_storage()
 
-    return {"ok": True, "media_id": new_id, "is_new": True}, 201
+    if is_new:
+        return {"ok": True, "media_id": target_id, "is_new": True}, 201
+    return {"ok": True, "media_id": target_id, "is_new": False}
+
+
+def _sync_pile_label_to_storage() -> None:
+    """Persist a newly-applied add-to-pile label to the detector's storage.
+
+    Mirrors the tail of :func:`vote_media` so the in-memory good/bad-votes
+    update also reaches the detector's on-disk labelset and any configured
+    :class:`LabelsetSource`. Without this, the label vanishes the next time
+    ``ensure_votes_match_active_dataset`` rehydrates the detector from disk.
+    (logical-bug-audit.md H33.)
+    """
+    from vtscore.detectors.label_sync import sync_labels_to_loaded_detector  # noqa: PLC0415
+
+    sync_labels_to_loaded_detector()
+
+    from vtscore.labels.sync import sync_to_labelset_source  # noqa: PLC0415
+
+    sync_to_labelset_source()


### PR DESCRIPTION
The backend half of §13.4 ("bump the default of 1") was already shipped by
§11.5 — gates use hardware-derived defaults and read limits fresh on every
acquire. The remaining gap is a frontend "Load selected" side-action; the
dashboard has multi-select + bulk Combine/Delete but no bulk-load button.
Record that split and the open follow-ups so the next contributor sees
what's actually left.

https://claude.ai/code/session_01WNfhjTb3yPua72FCZEKXm2