### PR TITLE
Shorten overly long demo dataset descriptions

### DIFF
--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -55,7 +55,7 @@ def build_demo_datasets() -> list[DemoDataset]:
     euro_folder = DATA_DIR / "EuroSAT_RGB"
     dogs_desc = "Fine-grained dog breeds with many visually similar classes."
     dogs_folder = DATA_DIR / "stanford_dogs" / "Images"
-    places_desc = "Scene photos spanning indoor, outdoor natural, and outdoor man-made environments."
+    places_desc = "Scene photos across indoor, natural, and man-made settings."
     places_folder = DATA_DIR / "places365" / "val_256"
     return [
         DemoDataset(

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -170,9 +170,9 @@ class TextMediaType(MediaType):
         ng_desc = "Early-1990s Usenet posts across technical and political topics."
         ag_desc = "Short news summaries across world, sports, business, tech."
         imdb_desc = "Long-form movie reviews with positive/negative sentiment labels."
-        wiki_desc = "Wikipedia abstracts across 14 DBpedia ontology topics — a bigger, cleaner cousin of 20 Newsgroups."
-        arxiv_desc = "arXiv paper titles + abstracts spanning CS, math, physics, biology, and astrophysics."
-        reuters_desc = "Reuters-21578 financial newswire — the historical baseline for text classification."
+        wiki_desc = "Wikipedia abstracts across 14 DBpedia ontology topics."
+        arxiv_desc = "arXiv titles + abstracts across CS, math, and the sciences."
+        reuters_desc = "Reuters-21578 financial newswire — a classic text benchmark."
         return [
             DemoDataset(
                 id="20newsgroups_s",


### PR DESCRIPTION
## Summary

Four demo dataset descriptions were 80-98 characters while the rest cluster at ~55-65 chars, stretching the description column in the demo picker table:

- **Places365** (81): "Scene photos spanning indoor, outdoor natural, and outdoor man-made environments." → "Scene photos across indoor, natural, and man-made settings."
- **DBpedia / Wikipedia** (98): "Wikipedia abstracts across 14 DBpedia ontology topics — a bigger, cleaner cousin of 20 Newsgroups." → "Wikipedia abstracts across 14 DBpedia ontology topics."
- **arXiv** (86): "arXiv paper titles + abstracts spanning CS, math, physics, biology, and astrophysics." → "arXiv titles + abstracts across CS, math, and the sciences."
- **Reuters** (83): "Reuters-21578 financial newswire — the historical baseline for text classification." → "Reuters-21578 financial newswire — a classic text benchmark."

All four are now in the same 55-62 char range as the existing entries.

## Test plan

- [ ] Open the demo dataset picker and verify the description column no longer distorts due to long rows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzAQtd5fdAWgfYBz4jXRcQ)_