### PR TITLE
Fix M4: invalidate label-embedding cache when region_box changes

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -455,9 +455,9 @@ Cross-section interaction agents:
 
 ### Detector
 
-- **M4.** `populate_label_embeddings` cache not invalidated when a
+- ~~**M4.** `populate_label_embeddings` cache not invalidated when a
   `region_box` is removed from an element; stale pooled vector
-  continues to be used.
+  continues to be used.~~
 - **M5.** `labelset_elements.resolve_current_dataset_cid` can return a
   colliding-MD5 cid in cross-dataset labelsets → clicks vote the
   wrong media.

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1423,6 +1423,73 @@ class TestRegionAwareTraining:
         populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
         np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
 
+    def test_populate_label_embeddings_invalidates_when_region_box_removed(self):
+        """Logical-bug-audit M4: when a labelset element loses its ``region_box``
+        (e.g. the user flipped good→bad on a previously region-voted media, or
+        un-voted/re-voted without a region), the cache must NOT keep returning
+        the previously-pooled region vector.  The next pass should produce the
+        image-level CLS embedding instead."""
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.state.core import DetectorContext
+
+        cid = 9004
+        media = self._register_synthetic_image(cid)
+        # First pass: element carries a region_box → cached as a pooled vector.
+        elem = LabeledElement(md5=media["md5"], label="good", region_box=(0.0, 0.0, 0.5, 0.5))
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        snap = {cid: media}
+
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        eid = stable_element_id(elem)
+        pooled = np.array(det_ctx.label_embeddings[eid], copy=True)
+        # Sanity: the cached vector is the pooled box, not the CLS embedding.
+        assert not np.allclose(pooled, media["embedding"])
+        assert det_ctx.label_embedding_regions[eid] == (0.0, 0.0, 0.5, 0.5)
+
+        # Simulate the bug-triggering edit: same element identity (same eid)
+        # but the user removed the region_box (e.g. flipped to bad, then back
+        # to good without a region; bad votes never carry a region_box).
+        elem.region_box = None
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        # The cached vector must now be the image-level CLS embedding, not
+        # the stale top-left pooled vector.
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], media["embedding"])
+        assert det_ctx.label_embedding_regions[eid] is None
+
+    def test_populate_label_embeddings_invalidates_when_region_box_added(self):
+        """Mirror of the M4 fix in the opposite direction: an image-level
+        cached entry must be re-pooled when the element gains a region_box.
+        (This already worked before M4 because the original cache check
+        gated on ``elem.region_box is None``, but the explicit test pins the
+        behaviour now that the cache check also consults the region cache.)"""
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.media.patch_embed import box_to_vote_vector
+        from vtscore.state.core import DetectorContext
+
+        cid = 9005
+        media = self._register_synthetic_image(cid)
+        elem = LabeledElement(md5=media["md5"], label="good")  # no region_box
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        snap = {cid: media}
+
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        eid = stable_element_id(elem)
+        assert det_ctx.label_embedding_regions[eid] is None
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], media["embedding"])
+
+        # User adds a region annotation to the element.
+        elem.region_box = (0.5, 0.5, 1.0, 1.0)
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        expected = box_to_vote_vector(media["patch_grid"], (0.5, 0.5, 1.0, 1.0))
+        np.testing.assert_allclose(det_ctx.label_embeddings[eid], expected, atol=1e-6)
+        assert det_ctx.label_embedding_regions[eid] == (0.5, 0.5, 1.0, 1.0)
+
 
 class TestRegionAwareTrainingCrossDataset:
     """Cross-dataset region-vote path: when a labelset element carries a

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -179,6 +179,7 @@ def _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name: str) -> None:
     """
     if det_ctx.embedder and embedder_name and det_ctx.embedder != embedder_name:
         det_ctx.label_embeddings.clear()
+        det_ctx.label_embedding_regions.clear()
 
 
 def _resolve_uncached_embedding(
@@ -247,25 +248,29 @@ def populate_label_embeddings(
     embedder_name = _embedder_for_active_dataset(snap)
     _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name)
     cache: dict[str, np.ndarray] = det_ctx.label_embeddings
+    region_cache: dict[str, tuple[float, float, float, float] | None] = det_ctx.label_embedding_regions
     total = len(labelset.elements)
     cached = 0
 
     for idx, elem in enumerate(labelset.elements):
         eid = stable_element_id(elem)
-        # Region-voted elements always re-pool from the source patch grid:
-        # the cache is keyed by ``stable_element_id`` (origin / md5), which
-        # is intentionally stable across region edits.  Re-pooling per
-        # training pass is cheap (one patch grid + uniform mean) and is the
-        # only way region_box changes propagate without an explicit cache
-        # invalidation.  Image-level elements keep the cached embedding so
-        # the existing fast path for non-region datasets is unchanged.
-        if eid in cache and elem.region_box is None:
+        # Cache hit only when the cached vector was built against the same
+        # ``region_box`` the element currently carries.  Region-voted
+        # elements (``region_box is not None``) always fall through so the
+        # patch grid is re-pooled with the latest box.  Image-level
+        # elements use the cache only when the cached vector was *also*
+        # built image-level — otherwise we'd return a stale region-pooled
+        # vector after a region→none transition (e.g. good→bad on a
+        # previously region-voted media; or un-vote / re-vote without a
+        # region).  See ``logical-bug-audit.md`` finding M4.
+        if eid in cache and elem.region_box is None and region_cache.get(eid) is None:
             cached += 1
             continue
 
         emb = _resolve_uncached_embedding(elem, snap, media_type=media_type, embedder_name=embedder_name)
         if emb is not None:
             cache[eid] = emb
+            region_cache[eid] = elem.region_box
             cached += 1
         if on_progress:
             on_progress(elem.origin_name or elem.filename or eid, idx + 1, total)
@@ -440,5 +445,7 @@ def update_cache_for_cid(
         return
     for elem in labelset.elements:
         if element_key(elem) == target_key:
-            det_ctx.label_embeddings[stable_element_id(elem)] = np.asarray(embedding)
+            eid = stable_element_id(elem)
+            det_ctx.label_embeddings[eid] = np.asarray(embedding)
+            det_ctx.label_embedding_regions[eid] = None
             return

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -317,6 +317,14 @@ class DetectorContext:
         # Cached in-memory data (never exported)
         "training_medias",  # voted media items with embeddings
         "label_embeddings",  # str → np.ndarray, keyed by stable_element_id
+        # Region box the cached ``label_embeddings`` entry was built against,
+        # keyed by stable_element_id.  ``None`` means the cached vector is
+        # image-level; a 4-tuple means it was pooled from that box.  Lets
+        # ``populate_label_embeddings`` detect a region→none (or any region
+        # edit) transition and re-resolve instead of returning a stale
+        # region-pooled vector keyed to an element that no longer has a
+        # region.  See ``logical-bug-audit.md`` finding M4.
+        "label_embedding_regions",
         "model",  # nn.Sequential | None — current trained MLP
         "threshold",  # decision threshold
         # Cross-dataset training-corpus counts (from on-disk labelset).  These
@@ -381,6 +389,7 @@ class DetectorContext:
         # training and learned-sort use *all* saved labels — including
         # those whose underlying media isn't part of the active dataset.
         self.label_embeddings: dict[str, Any] = {}
+        self.label_embedding_regions: dict[str, tuple[float, float, float, float] | None] = {}
         self.model: Any = None  # nn.Sequential | None
         self.threshold: float = 0.5
         self.labelset_good_count: int = 0
@@ -573,6 +582,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "inclusion", None)
         object.__setattr__(self, "training_medias", _FrozenDict("detector"))
         object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))
+        object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
         object.__setattr__(self, "model", None)
         object.__setattr__(self, "threshold", 0.5)
         object.__setattr__(self, "labelset_good_count", 0)


### PR DESCRIPTION
## Summary

Fixes logical-bug-audit finding **M4**.

`populate_label_embeddings` keyed the cache by `stable_element_id` (origin/md5, region-box-blind on purpose) and re-pooled every pass whenever the element carried a `region_box`. The reverse transition was unhandled: once a region-pooled vector was cached, **removing** the element's `region_box` (good→bad on a previously region-voted media, or un-vote/re-vote without a region) hit the cache and returned the stale pooled vector forever — feeding the MLP a top-left-region vector as if it were an image-level training example.

## What changed

- New `DetectorContext.label_embedding_regions: dict[str, tuple | None]` sibling to `label_embeddings`, recording the `region_box` each cached entry was built against.
- `populate_label_embeddings` gates the cache hit on the recorded region matching the element's current `region_box` (covers both the M4 region→none case and any future region edit).
- `_maybe_clear_cache_on_embedder_switch` clears both maps in lockstep.
- `update_cache_for_cid` (dead helper, but kept consistent) stamps `None` for its image-level write.
- `_RequestMissingDetectorContext` gets the matching `_FrozenDict` slot so writes through the request-missing sentinel still raise loudly.

## Test plan

- [x] New `test_populate_label_embeddings_invalidates_when_region_box_removed` — pins the M4 fix (region→none).
- [x] New `test_populate_label_embeddings_invalidates_when_region_box_added` — pins the mirror case (none→region).
- [x] Existing `test_populate_label_embeddings_keeps_cached_when_no_region_box` — fast path still works.
- [x] `./run-tests.sh` — 4050 passed, 1 skipped, 2 xpassed.

## Notes

- In-memory only (no persisted vectors per CLAUDE.md rule). Embedder-switch invalidation and the rebuild-from-origins contract are unchanged.
- Two adjacent, separately-tracked issues surfaced during the investigation but are out of scope for M4:
  - The learned-sort signature cache (`sorting.py:338`) is region-box-blind for the labelset path, so editing only the region on an already-good element returns cached scores without retraining.
  - `_live_models` in `labeling_progress.py` is keyed on `(frozenset(good), frozenset(bad))` and is similarly region-box-blind.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxD53FvnYRQcpPv1BTGRKv)_