### PR TITLE
Fix audit M8/M11/M12 — null-safe pickle embeddings + strict zip

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -584,8 +584,12 @@ Cross-section interaction agents:
 
 ### Datasets / loaders
 
-- **M8.** Thin-mode pickle loader treats `embedding: None` as present, then
-  `np.array(None)` produces an object-dtype row.
+- ~~**M8.** Thin-mode pickle loader treats `embedding: None` as present, then
+  `np.array(None)` produces an object-dtype row.~~ — fixed in
+  `vtscore/datasets/loader_pickle.py`: `_convert_one_pickle_media` now
+  treats a missing key and an explicit `None` value identically, skipping
+  the media and bumping the missing-media warning counter.  Regression
+  test in `tests_lib/datasets/test_thin_loading.py::TestThinLoadFromPickleNoneEmbedding`.
 - ~~**M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
   and `file_name` override entries exist with different embeddings.~~
 - **M10.** ~~`clipper_chain._run_clipper_step` assumes deterministic output count
@@ -596,10 +600,19 @@ Cross-section interaction agents:
   drift / no-match / ambiguous match, and returns `None` instead of
   silently picking `outputs[0]` (was a regression vs. the legacy
   `_clip_text_to_bytes` resolver path).
-- **M11.** Stale media in `cli._score_medias_with_detectors` when some
-  embeddings are `None` (zip truncates silently).
-- **M12.** `loader_pickle._build_pickle_full_media` has no null-check before
-  `np.array(media_info["embedding"])`.
+- ~~**M11.** Stale media in `cli._score_medias_with_detectors` when some
+  embeddings are `None` (zip truncates silently).~~ — fixed by switching
+  the `zip(all_ids, scores)` loop in `vtscore/cli.py:_score_medias_with_detectors`
+  to `zip(..., strict=True)` so any future partial-matrix bug fails
+  loudly with `ValueError` instead of silently dropping hits.
+  Regression test in
+  `tests/io/test_export_options.py::TestCliScoringNegativeHits::test_id_score_length_mismatch_raises`.
+- ~~**M12.** `loader_pickle._build_pickle_full_media` has no null-check before
+  `np.array(media_info["embedding"])`.~~ — fixed: full-mode pickle load
+  now preserves `embedding=None` verbatim so the load pipeline can
+  re-embed (which it already does for `embedding is None`), instead of
+  producing a poisoned `np.array(None)` 0-d object array.  Regression
+  test in `tests_lib/datasets/test_thin_loading.py::TestThinLoadFromPickleNoneEmbedding::test_full_preserves_none_embedding`.
 
 ### Routes / API
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -12,6 +12,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 import app as app_module
 
 SAMPLE_RESULTS = {
@@ -329,6 +331,36 @@ class TestCliScoringNegativeHits:
             assert isinstance(det_result["negative_hits"], list)
             total = len(det_result["hits"]) + len(det_result["negative_hits"])
             assert total == len(medias)
+
+    def test_id_score_length_mismatch_raises(self, client, monkeypatch):
+        """Regression for audit M11: a partial embedding matrix must surface
+        loudly via ``zip(strict=True)`` instead of silently truncating
+        scoring results."""
+        from vtscore.cli import _score_medias_with_detectors
+        from vtscore.detectors.training import train_and_threshold
+        from vtscore.embedding import matrix as matrix_module
+        from vtsearch.state import medias, snapshot_medias
+
+        snap = snapshot_medias()
+        good_ids = [1, 2, 3]
+        bad_ids = [18, 19, 20]
+        X = [snap[i]["embedding"] for i in good_ids + bad_ids]
+        y = [1.0] * len(good_ids) + [0.0] * len(bad_ids)
+        mlp, threshold = train_and_threshold(X, y, snap=snap)
+
+        real_get = matrix_module.get_embedding_matrix_for_snap
+
+        def _truncating_matrix(snap_arg):
+            ids, mat = real_get(snap_arg)
+            # Drop the last id but keep the full matrix so scores stays
+            # longer than ids — exactly the silent-truncation failure mode.
+            return ids[:-1], mat
+
+        monkeypatch.setattr(matrix_module, "get_embedding_matrix_for_snap", _truncating_matrix)
+
+        detector_mlps = {"test": {"mlp": mlp, "threshold": threshold}}
+        with pytest.raises(ValueError):
+            _score_medias_with_detectors(medias, detector_mlps)
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -254,6 +254,92 @@ class TestPickleMD5Preservation:
         assert medias[1]["md5"] == pre_md5
 
 
+class TestThinLoadFromPickleNoneEmbedding:
+    """Pickle entries with ``embedding=None`` must not poison thin/full loads.
+
+    Regression for audit M8 (thin mode would call ``np.array(None)`` and
+    produce a 0-d object array that crashes downstream embedding-matrix
+    consumers) and M12 (full mode had the same hazard).
+    """
+
+    def _make_pickle_with_embedding(self, tmp_path, embedding: Any) -> Path:
+        wav_bytes = _make_wav_bytes()
+        pkl_data = {
+            "medias": {
+                1: {
+                    "id": 1,
+                    "type": "audio",
+                    "duration": 0.1,
+                    "file_size": len(wav_bytes),
+                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    "embedding": embedding,
+                    "filename": "test.wav",
+                    "category": "test",
+                    "media_bytes": wav_bytes,
+                }
+            }
+        }
+        pkl_path = tmp_path / "test.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump(pkl_data, f)
+        return pkl_path
+
+    def test_thin_skips_media_with_none_embedding(self, tmp_path, capsys):
+        """thin=True must skip ``embedding=None`` entries (cannot re-embed)."""
+        pkl_path = self._make_pickle_with_embedding(tmp_path, embedding=None)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=True)
+        assert medias == {}
+        # The skip should be reported via the missing-media warning.
+        assert "missing" in capsys.readouterr().out.lower()
+
+    def test_thin_skips_media_without_embedding_key(self, tmp_path):
+        """Existing behavior: a missing ``embedding`` key still skips."""
+        wav_bytes = _make_wav_bytes()
+        pkl_data = {
+            "medias": {
+                1: {
+                    "id": 1,
+                    "type": "audio",
+                    "duration": 0.1,
+                    "file_size": len(wav_bytes),
+                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    # no "embedding" key at all
+                    "filename": "test.wav",
+                    "category": "test",
+                    "media_bytes": wav_bytes,
+                }
+            }
+        }
+        pkl_path = tmp_path / "test.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump(pkl_data, f)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=True)
+        assert medias == {}
+
+    def test_full_preserves_none_embedding(self, tmp_path):
+        """full mode keeps the media so the load pipeline can re-embed.
+
+        ``embedding`` stays ``None`` rather than becoming a poisoned
+        ``np.array(None)`` 0-d object array.
+        """
+        pkl_path = self._make_pickle_with_embedding(tmp_path, embedding=None)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert len(medias) == 1
+        assert medias[1]["embedding"] is None
+        assert medias[1]["media_bytes"] is not None
+
+    def test_full_still_loads_normal_embedding(self, tmp_path):
+        """Sanity check: a real embedding is still wrapped as an ndarray."""
+        pkl_path = self._make_pickle_with_embedding(tmp_path, embedding=np.zeros(512).tolist())
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert isinstance(medias[1]["embedding"], np.ndarray)
+        assert medias[1]["embedding"].shape == (512,)
+
+
 class TestThinImporters:
     """Test that importers pass thin parameter through correctly."""
 

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -234,7 +234,9 @@ def _score_medias_with_detectors(
 
         positive_hits: list[dict[str, Any]] = []
         negative_hits: list[dict[str, Any]] = []
-        for cid, score in zip(all_ids, scores):
+        # ``strict=True`` so a future partial embedding-matrix bug fails
+        # loudly instead of silently truncating scoring results.
+        for cid, score in zip(all_ids, scores, strict=True):
             hit = build_media_hit(cid, medias[cid], score)
             if score >= threshold:
                 positive_hits.append(hit)

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -151,8 +151,15 @@ def _build_pickle_full_media(
     media_path: str | None,
     extra_fields: list[str],
 ) -> dict[str, Any]:
-    """Build a full-mode media dict from a pickle entry."""
+    """Build a full-mode media dict from a pickle entry.
+
+    A missing or ``None`` ``embedding`` is preserved verbatim so the
+    downstream load pipeline can re-embed (e.g. pickles produced via
+    ``skip_embedding=True``).
+    """
     fname = media_info.get("filename", f"media_{new_id}.{media_type}")
+    raw_emb = media_info.get("embedding")
+    embedding = np.array(raw_emb) if raw_emb is not None else None
     media_data = {
         "id": new_id,
         "type": media_type,
@@ -160,7 +167,7 @@ def _build_pickle_full_media(
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", len(media_bytes)),
         "md5": media_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),
-        "embedding": np.array(media_info["embedding"]),
+        "embedding": embedding,
         "media_bytes": media_bytes,
         "media_string": media_string,
         "media_path": media_path or media_info.get("media_path"),
@@ -196,7 +203,12 @@ def _convert_one_pickle_media(
     extra_fields = extra_fields_map.get(media_type, [])
 
     if thin:
-        if "embedding" not in media_info:
+        # Treat a missing key and an explicit ``None`` value identically:
+        # both mean "no embedding" and thin mode cannot re-embed.  Without
+        # this check ``np.array(None)`` would silently produce a 0-d
+        # object array that poisons every downstream embedding-matrix
+        # consumer.
+        if media_info.get("embedding") is None:
             return None, True
         media_path = _resolve_thin_media_path(media_type, media_info, data, dir_keys)
         return _build_pickle_thin_media(new_id, media_info, media_type, media_path, extra_fields), False


### PR DESCRIPTION
Closing — superseded by dev. M8/M11/M12 are already shipped on dev under a different (cleaner) design: a single early `if media_info.get("embedding") is None` at the top of `_convert_one_pickle_media` unifies M8 + M12 in one return path, and the M11 `zip(..., strict=True)` fix landed identically. Nothing left here to merge.