### PR TITLE
Fix flaky test_run_chunked_cleans_up_staging_dir under parallel xdist

### DIFF
--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -334,7 +334,7 @@ class TestRunChunked:
                 )
             )
 
-    def test_run_chunked_cleans_up_staging_dir(self, tmp_path):
+    def test_run_chunked_cleans_up_staging_dir(self, tmp_path, monkeypatch):
         from helpers import make_raw_wav_bytes
 
         src = tmp_path / "only.wav"
@@ -342,10 +342,17 @@ class TestRunChunked:
         listing = tmp_path / "list.txt"
         listing.write_text(f"{src}\n")
 
-        # Snapshot existing tmp prefixes so we can detect a leak.
+        # Redirect the importer's ``tempfile.mkdtemp`` into a private dir
+        # under this test's ``tmp_path`` so the leak check is isolated
+        # from parallel xdist workers (run-tests.sh uses ``-n auto``),
+        # which would otherwise also create ``server_files_*`` dirs in
+        # the shared system tempdir.
         import tempfile as _tempfile
 
-        tmp_root = Path(_tempfile.gettempdir())
+        tmp_root = tmp_path / "stage_root"
+        tmp_root.mkdir()
+        monkeypatch.setattr(_tempfile, "tempdir", str(tmp_root))
+
         before = {p.name for p in tmp_root.iterdir() if p.name.startswith("server_files_")}
 
         imp = ServerFilesDatasetImporter()


### PR DESCRIPTION
## Summary

`tests_lib/io/test_server_files_importer.py::test_run_chunked_cleans_up_staging_dir` flaked once on a full-suite run and didn't reproduce on rerun or when the file/group ran alone. Root cause: the test snapshots the shared system tempdir for `server_files_*` entries before/after a single import, but `./run-tests.sh` runs with `-n auto` and a parallel xdist worker can race-create its own `server_files_*` staging dir (the importer hardcodes `tempfile.mkdtemp(prefix="server_files_")`) between the two snapshots — yielding a false-positive "leak" delta.

Fix: `monkeypatch.setattr(tempfile, "tempdir", <subdir of tmp_path>)` so the importer's `mkdtemp` writes inside this test's pytest-isolated `tmp_path`, and snapshot that subdir instead of the global tempdir. The leak-detection semantics are unchanged, but the snapshot can't see another worker's activity.

## Test plan

- [x] `python -m pytest tests_lib/io/test_server_files_importer.py -q -n auto -m "not gpu"` → all 23 pass
- [ ] Watch the next full-suite run; the previous flake on this test should not recur


---
_Generated by [Claude Code](https://claude.ai/code/session_01SgrmcoMhQiVXGZx51kQyCM)_