### PR TITLE
Simplify welcome banner to one-line prompt

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -27,11 +27,7 @@
       </ul>
     } @else if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
       <div class="welcome-banner">
-        <p class="welcome-banner-text">{{ welcomeBannerMessage }}</p>
-        <button class="btn btn--primary btn--sm welcome-banner-cta"
-          (click)="openImporterModalOnTab(welcomeBannerCtaTab)"
-          [disabled]="isLoading"
-          title="Open the dataset importer">{{ welcomeBannerCtaLabel }}</button>
+        <p class="welcome-banner-text">Welcome! Load data with '+' to get started.</p>
       </div>
     } @else {
       <div class="dashboard-grid">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -321,10 +321,6 @@
     max-width: 480px;
     line-height: 1.45;
   }
-
-  .welcome-banner-cta {
-    align-self: center;
-  }
 }
 
 .dashboard-actions {

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -402,67 +402,7 @@ describe('DashboardComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     const banner = el.querySelector('.welcome-banner');
     expect(banner).toBeTruthy();
-    expect(banner?.textContent || '').toContain('Welcome');
-  });
-
-  describe('welcome banner', () => {
-    it('should default to pushing Server Folder when no Services importers are registered', () => {
-      flushInitialRequests([], [], [
-        { name: 'server_folder', category: 'server' },
-        { name: 'demo', category: 'demo' },
-      ]);
-      expect(component.welcomeBannerMessage).toContain('Server Folder');
-      expect(component.welcomeBannerCtaLabel).toBe('Open Server');
-      expect(component.welcomeBannerCtaTab).toBe('server');
-    });
-
-    it('should name a single Services importer when exactly one is registered', () => {
-      flushInitialRequests([], [], [
-        { name: 'recaller', display_name: 'ReCaller', category: 'services' },
-        { name: 'server_folder', category: 'server' },
-      ]);
-      expect(component.welcomeBannerMessage).toContain('ReCaller');
-      expect(component.welcomeBannerMessage).toContain('Services');
-      expect(component.welcomeBannerCtaLabel).toBe('Open Services');
-      expect(component.welcomeBannerCtaTab).toBe('services');
-    });
-
-    it('should use generic wording when multiple Services importers are registered', () => {
-      flushInitialRequests([], [], [
-        { name: 'recaller', display_name: 'ReCaller', category: 'services' },
-        { name: 'other_service', display_name: 'Other', category: 'services' },
-      ]);
-      expect(component.welcomeBannerMessage).not.toContain('ReCaller');
-      expect(component.welcomeBannerMessage).toContain('Services');
-      expect(component.welcomeBannerCtaLabel).toBe('Open Services');
-      expect(component.welcomeBannerCtaTab).toBe('services');
-    });
-
-    it('should ignore hidden_from_picker importers when picking the welcome branch', () => {
-      flushInitialRequests([], [], [
-        { name: 'recaller', display_name: 'ReCaller', category: 'services', hidden_from_picker: true },
-        { name: 'server_folder', category: 'server' },
-      ]);
-      expect(component.servicesImporters.length).toBe(0);
-      expect(component.welcomeBannerMessage).toContain('Server Folder');
-    });
-
-    it('should open the importer modal pre-pinned to the chosen tab', () => {
-      flushInitialRequests();
-      const flows = TestBed.inject(NewThingFlowsService);
-      component.openImporterModalOnTab('services');
-      expect(component.importerModalOpen).toBeTrue();
-      expect(flows.importer.initialTab).toBe('services');
-    });
-
-    it('should reset the initial tab when the modal closes', () => {
-      flushInitialRequests();
-      const flows = TestBed.inject(NewThingFlowsService);
-      component.openImporterModalOnTab('server');
-      expect(flows.importer.initialTab).toBe('server');
-      flows.closeImporter();
-      expect(flows.importer.initialTab).toBe('');
-    });
+    expect(banner?.textContent || '').toContain("Welcome! Load data with '+' to get started.");
   });
 
   it('should render dataset table when datasets exist', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -913,57 +913,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Welcome-banner CTA: open the importer modal with one of the picker
-   *  tabs pre-selected so a fresh user lands on the relevant choices. */
-  openImporterModalOnTab(tabId: string): void {
-    this.importerClosing = false;
-    this.newThingFlows.openImporter({
-      initialTab: tabId,
-      guessedMediaType: this.guessedMediaType,
-      guessedMediaEmbedder: this.guessedMediaEmbedder,
-    });
-  }
-
   onImporterAnimationEnd(): void {
     this.importerClosing = false;
-  }
-
-  // --- First-run welcome banner ---
-
-  /** Visible importers in the Services tab, in registry order. */
-  get servicesImporters(): ImporterInfo[] {
-    return this.visibleImporters.filter((imp) => (imp.category || '') === 'services');
-  }
-
-  /** Pretty name for a Services importer (display_name falls back to name). */
-  private importerLabel(imp: ImporterInfo): string {
-    return imp.display_name || imp.name;
-  }
-
-  /** Body text for the welcome banner. Three branches:
-   *   - no Services importers → push Server Folder
-   *   - exactly one Services importer → name it
-   *   - multiple Services importers → generic Services prompt */
-  get welcomeBannerMessage(): string {
-    const services = this.servicesImporters;
-    if (services.length === 1) {
-      const label = this.importerLabel(services[0]);
-      return `Welcome — load a dataset to get started. You have ${label} registered in the Services tab, which is probably what you want.`;
-    }
-    if (services.length > 1) {
-      return 'Welcome — load a dataset to get started. You have importers registered in the Services tab, which is probably where to start.';
-    }
-    return 'Welcome — load a dataset to get started. Server Folder is the most common starting point: point it at a folder of files already on this machine.';
-  }
-
-  /** CTA label paired with the welcome-banner message. */
-  get welcomeBannerCtaLabel(): string {
-    return this.servicesImporters.length > 0 ? 'Open Services' : 'Open Server';
-  }
-
-  /** Picker tab the welcome-banner CTA pre-selects in the importer modal. */
-  get welcomeBannerCtaTab(): string {
-    return this.servicesImporters.length > 0 ? 'services' : 'server';
   }
 
   /** Open-state of the dataset importer modal (hosted on AppComponent;


### PR DESCRIPTION
## Summary
- Collapse the three-branch welcome-banner copy (Server Folder push / single Services importer / generic Services prompt) into a single line: `Welcome! Load data with '+' to get started.`
- Drop the inline CTA button from the banner — the message now points at the existing `+` icon at the top of the Datasets section, which already opens the importer modal.
- Remove the now-unused `servicesImporters`, `importerLabel`, `welcomeBannerMessage`, `welcomeBannerCtaLabel`, `welcomeBannerCtaTab` getters and the `openImporterModalOnTab` method on `DashboardComponent`, plus the `.welcome-banner-cta` SCSS rule. Spec coverage shrinks to a single render assertion against the new text.

## Test plan
- [ ] `cd frontend && npm run build:prod` succeeds with no warnings.
- [ ] With zero datasets registered, the dashboard shows the new one-line welcome message and no CTA button.
- [ ] The `+` icon at the top of the Datasets section still opens the importer modal.

https://claude.ai/code/session_01N78P8eHP89qF1oTMZGTPZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N78P8eHP89qF1oTMZGTPZ7)_