### PR TITLE
M11: surface None-embedding scoring bug + strict id↔score zips

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -618,13 +618,37 @@ Cross-section interaction agents:
   drift / no-match / ambiguous match, and returns `None` instead of
   silently picking `outputs[0]` (was a regression vs. the legacy
   `_clip_text_to_bytes` resolver path).
-- **M11.** ~~Stale media in `cli._score_medias_with_detectors` when some
-  embeddings are `None` (zip truncates silently).~~ **Shipped.**
-  `_score_medias_with_detectors` now uses `zip(all_ids, scores,
-  strict=True)` so a partial embedding matrix raises `ValueError`
-  instead of silently dropping hits. With the M12 fix in place this
-  loop should never be partial, but the strict zip guards against
-  future regressions.
+- ~~**M11.** Stale media in `cli._score_medias_with_detectors` when some
+  embeddings are `None` (zip truncates silently).~~ **Shipped (expanded
+  scope).** The literal "zip truncates" claim is wrong (both `all_ids`
+  and `scores` come from the same `(N, dim)` matrix, so lengths always
+  match). The real symptom under numpy 2.x is that a `None` embedding
+  becomes a NaN row via `matrix[i] = None`, propagates through the MLP
+  to a NaN score, fails every `score >= threshold` compare, and lands
+  in `negative_hits` with `NaN` in the JSON response. Fixed at three
+  layers:
+  (1) `vtscore/embedding/matrix.py` raises `ValueError` naming the
+  offending cid when any media has `embedding=None` — defensive root
+  guard catching every entry point (M8/M12 pickle loaders are one path;
+  `_fixup_clip_md5_and_embeddings` silently leaving `embedding=None`
+  after a failed bulk re-embed is another).
+  (2) `_drop_none_embeddings_stage` in
+  `vtscore/datasets/load_pipeline.py` removes any media with
+  `embedding=None` after the clipper stage and surfaces the dropped
+  count via the progress tracker so the load row reflects the real N.
+  (3) `zip(strict=True)` on every id↔score callsite
+  (`vtscore/cli.py` — already shipped with the M8/M12 PR;
+  `vtsearch/routes/sorting.py`,
+  `vtsearch/routes/detectors/{find,scoring}.py`,
+  `vtscore/detectors/{training,labelset_training,labeling_progress}.py`,
+  `vtscore/training/region_similarity.py`,
+  `vtscore/eval/voting_iterations.py`) so any future length divergence
+  fails loudly instead of silently truncating hits.
+  Regression tests in `tests_lib/core/test_embedding_matrix.py`,
+  `tests/datasets/test_load_stage_matrix_cache.py::TestDropNoneEmbeddingsStage`,
+  and `tests/io/test_export_options.py::TestCliScoringNegativeHits`
+  (the strict-zip regression already on dev plus a new None-embedding
+  loud-error regression).
 - **M12.** ~~`loader_pickle._build_pickle_full_media` has no null-check before
   `np.array(media_info["embedding"])`.~~ **Shipped.**
   `_convert_one_pickle_media` skips any entry whose `embedding` is

--- a/tests/datasets/test_load_stage_matrix_cache.py
+++ b/tests/datasets/test_load_stage_matrix_cache.py
@@ -27,6 +27,7 @@ from vtscore.concurrency.progress import LoadingTasksTracker
 from vtscore.datasets.load_pipeline import (
     _apply_clipper_stage,
     _collapse_duplicates_stage,
+    _drop_none_embeddings_stage,
 )
 from vtscore.embedding.matrix import get_embedding_matrix
 from vtscore.state.core import DatasetContext
@@ -106,3 +107,53 @@ class TestApplyClipperStageInvalidatesMatrix:
 
         # No mutation happened; cache survives.
         assert ctx._emb_matrix is cached_matrix
+
+
+class TestDropNoneEmbeddingsStage:
+    """Regression for M11 finalize step.
+
+    Audit M11 was framed as "stale media when some embeddings are None"
+    via silent zip truncation; the real symptom under numpy 2.x is that
+    a None embedding becomes a NaN row, propagates through the MLP, and
+    forces an always-False threshold compare so the media silently lands
+    in negative_hits with a NaN score (and ``NaN`` in the JSON response).
+    The drop stage in ``_run_origin_load_in_background`` ensures None
+    embeddings never reach the matrix builder, dedup, diversity tree,
+    or registry — and surfaces the dropped count to the user via the
+    progress tracker so the load row reflects the real N.
+    """
+
+    def test_drops_medias_with_none_embedding(self):
+        ctx = DatasetContext("test_drop_none")
+        ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+        ctx.medias[2] = {"id": 2, "embedding": None}  # embedder failed silently
+        ctx.medias[3] = {"id": 3, "embedding": np.full(4, 3.0, dtype=np.float32)}
+        ctx.medias[4] = {"id": 4, "embedding": None}
+
+        _populate_matrix(ctx)
+
+        _drop_none_embeddings_stage(ctx, _make_tracker())
+
+        assert set(ctx.medias.keys()) == {1, 3}
+        # Cache must be invalidated since the id set changed.
+        assert ctx._emb_matrix is None
+        assert ctx._emb_matrix_ids is None
+
+    def test_no_op_when_all_embeddings_present(self):
+        ctx = DatasetContext("test_drop_none_noop")
+        ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+        ctx.medias[2] = {"id": 2, "embedding": np.full(4, 2.0, dtype=np.float32)}
+
+        cached_matrix = _populate_matrix(ctx)
+
+        _drop_none_embeddings_stage(ctx, _make_tracker())
+
+        # No mutation: cache must NOT be invalidated.
+        assert set(ctx.medias.keys()) == {1, 2}
+        assert ctx._emb_matrix is cached_matrix
+
+    def test_empty_medias_ok(self):
+        ctx = DatasetContext("test_drop_none_empty")
+        # Should not raise.
+        _drop_none_embeddings_stage(ctx, _make_tracker())
+        assert ctx.medias == {}

--- a/tests/datasets/test_load_stage_matrix_cache.py
+++ b/tests/datasets/test_load_stage_matrix_cache.py
@@ -126,11 +126,18 @@ class TestDropNoneEmbeddingsStage:
     def test_drops_medias_with_none_embedding(self):
         ctx = DatasetContext("test_drop_none")
         ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
-        ctx.medias[2] = {"id": 2, "embedding": None}  # embedder failed silently
+        ctx.medias[2] = {"id": 2, "embedding": np.full(4, 2.0, dtype=np.float32)}
         ctx.medias[3] = {"id": 3, "embedding": np.full(4, 3.0, dtype=np.float32)}
-        ctx.medias[4] = {"id": 4, "embedding": None}
+        ctx.medias[4] = {"id": 4, "embedding": np.full(4, 4.0, dtype=np.float32)}
 
+        # Cache must exist before the drop so we can verify invalidation.
+        # The matrix builder itself now raises on None embeddings (M11
+        # root guard), so we build the cache against valid embeddings
+        # first and only then simulate the silent re-embed failure.
         _populate_matrix(ctx)
+
+        ctx.medias[2]["embedding"] = None
+        ctx.medias[4]["embedding"] = None
 
         _drop_none_embeddings_stage(ctx, _make_tracker())
 

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -1021,11 +1021,16 @@ class TestBackgroundLoadThreadContext:
         ran = threading.Event()
 
         def capture_load(target_medias):
+            import numpy as np  # noqa: PLC0415
+
             observed["thread_ctx"] = get_thread_dataset_context()
             observed["active_ctx"] = get_active_context()
             # Mutating the active context from the load_fn must land on
-            # the in-flight context, not on the empty fallback.
-            get_active_context().medias[1] = {"id": 1}
+            # the in-flight context, not on the empty fallback.  Give the
+            # stub media a real embedding so the load pipeline's
+            # ``_drop_none_embeddings_stage`` (M11 finalize) doesn't
+            # remove it before we can assert on it.
+            get_active_context().medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
             ran.set()
 
         task_id = _run_origin_load_in_background(

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -408,7 +408,9 @@ class TestCliScoringNegativeHits:
         """
         from vtscore.cli import _score_medias_with_detectors
         from vtscore.detectors.training import train_and_threshold
-        from vtsearch.state import medias, snapshot_medias
+        from vtscore.embedding.matrix import invalidate_embedding_matrix
+        from vtscore.state.core import get_active_context
+        from vtsearch.state import snapshot_medias
 
         snap = snapshot_medias()
         good_ids = [1, 2, 3]
@@ -417,9 +419,15 @@ class TestCliScoringNegativeHits:
         y = [1.0] * len(good_ids) + [0.0] * len(bad_ids)
         mlp, threshold = train_and_threshold(X, y, snap=snap)
 
-        broken = dict(snap)
-        # Pick any cid not in the training set, blank out its embedding.
-        victim_cid = next(cid for cid in broken if cid not in good_ids + bad_ids)
+        # Build a broken snap that doesn't share the active ctx's key set
+        # — that forces the fresh-build path in
+        # ``get_embedding_matrix_for_snap`` where the M11 guard lives.
+        # (The cached-matrix fast path would return the still-valid
+        # matrix built from the active ctx, masking the bug.)
+        broken: dict[int, dict] = {}
+        for cid in list(snap.keys())[:5]:
+            broken[10_000 + cid] = dict(snap[cid])
+        victim_cid = next(iter(broken))
         broken[victim_cid] = dict(broken[victim_cid])
         broken[victim_cid]["embedding"] = None
 
@@ -429,7 +437,8 @@ class TestCliScoringNegativeHits:
 
         # Untouched global state stays scorable — the broken dict was a
         # local snapshot, ``medias`` is intact.
-        det_results = _score_medias_with_detectors(medias, detector_mlps)
+        invalidate_embedding_matrix(get_active_context())
+        det_results = _score_medias_with_detectors(snapshot_medias(), detector_mlps)
         assert det_results
 
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -369,6 +369,69 @@ class TestCliScoringNegativeHits:
             total = len(det_result["hits"]) + len(det_result["negative_hits"])
             assert total == len(medias)
 
+    def test_id_score_length_mismatch_raises(self, client, monkeypatch):
+        """Regression for audit M11 (defensive layer): a future bug that
+        leaves ``all_ids`` and ``scores`` out of sync must fail loudly
+        via ``zip(strict=True)`` instead of silently truncating the
+        per-detector hit lists.
+        """
+        from vtscore.cli import _score_medias_with_detectors
+        from vtscore.detectors.training import train_and_threshold
+        from vtscore.embedding import matrix as matrix_module
+        from vtsearch.state import medias, snapshot_medias
+
+        snap = snapshot_medias()
+        good_ids = [1, 2, 3]
+        bad_ids = [18, 19, 20]
+        X = [snap[i]["embedding"] for i in good_ids + bad_ids]
+        y = [1.0] * len(good_ids) + [0.0] * len(bad_ids)
+        mlp, threshold = train_and_threshold(X, y, snap=snap)
+
+        real_get = matrix_module.get_embedding_matrix_for_snap
+
+        def _truncating_matrix(snap_arg):
+            ids, mat = real_get(snap_arg)
+            # Drop the last id but keep the full matrix so scores stays
+            # longer than ids — exactly the silent-truncation failure mode.
+            return ids[:-1], mat
+
+        monkeypatch.setattr(matrix_module, "get_embedding_matrix_for_snap", _truncating_matrix)
+
+        detector_mlps = {"test": {"mlp": mlp, "threshold": threshold}}
+        with pytest.raises(ValueError):
+            _score_medias_with_detectors(medias, detector_mlps)
+
+    def test_none_embedding_surfaces_loud_error(self, client):
+        """Regression for audit M11 (root cause): a media with
+        ``embedding=None`` must raise rather than silently producing
+        NaN-scored hits via ``matrix[i] = None`` (numpy 2.x).
+        """
+        from vtscore.cli import _score_medias_with_detectors
+        from vtscore.detectors.training import train_and_threshold
+        from vtsearch.state import medias, snapshot_medias
+
+        snap = snapshot_medias()
+        good_ids = [1, 2, 3]
+        bad_ids = [18, 19, 20]
+        X = [snap[i]["embedding"] for i in good_ids + bad_ids]
+        y = [1.0] * len(good_ids) + [0.0] * len(bad_ids)
+        mlp, threshold = train_and_threshold(X, y, snap=snap)
+
+        broken = dict(snap)
+        # Pick any cid not in the training set, blank out its embedding.
+        victim_cid = next(cid for cid in broken if cid not in good_ids + bad_ids)
+        broken[victim_cid] = dict(broken[victim_cid])
+        broken[victim_cid]["embedding"] = None
+
+        detector_mlps = {"test": {"mlp": mlp, "threshold": threshold}}
+        with pytest.raises(ValueError, match=r"has no embedding"):
+            _score_medias_with_detectors(broken, detector_mlps)
+
+        # Untouched global state stays scorable — the broken dict was a
+        # local snapshot, ``medias`` is intact.
+        det_results = _score_medias_with_detectors(medias, detector_mlps)
+        assert det_results
+
 
 # ---------------------------------------------------------------------------
 # Export with Good/Bad/Both filtered results via API

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -1,0 +1,88 @@
+"""Regression tests for the embedding-matrix builders.
+
+Covers audit M11: a media item with ``embedding=None`` must NOT silently
+poison the matrix with a NaN row (numpy 2.x behaviour of
+``matrix[i] = None``).  The builder raises ``ValueError`` naming the
+offending cid instead.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.embedding.matrix import (
+    get_embedding_matrix,
+    get_embedding_matrix_for_snap,
+    invalidate_embedding_matrix,
+)
+from vtscore.state.core import DatasetContext, set_thread_dataset_context
+
+
+class TestGetEmbeddingMatrixRaisesOnNoneEmbedding:
+    def test_first_media_none_embedding(self):
+        ctx = DatasetContext("test_first_none")
+        ctx.medias[1] = {"id": 1, "embedding": None}
+        ctx.medias[2] = {"id": 2, "embedding": np.ones(4, dtype=np.float32)}
+
+        with pytest.raises(ValueError, match=r"media 1.*has no embedding"):
+            get_embedding_matrix(ctx)
+
+    def test_later_media_none_embedding(self):
+        """Without the guard, numpy 2.x silently fills row i with NaN."""
+        ctx = DatasetContext("test_later_none")
+        ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+        ctx.medias[2] = {"id": 2, "embedding": np.full(4, 2.0, dtype=np.float32)}
+        ctx.medias[3] = {"id": 3, "embedding": None}
+
+        with pytest.raises(ValueError, match=r"media 3.*has no embedding"):
+            get_embedding_matrix(ctx)
+
+    def test_empty_medias_ok(self):
+        ctx = DatasetContext("test_empty")
+        ids, mat = get_embedding_matrix(ctx)
+        assert ids == []
+        assert mat.shape == (0, 0)
+
+    def test_clean_medias_ok(self):
+        ctx = DatasetContext("test_clean")
+        for cid in (1, 2, 3):
+            ctx.medias[cid] = {"id": cid, "embedding": np.full(4, float(cid), dtype=np.float32)}
+        ids, mat = get_embedding_matrix(ctx)
+        assert ids == [1, 2, 3]
+        assert mat.shape == (3, 4)
+        # Row order matches sorted IDs.
+        assert mat[0, 0] == 1.0
+        assert mat[1, 0] == 2.0
+        assert mat[2, 0] == 3.0
+
+
+class TestGetEmbeddingMatrixForSnapRaisesOnNoneEmbedding:
+    """Same guarantee for the snap helper, including the cross-dataset
+    'temp dict' path that does NOT hit the cached active-ctx branch."""
+
+    def test_snap_with_none_in_temp_dict(self):
+        # Active ctx is empty so the snap can't match its key set; this
+        # forces the fresh-build (uncached) path.
+        ctx = DatasetContext("test_snap_temp")
+        set_thread_dataset_context(ctx)
+
+        snap = {
+            10: {"embedding": np.ones(4, dtype=np.float32)},
+            11: {"embedding": None},
+        }
+        with pytest.raises(ValueError, match=r"media 11.*has no embedding"):
+            get_embedding_matrix_for_snap(snap)
+
+    def test_snap_matching_active_ctx_with_none(self):
+        """The matching-keys fast path delegates to ``get_embedding_matrix``
+        on the active ctx — the same guard fires there too."""
+        ctx = DatasetContext("test_snap_match")
+        ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+        ctx.medias[2] = {"id": 2, "embedding": None}
+        set_thread_dataset_context(ctx)
+        invalidate_embedding_matrix(ctx)
+
+        snap = {cid: ctx.medias[cid] for cid in ctx.medias}
+        with pytest.raises(ValueError, match=r"media 2.*has no embedding"):
+            get_embedding_matrix_for_snap(snap)

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -752,6 +752,43 @@ def _apply_clipper_stage(
     invalidate_embedding_matrix(ctx)
 
 
+def _drop_none_embeddings_stage(ctx: DatasetContext, tracker) -> None:
+    """Drop any media that finished the clipper stage without an embedding.
+
+    ``_fixup_clip_md5_and_embeddings`` is best-effort: when its bulk
+    re-embed call fails (no embedder, vector ``None``, exception) the
+    clip is left in ``ctx.medias`` with ``embedding=None``.  Letting
+    those through poisons every downstream consumer — the matrix builder
+    in ``vtscore/embedding/matrix.py`` raises (M11 fix); sort/score
+    aggregations get wrong-length lists.  Drop them here so the rest of
+    the load pipeline (dedup, diversity tree, registry) sees a clean
+    dict, and surface the count to the progress tracker so the user
+    knows N is lower than the importer reported.
+    """
+    none_ids = [cid for cid, media in ctx.medias.items() if media.get("embedding") is None]
+    if not none_ids:
+        return
+
+    for cid in none_ids:
+        del ctx.medias[cid]
+
+    import logging  # noqa: PLC0415
+
+    logging.getLogger(__name__).warning(
+        "Dropped %d media item(s) with embedding=None (importer or re-embed step failed)",
+        len(none_ids),
+    )
+    tracker.update(
+        "loading",
+        f"Dropped {len(none_ids)} item(s) with failed embedding…",
+        current=0,
+        total=0,
+        step=_TOTAL_LOAD_STEPS,
+        total_steps=_TOTAL_LOAD_STEPS,
+    )
+    invalidate_embedding_matrix(ctx)
+
+
 def _collapse_duplicates_stage(ctx: DatasetContext, tracker) -> None:
     def _progress(current: int, total: int) -> None:
         tracker.check_cancelled()
@@ -1004,6 +1041,7 @@ def _run_origin_load_in_background(
             apply_custom_metadata_md5(ctx.medias)
             _tag_origins(ctx.medias, origin)
             _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
+            _drop_none_embeddings_stage(ctx, tracker)
             _collapse_duplicates_stage(ctx, tracker)
             _build_diversity_tree_stage(ctx, tracker)
             tracker.check_cancelled()

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -246,7 +246,10 @@ def _compute_step_stability(
         X_unlabeled = X_unlabeled.to(next(model.parameters()).device)
         scores_unl = torch.sigmoid(model(X_unlabeled)).squeeze(1).cpu().tolist()
 
-    predictions: dict[int, int] = {cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl)}
+    predictions: dict[int, int] = {
+        cid: 1 if score >= threshold else 0
+        for cid, score in zip(unlabeled_ids, scores_unl, strict=True)
+    }
 
     stability: Optional[dict[str, Any]] = None
     if _cache_prev_predictions is not None:
@@ -456,7 +459,7 @@ def _eval_cached_models(  # noqa: C901
             scores = torch.sigmoid(step["model"](X_in)).squeeze(1).cpu().tolist()
 
         fp = fn = 0
-        for score, true_label in zip(scores, eval_labels):
+        for score, true_label in zip(scores, eval_labels, strict=True):
             predicted = 1 if score >= step["threshold"] else 0
             if predicted == 1 and true_label == 0:
                 fp += 1

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -247,8 +247,7 @@ def _compute_step_stability(
         scores_unl = torch.sigmoid(model(X_unlabeled)).squeeze(1).cpu().tolist()
 
     predictions: dict[int, int] = {
-        cid: 1 if score >= threshold else 0
-        for cid, score in zip(unlabeled_ids, scores_unl, strict=True)
+        cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl, strict=True)
     }
 
     stability: Optional[dict[str, Any]] = None

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -417,7 +417,7 @@ def labelset_train_and_score(
     if safe_thresholds:
         threshold = calculate_safe_threshold(threshold, scores, len(X_list))
 
-    results = [{"id": cid, "score": s} for cid, s in zip(all_ids, scores)]
+    results = [{"id": cid, "score": s} for cid, s in zip(all_ids, scores, strict=True)]
     results.sort(key=lambda r: r["score"], reverse=True)
     return results, threshold, model
 

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -234,7 +234,7 @@ def _score_all_media(
 
     scores: list[float] = [-1.0] * len(all_ids)
     best_region: list[int] = [0] * len(all_ids)
-    for s, mi, ri in zip(flat_scores, media_index_per_row, region_index_per_row):
+    for s, mi, ri in zip(flat_scores, media_index_per_row, region_index_per_row, strict=True):
         if s > scores[mi]:
             scores[mi] = float(s)
             best_region[mi] = ri
@@ -256,7 +256,7 @@ def _format_results(
     region's box.
     """
     paired = sorted(
-        zip(all_ids, scores, best_region),
+        zip(all_ids, scores, best_region, strict=True),
         key=lambda t: t[1],
         reverse=True,
     )

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -12,11 +12,19 @@ Cache invalidation is keyed on ``sorted(ctx.medias.keys())``: when that
 list differs from the cached one, the matrix is rebuilt.  Callers that
 mutate ``ctx.medias`` don't need to do anything — the next access will
 detect the new key set and rebuild.
+
+Any media whose ``embedding`` is ``None`` causes the builder to raise
+``ValueError`` instead of silently filling the row with NaN — the bug
+described as M11 in ``docs/plans/logical-bug-audit.md``.  On numpy 2.x
+``matrix[i] = None`` quietly stores ``nan`` and the resulting score
+propagates through every downstream consumer (always-False threshold
+compares, NaN-poisoned sort, JSON ``NaN`` in the response).  Raising
+turns that into a loud, locatable failure naming the offending cid.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -24,6 +32,17 @@ from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
     from vtscore.state.core import DatasetContext
+
+
+def _require_embedding(cid: int, media: dict[str, Any]) -> Any:
+    emb = media.get("embedding")
+    if emb is None:
+        raise ValueError(
+            f"media {cid!r} has no embedding (embedding=None); "
+            "scoring/sorting require every media to have a vector. "
+            "This usually means an importer or re-embed step silently failed."
+        )
+    return emb
 
 
 def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
@@ -34,7 +53,7 @@ def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
     for a zero-copy view.
 
     Returns ``([], np.empty((0, 0), dtype=np.float32))`` when the dataset is
-    empty.
+    empty.  Raises ``ValueError`` if any media has ``embedding=None``.
     """
     with _state_lock:
         sorted_ids = sorted(ctx.medias.keys())
@@ -49,11 +68,11 @@ def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
             return [], ctx._emb_matrix
 
         medias = ctx.medias
-        first_emb = np.asarray(medias[sorted_ids[0]]["embedding"], dtype=np.float32)
+        first_emb = np.asarray(_require_embedding(sorted_ids[0], medias[sorted_ids[0]]), dtype=np.float32)
         dim = int(first_emb.shape[-1])
         matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
         for i, cid in enumerate(sorted_ids):
-            matrix[i] = medias[cid]["embedding"]
+            matrix[i] = _require_embedding(cid, medias[cid])
 
         ctx._emb_matrix_ids = sorted_ids
         ctx._emb_matrix = matrix
@@ -75,7 +94,8 @@ def get_embedding_matrix_for_snap(
     When *snap*'s key set matches the active :class:`DatasetContext`'s
     medias, the cached matrix is reused.  Otherwise (a different snapshot
     or a temp dict from cross-dataset Find) the matrix is built fresh
-    without populating the cache.
+    without populating the cache.  Raises ``ValueError`` if any entry in
+    *snap* has ``embedding=None``.
     """
     from vtscore.state.core import get_active_context
 
@@ -96,9 +116,9 @@ def get_embedding_matrix_for_snap(
         return get_embedding_matrix(ctx)
 
     # Temp dict / cross-dataset case: build fresh, don't cache.
-    first_emb = np.asarray(snap[sorted_ids[0]]["embedding"], dtype=np.float32)
+    first_emb = np.asarray(_require_embedding(sorted_ids[0], snap[sorted_ids[0]]), dtype=np.float32)
     dim = int(first_emb.shape[-1])
     matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
     for i, cid in enumerate(sorted_ids):
-        matrix[i] = snap[cid]["embedding"]
+        matrix[i] = _require_embedding(cid, snap[cid])
     return sorted_ids, matrix

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -98,7 +98,7 @@ def _evaluate_on_test(
     total_neg = len(true_labels) - total_pos
 
     fp = fn = 0
-    for score, label in zip(scores, true_labels):
+    for score, label in zip(scores, true_labels, strict=True):
         predicted = 1 if score >= threshold else 0
         if predicted == 1 and label == 0.0:
             fp += 1

--- a/vtscore/training/region_similarity.py
+++ b/vtscore/training/region_similarity.py
@@ -139,6 +139,6 @@ def cosine_sort_with_boxes(
     similarities = np.dot(all_embs, query_vec) / safe_norms
     similarities = np.where(norm_products == 0, 0.0, similarities)
     sims_list = similarities.tolist()
-    results = [{"id": cid, "similarity": round(float(sim), 4)} for cid, sim in zip(all_ids, similarities)]
+    results = [{"id": cid, "similarity": round(float(sim), 4)} for cid, sim in zip(all_ids, similarities, strict=True)]
     results.sort(key=lambda x: x["similarity"], reverse=True)
     return results, sims_list

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -316,7 +316,7 @@ def _record_verdicts(
     ``score=0`` for every id.
     """
     if scores is not None:
-        for cid, score in zip(all_ids, scores):
+        for cid, score in zip(all_ids, scores, strict=True):
             verdict = "Good" if score >= threshold else "Bad"
             media_results[cid]["detector_verdicts"][dc_name] = {
                 "verdict": verdict,

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -318,7 +318,7 @@ def find_label(body: dict):  # noqa: C901
                 total_steps=_FIND_LABEL_STEPS,
             )
 
-    results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
+    results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores, strict=True)]
     results.sort(key=lambda x: x["score"], reverse=True)
 
     update_find_progress(
@@ -445,7 +445,7 @@ def _score_detector_for_auto_detect(
 
         positive_hits = []
         negative_hits = []
-        for cid, score in zip(all_ids, scores):
+        for cid, score in zip(all_ids, scores, strict=True):
             clip_info = _media_info_for_response(snap[cid])
             clip_info["score"] = round(score, 4)
             if score >= threshold:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -889,7 +889,7 @@ def _train_and_score_dataset(X_list: list, y_list: list[float]) -> tuple[list[di
         X_all = X_all.to(next(model.parameters()).device)
         scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().tolist()
 
-    paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)
+    paired = sorted(zip(all_ids, scores, strict=True), key=lambda x: x[1], reverse=True)
     results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]
     return results, threshold
 


### PR DESCRIPTION
## Summary

Closes audit M11.  The audit framed it as "stale media when some embeddings are `None` (zip truncates silently)" but the literal claim is wrong — `all_ids` and `scores` both come from the same `(N, dim)` matrix, so `zip` lengths always match.  The real symptom on numpy 2.x is that `matrix[i] = None` silently fills the row with NaN, the MLP returns a NaN score, every `score >= threshold` compare is False, and the media silently lands in `negative_hits` with `NaN` in the JSON response.  See `docs/plans/logical-bug-audit.md` for the rewritten M11 entry.

Fixed at three layers:

- **Root guard** — `vtscore/embedding/matrix.py` raises `ValueError` naming the offending cid when any media has `embedding=None`, in both `get_embedding_matrix` and `get_embedding_matrix_for_snap` (including the cross-dataset fresh-build path).
- **Load-pipeline finalize** — new `_drop_none_embeddings_stage` runs after the clipper stage in `_run_origin_load_in_background`, removing medias whose embedding stayed `None` (e.g. when `_fixup_clip_md5_and_embeddings`'s bulk re-embed silently fails) and surfacing the dropped count via the progress tracker.
- **Defensive `strict=True`** on every id↔score `zip` callsite: `vtscore/cli.py`, `vtsearch/routes/sorting.py`, `vtsearch/routes/detectors/{find,scoring}.py`, `vtscore/detectors/{training,labelset_training,labeling_progress}.py`, `vtscore/training/region_similarity.py`, `vtscore/eval/voting_iterations.py`.  Cheap insurance against future divergence.

One pre-existing test (`test_load_fn_sees_in_flight_dataset_context`) inserted a stub `{"id": 1}` media with no embedding to probe context propagation; updated to attach an embedding so the new drop stage doesn't remove the marker before assertions run.

## Test plan

- [x] `./run-tests.sh` — 4080 passed, 1 skipped
- [x] `./run-tests.sh vtscore-clean` — 963 passed (matrix.py stays library-tier clean)
- [x] New regression tests:
  - `tests_lib/core/test_embedding_matrix.py` — matrix builder raises on `None` at any row, in both helpers, both cached and uncached paths.
  - `tests/datasets/test_load_stage_matrix_cache.py::TestDropNoneEmbeddingsStage` — drop stage removes None-embedding medias, invalidates the cache when it does, no-ops when nothing to drop.
  - `tests/io/test_export_options.py::TestCliScoringNegativeHits::test_id_score_length_mismatch_raises` — `zip(strict=True)` regression.
  - `tests/io/test_export_options.py::TestCliScoringNegativeHits::test_none_embedding_surfaces_loud_error` — None-embedding loud-error regression.

https://claude.ai/code/session_01Twgn981bTMnS5icdmoTf3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twgn981bTMnS5icdmoTf3K)_