### PR TITLE
fix(clipper-chain): fail closed on replay output drift (M10)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -534,8 +534,14 @@ Cross-section interaction agents:
   `np.array(None)` produces an object-dtype row.
 - ~~**M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
   and `file_name` override entries exist with different embeddings.~~
-- **M10.** `clipper_chain._run_clipper_step` assumes deterministic output count
-  across calls — no validation.
+- **M10.** ~~`clipper_chain._run_clipper_step` assumes deterministic output count
+  across calls — no validation.~~ **Shipped.** `_run_clipper_step` /
+  `_run_converter_step` now stamp `n_out`, `clip_index`, and a short
+  `content_hash` on every trail entry. `_select_chain_output` prefers
+  content matching over positional, logs warnings on output-count
+  drift / no-match / ambiguous match, and returns `None` instead of
+  silently picking `outputs[0]` (was a regression vs. the legacy
+  `_clip_text_to_bytes` resolver path).
 - **M11.** Stale media in `cli._score_medias_with_detectors` when some
   embeddings are `None` (zip truncates silently).
 - **M12.** `loader_pickle._build_pickle_full_media` has no null-check before

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -328,8 +328,8 @@ class TestReplayChainOnFile:
             }
         ]
         with caplog.at_level(logging.WARNING, logger="vtscore.datasets.clipper_chain"):
-            embedding = replay_chain_on_file(source, steps)
-        assert embedding is None
+            result = replay_chain_on_file(source, steps)
+        assert result is None
         assert called["n"] == 0
         assert any("clipper_chain" in r.message for r in caplog.records)
 
@@ -368,8 +368,11 @@ class TestReplayChainOnFile:
             }
         ]
         with caplog.at_level(logging.WARNING, logger="vtscore.datasets.clipper_chain"):
-            embedding = replay_chain_on_file(source, steps)
+            result = replay_chain_on_file(source, steps)
+        assert result is not None
+        embedding, content = result
         assert embedding is not None
+        assert content == b"Charlie."
         assert captured == ["Charlie."]
         assert any("drift" in r.message for r in caplog.records)
 

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -294,6 +294,135 @@ class TestReplayChainOnFile:
         source.write_text("anything", encoding="utf-8")
         assert replay_chain_on_file(source, []) is None
 
+    def test_replay_fails_closed_when_out_index_out_of_range(self, tmp_path, monkeypatch, caplog):
+        """If the source file produces fewer outputs than recorded, replay
+        must NOT silently embed outputs[0] — it must return None so the
+        resolver records an embed failure rather than training on the
+        wrong sub-clip's embedding."""
+        import logging
+
+        from vtscore.datasets.clipper_chain import replay_chain_on_file
+        from vtscore.detectors import resolver as resolver_module
+
+        called = {"n": 0}
+
+        def fake_embed_file(path, media_type, embedder_name=""):
+            called["n"] += 1
+            return np.zeros(8, dtype=np.float32)
+
+        monkeypatch.setattr(resolver_module, "embed_file", fake_embed_file)
+
+        # Source has only 2 sentences ...
+        source = tmp_path / "doc.txt"
+        source.write_text("Alpha. Bravo.", encoding="utf-8")
+
+        # ... but the trail recorded out_index=5 with no disambiguators.
+        # (Mimics an older trail predating the new clip_index/content_hash
+        # fields, where the source file has since been edited shorter.)
+        steps = [
+            {
+                "kind": "clipper",
+                "name": "text_sentence",
+                "params": {},
+                "out_index": 5,
+            }
+        ]
+        with caplog.at_level(logging.WARNING, logger="vtscore.datasets.clipper_chain"):
+            embedding = replay_chain_on_file(source, steps)
+        assert embedding is None
+        assert called["n"] == 0
+        assert any("clipper_chain" in r.message for r in caplog.records)
+
+    def test_replay_detects_n_out_drift_via_content_hash(self, tmp_path, monkeypatch, caplog):
+        """When n_out drifts, the selector should fall back to content
+        matching and pick the correctly-recorded sub-clip, not the one
+        at the recorded positional index."""
+        import logging
+
+        from vtscore.datasets.clipper_chain import replay_chain_on_file
+        from vtscore.detectors import resolver as resolver_module
+
+        captured: list[str] = []
+
+        def fake_embed_file(path, media_type, embedder_name=""):
+            captured.append(path.read_bytes().decode("utf-8", errors="replace"))
+            return np.zeros(8, dtype=np.float32)
+
+        monkeypatch.setattr(resolver_module, "embed_file", fake_embed_file)
+
+        # Replay produces 3 sentences. Trail recorded n_out=4 with
+        # content_hash matching "Charlie." — i.e. the original load had
+        # one extra sentence (now removed) but Charlie still exists.
+        source = tmp_path / "doc.txt"
+        source.write_text("Alpha. Bravo. Charlie.", encoding="utf-8")
+
+        target_hash = hashlib.md5(b"Charlie.").hexdigest()[:12]
+        steps = [
+            {
+                "kind": "clipper",
+                "name": "text_sentence",
+                "params": {},
+                "out_index": 3,
+                "n_out": 4,
+                "content_hash": target_hash,
+            }
+        ]
+        with caplog.at_level(logging.WARNING, logger="vtscore.datasets.clipper_chain"):
+            embedding = replay_chain_on_file(source, steps)
+        assert embedding is not None
+        assert captured == ["Charlie."]
+        assert any("drift" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Trail enrichment (n_out / clip_index / content_hash)
+# ---------------------------------------------------------------------------
+
+
+class TestTrailEnrichment:
+    def test_clipper_trail_records_n_out_and_clip_index_and_hash(self):
+        """Each clipper trail entry carries n_out, clip_index (when the
+        clipper stamps it), and a short content_hash."""
+        from vtscore.datasets.clipper_chain import _run_clipper_step
+
+        media = _make_text_media(1, "First. Second. Third.")
+        outputs, trail = _run_clipper_step(
+            media,
+            {"kind": "clipper", "name": "text_sentence", "params": {}},
+        )
+        assert len(outputs) == 3
+        assert len(trail) == 3
+        for idx, entry in enumerate(trail):
+            assert entry["out_index"] == idx
+            assert entry["n_out"] == 3
+            assert entry["clip_index"] == str(idx)
+            assert "content_hash" in entry
+            assert len(entry["content_hash"]) == 12
+
+    def test_select_chain_output_returns_none_on_ambiguous_match(self):
+        """If multiple replay outputs match the recorded disambiguators,
+        the selector refuses to guess and returns None."""
+        from vtscore.datasets.clipper_chain import _content_hash, _select_chain_output
+
+        # Two outputs with identical payload naturally produce the same
+        # content_hash. The recorded entry's only disambiguator is that
+        # hash → both outputs match → genuine ambiguity → None.
+        outputs = [
+            {"media_string": "duplicate sentence."},
+            {"media_string": "duplicate sentence."},
+        ]
+        h = _content_hash(outputs[0])
+        # n_out drift forces the selector past the indexed pick into the
+        # content-matching loop, where both outputs match the recorded hash.
+        entry = {
+            "kind": "clipper",
+            "name": "text_sentence",
+            "out_index": 0,
+            "n_out": 3,
+            "content_hash": h,
+        }
+        assert _select_chain_output(outputs, entry) is None
+
 
 # ---------------------------------------------------------------------------
 # Integration with _apply_clipper (load-pipeline entry point)

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -18,7 +18,9 @@ one code path.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -26,7 +28,25 @@ from typing import Any, Callable
 
 from marshmallow import ValidationError
 
+log = logging.getLogger(__name__)
+
 ChainStep = dict[str, Any]
+
+
+def _content_hash(clip: dict[str, Any]) -> str | None:
+    """Return a short md5 of a clip's payload, or None if no payload is present.
+
+    Used by the chain trail to disambiguate sub-clips when the runtime
+    output count or order drifts from the load-time recording (e.g. a
+    source file changed, a converter library version changed).
+    """
+    s = clip.get("media_string")
+    if isinstance(s, str) and s:
+        return hashlib.md5(s.encode("utf-8")).hexdigest()[:12]
+    b = clip.get("media_bytes")
+    if isinstance(b, (bytes, bytearray)) and b:
+        return hashlib.md5(bytes(b)).hexdigest()[:12]
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +159,7 @@ def _run_clipper_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
     resolved = base.resolve_for_media(media)
     effective = _resolved_clipper_params(resolved)
     outputs = resolved.clip(media)
+    n_out = len(outputs)
     trail_entries: list[ChainStep] = []
     for idx, clip in enumerate(outputs):
         entry: ChainStep = {
@@ -146,6 +167,7 @@ def _run_clipper_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
             "name": resolved.name,
             "params": dict(effective),
             "out_index": idx,
+            "n_out": n_out,
         }
         if clip.get("clip_start") is not None:
             entry["clip_start"] = str(clip["clip_start"])
@@ -153,6 +175,11 @@ def _run_clipper_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
             entry["clip_end"] = str(clip["clip_end"])
         if clip.get("clip_box") is not None:
             entry["clip_box"] = ",".join(str(v) for v in clip["clip_box"])
+        if clip.get("clip_index") is not None:
+            entry["clip_index"] = str(clip["clip_index"])
+        ch = _content_hash(clip)
+        if ch is not None:
+            entry["content_hash"] = ch
         trail_entries.append(entry)
     return outputs, trail_entries
 
@@ -166,17 +193,21 @@ def _run_converter_step(media: dict[str, Any], step: ChainStep) -> tuple[list[di
         raise ValueError(f"unknown converter {step['name']!r}")
     outputs = conv.convert(media, step.get("params") or {})
     target = conv.target_type
+    n_out = len(outputs)
     trail_entries: list[ChainStep] = []
     for idx, clip in enumerate(outputs):
         clip.setdefault("type", target)
-        trail_entries.append(
-            {
-                "kind": "converter",
-                "name": conv.name,
-                "params": dict(step.get("params") or {}),
-                "out_index": idx,
-            }
-        )
+        entry: ChainStep = {
+            "kind": "converter",
+            "name": conv.name,
+            "params": dict(step.get("params") or {}),
+            "out_index": idx,
+            "n_out": n_out,
+        }
+        ch = _content_hash(clip)
+        if ch is not None:
+            entry["content_hash"] = ch
+        trail_entries.append(entry)
     return outputs, trail_entries
 
 
@@ -362,29 +393,110 @@ def _load_source_as_media(file_path: Path, source_media_type: str) -> dict[str, 
     return media
 
 
-def _select_chain_output(
+def _output_matches_entry(out: dict[str, Any], entry: ChainStep) -> bool:
+    """Return True iff every recorded disambiguator on *entry* matches *out*.
+
+    Only fields actually recorded in *entry* are checked — missing fields
+    don't constrain the match. Returns True when no disambiguators are
+    recorded (the caller must decide what to do with an empty constraint
+    set, since that case can't distinguish siblings).
+    """
+    cs = entry.get("clip_start")
+    if cs is not None and str(out.get("clip_start")) != str(cs):
+        return False
+    ce = entry.get("clip_end")
+    if ce is not None and str(out.get("clip_end")) != str(ce):
+        return False
+    cb = entry.get("clip_box")
+    if cb is not None and ",".join(str(v) for v in (out.get("clip_box") or [])) != str(cb):
+        return False
+    ci = entry.get("clip_index")
+    if ci is not None and str(out.get("clip_index")) != str(ci):
+        return False
+    ch = entry.get("content_hash")
+    if ch is not None and _content_hash(out) != ch:
+        return False
+    return True
+
+
+def _entry_has_disambiguators(entry: ChainStep) -> bool:
+    """True iff *entry* carries any field that can distinguish sub-outputs."""
+    return any(entry.get(k) is not None for k in ("clip_start", "clip_end", "clip_box", "clip_index", "content_hash"))
+
+
+def _select_chain_output(  # noqa: C901
     outputs: list[dict[str, Any]],
     entry: ChainStep,
 ) -> dict[str, Any] | None:
-    """Pick the matching sub-output by ``out_index`` (or by boundary fields)."""
+    """Pick the sub-output recorded by *entry* from a replay's *outputs* list.
+
+    Selection prefers content-level matching (boundary fields, ``clip_index``,
+    ``content_hash``) over positional matching, because ``out_index`` is only
+    meaningful when the clipper/converter produces the same outputs in the
+    same order at replay time. Returns ``None`` rather than silently
+    selecting an arbitrary output when nothing matches — the caller treats
+    that as an embed failure, which is strictly better than training on
+    the wrong sub-clip's embedding.
+    """
     if not outputs:
         return None
+
+    name = entry.get("name", "?")
     idx = entry.get("out_index")
-    if isinstance(idx, int) and 0 <= idx < len(outputs):
+    n_out_recorded = entry.get("n_out")
+    n_out_now = len(outputs)
+    has_disambiguators = _entry_has_disambiguators(entry)
+
+    drift = isinstance(n_out_recorded, int) and n_out_recorded != n_out_now
+    if drift:
+        log.warning(
+            "clipper_chain: replay output count drift for %r (recorded=%d, now=%d) — falling back to content matching",
+            name,
+            n_out_recorded,
+            n_out_now,
+        )
+
+    # Prefer content matching when we have anything to match against AND
+    # either the count drifted or the indexed pick wouldn't match.
+    if has_disambiguators:
+        in_range_pick = outputs[idx] if isinstance(idx, int) and 0 <= idx < n_out_now else None
+        if in_range_pick is not None and not drift and _output_matches_entry(in_range_pick, entry):
+            return in_range_pick
+        # Either the index is out of range, the count drifted, or the indexed
+        # pick disagrees with the recorded disambiguators. Search every output
+        # for a full disambiguator match.
+        candidates = [out for out in outputs if _output_matches_entry(out, entry)]
+        if len(candidates) == 1:
+            return candidates[0]
+        if not candidates:
+            log.warning(
+                "clipper_chain: no replay output matches recorded disambiguators for %r (idx=%r, n_out=%r→%d)",
+                name,
+                idx,
+                n_out_recorded,
+                n_out_now,
+            )
+            return None
+        log.warning(
+            "clipper_chain: %d replay outputs match recorded disambiguators for %r — ambiguous, refusing to guess",
+            len(candidates),
+            name,
+        )
+        return None
+
+    # No disambiguators recorded — the only handle we have is out_index.
+    if isinstance(idx, int) and 0 <= idx < n_out_now and not drift:
         return outputs[idx]
-    # Fallback: match by clip_start/clip_end/clip_box.
-    cs = entry.get("clip_start")
-    ce = entry.get("clip_end")
-    cb = entry.get("clip_box")
-    for out in outputs:
-        if cs is not None and str(out.get("clip_start")) != str(cs):
-            continue
-        if ce is not None and str(out.get("clip_end")) != str(ce):
-            continue
-        if cb is not None and ",".join(str(v) for v in (out.get("clip_box") or [])) != str(cb):
-            continue
-        return out
-    return outputs[0]
+
+    log.warning(
+        "clipper_chain: cannot select replay output for %r — no disambiguators recorded and "
+        "positional index unusable (idx=%r, n_out=%r→%d)",
+        name,
+        idx,
+        n_out_recorded,
+        n_out_now,
+    )
+    return None
 
 
 _FINAL_EXT_BY_TYPE = {


### PR DESCRIPTION
## Summary

`_select_chain_output` previously trusted `out_index` blindly and, when out of range, silently returned `outputs[0]` — selecting the wrong sub-clip's embedding during cross-dataset detector replay. The legacy single-clipper resolver path (`_clip_text_to_bytes`) correctly returns `None` here; the chain path was a silent regression.

- `_run_clipper_step` / `_run_converter_step` now stamp `n_out`, `clip_index` (when the clipper provides one), and a short `content_hash` on every trail entry — giving the replay selector real disambiguators beyond positional `out_index`.
- `_select_chain_output` prefers content matching over positional, logs warnings on output-count drift / no-match / ambiguous match, and returns `None` instead of guessing.
- Existing trails predating this change keep working: missing fields just don't constrain the match, so in-bounds `out_index` continues to return `outputs[idx]` for old labels.

## Behavior change

Labels that previously resolved to the **wrong** sub-clip's embedding (because the source file or converter output drifted) will now resolve to **no** embedding — surfaced via the existing `status="embed_failed"` path in `resolver.py` and accompanying warning logs. This is the desired outcome: a missing label is strictly better than a wrong-clip label silently training the MLP toward the wrong target.

## Test plan

- [x] `./run-tests.sh detectors` — 1080 passed
- [x] `./run-tests.sh` — 4052 passed, 1 skipped
- New regression coverage in `tests_lib/detectors/test_clipper_chain.py`:
  - `test_replay_fails_closed_when_out_index_out_of_range` — old-format trail with shortened source returns `None`, not `outputs[0]`.
  - `test_replay_detects_n_out_drift_via_content_hash` — when `n_out` drifts, selector falls back to content matching and picks the right sub-clip.
  - `test_clipper_trail_records_n_out_and_clip_index_and_hash` — new fields are stamped on every entry.
  - `test_select_chain_output_returns_none_on_ambiguous_match` — ambiguous content matches refuse to guess.

https://claude.ai/code/session_01THErG4cQijtJReWTZUDUEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01THErG4cQijtJReWTZUDUEp)_