### PR TITLE
docs: close M15 as not a real bug in logical-bug-audit

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -611,8 +611,27 @@ Cross-section interaction agents:
 
 ### Settings / sync
 
-- **M15.** Pending labelset sync stores `dataset_ctx = None` without checking;
-  later `_run_pending_sync` triggers `AttributeError`.
+- ~~**M15.** Pending labelset sync stores `dataset_ctx = None` without
+  checking; later `_run_pending_sync` triggers `AttributeError`.~~ —
+  investigated and closed as not a real bug.
+  `sync_to_labelset_source` captures `dataset_ctx = get_active_context()`
+  (`vtscore/labels/sync.py:97`), and `get_active_context()` /
+  `get_active_detector_context()` are invariantly non-None: their
+  resolution chain (`vtscore/state/core.py:461`, `:614`) falls back to a
+  `_request_missing_*` sentinel inside a Flask request and to
+  `_empty_*_context` outside one. The dead `is None` halves at
+  `vtscore/labels/sync.py:89` and `:207` are what tipped the audit toward
+  this finding, but the `not detector_ctx.labelset_source` half already
+  screens out both sentinels (their `labelset_source` is `None`). When
+  the timer fires, `validated_vote_snapshot` reads `medias` /
+  `dataset_id` off whatever ctx-shaped object was captured, so no
+  `AttributeError` can fire. Two adjacent real-but-milder concerns were
+  noted during the investigation and left open: a misconfigured request
+  with `X-Detector-Id` but no `X-Dataset-Id` silently no-ops the sync
+  (captured sentinel → `validated_vote_snapshot` returns `safe=False`),
+  and the captured ctx references survive an unload-before-fire race
+  inside the 200ms debounce window. Both are silent inconsistencies, not
+  crashes; file separate findings if they ever bite.
 - **M16.** Sync to source on first read after `_synced_users` marker can still
   return stale local config if source changes silently.
 - **M17.** Legacy migration `_maybe_migrate_legacy_settings_locked` pops keys


### PR DESCRIPTION
## Summary

- Investigated audit finding **M15** ("Pending labelset sync stores `dataset_ctx = None` without checking; later `_run_pending_sync` triggers `AttributeError`").
- Verdict: **not a real bug.** `sync_to_labelset_source` captures `dataset_ctx = get_active_context()` (`vtscore/labels/sync.py:97`), and `get_active_context()` / `get_active_detector_context()` are invariantly non-None — they fall back to `_request_missing_*` sentinels inside Flask requests and `_empty_*_context` outside. The dead `is None` halves at lines 89 / 207 are what made the finding look real on a defensive read; the `not detector_ctx.labelset_source` half already screens out both sentinels (their `labelset_source` is `None`). When the timer fires, `validated_vote_snapshot` reads `medias` / `dataset_id` off whatever ctx-shaped object was captured, so no `AttributeError` can occur.
- Closed M15 in `docs/plans/logical-bug-audit.md` with a strike-through and full investigation summary, mirroring how M6 was closed in 68448b62.

## Adjacent concerns noted (not fixed here)

Two silent-no-op behaviours were observed during the investigation and left as future follow-ups:

- A request with `X-Detector-Id` (labelset_source configured) but no `X-Dataset-Id` captures the request-missing sentinel; `validated_vote_snapshot` then returns `safe=False` and the push is dropped with no log line.
- `_PendingSync` holds direct references to the captured ctx objects, so an unload between scheduling and the 200ms timer fire pushes state for a logically-evicted detector.

Both are silent inconsistencies, not crashes. File separate findings if they ever bite.

## Test plan

- [x] Docs-only change; no code paths touched.
- [x] Verified `get_active_context()` and `get_active_detector_context()` resolution chains in `vtscore/state/core.py` never return `None`.
- [x] Confirmed `_FrozenDict("dataset")` on the request-missing sentinel converts cleanly via `dict(...)` in `validated_vote_snapshot`.

https://claude.ai/code/session_017semZ1i1AkHnPYpsn8Frv8

---
_Generated by [Claude Code](https://claude.ai/code/session_017semZ1i1AkHnPYpsn8Frv8)_