### PR TITLE
M7: invalidate cached DetectorContext model on training-setting change

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -524,9 +524,28 @@ Cross-section interaction agents:
   (`vtscore/detectors/resolver.py:_resolve_converter`) while the
   dataset stores the converted-output md5 — track under detector
   findings if it bites.
-- **M7.** `safe_thresholds` is read at *training* time and baked into the
-  detector JSON; per-user threshold preference cannot change after
-  save.
+- ~~**M7. `safe_thresholds` read at training time, cached on DetectorContext, never refreshed**~~
+  — partial close. The audit's "baked into the detector JSON" claim was
+  wrong: the threshold is never serialised (see the "No Persisted Vectors
+  or MLPs" rule in `CLAUDE.md`) — every detector JSON write site lists
+  only `name` / `text_query` / `media_example` / `media_type` / `examples`
+  / `created_at` / `labelset` / `input_spec`. But a narrower staleness
+  was real: the in-memory `DetectorContext.model` / `threshold` cached on
+  detector load were not invalidated when the user changed
+  `safe_thresholds` / `inclusion` / `calibrate_count` /
+  `calibration_fraction`, so `/api/find-label`, `/api/find`, and
+  `/api/auto-detect` (the three consumers that short-circuit on the
+  cached MLP) kept scoring with the prior setting. Sort / vote paths
+  retrained every call and so were already correct. Fixed by a new
+  `vtscore.state.core.invalidate_loaded_detector_models()` that walks
+  every loaded `DetectorContext` and clears `model` + `threshold`; the
+  setters for all four training-relevant settings in
+  `vtscore/state/__init__.py` call it on actual change. The
+  `/api/settings PUT` route now dispatches those three keys through
+  `vtsearch.state` (matching the existing `inclusion` path) so both the
+  dedicated endpoints (`/api/safe-thresholds` etc.) and the bulk
+  settings endpoint trigger invalidation. Regression test:
+  `tests/sorting/test_safe_thresholds.py::TestTrainingSettingsInvalidateLoadedDetector`.
 
 ### Datasets / loaders
 

--- a/tests/sorting/test_safe_thresholds.py
+++ b/tests/sorting/test_safe_thresholds.py
@@ -227,6 +227,85 @@ class TestSafeThresholdsAPI:
         assert "safe_thresholds" in resp.get_json()["errors"]["json"]
 
 
+class TestTrainingSettingsInvalidateLoadedDetector:
+    """Regression for M7: changing a training-relevant setting must drop the
+    cached MLP / threshold on every loaded detector so the next
+    ``/api/find-label`` / ``/api/find`` / ``/api/auto-detect`` retrains
+    under the new setting instead of scoring with a stale threshold.
+    """
+
+    def _loaded_ctx(self):
+        from vtsearch.state import DetectorContext, register_detector_context
+
+        # Sentinel object stands in for a trained MLP — invalidation just
+        # needs to drop the reference, it doesn't introspect the model.
+        ctx = DetectorContext("det-m7", name="m7")
+        ctx.model = object()
+        ctx.threshold = 0.73
+        register_detector_context(ctx)
+        return ctx
+
+    def test_set_safe_thresholds_invalidates_loaded_model(self):
+        from vtsearch.state import get_safe_thresholds, set_safe_thresholds
+
+        ctx = self._loaded_ctx()
+        set_safe_thresholds(not get_safe_thresholds())
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+    def test_set_safe_thresholds_unchanged_keeps_model(self):
+        from vtsearch.state import get_safe_thresholds, set_safe_thresholds
+
+        ctx = self._loaded_ctx()
+        # Set to the current value — no-op, must not invalidate.
+        set_safe_thresholds(get_safe_thresholds())
+        assert ctx.model is not None
+        assert ctx.threshold == 0.73
+
+    def test_set_inclusion_invalidates_loaded_model(self):
+        from vtsearch.state import get_inclusion, set_inclusion
+
+        ctx = self._loaded_ctx()
+        set_inclusion(get_inclusion() + 1)
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+    def test_set_calibrate_count_invalidates_loaded_model(self):
+        from vtsearch.state import get_calibrate_count, set_calibrate_count
+
+        ctx = self._loaded_ctx()
+        set_calibrate_count(get_calibrate_count() + 1)
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+    def test_set_calibration_fraction_invalidates_loaded_model(self):
+        from vtsearch.state import get_calibration_fraction, set_calibration_fraction
+
+        ctx = self._loaded_ctx()
+        new_fraction = 0.25 if get_calibration_fraction() != 0.25 else 0.35
+        set_calibration_fraction(new_fraction)
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+    def test_settings_put_safe_thresholds_invalidates_loaded_model(self, client):
+        ctx = self._loaded_ctx()
+        # PUT through /api/settings routes through vtsearch.state setters
+        # so the invalidation hook fires even on this code path (M7 fix).
+        resp = client.put("/api/settings", json={"safe_thresholds": True})
+        assert resp.status_code == 200
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+    def test_settings_put_calibrate_count_invalidates_loaded_model(self, client):
+        from vtsearch.state import get_calibrate_count
+
+        ctx = self._loaded_ctx()
+        resp = client.put("/api/settings", json={"calibrate_count": get_calibrate_count() + 1})
+        assert resp.status_code == 200
+        assert ctx.model is None
+        assert ctx.threshold == 0.5
+
+
 class TestSafeThresholdsEval:
     """Test that eval functions accept safe_thresholds parameter."""
 

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -207,6 +207,7 @@ def set_inclusion(value: int) -> None:
         from vtscore.detectors.labeling_progress import clear_progress_cache
 
         clear_progress_cache()
+        _core.invalidate_loaded_detector_models()
 
 
 def get_dataset_display_name() -> str | None:
@@ -230,7 +231,10 @@ def get_calibrate_count() -> int:
 
 def set_calibrate_count(value: int) -> None:
     """Set the calibrate count.  Persistence delegated to the registered hook."""
+    changed = value != get_calibrate_count()
     _persist_setting("calibrate_count", value)
+    if changed:
+        _core.invalidate_loaded_detector_models()
 
 
 def get_calibration_fraction() -> float:
@@ -242,7 +246,10 @@ def get_calibration_fraction() -> float:
 
 def set_calibration_fraction(value: float) -> None:
     """Set the calibration fraction.  Persistence delegated to the registered hook."""
+    changed = value != get_calibration_fraction()
     _persist_setting("calibration_fraction", value)
+    if changed:
+        _core.invalidate_loaded_detector_models()
 
 
 def get_safe_thresholds() -> bool:
@@ -254,4 +261,7 @@ def get_safe_thresholds() -> bool:
 
 def set_safe_thresholds(value: bool) -> None:
     """Set the safe-thresholds flag.  Persistence delegated to the registered hook."""
+    changed = value != get_safe_thresholds()
     _persist_setting("safe_thresholds", value)
+    if changed:
+        _core.invalidate_loaded_detector_models()

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -726,6 +726,24 @@ def clear_all_detector_contexts() -> None:
         _empty_detector_context.__init__("")  # type: ignore[misc]
 
 
+def invalidate_loaded_detector_models() -> None:
+    """Drop the cached MLP and threshold on every loaded detector context.
+
+    Called by the setters of training-relevant settings (``inclusion``,
+    ``safe_thresholds``, ``calibrate_count``, ``calibration_fraction``) so
+    the next consumer that would otherwise short-circuit on the cached
+    ``det_ctx.model`` / ``det_ctx.threshold`` (``/api/find-label``,
+    ``/api/find``, ``/api/auto-detect``) retrains under the new setting.
+
+    Sort / vote paths already retrain every call, so this is purely about
+    making the cached-MLP consumers honour live setting changes.
+    """
+    with _state_lock:
+        for ctx in _detector_contexts.values():
+            ctx.model = None
+            ctx.threshold = 0.5
+
+
 # ---------------------------------------------------------------------------
 # Scalar state accessors
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -27,6 +27,11 @@ from flask_smorest import Blueprint, abort
 
 from vtsearch import settings
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
+from vtsearch.state import (
+    set_calibrate_count as _state_set_calibrate_count,
+    set_calibration_fraction as _state_set_calibration_fraction,
+    set_safe_thresholds as _state_set_safe_thresholds,
+)
 
 settings_bp = Blueprint(
     "settings",
@@ -39,13 +44,21 @@ settings_bp = Blueprint(
 # ``vtsearch.settings`` and enforce range clamping / value validation,
 # so this module's only job is to dispatch — marshmallow already
 # validated the *types*.
+#
+# The training-relevant settings (``safe_thresholds``, ``calibrate_count``,
+# ``calibration_fraction``) route through ``vtsearch.state`` rather than
+# ``vtsearch.settings`` so the state setter's side-effect
+# (``invalidate_loaded_detector_models``) fires and the cached MLP /
+# threshold on every loaded detector context is dropped — otherwise
+# ``/api/find-label`` / ``/api/find`` / ``/api/auto-detect`` would keep
+# scoring with a threshold computed under the prior setting (M7).
 _SCALAR_SETTERS: dict[str, Callable[[Any], Any]] = {
     "volume": settings.set_volume,
     "theme": settings.set_theme,
     "enrich_descriptions": settings.set_enrich_descriptions,
-    "safe_thresholds": settings.set_safe_thresholds,
-    "calibrate_count": settings.set_calibrate_count,
-    "calibration_fraction": settings.set_calibration_fraction,
+    "safe_thresholds": _state_set_safe_thresholds,
+    "calibrate_count": _state_set_calibrate_count,
+    "calibration_fraction": _state_set_calibration_fraction,
     "audio_playing": settings.set_audio_playing,
     "swipe_animation": settings.set_swipe_animation,
     "show_metadata": settings.set_show_metadata,


### PR DESCRIPTION
## Summary

The audit's M7 claim that `safe_thresholds` is "baked into the detector JSON" is false — the threshold is never serialised (see the "No Persisted Vectors or MLPs" rule in `CLAUDE.md`), and every training path re-reads `get_safe_thresholds()` live. But a narrower staleness was real: `DetectorContext.model` / `threshold` are cached on detector load and reused by `/api/find-label`, `/api/find`, and `/api/auto-detect` without retraining, so a mid-session setting change wasn't honoured until the next sort or vote. The same staleness applied to `inclusion`, `calibrate_count`, and `calibration_fraction`.

- New `vtscore.state.core.invalidate_loaded_detector_models()` walks every loaded `DetectorContext` and clears `model` + `threshold`. The four setters in `vtscore/state/__init__.py` call it on actual change.
- `/api/settings PUT` now routes `safe_thresholds` / `calibrate_count` / `calibration_fraction` through `vtsearch.state` (matching the existing `inclusion` path) so both the dedicated endpoints and the bulk settings endpoint trigger invalidation.
- M7 marked partially closed in `docs/plans/logical-bug-audit.md` with the corrected diagnosis.

## Test plan

- [x] `./run-tests.sh sorting` — 245 passed
- [x] `./run-tests.sh` — 4076 passed, 1 skipped
- [x] `./run-tests.sh vtscore-clean` — 957 passed
- [x] New regression class `TestTrainingSettingsInvalidateLoadedDetector` covers all four setters plus the `/api/settings PUT` path

https://claude.ai/code/session_017tQ8nzmnfXLxQVPgxXszWY

---
_Generated by [Claude Code](https://claude.ai/code/session_0176LTC77cKLr6sjYv6Pqkd1)_