### PR TITLE
M13: sanitize NaN/Inf in MLP scores before JSON

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -603,9 +603,20 @@ Cross-section interaction agents:
 
 ### Routes / API
 
-- **M13.** `learned_scores` in `/api/votes` can serialize as JSON
+- ~~**M13.** `learned_scores` in `/api/votes` can serialize as JSON
   `NaN`/`Infinity` if the MLP destabilizes — invalid JSON to strict
-  clients.
+  clients.~~ — fixed by routing every sigmoid→score path through
+  `vtscore.utils.scores.sigmoid_to_finite_scores` (NaN/±Inf → `-1.0`
+  sentinel) and adding a defensive `finite_or` guard at
+  `GET /api/votes`. Sanitised sites: `labelset_train_and_score`,
+  `train_and_threshold`, `_score_all_media`, `/api/learned-sort`,
+  `/api/label-file-sort`, `/api/find-label`, `/api/find` (live + cold
+  paths), `/api/auto-detect`, and CLI autodetect. `-1.0` sits outside
+  the `[0, 1]` sigmoid range so `score >= threshold` is always False
+  for sanitised scores and they sink to the bottom of any sort —
+  matches the frontend's existing `learnedScores[id] ?? -1` fallback.
+  Regression test in `tests/api/test_api_contracts.py` parses the
+  response with a `parse_constant` that rejects `NaN`/`Infinity`.
 - **M14.** `diversity_tree_next_sample` references stale media IDs after
   `/api/dataset/clear`.
 

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -99,6 +99,38 @@ class TestVotesContract:
         data = resp.get_json()
         assert isinstance(data["learned_scores"], dict)
 
+    def test_learned_scores_response_is_strict_json(self, client):
+        """Logical-bug audit M13: even if ``last_learned_scores`` somehow holds
+        a non-finite float, the ``/api/votes`` response must still parse under
+        strict JSON (``json.loads`` with ``parse_constant`` raising).  Python's
+        ``json.dumps`` emits the literal token ``NaN`` for ``float('nan')`` by
+        default, which browser ``JSON.parse`` rejects — so without the route's
+        ``finite_or`` guard this returns invalid JSON to every Angular client.
+        """
+        from vtsearch.state import last_learned_scores
+
+        last_learned_scores[1] = float("nan")
+        last_learned_scores[2] = float("inf")
+        last_learned_scores[3] = float("-inf")
+        last_learned_scores[4] = 0.42
+
+        resp = client.get("/api/votes")
+        assert resp.status_code == 200
+
+        # ``parse_constant`` is invoked for ``NaN``, ``Infinity``, and
+        # ``-Infinity`` — fail loudly so a regression at the route handler
+        # surfaces here instead of as a browser-side parse error in prod.
+        def _reject_constant(c):
+            raise AssertionError(f"non-strict JSON token in /api/votes response: {c!r}")
+
+        data = json.loads(resp.data.decode("utf-8"), parse_constant=_reject_constant)
+
+        # Non-finite inputs round-trip as the sentinel (-1.0); finite ones pass through.
+        assert data["learned_scores"]["1"] == -1.0
+        assert data["learned_scores"]["2"] == -1.0
+        assert data["learned_scores"]["3"] == -1.0
+        assert data["learned_scores"]["4"] == 0.42
+
     def test_vote_response_shape(self, client):
         resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200

--- a/tests_lib/detectors/test_score_sanitization.py
+++ b/tests_lib/detectors/test_score_sanitization.py
@@ -12,6 +12,7 @@ and at the consumers (``train_and_score``, ``labelset_train_and_score``).
 from __future__ import annotations
 
 import math
+from typing import cast
 
 import numpy as np
 import pytest
@@ -114,7 +115,10 @@ class TestScoreAllMediaNaNSafety:
             }
         model = _NaNProducingModel(input_dim=8).eval()
 
-        all_ids, scores, _best = _score_all_media(model, clips)
+        # ``_score_all_media`` is typed as ``nn.Sequential``, but its body only
+        # calls the model and reads ``.parameters()`` — both ``nn.Module`` APIs.
+        # ``cast`` quiets pyright without changing runtime behaviour.
+        all_ids, scores, _best = _score_all_media(cast(nn.Sequential, model), clips)
 
         assert all_ids == [1, 2, 3]
         assert all(math.isfinite(s) for s in scores), scores
@@ -173,7 +177,7 @@ class TestLabelsetTrainAndScoreNaNSafety:
             label="bad",
             md5="b" * 32,
         )
-        labelset = LabelSet(detector_name="test-det", elements=[good_elem, bad_elem])
+        labelset = LabelSet(elements=[good_elem, bad_elem])
         det_ctx.label_embeddings[stable_element_id(good_elem)] = rng.standard_normal(dim).astype(np.float32)
         det_ctx.label_embeddings[stable_element_id(bad_elem)] = rng.standard_normal(dim).astype(np.float32)
 

--- a/tests_lib/detectors/test_score_sanitization.py
+++ b/tests_lib/detectors/test_score_sanitization.py
@@ -1,0 +1,203 @@
+"""Tests for ``vtscore.utils.scores`` — NaN/Inf cannot leak into JSON scores.
+
+Logical-bug audit M13: ``learned_scores`` in ``/api/votes`` (and the cousin
+endpoints ``/api/learned-sort``, ``/api/find-label``, ``/api/find``,
+``/api/label-file-sort``) used to emit the literal token ``NaN`` when the
+MLP destabilised.  Browser ``JSON.parse`` rejects it, breaking the UI.
+
+These tests pin the invariant at the source (``sigmoid_to_finite_scores``)
+and at the consumers (``train_and_score``, ``labelset_train_and_score``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from vtscore.utils.scores import (
+    NON_FINITE_SCORE_SENTINEL,
+    finite_or,
+    sigmoid_to_finite_scores,
+)
+
+
+class TestFiniteOr:
+    """Single-value sentinel substitution used by the ``/api/votes`` guard."""
+
+    def test_finite_passthrough(self):
+        assert finite_or(0.5) == 0.5
+        assert finite_or(-1.0) == -1.0
+        assert finite_or(0.0) == 0.0
+
+    def test_nan_replaced(self):
+        assert finite_or(float("nan")) == NON_FINITE_SCORE_SENTINEL
+
+    def test_pos_inf_replaced(self):
+        assert finite_or(float("inf")) == NON_FINITE_SCORE_SENTINEL
+
+    def test_neg_inf_replaced(self):
+        assert finite_or(float("-inf")) == NON_FINITE_SCORE_SENTINEL
+
+    def test_custom_default(self):
+        assert finite_or(float("nan"), default=0.5) == 0.5
+
+
+class TestSigmoidToFiniteScores:
+    """Tensor-level helper used everywhere a sigmoid output reaches JSON."""
+
+    def test_finite_logits_round_trip(self):
+        logits = torch.tensor([[-2.0], [0.0], [2.0]])
+        scores = sigmoid_to_finite_scores(logits)
+        assert scores == pytest.approx([0.1192, 0.5, 0.8808], abs=1e-3)
+        assert all(math.isfinite(s) for s in scores)
+
+    def test_nan_logits_replaced_with_sentinel(self):
+        logits = torch.tensor([[float("nan")], [1.0], [float("nan")]])
+        scores = sigmoid_to_finite_scores(logits)
+        assert scores[0] == NON_FINITE_SCORE_SENTINEL
+        assert scores[2] == NON_FINITE_SCORE_SENTINEL
+        assert scores[1] == pytest.approx(0.7311, abs=1e-3)
+        assert all(math.isfinite(s) for s in scores)
+
+    def test_pos_inf_logits_produce_finite_scores(self):
+        # ``sigmoid(+inf) == 1.0`` already, no sentinel needed — but assert
+        # the result is finite so a numerical edge can't sneak through.
+        scores = sigmoid_to_finite_scores(torch.tensor([[float("inf")]]))
+        assert math.isfinite(scores[0])
+
+    def test_custom_default(self):
+        scores = sigmoid_to_finite_scores(torch.tensor([[float("nan")]]), default=0.5)
+        assert scores[0] == 0.5
+
+    def test_unsqueezed_input_handled(self):
+        # ``squeeze(-1)`` handles both ``(N, 1)`` and ``(N,)`` inputs.
+        scores = sigmoid_to_finite_scores(torch.tensor([0.0, float("nan"), 2.0]))
+        assert scores[0] == pytest.approx(0.5, abs=1e-3)
+        assert scores[1] == NON_FINITE_SCORE_SENTINEL
+        assert math.isfinite(scores[2])
+
+
+class _NaNProducingModel(nn.Module):
+    """A toy model whose forward pass deterministically returns NaN logits.
+
+    Used to simulate "MLP destabilised during training" without actually
+    having to provoke training divergence (which is non-deterministic).
+    """
+
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.linear = nn.Linear(input_dim, 1)
+
+    def forward(self, x):  # noqa: D401 - torch nn.Module override
+        out = self.linear(x)
+        # Poison the output uniformly so the downstream code paths see NaN
+        # without depending on training pathology.
+        return out * float("nan")
+
+
+class TestScoreAllMediaNaNSafety:
+    """``_score_all_media`` (non-region path) must not leak NaN to results."""
+
+    def test_non_region_path_replaces_nan_with_sentinel(self):
+        from vtscore.detectors.training import _score_all_media
+
+        rng = np.random.default_rng(0)
+        clips: dict[int, dict] = {}
+        for cid in (1, 2, 3):
+            clips[cid] = {
+                "embedding": rng.standard_normal(8).astype(np.float32),
+                "embedder": "test",
+            }
+        model = _NaNProducingModel(input_dim=8).eval()
+
+        all_ids, scores, _best = _score_all_media(model, clips)
+
+        assert all_ids == [1, 2, 3]
+        assert all(math.isfinite(s) for s in scores), scores
+        # ``_score_all_media`` seeds with -1.0; sentinel-substituted scores
+        # never beat that floor, so every entry stays at -1.0.
+        assert scores == [-1.0, -1.0, -1.0]
+
+
+class TestLabelsetTrainAndScoreNaNSafety:
+    """``labelset_train_and_score`` was the primary M13 leak site —
+    sigmoid outputs flowed straight to results with no finite filter.
+
+    We pre-populate ``det_ctx.label_embeddings`` and patch out
+    ``populate_label_embeddings`` / ``record_detector_embedder`` so the
+    test focuses on the scoring tail of the function instead of dragging
+    in the resolver, registry, and disk I/O.
+    """
+
+    def test_nan_model_produces_finite_scores(self, monkeypatch):
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+        from vtscore.detectors import labelset_training, registry as det_registry
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.state.core import DetectorContext
+        from vtscore.training import mlp as mlp_mod
+
+        rng = np.random.default_rng(0)
+        dim = 8
+
+        # Replace the real ``train_model`` with one that returns a model
+        # that always produces NaN logits.  This is what M13 simulates:
+        # the trainer "successfully" produced an MLP, but its weights have
+        # destabilised so every forward pass is NaN.
+        def fake_train_model(X, y, input_dim, inclusion, hidden_dim=None):  # noqa: ARG001
+            return _NaNProducingModel(input_dim).eval()
+
+        # ``labelset_train_and_score`` does a local ``from vtscore.training.mlp
+        # import train_model`` — patch the source module so the local import
+        # resolves to our fake.
+        monkeypatch.setattr(mlp_mod, "train_model", fake_train_model)
+
+        # Bypass embedding resolution: we've pre-populated the cache below.
+        monkeypatch.setattr(labelset_training, "populate_label_embeddings", lambda *a, **kw: 0)
+        # Avoid registry disk writes — irrelevant for this test.
+        monkeypatch.setattr(det_registry, "record_detector_embedder", lambda *a, **kw: None)
+
+        det_ctx = DetectorContext(detector_id="test-det", media_type="audio")
+        good_elem = LabeledElement(
+            origin={"importer": "test", "params": {}},
+            origin_name="g",
+            label="good",
+            md5="g" * 32,
+        )
+        bad_elem = LabeledElement(
+            origin={"importer": "test", "params": {}},
+            origin_name="b",
+            label="bad",
+            md5="b" * 32,
+        )
+        labelset = LabelSet(detector_name="test-det", elements=[good_elem, bad_elem])
+        det_ctx.label_embeddings[stable_element_id(good_elem)] = rng.standard_normal(dim).astype(np.float32)
+        det_ctx.label_embeddings[stable_element_id(bad_elem)] = rng.standard_normal(dim).astype(np.float32)
+
+        # IDs 100+ to avoid clashing with the conftest-loaded test medias (1-20).
+        clips_dict = {
+            cid: {
+                "embedding": rng.standard_normal(dim).astype(np.float32),
+                "embedder": "test",
+                "type": "audio",
+                "md5": f"m{cid:031d}",
+            }
+            for cid in (100, 101, 102)
+        }
+
+        results, threshold, model = labelset_training.labelset_train_and_score(
+            det_ctx,
+            labelset,
+            media_type="audio",
+            clips_dict=clips_dict,
+        )
+
+        assert model is not None
+        assert math.isfinite(threshold)
+        assert len(results) == 3
+        for entry in results:
+            assert math.isfinite(entry["score"]), entry
+            assert entry["score"] == NON_FINITE_SCORE_SENTINEL

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -17,6 +17,7 @@ from vtscore import cli_progress
 
 from vtscore.datasets.loader import apply_custom_metadata_md5, load_dataset_from_pickle
 from vtscore.utils.hits import build_media_hit
+from vtscore.utils.scores import sigmoid_to_finite_scores
 
 
 def _list_importer_names() -> list[str]:
@@ -230,7 +231,7 @@ def _score_medias_with_detectors(
         threshold = info["threshold"]
         with torch.no_grad():
             X_in = X_all.to(next(mlp.parameters()).device)
-            scores = torch.sigmoid(mlp(X_in)).squeeze(1).cpu().tolist()
+            scores = sigmoid_to_finite_scores(mlp(X_in))
 
         positive_hits: list[dict[str, Any]] = []
         negative_hits: list[dict[str, Any]] = []

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 import numpy as np
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet
+from vtscore.utils.scores import sigmoid_to_finite_scores
 
 
 log = logging.getLogger(__name__)
@@ -412,7 +413,7 @@ def labelset_train_and_score(
     X_all = torch.from_numpy(all_embs)
     with torch.no_grad():
         X_all = X_all.to(next(model.parameters()).device)
-        scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().tolist()
+        scores = sigmoid_to_finite_scores(model(X_all))
 
     if safe_thresholds:
         threshold = calculate_safe_threshold(threshold, scores, len(X_list))

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from vtscore.utils.scores import sigmoid_to_finite_scores
+
 if TYPE_CHECKING:
     import torch.nn as nn
 
@@ -103,7 +105,7 @@ def train_and_threshold(
         X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             X_all = X_all.to(next(model.parameters()).device)
-            all_scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().tolist()
+            all_scores = sigmoid_to_finite_scores(model(X_all))
         threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))
 
     return model, threshold
@@ -230,7 +232,12 @@ def _score_all_media(
 
     with torch.no_grad():
         X_all = X_all.to(next(model.parameters()).device)
-        flat_scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().numpy()
+        # ``sigmoid_to_finite_scores`` replaces NaN/±Inf with the
+        # ``NON_FINITE_SCORE_SENTINEL`` (-1.0) so a destabilised MLP cannot
+        # leak non-finite floats into the JSON response. The downstream
+        # ``s > scores[mi]`` max-pool then incidentally drops sentinels in
+        # favour of any real score for the same media.
+        flat_scores = sigmoid_to_finite_scores(model(X_all))
 
     scores: list[float] = [-1.0] * len(all_ids)
     best_region: list[int] = [0] * len(all_ids)

--- a/vtscore/utils/__init__.py
+++ b/vtscore/utils/__init__.py
@@ -7,5 +7,7 @@ to their own top-level packages — see ``vtsearch/state``, ``vtsearch/plugins``
 
 Remaining here:
 - :mod:`vtscore.utils.hits` — ``build_media_hit`` helper for scoring/route hit dicts.
+- :mod:`vtscore.utils.scores` — ``sigmoid_to_finite_scores``/``finite_or`` for
+  JSON-safe MLP scoring (no NaN/Infinity leaks to strict clients).
 - :mod:`vtscore.utils.synthetic` — Synthetic media generators for the offline demo importer.
 """

--- a/vtscore/utils/scores.py
+++ b/vtscore/utils/scores.py
@@ -1,0 +1,68 @@
+"""Score-sanitization helpers shared by every score-emitting code path.
+
+A trained MLP can produce ``NaN`` logits when training destabilises (bad
+optimisation, corrupted input embeddings, AMP overflow on CUDA, extreme
+class-weight bias from a large ``inclusion_value`` shift, etc.).
+``torch.sigmoid(NaN)`` is ``NaN``, and ``json.dumps`` happily emits the
+literal token ``NaN`` (and ``Infinity``/``-Infinity``) by default — invalid
+JSON per RFC 7159, rejected by every browser ``JSON.parse``. A single
+poisoned response breaks the Angular client until the user clears votes.
+
+These helpers exist so every score-emitting path goes through one
+sentinel:
+
+* :data:`NON_FINITE_SCORE_SENTINEL` (``-1.0``) sits *outside* the ``[0, 1]``
+  sigmoid range, so ``score >= threshold`` is always ``False`` for a
+  sanitised score (broken items deterministically fall to the bottom of
+  any sort).
+* The frontend already treats missing scores as ``-1`` (see
+  ``label-list.component.ts``'s ``learnedScores[id] ?? -1``), so a
+  sanitised score renders identically to "no score yet" — no UI change.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+NON_FINITE_SCORE_SENTINEL: float = -1.0
+
+
+def sigmoid_to_finite_scores(
+    logits: torch.Tensor,
+    *,
+    default: float = NON_FINITE_SCORE_SENTINEL,
+) -> list[float]:
+    """Apply sigmoid to *logits* and return a list of JSON-safe floats.
+
+    Squeezes the trailing dim, applies sigmoid, replaces every non-finite
+    value with *default*, and copies the result to a Python list. Use this
+    in place of ``torch.sigmoid(model(X)).squeeze(1).cpu().tolist()`` at
+    every site whose output reaches a JSON response.
+
+    Args:
+        logits: Raw MLP output, shape ``(N, 1)`` or ``(N,)``.
+        default: Sentinel substituted for ``NaN`` / ``+Inf`` / ``-Inf``.
+            Defaults to :data:`NON_FINITE_SCORE_SENTINEL`.
+
+    Returns:
+        Python list of floats, all guaranteed ``math.isfinite``.
+    """
+    import torch  # noqa: PLC0415
+
+    scores = torch.sigmoid(logits).squeeze(-1)
+    scores = torch.nan_to_num(scores, nan=default, posinf=default, neginf=default)
+    return scores.cpu().tolist()
+
+
+def finite_or(value: float, default: float = NON_FINITE_SCORE_SENTINEL) -> float:
+    """Return *value* if finite, otherwise *default*.
+
+    Defensive guard for code that consumes already-stored float scores
+    (e.g. ``DetectorContext.last_learned_scores``) so a regression at any
+    write site cannot leak ``NaN``/``Infinity`` into a JSON response.
+    """
+    return value if math.isfinite(value) else default

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -19,6 +19,7 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.concurrency.progress import find_progress, update_find_progress
 from vtscore.detectors.training import train_and_threshold
+from vtscore.utils.scores import sigmoid_to_finite_scores
 from vtsearch.schemas.detectors import (
     FindCancelResponseSchema,
     FindCheckLabelsRequestSchema,
@@ -338,8 +339,7 @@ def _score_with_live_mlp(dc: dict, X_all, all_ids: list[int], media_results: dic
         mlp = dc["live_mlp"]
         with torch.no_grad():
             X_in = X_all.to(next(mlp.parameters()).device)
-            raw_logits = mlp(X_in)
-            scores = torch.sigmoid(raw_logits).squeeze(1).cpu().tolist()
+            scores = sigmoid_to_finite_scores(mlp(X_in))
         _record_verdicts(media_results, dc["name"], all_ids, scores, dc.get("threshold", 0.5), None)
     except Exception:
         _record_verdicts(media_results, dc["name"], all_ids, None, 0.0, "Error")
@@ -412,7 +412,7 @@ def _score_with_cold_detector(
         mlp, threshold = train_and_threshold(X_list, y_list)
         with torch.no_grad():
             X_in = X_all.to(next(mlp.parameters()).device)
-            scores = torch.sigmoid(mlp(X_in)).squeeze(1).cpu().tolist()
+            scores = sigmoid_to_finite_scores(mlp(X_in))
         _record_verdicts(media_results, dc["name"], all_ids, scores, threshold, None)
     except Exception:
         _record_verdicts(media_results, dc["name"], all_ids, None, 0.0, "Error")

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -24,6 +24,7 @@ from vtsearch.schemas.detectors import (
     FindLabelRequestSchema,
     FindLabelResponseSchema,
 )
+from vtscore.utils.scores import sigmoid_to_finite_scores
 from vtsearch.state import snapshot_medias
 
 logger = logging.getLogger(__name__)
@@ -308,7 +309,7 @@ def find_label(body: dict):  # noqa: C901
         for start in range(0, n_total, batch_size):
             end = min(start + batch_size, n_total)
             batch_logits = mlp(X_all[start:end])
-            scores.extend(torch.sigmoid(batch_logits).squeeze(1).cpu().tolist())
+            scores.extend(sigmoid_to_finite_scores(batch_logits))
             update_find_progress(
                 "running",
                 f"Scoring {n_total} items…",
@@ -441,7 +442,7 @@ def _score_detector_for_auto_detect(
 
         with torch.no_grad():
             X_in = X_all.to(next(mlp.parameters()).device)
-            scores = torch.sigmoid(mlp(X_in)).squeeze(1).cpu().tolist()
+            scores = sigmoid_to_finite_scores(mlp(X_in))
 
         positive_hits = []
         negative_hits = []

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -560,6 +560,7 @@ def cancel_learned_sort(job_id: str):
 def get_votes():
     """Return current good/bad votes, click times, and learned scores."""
     from vtscore.state.core import _empty_detector_context, get_active_detector_context
+    from vtscore.utils.scores import finite_or  # noqa: PLC0415
 
     click_times = get_vote_click_times()
     learned_scores = get_learned_scores()
@@ -570,11 +571,16 @@ def get_votes():
     else:
         labelset_good_count = len(good_votes)
         labelset_bad_count = len(bad_votes)
+    # Defensive guard against non-finite scores poisoning the response: every
+    # write site is already sanitised via ``sigmoid_to_finite_scores``, but
+    # ``round(NaN, 4)`` returns ``NaN`` and Flask's default JSON provider
+    # emits the literal token ``NaN`` — invalid JSON that breaks every
+    # browser ``JSON.parse``. Belt-and-braces audit M13.
     return {
         "good": sorted(good_votes),
         "bad": sorted(bad_votes),
         "click_times": {str(k): v for k, v in click_times.items()},
-        "learned_scores": {str(k): round(v, 4) for k, v in learned_scores.items()},
+        "learned_scores": {str(k): round(finite_or(v), 4) for k, v in learned_scores.items()},
         "labelset_good_count": labelset_good_count,
         "labelset_bad_count": labelset_bad_count,
     }
@@ -879,6 +885,7 @@ def _train_and_score_dataset(X_list: list, y_list: list[float]) -> tuple[list[di
 
     from vtscore.detectors.training import train_and_threshold
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
+    from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
 
     snap = snapshot_medias()
     model, threshold = train_and_threshold(X_list, y_list, snap=snap)
@@ -887,7 +894,7 @@ def _train_and_score_dataset(X_list: list, y_list: list[float]) -> tuple[list[di
     X_all = torch.from_numpy(all_embs)
     with torch.no_grad():
         X_all = X_all.to(next(model.parameters()).device)
-        scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().tolist()
+        scores = sigmoid_to_finite_scores(model(X_all))
 
     paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)
     results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]


### PR DESCRIPTION
## Summary

Closes audit M13 plus five cousin defects with the same root cause.

`torch.sigmoid(NaN) == NaN`, `round(NaN, 4) == NaN`, and Flask's default JSON provider emits the literal token `NaN` for non-finite floats — invalid JSON per RFC 7159, rejected by every browser `JSON.parse`. A destabilised MLP (corrupted input embeddings, AMP overflow on CUDA, large `inclusion_value` shifts) could therefore poison `GET /api/votes` and break the Angular client until the user cleared votes.

The audit named `/api/votes`, but the same defect lived in `/api/learned-sort`, `/api/find-label`, `/api/find` (live + cold), `/api/label-file-sort`, `/api/auto-detect`, and CLI autodetect — anywhere `sigmoid(model(X)).cpu().tolist()` flowed into a `score` field without a finite filter. (`vtscore/detectors/training._score_all_media` was incidentally safe because its `s > -1.0` max-pool drops NaN by accident — now made explicit.)

## Changes

- New `vtscore/utils/scores.py` with `sigmoid_to_finite_scores(logits)` (`sigmoid` + `nan_to_num` + `.cpu().tolist()`) and `finite_or(v)` (single-value sentinel substitution).
- Replaced every `torch.sigmoid(...).squeeze(1).cpu().tolist()` that reaches JSON with `sigmoid_to_finite_scores(...)`: `labelset_train_and_score`, `train_and_threshold`, `_score_all_media`, `/api/learned-sort`, `/api/label-file-sort`, `/api/find-label`, `/api/find` (live + cold), `/api/auto-detect`, and CLI autodetect.
- Defensive `finite_or` guard at `GET /api/votes` to catch any future regression in the write path.
- Sentinel chosen as `-1.0` to match the frontend's existing `learnedScores[id] ?? -1` fallback and to keep `score >= threshold` always False for sanitised entries (broken items sink to the bottom of any sort).
- Internal-only sigmoid sites (eval, labeling-progress analyser, voting iterations) are intentionally untouched — none feed JSON responses and they consume scores via comparisons where NaN already behaves correctly.

## Test plan

- `tests_lib/detectors/test_score_sanitization.py` covers the helpers (finite passthrough, NaN/±Inf → sentinel, custom default), the `_score_all_media` non-region path with a NaN-producing fake MLP, and the full `labelset_train_and_score` scoring tail with a NaN-producing fake MLP.
- `tests/api/test_api_contracts.py::TestVotesEndpointContract::test_learned_scores_response_is_strict_json` parses the response with `json.loads(parse_constant=…)` that raises on `NaN`/`Infinity` — would have failed before the fix.
- `./run-tests.sh` (full suite, 4103 tests) — all pass.
- `./run-tests.sh vtscore-clean` (980 tests, Flask-blocked) — still clean; the new helper has no app-tier dependencies.

## Notes

- `docs/plans/logical-bug-audit.md` updated with M13 closed and the full list of sanitised sites.
- No frontend changes: the sentinel already matches the existing fallback, so the UI behaves identically (just no longer crashes on `JSON.parse`).
- Side-effect on `/api/labels/fill-from-sort`: NaN scores previously fell into "bad" via `not (NaN >= thresh)` and were silently applied as bad labels; with sanitisation they still compare `-1.0 >= thresh == False` and land in "bad", but now reflect an explicit low-confidence verdict rather than a NaN coincidence. Behaviour for non-pathological inputs is unchanged.

https://claude.ai/code/session_01P4B4W6rhq7fr656DAzQHTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4B4W6rhq7fr656DAzQHTA)_