### PR TITLE
H25: mark shipped in logical-bug-audit + add regression spec

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -329,11 +329,30 @@ Cross-section interaction agents:
 ### Frontend
 
 - ~~**H24. Vote-state polling chain dies on a single error**~~
-- **H25. Active dataset pair is set before load completes** —
-  `frontend/src/app/services/context-switch.service.ts` L132–134.
-  `setActivePair()` runs before the load is verified; interceptor
-  immediately tags subsequent requests with a context that may not
-  be loaded → cascade of 404s.
+- ~~**H25. Active dataset pair is set before load completes**~~ —
+  shipped in commit `9470cf1a` (PR #1563, "Fix H25: split
+  ActiveContextService into intent + active layers").
+  `ActiveContextService` now exposes two layers:
+  **intent** (what the user just picked, flips immediately for UI
+  affordances like the pulldown highlight) and **active** (the loaded
+  pair — what `activeContextInterceptor` reads when attaching
+  `X-Dataset-Id` / `X-Detector-Id`).  `ContextSwitchService.flipAndLoad`
+  calls `setIntent()` on entry
+  (`frontend/src/app/services/context-switch.service.ts:147`) and
+  only promotes to `setActive()` inside `finishIfCurrent()` (L297)
+  after any required dataset / detector load endpoint has resolved
+  *and* the corresponding `loadingTasks` SSE channel has gone idle.
+  The latest-wins request-id check on the same line guards against a
+  stale switch racing past a newer one.  `setActivePair()` keeps its
+  atomic-both-layers semantics so cleanup paths
+  (`ActiveContextWatcherService` clearing a removed half,
+  `ActiveContextService.clear()`) work unchanged.  Regression tests:
+  `frontend/src/app/services/context-switch.service.spec.ts` cover
+  (a) intent flips immediately while active stays pinned mid-load,
+  (b) active promotion only after both the HTTP load and the
+  loading-tasks idle signal arrive, (c) cancel-and-replace via
+  request-id mismatch when a second switch starts before the first
+  finishes.
 - ~~**H26. `recordVote` runs before the HTTP vote returns**~~ — fixed
   by gating the undo-stack push on the POST's success.  A new
   `VoteStateService.submitToggleVoteAndRecord(id, vote, mediaName,

--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -1,0 +1,288 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { BehaviorSubject, Subject } from 'rxjs';
+
+import { ActiveContextService } from './active-context.service';
+import { ContextSwitchService } from './context-switch.service';
+import { DatasetStateService } from './dataset-state.service';
+import { DatasetsApiService } from './datasets-api.service';
+import { DetectorsApiService } from './detectors-api.service';
+import { ProgressEventsService } from './progress-events.service';
+import {
+  DatasetRegistryEntry,
+  DetectorRegistryEntry,
+  LoadingTask,
+} from '../models/api.models';
+
+/**
+ * Regression spec for H25 — "Active dataset pair is set before load
+ * completes" (see `docs/plans/logical-bug-audit.md`).
+ *
+ * The fix split `ActiveContextService` into two layers:
+ *   - **intent** — flips immediately on switch entry (for UI affordances)
+ *   - **active** — flips only after the dataset / detector load resolves
+ *     AND the corresponding `loadingTasks` SSE channel goes idle.
+ *
+ * The HTTP interceptor (`activeContextInterceptor`) reads the *active*
+ * layer.  These tests pin down that contract so a future refactor can't
+ * silently regress to flipping active up-front and re-introducing the
+ * 409 `dataset_not_loaded` cascade.
+ */
+describe('ContextSwitchService — H25 active/intent layering', () => {
+  let switcher: ContextSwitchService;
+  let activeContext: ActiveContextService;
+
+  // Stub state — we drive these directly from each test instead of
+  // letting the real services do HTTP / SSE work.
+  let datasets: DatasetRegistryEntry[];
+  let detectors: DetectorRegistryEntry[];
+  let loadRegisteredSubjects: Map<string, Subject<unknown>>;
+  let loadDetectorSubjects: Map<string, Subject<unknown>>;
+  let loadingTasks$: BehaviorSubject<LoadingTask[]>;
+  let detectorLoadingTasks$: BehaviorSubject<LoadingTask[]>;
+
+  function makeDataset(
+    id: string,
+    overrides: Partial<DatasetRegistryEntry> = {},
+  ): DatasetRegistryEntry {
+    return { id, name: id, media_type: 'audio', loaded: false, ...overrides };
+  }
+
+  function makeDetector(
+    id: string,
+    overrides: Partial<DetectorRegistryEntry> = {},
+  ): DetectorRegistryEntry {
+    return {
+      id,
+      name: id,
+      media_type: 'audio',
+      detector_loaded: false,
+      ...overrides,
+    };
+  }
+
+  function makeLoadingTask(overrides: Partial<LoadingTask>): LoadingTask {
+    return {
+      status: 'loading',
+      message: '',
+      current: 0,
+      total: 0,
+      task_id: 't',
+      name: 'n',
+      created_at: 0,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    datasets = [];
+    detectors = [];
+    loadRegisteredSubjects = new Map();
+    loadDetectorSubjects = new Map();
+    loadingTasks$ = new BehaviorSubject<LoadingTask[]>([]);
+    detectorLoadingTasks$ = new BehaviorSubject<LoadingTask[]>([]);
+
+    const datasetStateStub = {
+      get datasets(): DatasetRegistryEntry[] {
+        return datasets;
+      },
+      get detectors(): DetectorRegistryEntry[] {
+        return detectors;
+      },
+      setLoading: (_loading: boolean): void => {
+        /* no-op for tests */
+      },
+      refresh: (): void => {
+        /* no-op for tests */
+      },
+    };
+
+    const datasetsApiStub = {
+      loadRegistered: (id: string): Subject<unknown> => {
+        const s = new Subject<unknown>();
+        loadRegisteredSubjects.set(id, s);
+        return s;
+      },
+      cancelTask: (_taskId: string): Subject<unknown> => new Subject<unknown>(),
+    };
+
+    const detectorsApiStub = {
+      loadDetector: (id: string): Subject<unknown> => {
+        const s = new Subject<unknown>();
+        loadDetectorSubjects.set(id, s);
+        return s;
+      },
+      cancelDetectorLoadingTask: (_taskId: string): Subject<unknown> =>
+        new Subject<unknown>(),
+    };
+
+    const progressEventsStub = {
+      loadingTasks$: loadingTasks$.asObservable(),
+      detectorLoadingTasks$: detectorLoadingTasks$.asObservable(),
+      get loadingTasks(): LoadingTask[] {
+        return loadingTasks$.value;
+      },
+      get detectorLoadingTasks(): LoadingTask[] {
+        return detectorLoadingTasks$.value;
+      },
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: DatasetStateService, useValue: datasetStateStub },
+        { provide: DatasetsApiService, useValue: datasetsApiStub },
+        { provide: DetectorsApiService, useValue: detectorsApiStub },
+        { provide: ProgressEventsService, useValue: progressEventsStub },
+      ],
+    });
+
+    switcher = TestBed.inject(ContextSwitchService);
+    activeContext = TestBed.inject(ActiveContextService);
+  });
+
+  it('flips intent and active synchronously when nothing needs to load', () => {
+    datasets = [makeDataset('d1', { loaded: true })];
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+
+    expect(activeContext.intentDatasetId).toBe('d1');
+    expect(activeContext.intentModelId).toBe('m1');
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+
+  it('flips intent immediately but keeps active pinned while a dataset load is in flight', () => {
+    // Start from a known active pair so we can prove it does NOT change.
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1', { loaded: false })]; // needs load
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+    // Pre-populate a non-idle task so `waitForDatasetLoad`'s filter
+    // does NOT pass on its first emission — otherwise the empty initial
+    // BehaviorSubject value would satisfy "no task non-idle" trivially.
+    loadingTasks$.next([makeLoadingTask({ dataset_id: 'd1', status: 'loading' })]);
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+
+    // Intent reflects the user's pick immediately…
+    expect(activeContext.intentDatasetId).toBe('d1');
+    expect(activeContext.intentModelId).toBe('m1');
+    // …but the HTTP interceptor still reads the previous pair until
+    // the load completes (the whole point of H25).
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+
+    // HTTP load endpoint resolves — but the loading task is still
+    // non-idle, so active must stay pinned.
+    loadRegisteredSubjects.get('d1')!.next({});
+    loadRegisteredSubjects.get('d1')!.complete();
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+
+    // SSE channel goes idle — only now does active flip.
+    loadingTasks$.next([]);
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+
+  it('keeps active pinned while a detector load is in flight', () => {
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1', { loaded: true })];
+    detectors = [makeDetector('m1', { detector_loaded: false })]; // needs load
+    detectorLoadingTasks$.next([
+      makeLoadingTask({ detector_id: 'm1', status: 'loading' }),
+    ]);
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+
+    expect(activeContext.intentDatasetId).toBe('d1');
+    expect(activeContext.intentModelId).toBe('m1');
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+
+    loadDetectorSubjects.get('m1')!.next({});
+    loadDetectorSubjects.get('m1')!.complete();
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+
+    detectorLoadingTasks$.next([]);
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+
+  it('re-embeds labels when dataset and detector embedders differ, holding active until detector reloads', () => {
+    // detector_loaded is true but the embedders disagree → still needs
+    // a detector load to re-embed labels, and active must wait.
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [
+      makeDataset('d1', { loaded: true, embedder: 'clap' }),
+    ];
+    detectors = [
+      makeDetector('m1', { detector_loaded: true, embedder: 'xclip' }),
+    ];
+    detectorLoadingTasks$.next([
+      makeLoadingTask({ detector_id: 'm1', status: 'loading' }),
+    ]);
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+
+    expect(loadDetectorSubjects.has('m1')).toBeTrue();
+    expect(activeContext.datasetId).toBe('old-ds');
+
+    loadDetectorSubjects.get('m1')!.next({});
+    detectorLoadingTasks$.next([]);
+
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+
+  it('discards a stale switch via the request-id check when a second switch starts first', () => {
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1'), makeDataset('d2', { loaded: true })];
+    detectors = [
+      makeDetector('m1', { detector_loaded: true }),
+      makeDetector('m2', { detector_loaded: true }),
+    ];
+    loadingTasks$.next([makeLoadingTask({ dataset_id: 'd1', status: 'loading' })]);
+
+    // First switch: d1/m1 — needs a dataset load that we'll never finish.
+    switcher.applyActivePair('d1', 'm1').subscribe();
+    expect(activeContext.intentDatasetId).toBe('d1');
+
+    // Second switch starts before d1 finishes loading — d2/m2 is already
+    // loaded so no awaiting is needed.  This must replace the in-flight
+    // switch: intent and active both end up on d2/m2, and a *late*
+    // completion of the d1 load (next + idle tasks) must NOT roll
+    // active back to d1.
+    switcher.applyActivePair('d2', 'm2').subscribe();
+    expect(activeContext.intentDatasetId).toBe('d2');
+    expect(activeContext.datasetId).toBe('d2');
+    expect(activeContext.modelId).toBe('m2');
+
+    // Late arrival of the d1 load's tail (HTTP resolve + idle SSE).
+    // The request-id captured by the d1 ActiveSwitch is now stale, so
+    // finishIfCurrent() must short-circuit and leave active on d2/m2.
+    loadRegisteredSubjects.get('d1')!.next({});
+    loadingTasks$.next([]);
+
+    expect(activeContext.datasetId).toBe('d2');
+    expect(activeContext.modelId).toBe('m2');
+  });
+
+  it('promotes intent to active via the completion observable returned to the route guard', () => {
+    datasets = [makeDataset('d1', { loaded: true })];
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+
+    let completed = false;
+    switcher.applyActivePair('d1', 'm1').subscribe({ complete: () => (completed = true) });
+
+    expect(completed).toBeTrue();
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+});


### PR DESCRIPTION
## Summary

H25 ("Active dataset pair is set before load completes") was already
fixed on `dev` in commit `9470cf1a` (PR #1563) — `ActiveContextService`
was split into intent / active layers so `activeContextInterceptor`
never tags a request with an id the backend hasn't loaded yet. But
`docs/plans/logical-bug-audit.md` was never updated, and the fix
didn't ship with a dedicated regression spec.

- **Docs:** strike through H25 in the audit, point at the PR, and
  describe the layering contract.
- **Spec:** add `frontend/src/app/services/context-switch.service.spec.ts`
  exercising the H25 invariants directly through `ContextSwitchService`,
  with stubs for the dataset / detector / progress services so the
  observable timing is fully controllable from the test.

The spec pins down:

1. With nothing to load, intent and active flip synchronously.
2. While a dataset load is in flight, intent flips immediately but
   active stays on the previously loaded pair — both after the load
   HTTP resolves *and* until the `loadingTasks` SSE channel reports
   no in-flight task for that dataset.
3. Same contract for in-flight detector loads.
4. Embedder-mismatch case (dataset & detector embedders disagree) still
   triggers a detector reload and holds active until it completes.
5. Cancel-and-replace: a second `applyActivePair` starting before the
   first finishes wins via the request-id check, and a late tail of
   the first load (HTTP resolve + idle SSE) does *not* roll active
   back to the stale pair.
6. The completion observable returned to the route guard fires when
   intent has been promoted to active.

## Test plan

- [x] `npx tsc -p tsconfig.spec.json --noEmit` — clean.
- [x] `cd frontend && npm run build:prod` — clean, no warnings.
- [x] `codespell --toml pyproject.toml docs/plans/logical-bug-audit.md frontend/src/app/services/context-switch.service.spec.ts` — clean.
- [ ] Karma isn't wired up in this repo so the spec isn't executed by
      CI, but the test bodies are logically valid against the current
      service shape and ready to run if/when a browser-based runner
      lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6oxxwZJLQX5Ghg9K7DCPf)_