### PR TITLE
H15: hide symlinks that escape the file-browser root

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -159,10 +159,32 @@ Cross-section interaction agents:
   H34.
 - ~~**H13. `vote_media` silent-mistarget on dropped header**~~
 - ~~**H14. `export_labels` leaks votes across datasets**~~
-- **H15. File-browser symlink-traversal** — `vtsearch/routes/file_browser.py`
-  L84–92. `target.resolve().relative_to(root.resolve())` succeeds for
-  `/data/link → /etc`. If the configured root contains a symlink,
-  listings escape.
+- ~~**H15. File-browser symlink metadata leak**~~ — investigation
+  revised and fixed (2026-05-20). The audit's literal claim was
+  incorrect: the `target.resolve().relative_to(root)` check at
+  `vtsearch/routes/file_browser.py:90` does block drill-through into
+  symlinked-out directories (resolve canonicalises through the link,
+  and `relative_to` then raises). The real bug was in the listing
+  loop at L105–118: `entry.is_dir()` / `entry.is_file()` / `stat()`
+  all follow symlinks by default, so an in-root symlink pointing
+  outside the root showed up as an ordinary entry and leaked the
+  external target's existence, name, `size_bytes`, and `modified_at`.
+  In multi-user mode this violated the data-dir isolation contract
+  asserted by `TestMultiUserBrowseIsolation`. Fix: in the listing
+  loop, call `entry.resolve(strict=True).relative_to(root)` on
+  symlinks and skip any that escape root or are broken — intra-root
+  symlinks remain visible. Covered by `TestBrowseSymlinks` in
+  `tests/api/test_file_browser.py`
+  (`test_symlink_to_external_dir_hidden`,
+  `test_symlink_to_external_file_hidden`,
+  `test_intra_root_symlink_still_listed`,
+  `test_broken_symlink_skipped`,
+  `test_symlink_drill_through_blocked`). Note: a separate
+  symlink-follow content escape exists in
+  `vtscore/security/path_validation.py:rglob_follow_symlinks`
+  (importers walk with `followlinks=True` and per-file paths
+  outside the validated root are not re-checked) — that's a
+  different code path, not covered by this fix.
 - ~~**H16. Header refers to unloaded dataset → silent fallback**~~ —
   also closes the "header points to an unloaded id" half of H34 by the
   same mechanism. The "header absent → thread-local leak" half of H34

--- a/tests/api/test_file_browser.py
+++ b/tests/api/test_file_browser.py
@@ -8,12 +8,16 @@ Covers:
 - Non-existent directory handling
 - Multi-user isolation (users cannot browse into other users' folders)
 - No server filesystem path leakage in responses
+- Symlinks that escape the root are hidden from listings
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 
 from vtsearch.auth import (
@@ -198,6 +202,102 @@ class TestBrowseEndpoint:
         # Ensure no absolute path appears anywhere in the JSON values
         raw = resp.get_data(as_text=True)
         assert str(root) not in raw
+
+
+class TestBrowseSymlinks:
+    """Symlinks pointing outside the root must not appear in listings."""
+
+    def test_symlink_to_external_dir_hidden(self, client, tmp_path):
+        """A symlink to an out-of-root directory is omitted from the listing."""
+        root = _make_browse_root(tmp_path)
+        external = tmp_path / "external_target"
+        external.mkdir()
+        (external / "secret.txt").write_text("hidden")
+        try:
+            os.symlink(external, root / "link")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=root):
+            resp = client.get("/api/browse")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        all_names = [d["name"] for d in data["directories"]] + [f["name"] for f in data["files"]]
+        assert "link" not in all_names
+
+    def test_symlink_to_external_file_hidden(self, client, tmp_path):
+        """A symlink to an out-of-root file is omitted (no size/mtime leak)."""
+        root = _make_browse_root(tmp_path)
+        target = tmp_path / "external_file.txt"
+        target.write_text("sensitive content")
+        try:
+            os.symlink(target, root / "shortcut")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=root):
+            resp = client.get("/api/browse")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        file_names = [f["name"] for f in data["files"]]
+        assert "shortcut" not in file_names
+        # Size of the external target must not leak even by coincidence.
+        raw = resp.get_data(as_text=True)
+        assert "sensitive content" not in raw
+
+    def test_intra_root_symlink_still_listed(self, client, tmp_path):
+        """A symlink whose target resolves back inside root is still shown."""
+        root = _make_browse_root(tmp_path)
+        real = root / "real_dir"
+        real.mkdir()
+        (real / "child.txt").write_text("data")
+        try:
+            os.symlink(real, root / "alias")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=root):
+            resp = client.get("/api/browse")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        dir_names = [d["name"] for d in data["directories"]]
+        assert "alias" in dir_names
+        assert "real_dir" in dir_names
+
+    def test_broken_symlink_skipped(self, client, tmp_path):
+        """A symlink to a non-existent target is silently skipped, not 500."""
+        root = _make_browse_root(tmp_path)
+        try:
+            os.symlink(tmp_path / "does_not_exist", root / "dangling")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=root):
+            resp = client.get("/api/browse")
+
+        assert resp.status_code == 200
+        all_names = [d["name"] for d in resp.get_json()["directories"]] + [
+            f["name"] for f in resp.get_json()["files"]
+        ]
+        assert "dangling" not in all_names
+
+    def test_symlink_drill_through_blocked(self, client, tmp_path):
+        """Pre-existing guarantee: drilling through an external symlink is rejected."""
+        root = _make_browse_root(tmp_path)
+        external = tmp_path / "external"
+        external.mkdir()
+        try:
+            os.symlink(external, root / "escape")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=root):
+            resp = client.get("/api/browse?path=escape")
+
+        assert resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_file_browser.py
+++ b/tests/api/test_file_browser.py
@@ -279,9 +279,7 @@ class TestBrowseSymlinks:
             resp = client.get("/api/browse")
 
         assert resp.status_code == 200
-        all_names = [d["name"] for d in resp.get_json()["directories"]] + [
-            f["name"] for f in resp.get_json()["files"]
-        ]
+        all_names = [d["name"] for d in resp.get_json()["directories"]] + [f["name"] for f in resp.get_json()["files"]]
         assert "dangling" not in all_names
 
     def test_symlink_drill_through_blocked(self, client, tmp_path):

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -105,6 +105,15 @@ def browse(query: dict):  # noqa: C901
     for entry in entries:
         if entry.name.startswith("."):
             continue
+        # is_dir() / is_file() / stat() follow symlinks by default, so an
+        # in-root symlink pointing outside root would otherwise be listed
+        # like an ordinary entry and leak the target's name/size/mtime.
+        # Resolve symlinks up front and skip any that escape root.
+        if entry.is_symlink():
+            try:
+                entry.resolve(strict=True).relative_to(root)
+            except (OSError, ValueError):
+                continue
         rel = str(entry.relative_to(root))
         if entry.is_dir():
             directories.append({"name": entry.name, "path": rel, "modified_at": format_mtime(entry)})


### PR DESCRIPTION
## Summary

H15 in `docs/plans/logical-bug-audit.md` claimed `/api/browse` allowed
drill-through into symlinked-out directories. That part is wrong — the
`target.resolve().relative_to(root)` check at
`vtsearch/routes/file_browser.py:90` already blocks it (resolve
canonicalises through the link, then `relative_to` raises). But there's
a related bug in the same code window:

- `entry.is_dir()` / `entry.is_file()` / `stat()` follow symlinks by
  default, so an in-root symlink pointing **outside** root showed up
  as an ordinary entry in the listing, leaking the target's existence,
  filename, `size_bytes`, and `modified_at`. In multi-user mode this
  violates the data-dir isolation contract asserted by
  `TestMultiUserBrowseIsolation`.

Fix: in the listing loop, call `entry.resolve(strict=True).relative_to(root)`
on symlinks and skip any that escape root or are broken. Intra-root
symlinks remain visible.

Audit entry rewritten to describe the actual bug (metadata leak, not
drill-through escape) and marked shipped. A separate, unrelated
symlink-follow content escape in
`vtscore/security/path_validation.py:rglob_follow_symlinks` (importers
walk with `followlinks=True` and per-file paths outside the validated
root are not re-checked) is flagged in the audit note but **not** fixed
here.

## Test plan

- [x] `python -m pytest tests/api/test_file_browser.py -q` → 25 passed
  (5 new `TestBrowseSymlinks` cases + 20 pre-existing)
- [x] `./run-tests.sh` → 4041 passed, 1 skipped, 2 xpassed
- [x] ruff check / ruff format / codespell / deptry / frontend build
  all clean

New `TestBrowseSymlinks` covers:
- `test_symlink_to_external_dir_hidden`
- `test_symlink_to_external_file_hidden`
- `test_intra_root_symlink_still_listed`
- `test_broken_symlink_skipped`
- `test_symlink_drill_through_blocked` (regression for the
  pre-existing `relative_to` check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ALNreTHRVeEQb2wDTgUKN7)_