### PR TITLE
fix(label-import): isolate per-entry failures (H31)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -388,10 +388,14 @@ Cross-section interaction agents:
   `tests/detectors/test_workflow.py::TestPersistenceFailureIsTransactional`,
   `tests/api/test_api_contracts.py::TestVotesContract::test_disk_sync_failure_surfaces_as_500`,
   and `tests/detectors/test_detectors.py::TestSeedVotesFromExamples::test_seed_disk_sync_failure_surfaces_as_500`.
-- **H31. Partial label-import has no rollback** —
-  `vtsearch/routes/labels/importers.py` L143. Failure mid-loop leaves
-  a half-applied labelset; user has to manually figure out which
-  ones landed.
+- ~~**H31. Partial label-import has no rollback**~~ — fixed by
+  isolating each entry inside `_apply_labels` with a per-entry
+  try/except and surfacing the per-entry failures in the response
+  (`failed` / `failed_count`).  Downstream syncs
+  (`sync_labels_to_loaded_detector`, `sync_to_labelset_source`,
+  `record_detector_import`) still fire on partial success so the
+  in-memory detector and the labelset source stay consistent with what
+  actually landed.
 
 ---
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2677,6 +2677,16 @@
           "applied": {
             "type": "integer"
           },
+          "failed": {
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "failed_count": {
+            "type": "integer"
+          },
           "ingested": {
             "type": "integer"
           },
@@ -2686,6 +2696,8 @@
         },
         "required": [
           "applied",
+          "failed",
+          "failed_count",
           "ingested",
           "message"
         ],

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -137,8 +137,14 @@ export class LabelImporterModalComponent implements OnInit {
           // Show unresolved elements as a warning but don't prompt — the
           // backend already tried to auto-resolve them.
           this.error = `${res.missing_count} element(s) could not be resolved from their original sources.`;
+        } else if (res.failed_count > 0) {
+          // Per-entry application failures (logical-bug-audit H31) — the
+          // import partially landed and the user should know which entries
+          // need to be retried.
+          this.error = `${res.failed_count} element(s) failed to apply. The remaining labels were applied successfully.`;
         }
-        setTimeout(() => this.close(), res.missing_count > 0 ? 3000 : 1500);
+        const hasIssue = res.missing_count > 0 || res.failed_count > 0;
+        setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
       },
       error: (err) => {
         this.submitting = false;

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 
 import app as app_module
@@ -607,3 +608,170 @@ class TestLabelImportMissingElements:
         assert result["missing_count"] == 1
         assert result["missing"][0]["md5"] == "totally_unknown_md5"
         assert "could not be resolved" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure handling — logical-bug-audit H31
+#
+# A single entry that raises during ``apply_label`` must not abort the
+# rest of the import. The handler isolates each entry, reports the
+# failures in a ``failed`` list, and still runs the downstream sync
+# block for the entries that *did* land.
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailure:
+    def test_failing_entry_does_not_abort_remaining(self, client, tmp_path):
+        """One bad entry in the middle of the batch must not block later entries.
+
+        Patches ``apply_label`` to raise on a specific media id; the
+        importer should still apply the other labels and report the
+        failed entry in ``failed``.
+        """
+        md5_1 = app_module.medias[1]["md5"]
+        md5_2 = app_module.medias[2]["md5"]
+        md5_3 = app_module.medias[3]["md5"]
+
+        # Save & clear vote state so we can assert it precisely.
+        saved_good = dict(app_module.good_votes)
+        saved_bad = dict(app_module.bad_votes)
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        try:
+            payload = json.dumps(
+                {
+                    "labels": [
+                        {"md5": md5_1, "label": "good"},
+                        {"md5": md5_2, "label": "good"},
+                        {"md5": md5_3, "label": "good"},
+                    ]
+                }
+            )
+            p = tmp_path / "labels.json"
+            p.write_text(payload)
+
+            real_apply_label = __import__(
+                "vtsearch.routes.labels.importers", fromlist=["apply_label"]
+            )
+
+            def flaky_apply(cid, label, **kwargs):
+                if cid == 2:
+                    raise RuntimeError("simulated downstream failure")
+                # Re-enter the real apply_label from vtscore so the
+                # other ids still land.
+                from vtscore.state.votes import apply_label as inner
+
+                inner(cid, label, **kwargs)
+
+            with patch.object(real_apply_label, "apply_label", side_effect=flaky_apply):
+                res = client.post(
+                    "/api/label-importers/import/server_json_file",
+                    json={"filepath": str(p)},
+                )
+
+            assert res.status_code == 200
+            result = res.get_json()
+            # Two of three landed; one is in `failed`.
+            assert result["applied"] == 2
+            assert result["failed_count"] == 1
+            assert len(result["failed"]) == 1
+            assert result["failed"][0]["entry"]["md5"] == md5_2
+            assert "simulated downstream failure" in result["failed"][0]["error"]
+            # The successful entries' votes actually landed.
+            assert 1 in app_module.good_votes
+            assert 3 in app_module.good_votes
+            assert 2 not in app_module.good_votes
+            # Message advertises the failure.
+            assert "failed to apply" in result["message"]
+        finally:
+            app_module.good_votes.clear()
+            app_module.bad_votes.clear()
+            app_module.good_votes.update(saved_good)
+            app_module.bad_votes.update(saved_bad)
+
+    def test_clean_import_reports_zero_failed(self, client, tmp_path):
+        """The new ``failed``/``failed_count`` fields are always present in the response,
+        and read as 0 / [] on a clean import.
+        """
+        md5 = app_module.medias[1]["md5"]
+        payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
+        p = tmp_path / "labels.json"
+        p.write_text(payload)
+        res = client.post(
+            "/api/label-importers/import/server_json_file",
+            json={"filepath": str(p)},
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 1
+        assert result["failed_count"] == 0
+        assert result["failed"] == []
+
+    def test_failing_entry_still_triggers_sync_for_landed_entries(self, client, tmp_path):
+        """When at least one entry lands, the downstream sync block must run.
+
+        Before the H31 fix, an exception from ``apply_label`` aborted the
+        handler before ``sync_labels_to_loaded_detector`` was called,
+        leaving the loaded detector's ``num_training`` stale relative to
+        the votes that *did* land.
+        """
+        sync_calls = {"count": 0}
+
+        from vtsearch.routes.labels import importers as importers_module
+
+        # Real sync_labels_to_loaded_detector is imported inside the handler
+        # via ``from vtscore.detectors.label_sync import ...``. Stub it at
+        # the source module so the lazy import picks up our spy.
+        from vtscore.detectors import label_sync as label_sync_module
+
+        original = label_sync_module.sync_labels_to_loaded_detector
+
+        def spy():
+            sync_calls["count"] += 1
+
+        md5_1 = app_module.medias[1]["md5"]
+        md5_2 = app_module.medias[2]["md5"]
+
+        saved_good = dict(app_module.good_votes)
+        saved_bad = dict(app_module.bad_votes)
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        try:
+            payload = json.dumps(
+                {
+                    "labels": [
+                        {"md5": md5_1, "label": "good"},
+                        {"md5": md5_2, "label": "good"},
+                    ]
+                }
+            )
+            p = tmp_path / "labels.json"
+            p.write_text(payload)
+
+            def flaky_apply(cid, label, **kwargs):
+                if cid == 2:
+                    raise RuntimeError("boom")
+                from vtscore.state.votes import apply_label as inner
+
+                inner(cid, label, **kwargs)
+
+            label_sync_module.sync_labels_to_loaded_detector = spy
+            try:
+                with patch.object(importers_module, "apply_label", side_effect=flaky_apply):
+                    res = client.post(
+                        "/api/label-importers/import/server_json_file",
+                        json={"filepath": str(p)},
+                    )
+            finally:
+                label_sync_module.sync_labels_to_loaded_detector = original
+
+            assert res.status_code == 200
+            assert res.get_json()["applied"] == 1
+            assert res.get_json()["failed_count"] == 1
+            # Sync ran exactly once even though one entry failed mid-loop.
+            assert sync_calls["count"] == 1
+        finally:
+            app_module.good_votes.clear()
+            app_module.bad_votes.clear()
+            app_module.good_votes.update(saved_good)
+            app_module.bad_votes.update(saved_bad)

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -650,9 +650,7 @@ class TestPartialFailure:
             p = tmp_path / "labels.json"
             p.write_text(payload)
 
-            real_apply_label = __import__(
-                "vtsearch.routes.labels.importers", fromlist=["apply_label"]
-            )
+            real_apply_label = __import__("vtsearch.routes.labels.importers", fromlist=["apply_label"])
 
             def flaky_apply(cid, label, **kwargs):
                 if cid == 2:

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -7,6 +7,8 @@ Covers:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 
 # ---------------------------------------------------------------------------
 # API – POST /api/label-importers/ingest-missing
@@ -58,6 +60,51 @@ class TestIngestMissingEndpoint:
         assert res.status_code == 200
         result = res.get_json()
         assert result["ingested"] == 0
+
+    def test_partial_failure_is_reported_not_500(self, client):
+        """``ingest-missing`` shares the H31 partial-failure semantics with the
+        importer route: a single bad entry must not abort the whole batch,
+        and the response carries a ``failed`` list instead of bubbling a 500.
+        """
+        import app as app_module
+
+        md5_1 = app_module.medias[1]["md5"]
+        md5_2 = app_module.medias[2]["md5"]
+        entries = [
+            {"md5": md5_1, "label": "good"},
+            {"md5": md5_2, "label": "good"},
+        ]
+
+        from vtsearch.routes.labels import importers as importers_module
+
+        def flaky_apply(cid, label, **kwargs):
+            if cid == 2:
+                raise RuntimeError("simulated failure")
+            from vtscore.state.votes import apply_label as inner
+
+            inner(cid, label, **kwargs)
+
+        saved_good = dict(app_module.good_votes)
+        saved_bad = dict(app_module.bad_votes)
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        try:
+            with patch.object(importers_module, "apply_label", side_effect=flaky_apply):
+                res = client.post(
+                    "/api/label-importers/ingest-missing",
+                    json={"entries": entries},
+                )
+            assert res.status_code == 200
+            result = res.get_json()
+            assert result["applied"] == 1
+            assert result["failed_count"] == 1
+            assert len(result["failed"]) == 1
+            assert result["failed"][0]["entry"]["md5"] == md5_2
+        finally:
+            app_module.good_votes.clear()
+            app_module.bad_votes.clear()
+            app_module.good_votes.update(saved_good)
+            app_module.bad_votes.update(saved_bad)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -26,12 +26,29 @@ POST /api/label-importers/import/<importer_name>
 POST /api/label-importers/ingest-missing
     Accept a list of missing label entries, re-ingest them from their
     origins, and apply the labels. JSON-only — fully spec'd.
+
+Partial-failure semantics
+-------------------------
+:func:`_apply_labels` isolates each entry with a per-entry try/except.
+If ``apply_label`` raises mid-loop, that entry is recorded in the
+``failed`` return list and the loop continues with the remaining
+entries.  This addresses logical-bug-audit H31 — a single bad entry no
+longer aborts the whole import and silently strands the already-applied
+labels behind a 500 response.  The handler still runs the downstream
+sync block (``sync_labels_to_loaded_detector``,
+``sync_to_labelset_source``, ``record_detector_import``) whenever
+``applied > 0`` so the in-memory detector, the labelset source, and the
+achievement counters all reflect what actually landed.
 """
 
 from __future__ import annotations
 
+import logging
+
 from flask import jsonify
 from flask_smorest import Blueprint
+
+logger = logging.getLogger(__name__)
 
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
@@ -66,13 +83,19 @@ def _apply_labels(
     origin_lookup: dict[str, list[int]],
     md5_lookup: dict[str, list[int]],
     name_lookup: dict[str, list[int]] | None = None,
-) -> tuple[int, int]:
+) -> tuple[int, int, list[dict]]:
     """Apply label entries to the global vote state.
 
-    Returns ``(applied, skipped)`` counts.
+    Returns ``(applied, skipped, failed)``.  ``failed`` is a list of
+    ``{"entry": <original entry>, "error": <message>}`` dicts — one per
+    entry whose ``apply_label`` call raised.  A single bad entry never
+    aborts the loop (logical-bug-audit H31); the caller is expected to
+    surface the ``failed`` list to the user so they can retry just those
+    entries.
     """
     applied = 0
     skipped = 0
+    failed: list[dict] = []
 
     for entry in label_entries:
         label = entry.get("label", "")
@@ -84,11 +107,16 @@ def _apply_labels(
             skipped += 1
             continue
 
-        for cid in cids:
-            apply_label(cid, label)
+        try:
+            for cid in cids:
+                apply_label(cid, label)
+        except Exception as exc:
+            logger.exception("Failed to apply label for entry %r", entry)
+            failed.append({"entry": entry, "error": str(exc) or exc.__class__.__name__})
+            continue
         applied += 1
 
-    return applied, skipped
+    return applied, skipped, failed
 
 
 # ---------------------------------------------------------------------------
@@ -142,7 +170,7 @@ def run_label_import(importer_name: str):  # noqa: C901
 
     # Apply labels to global vote state
     origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
-    applied, skipped = _apply_labels(label_entries, origin_lookup, md5_lookup, name_lookup)
+    applied, skipped, failed = _apply_labels(label_entries, origin_lookup, md5_lookup, name_lookup)
 
     # Detect entries that could not be matched at all
     missing = find_missing_entries(label_entries, origin_lookup, md5_lookup, name_lookup)
@@ -162,10 +190,13 @@ def run_label_import(importer_name: str):  # noqa: C901
         if ingested > 0:
             # Re-apply labels now that new medias are available.  These entries
             # were already removed from `skipped` above when we subtracted
-            # `len(missing)`, so we only need to bump `applied` here.
+            # `len(missing)`, so we only need to bump `applied` here.  Any
+            # per-entry mutation errors from the auto-resolve pass are
+            # appended to the same `failed` list as the first pass.
             origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
-            resolved_applied, _ = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
+            resolved_applied, _, resolved_failed = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
             applied += resolved_applied
+            failed.extend(resolved_failed)
 
         # Check which entries still couldn't be resolved
         if ingested < len(missing):
@@ -193,6 +224,8 @@ def run_label_import(importer_name: str):  # noqa: C901
         msg += f" Auto-resolved {ingested} missing element(s) from their sources."
     if unresolved:
         msg += f" {len(unresolved)} element(s) could not be resolved."
+    if failed:
+        msg += f" {len(failed)} element(s) failed to apply (see 'failed' for details)."
 
     return jsonify(
         {
@@ -201,6 +234,8 @@ def run_label_import(importer_name: str):  # noqa: C901
             "missing_count": len(unresolved),
             "missing": unresolved,
             "ingested": ingested,
+            "failed_count": len(failed),
+            "failed": failed,
             "message": msg,
         }
     )
@@ -224,7 +259,7 @@ def ingest_missing(body: dict):
 
     # Now apply labels to the newly ingested medias
     origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
-    applied, _ = _apply_labels(entries, origin_lookup, md5_lookup, name_lookup)
+    applied, _, failed = _apply_labels(entries, origin_lookup, md5_lookup, name_lookup)
 
     # Sync updated votes into the loaded model so the dashboard reflects
     # the new label count immediately.
@@ -237,8 +272,14 @@ def ingest_missing(body: dict):
 
         sync_to_labelset_source()
 
+    message = f"Ingested {ingested} media(s), applied {applied} label(s)."
+    if failed:
+        message += f" {len(failed)} element(s) failed to apply."
+
     return {
         "ingested": ingested,
         "applied": applied,
-        "message": f"Ingested {ingested} media(s), applied {applied} label(s).",
+        "failed_count": len(failed),
+        "failed": failed,
+        "message": message,
     }

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -244,10 +244,17 @@ class IngestMissingRequestSchema(Schema):
 
 
 class IngestMissingResponseSchema(Schema):
-    """Response for ``POST /api/label-importers/ingest-missing``."""
+    """Response for ``POST /api/label-importers/ingest-missing``.
+
+    ``failed`` lists per-entry failures from the label-application
+    pass — see logical-bug-audit H31.  A single entry that raises during
+    ``apply_label`` no longer aborts the rest of the batch.
+    """
 
     ingested = fields.Integer(required=True)
     applied = fields.Integer(required=True)
+    failed_count = fields.Integer(required=True)
+    failed = fields.List(fields.Dict(), required=True)
     message = fields.String(required=True)
 
 
@@ -259,6 +266,11 @@ class RunLabelImporterResponseSchema(Schema):
     importer, so we declare it here for cross-reference. Currently
     *not* attached to the route via ``@response`` — kept for the
     eventual unified plugin-field migration.
+
+    ``failed`` carries per-entry application failures (logical-bug-audit
+    H31).  ``missing`` still tracks entries whose media couldn't be
+    located or ingested; ``failed`` is the new field for entries whose
+    ``apply_label`` call raised.
     """
 
     applied = fields.Integer(required=True)
@@ -266,6 +278,8 @@ class RunLabelImporterResponseSchema(Schema):
     missing_count = fields.Integer(required=True)
     missing = fields.List(fields.Dict(), required=True)
     ingested = fields.Integer(required=True)
+    failed_count = fields.Integer(required=True)
+    failed = fields.List(fields.Dict(), required=True)
     message = fields.String(required=True)
 
 


### PR DESCRIPTION
## Summary

Fixes logical-bug-audit **H31** — *Partial label-import has no rollback*.

Before this change, `_apply_labels` in `vtsearch/routes/labels/importers.py` looped through entries and called `apply_label(cid, label)` for each — with **no try/except** around the per-entry mutation. If anything inside that chain raised on entry N, the loop terminated, entries 1..N-1 were left applied, entries N..end never ran, the HTTP response was a generic 500 with no `applied`/`skipped`/`missing` info, and the downstream sync block (`sync_labels_to_loaded_detector`, `sync_to_labelset_source`, `record_detector_import`) was skipped — leaving the loaded detector's `num_training` stale and the labelset source out of sync with what *did* land.

This PR isolates each entry with a per-entry try/except. `_apply_labels` now returns `(applied, skipped, failed)`, and the handler surfaces the per-entry failures as `failed` / `failed_count` in the JSON response. The downstream sync block keys off `applied > 0` (it already did), so a partial success still syncs — the in-memory detector and the labelset source now stay consistent with what actually landed. The same treatment is applied to `/api/label-importers/ingest-missing`.

### Files

- **`vtsearch/routes/labels/importers.py`** — per-entry try/except in `_apply_labels`; new `failed`/`failed_count` keys in both route responses; auto-resolve second pass merges its failures into the same list.
- **`vtsearch/schemas/labels.py`** — `IngestMissingResponseSchema` and `RunLabelImporterResponseSchema` carry the new `failed`/`failed_count` fields.
- **`frontend/openapi.json`** — regenerated snapshot.
- **`frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts`** — surface the new `failed_count` in the modal's warning text and extend the dismiss-delay when there are failures to report.
- **`docs/plans/logical-bug-audit.md`** — H31 marked as shipped.
- **`tests/io/test_label_import_endpoint.py`** — new `TestPartialFailure` covering: (1) a mid-loop failure no longer aborts the rest, (2) the response surfaces `failed`/`failed_count` on every call (zero on a clean import), (3) downstream sync still fires when at least one entry lands.
- **`tests/io/test_label_import_ingestion.py`** — same partial-failure assertion against the `/ingest-missing` route.

### Side-effects worth calling out

- **Response shape grows by two fields** (`failed`, `failed_count`). Backward-compatible for clients that only read the existing keys.
- **`sync_to_labelset_source()` and `sync_labels_to_loaded_detector()` now run on partial success**. Previously a mid-loop exception caused a 500 and the sync block was skipped — the external labelset source was left out of sync entirely while the in-memory votes were partially applied. Now the source mirrors what actually landed, which is the contract sync sources were built around.
- **`record_detector_import` fires on partial success.** Same reasoning — an import did happen for the entries that landed.
- **No backwards-compat shim was added.** The two new schema fields are `required=True`, in keeping with the project policy that breaking changes are fine when they're clean.

## Test plan

- [x] `./run-tests.sh io` — 666 passed
- [x] `./run-tests.sh core` (includes frontend TypeScript build + frontend audit) — 562 passed, frontend build OK
- [x] `./run-tests.sh` (full default suite, excludes `gpu`/`slow`) — 4026 passed, 1 skipped
- [x] `./run-tests.sh vtscore-clean` (library-tier import-clean check) — 946 passed
- [x] OpenAPI snapshot regenerated; drift check passes
- [ ] Manual: trigger a label import where one entry fails mid-loop (covered by automated test via `patch.object(importers_module, "apply_label", ...)`)


---
_Generated by [Claude Code](https://claude.ai/code/session_0135HwzHywzPa4YgnCPKfYEq)_