### PR TITLE
fix(ingest): clip-aware MD5/bytes/file_size for re-ingested clips (H10)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -135,9 +135,19 @@ Cross-section interaction agents:
 
 - ~~**H8. Origin dict shared by reference across medias**~~
 - ~~**H9. Single-item split has 0 test samples**~~
-- **H10. Clipped media re-ingest reads whole file for MD5** —
-  `vtsearch/datasets/ingest.py` L275. MD5 of the full parent
-  ≠ MD5 of the clip, so dedup never re-matches the original clip.
+- ~~**H10. Clipped media re-ingest reads whole file for MD5**~~ —
+  fixed (2026-05-20). `vtscore/datasets/ingest.py` (formerly
+  `vtsearch/datasets/ingest.py`) now routes both `_ingest_via_source`
+  and `_ingest_via_resolver` through a new
+  `_resolve_clip_content_and_embedding` helper that pairs the clip
+  embedding with the clip's actual content bytes — so `md5`,
+  `file_size`, and `media_bytes` describe the clip, not the parent.
+  Video metadata-only clips (and other fall-through paths) fall back
+  to the load-pipeline's `MD5(parent_bytes) + boundary_tag` scheme so
+  distinct clips of the same parent still hash uniquely. The clip-bytes
+  return value is plumbed through `_apply_clip_and_embed` /
+  `_replay_chain` / `replay_chain_on_file`; see
+  `tests/io/test_label_import_ingestion.py::TestClippedReingest`.
 - ~~**H11. Multi-media import with empty form yields empty dataset**~~
 
 ### Routes / API

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -297,6 +297,7 @@ class TestClippedReingest:
         def _fake_embed_via_tempfile(*_args, **_kwargs):
             return fake_embedding
 
+        existing: dict = {}
         # Patch the embed sink so _apply_clip_and_embed completes without a
         # real audio embedder; the clip-to-bytes step still runs against the
         # real WAV file.
@@ -305,9 +306,12 @@ class TestClippedReingest:
             patch("vtscore.detectors.resolver.resolve_file_context", _fake_resolve_ctx),
             patch("vtscore.detectors.resolver._embed_via_tempfile", _fake_embed_via_tempfile),
         ):
-            ingested = _ingest_via_resolver(origin, entries, {}, lambda *a, **k: None)
+            ingested = _ingest_via_resolver(origin, entries, existing, lambda *a, **k: None)
 
         assert ingested == 1
+        media = next(iter(existing.values()))
+        assert media["md5"] == expected_clip_md5, "stored MD5 must be the clip's, not the parent's"
+        assert media["md5"] != parent_md5
 
     def test_two_clips_of_same_parent_get_distinct_md5s(self, tmp_path):
         """Re-ingesting two audio clips of the same parent yields two distinct MD5s.
@@ -339,8 +343,11 @@ class TestClippedReingest:
                 },
             }
 
-        entries_a = [{"origin": _origin(0.0, 2.0, 0), "origin_name": "test.wav", "md5": "", "label": "good"}]
-        entries_b = [{"origin": _origin(2.0, 4.0, 1), "origin_name": "test.wav", "md5": "", "label": "bad"}]
+        # Use unequal-length clips so the slices differ regardless of phase
+        # alignment (a 440 Hz sine sliced [0,2] and [2,4] is byte-identical
+        # because the wave is integer-cycle-aligned).
+        entries_a = [{"origin": _origin(0.0, 1.0, 0), "origin_name": "test.wav", "md5": "", "label": "good"}]
+        entries_b = [{"origin": _origin(1.0, 3.0, 1), "origin_name": "test.wav", "md5": "", "label": "bad"}]
 
         fake_embedding = rng.standard_normal(512).astype(np.float32)
 

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -240,3 +240,250 @@ class TestIngestMissingClips:
         assert 2 in existing_clips
         assert existing_clips[2]["origin_name"] == "hello.txt"
         assert existing_clips[2]["embedding"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Clipped-origin re-ingest (H10): MD5 / media_bytes / file_size must
+# describe the clip, not the parent — otherwise distinct clips of the same
+# parent collide on collapse_duplicates after a save+reload round-trip.
+# ---------------------------------------------------------------------------
+
+
+class TestClippedReingest:
+    def test_audio_clip_md5_is_clip_not_parent(self, tmp_path):
+        """A re-ingested audio clip's MD5 hashes the *clip* bytes, not the parent file."""
+        import hashlib
+
+        import numpy as np
+
+        from vtscore.datasets.ingest import _ingest_via_resolver
+        from vtscore.media.audio.audio_generator import generate_wav
+        from vtscore.media.audio.clipper import _wav_slice
+
+        rng = np.random.default_rng(42)
+
+        wav = generate_wav(440, 5.0)
+        wav_path = tmp_path / "test.wav"
+        wav_path.write_bytes(wav)
+
+        clip_start, clip_end = 0.0, 2.0
+        clip_bytes = _wav_slice(wav, clip_start, clip_end)
+        expected_clip_md5 = hashlib.md5(clip_bytes).hexdigest()
+        parent_md5 = hashlib.md5(wav).hexdigest()
+        assert expected_clip_md5 != parent_md5, "clip and parent MD5s must differ"
+
+        origin = {
+            "importer": "server_folder",
+            "params": {
+                "path": str(tmp_path),
+                "media_type": "audio",
+                "clipper": "sound_tiling",
+                "clip_start": str(clip_start),
+                "clip_end": str(clip_end),
+                "clip_index": "0",
+            },
+        }
+        entries = [{"origin": origin, "origin_name": "test.wav", "md5": expected_clip_md5, "label": "good"}]
+
+        fake_embedding = rng.standard_normal(512).astype(np.float32)
+
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        @contextmanager
+        def _fake_resolve_ctx(*_args, **_kwargs):
+            yield wav_path
+
+        def _fake_embed_via_tempfile(*_args, **_kwargs):
+            return fake_embedding
+
+        # Patch the embed sink so _apply_clip_and_embed completes without a
+        # real audio embedder; the clip-to-bytes step still runs against the
+        # real WAV file.
+        with (
+            patch("vtscore.datasets.ingest._media_type_from_origin", return_value="audio"),
+            patch("vtscore.detectors.resolver.resolve_file_context", _fake_resolve_ctx),
+            patch("vtscore.detectors.resolver._embed_via_tempfile", _fake_embed_via_tempfile),
+        ):
+            ingested = _ingest_via_resolver(origin, entries, {}, lambda *a, **k: None)
+
+        assert ingested == 1
+
+    def test_two_clips_of_same_parent_get_distinct_md5s(self, tmp_path):
+        """Re-ingesting two audio clips of the same parent yields two distinct MD5s.
+
+        Without the H10 fix, both clips inherit the parent's MD5 and
+        ``collapse_duplicates`` would merge them on the next save+reload.
+        """
+        import numpy as np
+
+        from vtscore.datasets.ingest import _ingest_via_resolver
+        from vtscore.media.audio.audio_generator import generate_wav
+
+        rng = np.random.default_rng(42)
+
+        wav = generate_wav(440, 5.0)
+        wav_path = tmp_path / "test.wav"
+        wav_path.write_bytes(wav)
+
+        def _origin(start: float, end: float, idx: int) -> dict:
+            return {
+                "importer": "server_folder",
+                "params": {
+                    "path": str(tmp_path),
+                    "media_type": "audio",
+                    "clipper": "sound_tiling",
+                    "clip_start": str(start),
+                    "clip_end": str(end),
+                    "clip_index": str(idx),
+                },
+            }
+
+        entries_a = [{"origin": _origin(0.0, 2.0, 0), "origin_name": "test.wav", "md5": "", "label": "good"}]
+        entries_b = [{"origin": _origin(2.0, 4.0, 1), "origin_name": "test.wav", "md5": "", "label": "bad"}]
+
+        fake_embedding = rng.standard_normal(512).astype(np.float32)
+
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        @contextmanager
+        def _fake_resolve_ctx(*_args, **_kwargs):
+            yield wav_path
+
+        existing: dict = {}
+        with (
+            patch("vtscore.datasets.ingest._media_type_from_origin", return_value="audio"),
+            patch("vtscore.detectors.resolver.resolve_file_context", _fake_resolve_ctx),
+            patch("vtscore.detectors.resolver._embed_via_tempfile", return_value=fake_embedding),
+        ):
+            assert _ingest_via_resolver(entries_a[0]["origin"], entries_a, existing, lambda *a, **k: None) == 1
+            assert _ingest_via_resolver(entries_b[0]["origin"], entries_b, existing, lambda *a, **k: None) == 1
+
+        assert len(existing) == 2
+        md5s = {m["md5"] for m in existing.values()}
+        assert len(md5s) == 2, f"expected distinct MD5s for distinct clips, got {md5s}"
+
+    def test_clip_media_bytes_and_file_size_describe_the_clip(self, tmp_path):
+        """media_bytes and file_size on a re-ingested clip describe the clip, not the parent."""
+        import numpy as np
+
+        from vtscore.datasets.ingest import _ingest_via_resolver
+        from vtscore.media.audio.audio_generator import generate_wav
+        from vtscore.media.audio.clipper import _wav_slice
+
+        rng = np.random.default_rng(42)
+
+        wav = generate_wav(440, 5.0)
+        wav_path = tmp_path / "test.wav"
+        wav_path.write_bytes(wav)
+
+        clip_start, clip_end = 0.0, 2.0
+        expected_clip_bytes = _wav_slice(wav, clip_start, clip_end)
+        assert len(expected_clip_bytes) < len(wav), "clip should be smaller than parent"
+
+        origin = {
+            "importer": "server_folder",
+            "params": {
+                "path": str(tmp_path),
+                "media_type": "audio",
+                "clipper": "sound_tiling",
+                "clip_start": str(clip_start),
+                "clip_end": str(clip_end),
+                "clip_index": "0",
+            },
+        }
+        entries = [{"origin": origin, "origin_name": "test.wav", "md5": "", "label": "good"}]
+
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        @contextmanager
+        def _fake_resolve_ctx(*_args, **_kwargs):
+            yield wav_path
+
+        fake_embedding = rng.standard_normal(512).astype(np.float32)
+
+        existing: dict = {}
+        with (
+            patch("vtscore.datasets.ingest._media_type_from_origin", return_value="audio"),
+            patch("vtscore.detectors.resolver.resolve_file_context", _fake_resolve_ctx),
+            patch("vtscore.detectors.resolver._embed_via_tempfile", return_value=fake_embedding),
+        ):
+            assert _ingest_via_resolver(origin, entries, existing, lambda *a, **k: None) == 1
+
+        media = next(iter(existing.values()))
+        assert media["media_bytes"] == expected_clip_bytes, "media_bytes must be clip bytes, not parent"
+        assert media["file_size"] == len(expected_clip_bytes), "file_size must reflect clip, not parent"
+
+    def test_video_metadata_only_clips_get_unique_md5_via_boundary_tag(self, tmp_path):
+        """Two video clips of the same parent (metadata-only) still get distinct MD5s.
+
+        Video clippers don't slice the underlying bytes — they only stamp
+        ``clip_start`` / ``clip_end``. Without the boundary-tag fallback,
+        all clips of one parent collide on the parent's MD5 and
+        ``collapse_duplicates`` merges them after a save+reload.
+        """
+        import numpy as np
+
+        from vtscore.datasets.ingest import _ingest_via_resolver
+
+        rng = np.random.default_rng(42)
+
+        # _apply_clip_and_embed's video branch falls through to embed_file
+        # (legacy _clip_to_bytes returns None for video).  We just need
+        # embed_file to return a non-None embedding so the function
+        # reaches the boundary-tag MD5 path.
+        fake_video = tmp_path / "movie.mp4"
+        fake_video.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"x" * 1024)
+
+        def _origin(start: float, end: float, idx: int) -> dict:
+            return {
+                "importer": "server_folder",
+                "params": {
+                    "path": str(tmp_path),
+                    "media_type": "video",
+                    "clipper": "video_tiling",
+                    "clip_start": str(start),
+                    "clip_end": str(end),
+                    "clip_index": str(idx),
+                },
+            }
+
+        fake_embedding = rng.standard_normal(512).astype(np.float32)
+
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        @contextmanager
+        def _fake_resolve_ctx(*_args, **_kwargs):
+            yield fake_video
+
+        existing: dict = {}
+        with (
+            patch("vtscore.datasets.ingest._media_type_from_origin", return_value="video"),
+            patch("vtscore.detectors.resolver.resolve_file_context", _fake_resolve_ctx),
+            patch("vtscore.detectors.resolver.embed_file", return_value=fake_embedding),
+        ):
+            assert (
+                _ingest_via_resolver(
+                    _origin(0.0, 2.0, 0),
+                    [{"origin": _origin(0.0, 2.0, 0), "origin_name": "movie.mp4", "md5": "", "label": "good"}],
+                    existing,
+                    lambda *a, **k: None,
+                )
+                == 1
+            )
+            assert (
+                _ingest_via_resolver(
+                    _origin(2.0, 4.0, 1),
+                    [{"origin": _origin(2.0, 4.0, 1), "origin_name": "movie.mp4", "md5": "", "label": "bad"}],
+                    existing,
+                    lambda *a, **k: None,
+                )
+                == 1
+            )
+
+        assert len(existing) == 2
+        md5s = {m["md5"] for m in existing.values()}
+        assert len(md5s) == 2, f"video clips of same parent must get distinct MD5s, got {md5s}"

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -276,8 +276,12 @@ class TestReplayChainOnFile:
                 "out_index": 1,
             }
         ]
-        embedding = replay_chain_on_file(source, steps)
+        result = replay_chain_on_file(source, steps)
+        assert result is not None
+        embedding, content = result
         assert embedding is not None
+        # The clip bytes returned match the picked sentence.
+        assert content == b"Bravo."
         # The captured tempfile must contain just the picked sentence.
         assert len(captured) == 1
         assert captured[0][0] == "Bravo."

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -400,12 +400,20 @@ def replay_chain_on_file(  # noqa: C901
     file_path: Path,
     steps: list[ChainStep],
     embedder_name: str = "",
-) -> Any:
+) -> tuple[Any, bytes | None] | None:
     """Re-run a chain against a source file and embed the final clip.
 
     Used by the resolver replay path to reproduce the exact sub-clip the
-    label originally referenced. Returns the embedding (np.ndarray) or
-    ``None`` if any step produced no output.
+    label originally referenced. Returns ``(embedding, content_bytes)``
+    where ``content_bytes`` is the final clip's bytes (after the last
+    chain step), or ``None`` if any step produced no output or the embed
+    failed.
+
+    ``content_bytes`` is ``None`` when the final chain step is a *video*
+    clipper, because video clippers are metadata-only (they record
+    ``clip_start`` / ``clip_end`` but do not slice the underlying bytes,
+    so the clip's bytes equal the parent's bytes — caller should switch
+    to a boundary-tag MD5 scheme for those clips).
 
     The chain must start with a step whose input type matches the source
     file's media type (the resolver infers this from the trail's first
@@ -460,7 +468,17 @@ def replay_chain_on_file(  # noqa: C901
             content = media.get("media_bytes") or b""
         os.write(fd, content)
         os.close(fd)
-        return embed_file(Path(tmp), current_type, embedder_name)
+        embedding = embed_file(Path(tmp), current_type, embedder_name)
+        if embedding is None:
+            return None
+        # Video clippers are metadata-only — the clip's bytes equal the
+        # parent's, so a caller hashing ``content`` would collide across
+        # distinct clips of the same parent.  Signal metadata-only by
+        # returning ``None`` for content_bytes; the caller falls back to
+        # parent-bytes + boundary-tag MD5.
+        if current_type == "video":
+            return embedding, None
+        return embedding, content
     finally:
         try:
             os.unlink(tmp)

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -257,9 +257,7 @@ def _ingest_via_source(
             if not media_type_id:
                 source.cleanup()
                 return -1
-            resolved = _resolve_clip_content_and_embedding(
-                file_path, media_type_id, origin_dict, embedder_name
-            )
+            resolved = _resolve_clip_content_and_embedding(file_path, media_type_id, origin_dict, embedder_name)
             if resolved is None:
                 source.cleanup()
                 return -1  # Signal caller to use legacy full-import path
@@ -338,9 +336,7 @@ def _ingest_via_resolver(
             # Clip-aware: produces the clip embedding and the clip's bytes
             # so the stored ``media_bytes`` / ``md5`` / ``file_size`` all
             # describe the clip, not the parent.
-            resolved = _resolve_clip_content_and_embedding(
-                file_path, media_type_id, origin_dict, embedder_name
-            )
+            resolved = _resolve_clip_content_and_embedding(file_path, media_type_id, origin_dict, embedder_name)
             if resolved is None:
                 continue
             embedding, file_bytes, md5 = resolved

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -145,6 +145,80 @@ def _build_media_data(
     return media_data
 
 
+def _has_clip_params(origin_dict: dict[str, Any]) -> bool:
+    """Return True if the origin carries any clip-aware params."""
+    params = origin_dict.get("params", {})
+    return bool(params.get("clipper") or params.get("clipper_chain"))
+
+
+def _boundary_tag(params: dict[str, Any]) -> str:
+    """Build a stable tag from clip metadata to disambiguate clips that share parent bytes.
+
+    Used for video metadata-only clips (and other fall-through paths where
+    the embedding step couldn't produce distinct content bytes) so each
+    clip still gets a unique MD5 instead of colliding on the parent's hash.
+    Mirrors the encoding in
+    :func:`vtscore.datasets.load_pipeline._fixup_clip_md5_and_embeddings`.
+    """
+    parts: list[str] = []
+    for key in ("clipper", "clipper_chain", "clip_start", "clip_end", "clip_box", "clip_index"):
+        if key in params:
+            parts.append(f"{key}={params[key]}")
+    return "|" + "|".join(parts) if parts else ""
+
+
+def _resolve_clip_content_and_embedding(
+    file_path: Any,
+    media_type_id: str,
+    origin_dict: dict[str, Any],
+    embedder_name: str,
+) -> tuple[Any, bytes, str] | None:
+    """Resolve embedding + ``media_bytes`` + ``md5`` for a (possibly clipped) origin.
+
+    Returns ``(embedding, content_bytes, md5)`` where:
+
+    * ``embedding`` is the clipped embedding when the origin has clip
+      params, otherwise the parent's embedding.
+    * ``content_bytes`` is the clip's bytes (audio / image / text clips)
+      OR the parent's bytes when the clip is metadata-only (e.g. video) or
+      when there are no clip params. The frontend can still play video
+      clips because ``clip_start`` / ``clip_end`` live in the origin.
+    * ``md5`` is the hash of ``content_bytes`` for true clips and
+      non-clipped medias. For metadata-only clips, the MD5 mixes the
+      parent's hash with a clip boundary tag so distinct clips of the same
+      parent don't collide under :func:`collapse_duplicates`.
+
+    Returns ``None`` when embedding fails.
+    """
+    from vtscore.detectors.resolver import _apply_clip_and_embed, embed_file
+
+    if _has_clip_params(origin_dict):
+        result = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
+        if result is None:
+            return None
+        embedding, clip_bytes = result
+        if clip_bytes is not None:
+            return embedding, clip_bytes, hashlib.md5(clip_bytes).hexdigest()
+
+        # Metadata-only clip (video) or fall-through: use parent bytes,
+        # but disambiguate the MD5 via a boundary tag so distinct clips of
+        # the same parent don't collapse together.
+        parent_bytes = file_path.read_bytes()
+        tag = _boundary_tag(origin_dict.get("params", {}))
+        if tag:
+            combined = hashlib.md5(parent_bytes).hexdigest() + tag
+            md5 = hashlib.md5(combined.encode()).hexdigest()
+        else:
+            md5 = hashlib.md5(parent_bytes).hexdigest()
+        return embedding, parent_bytes, md5
+
+    embedding = embed_file(file_path, media_type_id, embedder_name) if media_type_id else None
+    if embedding is None:
+        return None
+    parent_bytes = file_path.read_bytes()
+    return embedding, parent_bytes, hashlib.md5(parent_bytes).hexdigest()
+
+
 def _ingest_via_source(
     origin_dict: dict[str, Any],
     entries: list[dict[str, Any]],
@@ -166,8 +240,6 @@ def _ingest_via_source(
     media_type_id = _media_type_from_origin(origin_dict)
     embedder_name = _embedder_name_for_type(medias, media_type_id) if media_type_id else ""
 
-    from vtscore.detectors.resolver import embed_file
-
     ingested = 0
 
     try:
@@ -179,16 +251,19 @@ def _ingest_via_source(
             if file_path is None:
                 continue
 
-            # Embed the file — if embedding fails, fall back to legacy path
-            # so we don't produce medias without embeddings.
-            embedding = embed_file(file_path, media_type_id, embedder_name) if media_type_id else None
-            if embedding is None:
+            # Resolve embedding + clip-aware bytes/md5 — if any step fails,
+            # fall back to the legacy full-import path so we don't produce
+            # medias with mismatched embedding/MD5/bytes triples.
+            if not media_type_id:
+                source.cleanup()
+                return -1
+            resolved = _resolve_clip_content_and_embedding(
+                file_path, media_type_id, origin_dict, embedder_name
+            )
+            if resolved is None:
                 source.cleanup()
                 return -1  # Signal caller to use legacy full-import path
-
-            # Read file bytes and compute MD5
-            file_bytes = file_path.read_bytes()
-            md5 = hashlib.md5(file_bytes).hexdigest()
+            embedding, file_bytes, md5 = resolved
 
             media_data = _build_media_data(
                 origin_dict=origin_dict,
@@ -244,7 +319,7 @@ def _ingest_via_resolver(
 
     embedder_name = _embedder_name_for_type(medias, media_type_id)
 
-    from vtscore.detectors.resolver import embed_file, resolve_file_context
+    from vtscore.detectors.resolver import resolve_file_context
 
     ingested = 0
 
@@ -260,20 +335,15 @@ def _ingest_via_resolver(
             if file_path is None:
                 continue
 
-            # Use clip-aware embedding when the origin has clip params, so
-            # that re-ingested clipped media gets the correct (clipped)
-            # embedding.
-            if origin_dict.get("params", {}).get("clipper"):
-                from vtscore.detectors.resolver import _apply_clip_and_embed
-
-                embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
-            else:
-                embedding = embed_file(file_path, media_type_id, embedder_name)
-            if embedding is None:
+            # Clip-aware: produces the clip embedding and the clip's bytes
+            # so the stored ``media_bytes`` / ``md5`` / ``file_size`` all
+            # describe the clip, not the parent.
+            resolved = _resolve_clip_content_and_embedding(
+                file_path, media_type_id, origin_dict, embedder_name
+            )
+            if resolved is None:
                 continue
-
-            file_bytes = file_path.read_bytes()
-            md5 = hashlib.md5(file_bytes).hexdigest()
+            embedding, file_bytes, md5 = resolved
 
             media_data = _build_media_data(
                 origin_dict=origin_dict,

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -142,7 +142,11 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
             )
 
         if has_clipper:
-            return _apply_clip_and_embed(file_path, media_type, origin, embedder_name)
+            result = _apply_clip_and_embed(file_path, media_type, origin, embedder_name)
+            if result is None:
+                return None
+            embedding, _clip_bytes = result
+            return embedding
         return embed_file(file_path, media_type, embedder_name)
 
 

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -504,8 +504,15 @@ def _clip_to_bytes(file_path: Path, media_type: str, params: dict[str, Any]) -> 
     return None
 
 
-def _replay_chain(file_path: Path, chain_raw: Any, embedder_name: str) -> np.ndarray | None:
-    """Replay a clipper chain on *file_path*.  Returns None when nothing applies or the replay fails."""
+def _replay_chain(file_path: Path, chain_raw: Any, embedder_name: str) -> tuple[np.ndarray, bytes | None] | None:
+    """Replay a clipper chain on *file_path*.
+
+    Returns ``(embedding, clip_bytes)`` on success, or ``None`` when
+    nothing applies or the replay fails. ``clip_bytes`` is the content
+    bytes of the final clip (post-chain) — what the embedder consumed,
+    or ``None`` when the chain ends in a metadata-only clipper (e.g.
+    video) whose output bytes equal the parent's bytes.
+    """
     from vtscore.datasets.clipper_chain import parse_trail, replay_chain_on_file
 
     steps = parse_trail(chain_raw)
@@ -523,7 +530,7 @@ def _apply_clip_and_embed(
     media_type: str,
     origin: dict[str, Any],
     embedder_name: str = "",
-) -> np.ndarray | None:
+) -> tuple[np.ndarray, bytes | None] | None:
     """Apply clip params from *origin* to a resolved file and embed the result.
 
     If the origin contains clip parameters (``clip_start``/``clip_end`` for
@@ -531,30 +538,52 @@ def _apply_clip_and_embed(
     clipped first and the clipped content is embedded.  Falls back to
     :func:`embed_file` when no clip params apply (e.g. video, or an
     unrecognised clipper) or when the clip step raises.
+
+    Returns ``(embedding, clip_bytes)`` where ``clip_bytes`` is the bytes
+    that were actually embedded — i.e. the sliced/cropped content for
+    audio / image / text clippers (and for chain replays). ``clip_bytes``
+    is ``None`` when the function fell through to embedding the full
+    parent file (no clipper, clip step failed, or a media type whose
+    clipper is metadata-only such as video). The caller can use the
+    presence/absence of ``clip_bytes`` to decide whether to MD5-hash the
+    clip or fall back to a parent-bytes + boundary-tag scheme. Returns
+    ``None`` when embedding fails entirely.
     """
     params = origin.get("params", {})
 
     chain_raw = params.get("clipper_chain")
     if chain_raw:
-        embedding = _replay_chain(file_path, chain_raw, embedder_name)
-        if embedding is not None:
-            return embedding
+        result = _replay_chain(file_path, chain_raw, embedder_name)
+        if result is not None:
+            return result
         # Fall through to legacy/full-file embed.
 
     if not params.get("clipper"):
-        return embed_file(file_path, media_type, embedder_name)
+        embedding = embed_file(file_path, media_type, embedder_name)
+        if embedding is None:
+            return None
+        return embedding, None
 
     try:
         clipped = _clip_to_bytes(file_path, media_type, params)
     except Exception:
         log.debug("_apply_clip_and_embed: %s clip failed, falling back", media_type, exc_info=True)
-        return embed_file(file_path, media_type, embedder_name)
+        embedding = embed_file(file_path, media_type, embedder_name)
+        if embedding is None:
+            return None
+        return embedding, None
 
     if clipped is None:
-        return embed_file(file_path, media_type, embedder_name)
+        embedding = embed_file(file_path, media_type, embedder_name)
+        if embedding is None:
+            return None
+        return embedding, None
 
     data, suffix = clipped
-    return _embed_via_tempfile(data, suffix, media_type, embedder_name)
+    embedding = _embed_via_tempfile(data, suffix, media_type, embedder_name)
+    if embedding is None:
+        return None
+    return embedding, data
 
 
 @dataclass
@@ -608,7 +637,11 @@ def _embed_resolved_label(file_path: Path, media_type: str, origin: dict[str, An
     """Embed a resolved file, switching to clip-aware embedding when the origin demands it."""
     params = origin.get("params", {}) if origin is not None else {}
     if origin is not None and (params.get("clipper") or params.get("clipper_chain")):
-        return _apply_clip_and_embed(file_path, media_type, origin)
+        result = _apply_clip_and_embed(file_path, media_type, origin)
+        if result is None:
+            return None
+        embedding, _clip_bytes = result
+        return embedding
     return embed_file(file_path, media_type)
 
 


### PR DESCRIPTION
## Summary

Fixes **H10** from `docs/plans/logical-bug-audit.md`. When the label-importer ingest path re-ingested a clipped media (e.g. a label entry pointing to `clip_start=0.0` / `clip_end=2.0` of a parent audio file), it was hashing and storing the *parent* file's bytes for `md5` / `file_size` / `media_bytes`. Two failure modes:

1. **`collapse_duplicates` false-positive merging.** Distinct clips of one parent all received the parent's MD5, so a save+reload (which runs `collapse_duplicates` during load) merged them into a single representative — silently losing real data.
2. **MD5-based label matching broken.** Labelset entries hashing the clip couldn't re-match the re-ingested medias by MD5 (origin+name matching still worked, so labels usually still applied, but the MD5 fallback was dead).

A secondary variant in `_ingest_via_source` (the `MediaSource` fast path) was worse — it didn't apply clipping at all, so re-ingested clipped media also got *unclipped* embeddings.

## Resolution

- Plumb the clip's actual content bytes back through `_apply_clip_and_embed` / `_replay_chain` / `replay_chain_on_file` so callers can hash the clip — not the parent.
- New `_resolve_clip_content_and_embedding` helper in `vtscore/datasets/ingest.py` returns `(embedding, content_bytes, md5)` for any (possibly clipped) origin; both `_ingest_via_resolver` and `_ingest_via_source` route through it.
- For video metadata-only clips (clippers that record `clip_start` / `clip_end` without slicing bytes), fall back to the same `MD5(parent_bytes) + boundary_tag` scheme the normal load pipeline uses (`_fixup_clip_md5_and_embeddings`), so distinct clips of one parent still hash uniquely.

## Test plan

- [x] `./run-tests.sh` — full suite (4040 passed, 1 skipped, 2 xpassed).
- [x] New `TestClippedReingest` cases in `tests/io/test_label_import_ingestion.py` cover:
  - clip MD5 matches the slice, not the parent
  - two clips of the same parent get distinct MD5s (load-pipeline `collapse_duplicates` invariant)
  - `media_bytes` / `file_size` describe the clip
  - video metadata-only clips of the same parent get distinct MD5s via boundary-tag fallback
- [x] Existing `replay_chain_on_file` test updated for the new `(embedding, content_bytes)` tuple return.
- [x] Existing `_apply_clip_and_embed` callsite in `vtscore/detectors/labelset_training.py` updated to discard the new clip-bytes element.

https://claude.ai/code/session_01FtKRSx4TGqvj5JCKgMv9YS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtKRSx4TGqvj5JCKgMv9YS)_