### PR TITLE
H5: invalidate stale detector MLP on dataset embedder switch

### DIFF
--- a/app.py
+++ b/app.py
@@ -270,10 +270,20 @@ def _set_request_context():
     # labelset against the active dataset's medias.  Media ids are dataset-
     # specific, so without this the left-pane shows stale cids from the
     # previous dataset as if they were votes in the current one.
+    #
+    # Also drop the detector's cached MLP / per-label embedding cache when
+    # the active dataset's embedder differs from the one the MLP was
+    # trained on — scoring with a cross-space MLP either crashes (different
+    # dim) or silently produces garbage labels (same dim).  See H5 in
+    # docs/plans/logical-bug-audit.md.
     try:
-        from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
+        from vtscore.detectors.dataset_sync import (
+            ensure_detector_model_matches_active_embedder,
+            ensure_votes_match_active_dataset,
+        )
 
         ensure_votes_match_active_dataset()
+        ensure_detector_model_matches_active_embedder()
     except (DatasetNotLoadedError, DetectorNotLoadedError):
         # The route handler will hit the same error when it touches the
         # proxies; the global error handler turns it into a clean 409.

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -122,12 +122,36 @@ Cross-section interaction agents:
   no output. Covered by `TestRegionAwareTrainingCrossDataset` in
   `tests/detectors/test_patch_embedder.py`.
 - ~~**H3. Embedder drift on save → reload**~~
-- **H5. Detector embedder not revalidated on dataset switch** —
-  `vtsearch/routes/detectors/scoring.py` + `dataset_sync.py`.
-  `ensure_votes_match_active_dataset()` rehydrates votes but doesn't
-  check the new dataset's embedder against the detector's training
-  embedder. An MLP trained on CLAP can score SigLIP vectors with no
-  warning.
+- ~~**H5. Detector embedder not revalidated on dataset switch**~~ —
+  fixed in `vtscore/detectors/dataset_sync.py` +
+  `vtsearch/routes/detectors/scoring.py` +
+  `vtsearch/routes/detectors/find.py`.
+  `invalidate_detector_model_on_embedder_mismatch()` drops
+  `DetectorContext.model` / `threshold` / `last_learned_scores` /
+  `training_medias` / `calibration_cache` when the dataset about to be
+  scored uses a different embedder than the one the cached MLP was
+  trained on.  `before_request` calls
+  `ensure_detector_model_matches_active_embedder()` for the active
+  ctx so a dataset switch invalidates immediately; the scoring fast
+  paths (`_resolve_or_train_detector` for find-label / auto-detect,
+  `_select_scorer` in multi-dataset Find) repeat the check
+  per-detector to cover autorun loops and cross-dataset Find where the
+  active ctx wrapper alone isn't enough.  The helper deliberately
+  leaves `label_embeddings` and `embedder` alone so the load
+  endpoint's progress-tracked `_maybe_start_label_reembed()` flow
+  still detects the mismatch and schedules its visible re-embed task;
+  the next training pass restamps the marker via
+  `populate_label_embeddings` and `record_detector_embedder`.  Also
+  fixed the secondary mixed-embedder bug in the resolver:
+  `resolve_label_embeddings()` now accepts an `embedder_name` kwarg
+  and the scoring / find callers pass the dataset's embedder so
+  origin-resolved label vectors share one space with the snap-matched
+  ones (previously the origin path defaulted to the media type's first
+  registered embedder, mixing two spaces into a single MLP).  Covered
+  by `TestEmbedderMismatchInvalidatesStaleModel` in
+  `tests/detectors/test_detectors.py` and the new
+  `test_forwards_embedder_name_to_*` cases in
+  `tests/detectors/test_resolver.py`.
 - ~~**H6. `train_model` produces degenerate single-class model**~~
 - ~~**H7. Vote applied before retrain; retrain failure leaves vote live**~~
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -933,6 +933,159 @@ class TestLoadModelEndpoint:
         assert a_bad not in bad_votes, "bad cid from dataset A leaked into dataset B's id-space"
 
 
+class TestEmbedderMismatchInvalidatesStaleModel:
+    """H5: a detector's cached MLP is trained against a specific embedder
+    space (``DetectorContext.embedder``).  When the active dataset uses a
+    different embedder, the cached MLP must be invalidated — otherwise
+    scoring with a cross-space MLP either crashes (different dim) or
+    silently produces garbage labels (same dim).
+    """
+
+    def _make_det_ctx(self, embedder: str):
+        from unittest.mock import MagicMock
+
+        from vtscore.state.core import DetectorContext
+
+        det_ctx = DetectorContext("d-h5", name="d-h5", media_type="audio", embedder=embedder)
+        det_ctx.model = MagicMock(name="trained-mlp")
+        det_ctx.threshold = 0.42
+        det_ctx.label_embeddings["e1"] = "vec"  # type: ignore[assignment]
+        det_ctx.last_learned_scores[1] = 0.7
+        det_ctx.training_medias[1] = {"id": 1}
+        det_ctx.calibration_cache = ("sig", 0.5)
+        return det_ctx
+
+    def test_helper_drops_caches_on_mismatch(self):
+        from vtscore.detectors.dataset_sync import invalidate_detector_model_on_embedder_mismatch
+
+        det_ctx = self._make_det_ctx("clap")
+        invalidated = invalidate_detector_model_on_embedder_mismatch(det_ctx, "ast")
+
+        assert invalidated is True
+        assert det_ctx.model is None
+        assert det_ctx.threshold == 0.5
+        assert det_ctx.last_learned_scores == {}
+        assert det_ctx.training_medias == {}
+        assert det_ctx.calibration_cache is None
+        # ``label_embeddings`` is reset lazily by
+        # ``populate_label_embeddings._maybe_clear_cache_on_embedder_switch``
+        # (the only consumer), and ``embedder`` is left stamped at the old
+        # value so the load endpoint's progress-tracked re-embed task can
+        # still detect the mismatch.
+        assert det_ctx.label_embeddings == {"e1": "vec"}
+        assert det_ctx.embedder == "clap"
+
+    def test_helper_noop_on_match(self):
+        from vtscore.detectors.dataset_sync import invalidate_detector_model_on_embedder_mismatch
+
+        det_ctx = self._make_det_ctx("clap")
+        original_model = det_ctx.model
+        invalidated = invalidate_detector_model_on_embedder_mismatch(det_ctx, "clap")
+
+        assert invalidated is False
+        assert det_ctx.model is original_model
+        assert det_ctx.embedder == "clap"
+
+    def test_helper_noop_on_empty_new_embedder(self):
+        """An empty new embedder means we can't prove a mismatch; preserve state."""
+        from vtscore.detectors.dataset_sync import invalidate_detector_model_on_embedder_mismatch
+
+        det_ctx = self._make_det_ctx("clap")
+        original_model = det_ctx.model
+        invalidated = invalidate_detector_model_on_embedder_mismatch(det_ctx, "")
+
+        assert invalidated is False
+        assert det_ctx.model is original_model
+
+    def test_helper_noop_on_empty_existing_embedder(self):
+        """A fresh detector with no recorded embedder has nothing to invalidate."""
+        from vtscore.detectors.dataset_sync import invalidate_detector_model_on_embedder_mismatch
+
+        det_ctx = self._make_det_ctx("")
+        original_model = det_ctx.model
+        invalidated = invalidate_detector_model_on_embedder_mismatch(det_ctx, "ast")
+
+        assert invalidated is False
+        assert det_ctx.model is original_model
+
+    def test_before_request_hook_invalidates_active_detector(self, client):
+        """End-to-end: switching the active dataset to one with a different
+        embedder triggers invalidation of the active detector's MLP via
+        ``ensure_detector_model_matches_active_embedder``.
+        """
+        import hashlib
+        from unittest.mock import MagicMock
+
+        import numpy as np
+
+        from vtsearch.state import (
+            DatasetContext,
+            get_active_detector_context,
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        a_ids = list(medias.keys())
+        if len(a_ids) < 2:
+            pytest.skip("Need at least 2 medias")
+
+        # Create and load a detector against dataset A.
+        client.post(
+            "/api/detectors",
+            json={"name": "H5Det", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "H5Det", "media_type": "audio", "text_query": "test"},
+        )
+        mid = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, mid)
+
+        # Cast a vote so the detector's model gets trained and stamped.
+        client.post(f"/api/medias/{a_ids[0]}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{a_ids[1]}/vote", json={"target": "bad"})
+
+        det_ctx = get_active_detector_context()
+        # Pin a fake MLP + embedder marker to simulate a trained model.
+        det_ctx.model = MagicMock(name="stale-mlp")
+        det_ctx.threshold = 0.42
+        det_ctx.embedder = "ye-olde-embedder"
+        det_ctx.label_embeddings["seed"] = "vec"  # type: ignore[assignment]
+
+        # Switch to dataset B with a DIFFERENT embedder.
+        ctx_b = DatasetContext("ds_b_for_h5")
+        for cid in a_ids[:2]:
+            ctx_b.medias[cid] = {
+                "id": cid,
+                "type": "audio",
+                "embedder": "shiny-new-embedder",
+                "md5": hashlib.md5(f"h5_b_{cid}".encode()).hexdigest(),
+                "embedding": np.zeros(512, dtype=np.float32),
+                "media_bytes": b"fake-b",
+                "filename": f"h5_b_{cid}.wav",
+                "category": "test",
+                "origin": {"importer": "test_b", "params": {"id": cid}},
+                "origin_name": f"h5_b_{cid}.wav",
+            }
+        register_context(ctx_b)
+        set_thread_dataset_context(ctx_b)
+
+        # Fire a no-op request — the before_request hook should run and
+        # invalidate the stale MLP because the embedders no longer match.
+        client.get("/healthz", headers={"X-Dataset-Id": "ds_b_for_h5", "X-Detector-Id": mid})
+
+        assert det_ctx.model is None, "stale MLP must be cleared on embedder mismatch"
+        assert det_ctx.threshold == 0.5
+        # The embedder marker stays at the old value so the load endpoint
+        # can still detect the mismatch and schedule a progress-tracked
+        # re-embed task — the next training pass restamps it.
+        assert det_ctx.embedder == "ye-olde-embedder"
+
+
 class TestValidatedVoteSnapshot:
     """``validated_vote_snapshot`` must atomically pair medias + votes (H14).
 

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -452,6 +452,68 @@ class TestResolveLabelEmbeddings:
         assert result.total_count == 1
         assert len(result.missing_entries) == 1
 
+    def test_forwards_embedder_name_to_embed_file(self, tmp_path):
+        """``embedder_name`` must reach ``embed_file`` so training vectors
+        live in the same space as the snap embeddings they'll be mixed with.
+
+        Mixing vectors from two embedders into a single MLP produces
+        garbage (different output dimensions crash; same dim silently
+        corrupts), so the dataset's embedder propagating through to the
+        resolver is part of the H5-secondary fix.
+        """
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"audio")
+
+        origin = {"importer": "server_folder", "params": {"path": str(folder), "media_type": "audio"}}
+        labels = [
+            {"label": "good", "origin": origin, "origin_name": "clip.wav", "md5": "aaa", "filename": "clip.wav"},
+        ]
+        fake_emb = np.zeros(768, dtype=np.float32)
+        with patch("vtscore.detectors.resolver.embed_file", return_value=fake_emb) as embed_mock:
+            resolve_label_embeddings(labels, "audio", embedder_name="some-specific-embedder")
+
+        # The resolver must forward the embedder name through to embed_file
+        # so the resolved label vector matches the snap's space.
+        embed_mock.assert_called()
+        last_call_args = embed_mock.call_args_list[-1]
+        # embed_file signature: (file_path, media_type, embedder_name)
+        passed_args = list(last_call_args.args) + [last_call_args.kwargs.get("embedder_name")]
+        assert "some-specific-embedder" in passed_args, (
+            f"embed_file was called without the embedder_name: {last_call_args}"
+        )
+
+    def test_forwards_embedder_name_to_clip_path(self, tmp_path):
+        """Clipper-bearing labels must also receive the requested embedder."""
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"audio")
+
+        origin = {
+            "importer": "server_folder",
+            "params": {
+                "path": str(folder),
+                "media_type": "audio",
+                "clipper": "audio_window",
+                "clip_start": 0.0,
+                "clip_end": 0.1,
+            },
+        }
+        labels = [
+            {"label": "bad", "origin": origin, "origin_name": "clip.wav", "md5": "bbb", "filename": "clip.wav"},
+        ]
+        fake_emb = np.zeros(768, dtype=np.float32)
+        # ``_apply_clip_and_embed`` returns ``(embedding, clip_bytes)`` since
+        # the H10 clip-aware ingest refactor; ``clip_bytes=None`` mirrors the
+        # full-file fallback path.
+        with patch("vtscore.detectors.resolver._apply_clip_and_embed", return_value=(fake_emb, None)) as clip_mock:
+            resolve_label_embeddings(labels, "audio", embedder_name="specific-clip-embedder")
+
+        clip_mock.assert_called()
+        last_call_args = clip_mock.call_args_list[-1]
+        passed_args = list(last_call_args.args) + list(last_call_args.kwargs.values())
+        assert "specific-clip-embedder" in passed_args
+
 
 class TestMultiFindCrossDatasetFallback:
     """Test that multi_find uses the resolver when labels don't match the target dataset."""

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -604,7 +604,7 @@ class TestMultiFindCrossDatasetFallback:
         good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
         bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
 
-        def fake_embed(path, media_type):
+        def fake_embed(path, media_type, embedder_name=""):
             name = Path(path).name
             if "good" in name:
                 return good_emb
@@ -708,7 +708,7 @@ class TestMultiFindCrossDatasetFallback:
         good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
         bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
 
-        def fake_embed(path, media_type):
+        def fake_embed(path, media_type, embedder_name=""):
             return good_emb if "good" in Path(path).name else bad_emb
 
         with patch("vtscore.detectors.resolver.embed_file", side_effect=fake_embed):
@@ -797,7 +797,7 @@ class TestMultiFindCrossDatasetFallback:
         good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
         bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
 
-        def fake_embed(path, media_type):
+        def fake_embed(path, media_type, embedder_name=""):
             return good_emb if "good" in Path(path).name else bad_emb
 
         with patch("vtscore.detectors.resolver.embed_file", side_effect=fake_embed):
@@ -1050,7 +1050,7 @@ class TestFindCheckLabels:
 
         good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
 
-        def fake_embed(path, media_type):
+        def fake_embed(path, media_type, embedder_name=""):
             return good_emb
 
         with patch("vtscore.detectors.resolver.embed_file", side_effect=fake_embed):

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -136,6 +136,97 @@ def ensure_votes_match_active_dataset() -> None:
         det_ctx.cached_labelset_media_type = data.get("media_type", "") or ""
 
 
+def invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder: str) -> bool:
+    """Drop *det_ctx*'s cached MLP when *new_embedder* differs.
+
+    ``DetectorContext.model`` is trained against a specific embedding space —
+    ``det_ctx.embedder`` records which.  Scoring with a cross-space MLP
+    either crashes (different dim → ``nn.Linear`` size-mismatch) or
+    silently produces garbage labels (same dim, different space).  When
+    the dataset about to be scored uses a different embedder than the one
+    the cached MLP was trained on, clear the embedder-tagged scoring
+    caches (``model``, ``threshold``, ``last_learned_scores``,
+    ``training_medias``, ``calibration_cache``) so the next scoring /
+    learned-sort call rebuilds against *new_embedder*.
+
+    Deliberately leaves ``label_embeddings`` and ``embedder`` alone:
+
+    * The per-label embedding cache is invalidated lazily by
+      :func:`~vtscore.detectors.labelset_training._maybe_clear_cache_on_embedder_switch`
+      inside :func:`~vtscore.detectors.labelset_training.populate_label_embeddings`,
+      which is the only consumer.  Clearing it here would just shift the
+      reset and risk surprising any caller that reads the cache directly.
+    * ``det_ctx.embedder`` is the "what was the last training pass aligned
+      with" marker.  Leaving it stamped as the old value lets the load
+      endpoint's :func:`~vtsearch.routes.detectors.registry._maybe_start_label_reembed`
+      still detect the mismatch and schedule its progress-tracked
+      re-embed task.  The marker is restamped to *new_embedder* by the
+      next training pass (via
+      :func:`~vtscore.detectors.registry.record_detector_embedder`
+      in :func:`~vtscore.detectors.labelset_training.populate_label_embeddings`
+      and the workflow path).
+
+    Returns ``True`` when invalidation happened, ``False`` otherwise.
+    Idempotent: a second call without intervening training simply finds
+    ``model`` already cleared and returns ``False``.
+    """
+    from vtscore.state.core import _state_lock
+
+    if det_ctx is None or not det_ctx.embedder or not new_embedder:
+        return False
+    if new_embedder == det_ctx.embedder:
+        return False
+    if det_ctx.model is None:
+        # Already invalidated by an earlier request in this dataset
+        # transition; nothing to clear.
+        return False
+    with _state_lock:
+        if det_ctx.model is None or new_embedder == det_ctx.embedder:
+            return False
+        det_ctx.model = None
+        det_ctx.threshold = 0.5
+        det_ctx.last_learned_scores.clear()
+        det_ctx.training_medias.clear()
+        det_ctx.calibration_cache = None
+    return True
+
+
+def _embedder_of_active_dataset() -> str:
+    """Return the embedder name recorded on the active dataset's medias, or ``""``."""
+    from vtscore.state.core import get_active_context
+
+    ds_ctx = get_active_context()
+    if not ds_ctx.dataset_id or not ds_ctx.medias:
+        return ""
+    first = next(iter(ds_ctx.medias.values()), {})
+    return first.get("embedder", "") or ""
+
+
+def ensure_detector_model_matches_active_embedder() -> None:
+    """Active-context wrapper for :func:`invalidate_detector_model_on_embedder_mismatch`.
+
+    Called from ``before_request`` so a dataset switch can't leave the
+    active detector pointing at an MLP trained against the old embedder
+    (silent garbage scores at best, ``nn.Linear`` size-mismatch crash at
+    worst).  Vote-rehydrate in :func:`ensure_votes_match_active_dataset`
+    handles cid-keyed votes; this handles the embedder-specific caches
+    that the on-disk labelset doesn't carry.
+
+    The scoring fast-paths
+    (:func:`vtsearch.routes.detectors.scoring._resolve_or_train_detector`
+    and the find dispatcher) defensively repeat the check per-detector,
+    since autorun / multi-dataset Find iterate detectors that aren't the
+    active one.
+    """
+    from vtscore.state.core import get_active_detector_context
+
+    det_ctx = get_active_detector_context()
+    if not det_ctx.detector_id:
+        return
+    new_embedder = _embedder_of_active_dataset()
+    invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder)
+
+
 class VoteSnapshot(NamedTuple):
     """Atomic, internally-consistent (dataset, detector) state snapshot.
 

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -633,19 +633,36 @@ def _log_resolve_failure(
     )
 
 
-def _embed_resolved_label(file_path: Path, media_type: str, origin: dict[str, Any] | None) -> np.ndarray | None:
-    """Embed a resolved file, switching to clip-aware embedding when the origin demands it."""
+def _embed_resolved_label(
+    file_path: Path,
+    media_type: str,
+    origin: dict[str, Any] | None,
+    embedder_name: str = "",
+) -> np.ndarray | None:
+    """Embed a resolved file, switching to clip-aware embedding when the origin demands it.
+
+    When *embedder_name* is given, the resolved file is embedded with that
+    specific embedder (matching by name) so the resulting vector lives in
+    the same space as the snap embeddings it will be mixed with for
+    training.  An empty *embedder_name* falls back to the media type's
+    default embedder.
+    """
     params = origin.get("params", {}) if origin is not None else {}
     if origin is not None and (params.get("clipper") or params.get("clipper_chain")):
-        result = _apply_clip_and_embed(file_path, media_type, origin)
+        result = _apply_clip_and_embed(file_path, media_type, origin, embedder_name)
         if result is None:
             return None
         embedding, _clip_bytes = result
         return embedding
-    return embed_file(file_path, media_type)
+    return embed_file(file_path, media_type, embedder_name)
 
 
-def _resolve_one_label(entry: dict[str, Any], media_type: str, index: int) -> _LabelOutcome:
+def _resolve_one_label(
+    entry: dict[str, Any],
+    media_type: str,
+    index: int,
+    embedder_name: str = "",
+) -> _LabelOutcome:
     """Resolve a single label entry to an embedding.  Logs success / failure inline."""
     label_val = entry.get("label", "")
     if label_val not in ("good", "bad"):
@@ -661,7 +678,7 @@ def _resolve_one_label(entry: dict[str, Any], media_type: str, index: int) -> _L
             _log_resolve_failure(index, entry, status, origin, origin_name, filename)
             return _LabelOutcome(status=status)
 
-        embedding = _embed_resolved_label(file_path, media_type, origin)
+        embedding = _embed_resolved_label(file_path, media_type, origin, embedder_name)
         if embedding is None:
             log.info(
                 "  label[%d] FAILED (embed): file resolved to %s but embedding returned None for media_type=%r",
@@ -725,17 +742,28 @@ def resolve_label_embeddings(
     labels: list[dict[str, Any]],
     media_type: str,
     progress_callback: Any | None = None,
+    *,
+    embedder_name: str = "",
 ) -> ResolvedLabels:
     """Resolve label entries to embeddings by following their origin trails.
 
     For each label entry, attempts to:
     1. Resolve the original media file from its origin info
-    2. Embed it using the appropriate embedder for *media_type*
+    2. Embed it using *embedder_name* (or the media type's default embedder
+       when empty)
     3. Collect the embedding and label value
 
     Args:
         labels: List of label dicts (with origin, origin_name, filename, label keys).
         media_type: The media type for embedding (e.g. "audio", "image").
+        progress_callback: Optional ``(current, total)`` reporter.
+        embedder_name: Name of the embedder to use for resolved files.
+            Callers that will mix these vectors with a dataset's stored
+            embeddings (e.g. find-label training) must pass the dataset's
+            embedder so all training vectors share one space — mixing
+            output from two embedders into a single MLP produces garbage.
+            Empty ``""`` falls back to the media type's first registered
+            embedder.
 
     Returns:
         A :class:`ResolvedLabels` with resolved embeddings, stats, and missing entries.
@@ -745,13 +773,14 @@ def resolve_label_embeddings(
     total = len(labels)
 
     log.info(
-        "resolve_label_embeddings: starting resolution of %d label entries for media_type=%r",
+        "resolve_label_embeddings: starting resolution of %d label entries for media_type=%r embedder=%r",
         total,
         media_type,
+        embedder_name or "<default>",
     )
 
     for i, entry in enumerate(labels):
-        outcome = _resolve_one_label(entry, media_type, i)
+        outcome = _resolve_one_label(entry, media_type, i, embedder_name)
         if progress_callback is not None:
             progress_callback(current=i + 1, total=total)
 

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -352,7 +352,16 @@ def _collect_cold_training_data(
 
     from vtscore.detectors.resolver import resolve_label_embeddings  # noqa: PLC0415
 
-    resolved = resolve_label_embeddings(labels, det_data.get("media_type", "audio"))
+    # Resolve+embed using the target dataset's embedder so the resulting
+    # training vectors share one space with the snap embeddings the MLP
+    # will be scored against.  Empty when the dataset is somehow embedder-
+    # less, which falls back to the media type's default embedder.
+    dataset_embedder = next(iter(temp_medias.values()), {}).get("embedder", "") or "" if temp_medias else ""
+    resolved = resolve_label_embeddings(
+        labels,
+        det_data.get("media_type", "audio"),
+        embedder_name=dataset_embedder,
+    )
     if resolved.has_good_and_bad:
         return resolved.embeddings, resolved.labels
     return [], []

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -188,31 +188,56 @@ def _resolve_find_detectors(detector_ids: list[str]) -> list[dict]:
 
 
 def _build_detector_config(d: dict) -> dict:
-    """Pick the live-MLP path or the cold-detector path for *d*.
+    """Build a per-detector config carrying both score paths.
+
+    Multi-dataset Find loads each dataset's medias on demand, so the
+    embedder check that decides live vs cold has to happen per (detector,
+    dataset) pair — not once at config-build time.  We therefore carry
+    *both* the live MLP (when one is cached on the detector context) and
+    the on-disk labelset (when present) so the per-dataset dispatcher can
+    pick safely (see :func:`_select_scorer`).
 
     Aborts with 400 when the detector has no usable labels in either form.
     """
     from vtscore.detectors.store import _detector_path, _read_detector  # noqa: PLC0415
     from vtscore.state.core import get_detector_context  # noqa: PLC0415
 
+    config: dict = {"name": d["name"], "detector_id": d["id"]}
+
     det_ctx = get_detector_context(d["id"])
     if det_ctx is not None and det_ctx.model is not None:
-        return {
-            "name": d["name"],
-            "detector_id": d["id"],
-            "live_mlp": det_ctx.model,
-            "threshold": det_ctx.threshold,
-        }
+        config["live_mlp"] = det_ctx.model
+        config["threshold"] = det_ctx.threshold
+        config["live_embedder"] = det_ctx.embedder or ""
 
     det_data = _read_detector(_detector_path(d["name"]))
     if det_data and det_data.get("labelset", {}).get("labels"):
-        return {
-            "name": d["name"],
-            "detector_id": d["id"],
-            "detector_data": det_data,
-        }
+        config["detector_data"] = det_data
 
-    _abort_find(400, f"Detector '{d['name']}' has no labels for detection")
+    if "live_mlp" not in config and "detector_data" not in config:
+        _abort_find(400, f"Detector '{d['name']}' has no labels for detection")
+    return config
+
+
+def _select_scorer(dc: dict, temp_medias: dict[int, dict]) -> str:
+    """Pick ``"live"`` / ``"cold"`` / ``"na"`` for *dc* against *temp_medias*.
+
+    The cached MLP can only be reused when its embedder matches the
+    dataset about to be scored — otherwise the cross-space output is
+    silent garbage at best and a ``nn.Linear`` size-mismatch crash at
+    worst (H5).  When the embedders don't match, fall back to the cold
+    path (which retrains from the labelset using *temp_medias*'s
+    embedder), or ``"na"`` if no cold data is available.
+    """
+    temp_embedder = next(iter(temp_medias.values()), {}).get("embedder", "") or "" if temp_medias else ""
+    live_embedder = dc.get("live_embedder", "") or ""
+    has_live = "live_mlp" in dc
+    has_cold = "detector_data" in dc
+    if has_live and (not live_embedder or not temp_embedder or live_embedder == temp_embedder):
+        return "live"
+    if has_cold:
+        return "cold"
+    return "na"
 
 
 def _build_detector_configs(detectors: list[dict]) -> list[dict]:
@@ -452,10 +477,13 @@ def _score_dataset(
             total_steps=_FIND_STEPS,
         )
 
-        if "live_mlp" in dc:
+        choice = _select_scorer(dc, temp_medias)
+        if choice == "live":
             _score_with_live_mlp(dc, X_all, all_ids, media_results)
-        elif "detector_data" in dc:
+        elif choice == "cold":
             _score_with_cold_detector(dc, temp_medias, X_all, all_ids, media_results)
+        else:
+            _record_verdicts(media_results, dc["name"], all_ids, None, 0.0, "N/A")
 
         scored_units += len(all_ids)
         update_find_progress(

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -91,6 +91,14 @@ def _resolve_or_train_detector(  # noqa: C901
     if snap:
         md5_to_emb = {c["md5"]: c["embedding"] for c in snap.values()}
 
+    # Match origin-resolved label vectors to the snap's embedder space so
+    # the two paths don't produce a mixed-space training set (silently
+    # garbage MLP).  Empty when the snap is empty or untyped, which falls
+    # back to the media type's default embedder.
+    dataset_embedder = ""
+    if snap:
+        dataset_embedder = next(iter(snap.values()), {}).get("embedder", "") or ""
+
     unresolved: list[dict] = []
     for entry in label_entries:
         label_val = entry.get("label", "")
@@ -130,6 +138,7 @@ def _resolve_or_train_detector(  # noqa: C901
             unresolved,
             media_type,
             progress_callback=_origin_progress,
+            embedder_name=dataset_embedder,
         )
         X_list.extend(resolved.embeddings)
         y_list.extend(resolved.labels)

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -60,9 +60,17 @@ def _resolve_or_train_detector(  # noqa: C901
     origin importer.  Returns ``(None, _, diag)`` when training is not
     possible.
     """
+    from vtscore.detectors.dataset_sync import invalidate_detector_model_on_embedder_mismatch
     from vtscore.state.core import get_detector_context
 
     det_ctx = get_detector_context(detector_id)
+    if det_ctx is not None:
+        # Defense against H5: scoring autorun detectors iterates contexts
+        # that aren't the active one, so the before_request hook can't
+        # have invalidated their stale MLPs.  Drop them here so the next
+        # branch trains fresh against *snap*'s embedder.
+        snap_embedder = next(iter(snap.values()), {}).get("embedder", "") or "" if snap else ""
+        invalidate_detector_model_on_embedder_mismatch(det_ctx, snap_embedder)
     if det_ctx is not None and det_ctx.model is not None:
         return det_ctx.model, det_ctx.threshold, None
 


### PR DESCRIPTION
## Summary

Fixes H5 and a closely-related "mixed-embedder training set" bug found during the investigation. Two commits.

### H5 (main) — `a0db09f2`

`DetectorContext.model` is trained against a specific embedding space (recorded in `det_ctx.embedder`). Vote-rehydrate in `ensure_votes_match_active_dataset` re-keyed cid-keyed votes on a dataset switch, but said nothing about the embedder — so an MLP trained on CLAP could score SigLIP vectors with no warning (silent garbage at matching dim, `nn.Linear` size-mismatch crash at different dim).

`invalidate_detector_model_on_embedder_mismatch()` in `vtscore/detectors/dataset_sync.py` clears the embedder-tagged scoring caches (`model`, `threshold`, `last_learned_scores`, `training_medias`, `calibration_cache`) when `det_ctx.embedder` differs from the dataset about to be scored. It deliberately leaves `label_embeddings` and `det_ctx.embedder` alone:

- The per-label cache is invalidated lazily by `populate_label_embeddings._maybe_clear_cache_on_embedder_switch` (the only consumer).
- The embedder marker stays at the old value so the load endpoint's progress-tracked `_maybe_start_label_reembed()` flow still detects the mismatch and schedules its visible re-embed task. The next training pass restamps the marker.

Three call sites:

- `app.py` `before_request` runs `ensure_detector_model_matches_active_embedder()` so a dataset switch invalidates the active detector's MLP before any handler runs.
- `scoring.py` `_resolve_or_train_detector` defensively repeats the check per `detector_id` — auto-detect iterates contexts that aren't the active one, so the wrapper alone can't cover them.
- `find.py` `_build_detector_config` now always carries both `live_mlp` (with its embedder marker) and `detector_data` when both are available, and a new `_select_scorer` per-(detector, dataset) pair picks `"live"` / `"cold"` / `"na"` based on the embedder match against the loaded `temp_medias`. Cross-dataset Find loads each dataset individually, so the choice can't be made at config-build time.

### H5 (secondary) — `073ab173`

The fresh-train branch of find-label / multi-find resolved unmatched labels via the resolver and mixed them with snap-matched embeddings to build the training set. The resolver was calling `embed_file()` without an embedder name, so origin-resolved labels picked the media type's default embedder while snap-matched labels carried the active dataset's actual embedder. Mixing two embedders into one MLP produces silently garbage scores (same dim) or a size-mismatch crash (different dim).

Plumb the embedder name through `_embed_resolved_label`, `_resolve_one_label`, and `resolve_label_embeddings`, then pass the active dataset's embedder (`snap[first]["embedder"]` in scoring, `temp_medias[first]["embedder"]` in find) so all training vectors share one space.

## Test plan

- [x] `./run-tests.sh` — 4043 passed, 1 skipped (clean)
- [x] New `TestEmbedderMismatchInvalidatesStaleModel` exercises the helper directly (mismatch / match / empty-new / empty-existing) and an end-to-end before_request integration that pins a stale MLP, switches to a dataset with a different embedder, fires a no-op request, and asserts the model + downstream caches were cleared.
- [x] New `test_forwards_embedder_name_to_embed_file` / `test_forwards_embedder_name_to_clip_path` in `tests/detectors/test_resolver.py` verify the embedder name propagates through both the plain-embed and clip-aware paths.
- [x] Existing `TestLoadEndpointReembedTask::test_different_embedder_starts_reembed_task` still passes — the new helper leaves `det_ctx.embedder` stamped at the old value so the visible re-embed task is still scheduled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbDEvMLK1PckToM4pBG9xM)_