### PR TITLE
Close M6 as not a real bug in logical-bug-audit

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -461,9 +461,20 @@ Cross-section interaction agents:
 - **M5.** `labelset_elements.resolve_current_dataset_cid` can return a
   colliding-MD5 cid in cross-dataset labelsets → clicks vote the
   wrong media.
-- **M6.** `restore_labels_from_detector` resolves by MD5 only on the second
-  pass; dedup-collapsed cids can land votes on the wrong cid after
-  reload.
+- ~~**M6.** `restore_labels_from_detector` resolves by MD5 only on the
+  second pass; dedup-collapsed cids can land votes on the wrong cid
+  after reload.~~ — investigated and closed as not a real bug. Pass 1
+  already consults `md5_lookup` via `resolve_media_ids`
+  (`vtscore/state/media_lookup.py:62`), and the dedup-collapse reload
+  path lands on the correct rep cid in every case (deduped,
+  un-deduped, cross-dataset). The genuine "wrong cid" concern is
+  captured by **M5** (`resolve_current_dataset_cid` returns
+  `cids[0]` non-deterministically on md5 ties); a separately
+  worrying latent issue is that pass 2 recomputes the *parent*
+  file's md5 for `converter` origins
+  (`vtscore/detectors/resolver.py:_resolve_converter`) while the
+  dataset stores the converted-output md5 — track under detector
+  findings if it bites.
 - **M7.** `safe_thresholds` is read at *training* time and baked into the
   detector JSON; per-user threshold preference cannot change after
   save.


### PR DESCRIPTION
## Summary

Investigated M6 from `docs/plans/logical-bug-audit.md` ("`restore_labels_from_detector` resolves by MD5 only on the second pass; dedup-collapsed cids can land votes on the wrong cid after reload") and concluded it isn't a real bug at the current code level. Marked it struck through with a note explaining why and pointing at the related concerns.

## Findings

- **First-pass MD5 claim is wrong.** `restore_labels_from_detector` calls `resolve_media_ids` (`vtscore/state/media_lookup.py:62`), which already returns the union of origin+name **and** md5 matches in pass 1. The "second pass" is a separate file-resolve → recompute-md5 path for cross-dataset bridging.
- **Dedup-collapse handling is correct.** "Save Labels" uses `expand_dupes=False` (`vtsearch/routes/detectors/labels.py:137`), saving one labelset element per vote with the rep's md5 + `dupe_set` origin. On reload — whether the dataset re-dedups, doesn't dedup, or is a different dataset with the same content — pass 1's `md5_lookup` hit lands the label on the correct rep cid (or on all dupes when dedup wasn't applied, which is semantically right).
- **The real wrong-cid risk is M5.** `resolve_current_dataset_cid` returns `cids[0]` (`vtscore/detectors/labelset_elements.py:62`) when multiple cids share the md5 — that's the actual non-deterministic "wrong cid" surface and is already tracked as M5.
- **Bonus latent issue noted inline.** Pass 2 in `label_restoration.py:75–105` resolves `converter` origins back to the **parent** file (`vtscore/detectors/resolver.py:_resolve_converter`) and recomputes the parent's md5, but datasets store the **converted-output** md5 (`vtscore/converters/runner.py:138`). So pass 2 silently fails to match for clip-based datasets and could (improbably) match an unrelated media. Flagged in the M6 note so the next sweep can file it properly.

## Test plan

- [x] Documentation-only change; no runtime impact.
- [x] `git diff` reviewed — only the M6 bullet in `docs/plans/logical-bug-audit.md` changes (strike-through + inline rationale).

https://claude.ai/code/session_01C9ZtcHVZoF7AzGrcJD5F78

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9ZtcHVZoF7AzGrcJD5F78)_