### PR TITLE
M2: renumber chunk media IDs at the CLI boundary

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -497,8 +497,24 @@ Cross-section interaction agents:
   immediately repopulates state so the loss of cross-clear atomicity is
   acceptable).  Lock-order invariant documented in the
   `vtscore/detectors/labeling_progress.py` module docstring.
-- **M2.** `combine_datasets.run_chunked` re-issues IDs starting at 1 on every
-  call → cid collision when consumed twice.
+- ~~**M2.** `combine_datasets.run_chunked` re-issues IDs starting at 1 on every
+  call → cid collision when consumed twice.~~ — fixed in
+  `vtscore/cli.py`. Investigation showed this is not unique to
+  `combine_datasets`: every chunked importer/loader emits IDs `1..N`
+  per yielded chunk (the convention paired with
+  `consume_chunks_into`'s renumbering in the in-process loader). The
+  HTTP/UI path is safe — `vtscore/datasets/load_pipeline.py:1057-1073`
+  already renumbers. The CLI path (`_run_live_pipeline`) scored each
+  chunk independently and merged the per-chunk hit lists, so the
+  exported JSON's `id` fields collided across chunks (the CSV
+  exporter doesn't include `id`, so was unaffected). Fix: added
+  `_renumber_chunks()` at the CLI boundary and wrapped both
+  `_load_pickle_chunked` and `_load_importer_chunked` with it, giving
+  every media a globally unique id in the CLI flow regardless of
+  which chunked importer fed it. Covered by
+  `tests_lib/cli/test_chunk_renumber.py` (unit) and
+  `tests/cli/test_chunked_id_renumber.py` (end-to-end via pickle and
+  combine_datasets, including the JSON exporter).
 - ~~**M3.** `importers/base.py` L407–410 — skipped records leave `next_id`
   unincremented, ID collisions on first-record-skip.~~
 

--- a/tests/cli/test_chunked_id_renumber.py
+++ b/tests/cli/test_chunked_id_renumber.py
@@ -130,10 +130,11 @@ def _stub_detector_training(monkeypatch):
 
     def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
         # Tiny linear "MLP" that always returns 0.5 logit → 0.62 sigmoid.
-        mlp = nn.Sequential(nn.Linear(2, 1))
+        linear = nn.Linear(2, 1)
         with torch.no_grad():
-            mlp[0].weight.zero_()
-            mlp[0].bias.fill_(0.5)
+            linear.weight.data.zero_()
+            linear.bias.data.fill_(0.5)
+        mlp = nn.Sequential(linear)
         mlp.eval()
         return {name: {"mlp": mlp, "threshold": 0.5} for name in detector_names}
 
@@ -141,9 +142,7 @@ def _stub_detector_training(monkeypatch):
 
 
 class TestChunkedPickleIdRenumber:
-    def test_pickle_chunked_export_has_globally_unique_hit_ids(
-        self, client, tmp_path, _stub_detector_training
-    ):
+    def test_pickle_chunked_export_has_globally_unique_hit_ids(self, client, tmp_path, _stub_detector_training):
         """A pickle of 5 medias loaded with chunk_size=2 yields 3 chunks.
 
         Without renumbering, the chunks would carry ids ``[1,2]``,

--- a/tests/cli/test_chunked_id_renumber.py
+++ b/tests/cli/test_chunked_id_renumber.py
@@ -1,0 +1,238 @@
+"""End-to-end tests for chunk-id renumbering in the CLI autodetect flow.
+
+Every chunked importer/loader emits chunks with ids ``1..N`` — the
+in-process consumer ``consume_chunks_into`` renumbers them, but the CLI
+pipeline used to score and merge them as-is, which collided ``id``
+values across chunks in the merged hit lists and produced ambiguous
+``id`` fields in the exported JSON.  These tests pin the fix in place
+by running the actual CLI through to a JSON export and asserting the
+``id`` fields are globally unique across hits.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+import shutil
+from pathlib import Path
+
+import pytest
+
+from vtsearch.settings import get_detectors_dir
+
+
+def _unique_bytes(media_id: int) -> bytes:
+    """Return per-id unique bytes so MD5 hashes don't collide across pickles."""
+    return media_id.to_bytes(4, "little") + b"\x00" * 96
+
+
+def _make_audio_media(media_id: int) -> dict:
+    """Build a minimal audio media dict suitable for a thin pickle."""
+    raw = _unique_bytes(media_id)
+    md5 = hashlib.md5(raw).hexdigest()
+    return {
+        "id": media_id,
+        "type": "audio",
+        "duration": 1.0,
+        "file_size": len(raw),
+        "md5": md5,
+        # Two-dim embedding keeps the trained MLP trivially small.
+        "embedding": [float(media_id), float(media_id) + 0.5],
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": None,
+        "filename": f"clip_{media_id:03d}.wav",
+        "category": "test",
+        "origin": None,
+        "origin_name": f"clip_{media_id:03d}.wav",
+    }
+
+
+def _write_pickle_dataset(path: Path, medias: dict) -> None:
+    with open(path, "wb") as f:
+        pickle.dump({"medias": medias}, f)
+
+
+def _settings_file_with_detector(tmp_path: Path, detector_name: str) -> Path:
+    settings = {
+        "autorun_detectors": [detector_name],
+        "detectors_dir": str(get_detectors_dir()),
+    }
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps(settings))
+    return p
+
+
+def _write_pretrained_detector(name: str, dim: int = 2) -> Path:
+    """Write a detector with a labelset that yields a trainable MLP.
+
+    The CLI re-resolves the labelset's origins and re-embeds — we stub
+    that resolution out at runtime in the test bodies, so the labelset
+    contents only need to satisfy "has >=1 good and >=1 bad label".
+    """
+    from vtscore.detectors.store import _detector_path, _write_detector
+
+    path = _detector_path(name)
+    _write_detector(
+        path,
+        {
+            "name": name,
+            "text_query": "",
+            "media_type": "audio",
+            "examples": [],
+            "labelset": {
+                "labels": [
+                    {
+                        "md5": "a" * 32,
+                        "label": "good",
+                        "origin": {"importer": "stub_ds", "params": {}},
+                        "origin_name": "label_a.wav",
+                    },
+                    {
+                        "md5": "b" * 32,
+                        "label": "bad",
+                        "origin": {"importer": "stub_ds", "params": {}},
+                        "origin_name": "label_b.wav",
+                    },
+                ]
+            },
+        },
+    )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clean_detectors_dir():
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+    yield
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+
+
+@pytest.fixture
+def _stub_detector_training(monkeypatch):
+    """Bypass labelset-origin resolution and embed a 2-dim toy MLP.
+
+    The CLI's ``_load_and_train_detectors`` walks the labelset, resolves
+    origins, and re-embeds them.  For these tests we only care that
+    *some* trained MLP comes back — we stub the loader to return a
+    fixed (mlp, threshold) pair so the test focuses on chunk-id
+    renumbering, not training mechanics.
+    """
+    import torch
+    from torch import nn
+
+    import vtscore.cli as cli_mod
+
+    def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
+        # Tiny linear "MLP" that always returns 0.5 logit → 0.62 sigmoid.
+        mlp = nn.Sequential(nn.Linear(2, 1))
+        with torch.no_grad():
+            mlp[0].weight.zero_()
+            mlp[0].bias.fill_(0.5)
+        mlp.eval()
+        return {name: {"mlp": mlp, "threshold": 0.5} for name in detector_names}
+
+    monkeypatch.setattr(cli_mod, "_load_and_train_detectors", _fake_load_and_train)
+
+
+class TestChunkedPickleIdRenumber:
+    def test_pickle_chunked_export_has_globally_unique_hit_ids(
+        self, client, tmp_path, _stub_detector_training
+    ):
+        """A pickle of 5 medias loaded with chunk_size=2 yields 3 chunks.
+
+        Without renumbering, the chunks would carry ids ``[1,2]``,
+        ``[1,2]``, ``[1]`` — and the merged JSON would have ``id``
+        collisions.  After the fix every hit's ``id`` is unique.
+        """
+        _write_pretrained_detector("renum-tm")
+        settings_path = _settings_file_with_detector(tmp_path, "renum-tm")
+
+        # 5 medias, each with distinct MD5/filename.
+        medias = {i: _make_audio_media(i) for i in range(1, 6)}
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, medias)
+
+        export_path = tmp_path / "results.json"
+
+        from vtscore.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            dataset_path=str(ds_path),
+            chunk_size=2,
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(export_path)},
+        )
+
+        results = json.loads(export_path.read_text())
+        det_result = results["results"]["renum-tm"]
+        # 5 medias → 5 hits (all land in either hits or negative_hits;
+        # combine both lists to check global uniqueness).
+        all_ids = [h["id"] for h in det_result.get("hits", [])]
+        all_ids += [h["id"] for h in det_result.get("negative_hits", [])]
+        assert sorted(all_ids) == [1, 2, 3, 4, 5]
+        # And every filename appears exactly once (sanity — medias
+        # weren't dropped or duplicated).
+        all_names = [h["filename"] for h in det_result.get("hits", [])]
+        all_names += [h["filename"] for h in det_result.get("negative_hits", [])]
+        assert sorted(all_names) == [f"clip_{i:03d}.wav" for i in range(1, 6)]
+
+
+class TestChunkedCombineDatasetsIdRenumber:
+    def test_combine_datasets_chunked_export_has_globally_unique_hit_ids(
+        self, client, tmp_path, _stub_detector_training
+    ):
+        """combine_datasets emits one chunk per source pickle, each with ids 1..N.
+
+        Two source pickles → two chunks → ids ``[1,2]`` and ``[1,2]``
+        from the importer.  After CLI-boundary renumbering the merged
+        JSON's hit ids must be globally unique.
+        """
+        _write_pretrained_detector("combine-tm")
+        settings_path = _settings_file_with_detector(tmp_path, "combine-tm")
+
+        # Two pickles, two distinct medias each (different MD5s so no
+        # cross-pickle dedup).
+        p1_medias = {1: _make_audio_media(11), 2: _make_audio_media(12)}
+        p2_medias = {1: _make_audio_media(21), 2: _make_audio_media(22)}
+        p1 = tmp_path / "ds1.pkl"
+        p2 = tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, p1_medias)
+        _write_pickle_dataset(p2, p2_medias)
+
+        export_path = tmp_path / "combined.json"
+
+        from vtscore.cli import autodetect_importer_main_chunked
+
+        # chunk_size=100 is irrelevant for combine_datasets — it yields
+        # one chunk per source pickle regardless — but the CLI requires
+        # a positive int.
+        autodetect_importer_main_chunked(
+            "combine_datasets",
+            {"datasets": f"{p1},{p2}", "name": "test_combined"},
+            chunk_size=100,
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(export_path)},
+        )
+
+        results = json.loads(export_path.read_text())
+        det_result = results["results"]["combine-tm"]
+        all_ids = [h["id"] for h in det_result.get("hits", [])]
+        all_ids += [h["id"] for h in det_result.get("negative_hits", [])]
+        # 4 hits across both pickles, all with unique ids 1..4.
+        assert sorted(all_ids) == [1, 2, 3, 4]
+        all_names = [h["filename"] for h in det_result.get("hits", [])]
+        all_names += [h["filename"] for h in det_result.get("negative_hits", [])]
+        assert sorted(all_names) == [
+            "clip_011.wav",
+            "clip_012.wav",
+            "clip_021.wav",
+            "clip_022.wav",
+        ]

--- a/tests_lib/cli/test_chunk_renumber.py
+++ b/tests_lib/cli/test_chunk_renumber.py
@@ -1,0 +1,95 @@
+"""Tests for ``vtscore.cli._renumber_chunks``.
+
+Every chunked importer/loader yields chunks whose media IDs restart at
+1.  The in-process consumer ``consume_chunks_into`` renumbers them as it
+drains; the CLI pipeline used to score and merge them as-is, which
+collided ``id`` values across chunks in the merged hit lists.  This
+helper renumbers at the CLI boundary so the exported ``id`` field is
+globally unique regardless of which chunked importer is feeding it.
+"""
+
+from __future__ import annotations
+
+from vtscore.cli import _renumber_chunks
+
+
+class TestRenumberChunks:
+    def test_single_chunk_starts_at_one(self):
+        chunk = {1: {"id": 1, "name": "a"}, 2: {"id": 2, "name": "b"}}
+        out = list(_renumber_chunks(iter([chunk])))
+        assert len(out) == 1
+        assert sorted(out[0].keys()) == [1, 2]
+        assert out[0][1]["name"] == "a"
+        assert out[0][2]["name"] == "b"
+
+    def test_two_chunks_get_unique_ids(self):
+        # Both chunks re-use ids 1..2 (the standard chunked-importer
+        # convention).  After renumbering, ids must be 1..4 globally.
+        chunk_a = {1: {"id": 1, "name": "a1"}, 2: {"id": 2, "name": "a2"}}
+        chunk_b = {1: {"id": 1, "name": "b1"}, 2: {"id": 2, "name": "b2"}}
+        out = list(_renumber_chunks(iter([chunk_a, chunk_b])))
+        assert len(out) == 2
+        assert sorted(out[0].keys()) == [1, 2]
+        assert sorted(out[1].keys()) == [3, 4]
+        # The media dict's "id" field also reflects the new id.
+        assert out[0][1]["id"] == 1
+        assert out[0][2]["id"] == 2
+        assert out[1][3]["id"] == 3
+        assert out[1][4]["id"] == 4
+        # Original names are preserved (no media gets swapped).
+        names = [m["name"] for chunk in out for m in chunk.values()]
+        assert names == ["a1", "a2", "b1", "b2"]
+
+    def test_three_chunks_of_varying_size(self):
+        chunks = [
+            {1: {"id": 1, "tag": "x"}},
+            {1: {"id": 1, "tag": "y1"}, 2: {"id": 2, "tag": "y2"}, 3: {"id": 3, "tag": "y3"}},
+            {1: {"id": 1, "tag": "z1"}, 2: {"id": 2, "tag": "z2"}},
+        ]
+        out = list(_renumber_chunks(iter(chunks)))
+        # 1 + 3 + 2 = 6 globally unique ids.
+        all_ids = [cid for chunk in out for cid in chunk.keys()]
+        assert all_ids == [1, 2, 3, 4, 5, 6]
+        # Tags follow the original order across chunks.
+        tags = [m["tag"] for chunk in out for m in chunk.values()]
+        assert tags == ["x", "y1", "y2", "y3", "z1", "z2"]
+
+    def test_empty_iterator_yields_nothing(self):
+        assert list(_renumber_chunks(iter([]))) == []
+
+    def test_empty_chunk_skipped_but_does_not_advance_counter(self):
+        chunks = [{}, {1: {"id": 1, "name": "a"}}, {}, {1: {"id": 1, "name": "b"}}]
+        out = list(_renumber_chunks(iter(chunks)))
+        # Empty chunks pass through as empty dicts (the renumberer
+        # doesn't filter); only present medias consume an id.
+        assert [sorted(c.keys()) for c in out] == [[], [1], [], [2]]
+        assert out[1][1]["name"] == "a"
+        assert out[3][2]["name"] == "b"
+
+    def test_lazy_evaluation_does_not_consume_upstream(self):
+        """The helper should be a true generator — it must not buffer."""
+        consumed = []
+
+        def source():
+            for i in range(3):
+                consumed.append(i)
+                yield {1: {"id": 1, "i": i}}
+
+        it = _renumber_chunks(source())
+        # Pull one element only.
+        first = next(it)
+        assert first == {1: {"id": 1, "i": 0}}
+        # Only the first upstream chunk should have been consumed.
+        assert consumed == [0]
+
+    def test_media_dict_id_field_overwritten(self):
+        """The renumberer rewrites ``media["id"]`` in place, not just the dict key."""
+        chunks = [
+            {1: {"id": 1, "name": "a"}},
+            {1: {"id": 1, "name": "b"}},
+        ]
+        out = list(_renumber_chunks(iter(chunks)))
+        # ``b`` lives at global id 2 in both the outer dict and the
+        # media's own ``id`` field.
+        assert out[1][2]["id"] == 2
+        assert out[1][2]["name"] == "b"

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -374,6 +374,30 @@ def _load_pickle_whole(dataset_path: str) -> Iterator[dict[int, dict[str, Any]]]
     yield medias
 
 
+def _renumber_chunks(
+    chunks: Iterator[dict[int, dict[str, Any]]],
+) -> Iterator[dict[int, dict[str, Any]]]:
+    """Re-issue media IDs across a chunk stream so they are globally unique.
+
+    Every chunked importer (and every chunked pickle/folder loader) emits
+    chunks whose IDs restart at 1 — the in-process consumer
+    :func:`vtscore.datasets.load_pipeline.consume_chunks_into` renumbers
+    them as it drains. The CLI pipeline scores each chunk independently
+    and merges the per-chunk hit lists, so without renumbering the hits
+    in the merged export carry colliding ``id`` values across chunks.
+    Wrap the source generator with this helper at the CLI boundary to
+    give every media a unique id.
+    """
+    next_id = 1
+    for chunk in chunks:
+        renumbered: dict[int, dict[str, Any]] = {}
+        for media in chunk.values():
+            media["id"] = next_id
+            renumbered[next_id] = media
+            next_id += 1
+        yield renumbered
+
+
 def _load_pickle_chunked(dataset_path: str, chunk_size: int) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias loaded from a pickle file."""
     from vtscore.datasets.loader import load_dataset_from_pickle_chunked
@@ -382,7 +406,7 @@ def _load_pickle_chunked(dataset_path: str, chunk_size: int) -> Iterator[dict[in
     if not dataset_file.exists():
         raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
 
-    yield from load_dataset_from_pickle_chunked(dataset_file, chunk_size, thin=True)
+    yield from _renumber_chunks(load_dataset_from_pickle_chunked(dataset_file, chunk_size, thin=True))
 
 
 def _load_importer_whole(importer_name: str, field_values: dict[str, Any]) -> Iterator[dict[int, dict[str, Any]]]:
@@ -416,7 +440,7 @@ def _load_importer_chunked(
         raise ValueError(f"Unknown importer: {importer_name}. Available: {', '.join(available)}")
 
     importer.validate_cli_field_values(field_values)
-    yield from importer.run_chunked_cli(field_values, chunk_size, thin=True)
+    yield from _renumber_chunks(importer.run_chunked_cli(field_values, chunk_size, thin=True))
 
 
 def _validate_dry_run_source(sd: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Closes M2 from `docs/plans/logical-bug-audit.md`.

Every chunked importer/loader (`combine_datasets`, `pickle`, `server_files`, `server_folder`, `http_archive`, `local_*`) emits chunks with media IDs `1..N` — the convention paired with `consume_chunks_into`'s renumbering in the in-process loader. The HTTP/UI path is safe because `vtscore/datasets/load_pipeline.py:consume_chunks_into` already renumbers. The CLI path (`_run_live_pipeline`) scored each chunk independently and merged the per-chunk hit lists, so the exported JSON's `id` fields collided across chunks (the CSV exporter doesn't include `id`, so was unaffected).

The audit named `combine_datasets` specifically, but the bug class covers every chunked importer through CLI autodetect.

## Fix

Added `_renumber_chunks()` in `vtscore/cli.py` and wrapped both `_load_pickle_chunked` and `_load_importer_chunked` with it. Renumbering happens at the CLI boundary so every media gets a globally unique id regardless of which chunked importer is feeding it. No producer-side changes — the chunked-importer convention is preserved.

## Test plan

- [x] `tests_lib/cli/test_chunk_renumber.py` — unit tests for `_renumber_chunks` (single chunk, two chunks, three chunks of varying size, empty iterator, empty chunks, laziness, media-dict `id` field rewrite).
- [x] `tests/cli/test_chunked_id_renumber.py` — end-to-end via `autodetect_main_chunked` (pickle, 5 medias, `chunk_size=2`) and `autodetect_importer_main_chunked` (combine_datasets, two pickles), verifying the exported JSON's hit `id` fields are globally unique.
- [x] Full `./run-tests.sh` passes (4057 tests).
- [x] ruff check, ruff format --check, codespell, deptry, pyright all clean.

https://claude.ai/code/session_01FwKTbT1M2ojzYSFrQQu5ZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwKTbT1M2ojzYSFrQQu5ZZ)_