### PR TITLE
docs(audit): strike M3 — base.py default run() ID assignment is correct

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -440,8 +440,8 @@ Cross-section interaction agents:
   progress lock ordering creates a narrow but real deadlock window.
 - **M2.** `combine_datasets.run_chunked` re-issues IDs starting at 1 on every
   call → cid collision when consumed twice.
-- **M3.** `importers/base.py` L407–410 — skipped records leave `next_id`
-  unincremented, ID collisions on first-record-skip.
+- ~~**M3.** `importers/base.py` L407–410 — skipped records leave `next_id`
+  unincremented, ID collisions on first-record-skip.~~
 
 ### Detector
 


### PR DESCRIPTION
## Investigation: M3 from `logical-bug-audit.md`

**Claim:** `importers/base.py` L407–410 — skipped records leave `next_id` unincremented → ID collisions on first-record-skip.

**Verdict:** Not a real bug. Striking through.

### Why it isn't a bug

Current code (`vtscore/datasets/importers/base.py:420-428`):

```python
next_id = 1
for media in fetched:
    if media is None:
        continue
    media["id"] = next_id
    medias[next_id] = media
    next_id += 1
```

`next_id` is consumed **only on insertion** — leaving it unincremented on skip is correct, not buggy. With `fetched = [None, A, B]` the output is `{1: A, 2: B}`. No collision.

### Why the latent risk also doesn't bite

For a collision to occur, `medias` would have to be non-empty on entry (so `next_id = 1` would overwrite something). Every caller passes an empty dict:

- `vtscore/datasets/load_pipeline.py:1135` — fresh `DatasetContext.medias`
- `vtscore/cli.py:399-400` — literal `{}`
- Test sites in `tests/` and `tests_lib/` — literal `{}`

And the only importer that actually uses the default `run()` is `recaller`, which is a `hidden_from_picker=True` scaffold.

`server_folder` uses the safer pattern `max(medias.keys(), default=0) + 1` for the same case, which would harden the framework against a future caller violating the empty-dict contract — but that's a defensive change, not a fix for this finding, and the user opted to leave it alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJoD3jVeXaTNsoB2UHNA1z)_