### PR TITLE
Fix audit M8/M11/M12: skip null embeddings in pickle loader

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -584,8 +584,11 @@ Cross-section interaction agents:
 
 ### Datasets / loaders
 
-- **M8.** Thin-mode pickle loader treats `embedding: None` as present, then
-  `np.array(None)` produces an object-dtype row.
+- **M8.** ~~Thin-mode pickle loader treats `embedding: None` as present, then
+  `np.array(None)` produces an object-dtype row.~~ **Shipped (with M12).**
+  `_convert_one_pickle_media` now treats missing key and explicit `None`
+  identically for both thin and full modes — entry is skipped and the
+  "missing media" warning fires.
 - ~~**M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
   and `file_name` override entries exist with different embeddings.~~
 - **M10.** ~~`clipper_chain._run_clipper_step` assumes deterministic output count
@@ -596,10 +599,23 @@ Cross-section interaction agents:
   drift / no-match / ambiguous match, and returns `None` instead of
   silently picking `outputs[0]` (was a regression vs. the legacy
   `_clip_text_to_bytes` resolver path).
-- **M11.** Stale media in `cli._score_medias_with_detectors` when some
-  embeddings are `None` (zip truncates silently).
-- **M12.** `loader_pickle._build_pickle_full_media` has no null-check before
-  `np.array(media_info["embedding"])`.
+- **M11.** ~~Stale media in `cli._score_medias_with_detectors` when some
+  embeddings are `None` (zip truncates silently).~~ **Shipped.**
+  `_score_medias_with_detectors` now uses `zip(all_ids, scores,
+  strict=True)` so a partial embedding matrix raises `ValueError`
+  instead of silently dropping hits. With the M12 fix in place this
+  loop should never be partial, but the strict zip guards against
+  future regressions.
+- **M12.** ~~`loader_pickle._build_pickle_full_media` has no null-check before
+  `np.array(media_info["embedding"])`.~~ **Shipped.**
+  `_convert_one_pickle_media` skips any entry whose `embedding` is
+  missing or `None` before the build helpers run — symmetric with the
+  thin-mode path (M8) and with the folder loader's drop-on-no-embed
+  behaviour. The registry load path doesn't re-embed after
+  `load_dataset_from_pickle`, so preserving `None` would have just
+  pushed the crash into the first sort/find call; dropping the
+  poisoned entry keeps the dataset usable and surfaces the loss via
+  the existing `missing_media` warning.
 
 ### Routes / API
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -12,6 +12,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 import app as app_module
 
 SAMPLE_RESULTS = {
@@ -295,6 +297,43 @@ class TestFillFromSortConfirm:
 
 
 class TestCliScoringNegativeHits:
+    def test_strict_zip_raises_on_id_score_mismatch(self, client, monkeypatch):
+        """M11 regression: ``zip(all_ids, scores, strict=True)``.
+
+        If ``get_embedding_matrix_for_snap`` (or any future variant)
+        returned an id list whose length disagrees with the score
+        vector, the prior plain ``zip`` would silently truncate.  The
+        strict zip now raises ``ValueError`` so the bug is impossible
+        to miss.
+        """
+        import numpy as np
+        import torch
+
+        from vtscore.cli import _score_medias_with_detectors
+        from vtsearch.state import medias
+
+        first_cid = next(iter(medias))
+        emb = np.asarray(medias[first_cid]["embedding"], dtype=np.float32)
+        dim = int(emb.shape[-1])
+
+        # Stub the matrix builder so it claims 2 ids but only 1 row of
+        # embeddings.  ``scores`` ends up length 1, ``all_ids`` length
+        # 2 — exactly the mismatch the strict zip guards against.
+        extra_id = max(medias) + 1
+
+        def _mismatched(_snap):
+            return [first_cid, extra_id], emb.reshape(1, -1)
+
+        monkeypatch.setattr(
+            "vtscore.embedding.matrix.get_embedding_matrix_for_snap",
+            _mismatched,
+        )
+
+        mlp = torch.nn.Linear(dim, 1)
+        detector_mlps = {"det": {"mlp": mlp, "threshold": 0.5}}
+        with pytest.raises(ValueError):
+            _score_medias_with_detectors(medias, detector_mlps)
+
     def test_trainable_model_scoring_returns_negative_hits(self, client):
         """The detector CLI scorer should include negative_hits."""
         import torch

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -170,6 +170,154 @@ class TestThinLoadFromPickle:
         assert medias[1]["media_bytes"] is not None
 
 
+class TestPickleNullEmbedding:
+    """Skip-on-None pickle entries (audit M8 / M12).
+
+    ``np.array(None)`` returns a 0-d ``dtype=object`` array that survives
+    every ``is None`` guard in the codebase, so the pickle loader must
+    drop entries whose ``embedding`` field is missing or ``None`` before
+    they enter the medias dict.  Mirrors the folder loader, which
+    already returns ``None`` for failed embeds.
+    """
+
+    def _wav_pickle(
+        self,
+        tmp_path: Path,
+        *,
+        embedding: Any,
+        embedding_key_present: bool = True,
+        include_bytes: bool = True,
+    ) -> Path:
+        wav_bytes = _make_wav_bytes()
+        media: dict[str, Any] = {
+            "id": 1,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "filename": "test.wav",
+            "category": "test",
+        }
+        if embedding_key_present:
+            media["embedding"] = embedding
+        if include_bytes:
+            media["media_bytes"] = wav_bytes
+        pkl_path = tmp_path / "test.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": {1: media}}, f)
+        return pkl_path
+
+    def test_full_mode_skips_explicit_none_embedding(self, tmp_path, capsys):
+        pkl_path = self._wav_pickle(tmp_path, embedding=None)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert medias == {}
+        out = capsys.readouterr().out
+        assert "1 media files missing" in out
+
+    def test_full_mode_skips_missing_embedding_key(self, tmp_path, capsys):
+        pkl_path = self._wav_pickle(tmp_path, embedding=None, embedding_key_present=False)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert medias == {}
+        out = capsys.readouterr().out
+        assert "1 media files missing" in out
+
+    def test_thin_mode_skips_explicit_none_embedding(self, tmp_path, capsys):
+        """Regression for M8: prior code only checked key absence, not None."""
+        pkl_path = self._wav_pickle(tmp_path, embedding=None, include_bytes=False)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=True)
+        assert medias == {}
+        out = capsys.readouterr().out
+        assert "1 media files missing" in out
+
+    def test_thin_mode_skips_missing_embedding_key(self, tmp_path, capsys):
+        pkl_path = self._wav_pickle(
+            tmp_path, embedding=None, embedding_key_present=False, include_bytes=False
+        )
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=True)
+        assert medias == {}
+        out = capsys.readouterr().out
+        assert "1 media files missing" in out
+
+    def test_full_mode_mixed_keeps_good_drops_null(self, tmp_path):
+        wav_bytes = _make_wav_bytes()
+        good = {
+            "id": 1,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "embedding": np.zeros(512).tolist(),
+            "filename": "good.wav",
+            "category": "test",
+            "media_bytes": wav_bytes,
+        }
+        bad = {
+            "id": 2,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
+            "embedding": None,
+            "filename": "bad.wav",
+            "category": "test",
+            "media_bytes": wav_bytes,
+        }
+        pkl_path = tmp_path / "mixed.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": {1: good, 2: bad}}, f)
+
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert list(medias.keys()) == [1]
+        # No poisoned 0-d object array snuck through.
+        assert medias[1]["embedding"].ndim >= 1
+        assert medias[1]["embedding"].dtype != object
+
+    def test_chunked_loader_skips_null_embedding(self, tmp_path):
+        from vtscore.datasets.loader import load_dataset_from_pickle_chunked
+
+        wav_bytes = _make_wav_bytes()
+        pkl_data = {
+            "medias": {
+                1: {
+                    "id": 1,
+                    "type": "audio",
+                    "duration": 0.1,
+                    "file_size": len(wav_bytes),
+                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    "embedding": np.zeros(512).tolist(),
+                    "filename": "a.wav",
+                    "category": "test",
+                    "media_bytes": wav_bytes,
+                },
+                2: {
+                    "id": 2,
+                    "type": "audio",
+                    "duration": 0.1,
+                    "file_size": len(wav_bytes),
+                    "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
+                    "embedding": None,
+                    "filename": "b.wav",
+                    "category": "test",
+                    "media_bytes": wav_bytes,
+                },
+            }
+        }
+        pkl_path = tmp_path / "chunked.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump(pkl_data, f)
+
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10))
+        loaded = {cid: m for chunk in chunks for cid, m in chunk.items()}
+        assert len(loaded) == 1
+        only = next(iter(loaded.values()))
+        assert only["filename"] == "a.wav"
+
+
 class TestPickleMD5Preservation:
     """Test that load_dataset_from_pickle uses pre-existing MD5 from pickle data."""
 

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -233,9 +233,7 @@ class TestPickleNullEmbedding:
         assert "1 media files missing" in out
 
     def test_thin_mode_skips_missing_embedding_key(self, tmp_path, capsys):
-        pkl_path = self._wav_pickle(
-            tmp_path, embedding=None, embedding_key_present=False, include_bytes=False
-        )
+        pkl_path = self._wav_pickle(tmp_path, embedding=None, embedding_key_present=False, include_bytes=False)
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_pickle(pkl_path, medias, thin=True)
         assert medias == {}

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -234,7 +234,9 @@ def _score_medias_with_detectors(
 
         positive_hits: list[dict[str, Any]] = []
         negative_hits: list[dict[str, Any]] = []
-        for cid, score in zip(all_ids, scores):
+        # ``strict=True`` so a future partial embedding-matrix bug fails
+        # loudly instead of silently truncating scoring results.
+        for cid, score in zip(all_ids, scores, strict=True):
             hit = build_media_hit(cid, medias[cid], score)
             if score >= threshold:
                 positive_hits.append(hit)

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -188,16 +188,24 @@ def _convert_one_pickle_media(
     """Convert one pickle media entry to the app's media format.
 
     Returns ``(media_data, missing)``.  ``media_data`` is ``None`` when
-    the entry is unusable (thin without embedding, full without bytes);
-    ``missing`` is ``True`` only when an external file reference failed
-    to resolve (used to bump the "missing media" warning counter).
+    the entry is unusable (no usable embedding, or full mode without
+    bytes); ``missing`` is ``True`` when the entry was skipped because
+    its embedding or external-file reference could not be resolved
+    (used to bump the "missing media" warning counter).
     """
     media_type = media_info.get("type", "audio")
     extra_fields = extra_fields_map.get(media_type, [])
 
+    # Treat missing key and explicit ``None`` identically: both mean
+    # "no usable embedding".  Without this check ``np.array(None)``
+    # would silently produce a 0-d ``dtype=object`` array that survives
+    # the ``is None`` guards scattered across the codebase and later
+    # poisons every embedding-matrix consumer with a confusing
+    # ``TypeError: float() argument must be a real number, not 'NoneType'``.
+    if media_info.get("embedding") is None:
+        return None, True
+
     if thin:
-        if "embedding" not in media_info:
-            return None, True
         media_path = _resolve_thin_media_path(media_type, media_info, data, dir_keys)
         return _build_pickle_thin_media(new_id, media_info, media_type, media_path, extra_fields), False
 
@@ -238,8 +246,11 @@ def load_dataset_from_pickle(
 
     If media bytes are not stored inline in the pickle, the function attempts to
     load them from the companion directory entry in the pickle. Medias for which
-    no bytes can be resolved are silently skipped (a warning is printed to
-    stdout after loading).
+    no bytes can be resolved — or whose ``embedding`` field is missing or
+    ``None`` — are silently skipped (a warning is printed to stdout after
+    loading).  Skipping ``None`` embeddings is important: ``np.array(None)``
+    yields a 0-d ``dtype=object`` array that downstream consumers cannot
+    distinguish from a real vector until they crash.
 
     The ``medias`` dict is cleared before loading begins.
 


### PR DESCRIPTION
## Summary

- **M12 (root cause).** `loader_pickle._build_pickle_full_media` called `np.array(media_info["embedding"])` with no null check. When the pickle stored an explicit `embedding=None` (reachable via `load_dataset_from_folder(skip_embedding=True)` round-tripping through `export_dataset_to_file`), `np.array(None)` returned a 0-d `dtype=object` array that survived every downstream `is None` guard and crashed the embedding-matrix builder later with a confusing `TypeError: float() argument must be a real number, not 'NoneType'`. The registry load path doesn't re-embed after `load_dataset_from_pickle`, so preserving `None` (a prior unmerged attempt's approach) would have just pushed the crash into the first sort/find call.
- **M8 (sibling, bundled).** The thin-mode counterpart had a key-existence guard (`if "embedding" not in media_info`) but it didn't catch an explicit `None` value, so thin mode had the same poisoning bug.
- **Fix.** `_convert_one_pickle_media` now drops any entry whose `embedding` is missing or `None` before the build helpers run — symmetric across thin/full modes and consistent with the folder loader's drop-on-no-embed behaviour. The existing `missing_media` counter surfaces the loss via the post-load warning.
- **M11 (defensive, bundled).** `cli._score_medias_with_detectors` now uses `zip(all_ids, scores, strict=True)` so a partial embedding matrix raises `ValueError` instead of silently dropping hits. With M12 fixed this loop should never be partial, but the strict zip guards against future regressions.

Audit doc (`docs/plans/logical-bug-audit.md`) updated to mark M8/M11/M12 as shipped with a short note on the fix and why "preserve None" was rejected.

## Test plan

- [x] `./run-tests.sh datasets io` — 1221 passed
- [x] `./run-tests.sh` (full suite) — 4097 passed (one flaky `tests_lib/io/test_server_files_importer.py::TestRunChunked::test_run_chunked_cleans_up_staging_dir` on first run, passed in isolation and on re-run; unrelated to this change)
- [x] New `TestPickleNullEmbedding` in `tests_lib/datasets/test_thin_loading.py` covers: full-mode explicit-None, full-mode missing-key, thin-mode explicit-None (M8 regression), thin-mode missing-key, mixed pickle keeps good entries while dropping null, and chunked-loader honours the skip. Also asserts no 0-d object array sneaks into `medias`.
- [x] New `test_strict_zip_raises_on_id_score_mismatch` in `tests/io/test_export_options.py` exercises the M11 strict-zip by stubbing the matrix builder to return mismatched id/score lengths.

https://claude.ai/code/session_011ZkdjGQSJCNytwBNRe8zkM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZkdjGQSJCNytwBNRe8zkM)_