### PR TITLE
Add H33 regression tests for add-to-pile label persistence

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -178,17 +178,19 @@ Cross-section interaction agents:
   `_state_lock` immediately before assigning `new_id` and writing
   `medias[new_id]`, and dispatch to the existing-cid branch if a
   match appears in the recheck.
-- **H33. `add_media_to_pile` label not synced to disk** —
-  `vtsearch/routes/media/list.py` L614 and L692. `vote_media`
-  follows `toggle_vote` with `sync_labels_to_loaded_detector()` +
-  `sync_to_labelset_source()` (L555–561) so the change reaches the
-  detector's on-disk labelset and any configured `LabelsetSource`.
-  `add_media_to_pile` calls neither after `apply_label`. The
-  in-memory `good_votes` / `bad_votes` are updated, but the labelset
-  file is not — so the next time `ensure_votes_match_active_dataset`
-  rehydrates the detector from disk (e.g. on the next dataset /
-  detector switch handled by `before_request` in `app.py:247-257`),
-  the just-applied label silently disappears.
+- ~~**H33. `add_media_to_pile` label not synced to disk**~~ — fixed
+  in `vtsearch/routes/media/list.py`. Both branches of
+  `add_media_to_pile` (existing-MD5 match and new-media insertion)
+  now call `_sync_pile_label_to_storage()` after `apply_label`,
+  which mirrors `vote_media`'s tail by invoking
+  `sync_labels_to_loaded_detector()` + `sync_to_labelset_source()`.
+  The label reaches the detector's on-disk labelset and any
+  configured `LabelsetSource`, so a subsequent
+  `ensure_votes_match_active_dataset` rehydration restores it
+  instead of silently dropping it. Covered by
+  `TestAddToPile.test_existing_media_label_synced_to_disk`,
+  `test_new_media_label_synced_to_disk`, and
+  `test_label_survives_rehydration` in `tests/core/test_medias.py`.
 - **H34. Missing `X-Detector-Id` → silent detector fallback** —
   `vtscore/state/core.py` `get_active_detector_context()` falls
   through to the thread-local (then `_empty_detector_context`) when

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -706,3 +706,121 @@ class TestAddToPile:
         inserted_id = next(iter(media_ids))
         assert app_module.medias[inserted_id]["md5"] == hashlib.md5(wav_bytes).hexdigest()
         assert inserted_id in app_module.good_votes
+
+    def _setup_loaded_detector(self, client, name="H33Detector"):
+        """Create a detector, register it, load it, and return its registry id."""
+        from tests import load_detector_and_wait
+
+        client.post(
+            "/api/detectors",
+            json={"name": name, "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "text_query": "test"},
+        )
+        mid = res.get_json()["detector"]["id"]
+        load_detector_and_wait(client, mid)
+        return mid, name
+
+    def test_existing_media_label_synced_to_disk(self, client):
+        """H33 regression — MD5-match branch.
+
+        Without :func:`_sync_pile_label_to_storage` the vote applied to the
+        existing media never reaches the detector's JSON file, so the next
+        rehydration (dataset/detector switch, mtime advance) silently drops
+        it.  Assert the labelset on disk contains an entry keyed by the
+        matched media's origin with the right label.
+        """
+        from vtscore.datasets.labelset import LabelSet, element_key, media_element_key
+        from vtscore.detectors.store import _detector_path, _read_detector
+
+        media = app_module.medias[1]
+        _, name = self._setup_loaded_detector(client)
+
+        resp = client.post(
+            "/api/medias/add-to-pile",
+            data={"label": "good", "file": (io.BytesIO(media["media_bytes"]), "match.wav")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+
+        data = _read_detector(_detector_path(name))
+        assert data is not None, "detector JSON not written"
+        ls = LabelSet.from_dict(data.get("labelset") or {})
+        target_key = media_element_key(media)
+        match = next((el for el in ls.elements if element_key(el) == target_key), None)
+        assert match is not None, "matched-media label was not persisted to disk"
+        assert match.label == "good"
+
+    def test_new_media_label_synced_to_disk(self, client):
+        """H33 regression — new-media branch.
+
+        Newly inserted media items are session-only (not in the dataset
+        pickle), so the only durable record of an add-to-pile vote on them
+        is the detector's on-disk labelset.  Assert the labelset contains
+        an ``add_to_pile`` origin entry with the right label.
+        """
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.store import _detector_path, _read_detector
+
+        wav_bytes = app_module.generate_wav(33333, 0.2)
+        _, name = self._setup_loaded_detector(client)
+
+        resp = client.post(
+            "/api/medias/add-to-pile",
+            data={"label": "bad", "file": (io.BytesIO(wav_bytes), "fresh.wav")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+
+        data = _read_detector(_detector_path(name))
+        assert data is not None, "detector JSON not written"
+        ls = LabelSet.from_dict(data.get("labelset") or {})
+        match = next(
+            (
+                el
+                for el in ls.elements
+                if (el.origin or {}).get("importer") == "add_to_pile"
+                and el.origin_name == "fresh.wav"
+            ),
+            None,
+        )
+        assert match is not None, "add-to-pile origin entry missing from on-disk labelset"
+        assert match.label == "bad"
+
+    def test_label_survives_rehydration(self, client):
+        """H33 regression — end-to-end symptom.
+
+        ``ensure_votes_match_active_dataset`` rehydrates from the detector
+        file when the (dataset, detector) pair changes or the file's mtime
+        advances.  Before the fix, ``add_media_to_pile`` only mutated
+        in-memory dicts, so a forced rehydrate dropped the just-applied
+        vote.  Force a rehydration by clearing the cached labelset and
+        re-running the hook; the vote must come back from disk.
+        """
+        from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
+        from vtscore.state.core import get_active_detector_context
+
+        media = app_module.medias[2]
+        self._setup_loaded_detector(client)
+
+        resp = client.post(
+            "/api/medias/add-to-pile",
+            data={"label": "good", "file": (io.BytesIO(media["media_bytes"]), "rehydrate.wav")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        assert 2 in app_module.good_votes
+
+        # Invalidate the detector context's caches and drop the in-memory
+        # votes so the rehydrate hook must round-trip through the file.
+        det_ctx = get_active_detector_context()
+        det_ctx.good_votes.clear()
+        det_ctx.bad_votes.clear()
+        det_ctx.cached_labelset = None
+        det_ctx.cached_labelset_mtime = 0.0
+        det_ctx.votes_dataset_id = ""
+
+        ensure_votes_match_active_dataset()
+        assert 2 in app_module.good_votes, "label vanished on rehydration — H33 regressed"

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -781,8 +781,7 @@ class TestAddToPile:
             (
                 el
                 for el in ls.elements
-                if (el.origin or {}).get("importer") == "add_to_pile"
-                and el.origin_name == "fresh.wav"
+                if (el.origin or {}).get("importer") == "add_to_pile" and el.origin_name == "fresh.wav"
             ),
             None,
         )


### PR DESCRIPTION
## Summary

The H33 code fix already landed on `dev` (`_sync_pile_label_to_storage()` in `vtsearch/routes/media/list.py` mirrors `vote_media`'s sync tail after each `apply_label` call in `add_media_to_pile`), but there was no regression coverage and the audit doc still listed the bug as open.

- Add three regression tests in `TestAddToPile` covering the two branches and the user-facing rehydration symptom:
  - `test_existing_media_label_synced_to_disk` — MD5-match branch persists the matched media's label to the detector JSON.
  - `test_new_media_label_synced_to_disk` — new-media branch persists an `add_to_pile`-origin labelset entry.
  - `test_label_survives_rehydration` — after a forced `ensure_votes_match_active_dataset()` round-trip, the just-applied vote is restored from disk.
- Mark H33 shipped in `docs/plans/logical-bug-audit.md` with a brief "fixed in" note and test references, following the H1/H2 style.

## Test plan

- [x] `./run-tests.sh` — 4025 passed, 1 skipped.
- [x] `pytest tests/core/test_medias.py::TestAddToPile` — 13 passed (10 existing + 3 new).

https://claude.ai/code/session_01BbhRMFiXqZm73qMk65zdap

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbhRMFiXqZm73qMk65zdap)_