### PR TITLE
logical-bug-audit M1 — standardise state→progress lock order

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -446,8 +446,28 @@ Cross-section interaction agents:
 
 ### State / concurrency
 
-- **M1.** Lock held during cross-lock callbacks in `toggle_vote` — state ↔
-  progress lock ordering creates a narrow but real deadlock window.
+- ~~**M1.** Lock held during cross-lock callbacks in `toggle_vote` — state ↔
+  progress lock ordering creates a narrow but real deadlock window.~~ —
+  investigated and closed (2026-05-20).  The literal deadlock the audit
+  named was no longer reachable in the current code (post-H1 refactor:
+  nothing inside `_progress_lock` calls back into `_state_lock`-acquiring
+  code, and route callers of progress functions do not hold `_state_lock`
+  when entering the progress module).  But the design was fragile —
+  four sites (`vtscore/state/votes.py:_set_vote_locked` + `clear_votes`,
+  `vtscore/state/__init__.py:clear_medias` + `set_inclusion`) held
+  `_state_lock` while calling into the progress module, while two others
+  (`register_detector_context` / `unregister_detector_context`) explicitly
+  released it first.  Standardised all six sites on release-first: the
+  progress-cache calls now run strictly outside `_state_lock` everywhere,
+  so the canonical order is one-directional and adding a new state→progress
+  callsite is harder to get wrong.  `_set_vote_locked` no longer touches
+  `_progress_lock`; `set_vote` / `toggle_vote` invalidate the progress
+  cache after releasing `_state_lock`.  `clear_all` no longer wraps both
+  inner clears in a single `_state_lock`, since each inner now releases
+  before calling `clear_progress_cache` (the sole caller, dataset-load,
+  immediately repopulates state so the loss of cross-clear atomicity is
+  acceptable).  Lock-order invariant documented in the
+  `vtscore/detectors/labeling_progress.py` module docstring.
 - **M2.** `combine_datasets.run_chunked` re-issues IDs starting at 1 on every
   call → cid collision when consumed twice.
 - **M3.** `importers/base.py` L407–410 — skipped records leave `next_id`

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -632,3 +632,149 @@ class TestPluginRegistryLock:
 
         assert not errors
         assert call_count == 1, f"_discover called {call_count} times, expected 1"
+
+
+class TestStateProgressLockOrder:
+    """Regression for audit M1: never hold ``_state_lock`` while acquiring ``_progress_lock``.
+
+    The canonical lock order is ``_state_lock`` first, ``_progress_lock`` strictly
+    outside it.  Every state→progress callsite (``set_vote``, ``toggle_vote``,
+    ``clear_votes``, ``clear_medias``, ``set_inclusion``, ``register_detector_context``,
+    ``unregister_detector_context``) must release ``_state_lock`` before calling
+    into ``vtscore.detectors.labeling_progress``.  Otherwise a contributor adding
+    code that takes the locks in the reverse order opens a deadlock window.
+    """
+
+    def _patch_capture(self, monkeypatch, attr: str) -> list[bool]:
+        """Wrap ``labeling_progress.<attr>`` to record whether ``_state_lock`` was held.
+
+        Returns the list that captures one ``_is_owned()`` reading per call.
+        ``RLock._is_owned`` is a stable CPython attribute used by the
+        ``threading`` module itself, so depending on it for an invariant test
+        is acceptable here.
+        """
+        captured: list[bool] = []
+        original = getattr(_progress_mod, attr)
+
+        def wrapper(*args, **kwargs):
+            captured.append(_state._state_lock._is_owned())
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(_progress_mod, attr, wrapper)
+        return captured
+
+    def test_set_vote_releases_state_lock_before_progress_invalidate(self, monkeypatch):
+        held = self._patch_capture(monkeypatch, "invalidate_progress_cache_from")
+        from vtsearch.state import set_vote
+
+        # First vote: none→good, no invalidation (old == "none").
+        set_vote(1, "good")
+        # Second vote: good→bad, triggers invalidation (old == "good").
+        set_vote(1, "bad")
+        assert held, "invalidate_progress_cache_from was never called on good→bad"
+        assert held == [False] * len(held), f"_state_lock held during progress invalidate: {held}"
+
+    def test_toggle_vote_releases_state_lock_before_progress_invalidate(self, monkeypatch):
+        held = self._patch_capture(monkeypatch, "invalidate_progress_cache_from")
+        from vtsearch.state import toggle_vote
+
+        # First toggle: none→good (no invalidate).
+        toggle_vote(2, "good")
+        # Second toggle: good→none (triggers invalidate).
+        toggle_vote(2, "good")
+        assert held, "invalidate_progress_cache_from was never called on toggle-off"
+        assert held == [False] * len(held), f"_state_lock held during progress invalidate: {held}"
+
+    def test_clear_votes_releases_state_lock_before_progress_clear(self, monkeypatch):
+        held = self._patch_capture(monkeypatch, "clear_progress_cache")
+        from vtsearch.state import clear_votes
+
+        clear_votes()
+        assert held, "clear_progress_cache was never called from clear_votes"
+        assert held == [False] * len(held), f"_state_lock held during clear_progress_cache: {held}"
+
+    def test_clear_medias_releases_state_lock_before_progress_clear(self, monkeypatch):
+        held = self._patch_capture(monkeypatch, "clear_progress_cache")
+        from vtsearch.state import clear_medias
+
+        clear_medias()
+        assert held, "clear_progress_cache was never called from clear_medias"
+        assert held == [False] * len(held), f"_state_lock held during clear_progress_cache: {held}"
+
+    def test_set_inclusion_releases_state_lock_before_progress_clear(self, monkeypatch, isolated_settings):
+        held = self._patch_capture(monkeypatch, "clear_progress_cache")
+        import vtsearch.state as _vstate
+
+        # Two distinct values to force the change-detection branch that triggers a clear.
+        current = _vstate.get_inclusion()
+        new_value = (current + 1) % 11  # inclusion is in [-10, 10]; bump within range
+        _vstate.set_inclusion(new_value)
+        assert held, "clear_progress_cache was never called from set_inclusion"
+        assert held == [False] * len(held), f"_state_lock held during clear_progress_cache: {held}"
+
+    def test_vote_mutation_does_not_block_when_progress_lock_held(self):
+        """Concurrent ``set_vote`` mutations must not deadlock when ``_progress_lock`` is held.
+
+        With the pre-fix code, ``_set_vote_locked`` acquired ``_progress_lock``
+        while still holding ``_state_lock``.  A second thread doing any
+        ``_state_lock``-only mutation would then block — even though there's
+        no reason it should — because the first thread is parked waiting for
+        ``_progress_lock``.  After the fix, the first thread releases
+        ``_state_lock`` before attempting ``_progress_lock``, so the second
+        ``_state_lock``-only mutation proceeds independently.
+        """
+        from vtsearch.state import set_vote, good_votes
+
+        # Set media 3's initial vote so the next ``set_vote(3, "bad")`` will trigger
+        # progress-cache invalidation (old != "none").
+        set_vote(3, "good")
+        assert 3 in good_votes
+
+        unblock = threading.Event()
+
+        # Hold _progress_lock from a background thread to simulate a long-running
+        # progress-cache reader.
+        progress_held = threading.Event()
+
+        def holder():
+            with _progress_mod._progress_lock:
+                progress_held.set()
+                unblock.wait(timeout=10)
+
+        bg = threading.Thread(target=holder)
+        bg.start()
+        assert progress_held.wait(timeout=5), "background thread never acquired _progress_lock"
+
+        # In a separate thread, call set_vote(3, "bad") which will:
+        #   1. acquire _state_lock, mutate, release _state_lock
+        #   2. try to acquire _progress_lock (blocked because holder has it)
+        invalidating_done = threading.Event()
+
+        def invalidator():
+            set_vote(3, "bad")
+            invalidating_done.set()
+
+        inv = threading.Thread(target=invalidator)
+        inv.start()
+
+        # While the invalidator is parked waiting on _progress_lock, an unrelated
+        # _state_lock-only mutation must still complete promptly.
+        other_done = threading.Event()
+
+        def other():
+            set_vote(4, "good")
+            other_done.set()
+
+        other_thread = threading.Thread(target=other)
+        other_thread.start()
+        assert other_done.wait(timeout=5), (
+            "concurrent set_vote was blocked — invalidator is holding _state_lock while waiting "
+            "on _progress_lock (M1 regression)"
+        )
+        other_thread.join(timeout=5)
+
+        # Release _progress_lock; invalidator should finish.
+        unblock.set()
+        assert invalidating_done.wait(timeout=5), "invalidator did not complete after _progress_lock released"
+        inv.join(timeout=5)
+        bg.join(timeout=5)

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -657,7 +657,7 @@ class TestStateProgressLockOrder:
         original = getattr(_progress_mod, attr)
 
         def wrapper(*args, **kwargs):
-            captured.append(_state._state_lock._is_owned())
+            captured.append(_state._state_lock._is_owned())  # type: ignore[attr-defined]
             return original(*args, **kwargs)
 
         monkeypatch.setattr(_progress_mod, attr, wrapper)

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -9,6 +9,19 @@ infrastructure for tracking and cancelling long-running operations
 (``ProgressTracker`` and the dataset/sort/eval/find singletons).  The
 two modules used to share the ``progress.py`` name; this one was
 renamed to make the distinction obvious.
+
+Lock ordering (audit M1)
+------------------------
+``_progress_lock`` is acquired strictly *outside* ``vtscore.state.core._state_lock``.
+Every callsite that needs to invalidate or clear the cache after a
+state-lock'd mutation must release ``_state_lock`` before invoking a
+function in this module.  Conversely, code inside ``_progress_lock`` must
+not call into anything that acquires ``_state_lock`` — including helpers
+on ``DatasetContext`` / ``DetectorContext`` that take the state lock,
+and any of the resolve-context-then-mutate functions in
+:mod:`vtscore.state.votes` / :mod:`vtscore.state.diversity`.  Holding
+both locks in the opposite order would establish a cross-module cycle
+and could deadlock.
 """
 
 from __future__ import annotations

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -133,15 +133,23 @@ def clear_medias() -> None:
         ctx._emb_matrix = None
         ctx.diversity_tree = None
         ctx.dataset_display_name = None
-        clear_progress_cache()
+    # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
+    # two locks never establish a cross-module ordering (audit M1).
+    clear_progress_cache()
     gc.collect()
 
 
 def clear_all() -> None:
-    """Clear all medias, votes, and label history."""
-    with _state_lock:
-        clear_medias()
-        clear_votes()
+    """Clear all medias, votes, and label history.
+
+    Each clear acquires ``_state_lock`` independently — the two operations
+    are *not* atomic with respect to each other so the progress cache can
+    be cleared (under ``_progress_lock``) outside ``_state_lock`` (audit
+    M1).  The sole caller is dataset-load, which immediately rebuilds
+    state, so the transient mid-clear view is acceptable.
+    """
+    clear_medias()
+    clear_votes()
 
 
 # ---------------------------------------------------------------------------
@@ -187,12 +195,18 @@ def get_inclusion() -> int:
 def set_inclusion(value: int) -> None:
     """Set the global inclusion value and persist it via the registered hook."""
     with _state_lock:
-        if value != _core._get_inclusion():
-            from vtscore.detectors.labeling_progress import clear_progress_cache
-
-            clear_progress_cache()
+        changed = value != _core._get_inclusion()
         _core._set_inclusion(value)
         _persist_setting("inclusion", value)
+    # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
+    # two locks never establish a cross-module ordering (audit M1).
+    # ``_ensure_cache`` self-heals if a concurrent reader observes the new
+    # inclusion before this clear runs — it re-clears whenever
+    # ``_cache_inclusion`` differs from the current value.
+    if changed:
+        from vtscore.detectors.labeling_progress import clear_progress_cache
+
+        clear_progress_cache()
 
 
 def get_dataset_display_name() -> str | None:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -672,8 +672,8 @@ def register_detector_context(ctx: DetectorContext) -> None:
 
     with _state_lock:
         _detector_contexts[ctx.detector_id] = ctx
-    # clear_progress_cache acquires its own lock; call outside _state_lock
-    # to avoid lock-ordering concerns.
+    # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
+    # two locks never establish a cross-module ordering (audit M1).
     clear_progress_cache()
 
 
@@ -690,6 +690,8 @@ def unregister_detector_context(detector_id: str) -> DetectorContext | None:
         tl_ctx = getattr(_thread_local, "detector_context", None)
         if tl_ctx is not None and tl_ctx.detector_id == detector_id:
             _thread_local.detector_context = None
+    # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
+    # two locks never establish a cross-module ordering (audit M1).
     clear_progress_cache()
     return ctx
 

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -43,7 +43,9 @@ def clear_votes() -> None:
         ctx.click_counter = 0
         ctx.last_learned_scores.clear()
         ctx.find_initial_labels.clear()
-        clear_progress_cache()
+    # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
+    # two locks never establish a cross-module ordering (audit M1).
+    clear_progress_cache()
 
 
 def add_label_to_history(media_id: int, label: str) -> None:
@@ -153,9 +155,12 @@ def _set_vote_locked(
     Returns ``(old_label, new_label, click_time)`` where ``click_time`` is the
     ordinal assigned to a newly-labeled media (or ``None`` when *target* is
     ``"none"`` or the call was idempotent).
-    """
-    from vtscore.detectors.labeling_progress import invalidate_progress_cache_from
 
+    Does **not** acquire ``_progress_lock``.  The public wrappers
+    (:func:`set_vote`, :func:`toggle_vote`) decide whether to invalidate the
+    progress cache *after* releasing ``_state_lock`` based on the returned
+    ``old_label`` — see the lock-ordering note on those wrappers (audit M1).
+    """
     if target not in ("good", "bad", "none"):
         raise ValueError(f"target must be 'good', 'bad', or 'none' (got {target!r})")
 
@@ -203,21 +208,26 @@ def _set_vote_locked(
         diversity_tree_unlabel(media_id)
         click_time = None
 
-    # Invalidate the progress cache on ANY training-set membership change for
-    # this media.  The old `toggle_vote` only invalidated on polarity flips,
-    # leaving cached steps stale on good→none / bad→none.  Cached models that
-    # included this media are now wrong regardless of whether the new state is
-    # the opposite polarity or "none", so the rule is: invalidate iff the media
-    # was previously labeled.
-    if old != "none":
-        invalidate_progress_cache_from(media_id)
-
     # Counter increments only on a transition that produces a labeled state.
     # Un-vote (X→none) and idempotent re-apply (handled above) credit nothing.
     if target != "none":
         _record_vote_locked()
 
     return (old, target, click_time)
+
+
+def _needs_progress_invalidate(old_label: str, new_label: str) -> bool:
+    """Whether an ``old_label → new_label`` transition requires a progress-cache invalidate.
+
+    Cached models that included this media are stale on ANY training-set
+    membership change for it.  The old ``toggle_vote`` only invalidated on
+    polarity flips, which left the cache stale on good→none / bad→none.  The
+    rule is now: invalidate iff the media was previously labeled *and* the
+    new label is different (idempotent re-applies — including a re-vote with
+    a new region box — do not invalidate, matching the pre-M1 behaviour
+    where the idempotent path returned early before the invalidate site).
+    """
+    return old_label != "none" and old_label != new_label
 
 
 def set_vote(
@@ -255,7 +265,16 @@ def set_vote(
         idempotent calls.
     """
     with _state_lock:
-        return _set_vote_locked(media_id, target, region_box=region_box)
+        result = _set_vote_locked(media_id, target, region_box=region_box)
+    # Progress-cache invalidation runs *after* ``_state_lock`` is released so
+    # we never establish a ``_state_lock → _progress_lock`` ordering across
+    # the two modules (audit M1).
+    old_label, new_label, _click_time = result
+    if _needs_progress_invalidate(old_label, new_label):
+        from vtscore.detectors.labeling_progress import invalidate_progress_cache_from
+
+        invalidate_progress_cache_from(media_id)
+    return result
 
 
 def toggle_vote(
@@ -289,11 +308,16 @@ def toggle_vote(
             target = "none" if current == "bad" else "bad"
         else:
             raise ValueError(f"vote must be 'good' or 'bad' (got {vote!r})")
-        _set_vote_locked(
+        old, new, _click_time = _set_vote_locked(
             media_id,
             target,
             region_box=region_box if target == "good" else None,
         )
+    # See the lock-ordering note on :func:`set_vote`.
+    if _needs_progress_invalidate(old, new):
+        from vtscore.detectors.labeling_progress import invalidate_progress_cache_from
+
+        invalidate_progress_cache_from(media_id)
 
 
 def apply_label(


### PR DESCRIPTION
## Summary

Closes audit finding **M1** ("Lock held during cross-lock callbacks in `toggle_vote` — state ↔ progress lock ordering creates a narrow but real deadlock window").

The literal deadlock the audit named is no longer reachable in current code (post-H1 refactor: nothing inside `_progress_lock` calls back into `_state_lock`-acquiring code, and route callers of progress functions don't hold `_state_lock` when entering the module). But the design was fragile — four sites held `_state_lock` while calling into the progress module, while two others (`register_detector_context` / `unregister_detector_context`) explicitly released it first with a defensive comment. This PR makes the rule uniform: `_state_lock → _progress_lock` ordering is now never established anywhere.

## Changes

- `_set_vote_locked` no longer calls `invalidate_progress_cache_from`. The public wrappers (`set_vote`, `toggle_vote`) decide whether to invalidate based on the returned `(old, new)` labels and call into the progress module *after* releasing `_state_lock`.
- New `_needs_progress_invalidate(old, new)` helper captures the "previously labeled → different label" rule. It intentionally excludes the idempotent re-apply case (e.g. good→good with a new `region_box`), preserving the pre-refactor early-return behaviour where the idempotent path bypassed the invalidate site.
- `clear_votes`, `clear_medias`, `set_inclusion` now exit `_state_lock` before calling `clear_progress_cache`.
- `clear_all` no longer wraps its inner clears in an outer `_state_lock`, since each inner must release before calling `clear_progress_cache`. The only caller is dataset-load which immediately rebuilds state, so the lost cross-clear atomicity is acceptable (documented in the docstring).
- Lock-order invariant documented in the `vtscore/detectors/labeling_progress.py` module docstring.
- Audit entry struck-through with a closure note.

## Test plan

- [x] `./run-tests.sh` — 4054 passed (1 skipped)
- [x] Six new regression tests under `TestStateProgressLockOrder` in `tests/integration/test_thread_safety.py`:
  - Five tests monkey-patch each progress entry point (`invalidate_progress_cache_from`, `clear_progress_cache`) to capture `_state_lock._is_owned()` at call time and assert it's always `False`, covering `set_vote`, `toggle_vote`, `clear_votes`, `clear_medias`, `set_inclusion`.
  - One behavioural test holds `_progress_lock` from a background thread, parks an invalidator on it, and verifies that an unrelated `_state_lock`-only mutation still completes promptly (would have deadlocked in the pre-fix design pattern).

## Backwards compatibility

No public-API changes. `set_vote` returns the same `(old, new, click_time)` tuple it always did. The idempotent re-apply still skips invalidation (matching pre-refactor behaviour). Achievement credit, click-time assignment, and label-history append are unchanged.

https://claude.ai/code/session_01P6pKZSxsYCyqVgCT4Bt3yT

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6pKZSxsYCyqVgCT4Bt3yT)_