### PR TITLE
logical-bug-audit M14 — close + fix two adjacent diversity-tree bugs

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -662,8 +662,25 @@ Cross-section interaction agents:
   matches the frontend's existing `learnedScores[id] ?? -1` fallback.
   Regression test in `tests/api/test_api_contracts.py` parses the
   response with a `parse_constant` that rejects `NaN`/`Infinity`.
-- **M14.** `diversity_tree_next_sample` references stale media IDs after
-  `/api/dataset/clear`.
+- ~~**M14.** `diversity_tree_next_sample` references stale media IDs after
+  `/api/dataset/clear`.~~ — investigated and closed.  The literal scenario
+  the audit named is no longer reachable: `clear_medias` (called via
+  `clear_dataset → clear_all`) sets `ctx.diversity_tree = None`, and the
+  active-dataset path of `/api/dataset/clear` unregisters the context so
+  subsequent requests either raise `DatasetNotLoadedError` (H16) or hit the
+  request-missing sentinel (whose tree is `None`).  A regression test pins
+  the behavior.  Two adjacent bugs surfaced during the investigation and
+  were fixed in the same PR: `clear_votes()` did not reset the dataset's
+  diversity-tree `seen` / `_labeled` sets, so `/api/votes/clear` left
+  `diversity_tree_next_sample` skipping previously-voted nodes and the
+  diversity-level chip stuck above zero; and
+  `ensure_votes_match_active_dataset` rehydrated detector votes via
+  `apply_label(silent=True)` (which skips the per-vote tree update)
+  without replaying onto the tree, so swapping detectors on the same
+  dataset left the tree reflecting the previous detector's seen state.
+  Both now reset the tree under `_state_lock` via a new
+  `DiversityTree.reset_seen()` / `resync_diversity_tree_to_detector`
+  helper pair that also dedupes the replay loop in `build_diversity_tree`.
 
 ### Settings / sync
 

--- a/tests/sorting/test_diversity_tree_integration.py
+++ b/tests/sorting/test_diversity_tree_integration.py
@@ -483,3 +483,178 @@ class TestDiversityLevelOverTime:
         data = resp.get_json()
         assert "diversity_level" in data["span"]
         assert isinstance(data["span"]["diversity_level"], (int, float))
+
+
+# ---------------------------------------------------------------------------
+# Audit M14 — `/api/dataset/clear` must not leave a stale diversity tree
+# ---------------------------------------------------------------------------
+
+
+class TestClearDatasetClearsTree:
+    """Regression for audit finding M14.
+
+    After ``/api/dataset/clear`` the active dataset's diversity tree must
+    not return media IDs that no longer exist in ``medias``.  In current
+    code ``clear_medias`` nulls ``ctx.diversity_tree`` and the unregister
+    path makes the cleared context unreachable; the tests here pin that
+    behavior so a future refactor cannot reintroduce the stale-ID bug.
+    """
+
+    def test_next_sample_returns_none_after_clear(self, client):
+        """POST /api/dataset/clear → GET /api/diversity-tree/next returns id=None."""
+        _build_tree()
+        # Sanity: tree exists and returns an id.
+        pre = client.post("/api/diversity-tree/next", json={})
+        assert pre.status_code == 200
+        assert pre.get_json()["id"] is not None
+
+        saved = dict(medias)
+        try:
+            resp = client.post("/api/dataset/clear")
+            assert resp.status_code == 200
+
+            resp = client.post("/api/diversity-tree/next", json={})
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["id"] is None
+            assert data["diversity_level"] == 0
+            # No tree != exhausted (matches `test_returns_null_when_no_tree`).
+            assert data["exhausted"] is False
+        finally:
+            medias.update(saved)
+
+    def test_clear_medias_nulls_diversity_tree(self):
+        """``clear_medias`` releases the tree so a stale reference can't survive."""
+        from vtsearch.state import clear_medias
+
+        _build_tree()
+        assert get_diversity_tree() is not None
+        saved = dict(medias)
+        try:
+            clear_medias()
+            assert get_diversity_tree() is None
+        finally:
+            medias.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# R1 — `/api/votes/clear` must reset the diversity tree's `seen` state
+# ---------------------------------------------------------------------------
+
+
+class TestClearVotesResetsTree:
+    """``clear_votes`` must reset ``ctx.diversity_tree.seen`` /``_labeled``.
+
+    Without the reset, ``next_sample`` keeps skipping nodes that the
+    just-cleared votes had marked seen and the diversity-level UI stays
+    elevated despite zero labels.
+    """
+
+    def test_clear_votes_resets_seen_set(self, client):
+        tree = _build_tree()
+        # Vote on multiple medias so several nodes become seen.
+        for cid in list(tree.vector_to_leaf)[:3]:
+            resp = client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
+            assert resp.status_code == 200
+        assert tree.diversity_level() > 0
+        assert len(tree.seen) > 0
+        assert len(tree.labeled_ids) > 0
+
+        resp = client.post("/api/votes/clear")
+        assert resp.status_code == 200
+
+        assert tree.diversity_level() == 0
+        assert tree.seen == set()
+        assert tree.labeled_ids == set()
+
+    def test_next_sample_starts_over_after_clear_votes(self, client):
+        """After clearing votes, the very first un-seen node is the root again."""
+        tree = _build_tree()
+        # Pick `next_sample`'s first suggestion and label it via the API so
+        # tree.seen picks it up.  Then clear and verify next_sample once
+        # more returns a valid (now un-seen) media id.
+        first = diversity_tree_next_sample()
+        assert first is not None
+        resp = client.post(f"/api/medias/{first}/vote", json={"target": "good"})
+        assert resp.status_code == 200
+        assert first in tree.labeled_ids
+
+        resp = client.post("/api/votes/clear")
+        assert resp.status_code == 200
+
+        # With zero seen nodes the BFS walk starts from the root again and
+        # may pick the same id; the important part is that we get a real
+        # in-medias id rather than None.
+        nxt = diversity_tree_next_sample()
+        assert nxt is not None
+        assert nxt in medias
+
+
+# ---------------------------------------------------------------------------
+# R2 — Detector swap on the same dataset must re-derive the tree's seen set
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorSwapResyncsTree:
+    """``ensure_votes_match_active_dataset`` must replay the new detector's
+    votes onto the dataset's diversity tree.
+
+    Restored labels are applied with ``silent=True`` (see
+    ``label_restoration.py``), which skips the per-vote tree update.
+    Without the bulk re-sync, the tree would keep reflecting the previous
+    detector's seen state.
+    """
+
+    def test_resync_diversity_tree_to_detector_resets_then_replays(self):
+        from vtscore.state import (
+            DetectorContext,
+            get_active_context,
+            resync_diversity_tree_to_detector,
+        )
+
+        tree = _build_tree()
+        ids = list(tree.vector_to_leaf)
+        # Mark a couple of ids as seen via the per-vote helper.
+        for cid in ids[:2]:
+            diversity_tree_label(cid)
+        assert len(tree.seen) > 0
+        prev_seen = set(tree.seen)
+
+        # Build a detector context that "votes" only on a different id so
+        # the replay should produce a different seen set.
+        det = DetectorContext("test-det")
+        if len(ids) > 2:
+            det.good_votes[ids[2]] = None
+
+        resync_diversity_tree_to_detector(get_active_context(), det)
+
+        # The previous seen set must be gone, replaced by the leaves of the
+        # newly-labeled id (and its ancestors).
+        assert tree.labeled_ids == set(det.good_votes) | set(det.bad_votes)
+        if len(ids) > 2:
+            assert ids[2] in tree.labeled_ids
+            assert tree.lookup(ids[2]) in tree.seen
+            # The previously-seen leaves should no longer be marked seen
+            # unless they happen to share an ancestor with ids[2].  The
+            # leaf-level guarantee is the one that matters for
+            # `next_sample`'s correctness.
+            for old_cid in ids[:2]:
+                assert old_cid not in tree.labeled_ids
+        else:
+            # Tiny test corpus — at minimum, the reset half must have run.
+            assert prev_seen  # was non-empty
+            assert tree.labeled_ids == set()
+
+    def test_resync_is_noop_when_no_tree(self):
+        """``resync_diversity_tree_to_detector`` tolerates a missing tree."""
+        from vtscore.state import (
+            DatasetContext,
+            DetectorContext,
+            resync_diversity_tree_to_detector,
+        )
+
+        ds = DatasetContext("no-tree")
+        det = DetectorContext("d")
+        det.good_votes[1] = None
+        # Must not raise.
+        resync_diversity_tree_to_detector(ds, det)

--- a/tests_lib/sorting/test_diversity_tree.py
+++ b/tests_lib/sorting/test_diversity_tree.py
@@ -261,6 +261,48 @@ class TestUnlabeling:
 
 
 # ---------------------------------------------------------------------------
+# Bulk reset (used when votes are cleared or detector swaps)
+# ---------------------------------------------------------------------------
+
+
+class TestResetSeen:
+    def test_reset_seen_clears_everything(self):
+        vecs = _make_clustered_vectors([30, 30], dim=32)
+        tree = DiversityTree(vecs, k=2, min_node_size=10)
+        tree.label(1)
+        tree.label(31)
+        assert len(tree.seen) > 0
+        assert len(tree.labeled_ids) == 2
+
+        tree.reset_seen()
+        assert tree.seen == set()
+        assert tree.labeled_ids == set()
+        assert tree.diversity_level() == 0
+
+    def test_reset_then_relabel_picks_up_new_state(self):
+        """After reset, label calls reproduce the seen set from scratch."""
+        vecs = _make_clustered_vectors([30, 30], dim=32)
+        tree = DiversityTree(vecs, k=2, min_node_size=10)
+        tree.label(1)
+        leaf1 = tree.lookup(1)
+        assert leaf1 in tree.seen
+
+        tree.reset_seen()
+        # Label a different vector — only its leaf+ancestors should be seen.
+        tree.label(31)
+        leaf31 = tree.lookup(31)
+        assert leaf31 in tree.seen
+        if leaf1 != leaf31:
+            assert leaf1 not in tree.seen
+
+    def test_reset_on_empty_tree_is_noop(self):
+        tree = DiversityTree({}, k=2)
+        tree.reset_seen()  # must not raise
+        assert tree.seen == set()
+        assert tree.labeled_ids == set()
+
+
+# ---------------------------------------------------------------------------
 # Diversity level
 # ---------------------------------------------------------------------------
 

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -107,9 +107,12 @@ def ensure_votes_match_active_dataset() -> None:
             det_ctx.cached_labelset = None
             det_ctx.cached_labelset_mtime = 0.0
             det_ctx.cached_labelset_media_type = ""
+            if ds_ctx.diversity_tree is not None:
+                ds_ctx.diversity_tree.reset_seen()
         return
 
     from vtscore.datasets.labelset import LabelSet
+    from vtscore.state.diversity import resync_diversity_tree_to_detector
 
     with _state_lock:
         # Re-check inside the lock — another request may have rehydrated us.
@@ -134,6 +137,15 @@ def ensure_votes_match_active_dataset() -> None:
         det_ctx.cached_labelset = LabelSet.from_dict(data.get("labelset") or {})
         det_ctx.cached_labelset_mtime = refreshed_mtime
         det_ctx.cached_labelset_media_type = data.get("media_type", "") or ""
+        # The dataset's diversity tree was either built for a previous
+        # detector on this dataset (so its ``seen`` set reflects that
+        # detector's votes) or built before any votes existed.  Re-derive
+        # it against the freshly-restored votes so ``next_sample`` /
+        # ``diversity_level`` track the now-active detector.  Restored
+        # labels above are applied with ``silent=True`` (see
+        # ``label_restoration.py``) and therefore skip the per-vote tree
+        # update — this is where the equivalent bulk update lands.
+        resync_diversity_tree_to_detector(ds_ctx, det_ctx)
 
 
 def invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder: str) -> bool:

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -80,6 +80,7 @@ from vtscore.state.diversity import (  # noqa: F401
     diversity_tree_next_sample,
     diversity_tree_unlabel,
     get_diversity_tree,
+    resync_diversity_tree_to_detector,
 )
 
 # Re-export media lookup ----------------------------------------------------

--- a/vtscore/state/diversity.py
+++ b/vtscore/state/diversity.py
@@ -13,10 +13,39 @@ from typing import Any
 
 from vtscore.state.core import (
     DatasetContext,
+    DetectorContext,
     _state_lock,
     get_active_context,
     get_active_detector_context,
 )
+
+
+def resync_diversity_tree_to_detector(
+    ds_ctx: DatasetContext,
+    det_ctx: DetectorContext,
+) -> None:
+    """Rebuild *ds_ctx*'s diversity-tree seen state from *det_ctx*'s votes.
+
+    Clears the tree's ``seen`` / ``_labeled`` sets and replays every cid in
+    ``det_ctx.good_votes`` / ``det_ctx.bad_votes`` whose leaf is known to the
+    tree.  Used when the labeled set is replaced wholesale — votes are
+    cleared, or the active detector is swapped on the same dataset — so the
+    tree continues to reflect the *current* detector's labels instead of
+    whatever it last observed.
+
+    Callers must already hold ``_state_lock``.  No-op when the dataset has
+    no diversity tree.
+    """
+    tree = ds_ctx.diversity_tree
+    if tree is None:
+        return
+    tree.reset_seen()
+    for cid in det_ctx.good_votes:
+        if cid in tree.vector_to_leaf:
+            tree.label(cid)
+    for cid in det_ctx.bad_votes:
+        if cid in tree.vector_to_leaf:
+            tree.label(cid)
 
 
 def build_diversity_tree(
@@ -54,13 +83,7 @@ def build_diversity_tree(
         ds_ctx.diversity_tree = tree
 
         # Replay existing labels so the tree reflects the current vote state.
-        det_ctx = get_active_detector_context()
-        for cid in det_ctx.good_votes:
-            if cid in tree.vector_to_leaf:
-                tree.label(cid)
-        for cid in det_ctx.bad_votes:
-            if cid in tree.vector_to_leaf:
-                tree.label(cid)
+        resync_diversity_tree_to_detector(ds_ctx, get_active_detector_context())
 
 
 def build_diversity_tree_for_context(

--- a/vtscore/state/diversity_tree.py
+++ b/vtscore/state/diversity_tree.py
@@ -192,6 +192,17 @@ class DiversityTree:
             self.seen.add(node)
             node = self.nodes[node]["parent"]
 
+    def reset_seen(self) -> None:
+        """Mark every node as un-seen and forget every labeled vector ID.
+
+        Used when the labeled set is replaced wholesale — e.g. votes are
+        cleared, or the active detector is swapped on the same dataset and
+        the tree's per-leaf seen state needs to be rebuilt from the new
+        detector's votes (see :func:`resync_diversity_tree_to_detector`).
+        """
+        self.seen.clear()
+        self._labeled.clear()
+
     def unlabel(self, vector_id: int) -> None:
         """Remove a vector's label and propagate unseen status upward."""
         self._labeled.discard(vector_id)

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -27,8 +27,11 @@ def clear_votes() -> None:
 
     Removes all entries from ``good_votes``, ``bad_votes``, and
     ``label_history`` in place on the active detector context. Does not affect
-    any dataset's ``medias`` dict.  Also clears the progress model cache and
-    click-time / score tracking.
+    any dataset's ``medias`` dict.  Also clears the progress model cache,
+    click-time / score tracking, and the active dataset's diversity tree
+    ``seen`` state — otherwise ``diversity_tree_next_sample`` would keep
+    skipping nodes that the just-cleared votes had marked seen, and the
+    UI's diversity-level chip would stay elevated despite zero labels.
     """
     from vtscore.detectors.labeling_progress import clear_progress_cache
 
@@ -43,6 +46,9 @@ def clear_votes() -> None:
         ctx.click_counter = 0
         ctx.last_learned_scores.clear()
         ctx.find_initial_labels.clear()
+        ds_tree = get_active_context().diversity_tree
+        if ds_tree is not None:
+            ds_tree.reset_seen()
     # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
     # two locks never establish a cross-module ordering (audit M1).
     clear_progress_cache()

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -64,6 +64,7 @@ from vtscore.state import (  # noqa: F401
     register_setting_persister,
     remove_click_time,
     resolve_media_ids,
+    resync_diversity_tree_to_detector,
     set_calibrate_count,
     set_calibration_fraction,
     set_dataset_display_name,


### PR DESCRIPTION
## Summary

- Investigated M14 (`diversity_tree_next_sample` references stale media IDs after `/api/dataset/clear`) and closed it as not-currently-a-bug: `clear_medias` nulls `ctx.diversity_tree`, and the unregister path makes the cleared context unreachable (request-missing sentinel or `DatasetNotLoadedError`). Added a regression test so a future refactor can't reintroduce it.
- Fixed two adjacent bugs surfaced during the investigation:
  - **R1 — `/api/votes/clear` left the diversity tree's `seen` / `_labeled` state populated**, so `next_sample` kept skipping nodes that the just-cleared votes had marked seen and the diversity-level UI stayed elevated despite zero labels. `clear_votes()` now resets the tree under the same `_state_lock` acquisition.
  - **R2 — Detector swap on the same dataset left the tree reflecting the previous detector's seen state.** Restored labels are applied with `silent=True` (which skips the per-vote tree update), so `ensure_votes_match_active_dataset` now replays the freshly-restored votes onto the dataset's diversity tree.
- Refactor: extracted `DiversityTree.reset_seen()` and `resync_diversity_tree_to_detector(ds, det)` helper; `build_diversity_tree`'s replay loop now delegates to the helper instead of duplicating it.

## Test plan

- [x] `python -m pytest tests_lib/sorting/test_diversity_tree.py tests/sorting/test_diversity_tree_integration.py -q` → 102 passed.
- [x] `./run-tests.sh` (full suite, including ruff / codespell / deptry / frontend build) → 4115 passed, 1 skipped, 2 xpassed.
- [x] `./run-tests.sh vtscore-clean` (library-tier import-clean) → 977 passed.

New tests:
- `tests/sorting/test_diversity_tree_integration.py::TestClearDatasetClearsTree` — M14 regression: after `/api/dataset/clear`, `GET /api/diversity-tree/next` returns `{"id": null, "diversity_level": 0, "exhausted": false}`, and `clear_medias` nulls the tree directly.
- `tests/sorting/test_diversity_tree_integration.py::TestClearVotesResetsTree` — R1: `/api/votes/clear` empties `tree.seen` / `tree.labeled_ids` and drops `diversity_level` to 0.
- `tests/sorting/test_diversity_tree_integration.py::TestDetectorSwapResyncsTree` — R2: `resync_diversity_tree_to_detector` clears prior seen state and replays the new detector's votes; no-op when the dataset has no tree.
- `tests_lib/sorting/test_diversity_tree.py::TestResetSeen` — library-tier coverage of `reset_seen()` (clears everything; reset+relabel produces a fresh seen set; empty-tree reset is a no-op).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YXmCaMp9eqWeQVbQHeeXrn)_