### PR TITLE
Fix M16: settings sync staleness + TOCTOU race + first-failure lockout

### DIFF
--- a/app.py
+++ b/app.py
@@ -511,7 +511,8 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
 
     Per-user ``settings_source`` sync runs lazily on each user's first
     settings access (see
-    :func:`vtsearch.settings._maybe_sync_from_source_locked`), not at
+    :func:`vtsearch.settings._run_sync_from_source`) and re-fires
+    whenever the source's ``peek_version`` token changes, not at
     server boot — there is no server-wide user to sync for.
     """
     print(f"\U0001f680 Running in {mode_label} mode", flush=True)

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -667,8 +667,33 @@ Cross-section interaction agents:
   and the captured ctx references survive an unload-before-fire race
   inside the 200ms debounce window. Both are silent inconsistencies, not
   crashes; file separate findings if they ever bite.
-- **M16.** Sync to source on first read after `_synced_users` marker can still
-  return stale local config if source changes silently.
+- ~~**M16.** Sync to source on first read after `_synced_users` marker can
+  still return stale local config if source changes silently.~~ — fixed
+  alongside two adjacent latent defects in `_ensure_user_loaded`.
+  Replaced the `_synced_users: set[str]` "claim-then-sync" marker with
+  per-user `_UserSyncState` bookkeeping (`last_version`,
+  `last_check_monotonic`, `last_sync_succeeded`, `dirty_keys`) protected
+  by a per-user `_per_user_sync_lock` RLock, so:
+  (a) the TOCTOU race where a concurrent reader saw the marker before
+  the actual sync had populated the cache is gone — the lock now
+  serialises the decide-and-sync slow path,
+  (b) a transient first-sync failure no longer permanently locks the
+  user out of sync (`last_sync_succeeded` stays `False` and the slow
+  path retries past a 1-second rate-limit window),
+  (c) a new `SyncSource.peek_version` hook (default `None`, implemented
+  for `server_json_file` via `st_mtime_ns`) makes an upstream change
+  visible automatically on the next read after the freshness window
+  elapses, instead of requiring manual `POST /api/settings-sources/sync`
+  or process restart.  Auto re-sync respects local `dirty_keys` so a
+  freshly clicked toggle isn't silently overwritten by an upstream
+  value; manual `sync_from_settings_source` ignores dirty markers
+  (explicit user pull) and clears them.  `_sync_to_source` clears
+  dirty markers on a successful export (source now matches local).
+  Regression tests:
+  `tests/io/test_sync_sources.py::TestSyncFromSourceFreshness`
+  (six cases — version-bump detection, first-failure retry, concurrent
+  reader sees post-sync cache, dirty-key skip on auto re-sync, manual
+  sync clears dirty, freshness window avoids repeat probes).
 - ~~**M17.** Legacy migration `_maybe_migrate_legacy_settings_locked` pops keys
   from in-memory cache before per-user disk write; per-user-write
   failure leaves cache and disk diverged.~~ — investigated and partially

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -639,6 +639,258 @@ class TestStartupAutoImport:
 
 
 # ---------------------------------------------------------------------------
+# M16 regression tests — lazy auto-sync semantics (race, retry, freshness)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFromSourceFreshness:
+    """Regression tests for M16 and the two adjacent defects.
+
+    See ``docs/plans/logical-bug-audit.md`` § Settings / sync — M16.
+    """
+
+    def test_source_file_change_triggers_resync_on_next_read(self, tmp_path, isolated_settings):
+        """Auto re-sync fires when ``peek_version`` (st_mtime_ns) bumps.
+
+        Before the M16 fix this test would have failed: ``_synced_users``
+        recorded "synced once" and no subsequent read pulled the new
+        value, so ``get_volume`` returned the stale local cache.
+        """
+        import os
+
+        from vtsearch import settings
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+
+        # First read primes the cache: source has volume=0.40.
+        source_file.write_text(json.dumps({"volume": 0.40}))
+        # Bump mtime past the just-stamped post-configure sync token.
+        new_mtime = source_file.stat().st_mtime_ns + 10_000_000_000
+        os.utime(source_file, ns=(new_mtime, new_mtime))
+        # Push past the 1s freshness window so the slow path probes.
+        settings._sync_state["default"].last_check_monotonic -= 5.0
+        assert settings.get_volume() == 0.40
+
+        # External writer overwrites the source.
+        source_file.write_text(json.dumps({"volume": 0.80}))
+        new_mtime += 10_000_000_000
+        os.utime(source_file, ns=(new_mtime, new_mtime))
+        # Force the freshness window open again.
+        settings._sync_state["default"].last_check_monotonic -= 5.0
+
+        # Next read picks up the new source value automatically.
+        assert settings.get_volume() == 0.80
+
+    def test_first_sync_failure_does_not_lock_out_retry(self, tmp_path, isolated_settings, monkeypatch):
+        """A transient source failure on the first sync must allow retry.
+
+        Before the M16 fix this test would have failed: ``_synced_users``
+        was set inside the lock *before* the sync ran, so even if the
+        first attempt raised, the user was permanently marked synced
+        and the source was never tried again until process restart.
+        """
+        from vtsearch import settings
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+        source_file.write_text(json.dumps({"volume": 0.55}))
+
+        src = get_settings_source("server_json_file")
+        assert src is not None
+        calls = {"n": 0}
+        real_load = src.load
+
+        def flaky_load(field_values):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("transient")
+            return real_load(field_values)
+
+        monkeypatch.setattr(src, "load", flaky_load)
+        # Reset state so the first read forces a sync attempt.
+        settings._sync_state.pop("default", None)
+        # First read: load() raises, last_sync_succeeded stays False.
+        settings.get_volume()
+        state = settings._sync_state.get("default")
+        assert state is not None
+        assert state.last_sync_succeeded is False
+        # Push past the retry rate-limit window.
+        state.last_check_monotonic -= 5.0
+        # Second read: load() succeeds, value gets pulled from source.
+        assert settings.get_volume() == 0.55
+        assert calls["n"] >= 2
+
+    def test_concurrent_readers_observe_post_sync_cache(self, tmp_path, isolated_settings):
+        """A second thread entering during the first sync must not see stale local.
+
+        Before the M16 fix this test would have failed: the marker was
+        set before the sync ran (TOCTOU race), so a concurrent reader
+        would see the pre-sync local cache.  The per-user sync RLock
+        now serialises the slow path so the second thread blocks until
+        the first finishes and sees the freshly-applied source values.
+        """
+        import threading
+
+        from vtsearch import settings
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+        source_file.write_text(json.dumps({"volume": 0.31}))
+
+        # Force a fresh sync attempt and slow down the source load so
+        # the racing window is wide and deterministic.
+        settings._sync_state.pop("default", None)
+        src = get_settings_source("server_json_file")
+        assert src is not None
+        real_load = src.load
+        first_load_in_flight = threading.Event()
+        release_first_load = threading.Event()
+
+        def slow_load(field_values):
+            if not first_load_in_flight.is_set():
+                first_load_in_flight.set()
+                release_first_load.wait(timeout=5)
+            return real_load(field_values)
+
+        src.load = slow_load  # type: ignore[assignment]
+
+        results: dict[str, float] = {}
+
+        def reader(name: str):
+            results[name] = settings.get_volume()
+
+        try:
+            t_a = threading.Thread(target=reader, args=("a",))
+            t_a.start()
+            assert first_load_in_flight.wait(timeout=5), "first load never started"
+            t_b = threading.Thread(target=reader, args=("b",))
+            t_b.start()
+            # Let A's sync complete.
+            release_first_load.set()
+            t_a.join(timeout=5)
+            t_b.join(timeout=5)
+        finally:
+            src.load = real_load  # type: ignore[assignment]
+
+        # Both threads must observe the post-sync value.  Before the
+        # race fix, thread B would have observed the pre-sync local
+        # default for ``volume``.
+        assert results["a"] == 0.31
+        assert results["b"] == 0.31
+
+    def test_local_write_dirty_key_survives_auto_resync(self, tmp_path, isolated_settings):
+        """An auto re-sync (version-bump) must not silently overwrite a
+        key the user has just written locally.
+        """
+        import os
+
+        from vtsearch import settings
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+
+        # User locally sets volume to 0.91.  ``_sync_to_source`` exports
+        # this, so source == local == 0.91, dirty_keys cleared.
+        settings.set_volume(0.91)
+
+        # Simulate an external writer who's seen an older volume value.
+        # We need to write the file directly without going through our
+        # ``_sync_to_source``, then bump mtime past the rate-limit window.
+        source_file.write_text(json.dumps({"volume": 0.10, "theme": "highviz"}))
+        new_mtime = source_file.stat().st_mtime_ns + 10_000_000_000
+        os.utime(source_file, ns=(new_mtime, new_mtime))
+
+        # Re-introduce the dirty marker as if the local write happened
+        # *after* the external write but *before* ``_sync_to_source``
+        # could update the source.  In real life this is the race
+        # window: local writer flips ``volume``, an external process
+        # writes a different value to the source file, and an auto
+        # re-sync fires before ``_sync_to_source`` catches up.
+        settings._sync_state["default"].dirty_keys.add("volume")
+        settings._sync_state["default"].last_check_monotonic -= 5.0
+        settings._sync_state["default"].last_version = None  # force probe
+
+        # Next read: auto re-sync runs, sees ``volume`` is dirty → skips
+        # it, applies the other source keys.  Local ``volume`` survives.
+        assert settings.get_volume() == 0.91
+        assert settings.get_theme() == "highviz"
+
+    def test_manual_sync_clears_dirty_keys(self, tmp_path, isolated_settings):
+        """A manual POST sync ignores ``dirty_keys`` (explicit user pull)."""
+        from vtsearch import settings
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+        settings.set_volume(0.91)  # local + source = 0.91
+        settings._sync_state["default"].dirty_keys.add("volume")  # simulate unflushed dirty
+
+        source_file.write_text(json.dumps({"volume": 0.10}))
+
+        # Manual sync explicitly overrides local edits.
+        settings.sync_from_settings_source()
+        assert settings.get_volume() == 0.10
+        assert not settings._sync_state["default"].dirty_keys
+
+    def test_freshness_window_avoids_repeat_probes(self, tmp_path, isolated_settings, monkeypatch):
+        """Inside the 1s rate-limit window the slow path doesn't probe.
+
+        Pins the freshness optimisation: settings reads should stay hot
+        even with a configured source.  Without it, every
+        ``get_volume()`` would stat the source file.
+        """
+        from vtsearch import settings
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source_file = tmp_path / "remote.json"
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+        source_file.write_text(json.dumps({"volume": 0.40}))
+
+        src = get_settings_source("server_json_file")
+        assert src is not None
+        probes = {"n": 0}
+        real_peek = src.peek_version
+
+        def counted(fv):
+            probes["n"] += 1
+            return real_peek(fv)
+
+        monkeypatch.setattr(src, "peek_version", counted)
+
+        # Many reads inside the freshness window — at most one probe.
+        baseline = probes["n"]
+        for _ in range(20):
+            settings.get_volume()
+        assert probes["n"] - baseline <= 1
+
+
+# ---------------------------------------------------------------------------
 # DetectorContext.labelset_source field
 # ---------------------------------------------------------------------------
 

--- a/vtscore/sync/__init__.py
+++ b/vtscore/sync/__init__.py
@@ -53,3 +53,18 @@ class SyncSource(PluginBase, Generic[LoadT, SaveT]):
             NotImplementedError: If the subclass has not implemented this.
         """
         raise NotImplementedError(f"{type(self).__name__}.save() is not implemented")
+
+    def peek_version(self, field_values: dict[str, Any]) -> Any | None:
+        """Return an opaque token representing the source's current version.
+
+        Used to cheaply detect whether the source has changed since the
+        last successful :meth:`load`.  The caller compares the returned
+        token against a previously-stashed value; if they differ, a full
+        load is due.
+
+        Subclasses should override with a cheap freshness probe (e.g.
+        ``st_mtime_ns`` for a local file, ``ETag`` for an HTTP source).
+        The default returns ``None``, which means *"I can't cheaply
+        check"* — the caller falls back to explicit manual sync.
+        """
+        return None

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -25,7 +25,9 @@ import json
 import logging
 import os
 import threading
+import time
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -176,20 +178,83 @@ _server_cache: dict[str, Any] | None = None
 # Per-user caches keyed by username.
 _user_caches: dict[str, dict[str, Any]] = {}
 
-# Set of usernames whose sync-from-source has run this process lifetime;
-# guards lazy startup-equivalent sync per user.
-_synced_users: set[str] = set()
+
+@dataclass
+class _UserSyncState:
+    """Per-user sync-from-source bookkeeping.
+
+    - ``last_version``: opaque token from :meth:`SettingsSource.peek_version`
+      stashed at the last successful sync.  Compared on every read to
+      decide whether a re-sync is due.  ``None`` if the source can't
+      cheaply check freshness.
+    - ``last_check_monotonic``: :func:`time.monotonic` of the last peek.
+      Used to rate-limit ``peek_version`` calls so a hot read path doesn't
+      stat the source file on every ``get_volume()``.
+    - ``last_sync_succeeded``: ``False`` means the user has never been
+      successfully synced this process lifetime (or the last attempt
+      failed).  A transient source failure no longer permanently locks
+      the user out of sync — the slow-path retries (rate-limited) until
+      it succeeds.
+    - ``dirty_keys``: keys the user has set locally since the last
+      successful :func:`_sync_to_source`.  An auto re-sync (from a
+      version-bump on the source) skips these keys so a freshly clicked
+      local toggle isn't silently overwritten by an upstream value.
+      Cleared whenever ``_sync_to_source`` succeeds (because the source
+      then matches local) or when a manual :func:`sync_from_settings_source`
+      runs (explicit user pull).
+    """
+
+    last_version: Any = None
+    last_check_monotonic: float = 0.0
+    last_sync_succeeded: bool = False
+    dirty_keys: set[str] = field(default_factory=set)
+
+
+# Per-user sync bookkeeping.  Replaces the old ``_synced_users: set[str]``,
+# which couldn't distinguish "never synced" from "synced ages ago" or
+# "tried once and failed."
+_sync_state: dict[str, _UserSyncState] = {}
 
 # One-shot legacy-migration guard.
 _legacy_migrated: bool = False
 
-# Reentrant lock covering both tiers' caches and the syncing flag.
+# Reentrant lock covering both tiers' caches, the syncing flag, and
+# ``_sync_state``.  Not held while running the actual sync I/O.
 _settings_lock = threading.RLock()
+
+# Per-user reentrant locks wrapping the sync-from-source critical
+# section.  Acquiring this means "I'm responsible for this user's
+# sync-from-source pass right now"; another thread for the same user
+# blocks until we're done and then sees the freshly-applied cache.
+# Reentrant so a setter called from inside ``_apply_settings`` (which
+# routes back through ``_ensure_user_loaded``) doesn't self-deadlock.
+_user_sync_locks: dict[str, threading.RLock] = {}
+_user_sync_locks_guard = threading.Lock()
+
+# Rate-limit window for the ``peek_version`` freshness probe.  Settings
+# reads happen in hot paths (``before_request``, every accessor); we
+# don't want to stat the source file on every one.  The first read in a
+# window does the probe; subsequent reads inside the window short-circuit
+# back to the local cache.
+_FRESHNESS_CHECK_INTERVAL = 1.0
 
 # Set of usernames currently being imported from their settings_source.
 # A per-user save that fires while the user is in this set skips
-# ``_sync_to_source`` so the import isn't immediately re-exported.
+# ``_sync_to_source`` so the import isn't immediately re-exported.  Also
+# acts as a recursion guard for ``_ensure_user_loaded``: a setter called
+# from inside ``_apply_settings`` re-enters the function but must skip
+# the sync path.
 _syncing: set[str] = set()
+
+
+def _per_user_sync_lock(username: str) -> threading.RLock:
+    """Return (creating if needed) the sync RLock for *username*."""
+    with _user_sync_locks_guard:
+        lock = _user_sync_locks.get(username)
+        if lock is None:
+            lock = threading.RLock()
+            _user_sync_locks[username] = lock
+        return lock
 
 
 # ---------------------------------------------------------------------------
@@ -332,15 +397,21 @@ def _ensure_server_loaded() -> dict[str, Any]:
 
 
 def _ensure_user_loaded(username: str) -> dict[str, Any]:
-    """Load *username*'s per-user cache on first access.
+    """Load *username*'s per-user cache on first access and reconcile with the source.
 
-    Sync-from-source is triggered the first time a user's cache is
-    populated each process lifetime — but **outside** the in-process
-    settings lock, because the setters it invokes acquire
-    ``_file_lock`` first and would otherwise invert the canonical lock
-    order with another thread that's reading the same user's cache.
+    Fast path: take ``_settings_lock`` briefly, hydrate the local cache
+    if needed, and return immediately when no sync work is due (no
+    source configured, freshness window still valid, or we're already
+    inside an import for this user).
+
+    Slow path: take the per-user sync RLock so the actual ``peek_version``
+    + ``load`` + ``_apply_settings`` work happens serially for the same
+    user, and concurrent readers see the post-sync cache when they
+    acquire the lock.  Without this lock the previous design had a
+    TOCTOU race: thread A set the "synced" marker before running the
+    sync, so a concurrent thread B saw the marker and returned the
+    pre-sync local cache.
     """
-    needs_sync = False
     with _settings_lock:
         cache = _user_caches.get(username)
         if cache is None:
@@ -352,14 +423,168 @@ def _ensure_user_loaded(username: str) -> dict[str, Any]:
             if cache is None:
                 cache = _load_path(_user_settings_path(username))
                 _user_caches[username] = cache
-        if username not in _synced_users:
-            _synced_users.add(username)
-            needs_sync = True
+        # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
+        # this function while the outer call holds the sync lock.  Skip
+        # the sync path so we don't recurse or fire another peek probe.
+        if username in _syncing:
+            return cache
+        cfg = cache.get("settings_source")
+        has_source = isinstance(cfg, dict) and bool(cfg.get("source_name"))
+        if not has_source:
+            return cache
+        state = _sync_state.get(username)
+        if state is not None and state.last_sync_succeeded:
+            now = time.monotonic()
+            if now - state.last_check_monotonic < _FRESHNESS_CHECK_INTERVAL:
+                # Hot path: a recent successful sync exists and we're
+                # inside the rate-limit window.  No probe, no lock.
+                return cache
 
-    if needs_sync:
-        _maybe_sync_from_source(username)
+    sync_lock = _per_user_sync_lock(username)
+    with sync_lock:
+        if _needs_sync_from_source(username):
+            _run_sync_from_source(username)
 
     return _user_caches[username]
+
+
+def _needs_sync_from_source(username: str) -> bool:
+    """Decide whether a sync-from-source pass is due for *username*.
+
+    Called with the per-user sync lock held (so the decision and the
+    subsequent sync are atomic with respect to other threads on the
+    same user).  A sync is due when:
+
+    1. We've never attempted one this process lifetime, OR
+    2. The last attempt failed and the rate-limit window has elapsed
+       (so a transient source outage no longer permanently locks
+       the user out of sync — old ``_synced_users`` did exactly that), OR
+    3. A previous attempt succeeded but the source's
+       :meth:`SettingsSource.peek_version` token has changed since
+       (source file rewritten by another process, hand-edited, etc.).
+
+    Refreshes ``last_check_monotonic`` on the no-sync paths so the
+    freshness probe is rate-limited even when state is being mutated.
+    """
+    with _settings_lock:
+        state = _sync_state.get(username)
+        cache_cfg = _user_caches.get(username, {}).get("settings_source")
+    if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
+        return False
+
+    now = time.monotonic()
+
+    if state is None or state.last_check_monotonic == 0.0:
+        # No state, or state exists only because a setter populated it
+        # via ``_mark_user_keys_dirty`` before we'd ever talked to the
+        # source.  Either way: first sync attempt is due.
+        return True
+
+    if not state.last_sync_succeeded:
+        # Rate-limited retry after a failure.
+        return (now - state.last_check_monotonic) >= _FRESHNESS_CHECK_INTERVAL
+
+    # Last attempt succeeded.  If we're still inside the freshness
+    # window, skip (the fast path in ``_ensure_user_loaded`` usually
+    # handles this; keep the check here in case the slow path was
+    # entered via a different code route).
+    if (now - state.last_check_monotonic) < _FRESHNESS_CHECK_INTERVAL:
+        return False
+
+    # Window elapsed — cheap probe to detect upstream changes.
+    from vtsearch.settings_io.sources import get_settings_source
+
+    source = get_settings_source(cache_cfg["source_name"])
+    if source is None:
+        return False
+    field_values = cache_cfg.get("field_values", {})
+    try:
+        current_version = source.peek_version(field_values)
+    except Exception:
+        # Transient peek failure — back off until next window, keep
+        # serving the local cache.
+        with _settings_lock:
+            s = _sync_state.get(username)
+            if s is not None:
+                s.last_check_monotonic = now
+        return False
+
+    if current_version is None or current_version == state.last_version:
+        # Source can't cheaply check, or unchanged since last sync.
+        with _settings_lock:
+            s = _sync_state.get(username)
+            if s is not None:
+                s.last_check_monotonic = now
+        return False
+
+    return True
+
+
+def _run_sync_from_source(username: str) -> None:
+    """Pull settings from *username*'s configured source and apply them.
+
+    Called with the per-user sync lock held.  Respects ``dirty_keys``:
+    keys the user has set locally since the last successful
+    ``_sync_to_source`` are skipped so a clicked-toggle isn't silently
+    overwritten by an upstream value.
+
+    On success: stash the new ``peek_version`` token, mark the user as
+    successfully synced, and refresh the freshness-check timestamp.
+    On failure: log the error and refresh only the check timestamp
+    (``last_sync_succeeded`` stays ``False``) so the slow path retries
+    once the rate-limit window elapses.
+    """
+    with _settings_lock:
+        cache_cfg = _user_caches.get(username, {}).get("settings_source")
+        state = _sync_state.setdefault(username, _UserSyncState())
+        dirty_snapshot = set(state.dirty_keys)
+    if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
+        return
+
+    from vtsearch.settings_io.sources import get_settings_source
+
+    source = get_settings_source(cache_cfg["source_name"])
+    if source is None:
+        logger.warning("Unknown settings source: %s", cache_cfg["source_name"])
+        return
+
+    field_values = cache_cfg.get("field_values", {})
+    new_version: Any = None
+    try:
+        new_version = source.peek_version(field_values)
+    except Exception:
+        new_version = None
+
+    try:
+        imported = source.load(field_values)
+    except Exception as exc:
+        logger.exception("Failed to load from settings source for %s: %s", username, exc)
+        with _settings_lock:
+            state = _sync_state.setdefault(username, _UserSyncState())
+            state.last_check_monotonic = time.monotonic()
+            # Leave last_sync_succeeded as-is: a transient failure after
+            # a previous success must not erase the success flag (the
+            # local cache is still valid).
+        return
+
+    if imported:
+        with _settings_lock:
+            _syncing.add(username)
+        try:
+            _apply_settings(imported, skip_keys=dirty_snapshot)
+        finally:
+            with _settings_lock:
+                _syncing.discard(username)
+
+    with _settings_lock:
+        state = _sync_state.setdefault(username, _UserSyncState())
+        state.last_version = new_version
+        state.last_check_monotonic = time.monotonic()
+        state.last_sync_succeeded = True
+        # dirty_keys preserved across an auto re-sync — the user's local
+        # edits stay protected until an explicit ``_sync_to_source`` push
+        # confirms the source matches local (which clears them) or a
+        # manual POST sync clears them on purpose.
 
 
 def _maybe_migrate_legacy_settings_locked() -> None:
@@ -497,6 +722,10 @@ def mutate_user(mutator) -> None:
     _ensure_user_loaded(username)
     sync_data = _mutate_user_locked(username, mutator)
     if sync_data is not None:
+        # ``mutate_user`` can change arbitrary top-level keys; mark
+        # every exportable key dirty so an auto re-sync between now
+        # and the ``_sync_to_source`` push doesn't clobber the mutation.
+        _mark_user_keys_dirty(username, [k for k in sync_data if k not in _EXCLUDE_FROM_SOURCE_EXPORT])
         _sync_to_source(username, sync_data)
 
 
@@ -535,10 +764,25 @@ def _write_value(key: str, value: Any) -> None:
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
-    _ensure_user_loaded(username)  # one-shot lazy sync-from-source
+    _ensure_user_loaded(username)  # reconciles with source if due
     sync_data = _mutate_user_locked(username, lambda c: c.__setitem__(key, value))
     if sync_data is not None:
+        # User-initiated write (not from an in-progress import).  Mark
+        # this key dirty so an auto re-sync running between now and the
+        # ``_sync_to_source`` push leaves it alone — the source push
+        # below clears the dirty flag again once it succeeds.
+        if key not in _EXCLUDE_FROM_SOURCE_EXPORT:
+            _mark_user_keys_dirty(username, [key])
         _sync_to_source(username, sync_data)
+
+
+def _mark_user_keys_dirty(username: str, keys) -> None:
+    """Add *keys* to the user's ``dirty_keys`` set."""
+    if not keys:
+        return
+    with _settings_lock:
+        state = _sync_state.setdefault(username, _UserSyncState())
+        state.dirty_keys.update(keys)
 
 
 # ---------------------------------------------------------------------------
@@ -1019,9 +1263,11 @@ def reset() -> None:
     with _settings_lock:
         _server_cache = None
         _user_caches.clear()
-        _synced_users.clear()
+        _sync_state.clear()
         _syncing.clear()
         _legacy_migrated = False
+    with _user_sync_locks_guard:
+        _user_sync_locks.clear()
 
 
 # -------------------------------------------------------------------
@@ -1065,7 +1311,18 @@ def set_settings_source_config(config: dict[str, Any] | None) -> None:
             cache["settings_source"] = config
 
     sync_data = _mutate_user_locked(username, _apply)
+    if config is None:
+        # Source cleared — drop any cached sync state so a future
+        # configure-then-read doesn't believe it's still "synced" to
+        # the previously-configured target.
+        with _settings_lock:
+            _sync_state.pop(username, None)
+        return
     if sync_data is not None:
+        # ``_sync_to_source`` exports the full local dict to the new
+        # source location and stamps the user as freshly synced
+        # (so the next ``_ensure_user_loaded`` doesn't immediately
+        # pull what we just pushed).
         _sync_to_source(username, sync_data)
 
 
@@ -1087,15 +1344,20 @@ def _get_setter_map() -> dict:
     return _SETTER_MAP
 
 
-def _apply_settings(imported: dict) -> None:
+def _apply_settings(imported: dict, skip_keys: set[str] | None = None) -> None:
     """Apply a dict of settings via this module's ``set_*`` functions.
 
     Unknown keys or values that fail validation are silently skipped.
-    Used by :func:`sync_from_settings_source` and by the settings-import
-    route in ``routes/settings_io.py``.
+    Keys in *skip_keys* are also skipped — used by the auto re-sync
+    path so an upstream value doesn't silently overwrite a key the
+    user has just edited locally.  Used by :func:`sync_from_settings_source`
+    and by the settings-import route in ``routes/settings/io.py``.
     """
     setter_map = _get_setter_map()
+    skip = skip_keys or set()
     for key, value in imported.items():
+        if key in skip:
+            continue
         setter = setter_map.get(key)
         if setter is not None:
             try:
@@ -1112,9 +1374,15 @@ def sync_from_settings_source() -> dict[str, Any] | None:
 
     Triggered:
 
-    - Lazily on first per-user cache load each process lifetime (see
-      :func:`_maybe_sync_from_source`).
+    - Automatically from :func:`_ensure_user_loaded` whenever the
+      source's :meth:`SettingsSource.peek_version` token differs from
+      the cached one (or no successful sync has happened yet this
+      process lifetime).
     - Manually via ``POST /api/settings-sources/sync``.
+
+    This (explicit) path **ignores the local ``dirty_keys`` set**: the
+    user clicked "Sync now" precisely to get the source values, so a
+    locally-edited key is overwritten and the dirty marker is cleared.
     """
     cfg = get_settings_source_config()
     if cfg is None:
@@ -1129,6 +1397,12 @@ def sync_from_settings_source() -> dict[str, Any] | None:
         return None
 
     field_values = cfg.get("field_values", {})
+    new_version: Any = None
+    try:
+        new_version = source.peek_version(field_values)
+    except Exception:
+        new_version = None
+
     try:
         imported = source.load(field_values)
     except Exception as exc:
@@ -1151,55 +1425,31 @@ def sync_from_settings_source() -> dict[str, Any] | None:
         with _settings_lock:
             _syncing.discard(username)
 
+    with _settings_lock:
+        _sync_state[username] = _UserSyncState(
+            last_version=new_version,
+            last_check_monotonic=time.monotonic(),
+            last_sync_succeeded=True,
+            dirty_keys=set(),
+        )
+
     return imported
-
-
-def _maybe_sync_from_source(username: str) -> None:
-    """Lazy sync-from-source for *username*.
-
-    Called once per process per username from :func:`_ensure_user_loaded`
-    **after** releasing ``_settings_lock``; the caller is responsible
-    for the ``_synced_users.add`` claim. Errors are logged and swallowed
-    so a misconfigured source never blocks ordinary settings access.
-    """
-    with _settings_lock:
-        cache_snapshot = dict(_user_caches.get(username) or {})
-    cfg = cache_snapshot.get("settings_source")
-    if not isinstance(cfg, dict) or not cfg.get("source_name"):
-        return
-
-    from vtsearch.settings_io.sources import get_settings_source
-
-    source = get_settings_source(cfg["source_name"])
-    if source is None:
-        logger.warning("Unknown settings source: %s", cfg["source_name"])
-        return
-
-    field_values = cfg.get("field_values", {})
-    try:
-        imported = source.load(field_values)
-    except Exception as exc:
-        logger.exception("Failed to load from settings source for %s: %s", username, exc)
-        return
-    if not imported:
-        return
-
-    with _settings_lock:
-        _syncing.add(username)
-    try:
-        _apply_settings(imported)
-    finally:
-        with _settings_lock:
-            _syncing.discard(username)
 
 
 def _sync_to_source(username: str, data: dict[str, Any]) -> None:
     """Push *username*'s current settings to their active source (if any).
 
-    Called from :func:`_write_value` / :func:`mutate_user` after the
-    per-user file is written, **outside** the cross-process file lock
-    so a slow sync target can't block other settings writes.
-    Strips the ``settings_source`` key itself to avoid circular config.
+    Called from :func:`_write_value` / :func:`mutate_user` /
+    :func:`set_settings_source_config` after the per-user file is
+    written, **outside** the cross-process file lock so a slow sync
+    target can't block other settings writes.  Strips the
+    ``settings_source`` key itself to avoid circular config.
+
+    On successful save the user is stamped as freshly synced
+    (``last_version`` refreshed from the post-save ``peek_version``,
+    ``dirty_keys`` cleared) — source now matches local, so the next
+    :func:`_ensure_user_loaded` short-circuits via the fast path
+    instead of pulling back the values we just pushed.
     """
     cfg = data.get("settings_source")
     if not isinstance(cfg, dict) or not cfg.get("source_name"):
@@ -1218,3 +1468,20 @@ def _sync_to_source(username: str, data: dict[str, Any]) -> None:
         source.save(export_data, field_values)
     except Exception as exc:
         logger.exception("Failed to sync settings to source for %s: %s", username, exc)
+        return
+
+    # Source now matches local for every exported key — clear the dirty
+    # set and refresh the version token so an auto re-sync doesn't fire
+    # for the change we just exported.
+    new_version: Any = None
+    try:
+        new_version = source.peek_version(field_values)
+    except Exception:
+        new_version = None
+    with _settings_lock:
+        _sync_state[username] = _UserSyncState(
+            last_version=new_version,
+            last_check_monotonic=time.monotonic(),
+            last_sync_succeeded=True,
+            dirty_keys=set(),
+        )

--- a/vtsearch/settings_io/sources/server_json_file/__init__.py
+++ b/vtsearch/settings_io/sources/server_json_file/__init__.py
@@ -63,6 +63,24 @@ class ServerFileSettingsSource(SettingsSource):
             os.fsync(f.fileno())
         os.replace(tmp, filepath)
 
+    def peek_version(self, field_values: dict[str, Any]) -> int | None:
+        """Return the source file's ``st_mtime_ns`` as a freshness token.
+
+        A change in the returned value signals the file has been
+        rewritten since the last sync.  Returns ``None`` if the file
+        doesn't exist (or the path can't be resolved / statted) — the
+        settings layer interprets that as "skip the auto re-sync until
+        the file appears."
+        """
+        try:
+            path = Path(_resolve_filepath(field_values))
+        except Exception:
+            return None
+        try:
+            return path.stat().st_mtime_ns
+        except OSError:
+            return None
+
 
 def _resolve_filepath(field_values: dict[str, Any]) -> str:
     """Resolve the filepath, expanding the ``{username}`` template.


### PR DESCRIPTION
## Summary

Closes audit finding **M16** ("Sync to source on first read after `_synced_users` marker can still return stale local config if source changes silently") plus two adjacent latent defects in `_ensure_user_loaded` surfaced during the investigation.

### What changed

- **TOCTOU race fix.** The old `_synced_users: set[str]` marker was set *inside* `_settings_lock` *before* the actual sync ran, so a concurrent reader for the same user could observe the "synced" claim and return the pre-sync local cache. Replaced with per-user `_UserSyncState` bookkeeping protected by a per-user `_per_user_sync_lock` RLock that wraps the entire decide-and-sync slow path. A second reader now blocks until the first completes and sees the post-sync cache.

- **First-failure lockout fix.** A transient source failure on the first sync still flipped the marker, so the source was never retried until process restart. `last_sync_succeeded` now stays `False` on failure and the slow path retries past a 1-second rate-limit window.

- **M16 staleness fix.** New `SyncSource.peek_version(field_values)` hook (default `None` = "can't cheaply check") with a `st_mtime_ns` implementation for `server_json_file`. The fast path in `_ensure_user_loaded` short-circuits inside a 1-second rate-limit window (settings reads stay hot); past that, the slow path probes for a version bump and re-syncs automatically. No more "stale until restart or manual POST."

- **Conflict policy.** Auto re-sync (version-bump driven) respects local `dirty_keys` so a freshly-clicked toggle isn't silently overwritten by an upstream value. Manual `POST /api/settings-sources/sync` ignores `dirty_keys` (explicit user pull) and clears them. `_sync_to_source` clears `dirty_keys` on a successful export since the source then matches local.

- **Audit doc.** Struck M16 with a summary of the fixes; test references included.

### Test plan

- [x] `./run-tests.sh io core` — 1255 passed (sync sources, settings, frontend build, lint stack).
- [x] `./run-tests.sh` — 4096 passed across the full suite, no regressions.
- [x] Six new regressions in `tests/io/test_sync_sources.py::TestSyncFromSourceFreshness`:
  - source `st_mtime_ns` bump triggers auto re-sync on next read
  - first-sync failure does not lock out retry
  - concurrent readers during the first sync see the post-sync cache
  - dirty key survives auto re-sync (local edit protected)
  - manual sync clears dirty keys (explicit pull)
  - freshness window short-circuits repeat `peek_version` probes


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7M2FgxyyqDtt3upzrz5Fb)_