### PR TITLE
fix(settings): close H29 — release _settings_lock over local file I/O

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -363,14 +363,24 @@ Cross-section interaction agents:
     to the in-process lock only. Not a regression (the codebase ships
     Linux-only Docker images), but worth a note if a contributor ever
     wants to test on Windows.
-- **H29. `_save_user` holds `_settings_lock` across sync I/O** —
-  `vtsearch/settings.py` ~L331–338. Slow source (NFS, webhook) blocks
-  all other settings reads/writes globally. (Per-user side is
-  incidentally addressed by H28's fix — `_sync_to_source` now runs
-  outside the file lock and outside `_settings_lock`. Server-tier
-  paths through `_atomic_write` no longer hold `_settings_lock` across
-  file I/O either, but a dedicated audit of every remaining sink is
-  still warranted.)
+- ~~**H29. `_save_user` holds `_settings_lock` across sync I/O**~~ —
+  was at `vtsearch/settings.py` ~L331–338. H28's fix already moved
+  `_sync_to_source` outside both the file lock and `_settings_lock`,
+  which neutralised the worst case (a hung NFS/webhook source could
+  no longer freeze every settings read/write process-wide). The H29
+  follow-up closes the remaining surface: `_atomic_write` and
+  `_load_path` inside `_mutate_server_locked` / `_mutate_user_locked`
+  now run under the cross-process `_file_lock` only, and
+  `_settings_lock` is acquired briefly at the end just to swap the
+  in-memory cache.  A slow local fsync (NFS data dir, full disk,
+  hung disk controller) therefore no longer blocks unrelated
+  settings reads, and only blocks writes to the *same* user's file
+  via the per-file lock — different users' writes proceed in
+  parallel.  Regression tests:
+  `tests/integration/test_thread_safety.py::TestSlowSettingsIODoesNotBlockOthers`
+  (slow `_sync_to_source` doesn't block a reader; slow
+  `_atomic_write` for user A doesn't block user B's write; slow
+  `_atomic_write` doesn't block settings reads).
 
 ### Error flow
 

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -371,6 +371,199 @@ class TestConcurrentSettingsAccess:
         assert not errors
 
 
+class TestSlowSettingsIODoesNotBlockOthers:
+    """H29 regression: a slow settings I/O sink must not stall unrelated
+    settings reads/writes.
+
+    H28's fix moved ``_sync_to_source`` outside the file lock, and the
+    H29 completion follow-up moved ``_atomic_write`` outside
+    ``_settings_lock`` (it still runs under the per-file
+    cross-process ``_file_lock``). Combined, this means:
+
+    * A hung NFS/webhook ``source.save`` can't stall any settings access.
+    * A slow local fsync only stalls writes to the *same* user's file
+      (via the per-file lock); other users' writes and any reads
+      proceed.
+    """
+
+    def test_slow_sync_to_source_does_not_block_reader(
+        self, monkeypatch, isolated_settings
+    ):
+        """One thread inside _sync_to_source must NOT freeze a reader."""
+        # Plant a placeholder source config first so the setter under
+        # test actually invokes _sync_to_source — only then install the
+        # slow stub so the placeholder write itself stays fast.
+        _settings_mod.set_settings_source_config(
+            {"source_name": "_h29_unused", "field_values": {}}
+        )
+
+        in_sync = threading.Event()
+        unblock = threading.Event()
+
+        def slow_sync(username, data):
+            in_sync.set()
+            # Generous upper bound so the suite never hangs if something
+            # unexpected goes wrong; the test releases this in <1s.
+            unblock.wait(timeout=30)
+
+        monkeypatch.setattr(_settings_mod, "_sync_to_source", slow_sync)
+
+        errors: list[BaseException] = []
+        reader_done = threading.Event()
+
+        def slow_setter():
+            try:
+                _settings_mod.set_volume(0.42)
+            except BaseException as exc:  # pragma: no cover - surfaced via errors
+                errors.append(exc)
+
+        def reader():
+            try:
+                _settings_mod.get_theme()
+                _settings_mod.get_volume()
+                reader_done.set()
+            except BaseException as exc:  # pragma: no cover - surfaced via errors
+                errors.append(exc)
+
+        setter_thread = threading.Thread(target=slow_setter)
+        setter_thread.start()
+        assert in_sync.wait(timeout=5), "_sync_to_source was never called"
+
+        reader_thread = threading.Thread(target=reader)
+        reader_thread.start()
+        assert reader_done.wait(timeout=5), (
+            "Reader thread was blocked by the slow source — H29 has regressed"
+        )
+
+        unblock.set()
+        setter_thread.join(timeout=5)
+        reader_thread.join(timeout=5)
+        assert not setter_thread.is_alive()
+        assert not reader_thread.is_alive()
+        assert not errors, f"Threads raised: {errors!r}"
+
+    def test_slow_atomic_write_does_not_block_other_users(
+        self, monkeypatch, isolated_settings, tmp_path
+    ):
+        """While user A's local fsync hangs, user B's set_volume must complete.
+
+        ``_atomic_write`` runs under the per-file cross-process lock only
+        (not under ``_settings_lock`` after the H29 follow-up), and each
+        user has its own ``.lock`` file, so user B's setter is unaffected.
+        """
+        from vtsearch.auth import set_thread_user
+
+        # Per-user files under tmp_path/<user>/user_settings.json so the
+        # two users are truly isolated on disk.
+        _settings_mod.set_user_data_dir_override(tmp_path)
+
+        in_write_for_user_a = threading.Event()
+        unblock = threading.Event()
+        real_atomic_write = _settings_mod._atomic_write
+
+        def selective_atomic_write(path, data):
+            if "user_a" in str(path):
+                in_write_for_user_a.set()
+                unblock.wait(timeout=30)
+            real_atomic_write(path, data)
+
+        monkeypatch.setattr(_settings_mod, "_atomic_write", selective_atomic_write)
+
+        errors: list[BaseException] = []
+        user_b_done = threading.Event()
+
+        def user_a_setter():
+            try:
+                set_thread_user("user_a")
+                _settings_mod.set_volume(0.1)
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+            finally:
+                set_thread_user(None)
+
+        def user_b_setter():
+            try:
+                set_thread_user("user_b")
+                _settings_mod.set_volume(0.9)
+                user_b_done.set()
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+            finally:
+                set_thread_user(None)
+
+        ta = threading.Thread(target=user_a_setter)
+        ta.start()
+        assert in_write_for_user_a.wait(timeout=5), (
+            "user_a's _atomic_write was never reached"
+        )
+
+        tb = threading.Thread(target=user_b_setter)
+        tb.start()
+        assert user_b_done.wait(timeout=5), (
+            "user_b's set_volume was blocked by user_a's hung fsync — H29 has regressed"
+        )
+
+        unblock.set()
+        ta.join(timeout=5)
+        tb.join(timeout=5)
+        _settings_mod.set_user_data_dir_override(None)
+        assert not ta.is_alive()
+        assert not tb.is_alive()
+        assert not errors, f"Threads raised: {errors!r}"
+
+    def test_slow_atomic_write_does_not_block_settings_reads(
+        self, monkeypatch, isolated_settings
+    ):
+        """A hung local fsync for the current user must NOT block other
+        threads doing settings *reads* — those only need ``_settings_lock``,
+        which is no longer held across file I/O.
+        """
+        in_write = threading.Event()
+        unblock = threading.Event()
+        real_atomic_write = _settings_mod._atomic_write
+
+        def slow_atomic_write(path, data):
+            in_write.set()
+            unblock.wait(timeout=30)
+            real_atomic_write(path, data)
+
+        monkeypatch.setattr(_settings_mod, "_atomic_write", slow_atomic_write)
+
+        errors: list[BaseException] = []
+        reader_done = threading.Event()
+
+        def slow_setter():
+            try:
+                _settings_mod.set_volume(0.42)
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        def reader():
+            try:
+                _settings_mod.get_theme()
+                _settings_mod.get_volume()
+                reader_done.set()
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        setter_thread = threading.Thread(target=slow_setter)
+        setter_thread.start()
+        assert in_write.wait(timeout=5), "_atomic_write was never reached"
+
+        reader_thread = threading.Thread(target=reader)
+        reader_thread.start()
+        assert reader_done.wait(timeout=5), (
+            "Reader thread was blocked by the slow local fsync — H29 has regressed"
+        )
+
+        unblock.set()
+        setter_thread.join(timeout=5)
+        reader_thread.join(timeout=5)
+        assert not setter_thread.is_alive()
+        assert not reader_thread.is_alive()
+        assert not errors, f"Threads raised: {errors!r}"
+
+
 class TestProgressLock:
     """Verify that _progress_lock exists and is an RLock."""
 

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -386,16 +386,12 @@ class TestSlowSettingsIODoesNotBlockOthers:
       proceed.
     """
 
-    def test_slow_sync_to_source_does_not_block_reader(
-        self, monkeypatch, isolated_settings
-    ):
+    def test_slow_sync_to_source_does_not_block_reader(self, monkeypatch, isolated_settings):
         """One thread inside _sync_to_source must NOT freeze a reader."""
         # Plant a placeholder source config first so the setter under
         # test actually invokes _sync_to_source — only then install the
         # slow stub so the placeholder write itself stays fast.
-        _settings_mod.set_settings_source_config(
-            {"source_name": "_h29_unused", "field_values": {}}
-        )
+        _settings_mod.set_settings_source_config({"source_name": "_h29_unused", "field_values": {}})
 
         in_sync = threading.Event()
         unblock = threading.Event()
@@ -431,9 +427,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
 
         reader_thread = threading.Thread(target=reader)
         reader_thread.start()
-        assert reader_done.wait(timeout=5), (
-            "Reader thread was blocked by the slow source — H29 has regressed"
-        )
+        assert reader_done.wait(timeout=5), "Reader thread was blocked by the slow source — H29 has regressed"
 
         unblock.set()
         setter_thread.join(timeout=5)
@@ -442,9 +436,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
         assert not reader_thread.is_alive()
         assert not errors, f"Threads raised: {errors!r}"
 
-    def test_slow_atomic_write_does_not_block_other_users(
-        self, monkeypatch, isolated_settings, tmp_path
-    ):
+    def test_slow_atomic_write_does_not_block_other_users(self, monkeypatch, isolated_settings, tmp_path):
         """While user A's local fsync hangs, user B's set_volume must complete.
 
         ``_atomic_write`` runs under the per-file cross-process lock only
@@ -493,15 +485,11 @@ class TestSlowSettingsIODoesNotBlockOthers:
 
         ta = threading.Thread(target=user_a_setter)
         ta.start()
-        assert in_write_for_user_a.wait(timeout=5), (
-            "user_a's _atomic_write was never reached"
-        )
+        assert in_write_for_user_a.wait(timeout=5), "user_a's _atomic_write was never reached"
 
         tb = threading.Thread(target=user_b_setter)
         tb.start()
-        assert user_b_done.wait(timeout=5), (
-            "user_b's set_volume was blocked by user_a's hung fsync — H29 has regressed"
-        )
+        assert user_b_done.wait(timeout=5), "user_b's set_volume was blocked by user_a's hung fsync — H29 has regressed"
 
         unblock.set()
         ta.join(timeout=5)
@@ -511,9 +499,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
         assert not tb.is_alive()
         assert not errors, f"Threads raised: {errors!r}"
 
-    def test_slow_atomic_write_does_not_block_settings_reads(
-        self, monkeypatch, isolated_settings
-    ):
+    def test_slow_atomic_write_does_not_block_settings_reads(self, monkeypatch, isolated_settings):
         """A hung local fsync for the current user must NOT block other
         threads doing settings *reads* — those only need ``_settings_lock``,
         which is no longer held across file I/O.
@@ -552,9 +538,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
 
         reader_thread = threading.Thread(target=reader)
         reader_thread.start()
-        assert reader_done.wait(timeout=5), (
-            "Reader thread was blocked by the slow local fsync — H29 has regressed"
-        )
+        assert reader_done.wait(timeout=5), "Reader thread was blocked by the slow local fsync — H29 has regressed"
 
         unblock.set()
         setter_thread.join(timeout=5)

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -431,15 +431,21 @@ def _mutate_server_locked(mutator) -> None:
     The legacy migration is left to ``_ensure_server_loaded`` and never
     fires from inside the lock — by the time any setter runs the cache
     has been loaded at least once.
+
+    File I/O (``_load_path``, ``_atomic_write``) runs under the
+    cross-process file lock only; ``_settings_lock`` is acquired briefly
+    at the end just to swap the in-memory cache, so a slow local fsync
+    (NFS, full disk, hung disk controller) can't stall unrelated
+    settings reads — see H29 in ``docs/plans/logical-bug-audit.md``.
     """
     global _server_cache
     path = _server_settings_path()
     with _file_lock(path):
+        fresh = _load_path(path)
+        mutator(fresh)
+        _atomic_write(path, fresh)
         with _settings_lock:
-            fresh = _load_path(path)
-            mutator(fresh)
             _server_cache = fresh
-            _atomic_write(path, fresh)
 
 
 def _mutate_user_locked(username: str, mutator) -> dict[str, Any] | None:
@@ -450,14 +456,19 @@ def _mutate_user_locked(username: str, mutator) -> dict[str, Any] | None:
     slow sync target (NFS, webhook) can't block other settings writes.
     Returns ``None`` if the cache should not be synced (i.e. we are
     currently importing from the source).
+
+    Like :func:`_mutate_server_locked`, file I/O runs under the
+    cross-process file lock only; ``_settings_lock`` is acquired briefly
+    at the end just to swap the in-memory cache and read the ``_syncing``
+    flag.
     """
     path = _user_settings_path(username)
     with _file_lock(path):
+        fresh = _load_path(path)
+        mutator(fresh)
+        _atomic_write(path, fresh)
         with _settings_lock:
-            fresh = _load_path(path)
-            mutator(fresh)
             _user_caches[username] = fresh
-            _atomic_write(path, fresh)
             if username in _syncing:
                 return None
             return dict(fresh)


### PR DESCRIPTION
## Summary

Completes **H29** from `docs/plans/logical-bug-audit.md`. The original report — `_save_user` holding `_settings_lock` across slow source I/O — was already substantially fixed by **H28** (PR #1564), which moved `_sync_to_source` out of the file lock and out of `_settings_lock` as an incidental improvement. The audit entry was left open because `_mutate_server_locked` / `_mutate_user_locked` still held `_settings_lock` across the *local* `_load_path` + `_atomic_write` I/O, so a slow local fsync (NFS data dir, full disk, hung disk controller) could still stall unrelated settings reads.

This PR closes that remaining surface.

### Note on history

The earlier commits on this branch (a different `_save_user` refactor written before H28 landed on `dev`) were superseded by H28's design. The branch was hard-reset to `origin/dev` and this small, focused follow-up rebuilt on top.

### Changes

- `vtsearch/settings.py` — `_mutate_server_locked` and `_mutate_user_locked` now run `_load_path` + `_atomic_write` under the cross-process `_file_lock` only; `_settings_lock` is acquired briefly at the end just to swap the in-memory cache (and, for the user path, to read `_syncing`). Lock order stays `file_lock → settings_lock`.
- `tests/integration/test_thread_safety.py` — new `TestSlowSettingsIODoesNotBlockOthers` class with three regressions:
  - **`test_slow_sync_to_source_does_not_block_reader`** — stubs `_sync_to_source` to block on an `Event`; an unrelated `get_theme()` / `get_volume()` must complete while the setter is mid-sync.
  - **`test_slow_atomic_write_does_not_block_other_users`** — stubs `_atomic_write` to block only for user A's file; user B's `set_volume(...)` must complete (verifies the per-file, not global, scoping).
  - **`test_slow_atomic_write_does_not_block_settings_reads`** — stubs `_atomic_write` to block; a reader on `get_theme()` / `get_volume()` for the same user must complete (verifies `_settings_lock` is no longer held over file I/O).
- `docs/plans/logical-bug-audit.md` — struck through H29 and added the fix description.

### Why this is safe

The cross-process `_file_lock` is per-file (sibling `<path>.lock`), so it already serialises read-modify-write for the same file across both threads and sibling processes. Moving the I/O out from under `_settings_lock` doesn't introduce a new race: two threads can't reach the file write for the same user at the same time (the file lock prevents it), and `_settings_lock` is only needed to keep the in-memory cache consistent with what's on disk — which is preserved by swapping the cache at the end, after `_atomic_write` has succeeded.

A reader may now briefly see the *old* cache value while the new value is on disk (between `_atomic_write` returning and `_user_caches[username] = fresh` running). Previously the inverted window existed — readers could see the new cache before the file was on disk. Both are short, neither corrupts state, and the new ordering has the nicer property that the in-memory cache always lags or matches disk, never leads it.

## Test plan

- [x] `./run-tests.sh` — 4039 passed, 1 skipped, 2 xpassed
- [x] `./run-tests.sh core integration` — 648 passed (includes the three new H29 regression tests)
- [x] `ruff check` / `ruff format --check` / codespell / deptry — clean

https://claude.ai/code/session_01RbAdfSPq12z5rp6juRaXwn