### PR TITLE
Skip redundant sub-tab click when a category has one importer

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -15,23 +15,26 @@
     }
 
     @if (activeImporterTab) {
-      <div class="importer-subtab-bar">
-        @if (importersForActiveTab.length === 0) {
+      @if (importersForActiveTab.length === 0) {
+        <div class="importer-subtab-bar">
           <span class="empty-state empty-state--inline">No importers in this category.</span>
+        </div>
+      } @else if (importersForActiveTab.length > 1) {
+        <div class="importer-subtab-bar">
+          @for (imp of importersForActiveTab; track imp.name) {
+            <button
+              class="importer-subtab"
+              [class.active]="selectedImporter?.name === imp.name"
+              [class.disabled]="imp['enabled'] === false"
+              [disabled]="imp['enabled'] === false"
+              (click)="selectImporter(imp)"
+              [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
+            >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
+          }
+        </div>
+        @if (!selectedImporter) {
+          <p class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</p>
         }
-        @for (imp of importersForActiveTab; track imp.name) {
-          <button
-            class="importer-subtab"
-            [class.active]="selectedImporter?.name === imp.name"
-            [class.disabled]="imp['enabled'] === false"
-            [disabled]="imp['enabled'] === false"
-            (click)="selectImporter(imp)"
-            [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
-          >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
-        }
-      </div>
-      @if (!selectedImporter && importersForActiveTab.length > 0) {
-        <p class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</p>
       }
     }
   </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -348,10 +348,15 @@ export class DatasetImporterModalComponent implements OnInit {
 
   selectImporterTab(tabId: string): void {
     this.activeImporterTab = tabId;
-    // Clearing the selected importer keeps the inner sub-tab row blank
-    // until the user explicitly clicks one — matching the "no auto-select"
-    // policy that applies at every tab level.
     this.selectedImporter = null;
+    // When the tab has exactly one importer, the inner sub-tab row is
+    // redundant — clicking the outer tab already declared the intent.
+    // Auto-select the lone importer so the user lands directly on its
+    // form instead of having to click a single-option card.
+    const importers = this.importersForActiveTab;
+    if (importers.length === 1 && importers[0]['enabled'] !== false) {
+      this.selectImporter(importers[0]);
+    }
   }
 
   /** Title shown at the top of the modal. */


### PR DESCRIPTION
## Summary

The Local and Server picker tabs each hold a single importer card now that `server_folder` absorbed `server_files` (and `local` absorbed `lf-files`). The picker was still rendering a one-item sub-tab row plus an absurd "Select how to add a Server dataset." hint, forcing the user through a no-op click before landing on the actual form.

- `selectImporterTab` now auto-selects the lone enabled importer when its category contains exactly one.
- The inner sub-tab bar (and the now-meaningless hint) is hidden whenever the active tab has a single importer; tabs with two or more keep the existing picker.

## Test plan
- [ ] Open "Add Dataset"; clicking **Local** lands directly on the local-folder uploader (no inner card click, no "Select how to add a Local dataset." hint).
- [ ] Clicking **Server** lands directly on the server-folder browser the same way.
- [ ] Tabs with multiple importers (e.g. once a "Services" category has more than one) still render the sub-tab row and the picker hint.
- [ ] `npm run build:prod` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJXFwqX6UPsZShtst9kHHK)_