### PR TITLE
Fix video tile embeddings sharing parent video frames

### DIFF
--- a/tests_lib/detectors/test_video_clip_embedding.py
+++ b/tests_lib/detectors/test_video_clip_embedding.py
@@ -291,20 +291,22 @@ def _make_tiled_video_clips() -> list[dict]:
     parent_md5 = hashlib.md5(parent_bytes).hexdigest()
     tiles = []
     for idx, (t0, t1) in enumerate([(0.0, 2.0), (2.0, 4.0), (4.0, 6.0)]):
-        tiles.append({
-            "id": 100 + idx,
-            "type": "video",
-            "media_bytes": parent_bytes,
-            "media_path": "/data/parent.mp4",
-            "md5": parent_md5,  # stale; the fixup should rewrite it
-            "duration": 2.0,
-            "clip_index": idx,
-            "clip_start": t0,
-            "clip_end": t1,
-            "filename": "parent.mp4",
-            "origin_name": "parent.mp4",
-            "embedding": None,
-        })
+        tiles.append(
+            {
+                "id": 100 + idx,
+                "type": "video",
+                "media_bytes": parent_bytes,
+                "media_path": "/data/parent.mp4",
+                "md5": parent_md5,  # stale; the fixup should rewrite it
+                "duration": 2.0,
+                "clip_index": idx,
+                "clip_start": t0,
+                "clip_end": t1,
+                "filename": "parent.mp4",
+                "origin_name": "parent.mp4",
+                "embedding": None,
+            }
+        )
     return tiles
 
 

--- a/tests_lib/detectors/test_video_clip_embedding.py
+++ b/tests_lib/detectors/test_video_clip_embedding.py
@@ -1,0 +1,357 @@
+"""Tests for the video-clip embedding boundary fix.
+
+Before the fix, ``VideoTilingClipper`` tiles all shared the parent video's
+embedding because:
+
+  1. ``_build_clip_embed_input`` dropped ``clip_start`` / ``clip_end``;
+  2. ``_fixup_clip_md5_and_embeddings`` skipped re-embedding for video
+     (since video clippers don't slice bytes);
+  3. The video embedders sampled ``np.linspace(0, frame_count - 1, n)``
+     unconditionally — ignoring the clip range.
+
+These tests cover all three layers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _frame_index_range — boundary math
+# ---------------------------------------------------------------------------
+
+
+class TestFrameIndexRange:
+    def test_full_range_when_no_boundaries(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        media: dict[str, Any] = {}
+        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
+        assert (start, end) == (0, 99)
+
+    def test_clip_boundaries_map_to_indices(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        media = {"clip_start": 2.0, "clip_end": 5.0}
+        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
+        # 2.0s @ 10fps = frame 20; 5.0s @ 10fps -> last frame = 50 - 1 = 49.
+        assert start == 20
+        assert end == 49
+
+    def test_clip_boundaries_clamped_to_video(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        media = {"clip_start": 99.0, "clip_end": 200.0}
+        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
+        # clip_start far past end: clamp to last frame; end must not precede start.
+        assert start == 99
+        assert end == 99
+
+    def test_falls_back_to_full_when_fps_zero(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        media = {"clip_start": 1.0, "clip_end": 2.0}
+        start, end = _frame_index_range(media, frame_count=50, fps=0.0)
+        assert (start, end) == (0, 49)
+
+    def test_falls_back_to_full_when_end_le_start(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        media = {"clip_start": 3.0, "clip_end": 3.0}
+        start, end = _frame_index_range(media, frame_count=50, fps=10.0)
+        assert (start, end) == (0, 49)
+
+    def test_distinct_tiles_get_distinct_ranges(self):
+        from vtscore.media.video._frame_sampling import _frame_index_range
+
+        # Parent: 10s @ 25fps -> 250 frames.  Tile into 2s segments.
+        tile_a = {"clip_start": 0.0, "clip_end": 2.0}
+        tile_b = {"clip_start": 2.0, "clip_end": 4.0}
+        tile_c = {"clip_start": 8.0, "clip_end": 10.0}
+
+        a = _frame_index_range(tile_a, frame_count=250, fps=25.0)
+        b = _frame_index_range(tile_b, frame_count=250, fps=25.0)
+        c = _frame_index_range(tile_c, frame_count=250, fps=25.0)
+
+        assert a == (0, 49)
+        assert b == (50, 99)
+        assert c == (200, 249)
+
+
+# ---------------------------------------------------------------------------
+# sample_video_frames — uses clip_start/clip_end to pick frame indices
+# ---------------------------------------------------------------------------
+
+
+class _FakeCapture:
+    """Stand-in for ``cv2.VideoCapture`` that records seeks.
+
+    Returns deterministic 1x1 BGR frames so the helper produces a list of
+    PIL Images we can introspect.  ``positions_seen`` exposes every frame
+    index the caller seeked to via ``CAP_PROP_POS_FRAMES``.
+    """
+
+    def __init__(self, *, frame_count: int, fps: float):
+        self._frame_count = frame_count
+        self._fps = fps
+        self.positions_seen: list[int] = []
+        self._next_pos = 0
+
+    def isOpened(self) -> bool:  # noqa: N802 (cv2 API)
+        return True
+
+    def get(self, prop: int) -> float:
+        import cv2  # noqa: PLC0415
+
+        if prop == cv2.CAP_PROP_FRAME_COUNT:
+            return float(self._frame_count)
+        if prop == cv2.CAP_PROP_FPS:
+            return self._fps
+        return 0.0
+
+    def set(self, prop: int, value: float) -> bool:
+        import cv2  # noqa: PLC0415
+
+        if prop == cv2.CAP_PROP_POS_FRAMES:
+            self._next_pos = int(value)
+            self.positions_seen.append(self._next_pos)
+        return True
+
+    def read(self):
+        # Encode the position into the frame so different seeks produce
+        # different PIL Images — useful as a sanity check.
+        b = max(0, min(255, self._next_pos))
+        frame = np.full((1, 1, 3), b, dtype=np.uint8)
+        return True, frame
+
+    def release(self) -> None:
+        pass
+
+
+@pytest.fixture
+def fake_video(monkeypatch):
+    """Patch cv2.VideoCapture with a captured _FakeCapture instance."""
+    import cv2
+
+    captures: list[_FakeCapture] = []
+
+    def _factory(*, frame_count: int, fps: float):
+        def _ctor(_path):
+            cap = _FakeCapture(frame_count=frame_count, fps=fps)
+            captures.append(cap)
+            return cap
+
+        monkeypatch.setattr(cv2, "VideoCapture", _ctor)
+        return captures
+
+    return _factory
+
+
+class TestSampleVideoFrames:
+    def test_full_range_sampled_without_boundaries(self, fake_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        captures = fake_video(frame_count=100, fps=10.0)
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"fake")
+        frames = sample_video_frames({"media_path": str(video)}, num_frames=8)
+
+        assert len(frames) == 8
+        assert len(captures) == 1
+        # 8 frames linspace'd over [0, 99].
+        seen = captures[0].positions_seen
+        assert seen[0] == 0
+        assert seen[-1] == 99
+
+    def test_clip_boundaries_restrict_sampled_frames(self, fake_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        captures = fake_video(frame_count=250, fps=25.0)
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"fake")
+
+        frames = sample_video_frames(
+            {"media_path": str(video), "clip_start": 2.0, "clip_end": 4.0},
+            num_frames=8,
+        )
+        assert len(frames) == 8
+        seen = captures[0].positions_seen
+        # Range [50, 99] from clip_start=2.0s and clip_end=4.0s @ 25fps.
+        assert min(seen) >= 50
+        assert max(seen) <= 99
+        assert seen[0] == 50
+        assert seen[-1] == 99
+
+    def test_distinct_tiles_produce_distinct_frame_indices(self, fake_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        # Tile A and Tile B share the same media_path/bytes but cover
+        # disjoint time ranges; the frame indices the embedder samples
+        # must therefore be disjoint.
+        captures = fake_video(frame_count=250, fps=25.0)
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"fake")
+
+        sample_video_frames(
+            {"media_path": str(video), "clip_start": 0.0, "clip_end": 2.0},
+            num_frames=8,
+        )
+        sample_video_frames(
+            {"media_path": str(video), "clip_start": 8.0, "clip_end": 10.0},
+            num_frames=8,
+        )
+        a_positions = set(captures[0].positions_seen)
+        b_positions = set(captures[1].positions_seen)
+        assert a_positions.isdisjoint(b_positions)
+
+    def test_falls_back_to_tempfile_when_no_path(self, fake_video):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        captures = fake_video(frame_count=100, fps=10.0)
+        frames = sample_video_frames({"media_bytes": b"\x00\x01\x02"}, num_frames=8)
+        assert len(frames) == 8
+        assert len(captures) == 1
+
+    def test_returns_empty_without_path_or_bytes(self):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        assert sample_video_frames({}, num_frames=8) == []
+
+
+# ---------------------------------------------------------------------------
+# _build_clip_embed_input — propagates clip metadata for video
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClipEmbedInput:
+    def test_video_includes_clip_boundaries(self):
+        from vtscore.datasets.load_pipeline import _build_clip_embed_input
+
+        clip = {
+            "origin_name": "x.mp4",
+            "filename": "x.mp4",
+            "media_bytes": b"parent",
+            "media_path": "/data/x.mp4",
+            "clip_start": 1.0,
+            "clip_end": 3.0,
+            "clip_index": 1,
+        }
+        out = _build_clip_embed_input(clip, "video")
+        assert out["media_bytes"] == b"parent"
+        assert out["media_path"] == "/data/x.mp4"
+        assert out["clip_start"] == 1.0
+        assert out["clip_end"] == 3.0
+
+    def test_video_without_path_still_carries_boundaries(self):
+        from vtscore.datasets.load_pipeline import _build_clip_embed_input
+
+        clip = {
+            "origin_name": "x.mp4",
+            "filename": "x.mp4",
+            "media_bytes": b"parent",
+            "clip_start": 0.0,
+            "clip_end": 2.0,
+        }
+        out = _build_clip_embed_input(clip, "video")
+        assert "media_path" not in out
+        assert out["clip_start"] == 0.0
+        assert out["clip_end"] == 2.0
+
+    def test_audio_unaffected(self):
+        from vtscore.datasets.load_pipeline import _build_clip_embed_input
+
+        clip = {
+            "origin_name": "a.wav",
+            "filename": "a.wav",
+            "media_bytes": b"sliced",
+            "clip_start": 1.0,
+            "clip_end": 2.0,
+        }
+        out = _build_clip_embed_input(clip, "audio")
+        assert out["media_bytes"] == b"sliced"
+        # Audio clipper slices bytes, so it has no need for boundary metadata.
+        assert "clip_start" not in out
+        assert "clip_end" not in out
+
+
+# ---------------------------------------------------------------------------
+# _fixup_clip_md5_and_embeddings — video tiles each get their own embedding
+# ---------------------------------------------------------------------------
+
+
+def _make_tiled_video_clips() -> list[dict]:
+    """Build three tiles of one parent video — same bytes, distinct boundaries."""
+    parent_bytes = b"parent-video-bytes"
+    parent_md5 = hashlib.md5(parent_bytes).hexdigest()
+    tiles = []
+    for idx, (t0, t1) in enumerate([(0.0, 2.0), (2.0, 4.0), (4.0, 6.0)]):
+        tiles.append({
+            "id": 100 + idx,
+            "type": "video",
+            "media_bytes": parent_bytes,
+            "media_path": "/data/parent.mp4",
+            "md5": parent_md5,  # stale; the fixup should rewrite it
+            "duration": 2.0,
+            "clip_index": idx,
+            "clip_start": t0,
+            "clip_end": t1,
+            "filename": "parent.mp4",
+            "origin_name": "parent.mp4",
+            "embedding": None,
+        })
+    return tiles
+
+
+class TestFixupClipMd5AndEmbeddingsVideo:
+    def test_tiles_get_distinct_md5(self):
+        from vtscore.datasets.load_pipeline import _fixup_clip_md5_and_embeddings
+
+        clips = _make_tiled_video_clips()
+        # Stub the embedder so we don't try to decode a fake mp4.
+        fake = MagicMock()
+        fake._on_progress = lambda *a, **k: None
+        fake.embed_media_bulk.return_value = [np.array([0.0], dtype=np.float32)] * len(clips)
+
+        with patch(
+            "vtscore.datasets.load_pipeline._resolve_clip_embedder",
+            return_value=fake,
+        ):
+            _fixup_clip_md5_and_embeddings(clips, [True] * len(clips), "video")
+
+        md5s = [c["md5"] for c in clips]
+        assert len(set(md5s)) == len(clips), f"Tiles share MD5: {md5s}"
+
+    def test_tiles_get_distinct_embeddings(self):
+        """The embedder must see each tile's boundaries and produce distinct
+        vectors — modelled here by returning ``clip_start`` as the embedding."""
+        from vtscore.datasets.load_pipeline import _fixup_clip_md5_and_embeddings
+
+        clips = _make_tiled_video_clips()
+
+        def fake_bulk(inputs: list[dict]) -> list[np.ndarray]:
+            # Sanity: every input must carry the tile's clip boundaries.
+            assert all("clip_start" in m and "clip_end" in m for m in inputs), inputs
+            # Emit one-hot-ish vectors keyed by the tile's clip_start so the
+            # caller can verify each tile gets its own embedding.
+            return [np.array([m["clip_start"], m["clip_end"]], dtype=np.float32) for m in inputs]
+
+        fake = MagicMock()
+        fake._on_progress = lambda *a, **k: None
+        fake.embed_media_bulk.side_effect = fake_bulk
+
+        with patch(
+            "vtscore.datasets.load_pipeline._resolve_clip_embedder",
+            return_value=fake,
+        ):
+            _fixup_clip_md5_and_embeddings(clips, [True] * len(clips), "video")
+
+        embs = [c["embedding"] for c in clips]
+        assert all(e is not None for e in embs)
+        # Tile boundaries: (0,2), (2,4), (4,6) -> vectors must all differ.
+        assert {tuple(e.tolist()) for e in embs} == {(0.0, 2.0), (2.0, 4.0), (4.0, 6.0)}

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -414,8 +414,14 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
             continue
 
         content_bytes = _clip_content_bytes(clip, media_type)
-        if content_bytes is None:
-            if recompute:
+        metadata_only = content_bytes is None and media_type == "video"
+        if content_bytes is None and not metadata_only:
+            continue
+
+        if recompute:
+            if content_bytes is not None:
+                clip["md5"] = hashlib.md5(content_bytes).hexdigest()
+            else:
                 # Metadata-only clips (e.g. video): bytes unchanged but
                 # boundaries differ — create a unique MD5 by hashing the
                 # parent bytes + clip boundaries so dedup doesn't collapse
@@ -424,10 +430,6 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
                 boundary_tag = f"|clip_start={clip.get('clip_start')}|clip_end={clip.get('clip_end')}"
                 combined = hashlib.md5(parent_bytes).hexdigest() + boundary_tag
                 clip["md5"] = hashlib.md5(combined.encode()).hexdigest()
-            continue
-
-        if recompute:
-            clip["md5"] = hashlib.md5(content_bytes).hexdigest()
         embed_indices.append(clip_idx)
         embed_inputs.append(_build_clip_embed_input(clip, media_type))
 
@@ -493,11 +495,16 @@ def _clip_content_bytes(clip: dict, media_type: str) -> bytes | None:
 def _build_clip_embed_input(clip: dict, media_type: str) -> dict:
     """Build the minimal media dict a bulk embedder needs for a clip.
 
-    Hands the embedder the in-memory ``media_bytes`` (audio/image) or
+    Hands the embedder the in-memory ``media_bytes`` (audio/image/video) or
     ``media_string`` (text) so the bulk surface never has to round-trip
     the content through a tempfile.  Preserves ``origin_name`` and
     ``filename`` so embedders that surface diagnostic paths still log
     something useful.
+
+    Video clips additionally carry ``clip_start`` / ``clip_end`` (and
+    ``media_path`` when available) because the underlying parent bytes
+    are shared across every tile — the embedder uses the boundary
+    metadata to sample distinct frame ranges per tile.
     """
     base: dict = {
         "origin_name": clip.get("origin_name", ""),
@@ -507,6 +514,13 @@ def _build_clip_embed_input(clip: dict, media_type: str) -> dict:
         base["media_string"] = clip.get("media_string", "")
     else:
         base["media_bytes"] = clip.get("media_bytes")
+    if media_type == "video":
+        if clip.get("media_path"):
+            base["media_path"] = clip["media_path"]
+        if "clip_start" in clip:
+            base["clip_start"] = clip["clip_start"]
+        if "clip_end" in clip:
+            base["clip_end"] = clip["clip_end"]
     return base
 
 

--- a/vtscore/media/video/_frame_sampling.py
+++ b/vtscore/media/video/_frame_sampling.py
@@ -44,9 +44,7 @@ def _resolve_video_path(media: dict) -> Iterator[Optional[Path]]:
             pass
 
 
-def _frame_index_range(
-    media: dict, frame_count: int, fps: float
-) -> tuple[int, int]:
+def _frame_index_range(media: dict, frame_count: int, fps: float) -> tuple[int, int]:
     """Map ``clip_start``/``clip_end`` to ``[start_frame, end_frame]`` indices.
 
     Falls back to the full video range when boundaries are absent or ``fps``
@@ -54,13 +52,7 @@ def _frame_index_range(
     """
     clip_start = media.get("clip_start")
     clip_end = media.get("clip_end")
-    if (
-        clip_start is None
-        or clip_end is None
-        or not fps
-        or fps <= 0
-        or float(clip_end) <= float(clip_start)
-    ):
+    if clip_start is None or clip_end is None or not fps or fps <= 0 or float(clip_end) <= float(clip_start):
         return 0, frame_count - 1
 
     start_idx = int(round(float(clip_start) * fps))

--- a/vtscore/media/video/_frame_sampling.py
+++ b/vtscore/media/video/_frame_sampling.py
@@ -1,0 +1,122 @@
+"""Shared video frame sampling for the X-CLIP / LanguageBind / VideoMAE embedders.
+
+Reads ``clip_start`` / ``clip_end`` off the media dict so tiled clips of the
+same parent video sample different frame ranges.  Without this, every tile
+would call ``np.linspace(0, frame_count - 1, num_frames)`` against the full
+parent video and produce identical embeddings.
+
+Also accepts ``media_bytes`` (round-tripped through a tempfile) when the
+caller cannot supply a local ``media_path`` — matches the audio embedder's
+two-source convention so re-embedding works from in-memory dataset bytes.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+
+@contextmanager
+def _resolve_video_path(media: dict) -> Iterator[Optional[Path]]:
+    """Yield a usable filesystem path for *media*'s video, tempfile if needed."""
+    path_str = media.get("media_path")
+    if path_str:
+        yield Path(path_str)
+        return
+
+    video_bytes = media.get("media_bytes")
+    if not isinstance(video_bytes, (bytes, bytearray)) or not video_bytes:
+        yield None
+        return
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    try:
+        tmp.write(bytes(video_bytes))
+        tmp.close()
+        yield Path(tmp.name)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+def _frame_index_range(
+    media: dict, frame_count: int, fps: float
+) -> tuple[int, int]:
+    """Map ``clip_start``/``clip_end`` to ``[start_frame, end_frame]`` indices.
+
+    Falls back to the full video range when boundaries are absent or ``fps``
+    is non-positive.  ``end_frame`` is inclusive.
+    """
+    clip_start = media.get("clip_start")
+    clip_end = media.get("clip_end")
+    if (
+        clip_start is None
+        or clip_end is None
+        or not fps
+        or fps <= 0
+        or float(clip_end) <= float(clip_start)
+    ):
+        return 0, frame_count - 1
+
+    start_idx = int(round(float(clip_start) * fps))
+    end_idx = int(round(float(clip_end) * fps)) - 1
+    start_idx = max(0, min(start_idx, frame_count - 1))
+    end_idx = max(start_idx, min(end_idx, frame_count - 1))
+    return start_idx, end_idx
+
+
+def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
+    """Return up to *num_frames* PIL Images sampled from *media*'s video.
+
+    When ``media`` carries ``clip_start`` and ``clip_end``, sampling is
+    restricted to that interval — distinct tiles of the same parent video
+    produce distinct frame sets (and therefore distinct embeddings).
+    Otherwise the whole video is sampled.
+
+    The returned list is padded by repeating the last frame to exactly
+    *num_frames* entries, matching the per-embedder padding loops it
+    replaces.  Returns ``[]`` on any decoding failure.
+    """
+    import cv2  # noqa: PLC0415
+    import numpy as np  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+
+    with _resolve_video_path(media) as path:
+        if path is None:
+            return []
+        cap = cv2.VideoCapture(str(path))
+        if not cap.isOpened():
+            return []
+        try:
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            if frame_count <= 0:
+                return []
+            fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+            start_idx, end_idx = _frame_index_range(media, frame_count, fps)
+            n_avail = end_idx - start_idx + 1
+            n_to_sample = min(num_frames, max(1, n_avail))
+            if n_to_sample == 1:
+                indices = np.array([start_idx], dtype=int)
+            else:
+                indices = np.linspace(start_idx, end_idx, n_to_sample, dtype=int)
+
+            frames: list[Any] = []
+            for idx in indices:
+                cap.set(cv2.CAP_PROP_POS_FRAMES, int(idx))
+                ret, frame = cap.read()
+                if ret:
+                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    frames.append(Image.fromarray(frame_rgb))
+        finally:
+            cap.release()
+
+    if not frames:
+        return []
+    while len(frames) < num_frames:
+        frames.append(frames[-1])
+    return frames

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -17,6 +16,7 @@ from vtscore.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtscore.media.video._frame_sampling import sample_video_frames
 
 # CLIP normalization constants (shared with LanguageBind).
 _CLIP_MEAN = np.array([0.48145466, 0.4578275, 0.40821073], dtype=np.float32)
@@ -147,42 +147,14 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._tokenizer is None:
             return None
-        file_path = Path(media["media_path"])
+        source_repr = media.get("media_path") or media.get("filename") or "<bytes>"
         try:
-            import cv2  # noqa: PLC0415
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            cap = cv2.VideoCapture(str(file_path))
-            if not cap.isOpened():
-                print(f"Error opening video {file_path}")
-                return None
-
-            try:
-                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                if frame_count <= 0:
-                    print(f"Error: could not determine frame count for {file_path}")
-                    return None
-                num_frames = min(_NUM_FRAMES, max(1, frame_count))
-                indices = np.linspace(0, frame_count - 1, num_frames, dtype=int)
-
-                frames = []
-                for idx in indices:
-                    cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
-                    ret, frame = cap.read()
-                    if ret:
-                        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                        frames.append(Image.fromarray(frame))
-            finally:
-                cap.release()
-
+            frames = sample_video_frames(media, _NUM_FRAMES)
             if not frames:
-                print(f"Error: could not extract frames from {file_path}")
+                logging.getLogger(__name__).error("Could not extract frames from %s", source_repr)
                 return None
-
-            # LanguageBind expects exactly 8 frames; pad by repeating if fewer.
-            while len(frames) < _NUM_FRAMES:
-                frames.append(frames[-1])
 
             # Preprocess: resize, center-crop, normalize -> (C, T, H, W).
             pixel_values = _preprocess_frames(frames)
@@ -198,7 +170,7 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
                 embedding = video_features.detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -13,7 +13,6 @@ caption says*; pair with image-/text-based detectors for hybrid flows.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
@@ -27,6 +26,7 @@ from vtscore.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtscore.media.video._frame_sampling import sample_video_frames
 
 # ImageNet normalisation — VideoMAE's standard preprocessing pipeline.
 _IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
@@ -168,42 +168,14 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None:
             return None
-        file_path = Path(media["media_path"])
+        source_repr = media.get("media_path") or media.get("filename") or "<bytes>"
         try:
-            import cv2  # noqa: PLC0415
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            cap = cv2.VideoCapture(str(file_path))
-            if not cap.isOpened():
-                logging.getLogger(__name__).error("Error opening video %s", file_path)
-                return None
-
-            try:
-                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                if frame_count <= 0:
-                    logging.getLogger(__name__).error("Could not determine frame count for %s", file_path)
-                    return None
-                num_frames = min(_NUM_FRAMES, max(1, frame_count))
-                indices = np.linspace(0, frame_count - 1, num_frames, dtype=int)
-
-                frames = []
-                for idx in indices:
-                    cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
-                    ret, frame = cap.read()
-                    if ret:
-                        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                        frames.append(Image.fromarray(frame))
-            finally:
-                cap.release()
-
+            frames = sample_video_frames(media, _NUM_FRAMES)
             if not frames:
-                logging.getLogger(__name__).error("Could not extract frames from %s", file_path)
+                logging.getLogger(__name__).error("Could not extract frames from %s", source_repr)
                 return None
-
-            # VideoMAE v2 expects exactly 16 frames; pad by repeating if fewer.
-            while len(frames) < _NUM_FRAMES:
-                frames.append(frames[-1])
 
             # (T, C, H, W) -> (1, T, C, H, W)
             pixel_values = _preprocess_frames(frames)
@@ -220,7 +192,7 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
                 embedding = pooled.detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
@@ -18,6 +17,9 @@ from vtscore.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtscore.media.video._frame_sampling import sample_video_frames
+
+_NUM_FRAMES = 8
 
 
 class VideoXClipEmbedder(MediaEmbedder):
@@ -103,42 +105,14 @@ class VideoXClipEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        source_repr = media.get("media_path") or media.get("filename") or "<bytes>"
         try:
-            import cv2  # noqa: PLC0415
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            cap = cv2.VideoCapture(str(file_path))
-            if not cap.isOpened():
-                print(f"Error opening video {file_path}")
-                return None
-
-            try:
-                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                if frame_count <= 0:
-                    print(f"Error: could not determine frame count for {file_path}")
-                    return None
-                num_frames = min(8, max(1, frame_count))
-                indices = np.linspace(0, frame_count - 1, num_frames, dtype=int)
-
-                frames = []
-                for idx in indices:
-                    cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
-                    ret, frame = cap.read()
-                    if ret:
-                        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                        frames.append(Image.fromarray(frame))
-            finally:
-                cap.release()
-
+            frames = sample_video_frames(media, _NUM_FRAMES)
             if not frames:
-                print(f"Error: could not extract frames from {file_path}")
+                logging.getLogger(__name__).error("Could not extract frames from %s", source_repr)
                 return None
-
-            # X-CLIP expects exactly 8 frames; pad by repeating if we have fewer
-            while len(frames) < 8:
-                frames.append(frames[-1])
 
             inputs = self._processor(images=[list(frames)], return_tensors="pt")
             device = next(self._model.parameters()).device
@@ -148,7 +122,7 @@ class VideoXClipEmbedder(MediaEmbedder):
                 embedding = _extract_tensor(outputs).detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:


### PR DESCRIPTION
## Summary

`VideoTilingClipper` (and `VideoSceneClipper`) record `clip_start`/`clip_end` on each tile *without* slicing the parent's bytes — transcoding would drag in ffmpeg/moviepy. The downstream code didn't honor those boundaries, so every tile of one video produced the same embedding:

- `_build_clip_embed_input` dropped `clip_start`/`clip_end` and never passed `media_path`.
- `_fixup_clip_md5_and_embeddings` updated the per-tile MD5 from the boundary hash, then `continue`'d out before re-embedding because `_clip_content_bytes` returns `None` for video.
- The three video embedders (X-CLIP, LanguageBind, VideoMAE) each called `np.linspace(0, frame_count - 1, n)` against the *full* parent video — they never looked at clip metadata.

So a 10-tile video produced 10 identical vectors, all sorted/scored as one item.

## Changes

- New `vtscore/media/video/_frame_sampling.py` with `sample_video_frames(media, num_frames)` — maps `clip_start`/`clip_end` to inclusive `[start_frame, end_frame]` via the video's fps, samples within that range, and falls back to the full video when boundaries are absent. Resolves `media_path` first and falls back to a tempfile written from `media_bytes` (matches the audio embedder's two-source convention).
- X-CLIP, LanguageBind, and VideoMAE embedders route through the helper instead of each duplicating the cv2 sampling loop.
- `_build_clip_embed_input` now propagates `clip_start`/`clip_end` (and `media_path` when present) for video clips.
- `_fixup_clip_md5_and_embeddings` runs the embedding pass for metadata-only video clips instead of bailing after the MD5 fixup.

## Test plan

- [x] `./run-tests.sh` — 4122 passed, 1 skipped (full suite, including ruff/format/codespell/deptry/frontend build).
- [x] New `tests_lib/detectors/test_video_clip_embedding.py` (16 tests):
  - `_frame_index_range` boundary math (full-range fallback, clamping, disjoint tile ranges, fps=0 fallback, end≤start fallback).
  - `sample_video_frames` with a mocked `cv2.VideoCapture` that records every seek: verifies clip boundaries restrict sampled frame indices, distinct tiles produce *disjoint* index sets, tempfile fallback when only `media_bytes` is set.
  - `_build_clip_embed_input` propagates clip metadata for video and leaves audio untouched.
  - `_fixup_clip_md5_and_embeddings` end-to-end: three tiles of one parent video get **distinct MD5s and distinct embeddings**.

https://claude.ai/code/session_015RK1CHYxEgNvFimWZqKpRj

---
_Generated by [Claude Code](https://claude.ai/code/session_015RK1CHYxEgNvFimWZqKpRj)_