### PR TITLE
M9: validate folder-loader override-key ambiguity

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -472,8 +472,8 @@ Cross-section interaction agents:
 
 - **M8.** Thin-mode pickle loader treats `embedding: None` as present, then
   `np.array(None)` produces an object-dtype row.
-- **M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
-  and `file_name` override entries exist with different embeddings.
+- ~~**M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
+  and `file_name` override entries exist with different embeddings.~~
 - **M10.** `clipper_chain._run_clipper_step` assumes deterministic output count
   across calls — no validation.
 - **M11.** Stale media in `cli._score_medias_with_detectors` when some

--- a/tests_lib/io/test_loader_folder_override_keys.py
+++ b/tests_lib/io/test_loader_folder_override_keys.py
@@ -1,0 +1,300 @@
+"""Override-map ambiguity checks in ``load_dataset_from_folder``.
+
+The loader accepts ``content_vectors`` / ``content_md5s`` /
+``custom_metadata_map`` keyed by either the file's relative path or its
+basename (relative path wins).  Two situations used to silently
+miscompute and are now surfaced:
+
+1. A file has *both* its relative path *and* its basename as keys in the
+   same override map with different values — the loader keeps the
+   relative-path entry and logs a warning naming both keys.
+
+2. A bare basename key matches multiple files in the folder and not
+   every one of those files has its own relative-path entry — the
+   loader raises ``ValueError`` rather than silently fanning the same
+   value out to every match.
+
+These tests verify both behaviours against the folder loader directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest.mock as mock
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from helpers import make_raw_wav_bytes as _make_wav_bytes
+
+
+def _make_bulk_embedder(embed_return_dim: int = 3):
+    emb = mock.MagicMock()
+    emb.name = "fake_bulk"
+    emb.media_type_id = "audio"
+    emb._model = True
+    emb._on_progress = lambda *a, **kw: None
+
+    def _bulk(medias):
+        return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(medias)]
+
+    emb.embed_media_bulk.side_effect = _bulk
+    return emb
+
+
+def _make_media_type_for_audio():
+    mt = mock.MagicMock()
+    mt.type_id = "audio"
+    mt.file_extensions = ["*.wav"]
+    mt.load_media_data.return_value = {"duration": 1.0}
+    return mt
+
+
+def _write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_make_wav_bytes())
+
+
+def _patches(mt, emb):
+    return (
+        mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
+        mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+    )
+
+
+class TestRelPathVsBasenameConflictWarns:
+    """When both rel_path and basename keys exist with different values,
+    the loader keeps the rel_path entry and logs a warning."""
+
+    def test_content_vectors_conflict_logs_warning(self, tmp_path, caplog):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "sub" / "foo.wav")
+
+        rel_vec = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        basename_vec = np.array([2.0, 2.0, 2.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with caplog.at_level(logging.WARNING, logger="vtscore.datasets.loader_folder"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    content_vectors={"sub/foo.wav": rel_vec, "foo.wav": basename_vec},
+                    on_progress=lambda *a: None,
+                )
+
+        assert len(medias) == 1
+        only = next(iter(medias.values()))
+        np.testing.assert_array_equal(only["embedding"], rel_vec)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "content_vectors" in r.getMessage() and "sub/foo.wav" in r.getMessage() and "foo.wav" in r.getMessage()
+            for r in warnings
+        )
+
+    def test_content_vectors_matching_entries_do_not_warn(self, tmp_path, caplog):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "sub" / "foo.wav")
+
+        same = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with caplog.at_level(logging.WARNING, logger="vtscore.datasets.loader_folder"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    content_vectors={"sub/foo.wav": same, "foo.wav": same.copy()},
+                    on_progress=lambda *a: None,
+                )
+
+        assert len(medias) == 1
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    def test_content_md5s_conflict_logs_warning(self, tmp_path, caplog):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "sub" / "foo.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with caplog.at_level(logging.WARNING, logger="vtscore.datasets.loader_folder"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    content_md5s={"sub/foo.wav": "a" * 32, "foo.wav": "b" * 32},
+                    on_progress=lambda *a: None,
+                )
+
+        assert len(medias) == 1
+        only = next(iter(medias.values()))
+        assert only["md5"] == "a" * 32
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("content_md5s" in r.getMessage() for r in warnings)
+
+    def test_custom_metadata_conflict_logs_warning(self, tmp_path, caplog):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "sub" / "foo.wav")
+
+        rel_vec = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        basename_vec = np.array([2.0, 2.0, 2.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with caplog.at_level(logging.WARNING, logger="vtscore.datasets.loader_folder"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    custom_metadata_map={
+                        "sub/foo.wav": {"embedding": rel_vec, "md5": "a" * 32},
+                        "foo.wav": {"embedding": basename_vec, "md5": "b" * 32},
+                    },
+                    on_progress=lambda *a: None,
+                )
+
+        assert len(medias) == 1
+        only = next(iter(medias.values()))
+        np.testing.assert_array_equal(only["embedding"], rel_vec)
+        assert only["md5"] == "a" * 32
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("custom_metadata_map" in m and "embeddings" in m for m in warnings)
+        assert any("custom_metadata_map" in m and "md5s" in m for m in warnings)
+
+
+class TestAmbiguousBasenameKeyRaises:
+    """A bare basename that matches multiple files (and isn't disambiguated
+    by per-file rel_path entries) is a data error, not a fallback."""
+
+    def test_content_vectors_basename_spanning_multiple_files_raises(self, tmp_path):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "class_a" / "foo.wav")
+        _write_wav(tmp_path / "class_b" / "foo.wav")
+
+        vec = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with pytest.raises(ValueError, match=r"content_vectors.*bare-basename.*foo\.wav"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    content_vectors={"foo.wav": vec},
+                    on_progress=lambda *a: None,
+                )
+
+    def test_content_md5s_basename_spanning_multiple_files_raises(self, tmp_path):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "class_a" / "foo.wav")
+        _write_wav(tmp_path / "class_b" / "foo.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with pytest.raises(ValueError, match=r"content_md5s.*bare-basename"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    content_md5s={"foo.wav": "a" * 32},
+                    on_progress=lambda *a: None,
+                )
+
+    def test_custom_metadata_basename_spanning_multiple_files_raises(self, tmp_path):
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "class_a" / "foo.wav")
+        _write_wav(tmp_path / "class_b" / "foo.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            with pytest.raises(ValueError, match=r"custom_metadata_map.*bare-basename"):
+                load_dataset_from_folder(
+                    tmp_path,
+                    "audio",
+                    medias,
+                    custom_metadata_map={"foo.wav": {"md5": "a" * 32}},
+                    on_progress=lambda *a: None,
+                )
+
+    def test_basename_collision_with_full_rel_path_coverage_does_not_raise(self, tmp_path):
+        """If every same-basename file has its own rel_path entry, the
+        bare-basename key is harmless and should be allowed."""
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "class_a" / "foo.wav")
+        _write_wav(tmp_path / "class_b" / "foo.wav")
+
+        vec_a = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        vec_b = np.array([2.0, 2.0, 2.0], dtype=np.float32)
+        vec_basename = np.array([99.0, 99.0, 99.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            load_dataset_from_folder(
+                tmp_path,
+                "audio",
+                medias,
+                content_vectors={
+                    "class_a/foo.wav": vec_a,
+                    "class_b/foo.wav": vec_b,
+                    "foo.wav": vec_basename,
+                },
+                on_progress=lambda *a: None,
+            )
+
+        by_filename = {m["filename"]: m["embedding"] for m in medias.values()}
+        np.testing.assert_array_equal(by_filename["class_a/foo.wav"], vec_a)
+        np.testing.assert_array_equal(by_filename["class_b/foo.wav"], vec_b)
+
+    def test_unique_basename_in_recursive_scan_uses_basename_fallback(self, tmp_path):
+        """A basename key that uniquely identifies one file in a nested
+        layout is fine — that's the whole point of the fallback."""
+        from vtscore.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "sub" / "only.wav")
+
+        vec = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_bulk_embedder()
+        medias: dict = {}
+        with _patches(mt, emb)[0], _patches(mt, emb)[1]:
+            load_dataset_from_folder(
+                tmp_path,
+                "audio",
+                medias,
+                content_vectors={"only.wav": vec},
+                on_progress=lambda *a: None,
+            )
+
+        assert len(medias) == 1
+        np.testing.assert_array_equal(next(iter(medias.values()))["embedding"], vec)

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -368,47 +368,72 @@ def _check_per_file_conflicts(
         for rel_path in rel_paths:
             if rel_path == basename:
                 continue
-            if content_vectors and rel_path in content_vectors and basename in content_vectors:
-                if not _embeddings_equal(content_vectors[rel_path], content_vectors[basename]):
-                    logger.warning(
-                        "content_vectors has conflicting entries for %r and %r; "
-                        "using the relative-path entry.",
-                        rel_path,
-                        basename,
-                    )
-            if content_md5s and rel_path in content_md5s and basename in content_md5s:
-                if content_md5s[rel_path] != content_md5s[basename]:
-                    logger.warning(
-                        "content_md5s has conflicting entries for %r and %r "
-                        "(%r vs %r); using the relative-path entry.",
-                        rel_path,
-                        basename,
-                        content_md5s[rel_path],
-                        content_md5s[basename],
-                    )
-            if custom_metadata_map and rel_path in custom_metadata_map and basename in custom_metadata_map:
-                rp_cm = custom_metadata_map[rel_path] or {}
-                bn_cm = custom_metadata_map[basename] or {}
-                rp_emb = _get_embedding_value(rp_cm)
-                bn_emb = _get_embedding_value(bn_cm)
-                if not _embeddings_equal(rp_emb, bn_emb):
-                    logger.warning(
-                        "custom_metadata_map has conflicting embeddings for %r and %r; "
-                        "using the relative-path entry.",
-                        rel_path,
-                        basename,
-                    )
-                rp_md5 = _get_md5_value(rp_cm)
-                bn_md5 = _get_md5_value(bn_cm)
-                if rp_md5 and bn_md5 and rp_md5 != bn_md5:
-                    logger.warning(
-                        "custom_metadata_map has conflicting md5s for %r and %r "
-                        "(%r vs %r); using the relative-path entry.",
-                        rel_path,
-                        basename,
-                        rp_md5,
-                        bn_md5,
-                    )
+            _warn_if_content_vectors_conflict(rel_path, basename, content_vectors)
+            _warn_if_content_md5s_conflict(rel_path, basename, content_md5s)
+            _warn_if_custom_metadata_conflict(rel_path, basename, custom_metadata_map)
+
+
+def _warn_if_content_vectors_conflict(
+    rel_path: str,
+    basename: str,
+    content_vectors: dict[str, Any] | None,
+) -> None:
+    if not content_vectors or rel_path not in content_vectors or basename not in content_vectors:
+        return
+    if _embeddings_equal(content_vectors[rel_path], content_vectors[basename]):
+        return
+    logger.warning(
+        "content_vectors has conflicting entries for %r and %r; using the relative-path entry.",
+        rel_path,
+        basename,
+    )
+
+
+def _warn_if_content_md5s_conflict(
+    rel_path: str,
+    basename: str,
+    content_md5s: dict[str, str] | None,
+) -> None:
+    if not content_md5s or rel_path not in content_md5s or basename not in content_md5s:
+        return
+    if content_md5s[rel_path] == content_md5s[basename]:
+        return
+    logger.warning(
+        "content_md5s has conflicting entries for %r and %r (%r vs %r); using the relative-path entry.",
+        rel_path,
+        basename,
+        content_md5s[rel_path],
+        content_md5s[basename],
+    )
+
+
+def _warn_if_custom_metadata_conflict(
+    rel_path: str,
+    basename: str,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> None:
+    if not custom_metadata_map or rel_path not in custom_metadata_map or basename not in custom_metadata_map:
+        return
+    rp_cm = custom_metadata_map[rel_path] or {}
+    bn_cm = custom_metadata_map[basename] or {}
+    rp_emb = _get_embedding_value(rp_cm)
+    bn_emb = _get_embedding_value(bn_cm)
+    if not _embeddings_equal(rp_emb, bn_emb):
+        logger.warning(
+            "custom_metadata_map has conflicting embeddings for %r and %r; using the relative-path entry.",
+            rel_path,
+            basename,
+        )
+    rp_md5 = _get_md5_value(rp_cm)
+    bn_md5 = _get_md5_value(bn_cm)
+    if rp_md5 and bn_md5 and rp_md5 != bn_md5:
+        logger.warning(
+            "custom_metadata_map has conflicting md5s for %r and %r (%r vs %r); using the relative-path entry.",
+            rel_path,
+            basename,
+            rp_md5,
+            bn_md5,
+        )
 
 
 def _check_ambiguous_basename_keys(

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import gc
 import hashlib
+import logging
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
@@ -21,6 +23,8 @@ from vtscore.datasets.loader import (
     _streaming_md5,
 )
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+
+logger = logging.getLogger(__name__)
 
 
 def _scan_files(folder: Path, pattern: str, recursive: bool) -> list[Path]:
@@ -240,15 +244,17 @@ def _resolve_folder_load_inputs(
     skip_embedding: bool,
     recursive: bool,
     content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
     custom_metadata_map: dict[str, dict[str, Any]] | None,
     on_progress: ProgressCallback,
 ) -> tuple[Any, Any, list[Path], int]:
     """Shared front-matter for the folder loaders.
 
-    Resolves the media type + embedder, scans the folder, and eagerly
-    loads model weights when needed.  Returns
-    ``(mt, emb, media_files, total_files)``.  Raises ``ValueError`` for
-    unknown media types, unknown embedder names, or empty folders.
+    Resolves the media type + embedder, scans the folder, validates the
+    override maps against the scanned file list, and eagerly loads model
+    weights when needed.  Returns ``(mt, emb, media_files, total_files)``.
+    Raises ``ValueError`` for unknown media types, unknown embedder names,
+    empty folders, or ambiguous basename keys in any override map.
     """
     mt, emb = _resolve_folder_embedder(media_type, embedder_name, skip_embedding)
 
@@ -258,6 +264,14 @@ def _resolve_folder_load_inputs(
 
     if not media_files:
         raise ValueError(f"No {media_type} files found in folder")
+
+    _validate_override_keys(
+        media_files,
+        folder_path,
+        content_vectors,
+        content_md5s,
+        custom_metadata_map,
+    )
 
     if not skip_embedding and emb is not None:
         _eager_load_embedder_models(
@@ -270,6 +284,159 @@ def _resolve_folder_load_inputs(
         )
 
     return mt, emb, media_files, len(media_files)
+
+
+def _embeddings_equal(a: Any, b: Any) -> bool:
+    """Return True if two override-map values represent the same embedding.
+
+    Numpy arrays compare via ``np.array_equal`` (shape + element equality,
+    no NaN-vs-NaN special case).  Anything else uses ``==``; a falsy
+    result or a ``ValueError`` from the comparison means "different".
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    try:
+        import numpy as np  # noqa: PLC0415
+
+        return bool(np.array_equal(a, b))
+    except Exception:
+        try:
+            return bool(a == b)
+        except Exception:
+            return False
+
+
+def _validate_override_keys(
+    media_files: list[Path],
+    folder_path: Path,
+    content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> None:
+    """Audit the override maps for ambiguity before the loader uses them.
+
+    Two failure modes are covered:
+
+    1. **Per-file rel_path vs basename conflict.**  If a file's relative
+       path *and* its basename are both present as keys in the same
+       override map with **different** values, the resolution chain
+       silently picks the rel_path entry.  Log a warning so the caller
+       knows their data is inconsistent.
+
+    2. **Ambiguous basename key spanning multiple files.**  When several
+       files share a basename (typical for recursive imports with files
+       like ``class_a/foo.wav`` and ``class_b/foo.wav``) *and* that
+       basename appears in an override map *without* a rel_path entry
+       for every affected file, the basename fallback would silently
+       assign the same vector/md5/metadata to all of them.  That is
+       genuinely wrong data, so raise ``ValueError``.
+
+    The validation only warns when there is at least one true conflict;
+    it does not flag redundant keys that resolve to the same value, and
+    it does not flag unused keys (e.g. an NPZ that ships more entries
+    than the folder contains).
+    """
+    rel_paths_by_basename: dict[str, list[str]] = defaultdict(list)
+    for file_path in media_files:
+        rel_path = file_path.relative_to(folder_path).as_posix()
+        rel_paths_by_basename[file_path.name].append(rel_path)
+
+    _check_per_file_conflicts(
+        rel_paths_by_basename,
+        content_vectors,
+        content_md5s,
+        custom_metadata_map,
+    )
+    _check_ambiguous_basename_keys(
+        rel_paths_by_basename,
+        content_vectors,
+        content_md5s,
+        custom_metadata_map,
+    )
+
+
+def _check_per_file_conflicts(
+    rel_paths_by_basename: dict[str, list[str]],
+    content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> None:
+    """Log a warning when a file's rel_path and basename keys disagree."""
+    for basename, rel_paths in rel_paths_by_basename.items():
+        for rel_path in rel_paths:
+            if rel_path == basename:
+                continue
+            if content_vectors and rel_path in content_vectors and basename in content_vectors:
+                if not _embeddings_equal(content_vectors[rel_path], content_vectors[basename]):
+                    logger.warning(
+                        "content_vectors has conflicting entries for %r and %r; "
+                        "using the relative-path entry.",
+                        rel_path,
+                        basename,
+                    )
+            if content_md5s and rel_path in content_md5s and basename in content_md5s:
+                if content_md5s[rel_path] != content_md5s[basename]:
+                    logger.warning(
+                        "content_md5s has conflicting entries for %r and %r "
+                        "(%r vs %r); using the relative-path entry.",
+                        rel_path,
+                        basename,
+                        content_md5s[rel_path],
+                        content_md5s[basename],
+                    )
+            if custom_metadata_map and rel_path in custom_metadata_map and basename in custom_metadata_map:
+                rp_cm = custom_metadata_map[rel_path] or {}
+                bn_cm = custom_metadata_map[basename] or {}
+                rp_emb = _get_embedding_value(rp_cm)
+                bn_emb = _get_embedding_value(bn_cm)
+                if not _embeddings_equal(rp_emb, bn_emb):
+                    logger.warning(
+                        "custom_metadata_map has conflicting embeddings for %r and %r; "
+                        "using the relative-path entry.",
+                        rel_path,
+                        basename,
+                    )
+                rp_md5 = _get_md5_value(rp_cm)
+                bn_md5 = _get_md5_value(bn_cm)
+                if rp_md5 and bn_md5 and rp_md5 != bn_md5:
+                    logger.warning(
+                        "custom_metadata_map has conflicting md5s for %r and %r "
+                        "(%r vs %r); using the relative-path entry.",
+                        rel_path,
+                        basename,
+                        rp_md5,
+                        bn_md5,
+                    )
+
+
+def _check_ambiguous_basename_keys(
+    rel_paths_by_basename: dict[str, list[str]],
+    content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> None:
+    """Raise when a basename override would silently fan out to multiple files."""
+    for basename, rel_paths in rel_paths_by_basename.items():
+        if len(rel_paths) < 2:
+            continue
+        for label, override_map in (
+            ("content_vectors", content_vectors),
+            ("content_md5s", content_md5s),
+            ("custom_metadata_map", custom_metadata_map),
+        ):
+            if not override_map or basename not in override_map:
+                continue
+            unresolved = [rp for rp in rel_paths if rp != basename and rp not in override_map]
+            if not unresolved:
+                continue
+            raise ValueError(
+                f"{label} has a bare-basename key {basename!r} that would be applied to "
+                f"multiple files via the basename fallback ({', '.join(sorted(unresolved))}). "
+                "Use the full relative path for each file (e.g. 'subdir/file.ext') "
+                "to disambiguate."
+            )
 
 
 def _lookup_file_custom_metadata(
@@ -603,10 +770,16 @@ def load_dataset_from_folder(
             embedding ``numpy.ndarray``.  Keys may be relative paths
             (``"subdir/file.wav"``) or basenames (``"file.wav"``); relative
             paths are checked first for an exact match, then basenames as a
-            fallback.
+            fallback.  When a bare basename would match more than one file
+            in the folder (without a disambiguating relative-path entry for
+            every match) the load fails with ``ValueError``; when both a
+            relative-path entry and a basename entry exist for the same
+            file with different values, the loader logs a warning and
+            keeps the relative-path entry.
         content_md5s: Optional mapping of filename to a pre-computed MD5 hex
             digest string.  Keys follow the same lookup logic as
-            ``content_vectors`` (relative path first, then basename).
+            ``content_vectors`` (relative path first, then basename), and
+            the same ambiguity checks apply.
         origin: Optional serialised
             :class:`~vtscore.datasets.origin.Origin` dict to attach to each
             media (as ``media["origin"]``).  When ``None`` no origin is set
@@ -620,13 +793,14 @@ def load_dataset_from_folder(
             is used.
         custom_metadata_map: Optional mapping of filename to a metadata dict.
             Keys follow the same lookup logic as ``content_vectors`` (relative
-            path first, then basename).  When a metadata dict contains a
-            non-empty ``"md5"`` key, that value is used as the media's MD5
-            instead of computing it from the file contents.  When it contains
-            an ``"embedding"`` key, that value is used as the media's
-            embedding vector (highest priority, above ``content_vectors``
-            and the embedding model).  The metadata dict is also attached
-            to the media as ``custom_metadata``.
+            path first, then basename), and the same ambiguity checks apply.
+            When a metadata dict contains a non-empty ``"md5"`` key, that
+            value is used as the media's MD5 instead of computing it from
+            the file contents.  When it contains an ``"embedding"`` key,
+            that value is used as the media's embedding vector (highest
+            priority, above ``content_vectors`` and the embedding model).
+            The metadata dict is also attached to the media as
+            ``custom_metadata``.
         skip_embedding: When ``True``, skip embedder resolution and model
             loading entirely.  Files with pre-computed vectors in
             ``content_vectors`` use those; files without are included with
@@ -634,8 +808,10 @@ def load_dataset_from_folder(
             downloaded or computed externally.
 
     Raises:
-        ValueError: If ``media_type`` is not recognised, or if no matching
-            files are found in ``folder_path``.
+        ValueError: If ``media_type`` is not recognised, if no matching
+            files are found in ``folder_path``, or if an override map has
+            a bare-basename key that would silently fan out to multiple
+            files in the folder.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -649,6 +825,7 @@ def load_dataset_from_folder(
         skip_embedding,
         recursive,
         content_vectors,
+        content_md5s,
         custom_metadata_map,
         on_progress,
     )
@@ -789,8 +966,10 @@ def load_dataset_from_folder_chunked(
         Each yielded dict contains at most *chunk_size* medias.
 
     Raises:
-        ValueError: If ``media_type`` is not recognised, or if no matching
-            files are found in ``folder_path``.
+        ValueError: If ``media_type`` is not recognised, if no matching
+            files are found in ``folder_path``, or if an override map has
+            a bare-basename key that would silently fan out to multiple
+            files in the folder.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -804,6 +983,7 @@ def load_dataset_from_folder_chunked(
         skip_embedding,
         recursive,
         content_vectors,
+        content_md5s,
         custom_metadata_map,
         on_progress,
     )

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -142,8 +142,15 @@ populate during `run()`:
 | `custom_metadata_map: dict[str, dict[str, Any]]` | filename → per-file metadata dict; entries with an `"md5"` or `"embedding"` key override the above |
 
 Lookup tries the relative path first (for files in subdirectories),
-then the basename. Don't persist vectors or MLP weights to disk on
-your own — the library re-derives them from origins.
+then the basename. When both keys exist for the same file with
+different values, the loader logs a warning and keeps the
+relative-path entry. When a bare basename would match multiple files
+in the folder (e.g. `class_a/foo.wav` and `class_b/foo.wav` with a
+single `"foo.wav"` key) without an explicit relative-path entry for
+every match, the loader raises `ValueError` — supply the full
+relative path for each file to disambiguate. Don't persist vectors
+or MLP weights to disk on your own — the library re-derives them
+from origins.
 
 ## Multi-media imports
 


### PR DESCRIPTION
## Summary

Fixes [M9](../blob/dev/docs/plans/logical-bug-audit.md) in the logical-bug audit. The folder loader's "rel_path first, then basename" override-key fallback was silently lossy in two ways:

1. When both a file's relative path and its basename existed as keys in `content_vectors` / `content_md5s` / `custom_metadata_map` with **different** values, the loader picked the rel_path entry and discarded the basename entry without warning. Same root cause applied to `content_md5s` (wrong dedup hashes) and to `custom_metadata_map`'s embedding/md5 fields.
2. When a bare basename key matched **multiple** files in a recursive scan (e.g. `class_a/foo.wav` and `class_b/foo.wav` with a single `"foo.wav"` content-vector key), the basename fallback silently fanned the same vector out to every match — two distinct files ended up embedding-identical and could get collapsed by dedup.

This PR adds an up-front `_validate_override_keys` pass in `_resolve_folder_load_inputs` that:

- logs a `WARNING` (one per conflicting key) when a file's rel_path and basename entries disagree inside the same override map — values that resolve equal (`np.array_equal` for embeddings, `==` for md5s) don't warn;
- raises `ValueError` when a bare-basename key would silently match multiple files in the folder without per-rel_path coverage for every match — that case is unambiguously wrong data, not a fallback opportunity.

Behaviour for previously-correct inputs is unchanged: unique basename keys in nested layouts still work, redundant rel_path-and-basename entries with the same value are silent, and bare-basename keys are still honoured when only one file in the folder has that basename.

Three sites (`_resolve_file_embedding`, `_resolve_file_md5`, `_lookup_file_custom_metadata`) keep their "rel_path wins" precedence — the validation runs ahead of them, so by the time they execute the inputs are either consistent or already flagged.

Updates `vtscore/docs/extending/dataset-importers.md` to describe the warning + error semantics. Audit doc has M9 marked shipped.

## Test plan

- [x] `./run-tests.sh io` (675 passed) — covers folder-loader + npz importer paths
- [x] `./run-tests.sh datasets` (534 passed, 2 skipped) — covers folder loader directly
- [x] `./run-tests.sh` full suite (4057 passed, 1 skipped, 2 xpassed)
- [x] New `tests_lib/io/test_loader_folder_override_keys.py` covers:
  - rel_path-vs-basename conflict on each of the three override maps emits a warning naming both keys
  - matching rel_path-and-basename entries with the same value do **not** warn
  - basename key spanning multiple files raises `ValueError` for each map
  - basename collision with full rel_path coverage is allowed (every file has its own entry)
  - unique basename in a recursive scan still uses the basename fallback as documented


---
_Generated by [Claude Code](https://claude.ai/code/session_0199ZwFgndd4k22U5T7efXqm)_