### PR TITLE
docker: build the Angular frontend inside every image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,8 +28,12 @@ data/
 tests/
 run-tests.sh
 
-# Frontend source (build output is in static/)
-frontend/
+# Frontend node_modules and build cache — the Dockerfile's frontend
+# build stage runs `npm ci` and `ng build` inside the image, so we want
+# the frontend source in the context but never these generated dirs.
+frontend/node_modules/
+frontend/.angular/
+frontend/dist/
 
 # Docker files (no need to copy into the image)
 docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,18 @@
 #   docker run -p 5000:5000 -v vtsearch-data:/app/data vtsearch
 # -----------------------------------------------------------------
 
+# ---------- frontend build stage ----------
+# Builds the Angular SPA inside the image so callers never have to run
+# `npm run build:prod` on the host. Output lands at /static because
+# frontend/angular.json sets outputPath to "../static" relative to the
+# frontend/ workdir. The final stage COPYs /static into /app/static.
+FROM node:20-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build:prod
+
 FROM python:3.10-slim AS base
 
 # System packages needed by opencv, librosa, and other native deps
@@ -35,6 +47,11 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 
 # ---------- application layer ----------
 COPY . .
+
+# Overlay the freshly-built Angular bundle from the frontend stage so
+# the image is never served with a stale checked-in static/ snapshot.
+RUN rm -rf /app/static
+COPY --from=frontend /static/ /app/static/
 
 # Bake the version into the image. The host computes it from git
 # (e.g. `TZ=UTC git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ`)

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -10,6 +10,18 @@
 #   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/
 # -----------------------------------------------------------------
 
+# ---------- frontend build stage ----------
+# Builds the Angular SPA inside the image so callers never have to run
+# `npm run build:prod` on the host. Output lands at /static because
+# frontend/angular.json sets outputPath to "../static" relative to the
+# frontend/ workdir. The final stage COPYs /static into /app/static.
+FROM node:20-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build:prod
+
 FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 
 # Avoid interactive prompts during apt-get
@@ -49,6 +61,11 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 
 # ---------- application layer ----------
 COPY . .
+
+# Overlay the freshly-built Angular bundle from the frontend stage so
+# the image is never served with a stale checked-in static/ snapshot.
+RUN rm -rf /app/static
+COPY --from=frontend /static/ /app/static/
 
 # Bake the version into the image. See Dockerfile for the pattern.
 ARG VTSEARCH_VERSION=

--- a/docker/Dockerfile.image-embedders
+++ b/docker/Dockerfile.image-embedders
@@ -68,6 +68,18 @@
 #   * VTSEARCH_VERSION  — bake a version string into the image
 # -----------------------------------------------------------------
 
+# ---------- frontend build stage ----------
+# Builds the Angular SPA inside the image so callers never have to run
+# `npm run build:prod` on the host. Output lands at /static because
+# frontend/angular.json sets outputPath to "../static" relative to the
+# frontend/ workdir. The final stage COPYs /static into /app/static.
+FROM node:20-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build:prod
+
 FROM python:3.10-slim AS base
 
 WORKDIR /app
@@ -203,6 +215,11 @@ print('EUPE weights cached via torch.hub.', flush=True)" \
 
 # ---------- application layer ----------
 COPY . .
+
+# Overlay the freshly-built Angular bundle from the frontend stage so
+# the image is never served with a stale checked-in static/ snapshot.
+RUN rm -rf /app/static
+COPY --from=frontend /static/ /app/static/
 
 # Bake the version into the image. See Dockerfile for the pattern.
 ARG VTSEARCH_VERSION=

--- a/docker/Dockerfile.image-embedders.gpu
+++ b/docker/Dockerfile.image-embedders.gpu
@@ -48,6 +48,18 @@
 #   * VTSEARCH_VERSION  — bake a version string into the image
 # -----------------------------------------------------------------
 
+# ---------- frontend build stage ----------
+# Builds the Angular SPA inside the image so callers never have to run
+# `npm run build:prod` on the host. Output lands at /static because
+# frontend/angular.json sets outputPath to "../static" relative to the
+# frontend/ workdir. The final stage COPYs /static into /app/static.
+FROM node:20-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build:prod
+
 FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 
 # Avoid interactive prompts during apt-get
@@ -179,6 +191,11 @@ print('EUPE weights cached via torch.hub.', flush=True)" \
 
 # ---------- application layer ----------
 COPY . .
+
+# Overlay the freshly-built Angular bundle from the frontend stage so
+# the image is never served with a stale checked-in static/ snapshot.
+RUN rm -rf /app/static
+COPY --from=frontend /static/ /app/static/
 
 # Bake the version into the image. See Dockerfile for the pattern.
 ARG VTSEARCH_VERSION=

--- a/docker/Dockerfile.labbench
+++ b/docker/Dockerfile.labbench
@@ -13,6 +13,18 @@
 #   docker run -p 5000:5000 -v vtsearch-data:/app/data vtsearch:labbench
 # -----------------------------------------------------------------
 
+# ---------- frontend build stage ----------
+# Builds the Angular SPA inside the image so callers never have to run
+# `npm run build:prod` on the host. Output lands at /static because
+# frontend/angular.json sets outputPath to "../static" relative to the
+# frontend/ workdir. The final stage COPYs /static into /app/static.
+FROM node:20-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build:prod
+
 FROM python:3.10-slim AS base
 
 WORKDIR /app
@@ -52,6 +64,11 @@ RUN mkdir -p "$VTSEARCH_MODELS_DIR" && \
 
 # ---------- application layer ----------
 COPY . .
+
+# Overlay the freshly-built Angular bundle from the frontend stage so
+# the image is never served with a stale checked-in static/ snapshot.
+RUN rm -rf /app/static
+COPY --from=frontend /static/ /app/static/
 
 # Bake the version into the image. See Dockerfile for the pattern.
 ARG VTSEARCH_VERSION=

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -268,10 +268,12 @@ docker build -f docker/Dockerfile -t vtsearch .
 docker run -p 5000:5000 -v vtsearch-data:/app/data vtsearch
 ```
 
-> **Note:** The Dockerfile does not include a Node.js build stage. You must
-> build the frontend locally (`cd frontend && npm install && npm run build:prod`)
-> before running `docker build`, so the `static/` directory contains the
-> compiled Angular app.
+> **Note:** Every VTSearch Dockerfile (`Dockerfile`, `Dockerfile.gpu`,
+> `Dockerfile.labbench`, `Dockerfile.image-embedders`,
+> `Dockerfile.image-embedders.gpu`) includes a Node.js `frontend` build
+> stage that runs `npm ci` and `npm run build:prod` inside the image, so
+> you do **not** need to build the Angular app on the host first — any
+> stale checked-in `static/` is overwritten with the freshly built bundle.
 
 ### GPU
 


### PR DESCRIPTION
## Summary

- Add a Node 20 `frontend` build stage to all five Dockerfiles (`Dockerfile`, `Dockerfile.gpu`, `Dockerfile.labbench`, `Dockerfile.image-embedders`, `Dockerfile.image-embedders.gpu`). The stage runs `npm ci` then `npm run build:prod`, which writes to `/static` (Angular's `outputPath` is `../static` relative to the `frontend/` workdir).
- After `COPY . .` the final stage clears `/app/static` and copies the freshly built bundle from the `frontend` stage, so any stale checked-in `static/` snapshot in the build context is replaced.
- `.dockerignore` now keeps `frontend/` in the build context but still excludes `frontend/node_modules/`, `frontend/.angular/`, and `frontend/dist/`.
- `docs/SETUP.md` drops the "build the frontend locally before docker build" note.

Result: `docker build` (and every `docker compose` flow in `docker/compose/`) is now self-contained — callers no longer need a working Node toolchain on the host.

## Test plan

- [ ] `docker build -f docker/Dockerfile -t vtsearch .` succeeds and `/app/static/index.html` exists in the resulting image
- [ ] `docker build -f docker/Dockerfile.gpu -t vtsearch:gpu .` succeeds
- [ ] `docker build -f docker/Dockerfile.labbench -t vtsearch:labbench .` succeeds and the app serves the freshly built SPA
- [ ] `docker build -f docker/Dockerfile.image-embedders -t vtsearch:image-embedders .` succeeds
- [ ] `docker build -f docker/Dockerfile.image-embedders.gpu -t vtsearch:image-embedders-gpu .` succeeds
- [ ] `docker compose -f docker/compose/docker-compose.yml up` runs and serves the UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM1tbJigiyuVsWXmsYPQun)_