### PR TITLE
M17: defer legacy-migration cache pop until server-file write succeeds

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -555,9 +555,23 @@ Cross-section interaction agents:
   later `_run_pending_sync` triggers `AttributeError`.
 - **M16.** Sync to source on first read after `_synced_users` marker can still
   return stale local config if source changes silently.
-- **M17.** Legacy migration `_maybe_migrate_legacy_settings_locked` pops keys
+- ~~**M17.** Legacy migration `_maybe_migrate_legacy_settings_locked` pops keys
   from in-memory cache before per-user disk write; per-user-write
-  failure leaves cache and disk diverged.
+  failure leaves cache and disk diverged.~~ — investigated and partially
+  closed (2026-05-21). The literal ordering claim is **inverted**:
+  `_maybe_migrate_legacy_settings_locked` writes the user file
+  *before* popping `_server_cache`, and returns early on user-write
+  failure, so the divergence described is impossible. A separate,
+  narrower divergence existed in the *server*-file rewrite step: if
+  `_atomic_write(_server_settings_path(), _server_cache)` raised
+  after the in-memory pop, `_server_cache` (legacy keys gone) and
+  the on-disk server file (legacy keys still present) would silently
+  disagree until the next `_mutate_server_locked()` re-read the disk.
+  Fix: compute the server-tier-only candidate first, write it, and only
+  pop the in-memory cache after the disk write returns successfully
+  (early-return on failure mirrors the user-write branch). Failure-path
+  coverage added in `tests/core/test_per_user_settings.py` for both
+  the user-write and server-rewrite branches.
 
 ### Embedding / training
 

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -127,6 +127,99 @@ class TestLegacyMigration:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()
 
+    def test_user_write_failure_keeps_cache_and_disk_consistent(self, tmp_path, monkeypatch):
+        """If the per-user write fails, the in-memory cache and on-disk
+        server file must stay aligned (no half-migrated state)."""
+        from vtsearch import settings as settings_mod
+
+        legacy = {
+            "saved_datasets_dir": "/tmp/legacy",
+            "volume": 0.33,
+            "theme": "light",
+        }
+        server_path = tmp_path / "settings.json"
+        server_path.write_text(json.dumps(legacy))
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
+        settings_mod.set_user_data_dir_override(tmp_path / "users")
+        settings_mod.reset()
+
+        real_atomic_write = settings_mod._atomic_write
+        user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
+
+        def failing_atomic_write(path, data):
+            if path == user_settings_path:
+                raise OSError("simulated user-file write failure")
+            return real_atomic_write(path, data)
+
+        monkeypatch.setattr(settings_mod, "_atomic_write", failing_atomic_write)
+        try:
+            # Triggers migration; user-file write raises and is swallowed.
+            settings_mod.get_saved_datasets_dir()
+
+            # Server file on disk is untouched (legacy keys still present).
+            on_disk = json.loads(server_path.read_text())
+            assert on_disk == legacy
+
+            # In-memory server cache matches disk (legacy keys still there).
+            assert settings_mod._server_cache is not None
+            assert settings_mod._server_cache.get("volume") == 0.33
+            assert settings_mod._server_cache.get("theme") == "light"
+
+            # No phantom user file was created.
+            assert not user_settings_path.exists()
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
+
+    def test_server_rewrite_failure_keeps_cache_and_disk_consistent(self, tmp_path, monkeypatch):
+        """If the server-file rewrite fails after the user write succeeds,
+        the in-memory ``_server_cache`` must not have legacy keys popped —
+        otherwise it would silently disagree with the on-disk server file."""
+        from vtsearch import settings as settings_mod
+
+        legacy = {
+            "saved_datasets_dir": "/tmp/legacy",
+            "volume": 0.33,
+            "theme": "light",
+        }
+        server_path = tmp_path / "settings.json"
+        server_path.write_text(json.dumps(legacy))
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
+        settings_mod.set_user_data_dir_override(tmp_path / "users")
+        settings_mod.reset()
+
+        real_atomic_write = settings_mod._atomic_write
+        user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
+
+        def failing_atomic_write(path, data):
+            if path == server_path:
+                raise OSError("simulated server-file write failure")
+            return real_atomic_write(path, data)
+
+        monkeypatch.setattr(settings_mod, "_atomic_write", failing_atomic_write)
+        try:
+            # Triggers migration; user write succeeds, server rewrite raises.
+            settings_mod.get_saved_datasets_dir()
+
+            # User file was written successfully.
+            assert user_settings_path.exists()
+            user_data = json.loads(user_settings_path.read_text())
+            assert user_data["volume"] == 0.33
+            assert user_data["theme"] == "light"
+
+            # Server file on disk still has legacy keys (rewrite failed).
+            on_disk = json.loads(server_path.read_text())
+            assert on_disk == legacy
+
+            # Crucially, in-memory cache matches disk — legacy keys NOT popped.
+            assert settings_mod._server_cache is not None
+            assert settings_mod._server_cache.get("volume") == 0.33
+            assert settings_mod._server_cache.get("theme") == "light"
+            assert settings_mod._server_cache.get("saved_datasets_dir") == "/tmp/legacy"
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
+
 
 class TestBackgroundThreadPropagation:
     def test_thread_local_user_routes_writes(self, isolated_settings):

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -394,14 +394,17 @@ def _maybe_migrate_legacy_settings_locked() -> None:
         logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
         return
 
-    # Rewrite the server file with only server-tier keys.
+    # Build the server-tier-only shape first; a failure here must not pop
+    # the in-memory cache, or _server_cache and disk would silently diverge.
+    new_server = {k: v for k, v in _server_cache.items() if k in _SERVER_KEYS}
+    try:
+        _atomic_write(_server_settings_path(), new_server)
+    except Exception as exc:
+        logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
+        return
     for k in list(_server_cache.keys()):
         if k not in _SERVER_KEYS:
             _server_cache.pop(k, None)
-    try:
-        _atomic_write(_server_settings_path(), _server_cache)
-    except Exception as exc:
-        logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
 
     # Refresh the default user's cache if it was already materialised
     # (unlikely, since this runs from _ensure_server_loaded, but safe).


### PR DESCRIPTION
## Summary

The audit's M17 literal claim ("pops in-memory cache **before** per-user disk write; per-user-write failure leaves cache and disk diverged") is **inverted** for current `dev`: `_maybe_migrate_legacy_settings_locked` writes the user file *before* popping `_server_cache`, and returns early on user-write failure — so the described divergence is impossible.

A **narrower, real divergence** existed in the server-file rewrite step: if `_atomic_write(_server_settings_path(), _server_cache)` raised after the in-memory pop, `_server_cache` (legacy keys gone) and the on-disk server file (legacy keys still present) silently disagreed until the next `_mutate_server_locked()` re-read disk.

- Fix: build the server-tier-only candidate dict first, write it, and only pop legacy keys from `_server_cache` after the write returns. On failure, log and return — mirroring the user-write branch.
- Added two failure-path tests under `TestLegacyMigration` covering the user-write and server-rewrite branches (the existing test only covered the happy path).
- Marked M17 closed in `docs/plans/logical-bug-audit.md` with a note explaining the inverted literal claim and the actual fix.

## Test plan

- [x] `./run-tests.sh core` — 572 passed
- [x] `./run-tests.sh` — 4071 passed, 1 skipped (one flaky `tests_lib/io` failure on the first run did not reproduce on rerun and is unrelated to this change)

https://claude.ai/code/session_01Buqgr7skvPJ4i71KoMJs8B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Buqgr7skvPJ4i71KoMJs8B)_