### PR TITLE
H34: reject vote-mutating endpoints when context header is absent

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -225,18 +225,28 @@ Cross-section interaction agents:
   `TestAddToPile.test_existing_media_label_synced_to_disk`,
   `test_new_media_label_synced_to_disk`, and
   `test_label_survives_rehydration` in `tests/core/test_medias.py`.
-- **H34. Missing `X-Detector-Id` → silent detector fallback** —
-  `vtscore/state/core.py` `get_active_detector_context()` falls
-  through to the thread-local (then `_empty_detector_context`) when
-  `g._detector_context` is unset. The H16 fix closed the sub-case
-  where the header is *present* but names an unloaded id (now 409);
-  the *header-absent* case remains open. Any route that mutates votes
-  without requiring the header — `add_media_to_pile`, `vote_media`,
-  bulk-label endpoints — silently writes to whatever the thread-local
-  resolves to, which on a Flask threaded-server worker can be the
-  detector left over from a previous request on the same thread.
-  Detector-side analog of H13; the fix is the same shape (reject the
-  request when the header is absent for any vote-mutating endpoint).
+- ~~**H34. Missing `X-Detector-Id` → silent detector fallback**~~ —
+  fixed in `vtsearch/routes/_shared.py`. Added two stateless route
+  decorators, `require_detector_header` and `require_dataset_header`,
+  that reject 400 when the corresponding header (or its `?detector_id=`
+  / `?dataset_id=` query-param fallback) is absent. Applied to every
+  vote-mutating endpoint: `vote_media` and `add_media_to_pile`
+  (`media/list.py`), `import_labels` and `fill_labels_from_sort`
+  (`labels/vote.py`), `run_label_import` and `ingest_missing`
+  (`labels/importers.py`), `clear_votes_route` (detector only) and
+  `seed_votes_from_examples` (`sorting.py`), and `find_label`
+  (`detectors/scoring.py`). The decorators run *before* the resolver
+  chain so a thread-local leak on a Flask worker can't silently
+  mistarget a vote even if a future code path were to leave a
+  thread-local detector pinned across requests. Pure-read endpoints
+  (registry listings, dashboard, file browser, settings GET) keep the
+  fall-through behaviour so background scripts and the standalone CLI
+  still work without headers. Test plumbing: `tests/conftest.py` now
+  wraps `client.open()` to auto-inject `X-Dataset-Id` /
+  `X-Detector-Id` from the thread-local active context (mimicking
+  Angular's `activeContextInterceptor`), so the existing test corpus
+  keeps working unchanged; tests that need to exercise the
+  header-absent path drop the thread-local first.
 
 ### Plugins / converters / exporters
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,17 +402,14 @@ def _active_id_for_tests(thread_local_getter, registry_getter) -> str | None:
     """Return the active context's id, but only if it's still registered.
 
     Reads the *thread-local* context directly rather than going through
-    ``get_active_*_context()``. The high-level resolver also checks
-    ``g._*_context`` first — but Flask's test client preserves the
-    previous request's request context inside ``with app.test_client() as c:``
-    blocks (so tests can inspect ``session`` / ``g`` after the response).
-    That means a request just after another request would read the
-    *previous* request's ``g._detector_context`` (always
-    ``_test_default_det`` in tests) instead of whatever thread-local
-    update the test code just made, e.g. via
-    ``set_thread_detector_context(get_detector_context(<new id>))``
-    after loading a fresh detector. Reading thread-local directly
-    sidesteps that staleness.
+    ``get_active_*_context()``. The high-level resolver also consults
+    Flask's per-request ``g._*_context`` — which only returns a sensible
+    value while a request handler is actively running (the resolver
+    gates on ``g._vts_in_request_handler``). Between requests in a
+    ``with app.test_client() as c:`` block, ``g`` exists but is no
+    longer "active". Either path would work here, but going straight
+    to the thread-local avoids paying the cost of a noop g lookup on
+    every test request.
 
     Skips:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,21 +398,46 @@ def isolated_settings(tmp_path, monkeypatch):
     det_reg_mod.reset_for_tests()
 
 
-def _active_id_for_tests(getter) -> str | None:
-    """Return the active context's id from the thread-local, or ``None``.
+def _active_id_for_tests(thread_local_getter, registry_getter) -> str | None:
+    """Return the active context's id, but only if it's still registered.
 
-    Skips the request-missing sentinel and the empty fallback (their
-    ids are not registered, so injecting them would just cause 409
-    "not loaded" downstream).
+    Reads the *thread-local* context directly rather than going through
+    ``get_active_*_context()``. The high-level resolver also checks
+    ``g._*_context`` first — but Flask's test client preserves the
+    previous request's request context inside ``with app.test_client() as c:``
+    blocks (so tests can inspect ``session`` / ``g`` after the response).
+    That means a request just after another request would read the
+    *previous* request's ``g._detector_context`` (always
+    ``_test_default_det`` in tests) instead of whatever thread-local
+    update the test code just made, e.g. via
+    ``set_thread_detector_context(get_detector_context(<new id>))``
+    after loading a fresh detector. Reading thread-local directly
+    sidesteps that staleness.
+
+    Skips:
+
+    - ``None`` contexts and ones whose id is an empty string or a
+      ``__sentinel__`` marker.
+    - Ids whose entry has been removed from the registry — e.g. a
+      previous request unloaded the detector but the test thread's
+      thread-local still points to the now-orphaned object. Injecting
+      a stale id would cause ``before_request`` to stash
+      ``_unloaded_detector_id`` and turn every proxy access into a
+      409, which is exactly the silent-mistarget surface H34 is
+      trying to avoid in *production* — but in the test wrapper we
+      want a clean "no header sent" so the route hits the proper
+      no-active-context path instead.
     """
     try:
-        ctx = getter()
+        ctx = thread_local_getter()
     except Exception:
         return None
     if ctx is None:
         return None
     cid = getattr(ctx, "dataset_id", None) or getattr(ctx, "detector_id", None)
-    if not cid or cid.startswith("__") or cid == "":
+    if not cid or cid.startswith("__"):
+        return None
+    if registry_getter(cid) is None:
         return None
     return cid
 
@@ -441,11 +466,11 @@ def _install_active_context_headers(c):
             headers = kwargs.get("headers")
             hdrs = Headers(headers) if headers is not None else Headers()
             if "X-Dataset-Id" not in hdrs:
-                ds_id = _active_id_for_tests(_core.get_active_context)
+                ds_id = _active_id_for_tests(_core.get_thread_dataset_context, _core.get_context)
                 if ds_id:
                     hdrs.add("X-Dataset-Id", ds_id)
             if "X-Detector-Id" not in hdrs:
-                det_id = _active_id_for_tests(_core.get_active_detector_context)
+                det_id = _active_id_for_tests(_core.get_thread_detector_context, _core.get_detector_context)
                 if det_id:
                     hdrs.add("X-Detector-Id", det_id)
             kwargs["headers"] = hdrs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,10 +398,67 @@ def isolated_settings(tmp_path, monkeypatch):
     det_reg_mod.reset_for_tests()
 
 
+def _active_id_for_tests(getter) -> str | None:
+    """Return the active context's id from the thread-local, or ``None``.
+
+    Skips the request-missing sentinel and the empty fallback (their
+    ids are not registered, so injecting them would just cause 409
+    "not loaded" downstream).
+    """
+    try:
+        ctx = getter()
+    except Exception:
+        return None
+    if ctx is None:
+        return None
+    cid = getattr(ctx, "dataset_id", None) or getattr(ctx, "detector_id", None)
+    if not cid or cid.startswith("__") or cid == "":
+        return None
+    return cid
+
+
+def _install_active_context_headers(c):
+    """Make the test client behave like Angular's ``activeContextInterceptor``.
+
+    Production routes that mutate vote / dataset state require ``X-Dataset-Id``
+    and ``X-Detector-Id`` headers (logical-bug-audit H34). In production those
+    headers are attached transparently by ``activeContextInterceptor`` in the
+    Angular frontend. The Flask test client has no such interceptor, so this
+    wrapper inspects the thread-local active context on each ``client.open()``
+    call and fills in the headers when they're not already provided. Tests
+    that need to exercise the header-absent code path can pass
+    ``headers={"X-Dataset-Id": ""}`` / ``"X-Detector-Id": ""`` to suppress
+    auto-injection for that key while still preserving the empty-string value
+    (which fails the ``bool(...)`` check the decorators apply).
+    """
+    from werkzeug.datastructures import Headers
+
+    original_open = c.open
+
+    def _open(*args, **kwargs):
+        path = args[0] if args else kwargs.get("path", "")
+        if isinstance(path, str) and path.startswith("/api/"):
+            headers = kwargs.get("headers")
+            hdrs = Headers(headers) if headers is not None else Headers()
+            if "X-Dataset-Id" not in hdrs:
+                ds_id = _active_id_for_tests(_core.get_active_context)
+                if ds_id:
+                    hdrs.add("X-Dataset-Id", ds_id)
+            if "X-Detector-Id" not in hdrs:
+                det_id = _active_id_for_tests(_core.get_active_detector_context)
+                if det_id:
+                    hdrs.add("X-Detector-Id", det_id)
+            kwargs["headers"] = hdrs
+        return original_open(*args, **kwargs)
+
+    c.open = _open
+
+
 @pytest.fixture
 def client():
     app_module.app.config["TESTING"] = True
     with app_module.app.test_client() as c:
+        _install_active_context_headers(c)
         yield c
 
 

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -664,11 +664,19 @@ class TestAddToPile:
                 # client preserves request contexts on its own ExitStack —
                 # invoking it from worker threads pushes contexts onto the
                 # workers' ContextVars and breaks the main-thread teardown.
+                # The conftest ``client`` fixture auto-injects context
+                # headers; freshly-built test clients don't, so we attach
+                # them explicitly here (H34 — vote/pile-add now requires
+                # ``X-Dataset-Id`` / ``X-Detector-Id``).
                 with app_module.app.test_client() as c:
                     r = c.post(
                         "/api/medias/add-to-pile",
                         data={"label": "good", "file": (io.BytesIO(wav_bytes), "race.wav")},
                         content_type="multipart/form-data",
+                        headers={
+                            "X-Dataset-Id": ds_ctx.dataset_id,
+                            "X-Detector-Id": det_ctx.detector_id,
+                        },
                     )
                 with lock:
                     results.append((r.status_code, r.get_json()))

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -5,6 +5,8 @@ Phase 1 of the "active" state simplification: the frontend can send
 dataset/model a request operates on, without mutating global "active" state.
 """
 
+import io
+
 import numpy as np
 
 from vtsearch.state import bad_votes, good_votes, medias
@@ -486,3 +488,136 @@ class TestRequestMissingSentinel:
         # acceptable safe-fail behaviour.  What matters is that we did
         # not silently apply the vote (which would be 200).
         assert resp.status_code in (400, 404)
+
+
+# ---------------------------------------------------------------------------
+# Tests: H34 — vote-mutating endpoints require explicit context headers
+# ---------------------------------------------------------------------------
+
+
+class TestVoteMutatingEndpointsRequireHeaders:
+    """logical-bug-audit H34: every endpoint that writes vote / pile state
+    rejects with 400 when the ``X-Dataset-Id`` / ``X-Detector-Id`` header
+    (or its ``?dataset_id=`` / ``?detector_id=`` query-param fallback) is
+    absent — even when a thread-local context is pinned. This rules out
+    silent-mistarget bugs on Flask threaded-server workers where a stale
+    thread-local from a previous request could otherwise absorb the
+    write.
+
+    Tests bypass the conftest test-client wrapper (which auto-injects
+    the headers from thread-local to mimic Angular's
+    ``activeContextInterceptor``) by passing an explicit empty-string
+    value for each header — the wrapper only fills in keys that are
+    absent from the request, and an empty string still fails the
+    decorator's ``bool(...)`` check.
+    """
+
+    DROP_HEADERS = {"X-Dataset-Id": "", "X-Detector-Id": ""}
+
+    def test_vote_media_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/medias/42/vote",
+            json={"target": "good"},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+        assert "X-Dataset-Id" in resp.get_data(as_text=True) or "X-Detector-Id" in resp.get_data(as_text=True)
+
+    def test_add_media_to_pile_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/medias/add-to-pile",
+            data={"label": "good", "file": (io.BytesIO(b"x"), "x.wav")},
+            content_type="multipart/form-data",
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_clear_votes_rejects_without_detector_header(self, client):
+        # /api/votes/clear only needs the detector header (it doesn't touch
+        # the dataset). Pass an empty detector header explicitly to suppress
+        # auto-injection while leaving the dataset header free.
+        resp = client.post(
+            "/api/votes/clear",
+            headers={"X-Detector-Id": ""},
+        )
+        assert resp.status_code == 400
+        assert "X-Detector-Id" in resp.get_data(as_text=True)
+
+    def test_seed_votes_from_examples_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": []},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_import_labels_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/labels/import",
+            json={"labels": []},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_fill_from_sort_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={"sort_results": [{"id": 1, "score": 0.9}], "threshold": 0.5},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_ingest_missing_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/label-importers/ingest-missing",
+            json={"entries": [{"label": "good", "md5": "x" * 32}]},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_find_label_rejects_without_headers(self, client):
+        resp = client.post(
+            "/api/find-label",
+            json={"detector_id": "anything"},
+            headers=self.DROP_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_thread_local_does_not_bypass_header_requirement(self, client):
+        """Even with the test fixture's default thread-local pin, the
+        explicit empty-string headers still cause a 400 — the decorator
+        runs *before* any context resolution, so a leaked thread-local
+        on a Flask worker can never substitute for the absent header.
+        This is the precise H34 surface: the route mustn't trust whatever
+        ``get_active_detector_context()`` happens to resolve to.
+        """
+        # Thread-local is _test_default / _test_default_det at this point
+        # (set by ``reset_state``). Without explicit empty-string headers,
+        # the wrapper would auto-inject and the request would succeed.
+        resp = client.post(
+            "/api/medias/42/vote",
+            json={"target": "good"},
+            headers={"X-Detector-Id": ""},
+        )
+        assert resp.status_code == 400
+        assert "X-Detector-Id" in resp.get_data(as_text=True)
+
+    def test_query_param_fallback_satisfies_the_check(self, client):
+        """``?detector_id=`` / ``?dataset_id=`` query params count as
+        identification for the header-required gate (matches the
+        browser-native fallback path documented for ``<img src>`` etc.).
+        """
+        # Use an empty header to suppress wrapper auto-injection but
+        # supply a query-param value. The route's pre-handler decorator
+        # accepts it; the routing then hits a different failure path
+        # (404 / 409 / etc.), not the 400 the decorator would produce.
+        resp = client.post(
+            "/api/medias/99999/vote?detector_id=any-id-here",
+            json={"target": "good"},
+            headers={"X-Detector-Id": ""},
+        )
+        # The decorator passes (header-or-query satisfied); the route
+        # itself returns 404 because media 99999 isn't loaded. Either
+        # way, the response is NOT the decorator's specific 400 message.
+        body = resp.get_data(as_text=True)
+        assert resp.status_code != 400 or ("X-Detector-Id header" not in body and "X-Dataset-Id header" not in body)

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable
 
 from flask import g, jsonify, request
 from flask_smorest import abort
@@ -15,6 +16,76 @@ if TYPE_CHECKING:
 import vtscore.security.path_validation as _paths
 
 logger = logging.getLogger(__name__)
+
+
+def _has_context_id(header_name: str, query_param: str) -> bool:
+    """Return True iff *header_name* or *query_param* identifies a context.
+
+    Matches the precedence applied by ``before_request`` in ``app.py``:
+    header first, then query-param fallback for browser-native requests
+    (``<img src>`` / ``<audio src>`` / ``<video src>``) that bypass
+    Angular's HttpClient interceptor.
+    """
+    return bool(request.headers.get(header_name) or request.args.get(query_param))
+
+
+def require_detector_header(fn: Callable) -> Callable:
+    """Route decorator: reject 400 if no ``X-Detector-Id`` is identified.
+
+    Closes logical-bug-audit H34: vote-mutating endpoints used to silently
+    write to whatever ``get_active_detector_context()`` resolved to when
+    the client dropped the header. The frozen ``_request_missing_detector_context``
+    sentinel catches the case where both the header *and* the thread-local
+    are absent, but if any future code path sets the thread-local on a
+    Flask request thread, a header-absent request would land on a stale
+    detector. This guard rejects header-absent requests *before* the
+    resolver chain runs, regardless of thread-local state — defence in
+    depth.
+
+    Apply to any endpoint that mutates ``DetectorContext`` state
+    (``good_votes`` / ``bad_votes`` / ``label_history`` / ``vote_*`` /
+    ``find_initial_labels`` / ``click_counter``). Pure reads, registry
+    listings, and dashboard endpoints don't need it.
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not _has_context_id("X-Detector-Id", "detector_id"):
+            abort(
+                400,
+                message=(
+                    "X-Detector-Id header (or ?detector_id= query param) is "
+                    "required for this endpoint."
+                ),
+            )
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def require_dataset_header(fn: Callable) -> Callable:
+    """Route decorator: reject 400 if no ``X-Dataset-Id`` is identified.
+
+    Sister of :func:`require_detector_header` — closes the dataset-side
+    analog of H34. Apply to any endpoint that mutates ``DatasetContext``
+    state (``medias`` insertions, ``diversity_tree`` rebuilds) or whose
+    correctness depends on knowing which dataset's cid-keyed votes are
+    being touched (label imports, fill-from-sort).
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not _has_context_id("X-Dataset-Id", "dataset_id"):
+            abort(
+                400,
+                message=(
+                    "X-Dataset-Id header (or ?dataset_id= query param) is "
+                    "required for this endpoint."
+                ),
+            )
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def error_response(error: str, status: int, detail: Any | None = None, **extra: Any):

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -53,10 +53,7 @@ def require_detector_header(fn: Callable) -> Callable:
         if not _has_context_id("X-Detector-Id", "detector_id"):
             abort(
                 400,
-                message=(
-                    "X-Detector-Id header (or ?detector_id= query param) is "
-                    "required for this endpoint."
-                ),
+                message=("X-Detector-Id header (or ?detector_id= query param) is required for this endpoint."),
             )
         return fn(*args, **kwargs)
 
@@ -78,10 +75,7 @@ def require_dataset_header(fn: Callable) -> Callable:
         if not _has_context_id("X-Dataset-Id", "dataset_id"):
             abort(
                 400,
-                message=(
-                    "X-Dataset-Id header (or ?dataset_id= query param) is "
-                    "required for this endpoint."
-                ),
+                message=("X-Dataset-Id header (or ?dataset_id= query param) is required for this endpoint."),
             )
         return fn(*args, **kwargs)
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -18,6 +18,7 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.concurrency.memory_budget import cap_workers_by_memory
 from vtscore.concurrency.progress import find_progress, update_find_progress
+from vtsearch.routes._shared import require_dataset_header, require_detector_header
 from vtsearch.schemas.detectors import (
     AutoDetectRequestSchema,
     AutoDetectResponseSchema,
@@ -181,6 +182,8 @@ def _resolve_or_train_detector(  # noqa: C901
 @detector_scoring_bp.response(200, FindLabelResponseSchema)
 @detector_scoring_bp.alt_response(400, description="No medias loaded, or the detector has no labels for scoring.")
 @detector_scoring_bp.alt_response(404, description="Detector not found.")
+@require_dataset_header
+@require_detector_header
 def find_label(body: dict):  # noqa: C901
     """Score all loaded medias with a detector and apply labels based on threshold.
 

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -53,6 +53,8 @@ logger = logging.getLogger(__name__)
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
     get_plugin_or_404,
+    require_dataset_header,
+    require_detector_header,
     run_plugin_or_error,
     validate_filepath_field,
     validate_plugin_args,
@@ -145,6 +147,8 @@ def get_label_importers():
 
 
 @label_importers_bp.route("/api/label-importers/import/<importer_name>", methods=["POST"])
+@require_dataset_header
+@require_detector_header
 def run_label_import(importer_name: str):  # noqa: C901
     """Run the named label importer and apply the resulting labels.
 
@@ -249,6 +253,8 @@ def run_label_import(importer_name: str):  # noqa: C901
 @label_importers_bp.route("/api/label-importers/ingest-missing", methods=["POST"])
 @label_importers_bp.arguments(IngestMissingRequestSchema)
 @label_importers_bp.response(200, IngestMissingResponseSchema)
+@require_dataset_header
+@require_detector_header
 def ingest_missing(body: dict):
     """Re-ingest missing medias from their origins, then apply their labels."""
     entries = body["entries"]

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -19,6 +19,7 @@ from vtsearch.schemas.labels import (
     LabelsImportResponseSchema,
 )
 from vtscore.detectors.dataset_sync import validated_vote_snapshot
+from vtsearch.routes._shared import require_dataset_header, require_detector_header
 from vtsearch.state import (
     apply_label,
     apply_label_with_click_time,
@@ -183,6 +184,8 @@ def export_labels(query: dict):
 @labels_bp.route("/api/labels/import", methods=["POST"])
 @labels_bp.arguments(LabelsImportRequestSchema)
 @labels_bp.response(200, LabelsImportResponseSchema)
+@require_dataset_header
+@require_detector_header
 def import_labels(body: dict):
     """Import labels from JSON, matching medias by origin+origin_name (MD5 fallback)."""
     labels = body["labels"]
@@ -226,6 +229,8 @@ def import_labels(body: dict):
 @labels_bp.route("/api/labels/fill-from-sort", methods=["POST"])
 @labels_bp.arguments(FillFromSortRequestSchema)
 @labels_bp.response(200, FillFromSortResponseSchema)
+@require_dataset_header
+@require_detector_header
 def fill_labels_from_sort(body: dict):  # noqa: C901
     """Fill labels from the current sort results.
 

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -35,6 +35,7 @@ from vtsearch.schemas.media import (
     MediaVoteRequestSchema,
     MediaVoteResponseSchema,
 )
+from vtsearch.routes._shared import require_dataset_header, require_detector_header
 from vtsearch.state import (
     _state_lock,
     apply_label,
@@ -521,6 +522,8 @@ def media_generic(media_id: int):
 @medias_bp.response(200, MediaVoteResponseSchema)
 @medias_bp.alt_response(400, description="region_box is malformed, or a non-good target carries a region_box.")
 @medias_bp.alt_response(404, description="Media not found.")
+@require_dataset_header
+@require_detector_header
 def vote_media(body: dict, media_id: int):
     """Set a single media's vote to an **absolute target state**.
 
@@ -606,6 +609,8 @@ def vote_media(body: dict, media_id: int):
         "invalid label), no dataset loaded, or no embedder available."
     ),
 )
+@require_dataset_header
+@require_detector_header
 def add_media_to_pile():  # noqa: C901
     """Upload a media file and add it directly to the Good or Bad pile.
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -26,6 +26,8 @@ from flask_smorest import Blueprint, abort
 from vtsearch.routes._shared import (
     format_exception_detail,
     get_embedder_for_medias,
+    require_dataset_header,
+    require_detector_header,
 )
 
 from vtscore.config import DATA_DIR
@@ -582,6 +584,7 @@ def get_votes():
 
 @sorting_bp.route("/api/votes/clear", methods=["POST"])
 @sorting_bp.response(200, OkResponseSchema)
+@require_detector_header
 def clear_votes_route():
     """Clear all votes without clearing medias.
 
@@ -597,6 +600,8 @@ def clear_votes_route():
 @sorting_bp.route("/api/votes/seed-from-examples", methods=["POST"])
 @sorting_bp.arguments(SeedFromExamplesRequestSchema)
 @sorting_bp.response(200, SeedFromExamplesResponseSchema)
+@require_dataset_header
+@require_detector_header
 def seed_votes_from_examples(body: dict):
     """Seed good votes from a model's media examples.
 

--- a/vtsearch/shim/__init__.py
+++ b/vtsearch/shim/__init__.py
@@ -23,6 +23,18 @@ def _flask_dataset_context_resolver() -> Any:
     library callers) so :func:`vtscore.state.core.get_active_context`
     can fall through to its thread-local / empty-context fallback.
 
+    Also returns ``None`` when Flask's test client is still preserving
+    the *previous* request's context for inspection (``with
+    app.test_client() as c:`` blocks pop-and-keep the request context
+    so the caller can read ``session`` / ``g`` after the response).
+    Inside that window we are no longer in the active handler — falling
+    back to the thread-local matches what the next real request would
+    see (and what production code, which never has a preserved context,
+    always saw). The ``before_request`` hook sets
+    ``g._vts_in_request_handler = True``; ``teardown_request`` clears
+    it back to ``False`` before the test client's preserved window
+    opens.
+
     Raises :class:`vtscore.state.core.DatasetNotLoadedError` if the
     request explicitly named a dataset (``X-Dataset-Id`` header or
     ``?dataset_id=`` query param) that is not loaded. Without this, the
@@ -32,6 +44,8 @@ def _flask_dataset_context_resolver() -> Any:
     from flask import g, has_request_context
 
     if not has_request_context():
+        return None
+    if not getattr(g, "_vts_in_request_handler", False):
         return None
     ctx = getattr(g, "_dataset_context", None)
     if ctx is None:
@@ -48,6 +62,8 @@ def _flask_detector_context_resolver() -> Any:
     from flask import g, has_request_context
 
     if not has_request_context():
+        return None
+    if not getattr(g, "_vts_in_request_handler", False):
         return None
     ctx = getattr(g, "_detector_context", None)
     if ctx is None:


### PR DESCRIPTION
## Summary

Closes logical-bug-audit **H34**. Every Flask endpoint that writes vote / pile-add state now rejects with 400 when the request doesn't identify a detector (and, where applicable, a dataset) — even if a thread-local context happens to be pinned on the request thread. This rules out silent-mistarget bugs on Flask threaded-server workers where a stale thread-local from a previous request could otherwise absorb the write.

### Production changes

- **New decorators** in `vtsearch/routes/_shared.py`: `require_detector_header`, `require_dataset_header`. They check `X-Detector-Id` / `X-Dataset-Id` (or the `?detector_id=` / `?dataset_id=` query-param fallback for browser-native requests) *before* the resolver chain runs.
- **Applied to** every vote-mutating endpoint:
  - `vote_media` and `add_media_to_pile` — `vtsearch/routes/media/list.py`
  - `import_labels` and `fill_labels_from_sort` — `vtsearch/routes/labels/vote.py`
  - `run_label_import` and `ingest_missing` — `vtsearch/routes/labels/importers.py`
  - `clear_votes_route` (detector only) and `seed_votes_from_examples` — `vtsearch/routes/sorting.py`
  - `find_label` — `vtsearch/routes/detectors/scoring.py`
  - Pure-read endpoints (registry listings, dashboard, file browser, settings GET) keep the fall-through behaviour so background scripts and the CLI still work without headers.
- **Hardened the Flask shim resolver** (`vtsearch/shim/__init__.py`) to gate on `_vts_in_request_handler` so the preserved request context inside `with app.test_client() as c:` blocks can never leak into reads taken *between* requests. This matches production behaviour, where the request context is fully torn down at the end of each request.

### Test plumbing

- `tests/conftest.py` wraps `client.open()` to auto-inject `X-Dataset-Id` / `X-Detector-Id` from the test thread-local — mimicking Angular's `activeContextInterceptor` so the existing test corpus keeps working unchanged. It reads thread-local directly (rather than via `get_active_*_context()`) to dodge the test client's preserved-`g` window.
- `tests/datasets/test_request_context.py::TestVoteMutatingEndpointsRequireHeaders` (new) locks in the contract: empty-string headers fail the decorator's `bool(...)` check even when the test thread-local is pinned, query-param fallback satisfies it, and each decorated endpoint rejects with 400.
- `tests/core/test_medias.py::test_concurrent_uploads_same_md5_no_duplicate` (H32 regression test) builds its own test clients in worker threads, so the conftest auto-injector doesn't apply — it now passes the headers explicitly.

### Audit doc

- `docs/plans/logical-bug-audit.md` marks H34 as fixed and links to the closing code.

## Test plan

- [x] `./run-tests.sh` — all 4079 tests pass.
- [x] New `TestVoteMutatingEndpointsRequireHeaders` (10 tests) — each decorated endpoint returns 400 with empty headers.
- [x] Existing `test_vote_endpoint_returns_4xx_without_dataset_header` (TestRequestMissingSentinel) — still passes; now 400 from the decorator instead of 404 from the get_media fallthrough.
- [x] Backwards compat: detector-load / vote / find-label / fill-from-sort / clear-votes flows all keep working through the conftest's auto-injector.

https://claude.ai/code/session_01QkC3Snwo5AYkirhYu29yCp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkC3Snwo5AYkirhYu29yCp)_