### PR TITLE
Soften detector-deletion confirmation copy

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -653,10 +653,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         targets.length === 1
           ? `Delete detector ${names}?`
           : `Delete ${targets.length} detectors: ${names}?`;
-      const detail =
-        targets.length === 1
-          ? 'This removes its labelset and training metadata. The dataset is unaffected.'
-          : 'This removes their labelsets and training metadata. The datasets are unaffected.';
+      const detail = '(This deletes your labels. The underlying media is unaffected.)';
       ok = await this.dialog.confirmDestructive(question, detail);
     } finally {
       this.deletingSelectedDetectorsConfirm = false;
@@ -802,7 +799,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.deletingDetectorId = model.id;
     const ok = await this.dialog.confirmDestructive(
       `Delete detector "${model.name}"?`,
-      'This removes its labelset and training metadata. The dataset is unaffected.',
+      '(This deletes your labels. The underlying media is unaffected.)',
     );
     this.deletingDetectorId = '';
     if (!ok) return;

--- a/frontend/src/app/services/dialog.service.ts
+++ b/frontend/src/app/services/dialog.service.ts
@@ -58,7 +58,7 @@ export class VtDialogService {
    * `question` should name the operation and its target, e.g.
    *   "Delete detector 'cats'?"
    * `detail` should explain what is removed and what is unaffected, e.g.
-   *   "This removes its labelset and training metadata. The dataset is unaffected."
+   *   "(This deletes your labels. The underlying media is unaffected.)"
    * `actionLabel` is the verb on the primary button (default "Delete").
    */
   confirmDestructive(question: string, detail: string, actionLabel = 'Delete'): Promise<boolean> {


### PR DESCRIPTION
The detector-delete confirm dialog previously read:

> Delete detector "Mammals"? This removes its labelset and training metadata. The dataset is unaffected.

That's wordy and leaks internal jargon ("labelset", "training metadata") at the user. Replaced with:

> Delete detector "Mammals"? (This deletes your labels. The underlying media is unaffected.)

The same string works for the multi-select delete path, so the separate plural variant is gone.

## Changes
- `dashboard.component.ts` — single + multi-detector delete prompts both use the new detail string.
- `dialog.service.ts` — docstring example updated to match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L6Nsm2pbHwyeDhRUAnETcb)_