### PR TITLE
Populate OpenAPI operationIds from Flask view function names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,33 @@
 
 Trainable media search tool. Searches collections of audio, images, text, video, and documents using a **detector** — a small trained ranker that scores each item by how well it matches. Two ways to search: **train a new detector** (vote good/bad on a handful of items; a small MLP learns to rank the rest) or **use an existing detector** (saved or imported). Trained detectors are reusable across compatible datasets. Text queries (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) seed either flow or work as a quick stand-alone search. Flask + Angular + PyTorch.
 
+## Ask Questions via `AskUserQuestion` — NOT prose (CRITICAL, READ FIRST)
+
+This is the **#1 rule** in this repo. Read it on every turn. If you only read one section of CLAUDE.md, read this one.
+
+When you have a question for the user — to disambiguate requirements, choose between approaches, confirm scope, or surface a non-obvious tradeoff — **ask it via the `AskUserQuestion` tool**. Do not guess silently. Do not bury the question in prose at the end of a response. A 10-second clarification beats a 10-minute wrong-direction implementation, and a one-click answer beats a typed answer every time.
+
+**Always ask via the `AskUserQuestion` tool when the question fits its shape** (a discrete choice with a small number of options). Do not leave dangling questions like "Want me to go with approach A or approach B?" at the end of a prose response — those are easy to miss and force the user to type out an answer that could have been a single click. The tool also captures the choice cleanly in the transcript.
+
+This applies *especially* to end-of-investigation "what scope should I take next?" prompts: when a research/investigation turn ends by offering Phase 1 / Phase 2 / smaller scope, the scope choice goes through `AskUserQuestion`, **not** into the prose summary. The investigation findings stay in prose; the "what next?" question is a tool call.
+
+Use plain prose questions only when the answer is genuinely open-ended (e.g. "What should this field be named?") and a multiple-choice list would be artificial.
+
+### Trip-wire — scan your turn before sending
+
+Before sending a turn, scan its last paragraph for any of these phrases:
+
+- "Want me to …?"
+- "Should I …?"
+- "Do you want … or …?"
+- "Let me know if …"
+- "(a) … and/or (b) …?"
+- "Recommend I …?"
+
+If you see one, **stop**: that sentence is an `AskUserQuestion` call you almost emitted as prose. Convert it into the tool call before sending — even if you're confident the user will say yes, even if the options feel obvious, even if you've already invested effort in the prose summary. The cost of the extra tool call is zero; the cost of a missed or typed-out answer is a wasted round-trip.
+
+This rule has **no exceptions for "quick" yes/no follow-ups.** Yes/no offers belong in the tool too (with `["Yes", "No"]` options) — they are exactly the case where a one-click reply beats a typed reply. A pure progress update with no question at the end is fine; an update that ends in an offer is not.
+
 ## Branch Policy (CRITICAL)
 
 - **Always base work on `dev`.** The `.claude/hooks/session-start.sh` SessionStart hook runs `git fetch origin --prune && git rebase origin/dev` automatically in remote sessions, so a fresh container lands rebased onto `dev`. If the hook reports "skipping" (dirty tree, detached HEAD) or "rebase failed", run the fetch+rebase yourself before making any changes. The harness cuts the working branch off `main` (the GitHub default), so this rebase is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch — `dev` is Claude's starting point, not the public default.
@@ -39,31 +66,6 @@ Never ask the user whether to subscribe to PR activity, and never call `subscrib
 ## Backwards Compatibility
 
 Breaking backwards compatibility is acceptable — do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.
-
-## Ask Questions (use the Question tool)
-
-When you have a question for the user — to disambiguate requirements, choose between approaches, confirm scope, or surface a non-obvious tradeoff — **ask it**. Do not guess silently and hope the choice was right. A 10-second clarification beats a 10-minute wrong-direction implementation.
-
-**Always ask via the `AskUserQuestion` tool when the question fits its shape** (a discrete choice with a small number of options). Do not leave dangling questions like "Want me to go with approach A or approach B?" at the end of a prose response — those are easy to miss and force the user to type out an answer that could have been a single click. The tool also captures the choice cleanly in the transcript.
-
-This applies *especially* to end-of-investigation "what scope should I take next?" prompts: when a research/investigation turn ends by offering Phase 1 / Phase 2 / smaller scope, the scope choice goes through `AskUserQuestion`, **not** into the prose summary. The investigation findings stay in prose; the "what next?" question is a tool call.
-
-Use plain prose questions only when the answer is genuinely open-ended (e.g. "What should this field be named?") and a multiple-choice list would be artificial.
-
-### Trip-wire — scan your turn before sending
-
-Before sending a turn, scan its last paragraph for any of these phrases:
-
-- "Want me to …?"
-- "Should I …?"
-- "Do you want … or …?"
-- "Let me know if …"
-- "(a) … and/or (b) …?"
-- "Recommend I …?"
-
-If you see one, **stop**: that sentence is an `AskUserQuestion` call you almost emitted as prose. Convert it into the tool call before sending — even if you're confident the user will say yes, even if the options feel obvious, even if you've already invested effort in the prose summary. The cost of the extra tool call is zero; the cost of a missed or typed-out answer is a wasted round-trip.
-
-This rule has **no exceptions for "quick" yes/no follow-ups.** Yes/no offers belong in the tool too (with `["Yes", "No"]` options) — they are exactly the case where a one-click reply beats a typed reply. A pure progress update with no question at the end is fine; an update that ends in an offer is not.
 
 ## Frontend Scope: Desktop Only
 

--- a/app.py
+++ b/app.py
@@ -137,7 +137,28 @@ app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-
 
 from flask_smorest import Api  # noqa: E402
 
+from vtsearch.openapi_postprocess import assign_operation_ids  # noqa: E402
+
 api = Api(app)
+
+
+# flask-smorest / apispec doesn't populate ``operationId`` on its own, so
+# ng-openapi-gen ends up synthesising client method names from path+method
+# (``apiDetectorsRegistryDatasetIdRenamePut`` etc.). Wrap ``spec.to_dict``
+# so both the live ``/api/openapi.json`` endpoint and ``dump_openapi.py``
+# see operations tagged with their Flask view function name. The patch is
+# safe to apply now because ``to_dict`` is only called lazily — blueprints
+# registered later in this module are picked up automatically.
+_apispec_to_dict = api.spec.to_dict
+
+
+def _to_dict_with_operation_ids() -> dict:
+    spec = _apispec_to_dict()
+    assign_operation_ids(app, spec)
+    return spec
+
+
+api.spec.to_dict = _to_dict_with_operation_ids
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4710,6 +4710,7 @@
   "paths": {
     "/": {
       "get": {
+        "operationId": "index",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -4723,6 +4724,7 @@
     },
     "/api/achievements": {
       "get": {
+        "operationId": "get_achievements",
         "responses": {
           "200": {
             "content": {
@@ -4746,6 +4748,7 @@
     },
     "/api/achievements/check-phrase": {
       "post": {
+        "operationId": "check_phrase",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4783,6 +4786,7 @@
     "/api/achievements/docs/{doc_id}/raw": {
       "get": {
         "description": "Plain-text response \u2014 intentionally undecorated so it stays out of\nthe OpenAPI spec (the spec is for JSON APIs).",
+        "operationId": "get_doc_raw",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -4818,6 +4822,7 @@
         }
       ],
       "post": {
+        "operationId": "acknowledge_achievement",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4854,6 +4859,7 @@
     },
     "/api/auth/login": {
       "post": {
+        "operationId": "auth_login",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4893,6 +4899,7 @@
     },
     "/api/auth/logout": {
       "post": {
+        "operationId": "auth_logout",
         "responses": {
           "200": {
             "content": {
@@ -4919,6 +4926,7 @@
     },
     "/api/auth/status": {
       "get": {
+        "operationId": "auth_status",
         "responses": {
           "200": {
             "content": {
@@ -4943,6 +4951,7 @@
     "/api/auto-detect": {
       "post": {
         "description": "Iterates :func:`~vtsearch.settings.get_autorun_detectors` and trains each\none's MLP on demand from its on-disk labelset.  Returns one result column\nper detector. Pass ``detector_name`` to run a single autorun detector.",
+        "operationId": "auto_detect",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4985,6 +4994,7 @@
     },
     "/api/auto-extract": {
       "post": {
+        "operationId": "auto_extract",
         "responses": {
           "200": {
             "content": {
@@ -5011,6 +5021,7 @@
     },
     "/api/auto-localize": {
       "post": {
+        "operationId": "auto_localize",
         "responses": {
           "200": {
             "content": {
@@ -5037,6 +5048,7 @@
     },
     "/api/autorun-extractors": {
       "get": {
+        "operationId": "get_autorun_extractors_route",
         "responses": {
           "200": {
             "content": {
@@ -5058,6 +5070,7 @@
         ]
       },
       "post": {
+        "operationId": "add_autorun_extractor_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5097,6 +5110,7 @@
     },
     "/api/autorun-extractors/{name}": {
       "delete": {
+        "operationId": "delete_autorun_extractor_route",
         "responses": {
           "200": {
             "content": {
@@ -5145,6 +5159,7 @@
         }
       ],
       "put": {
+        "operationId": "rename_autorun_extractor_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5184,6 +5199,7 @@
     },
     "/api/autorun-localizers": {
       "get": {
+        "operationId": "get_autorun_localizers_route",
         "responses": {
           "200": {
             "content": {
@@ -5205,6 +5221,7 @@
         ]
       },
       "post": {
+        "operationId": "add_autorun_localizer_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5244,6 +5261,7 @@
     },
     "/api/autorun-localizers/{name}": {
       "delete": {
+        "operationId": "delete_autorun_localizer_route",
         "responses": {
           "200": {
             "content": {
@@ -5292,6 +5310,7 @@
         }
       ],
       "put": {
+        "operationId": "rename_autorun_localizer_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5332,6 +5351,7 @@
     "/api/browse": {
       "get": {
         "description": "Returns a directories+files listing with names, relative paths,\nmodification times, and (for files) sizes in bytes. The server's\nabsolute root is intentionally omitted from the response.",
+        "operationId": "browse",
         "parameters": [
           {
             "description": "Relative path within the allowed root. Empty string means the root itself.",
@@ -5390,6 +5410,7 @@
     "/api/browse-media-files": {
       "get": {
         "description": "Query parameters:\n\n* ``source`` \u2014 one of ``demo:<name>`` or ``folder``.\n* ``path`` \u2014 relative sub-path within the root (default ``\"\"``).\n\nReturns::\n\n    {\n        \"directories\": [{\"name\": \"dog\"}, {\"name\": \"cat\"}, ...],\n        \"files\": [\n            {\"name\": \"bark.wav\", \"path\": \"dog/bark.wav\", \"size_bytes\": 12345},\n            ...\n        ]\n    }",
+        "operationId": "browse_media_files",
         "parameters": [
           {
             "description": "One of ``demo:<name>`` or ``folder``.",
@@ -5445,6 +5466,7 @@
     "/api/browse-media-files/select": {
       "post": {
         "description": "Expects JSON::\n\n    {\"source\": \"demo:esc50_s\", \"path\": \"dog/1-100032-A-0.wav\"}\n\nReturns::\n\n    {\"filename\": \"<safe-name>\", \"original_name\": \"1-100032-A-0.wav\"}",
+        "operationId": "select_browsed_file",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5488,6 +5510,7 @@
     "/api/clippers": {
       "get": {
         "description": "Query parameters:\nmedia_type: A ``type_id`` (e.g. ``\"image\"``) or ``folder_import_name``\n    (e.g. ``\"images\"``).  When provided, only clippers whose\n    ``media_type`` matches are returned.",
+        "operationId": "clippers_list",
         "parameters": [
           {
             "description": "Optional ``type_id`` (e.g. ``image``) or ``folder_import_name`` (e.g. ``images``). When provided, only matching entries are returned.",
@@ -5527,6 +5550,7 @@
     "/api/converters": {
       "get": {
         "description": "Query parameters:\ntarget: A ``type_id`` (e.g. ``\"image\"``) or ``folder_import_name``\n    (e.g. ``\"images\"``).  When provided, only converters whose\n    ``target_type`` matches are returned.\nsource: A ``type_id`` (e.g. ``\"video\"``) or ``folder_import_name``\n    (e.g. ``\"videos\"``).  When provided, only converters whose\n    ``source_type`` matches are returned.",
+        "operationId": "converters_list",
         "parameters": [
           {
             "in": "query",
@@ -5574,6 +5598,7 @@
     "/api/dashboard/dataset-info": {
       "get": {
         "description": "Returns a JSON object with ``name``, ``num_medias``, ``media_type``, and\n``origin`` extracted from the first media that has origin info.",
+        "operationId": "dashboard_dataset_info",
         "responses": {
           "200": {
             "content": {
@@ -5600,6 +5625,7 @@
     },
     "/api/dashboard/dataset-rename": {
       "put": {
+        "operationId": "dashboard_dataset_rename",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5636,6 +5662,7 @@
     },
     "/api/dashboard/disk-usage": {
       "get": {
+        "operationId": "dashboard_disk_usage",
         "responses": {
           "200": {
             "content": {
@@ -5659,6 +5686,7 @@
     },
     "/api/dataset/all-importers": {
       "get": {
+        "operationId": "dataset_all_importers",
         "responses": {
           "200": {
             "content": {
@@ -5682,6 +5710,7 @@
     },
     "/api/dataset/available-files": {
       "get": {
+        "operationId": "available_dataset_files",
         "responses": {
           "200": {
             "content": {
@@ -5706,6 +5735,7 @@
     "/api/dataset/cancel": {
       "post": {
         "description": "Cancels all active loading tasks and the legacy global tracker.",
+        "operationId": "cancel_dataset_load",
         "responses": {
           "200": {
             "content": {
@@ -5740,6 +5770,7 @@
         }
       ],
       "post": {
+        "operationId": "cancel_dataset_load_task",
         "responses": {
           "200": {
             "content": {
@@ -5767,6 +5798,7 @@
     "/api/dataset/clear": {
       "post": {
         "description": "Uses the ``X-Dataset-Id`` header (via ``get_active_context()``) to\ndetermine which dataset to clear.",
+        "operationId": "clear_dataset_route",
         "responses": {
           "200": {
             "content": {
@@ -5790,6 +5822,7 @@
     },
     "/api/dataset/combine": {
       "post": {
+        "operationId": "combine_datasets_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5833,6 +5866,7 @@
     "/api/dataset/demo-categories/{name}": {
       "get": {
         "description": "Returns ``{\"categories\": [\"cat1\", \"cat2\", ...]}`` for the named demo.",
+        "operationId": "demo_dataset_categories",
         "responses": {
           "200": {
             "content": {
@@ -5871,6 +5905,7 @@
     "/api/dataset/demo-list": {
       "get": {
         "description": "Each dataset has a ``status`` field with one of three values:\n\n* ``\"ready\"`` \u2013 embeddings are cached and source data is present.\n* ``\"needs_embedding\"`` \u2013 source data is downloaded but not yet embedded.\n* ``\"needs_download\"`` \u2013 source data must be downloaded (and then embedded).",
+        "operationId": "demo_dataset_list",
         "parameters": [
           {
             "in": "query",
@@ -5918,6 +5953,7 @@
     "/api/dataset/detect-media-type": {
       "get": {
         "description": "Powers the auto-detect hint in the import modal: rather than making\nthe user pick ``media_type`` blindly, the modal calls this after the\nuser selects a folder and pre-fills the dropdown with whichever type\nhas the most matching files in the first ``limit`` files of the tree.\n\nThe 404 returned when the source is unavailable on disk is\nintercepted by the app-level ``NotFound`` errorhandler and keeps the\nlegacy ``{\"error\": \"Not Found\", \"request_id\": ...}`` envelope.",
+        "operationId": "detect_media_type",
         "parameters": [
           {
             "description": "One of ``demo:<name>`` or ``folder`` (matches ``/api/browse-media-files``).",
@@ -5990,6 +6026,7 @@
     "/api/dataset/export": {
       "get": {
         "description": "Success returns a binary ``application/octet-stream`` download; that\nbody is left undescribed in the spec (mirroring the audio / video /\nimage streaming routes in ``media/list.py``).",
+        "operationId": "export_dataset",
         "responses": {
           "400": {
             "description": "No dataset is currently loaded."
@@ -6010,6 +6047,7 @@
     "/api/dataset/import-local-folder": {
       "post": {
         "description": "The browser uses ``<input type=\"file\" webkitdirectory>`` to let the\nuser pick a directory; each selected ``File`` is appended to the\nmultipart body under the key ``\"files\"`` with its ``webkitRelativePath``\nas the multipart filename.  We stream each file to a temporary\ndirectory on the server (preserving sub-directory structure) and then\ndelegate to the regular folder importer to do the actual scanning,\nembedding, and dataset registration.  The temp directory is removed\nonce the importer finishes (success or failure).\n\nLocal-files uploads may additionally include a ``vectors_file`` form\nfield carrying a ``.npz`` archive of pre-computed embedding vectors\nkeyed by uploaded-file name (basename or relative path).  Files\nwhose name matches an NPZ key reuse the supplied vector instead of\nrunning the embedding model.",
+        "operationId": "import_local_folder",
         "responses": {
           "200": {
             "content": {
@@ -6051,6 +6089,7 @@
       ],
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "import_dataset",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -6076,6 +6115,7 @@
       ],
       "post": {
         "description": "The importer's ``get_field_options(field_key, current_values)`` is\ncalled with the supplied snapshot of current form values. Errors\nfrom the plugin (network failure, auth error, etc.) are surfaced as\na 502 with the original message so the frontend can display them\ninline.",
+        "operationId": "importer_field_options",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6127,6 +6167,7 @@
     },
     "/api/dataset/importers": {
       "get": {
+        "operationId": "dataset_importers",
         "responses": {
           "200": {
             "content": {
@@ -6151,6 +6192,7 @@
     "/api/dataset/load-demo": {
       "post": {
         "description": "When a ``converter`` is specified, the demo data is loaded using its\noriginal media type, then converted to the converter's target type.\nThe resulting dataset has the *target* type, not the demo's original\ntype.",
+        "operationId": "load_demo_dataset_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6193,6 +6235,7 @@
     },
     "/api/dataset/load-file": {
       "post": {
+        "operationId": "load_dataset_file",
         "responses": {
           "200": {
             "content": {
@@ -6219,6 +6262,7 @@
     },
     "/api/dataset/load-folder": {
       "post": {
+        "operationId": "load_dataset_folder",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6258,6 +6302,7 @@
     },
     "/api/dataset/load-source": {
       "post": {
+        "operationId": "load_dataset_from_source",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6308,6 +6353,7 @@
         }
       ],
       "post": {
+        "operationId": "stage_demo",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6350,6 +6396,7 @@
     },
     "/api/dataset/stage-file": {
       "post": {
+        "operationId": "stage_file",
         "responses": {
           "200": {
             "content": {
@@ -6388,6 +6435,7 @@
       ],
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "stage_import",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -6401,6 +6449,7 @@
     },
     "/api/dataset/staging": {
       "delete": {
+        "operationId": "clear_staging",
         "responses": {
           "200": {
             "content": {
@@ -6424,6 +6473,7 @@
     },
     "/api/dataset/status": {
       "get": {
+        "operationId": "dataset_status",
         "responses": {
           "200": {
             "content": {
@@ -6448,6 +6498,7 @@
     "/api/datasets/registry": {
       "get": {
         "description": "Each entry includes:\n- ``loaded``: whether the dataset is currently in memory",
+        "operationId": "list_registered_datasets",
         "responses": {
           "200": {
             "content": {
@@ -6471,6 +6522,7 @@
     },
     "/api/datasets/registry/{dataset_id}": {
       "delete": {
+        "operationId": "delete_registered_dataset",
         "responses": {
           "200": {
             "content": {
@@ -6523,6 +6575,7 @@
       ],
       "post": {
         "description": "If the dataset is already loaded in memory, it is simply activated\n(made the current UI-facing dataset) without re-reading the pkl.",
+        "operationId": "load_registered_dataset",
         "responses": {
           "200": {
             "content": {
@@ -6564,6 +6617,7 @@
       ],
       "post": {
         "description": "Called by the dashboard when the user selects a dataset row so that\nthe embedder is ready by the time they click Train. Idempotent: the\nbackground worker exits immediately if the embedder is already in\nmemory. Returns ``embedder`` set to the resolved embedder name (or\n``\"\"`` if no embedder could be resolved for this dataset's media\ntype).",
+        "operationId": "preload_dataset_embedder",
         "responses": {
           "200": {
             "content": {
@@ -6605,6 +6659,7 @@
       ],
       "put": {
         "description": "Body: ``{\"readers\": [\"alice\", \"bob\"]}``\nUse ``[\"*\"]`` to make the dataset public to all users.",
+        "operationId": "update_dataset_readers",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6658,6 +6713,7 @@
         }
       ],
       "put": {
+        "operationId": "rename_registered_dataset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6700,6 +6756,7 @@
     },
     "/api/datasets/registry/{dataset_id}/stats": {
       "get": {
+        "operationId": "get_dataset_stats",
         "responses": {
           "200": {
             "content": {
@@ -6749,6 +6806,7 @@
       ],
       "post": {
         "description": "The dataset's context is removed, freeing its RAM.  If it was the\nactive dataset, the active pointer is cleared.",
+        "operationId": "unload_registered_dataset",
         "responses": {
           "200": {
             "content": {
@@ -6778,6 +6836,7 @@
     },
     "/api/detectors": {
       "get": {
+        "operationId": "list_detectors",
         "responses": {
           "200": {
             "content": {
@@ -6800,6 +6859,7 @@
       },
       "post": {
         "description": "Requires ``name`` and ``media_type``; at least one of ``text_query``,\n``media_example``, or ``examples`` must be provided.",
+        "operationId": "create_detector",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6853,6 +6913,7 @@
         }
       ],
       "post": {
+        "operationId": "cancel_detector_loading_task",
         "responses": {
           "200": {
             "content": {
@@ -6880,6 +6941,7 @@
     "/api/detectors/combine": {
       "post": {
         "description": "All source detectors must share the same ``media_type``.  The new\ndetector's labelset is the merge of all source labelsets, keyed by\n``Origin`` (importer + params + origin_name) and falling back to\n``md5`` for legacy entries.  Per ``conflict_policy=\"drop\"`` (the only\nsupported policy today), any element key that appears with disagreeing\nlabels across the sources is removed entirely.\n\nThe combined detector is *purely a labelset entry* \u2014 no\nlabelset-source is inherited from the sources, and the threshold/MLP\nare computed later when the detector is activated against a dataset.",
+        "operationId": "combine_detectors",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6925,6 +6987,7 @@
     },
     "/api/detectors/registry": {
       "get": {
+        "operationId": "list_registered_detectors",
         "responses": {
           "200": {
             "content": {
@@ -6946,6 +7009,7 @@
         ]
       },
       "post": {
+        "operationId": "register_detector_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6997,6 +7061,7 @@
       ],
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "register_detector_from_labelset",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -7011,6 +7076,7 @@
     "/api/detectors/registry/load": {
       "post": {
         "description": "Pass ``detector_id=null`` (or omit the field) to unload the active\ndetector without loading another one.",
+        "operationId": "load_detector_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7050,6 +7116,7 @@
     },
     "/api/detectors/registry/{detector_id}": {
       "delete": {
+        "operationId": "delete_registered_detector",
         "responses": {
           "200": {
             "content": {
@@ -7099,6 +7166,7 @@
       ],
       "put": {
         "description": "The flag is stored in ``settings.json`` under ``autorun_detectors`` so the\nCLI's ``--autodetect`` flow and the active-dataset ``/api/auto-detect``\nroute both see it.",
+        "operationId": "set_detector_autorun",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7153,6 +7221,7 @@
       ],
       "post": {
         "description": "Called by the frontend when the user confirms the *Move existing\nlabelset file?* prompt that surfaces after a rename leaves the file\nat the OLD template-resolved path on disk.",
+        "operationId": "move_labelset_source_file",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7209,6 +7278,7 @@
         }
       ],
       "put": {
+        "operationId": "rename_registered_detector",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7262,6 +7332,7 @@
         }
       ],
       "post": {
+        "operationId": "unload_detector_route",
         "responses": {
           "200": {
             "content": {
@@ -7291,6 +7362,7 @@
     },
     "/api/detectors/{detector_name}/labelset-source": {
       "get": {
+        "operationId": "get_detector_labelset_source",
         "responses": {
           "200": {
             "content": {
@@ -7324,6 +7396,7 @@
       ],
       "put": {
         "description": "A body of ``{}`` or one with empty ``source_name`` clears the source.",
+        "operationId": "set_detector_labelset_source",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7374,6 +7447,7 @@
         }
       ],
       "post": {
+        "operationId": "sync_detector_labelset_from_source",
         "responses": {
           "200": {
             "content": {
@@ -7400,6 +7474,7 @@
     },
     "/api/detectors/{name}": {
       "delete": {
+        "operationId": "delete_detector",
         "responses": {
           "200": {
             "content": {
@@ -7424,6 +7499,7 @@
         ]
       },
       "get": {
+        "operationId": "get_detector",
         "responses": {
           "200": {
             "content": {
@@ -7472,6 +7548,7 @@
         }
       ],
       "put": {
+        "operationId": "set_detector_examples",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7532,6 +7609,7 @@
       ],
       "post": {
         "description": "Unlike the regular ``/api/label-importers/import/`` route, this does\n**not** require a dataset to be loaded.  The imported label entries are\nmerged directly into the detector's persisted labelset, and the\ndetector-registry entry is updated so the dashboard reflects the new\ncount.\n\nWhen the detector is loaded into memory, the new labels are also resolved\nagainst the loaded dataset's medias, applied to the detector's votes, and\na fresh MLP is trained with a cross-validated threshold \u2014 all inside the\nloaded detector context.\n\nPlugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "import_labels_into_detector",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -7557,6 +7635,7 @@
       ],
       "post": {
         "description": "Reads good_votes/bad_votes from global state and the current medias\nto build a fresh LabelSet, then persists it into the detector's JSON file.",
+        "operationId": "save_detector_labels",
         "responses": {
           "200": {
             "content": {
@@ -7587,6 +7666,7 @@
     "/api/detectors/{name}/labels-detail": {
       "get": {
         "description": "Each element gets a stable ``id`` (derived from its origin/md5 identity)\nplus ``label``, ``media_type``, display ``name``, and \u2014 when the\nelement resolves into the active dataset \u2014 its current ``cid``,\n``time`` (click time), and ``score`` (last learned-sort score).\n\nThis is the right pane's data source in label/train mode.  Unlike\n``/api/votes`` it is *not* gated on the loaded dataset, so detector\nlabels survive across dataset switches.",
+        "operationId": "get_detector_labels_detail",
         "responses": {
           "200": {
             "content": {
@@ -7625,6 +7705,7 @@
     "/api/detectors/{name}/labels/{element_id}/preview": {
       "get": {
         "description": "Resolves the element via its origin (using the importer's\n``resolve_file()`` hook) and serves the raw bytes with a mimetype\nchosen by the detector's ``media_type``.  Returns 404 if the element\nis unknown or its file cannot be located.",
+        "operationId": "preview_detector_label",
         "responses": {
           "404": {
             "description": "Detector, element, or media file not found."
@@ -7662,6 +7743,7 @@
     "/api/detectors/{name}/labels/{element_id}/thumbnail": {
       "get": {
         "description": "Mirrors :func:`vtsearch.routes.media.list.media_image` for the right pane:\naudio elements get a waveform PNG, video elements a mid-frame PNG, image\nelements get the file bytes. When the element resolves into the active\ndataset we serve the cached in-memory ``thumbnail_bytes`` (fast path);\notherwise we resolve the underlying file via the importer and generate\non the fly. Much smaller than ``/preview`` (which serves the full file).",
+        "operationId": "thumbnail_detector_label",
         "responses": {
           "404": {
             "description": "Detector, element, or media file not found."
@@ -7722,6 +7804,7 @@
       ],
       "post": {
         "description": "Body: ``{\"vote\": \"good\"}`` or ``{\"vote\": \"bad\"}``.\n\nToggle semantics mirror :func:`~vtsearch.state.toggle_vote`: the same\nvote on an element with that label removes the element; the opposite\nvote flips it.  When the element resolves into the active dataset, the\ndetector's in-memory ``good_votes`` / ``bad_votes`` are kept in sync so\nMLP retraining and learned-sort see the change.",
+        "operationId": "vote_detector_label",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7772,6 +7855,7 @@
         }
       ],
       "put": {
+        "operationId": "rename_detector",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7815,6 +7899,7 @@
     "/api/diversity-tree/next": {
       "get": {
         "description": "Accepts an optional POST body with ``{\"scores\": {id: score, ...},\n\"threshold\": <float>}`` so the sort mode influences which element is\npicked from the next unseen node.  When a threshold is provided, the\nnode's median score determines direction: above-threshold nodes yield\nthe lowest-scored element (surprise in a \"good\" region), while\nbelow-threshold nodes yield the highest-scored element (surprise in a\n\"bad\" region).  Without scores the first element in the node is returned.\n\nReturns ``{\"id\": <media_id>}`` or ``{\"id\": null}`` when the tree is\nexhausted or not yet built.  Also includes ``diversity_level`` (the\nnumber of consecutive BFS-order seen nodes) so the frontend can display\nprogress, and ``exhausted`` (bool) which is true when the tree exists\nbut every node has already been seen.",
+        "operationId": "diversity_tree_next_get",
         "responses": {
           "200": {
             "content": {
@@ -7840,6 +7925,7 @@
       },
       "post": {
         "description": "Accepts an optional POST body with ``{\"scores\": {id: score, ...},\n\"threshold\": <float>}`` so the sort mode influences which element is\npicked from the next unseen node.  When a threshold is provided, the\nnode's median score determines direction: above-threshold nodes yield\nthe lowest-scored element (surprise in a \"good\" region), while\nbelow-threshold nodes yield the highest-scored element (surprise in a\n\"bad\" region).  Without scores the first element in the node is returned.\n\nReturns ``{\"id\": <media_id>}`` or ``{\"id\": null}`` when the tree is\nexhausted or not yet built.  Also includes ``diversity_level`` (the\nnumber of consecutive BFS-order seen nodes) so the frontend can display\nprogress, and ``exhausted`` (bool) which is true when the tree exists\nbut every node has already been seen.",
+        "operationId": "diversity_tree_next_post",
         "responses": {
           "200": {
             "content": {
@@ -7866,6 +7952,7 @@
     },
     "/api/embed": {
       "post": {
+        "operationId": "embed",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -7880,6 +7967,7 @@
     "/api/embedders": {
       "get": {
         "description": "Query parameters:\nmedia_type: A ``type_id`` (e.g. ``\"image\"``) or ``folder_import_name``\n    (e.g. ``\"images\"``).  When provided, only embedders whose\n    ``media_type_id`` matches are returned.",
+        "operationId": "embedders_list",
         "parameters": [
           {
             "description": "Optional ``type_id`` (e.g. ``image``) or ``folder_import_name`` (e.g. ``images``). When provided, only matching entries are returned.",
@@ -7919,6 +8007,7 @@
     "/api/eval/train-and-score": {
       "post": {
         "description": "The work walks the full ``label_history`` retraining a small MLP at\nevery step, which used to block every other request on the gthread\npool.  We now run it on a background daemon thread and return a\n``job_id``; clients poll ``/api/eval/train-and-score/result`` for the\nmetric data; the ``eval`` SSE channel on ``/api/events`` carries\nlive progress.\n\nA signature cache keyed by ``(metric, history, votes, inclusion,\ndataset, detector)`` short-circuits identical re-runs.\n\nTests can pass ``{\"wait\": true}`` to block until the job completes.",
+        "operationId": "eval_train_and_score",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7970,6 +8059,7 @@
       ],
       "post": {
         "description": "Sets the cancel flag on the :class:`AsyncJob`; the per-step retrain\nloop polls it cooperatively. Returns 200 even when the job has\nalready finished \u2014 see ``cancel_learned_sort`` for the rationale.",
+        "operationId": "cancel_eval_train_and_score",
         "responses": {
           "200": {
             "content": {
@@ -7996,6 +8086,7 @@
     },
     "/api/eval/train-and-score/result": {
       "get": {
+        "operationId": "eval_train_and_score_result",
         "parameters": [
           {
             "in": "query",
@@ -8039,6 +8130,7 @@
     "/api/example-sort": {
       "post": {
         "description": "Optional ``crop_params`` form field carries a JSON object with the\nbounds for a user-cropped sub-region (e.g. ``{\"start\": 1.5, \"end\": 3}``\nfor audio or ``{\"box\": [x1, y1, x2, y2]}`` for images).  When present\nthe file is cropped server-side before embedding.",
+        "operationId": "example_sort",
         "responses": {
           "200": {
             "content": {
@@ -8069,6 +8161,7 @@
     "/api/example-sort-by-id": {
       "post": {
         "description": "When ``crop_params`` is absent the existing ``media[\"embedding\"]``\nis reused \u2014 no fetch, no re-embed.  When set, the media's bytes are\nmaterialised, cropped, and re-embedded before sorting.",
+        "operationId": "example_sort_by_id",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8115,6 +8208,7 @@
     "/api/example-sort-origin": {
       "post": {
         "description": "Accepts a JSON body with ``origin`` (an origin dict as stored on medias)\nand ``key`` (the item key / relative path within the source).  The file\nis fetched via the :class:`~vtscore.datasets.sources.base.MediaSource`\nabstraction, embedded, and used for cosine-similarity sorting.\n\nExample request::\n\n    {\n        \"origin\": {\"importer\": \"server_folder\", \"params\": {\"path\": \"/data/sounds\"}},\n        \"key\": \"subdir/audio123.wav\"\n    }",
+        "operationId": "example_sort_origin",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8161,6 +8255,7 @@
     "/api/example-sort-server": {
       "post": {
         "description": "Optional ``crop_params`` body field carries a JSON-compatible dict with\nbounds for a user-cropped sub-region (audio: ``{\"start\", \"end\"}``;\nimage: ``{\"box\": [...]}``).  When set, the file is cropped server-side\nbefore embedding.",
+        "operationId": "example_sort_server",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8206,6 +8301,7 @@
     },
     "/api/exporters": {
       "get": {
+        "operationId": "get_exporters",
         "responses": {
           "200": {
             "content": {
@@ -8232,6 +8328,7 @@
     },
     "/api/exporters/export": {
       "post": {
+        "operationId": "run_export",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8277,6 +8374,7 @@
     },
     "/api/extract": {
       "post": {
+        "operationId": "run_extract",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8317,6 +8415,7 @@
     "/api/find": {
       "post": {
         "description": "For each dataset: loads it from its saved pkl, then for each detector runs\ndetection.  Returns a merged results table.",
+        "operationId": "multi_find",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8363,6 +8462,7 @@
     "/api/find-label": {
       "post": {
         "description": "Resolves the detector from the registry, scores every loaded media, and\napplies Good/Bad labels for ALL elements based on the threshold.  Returns\nthe sort results so the frontend can display the stripe and scroll order.",
+        "operationId": "find_label",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8406,6 +8506,7 @@
     "/api/find/cancel": {
       "post": {
         "description": "Sets the cancel flag on the shared ``find_progress`` tracker, which\nevery scoring path (``/api/find``, ``/api/find-label``, and\n``/api/auto-detect``) reports progress through. Long-running loops\npoll the flag between iterations and bail out by raising\n:class:`CancelledError`. Always returns 200 \u2014 calling cancel when\nnothing is running is a no-op.",
+        "operationId": "cancel_find",
         "responses": {
           "200": {
             "content": {
@@ -8430,6 +8531,7 @@
     "/api/find/check-labels": {
       "post": {
         "description": "Takes the same ``detector_ids`` / ``dataset_ids`` payload as ``/api/find``\nand returns per-detector resolution statistics so the frontend can warn\nthe user before starting the (potentially expensive) Find operation.",
+        "operationId": "find_check_labels",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8466,6 +8568,7 @@
     },
     "/api/inclusion": {
       "get": {
+        "operationId": "get_inclusion_route",
         "responses": {
           "200": {
             "content": {
@@ -8487,6 +8590,7 @@
         ]
       },
       "post": {
+        "operationId": "set_inclusion_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8524,6 +8628,7 @@
     "/api/indicator-score-history": {
       "get": {
         "description": "Reads only the per-step cache populated by the labeling-status\npolling \u2014 no models are retrained.",
+        "operationId": "indicator_score_history",
         "parameters": [
           {
             "description": "Which metric history to return: ``smart``, ``stable``, or ``diverse``.",
@@ -8570,6 +8675,7 @@
     "/api/jobs/active": {
       "get": {
         "description": "Used by the top-bar pulldown to render a spinner glyph on rows whose\npair has background work in flight (learned-sort, eval, \u2026). The endpoint\nis intentionally cheap \u2014 it walks the in-memory ``JOB_MANAGERS`` map and\nreads each manager's current/pending slot under the manager's own lock,\nnothing else. Safe to poll on a 2\u20133 second interval.",
+        "operationId": "active_jobs",
         "responses": {
           "200": {
             "content": {
@@ -8593,6 +8699,7 @@
     },
     "/api/label-file-sort": {
       "post": {
+        "operationId": "label_file_sort",
         "responses": {
           "200": {
             "content": {
@@ -8622,6 +8729,7 @@
     },
     "/api/label-importers": {
       "get": {
+        "operationId": "get_label_importers",
         "responses": {
           "200": {
             "content": {
@@ -8660,6 +8768,7 @@
       ],
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "run_label_import",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -8673,6 +8782,7 @@
     },
     "/api/label-importers/ingest-missing": {
       "post": {
+        "operationId": "ingest_missing",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8709,6 +8819,7 @@
     },
     "/api/labeling-progress": {
       "post": {
+        "operationId": "labeling_progress",
         "responses": {
           "200": {
             "content": {
@@ -8739,6 +8850,7 @@
     "/api/labeling-status": {
       "get": {
         "description": "Returns ``smart``, ``stable``, and ``span`` sub-objects, each with a\n``status`` field of ``\"red\"``, ``\"yellow\"``, or ``\"green\"``.",
+        "operationId": "labeling_status_indicator",
         "responses": {
           "200": {
             "content": {
@@ -8766,6 +8878,7 @@
     "/api/labels/export": {
       "get": {
         "description": "Each label entry includes the element's ``origin`` and ``origin_name``\nso consumers know exactly where each labeled element came from. The\nformat is a superset of the legacy export format \u2014 old consumers\nthat only read ``md5`` and ``label`` keys continue to work unchanged.",
+        "operationId": "export_labels",
         "parameters": [
           {
             "description": "If true, export only good labels.",
@@ -8832,6 +8945,7 @@
     "/api/labels/fill-from-sort": {
       "post": {
         "description": "Assigns Good/Bad labels to currently-unlabeled medias based on their\nposition relative to the sort threshold. With ``confirm=false`` (the\ndefault), returns counts only; with ``confirm=true``, applies the\nlabels and returns the resulting data as a results dict suitable for\nany exporter.",
+        "operationId": "fill_labels_from_sort",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8868,6 +8982,7 @@
     },
     "/api/labels/import": {
       "post": {
+        "operationId": "import_labels",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8904,6 +9019,7 @@
     },
     "/api/labelset-sources": {
       "get": {
+        "operationId": "list_labelset_sources_route",
         "responses": {
           "200": {
             "content": {
@@ -8931,6 +9047,7 @@
     "/api/learned-sort": {
       "post": {
         "description": "Training is GIL-bound and ran inline used to stall every other request\nserved by the small ``gthread`` pool \u2014 votes polls, thumbnails, even\nmedia bytes.  The endpoint now hands the work off to a background daemon\nthread and returns immediately with a ``job_id``; clients poll\n:func:`learned_sort_result` until ``status == \"done\"``.\n\nA small signature cache short-circuits the no-op case: when the votes,\ndetector, inclusion and thresholding settings are unchanged from the\nmost recent successful run, the previous result is returned directly.\n\nTests can pass ``{\"wait\": true}`` in the body to block until the job\ncompletes and receive the result inline.  The frontend leaves it false.",
+        "operationId": "learned_sort",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8985,6 +9102,7 @@
       ],
       "post": {
         "description": "Sets the cancel flag on the :class:`AsyncJob`; the training loop\npolls it cooperatively. Returns 200 even when the job has already\nfinished \u2014 the caller's contract is \"make sure it's no longer\nrunning\", which also holds for done / errored / already-cancelled\njobs.",
+        "operationId": "cancel_learned_sort",
         "responses": {
           "200": {
             "content": {
@@ -9012,6 +9130,7 @@
     "/api/learned-sort/result": {
       "get": {
         "description": "Returns the same shape as the POST endpoint's ``done`` response when the\njob has finished, or a ``running`` snapshot otherwise.",
+        "operationId": "learned_sort_result",
         "parameters": [
           {
             "in": "query",
@@ -9054,6 +9173,7 @@
     },
     "/api/localize": {
       "post": {
+        "operationId": "run_localize",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9093,6 +9213,7 @@
     },
     "/api/media-types": {
       "get": {
+        "operationId": "media_types_list",
         "responses": {
           "200": {
             "content": {
@@ -9117,6 +9238,7 @@
     "/api/medias/add-to-pile": {
       "post": {
         "description": "If a media with the same MD5 already exists in the dataset, the existing\nmedia is voted accordingly. Otherwise the file is embedded using the\ndataset's embedder, inserted as a new media item, and then voted. The\nrequest body is multipart/form-data with ``file`` (the upload) and\n``label`` (``\"good\"`` or ``\"bad\"``).",
+        "operationId": "add_media_to_pile",
         "responses": {
           "200": {
             "content": {
@@ -9154,6 +9276,7 @@
     "/api/medias/batch": {
       "post": {
         "description": "Callers request only the IDs they need (e.g. the ones currently visible\nin a virtual-scrolling viewport), keeping payload size bounded.  Use\n:func:`list_media_ids` (``GET /api/medias/ids``) to discover which\nmedia IDs exist in the loaded dataset.\n\nReturns a JSON array of media metadata dicts; unknown IDs are silently\nomitted.",
+        "operationId": "batch_medias",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9194,6 +9317,7 @@
     "/api/medias/ids": {
       "get": {
         "description": "Each item contains only the fields the frontend needs to build virtual\nscrollers and to inspect the dataset's media type / embedder *before*\nany item becomes visible: ``id``, ``type``, and ``embedder`` (when set).\nDisplay-worthy metadata (``filename``, ``md5``, ``custom_metadata``,\n``origin_name``, ``description``, ``clip_*``) is fetched on demand for\nthe items currently in the viewport via ``POST /api/medias/batch``.\n\nThis replaces the previous unpaginated ``GET /api/medias`` endpoint,\nwhich serialised the full metadata for every media in the dataset on\nevery call \u2014 a 10-20\u00d7 larger payload that the cache + batch pattern\nmakes unnecessary.",
+        "operationId": "list_media_ids",
         "responses": {
           "200": {
             "content": {
@@ -9221,6 +9345,7 @@
     "/api/medias/{media_id}/audio": {
       "get": {
         "description": "Returns an ``audio/wav`` file response on success (HTTP 200), or a 404\nJSON envelope if the media does not exist or its bytes are unavailable.",
+        "operationId": "media_audio",
         "responses": {
           "404": {
             "description": "Media not found, or media bytes unavailable."
@@ -9249,6 +9374,7 @@
     "/api/medias/{media_id}/image": {
       "get": {
         "description": "Determines the MIME type from the media's filename extension, defaulting\nto ``image/jpeg`` for unrecognised extensions. For non-image media types\nthat declare an ``image_response`` hook (audio waveforms, video frames),\nthe route delegates to that hook.",
+        "operationId": "media_image",
         "responses": {
           "400": {
             "description": "Media is not an image and has no image_response delegate."
@@ -9280,6 +9406,7 @@
     "/api/medias/{media_id}/media": {
       "get": {
         "description": "Determines the media type from the media item's ``\"type\"`` field and\ndelegates to the registered :class:`~vtscore.media.base.MediaType`'s\n:meth:`~vtscore.media.base.MediaType.media_response` method. This\nendpoint works for all current and future media types without\nmodification. Response body is either binary (image/audio/video bytes\nwith the appropriate mimetype) or JSON (text content); the spec leaves\nthe success body undescribed.",
+        "operationId": "media_generic",
         "responses": {
           "400": {
             "description": "Media has an unsupported media type."
@@ -9310,6 +9437,7 @@
     },
     "/api/medias/{media_id}/paragraph": {
       "get": {
+        "operationId": "media_paragraph_get_1",
         "responses": {
           "200": {
             "content": {
@@ -9350,6 +9478,7 @@
     },
     "/api/medias/{media_id}/text": {
       "get": {
+        "operationId": "media_paragraph_get_2",
         "responses": {
           "200": {
             "content": {
@@ -9391,6 +9520,7 @@
     "/api/medias/{media_id}/video": {
       "get": {
         "description": "Determines the MIME type from the media's filename extension, defaulting\nto ``video/mp4`` for unrecognised extensions.",
+        "operationId": "media_video",
         "responses": {
           "400": {
             "description": "Media is not a video."
@@ -9436,6 +9566,7 @@
       ],
       "post": {
         "description": "``target`` is one of:\n\n- ``\"good\"`` \u2014 set to good (overrides ``bad`` if present).\n- ``\"bad\"`` \u2014 set to bad (overrides ``good`` if present).\n- ``\"none\"`` \u2014 un-vote (remove any existing vote).\n\nBehaviour is **idempotent**: sending the current state is a no-op\nthat does not append to ``label_history``, does not credit\nachievements, and returns the existing click-time.  This is the\nfix for logical-bug-audit H1 \u2014 two stale-view tabs that race the\nsame media no longer alternate ADD/REMOVE on the server, so the\nachievement counter no longer inflates beyond the number of real\nlabeling decisions.\n\nYes-targets may carry ``\"region_box\": [x0, y0, x1, y1]`` (normalised\nimage coords in ``[0, 1]``) to designate the good region.\n``\"bad\"`` and ``\"none\"`` targets must not include ``region_box`` \u2014 by\ndesign no-votes are image-level always (patch-embedder v2).\n\nReturns ``{\"ok\": true, \"state\": <new state>, \"click_time\": <int|null>}``\nso the client can reconcile its optimistic view directly from the\nresponse.",
+        "operationId": "vote_media",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9478,6 +9609,7 @@
     },
     "/api/pregen-processors": {
       "get": {
+        "operationId": "list_pregen_processors",
         "responses": {
           "200": {
             "content": {
@@ -9502,6 +9634,7 @@
     "/api/pregen-processors/add": {
       "post": {
         "description": "Registers the OCR extractor, Speech extractor, and Face localizer\ninto the autorun extractors and localizers stores.",
+        "operationId": "add_pregen_processors",
         "responses": {
           "200": {
             "content": {
@@ -9525,6 +9658,7 @@
     },
     "/api/safe-thresholds": {
       "get": {
+        "operationId": "get_safe_thresholds_route",
         "responses": {
           "200": {
             "content": {
@@ -9546,6 +9680,7 @@
         ]
       },
       "post": {
+        "operationId": "set_safe_thresholds_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9582,6 +9717,7 @@
     },
     "/api/server-media-files": {
       "get": {
+        "operationId": "list_server_media_files",
         "responses": {
           "200": {
             "content": {
@@ -9606,6 +9742,7 @@
     "/api/server-media-files/from-media-id": {
       "post": {
         "description": "Used by the right-click ``Use as detector seed`` flow: the loaded\nmedia is materialised to disk so the new-detector form can reference\nit as ``media_example`` (the same field the upload path returns).",
+        "operationId": "server_media_file_from_media_id",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9649,6 +9786,7 @@
     "/api/server-media-files/upload": {
       "post": {
         "description": "Optional form fields:\n\n* ``media_type`` \u2014 required when ``crop_params`` is present (``\"audio\"``\n  or ``\"image\"``); identifies which bounded clipper to apply.\n* ``crop_params`` \u2014 JSON object with the user-cropped bounds.  When set,\n  the file is cropped server-side before being saved, so the persisted\n  example is the cropped sub-region (and downstream code that reads\n  the saved file by name does not need any changes).",
+        "operationId": "upload_server_media_file",
         "responses": {
           "201": {
             "content": {
@@ -9676,6 +9814,7 @@
     "/api/server-media-files/{filename}/thumbnail": {
       "get": {
         "description": "Used by the new-model dialog to show the user which example was selected.\nFor images this serves the file bytes; for audio it returns a waveform PNG;\nfor video it returns the middle-frame PNG.  Other media types return 404.",
+        "operationId": "server_media_file_thumbnail",
         "responses": {
           "400": {
             "description": "Filename escapes the example_media directory."
@@ -9709,6 +9848,7 @@
     "/api/sessions/recent": {
       "get": {
         "description": "Entries whose dataset or detector id is no longer registered are\nfiltered out. Most-recent first.",
+        "operationId": "list_recent_sessions",
         "responses": {
           "200": {
             "content": {
@@ -9731,6 +9871,7 @@
       },
       "post": {
         "description": "Upserts the pair, moves it to the front of the list, and trims\nthe list to :data:`MAX_RECENT_SESSIONS` entries. The response is\nthe same hydrated list as :func:`list_recent_sessions` so callers\ncan update local UI in one round-trip.",
+        "operationId": "bump_recent_session",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9767,6 +9908,7 @@
     },
     "/api/settings": {
       "get": {
+        "operationId": "get_settings",
         "responses": {
           "200": {
             "content": {
@@ -9789,6 +9931,7 @@
       },
       "put": {
         "description": "Only keys present in *body* are applied. Unknown keys are silently\ndropped (per the schema's ``unknown = \"exclude\"`` policy); type\nerrors raise 422 with the standard error envelope; setter-level\nvalidation failures (range / one-of / path traversal) raise 400.",
+        "operationId": "update_settings",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9828,6 +9971,7 @@
     },
     "/api/settings-exporters": {
       "get": {
+        "operationId": "get_settings_exporters",
         "responses": {
           "200": {
             "content": {
@@ -9854,6 +9998,7 @@
     },
     "/api/settings-exporters/export": {
       "post": {
+        "operationId": "run_settings_export",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9899,6 +10044,7 @@
     },
     "/api/settings-importers": {
       "get": {
+        "operationId": "get_settings_importers",
         "responses": {
           "200": {
             "content": {
@@ -9937,6 +10083,7 @@
       ],
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "run_settings_import",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -9950,6 +10097,7 @@
     },
     "/api/settings-sources": {
       "get": {
+        "operationId": "list_settings_sources_route",
         "responses": {
           "200": {
             "content": {
@@ -9976,6 +10124,7 @@
     },
     "/api/settings-sources/active": {
       "get": {
+        "operationId": "get_active_settings_source",
         "responses": {
           "200": {
             "content": {
@@ -9998,6 +10147,7 @@
       },
       "put": {
         "description": "A body of ``{}`` or one with empty ``source_name`` clears the active\nsource; otherwise both fields specify the new source.",
+        "operationId": "set_active_settings_source",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10037,6 +10187,7 @@
     },
     "/api/settings-sources/sync": {
       "post": {
+        "operationId": "sync_settings_from_source",
         "responses": {
           "200": {
             "content": {
@@ -10060,6 +10211,7 @@
     },
     "/api/settings/defaults": {
       "get": {
+        "operationId": "get_defaults",
         "responses": {
           "200": {
             "content": {
@@ -10083,6 +10235,7 @@
     },
     "/api/sort": {
       "post": {
+        "operationId": "sort_clips",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10125,6 +10278,7 @@
     },
     "/api/textsort-suggestions": {
       "get": {
+        "operationId": "get_textsort_suggestions_route",
         "responses": {
           "200": {
             "content": {
@@ -10146,6 +10300,7 @@
         ]
       },
       "post": {
+        "operationId": "add_textsort_suggestion_route",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10185,6 +10340,7 @@
     },
     "/api/version": {
       "get": {
+        "operationId": "version",
         "responses": {
           "200": {
             "content": {
@@ -10208,6 +10364,7 @@
     },
     "/api/votes": {
       "get": {
+        "operationId": "get_votes",
         "responses": {
           "200": {
             "content": {
@@ -10232,6 +10389,7 @@
     "/api/votes/clear": {
       "post": {
         "description": "Used by the Label flow to reset votes before importing a model's labelset\nso that labels from a previous session don't contaminate the new model.",
+        "operationId": "clear_votes_route",
         "responses": {
           "200": {
             "content": {
@@ -10256,6 +10414,7 @@
     "/api/votes/seed-from-examples": {
       "post": {
         "description": "For each ``type: \"media\"`` example, reads the file from\n``data/example_media/``, computes its MD5, and either marks the\nmatching loaded media as Good, or \u2014 if the example is new \u2014\nembeds it, inserts it into the ``medias`` dict, and votes it Good.\n\nReturns::\n\n    {\"seeded\": 2, \"skipped\": 1}",
+        "operationId": "seed_votes_from_examples",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10293,6 +10452,7 @@
     "/dashboard": {
       "get": {
         "description": "Angular Router handles these paths on the client side; the server\njust needs to return ``index.html`` for all of them.",
+        "operationId": "angular_routes_get_1",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -10306,6 +10466,7 @@
     },
     "/favicon-{variant}.ico": {
       "get": {
+        "operationId": "favicon_variant",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -10331,6 +10492,7 @@
     "/favicon.ico": {
       "get": {
         "description": "Returns:\nThe ``favicon.ico`` file from ``static/`` if it exists,\notherwise an empty ``(str, int)`` tuple with HTTP status 204.",
+        "operationId": "favicon",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -10345,6 +10507,7 @@
     "/healthz": {
       "get": {
         "description": "Intentionally does no work beyond returning a constant. Anything more\nexpensive risks turning a slow dependency into a restart loop.",
+        "operationId": "healthz",
         "responses": {
           "200": {
             "content": {
@@ -10369,6 +10532,7 @@
     "/label": {
       "get": {
         "description": "Angular Router handles these paths on the client side; the server\njust needs to return ``index.html`` for all of them.",
+        "operationId": "angular_routes_get_2",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -10383,6 +10547,7 @@
     "/logo.svg": {
       "get": {
         "description": "Returns:\nThe ``logo.svg`` file from ``static/`` if it exists,\notherwise an empty ``(str, int)`` tuple with HTTP status 204.",
+        "operationId": "logo",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -10397,6 +10562,7 @@
     "/readyz": {
       "get": {
         "description": "Sub-checks:\n\n* ``data_dir`` \u2014 :data:`vtscore.config.DATA_DIR` exists and is\n  writable (the app needs this for embeddings, model cache, settings).\n* ``models`` \u2014 every embedder implied by the dataset/detector\n  registries is warm (``_model is not None``).",
+        "operationId": "readyz",
         "responses": {
           "200": {
             "content": {
@@ -10431,6 +10597,7 @@
     "/{path}": {
       "get": {
         "description": "The Angular build output (main.js, polyfills.js, styles.css, etc.) is\nreferenced from index.html with ``<base href=\"/\">``, so the browser\nrequests them at ``/main.js`` rather than ``/static/main.js``.  This\nroute serves those files when they exist, and falls back to\n``index.html`` for any other path so that Angular Router can handle\nclient-side navigation.\n\nPaths under ``/api/`` are excluded \u2014 unmatched API routes should\nreturn 404, not the SPA page.",
+        "operationId": "catch_all",
         "responses": {
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -7,9 +7,9 @@ import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { AchievementState } from '../generated/api-client/models/achievement-state';
 import type { CheckPhraseResponse } from '../generated/api-client/models/check-phrase-response';
 import type { PendingAnnouncement } from '../generated/api-client/models/pending-announcement';
-import { apiAchievementsCategoryIdAcknowledgePost } from '../generated/api-client/fn/achievements/api-achievements-category-id-acknowledge-post';
-import { apiAchievementsCheckPhrasePost } from '../generated/api-client/fn/achievements/api-achievements-check-phrase-post';
-import { apiAchievementsGet } from '../generated/api-client/fn/achievements/api-achievements-get';
+import { acknowledgeAchievement } from '../generated/api-client/fn/achievements/acknowledge-achievement';
+import { checkPhrase } from '../generated/api-client/fn/achievements/check-phrase';
+import { getAchievements } from '../generated/api-client/fn/achievements/get-achievements';
 
 const EMPTY_STATE: AchievementState = {
   tier_names: [],
@@ -57,7 +57,7 @@ export class AchievementsService {
   refresh(): void {
     if (this.inFlight) return;
     this.inFlight = true;
-    apiAchievementsGet(this.http, this.config.rootUrl)
+    getAchievements(this.http, this.config.rootUrl)
       .pipe(
         map((r) => r.body),
         catchError(() => of(EMPTY_STATE)),
@@ -76,7 +76,7 @@ export class AchievementsService {
    * Refreshes state afterward to update the panel display.
    */
   acknowledge(categoryId: string, tierIdx: number): void {
-    apiAchievementsCategoryIdAcknowledgePost(this.http, this.config.rootUrl, {
+    acknowledgeAchievement(this.http, this.config.rootUrl, {
       category_id: categoryId,
       body: { tier_idx: tierIdx },
     })
@@ -91,7 +91,7 @@ export class AchievementsService {
    */
   checkPhrase(phrase: string): Observable<CheckPhraseResponse> {
     return new Observable<CheckPhraseResponse>((subscriber) => {
-      apiAchievementsCheckPhrasePost(this.http, this.config.rootUrl, { body: { phrase } })
+      checkPhrase(this.http, this.config.rootUrl, { body: { phrase } })
         .pipe(
           map((r) => r.body),
           catchError(() =>

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -5,9 +5,9 @@ import { map, tap } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { AuthStatus } from '../generated/api-client/models/auth-status';
-import { apiAuthLoginPost } from '../generated/api-client/fn/auth/api-auth-login-post';
-import { apiAuthLogoutPost } from '../generated/api-client/fn/auth/api-auth-logout-post';
-import { apiAuthStatusGet } from '../generated/api-client/fn/auth/api-auth-status-get';
+import { authLogin } from '../generated/api-client/fn/auth/auth-login';
+import { authLogout } from '../generated/api-client/fn/auth/auth-logout';
+import { authStatus } from '../generated/api-client/fn/auth/auth-status';
 import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 
 @Injectable({ providedIn: 'root' })
@@ -28,7 +28,7 @@ export class AuthService {
     // (we fall back to "no login required") and would otherwise pop up a
     // banner every time the user opens the app while offline.
     const context = new HttpContext().set(SKIP_ERROR_TOAST, true);
-    apiAuthStatusGet(this.http, this.config.rootUrl, undefined, context)
+    authStatus(this.http, this.config.rootUrl, undefined, context)
       .pipe(map((r) => r.body))
       .subscribe({
         next: (status) => {
@@ -58,14 +58,14 @@ export class AuthService {
     // Skip the global error banner: the login form renders its own
     // inline error message, and a duplicate banner would be redundant.
     const context = new HttpContext().set(SKIP_ERROR_TOAST, true);
-    return apiAuthLoginPost(this.http, this.config.rootUrl, { body: { username } }, context).pipe(
+    return authLogin(this.http, this.config.rootUrl, { body: { username } }, context).pipe(
       map((r) => r.body),
       tap((status) => this.statusSubject.next(status)),
     );
   }
 
   logout(): Observable<AuthStatus> {
-    return apiAuthLogoutPost(this.http, this.config.rootUrl).pipe(
+    return authLogout(this.http, this.config.rootUrl).pipe(
       map((r) => r.body),
       tap((status) => this.statusSubject.next(status)),
     );

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -38,37 +38,37 @@ import type {
   ImporterInfo,
   ImporterPickerTab,
 } from '../models/api.models';
-import { apiBrowseMediaFilesGet } from '../generated/api-client/fn/datasets-ui/api-browse-media-files-get';
-import { apiBrowseMediaFilesSelectPost } from '../generated/api-client/fn/datasets-ui/api-browse-media-files-select-post';
-import { apiClippersGet } from '../generated/api-client/fn/datasets-listings/api-clippers-get';
-import { apiConvertersGet } from '../generated/api-client/fn/datasets-listings/api-converters-get';
-import { apiDashboardDiskUsageGet } from '../generated/api-client/fn/datasets-ui/api-dashboard-disk-usage-get';
-import { apiDatasetAllImportersGet } from '../generated/api-client/fn/datasets-listings/api-dataset-all-importers-get';
-import { apiDatasetAvailableFilesGet } from '../generated/api-client/fn/datasets-staging/api-dataset-available-files-get';
-import { apiDatasetCancelPost } from '../generated/api-client/fn/datasets-status/api-dataset-cancel-post';
-import { apiDatasetCancelTaskIdPost } from '../generated/api-client/fn/datasets-status/api-dataset-cancel-task-id-post';
-import { apiDatasetClearPost } from '../generated/api-client/fn/datasets-load/api-dataset-clear-post';
-import { apiDatasetCombinePost } from '../generated/api-client/fn/datasets-staging/api-dataset-combine-post';
-import { apiDatasetDemoCategoriesNameGet } from '../generated/api-client/fn/datasets-ui/api-dataset-demo-categories-name-get';
-import { apiDatasetDemoListGet } from '../generated/api-client/fn/datasets-ui/api-dataset-demo-list-get';
-import { apiDatasetDetectMediaTypeGet } from '../generated/api-client/fn/datasets-ui/api-dataset-detect-media-type-get';
-import { apiDatasetImportImporterNameOptionsPost } from '../generated/api-client/fn/datasets-staging/api-dataset-import-importer-name-options-post';
-import { apiDatasetImportersGet } from '../generated/api-client/fn/datasets-listings/api-dataset-importers-get';
-import { apiDatasetLoadDemoPost } from '../generated/api-client/fn/datasets-load/api-dataset-load-demo-post';
-import { apiDatasetLoadFolderPost } from '../generated/api-client/fn/datasets-load/api-dataset-load-folder-post';
-import { apiDatasetLoadSourcePost } from '../generated/api-client/fn/datasets-load/api-dataset-load-source-post';
-import { apiDatasetStageDemoNamePost } from '../generated/api-client/fn/datasets-staging/api-dataset-stage-demo-name-post';
-import { apiDatasetStagingDelete } from '../generated/api-client/fn/datasets-staging/api-dataset-staging-delete';
-import { apiDatasetStatusGet } from '../generated/api-client/fn/datasets-status/api-dataset-status-get';
-import { apiDatasetsRegistryDatasetIdDelete } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-delete';
-import { apiDatasetsRegistryDatasetIdLoadPost } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-load-post';
-import { apiDatasetsRegistryDatasetIdReadersPut } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-readers-put';
-import { apiDatasetsRegistryDatasetIdRenamePut } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-rename-put';
-import { apiDatasetsRegistryDatasetIdStatsGet } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-stats-get';
-import { apiDatasetsRegistryDatasetIdUnloadPost } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-unload-post';
-import { apiDatasetsRegistryGet } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-get';
-import { apiEmbeddersGet } from '../generated/api-client/fn/datasets-listings/api-embedders-get';
-import { apiMediaTypesGet } from '../generated/api-client/fn/datasets-listings/api-media-types-get';
+import { browseMediaFiles } from '../generated/api-client/fn/datasets-ui/browse-media-files';
+import { selectBrowsedFile } from '../generated/api-client/fn/datasets-ui/select-browsed-file';
+import { clippersList } from '../generated/api-client/fn/datasets-listings/clippers-list';
+import { convertersList } from '../generated/api-client/fn/datasets-listings/converters-list';
+import { dashboardDiskUsage } from '../generated/api-client/fn/datasets-ui/dashboard-disk-usage';
+import { datasetAllImporters } from '../generated/api-client/fn/datasets-listings/dataset-all-importers';
+import { availableDatasetFiles } from '../generated/api-client/fn/datasets-staging/available-dataset-files';
+import { cancelDatasetLoad } from '../generated/api-client/fn/datasets-status/cancel-dataset-load';
+import { cancelDatasetLoadTask } from '../generated/api-client/fn/datasets-status/cancel-dataset-load-task';
+import { clearDatasetRoute } from '../generated/api-client/fn/datasets-load/clear-dataset-route';
+import { combineDatasetsRoute } from '../generated/api-client/fn/datasets-staging/combine-datasets-route';
+import { demoDatasetCategories } from '../generated/api-client/fn/datasets-ui/demo-dataset-categories';
+import { demoDatasetList } from '../generated/api-client/fn/datasets-ui/demo-dataset-list';
+import { detectMediaType } from '../generated/api-client/fn/datasets-ui/detect-media-type';
+import { importerFieldOptions } from '../generated/api-client/fn/datasets-staging/importer-field-options';
+import { datasetImporters } from '../generated/api-client/fn/datasets-listings/dataset-importers';
+import { loadDemoDatasetRoute } from '../generated/api-client/fn/datasets-load/load-demo-dataset-route';
+import { loadDatasetFolder } from '../generated/api-client/fn/datasets-load/load-dataset-folder';
+import { loadDatasetFromSource } from '../generated/api-client/fn/datasets-load/load-dataset-from-source';
+import { stageDemo } from '../generated/api-client/fn/datasets-staging/stage-demo';
+import { clearStaging } from '../generated/api-client/fn/datasets-staging/clear-staging';
+import { datasetStatus } from '../generated/api-client/fn/datasets-status/dataset-status';
+import { deleteRegisteredDataset } from '../generated/api-client/fn/datasets-registry/delete-registered-dataset';
+import { loadRegisteredDataset } from '../generated/api-client/fn/datasets-registry/load-registered-dataset';
+import { updateDatasetReaders } from '../generated/api-client/fn/datasets-registry/update-dataset-readers';
+import { renameRegisteredDataset } from '../generated/api-client/fn/datasets-registry/rename-registered-dataset';
+import { getDatasetStats } from '../generated/api-client/fn/datasets-registry/get-dataset-stats';
+import { unloadRegisteredDataset } from '../generated/api-client/fn/datasets-registry/unload-registered-dataset';
+import { listRegisteredDatasets } from '../generated/api-client/fn/datasets-registry/list-registered-datasets';
+import { embeddersList } from '../generated/api-client/fn/datasets-listings/embedders-list';
+import { mediaTypesList } from '../generated/api-client/fn/datasets-listings/media-types-list';
 
 /** The importer/clipper/embedder/converter listings return plugin
  *  ``to_dict()`` payloads — the generated types describe them as
@@ -86,47 +86,47 @@ export class DatasetsApiService {
   private config = inject(ApiConfiguration);
 
   getStatus(): Observable<DatasetStatusResponse> {
-    return apiDatasetStatusGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return datasetStatus(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getImporters(): Observable<ImportersResponse> {
-    return apiDatasetImportersGet(this.http, this.config.rootUrl).pipe(
+    return datasetImporters(this.http, this.config.rootUrl).pipe(
       map((r) => r.body as unknown as ImportersResponse),
     );
   }
 
   getAllImporters(): Observable<ImportersResponse> {
-    return apiDatasetAllImportersGet(this.http, this.config.rootUrl).pipe(
+    return datasetAllImporters(this.http, this.config.rootUrl).pipe(
       map((r) => r.body as unknown as ImportersResponse),
     );
   }
 
   getDemoList(embedder?: string, clipper?: string): Observable<DemoDatasetListResponse> {
-    return apiDatasetDemoListGet(this.http, this.config.rootUrl, { embedder, clipper }).pipe(
+    return demoDatasetList(this.http, this.config.rootUrl, { embedder, clipper }).pipe(
       map((r) => r.body),
     );
   }
 
   getDemoCategories(name: string): Observable<DemoCategoriesResponse> {
-    return apiDatasetDemoCategoriesNameGet(this.http, this.config.rootUrl, { name }).pipe(
+    return demoDatasetCategories(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
 
   browseMediaFiles(source: string, path: string): Observable<BrowseMediaFilesResponse> {
-    return apiBrowseMediaFilesGet(this.http, this.config.rootUrl, { source, path }).pipe(
+    return browseMediaFiles(this.http, this.config.rootUrl, { source, path }).pipe(
       map((r) => r.body),
     );
   }
 
   selectBrowsedFile(source: string, path: string): Observable<BrowseMediaFilesSelectResponse> {
-    return apiBrowseMediaFilesSelectPost(this.http, this.config.rootUrl, {
+    return selectBrowsedFile(this.http, this.config.rootUrl, {
       body: { source, path },
     }).pipe(map((r) => r.body));
   }
 
   getMediaTypes(): Observable<{ media_types: import('../models/api.models').MediaTypeInfo[] }> {
-    return apiMediaTypesGet(this.http, this.config.rootUrl).pipe(
+    return mediaTypesList(this.http, this.config.rootUrl).pipe(
       map((r) => r.body as unknown as { media_types: import('../models/api.models').MediaTypeInfo[] }),
     );
   }
@@ -137,7 +137,7 @@ export class DatasetsApiService {
     recursive: boolean,
     limit = 50,
   ): Observable<DetectMediaTypeResponse> {
-    return apiDatasetDetectMediaTypeGet(this.http, this.config.rootUrl, {
+    return detectMediaType(this.http, this.config.rootUrl, {
       source,
       path,
       recursive,
@@ -146,25 +146,25 @@ export class DatasetsApiService {
   }
 
   getClippers(mediaType?: string): Observable<ClipperInfo[]> {
-    return apiClippersGet(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
+    return clippersList(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
       map((r) => r.body.clippers as unknown as ClipperInfo[]),
     );
   }
 
   getEmbedders(mediaType?: string): Observable<EmbedderInfo[]> {
-    return apiEmbeddersGet(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
+    return embeddersList(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
       map((r) => r.body.embedders as unknown as EmbedderInfo[]),
     );
   }
 
   getConverters(target?: string): Observable<ConverterInfo[]> {
-    return apiConvertersGet(this.http, this.config.rootUrl, { target }).pipe(
+    return convertersList(this.http, this.config.rootUrl, { target }).pipe(
       map((r) => r.body.converters as unknown as ConverterInfo[]),
     );
   }
 
   getAvailableFiles(): Observable<DatasetAvailableFilesResponse> {
-    return apiDatasetAvailableFilesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return availableDatasetFiles(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Plugin-field route — body shape is plugin-dependent, not described in
@@ -182,7 +182,7 @@ export class DatasetsApiService {
     fieldKey: string,
     values: Record<string, unknown>,
   ): Observable<ImporterFieldOptionsResponse> {
-    return apiDatasetImportImporterNameOptionsPost(this.http, this.config.rootUrl, {
+    return importerFieldOptions(this.http, this.config.rootUrl, {
       importer_name: importerName,
       body: { field_key: fieldKey, values },
     }).pipe(map((r) => r.body));
@@ -199,7 +199,7 @@ export class DatasetsApiService {
 
   loadDemo(name: string, params?: Record<string, string>): Observable<DatasetLoadStartedResponse> {
     const body: DatasetLoadDemoRequest = { name, ...params };
-    return apiDatasetLoadDemoPost(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));
+    return loadDemoDatasetRoute(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));
   }
 
   /** Multipart upload — see {@link importLocalFolder}. */
@@ -223,34 +223,34 @@ export class DatasetsApiService {
   }
 
   stageDemo(name: string): Observable<DatasetStagingStartedResponse> {
-    return apiDatasetStageDemoNamePost(this.http, this.config.rootUrl, {
+    return stageDemo(this.http, this.config.rootUrl, {
       name,
       body: {},
     }).pipe(map((r) => r.body));
   }
 
   clearStaging(): Observable<ClearStagingResponse> {
-    return apiDatasetStagingDelete(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return clearStaging(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   combineDatasets(params: DatasetCombineRequest): Observable<DatasetLoadStartedResponse> {
-    return apiDatasetCombinePost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return combineDatasetsRoute(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   cancelIngest(): Observable<CancelDatasetLoadResponse> {
-    return apiDatasetCancelPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return cancelDatasetLoad(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   cancelTask(taskId: string): Observable<CancelDatasetLoadResponse> {
-    return apiDatasetCancelTaskIdPost(this.http, this.config.rootUrl, { task_id: taskId }).pipe(
+    return cancelDatasetLoadTask(this.http, this.config.rootUrl, { task_id: taskId }).pipe(
       map((r) => r.body),
     );
   }
 
   clearDataset(): Observable<DatasetClearResponse> {
-    return apiDatasetClearPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return clearDatasetRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Binary stream — stays on plain ``HttpClient`` so ``responseType: 'blob'``
@@ -261,23 +261,23 @@ export class DatasetsApiService {
   }
 
   getRegistry(): Observable<DatasetsRegistryListResponse> {
-    return apiDatasetsRegistryGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listRegisteredDatasets(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   loadRegistered(datasetId: string): Observable<DatasetRegistryLoadResponse> {
-    return apiDatasetsRegistryDatasetIdLoadPost(this.http, this.config.rootUrl, {
+    return loadRegisteredDataset(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
     }).pipe(map((r) => r.body));
   }
 
   unloadRegistered(datasetId: string): Observable<DatasetRegistryOkResponse> {
-    return apiDatasetsRegistryDatasetIdUnloadPost(this.http, this.config.rootUrl, {
+    return unloadRegisteredDataset(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
     }).pipe(map((r) => r.body));
   }
 
   deleteRegistered(datasetId: string): Observable<DatasetRegistryOkResponse> {
-    return apiDatasetsRegistryDatasetIdDelete(this.http, this.config.rootUrl, {
+    return deleteRegisteredDataset(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
     }).pipe(map((r) => r.body));
   }
@@ -286,7 +286,7 @@ export class DatasetsApiService {
     datasetId: string,
     newName: string,
   ): Observable<DatasetRegistryRenameResponse> {
-    return apiDatasetsRegistryDatasetIdRenamePut(this.http, this.config.rootUrl, {
+    return renameRegisteredDataset(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
       body: { name: newName },
     }).pipe(map((r) => r.body));
@@ -296,14 +296,14 @@ export class DatasetsApiService {
     datasetId: string,
     readers: string[],
   ): Observable<DatasetRegistryReadersResponse> {
-    return apiDatasetsRegistryDatasetIdReadersPut(this.http, this.config.rootUrl, {
+    return updateDatasetReaders(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
       body: { readers },
     }).pipe(map((r) => r.body));
   }
 
   loadSource(params: DatasetLoadSourceRequest): Observable<DatasetLoadStartedResponse> {
-    return apiDatasetLoadSourcePost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return loadDatasetFromSource(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
@@ -319,12 +319,12 @@ export class DatasetsApiService {
   }
 
   getDatasetStats(datasetId: string): Observable<DatasetRegistryStatsResponse> {
-    return apiDatasetsRegistryDatasetIdStatsGet(this.http, this.config.rootUrl, {
+    return getDatasetStats(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
     }).pipe(map((r) => r.body));
   }
 
   getDiskUsage(): Observable<DashboardDiskUsageResponse> {
-    return apiDashboardDiskUsageGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return dashboardDiskUsage(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -52,44 +52,44 @@ import type { LocalizeRequest } from '../generated/api-client/models/localize-re
 import type { LocalizeResponse } from '../generated/api-client/models/localize-response';
 import type { PregenProcessorsAddResponse } from '../generated/api-client/models/pregen-processors-add-response';
 import type { PregenProcessorsListResponse } from '../generated/api-client/models/pregen-processors-list-response';
-import { apiAutoDetectPost } from '../generated/api-client/fn/detector-scoring/api-auto-detect-post';
-import { apiAutoExtractPost } from '../generated/api-client/fn/processors-scoring/api-auto-extract-post';
-import { apiAutoLocalizePost } from '../generated/api-client/fn/processors-scoring/api-auto-localize-post';
-import { apiAutorunExtractorsGet } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-get';
-import { apiAutorunExtractorsNameDelete } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-name-delete';
-import { apiAutorunExtractorsNameRenamePut } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-name-rename-put';
-import { apiAutorunExtractorsPost } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-post';
-import { apiAutorunLocalizersGet } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-get';
-import { apiAutorunLocalizersNameDelete } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-name-delete';
-import { apiAutorunLocalizersNameRenamePut } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-name-rename-put';
-import { apiAutorunLocalizersPost } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-post';
-import { apiDetectorsCancelTaskIdPost } from '../generated/api-client/fn/detectors-registry/api-detectors-cancel-task-id-post';
-import { apiDetectorsCombinePost } from '../generated/api-client/fn/detectors-crud/api-detectors-combine-post';
-import { apiDetectorsGet } from '../generated/api-client/fn/detectors-crud/api-detectors-get';
-import { apiDetectorsNameDelete } from '../generated/api-client/fn/detectors-crud/api-detectors-name-delete';
-import { apiDetectorsNameExamplesPut } from '../generated/api-client/fn/detectors-crud/api-detectors-name-examples-put';
-import { apiDetectorsNameGet } from '../generated/api-client/fn/detectors-crud/api-detectors-name-get';
-import { apiDetectorsNameLabelsDetailGet } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-detail-get';
-import { apiDetectorsNameLabelsElementIdVotePost } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-element-id-vote-post';
-import { apiDetectorsNameLabelsPost } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-post';
-import { apiDetectorsNameRenamePut } from '../generated/api-client/fn/detectors-crud/api-detectors-name-rename-put';
-import { apiDetectorsPost } from '../generated/api-client/fn/detectors-crud/api-detectors-post';
-import { apiDetectorsRegistryDetectorIdAutorunPut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-autorun-put';
-import { apiDetectorsRegistryDetectorIdDelete } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-delete';
-import { apiDetectorsRegistryDetectorIdLabelsetSourceMoveFilePost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-labelset-source-move-file-post';
-import { apiDetectorsRegistryDetectorIdRenamePut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-rename-put';
-import { apiDetectorsRegistryDetectorIdUnloadPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-unload-post';
-import { apiDetectorsRegistryGet } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-get';
-import { apiDetectorsRegistryLoadPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-load-post';
-import { apiDetectorsRegistryPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-post';
-import { apiExtractPost } from '../generated/api-client/fn/processors-scoring/api-extract-post';
-import { apiFindCancelPost } from '../generated/api-client/fn/detector-find/api-find-cancel-post';
-import { apiFindCheckLabelsPost } from '../generated/api-client/fn/detector-find/api-find-check-labels-post';
-import { apiFindLabelPost } from '../generated/api-client/fn/detector-scoring/api-find-label-post';
-import { apiFindPost } from '../generated/api-client/fn/detector-find/api-find-post';
-import { apiLocalizePost } from '../generated/api-client/fn/processors-scoring/api-localize-post';
-import { apiPregenProcessorsAddPost } from '../generated/api-client/fn/processors-crud/api-pregen-processors-add-post';
-import { apiPregenProcessorsGet } from '../generated/api-client/fn/processors-crud/api-pregen-processors-get';
+import { autoDetect } from '../generated/api-client/fn/detector-scoring/auto-detect';
+import { autoExtract } from '../generated/api-client/fn/processors-scoring/auto-extract';
+import { autoLocalize } from '../generated/api-client/fn/processors-scoring/auto-localize';
+import { getAutorunExtractorsRoute } from '../generated/api-client/fn/processors-crud/get-autorun-extractors-route';
+import { deleteAutorunExtractorRoute } from '../generated/api-client/fn/processors-crud/delete-autorun-extractor-route';
+import { renameAutorunExtractorRoute } from '../generated/api-client/fn/processors-crud/rename-autorun-extractor-route';
+import { addAutorunExtractorRoute } from '../generated/api-client/fn/processors-crud/add-autorun-extractor-route';
+import { getAutorunLocalizersRoute } from '../generated/api-client/fn/processors-crud/get-autorun-localizers-route';
+import { deleteAutorunLocalizerRoute } from '../generated/api-client/fn/processors-crud/delete-autorun-localizer-route';
+import { renameAutorunLocalizerRoute } from '../generated/api-client/fn/processors-crud/rename-autorun-localizer-route';
+import { addAutorunLocalizerRoute } from '../generated/api-client/fn/processors-crud/add-autorun-localizer-route';
+import { cancelDetectorLoadingTask } from '../generated/api-client/fn/detectors-registry/cancel-detector-loading-task';
+import { combineDetectors } from '../generated/api-client/fn/detectors-crud/combine-detectors';
+import { listDetectors } from '../generated/api-client/fn/detectors-crud/list-detectors';
+import { deleteDetector } from '../generated/api-client/fn/detectors-crud/delete-detector';
+import { setDetectorExamples } from '../generated/api-client/fn/detectors-crud/set-detector-examples';
+import { getDetector } from '../generated/api-client/fn/detectors-crud/get-detector';
+import { getDetectorLabelsDetail } from '../generated/api-client/fn/detectors-labels/get-detector-labels-detail';
+import { voteDetectorLabel } from '../generated/api-client/fn/detectors-labels/vote-detector-label';
+import { saveDetectorLabels } from '../generated/api-client/fn/detectors-labels/save-detector-labels';
+import { renameDetector } from '../generated/api-client/fn/detectors-crud/rename-detector';
+import { createDetector } from '../generated/api-client/fn/detectors-crud/create-detector';
+import { setDetectorAutorun } from '../generated/api-client/fn/detectors-registry/set-detector-autorun';
+import { deleteRegisteredDetector } from '../generated/api-client/fn/detectors-registry/delete-registered-detector';
+import { moveLabelsetSourceFile } from '../generated/api-client/fn/detectors-registry/move-labelset-source-file';
+import { renameRegisteredDetector } from '../generated/api-client/fn/detectors-registry/rename-registered-detector';
+import { unloadDetectorRoute } from '../generated/api-client/fn/detectors-registry/unload-detector-route';
+import { listRegisteredDetectors } from '../generated/api-client/fn/detectors-registry/list-registered-detectors';
+import { loadDetectorRoute } from '../generated/api-client/fn/detectors-registry/load-detector-route';
+import { registerDetectorRoute } from '../generated/api-client/fn/detectors-registry/register-detector-route';
+import { runExtract } from '../generated/api-client/fn/processors-scoring/run-extract';
+import { cancelFind } from '../generated/api-client/fn/detector-find/cancel-find';
+import { findCheckLabels } from '../generated/api-client/fn/detector-find/find-check-labels';
+import { findLabel } from '../generated/api-client/fn/detector-scoring/find-label';
+import { multiFind } from '../generated/api-client/fn/detector-find/multi-find';
+import { runLocalize } from '../generated/api-client/fn/processors-scoring/run-localize';
+import { addPregenProcessors } from '../generated/api-client/fn/processors-crud/add-pregen-processors';
+import { listPregenProcessors } from '../generated/api-client/fn/processors-crud/list-pregen-processors';
 import { ActiveContextService } from './active-context.service';
 import { VtDialogService } from './dialog.service';
 
@@ -112,27 +112,27 @@ export class DetectorsApiService {
   // --- Detector CRUD ---
 
   list(): Observable<DetectorsListResponse> {
-    return apiDetectorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listDetectors(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   create(params: DetectorCreateRequest): Observable<DetectorCreateResponse> {
-    return apiDetectorsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return createDetector(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   get(name: string): Observable<DetectorDetail> {
-    return apiDetectorsNameGet(this.http, this.config.rootUrl, { name }).pipe(map((r) => r.body));
+    return getDetector(this.http, this.config.rootUrl, { name }).pipe(map((r) => r.body));
   }
 
   delete(name: string): Observable<DetectorDeleteResponse> {
-    return apiDetectorsNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+    return deleteDetector(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
 
   rename(name: string, newName: string): Observable<DetectorRenameResponse> {
-    return apiDetectorsNameRenamePut(this.http, this.config.rootUrl, {
+    return renameDetector(this.http, this.config.rootUrl, {
       name,
       body: { new_name: newName },
     }).pipe(map((r) => r.body));
@@ -142,20 +142,20 @@ export class DetectorsApiService {
     name: string,
     examples: DetectorExamplesRequest['examples'],
   ): Observable<DetectorExamplesResponse> {
-    return apiDetectorsNameExamplesPut(this.http, this.config.rootUrl, {
+    return setDetectorExamples(this.http, this.config.rootUrl, {
       name,
       body: { examples },
     }).pipe(map((r) => r.body));
   }
 
   saveLabels(name: string): Observable<DetectorSaveLabelsResponse> {
-    return apiDetectorsNameLabelsPost(this.http, this.config.rootUrl, { name }).pipe(
+    return saveDetectorLabels(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
 
   getLabelsDetail(name: string): Observable<DetectorLabelsDetailResponse> {
-    return apiDetectorsNameLabelsDetailGet(this.http, this.config.rootUrl, { name }).pipe(
+    return getDetectorLabelsDetail(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
@@ -165,7 +165,7 @@ export class DetectorsApiService {
     elementId: string,
     vote: 'good' | 'bad',
   ): Observable<DetectorLabelVoteResponse> {
-    return apiDetectorsNameLabelsElementIdVotePost(this.http, this.config.rootUrl, {
+    return voteDetectorLabel(this.http, this.config.rootUrl, {
       name,
       element_id: elementId,
       body: { vote },
@@ -193,7 +193,7 @@ export class DetectorsApiService {
     newName: string,
     conflictPolicy: DetectorCombineRequest['conflict_policy'] = 'drop',
   ): Observable<DetectorCombineResponse> {
-    return apiDetectorsCombinePost(this.http, this.config.rootUrl, {
+    return combineDetectors(this.http, this.config.rootUrl, {
       body: { names, new_name: newName, conflict_policy: conflictPolicy },
     }).pipe(map((r) => r.body));
   }
@@ -201,13 +201,13 @@ export class DetectorsApiService {
   // --- Detector Registry ---
 
   getRegistry(): Observable<DetectorRegistryListResponse> {
-    return apiDetectorsRegistryGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listRegisteredDetectors(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   registerDetector(
     params: DetectorRegistryCreateRequest,
   ): Observable<DetectorRegistryCreateResponse> {
-    return apiDetectorsRegistryPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return registerDetectorRoute(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
@@ -236,7 +236,7 @@ export class DetectorsApiService {
   }
 
   deleteFromRegistry(detectorId: string): Observable<DetectorRegistryDeleteResponse> {
-    return apiDetectorsRegistryDetectorIdDelete(this.http, this.config.rootUrl, {
+    return deleteRegisteredDetector(this.http, this.config.rootUrl, {
       detector_id: detectorId,
     }).pipe(map((r) => r.body));
   }
@@ -245,7 +245,7 @@ export class DetectorsApiService {
     detectorId: string,
     newName: string,
   ): Observable<DetectorRegistryRenameResponse> {
-    return apiDetectorsRegistryDetectorIdRenamePut(this.http, this.config.rootUrl, {
+    return renameRegisteredDetector(this.http, this.config.rootUrl, {
       detector_id: detectorId,
       body: { name: newName },
     }).pipe(map((r) => r.body));
@@ -256,7 +256,7 @@ export class DetectorsApiService {
     oldPath: string,
     newPath: string,
   ): Observable<DetectorLabelsetMoveResponse> {
-    return apiDetectorsRegistryDetectorIdLabelsetSourceMoveFilePost(
+    return moveLabelsetSourceFile(
       this.http,
       this.config.rootUrl,
       {
@@ -294,25 +294,25 @@ export class DetectorsApiService {
   }
 
   loadDetector(detectorId: string | null): Observable<DetectorRegistryLoadResponse> {
-    return apiDetectorsRegistryLoadPost(this.http, this.config.rootUrl, {
+    return loadDetectorRoute(this.http, this.config.rootUrl, {
       body: { detector_id: detectorId },
     }).pipe(map((r) => r.body));
   }
 
   unloadDetector(detectorId: string): Observable<DetectorRegistryUnloadResponse> {
-    return apiDetectorsRegistryDetectorIdUnloadPost(this.http, this.config.rootUrl, {
+    return unloadDetectorRoute(this.http, this.config.rootUrl, {
       detector_id: detectorId,
     }).pipe(map((r) => r.body));
   }
 
   cancelDetectorLoadingTask(taskId: string): Observable<DetectorCancelResponse> {
-    return apiDetectorsCancelTaskIdPost(this.http, this.config.rootUrl, {
+    return cancelDetectorLoadingTask(this.http, this.config.rootUrl, {
       task_id: taskId,
     }).pipe(map((r) => r.body));
   }
 
   setAutorun(detectorId: string, autorun: boolean): Observable<DetectorRegistryAutorunResponse> {
-    return apiDetectorsRegistryDetectorIdAutorunPut(this.http, this.config.rootUrl, {
+    return setDetectorAutorun(this.http, this.config.rootUrl, {
       detector_id: detectorId,
       body: { autorun },
     }).pipe(map((r) => r.body));
@@ -321,25 +321,25 @@ export class DetectorsApiService {
   // --- Extractors ---
 
   getAutorunExtractors(): Observable<AutorunExtractorsListResponse> {
-    return apiAutorunExtractorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getAutorunExtractorsRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   createExtractor(
     params: AutorunExtractorCreateRequest,
   ): Observable<AutorunProcessorCreateResponse> {
-    return apiAutorunExtractorsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return addAutorunExtractorRoute(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   deleteExtractor(name: string): Observable<AutorunProcessorDeleteResponse> {
-    return apiAutorunExtractorsNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+    return deleteAutorunExtractorRoute(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
 
   renameExtractor(name: string, newName: string): Observable<AutorunProcessorRenameResponse> {
-    return apiAutorunExtractorsNameRenamePut(this.http, this.config.rootUrl, {
+    return renameAutorunExtractorRoute(this.http, this.config.rootUrl, {
       name,
       body: { new_name: newName },
     }).pipe(map((r) => r.body));
@@ -348,25 +348,25 @@ export class DetectorsApiService {
   // --- Localizers ---
 
   getAutorunLocalizers(): Observable<AutorunLocalizersListResponse> {
-    return apiAutorunLocalizersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getAutorunLocalizersRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   createLocalizer(
     params: AutorunLocalizerCreateRequest,
   ): Observable<AutorunProcessorCreateResponse> {
-    return apiAutorunLocalizersPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return addAutorunLocalizerRoute(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   deleteLocalizer(name: string): Observable<AutorunProcessorDeleteResponse> {
-    return apiAutorunLocalizersNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+    return deleteAutorunLocalizerRoute(this.http, this.config.rootUrl, { name }).pipe(
       map((r) => r.body),
     );
   }
 
   renameLocalizer(name: string, newName: string): Observable<AutorunProcessorRenameResponse> {
-    return apiAutorunLocalizersNameRenamePut(this.http, this.config.rootUrl, {
+    return renameAutorunLocalizerRoute(this.http, this.config.rootUrl, {
       name,
       body: { new_name: newName },
     }).pipe(map((r) => r.body));
@@ -375,61 +375,61 @@ export class DetectorsApiService {
   // --- Scoring ---
 
   autoDetect(params: AutoDetectRequest): Observable<AutoDetectResponse> {
-    return apiAutoDetectPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return autoDetect(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   extract(params: ExtractRequest): Observable<ExtractResponse> {
-    return apiExtractPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return runExtract(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   autoExtract(): Observable<AutoExtractResponse> {
-    return apiAutoExtractPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return autoExtract(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   localize(params: LocalizeRequest): Observable<LocalizeResponse> {
-    return apiLocalizePost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return runLocalize(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   autoLocalize(): Observable<AutoLocalizeResponse> {
-    return apiAutoLocalizePost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return autoLocalize(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   // --- Find ---
 
   findCheckLabels(params: FindCheckLabelsRequest): Observable<FindCheckLabelsResponse> {
-    return apiFindCheckLabelsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return findCheckLabels(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   find(params: FindRequest): Observable<FindResponse> {
-    return apiFindPost(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
+    return multiFind(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
   }
 
   findLabel(params: FindLabelRequest): Observable<FindLabelResponse> {
-    return apiFindLabelPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return findLabel(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
 
   /** Cancel any in-flight find / find-label / auto-detect scoring. */
   cancelFind(): Observable<FindCancelResponse> {
-    return apiFindCancelPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return cancelFind(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   // --- Pregen processors ---
 
   getPregenProcessors(): Observable<PregenProcessorsListResponse> {
-    return apiPregenProcessorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listPregenProcessors(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   addPregenProcessors(): Observable<PregenProcessorsAddResponse> {
-    return apiPregenProcessorsAddPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return addPregenProcessors(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/exporters-api.service.ts
+++ b/frontend/src/app/services/exporters-api.service.ts
@@ -7,8 +7,8 @@ import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { ExporterEntry } from '../generated/api-client/models/exporter-entry';
 import type { RunExportRequest } from '../generated/api-client/models/run-export-request';
 import type { RunExportResponse } from '../generated/api-client/models/run-export-response';
-import { apiExportersGet } from '../generated/api-client/fn/exporters/api-exporters-get';
-import { apiExportersExportPost } from '../generated/api-client/fn/exporters/api-exporters-export-post';
+import { getExporters } from '../generated/api-client/fn/exporters/get-exporters';
+import { runExport } from '../generated/api-client/fn/exporters/run-export';
 
 @Injectable({ providedIn: 'root' })
 export class ExportersApiService {
@@ -16,11 +16,11 @@ export class ExportersApiService {
   private config = inject(ApiConfiguration);
 
   getExporters(): Observable<ExporterEntry[]> {
-    return apiExportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getExporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   runExport(body: RunExportRequest): Observable<RunExportResponse> {
-    return apiExportersExportPost(this.http, this.config.rootUrl, { body }).pipe(
+    return runExport(this.http, this.config.rootUrl, { body }).pipe(
       map((r) => r.body),
     );
   }

--- a/frontend/src/app/services/file-browser-api.service.ts
+++ b/frontend/src/app/services/file-browser-api.service.ts
@@ -5,7 +5,7 @@ import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { BrowseResponse } from '../generated/api-client/models/browse-response';
-import { apiBrowseGet } from '../generated/api-client/fn/file-browser/api-browse-get';
+import { browse } from '../generated/api-client/fn/file-browser/browse';
 
 @Injectable({ providedIn: 'root' })
 export class FileBrowserApiService {
@@ -13,7 +13,7 @@ export class FileBrowserApiService {
   private config = inject(ApiConfiguration);
 
   browse(path: string, extensions?: string): Observable<BrowseResponse> {
-    return apiBrowseGet(this.http, this.config.rootUrl, { path, extensions }).pipe(
+    return browse(this.http, this.config.rootUrl, { path, extensions }).pipe(
       map((r) => r.body),
     );
   }

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -6,8 +6,8 @@ import { map } from 'rxjs/operators';
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { LabelImporterEntry } from '../generated/api-client/models/label-importer-entry';
 import type { IngestMissingResponse } from '../generated/api-client/models/ingest-missing-response';
-import { apiLabelImportersGet } from '../generated/api-client/fn/label-importers/api-label-importers-get';
-import { apiLabelImportersIngestMissingPost } from '../generated/api-client/fn/label-importers/api-label-importers-ingest-missing-post';
+import { getLabelImporters } from '../generated/api-client/fn/label-importers/get-label-importers';
+import { ingestMissing } from '../generated/api-client/fn/label-importers/ingest-missing';
 
 @Injectable({ providedIn: 'root' })
 export class LabelImportersApiService {
@@ -15,7 +15,7 @@ export class LabelImportersApiService {
   private config = inject(ApiConfiguration);
 
   list(): Observable<LabelImporterEntry[]> {
-    return apiLabelImportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getLabelImporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Plugin-field route — request body shape is plugin-dependent and not
@@ -60,7 +60,7 @@ export class LabelImportersApiService {
   }
 
   ingestMissing(entries: Record<string, unknown>[]): Observable<IngestMissingResponse> {
-    return apiLabelImportersIngestMissingPost(this.http, this.config.rootUrl, {
+    return ingestMissing(this.http, this.config.rootUrl, {
       body: { entries },
     }).pipe(map((r) => r.body));
   }

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -10,10 +10,10 @@ import type { MediaParagraphResponse } from '../generated/api-client/models/medi
 import type { MediaVoteRequest } from '../generated/api-client/models/media-vote-request';
 import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
 import type { MediaAddToPileResponse } from '../generated/api-client/models/media-add-to-pile-response';
-import { apiMediasIdsGet } from '../generated/api-client/fn/medias/api-medias-ids-get';
-import { apiMediasBatchPost } from '../generated/api-client/fn/medias/api-medias-batch-post';
-import { apiMediasMediaIdTextGet } from '../generated/api-client/fn/medias/api-medias-media-id-text-get';
-import { apiMediasMediaIdVotePost } from '../generated/api-client/fn/medias/api-medias-media-id-vote-post';
+import { listMediaIds } from '../generated/api-client/fn/medias/list-media-ids';
+import { batchMedias } from '../generated/api-client/fn/medias/batch-medias';
+import { mediaParagraphGet2 } from '../generated/api-client/fn/medias/media-paragraph-get-2';
+import { voteMedia } from '../generated/api-client/fn/medias/vote-media';
 
 @Injectable({ providedIn: 'root' })
 export class MediasApiService {
@@ -26,15 +26,15 @@ export class MediasApiService {
    * metadata is fetched on demand via {@link getMediasBatch}.
    */
   getMediaIds(): Observable<MediaIdsListResponse[]> {
-    return apiMediasIdsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listMediaIds(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getMediasBatch(ids: number[]): Observable<MediaBatchResponse[]> {
-    return apiMediasBatchPost(this.http, this.config.rootUrl, { body: { ids } }).pipe(map((r) => r.body));
+    return batchMedias(this.http, this.config.rootUrl, { body: { ids } }).pipe(map((r) => r.body));
   }
 
   getText(id: number): Observable<MediaParagraphResponse> {
-    return apiMediasMediaIdTextGet(this.http, this.config.rootUrl, { media_id: id }).pipe(map((r) => r.body));
+    return mediaParagraphGet2(this.http, this.config.rootUrl, { media_id: id }).pipe(map((r) => r.body));
   }
 
   /**
@@ -57,7 +57,7 @@ export class MediasApiService {
   ): Observable<MediaVoteResponse> {
     const body: MediaVoteRequest = { target };
     if (regionBox && regionBox.length === 4) body.region_box = [...regionBox];
-    return apiMediasMediaIdVotePost(this.http, this.config.rootUrl, { media_id: id, body }).pipe(
+    return voteMedia(this.http, this.config.rootUrl, { media_id: id, body }).pipe(
       map((r) => r.body),
     );
   }

--- a/frontend/src/app/services/recent-sessions.service.ts
+++ b/frontend/src/app/services/recent-sessions.service.ts
@@ -4,8 +4,8 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
-import { apiSessionsRecentGet } from '../generated/api-client/fn/sessions/api-sessions-recent-get';
-import { apiSessionsRecentPost } from '../generated/api-client/fn/sessions/api-sessions-recent-post';
+import { listRecentSessions } from '../generated/api-client/fn/sessions/list-recent-sessions';
+import { bumpRecentSession } from '../generated/api-client/fn/sessions/bump-recent-session';
 import type { RecentSession } from '../generated/api-client/models/recent-session';
 
 /**
@@ -33,7 +33,7 @@ export class RecentSessionsService {
   }
 
   refresh(): Observable<RecentSession[]> {
-    return apiSessionsRecentGet(this.http, this.config.rootUrl).pipe(
+    return listRecentSessions(this.http, this.config.rootUrl).pipe(
       map((r) => r.body.sessions ?? []),
       tap((sessions) => this.sessionsSubject.next(sessions)),
       catchError(() => of(this.sessionsSubject.value)),
@@ -42,7 +42,7 @@ export class RecentSessionsService {
 
   bump(datasetId: string, detectorId: string): void {
     if (!datasetId || !detectorId) return;
-    apiSessionsRecentPost(this.http, this.config.rootUrl, {
+    bumpRecentSession(this.http, this.config.rootUrl, {
       body: { dataset_id: datasetId, detector_id: detectorId },
     })
       .pipe(

--- a/frontend/src/app/services/settings-api.service.ts
+++ b/frontend/src/app/services/settings-api.service.ts
@@ -6,10 +6,10 @@ import { map } from 'rxjs/operators';
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { AppSettings } from '../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../generated/api-client/models/settings-update';
-import { apiSettingsDefaultsGet } from '../generated/api-client/fn/settings/api-settings-defaults-get';
-import { apiSettingsGet } from '../generated/api-client/fn/settings/api-settings-get';
-import { apiSettingsPut } from '../generated/api-client/fn/settings/api-settings-put';
-import { apiVersionGet } from '../generated/api-client/fn/main/api-version-get';
+import { getDefaults } from '../generated/api-client/fn/settings/get-defaults';
+import { getSettings } from '../generated/api-client/fn/settings/get-settings';
+import { updateSettings } from '../generated/api-client/fn/settings/update-settings';
+import { version } from '../generated/api-client/fn/main/version';
 
 @Injectable({ providedIn: 'root' })
 export class SettingsApiService {
@@ -17,18 +17,18 @@ export class SettingsApiService {
   private config = inject(ApiConfiguration);
 
   getSettings(): Observable<AppSettings> {
-    return apiSettingsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getSettings(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   updateSettings(data: SettingsUpdate): Observable<AppSettings> {
-    return apiSettingsPut(this.http, this.config.rootUrl, { body: data }).pipe(map((r) => r.body));
+    return updateSettings(this.http, this.config.rootUrl, { body: data }).pipe(map((r) => r.body));
   }
 
   getDefaults(): Observable<AppSettings> {
-    return apiSettingsDefaultsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getDefaults(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getVersion(): Observable<{ version: string }> {
-    return apiVersionGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return version(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/settings-io-api.service.ts
+++ b/frontend/src/app/services/settings-io-api.service.ts
@@ -8,9 +8,9 @@ import type { SettingsImporterEntry } from '../generated/api-client/models/setti
 import type { SettingsExporterEntry } from '../generated/api-client/models/settings-exporter-entry';
 import type { RunSettingsExportRequest } from '../generated/api-client/models/run-settings-export-request';
 import type { RunSettingsExportResponse } from '../generated/api-client/models/run-settings-export-response';
-import { apiSettingsImportersGet } from '../generated/api-client/fn/settings-io/api-settings-importers-get';
-import { apiSettingsExportersGet } from '../generated/api-client/fn/settings-io/api-settings-exporters-get';
-import { apiSettingsExportersExportPost } from '../generated/api-client/fn/settings-io/api-settings-exporters-export-post';
+import { getSettingsImporters } from '../generated/api-client/fn/settings-io/get-settings-importers';
+import { getSettingsExporters } from '../generated/api-client/fn/settings-io/get-settings-exporters';
+import { runSettingsExport } from '../generated/api-client/fn/settings-io/run-settings-export';
 
 /** Response shape for the plugin-field import route. The body shape is
  *  plugin-dependent and not described in the OpenAPI spec (the spec
@@ -28,7 +28,7 @@ export class SettingsIoApiService {
   private config = inject(ApiConfiguration);
 
   listImporters(): Observable<SettingsImporterEntry[]> {
-    return apiSettingsImportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getSettingsImporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   runImport(
@@ -55,7 +55,7 @@ export class SettingsIoApiService {
   }
 
   listExporters(): Observable<SettingsExporterEntry[]> {
-    return apiSettingsExportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getSettingsExporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   runExport(
@@ -66,7 +66,7 @@ export class SettingsIoApiService {
       exporter_name: exporterName,
       field_values: fieldValues as { [key: string]: unknown },
     };
-    return apiSettingsExportersExportPost(this.http, this.config.rootUrl, { body }).pipe(
+    return runSettingsExport(this.http, this.config.rootUrl, { body }).pipe(
       map((r) => r.body),
     );
   }

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -26,32 +26,32 @@ import type { ServerMediaUploadResponse } from '../generated/api-client/models/s
 import type { SortResponse } from '../generated/api-client/models/sort-response';
 import type { TextsortSuggestionsResponse } from '../generated/api-client/models/textsort-suggestions-response';
 import type { VotesResponse } from '../generated/api-client/models/votes-response';
-import { apiDiversityTreeNextGet } from '../generated/api-client/fn/sorting/api-diversity-tree-next-get';
-import { apiInclusionGet } from '../generated/api-client/fn/sorting/api-inclusion-get';
-import { apiInclusionPost } from '../generated/api-client/fn/sorting/api-inclusion-post';
-import { apiLearnedSortCancelJobIdPost } from '../generated/api-client/fn/sorting/api-learned-sort-cancel-job-id-post';
-import { apiLearnedSortPost } from '../generated/api-client/fn/sorting/api-learned-sort-post';
-import { apiLearnedSortResultGet } from '../generated/api-client/fn/sorting/api-learned-sort-result-get';
-import { apiSafeThresholdsGet } from '../generated/api-client/fn/sorting/api-safe-thresholds-get';
-import { apiSafeThresholdsPost } from '../generated/api-client/fn/sorting/api-safe-thresholds-post';
-import { apiSortPost } from '../generated/api-client/fn/sorting/api-sort-post';
-import { apiTextsortSuggestionsGet } from '../generated/api-client/fn/sorting/api-textsort-suggestions-get';
-import { apiTextsortSuggestionsPost } from '../generated/api-client/fn/sorting/api-textsort-suggestions-post';
-import { apiVotesClearPost } from '../generated/api-client/fn/sorting/api-votes-clear-post';
-import { apiVotesGet } from '../generated/api-client/fn/sorting/api-votes-get';
-import { apiLabelsExportGet } from '../generated/api-client/fn/labels/api-labels-export-get';
-import { apiLabelsFillFromSortPost } from '../generated/api-client/fn/labels/api-labels-fill-from-sort-post';
-import { apiLabelsImportPost } from '../generated/api-client/fn/labels/api-labels-import-post';
-import { apiEvalTrainAndScoreCancelJobIdPost } from '../generated/api-client/fn/eval/api-eval-train-and-score-cancel-job-id-post';
-import { apiEvalTrainAndScorePost } from '../generated/api-client/fn/eval/api-eval-train-and-score-post';
-import { apiEvalTrainAndScoreResultGet } from '../generated/api-client/fn/eval/api-eval-train-and-score-result-get';
-import { apiIndicatorScoreHistoryGet } from '../generated/api-client/fn/eval/api-indicator-score-history-get';
-import { apiLabelingStatusGet } from '../generated/api-client/fn/eval/api-labeling-status-get';
-import { apiExampleSortByIdPost } from '../generated/api-client/fn/media-server/api-example-sort-by-id-post';
-import { apiExampleSortOriginPost } from '../generated/api-client/fn/media-server/api-example-sort-origin-post';
-import { apiExampleSortServerPost } from '../generated/api-client/fn/media-server/api-example-sort-server-post';
-import { apiServerMediaFilesFromMediaIdPost } from '../generated/api-client/fn/media-server/api-server-media-files-from-media-id-post';
-import { apiServerMediaFilesGet } from '../generated/api-client/fn/media-server/api-server-media-files-get';
+import { diversityTreeNextGet } from '../generated/api-client/fn/sorting/diversity-tree-next-get';
+import { getInclusionRoute } from '../generated/api-client/fn/sorting/get-inclusion-route';
+import { setInclusionRoute } from '../generated/api-client/fn/sorting/set-inclusion-route';
+import { cancelLearnedSort } from '../generated/api-client/fn/sorting/cancel-learned-sort';
+import { learnedSort } from '../generated/api-client/fn/sorting/learned-sort';
+import { learnedSortResult } from '../generated/api-client/fn/sorting/learned-sort-result';
+import { getSafeThresholdsRoute } from '../generated/api-client/fn/sorting/get-safe-thresholds-route';
+import { setSafeThresholdsRoute } from '../generated/api-client/fn/sorting/set-safe-thresholds-route';
+import { sortClips } from '../generated/api-client/fn/sorting/sort-clips';
+import { getTextsortSuggestionsRoute } from '../generated/api-client/fn/sorting/get-textsort-suggestions-route';
+import { addTextsortSuggestionRoute } from '../generated/api-client/fn/sorting/add-textsort-suggestion-route';
+import { clearVotesRoute } from '../generated/api-client/fn/sorting/clear-votes-route';
+import { getVotes } from '../generated/api-client/fn/sorting/get-votes';
+import { exportLabels } from '../generated/api-client/fn/labels/export-labels';
+import { fillLabelsFromSort } from '../generated/api-client/fn/labels/fill-labels-from-sort';
+import { importLabels } from '../generated/api-client/fn/labels/import-labels';
+import { cancelEvalTrainAndScore } from '../generated/api-client/fn/eval/cancel-eval-train-and-score';
+import { evalTrainAndScore } from '../generated/api-client/fn/eval/eval-train-and-score';
+import { evalTrainAndScoreResult } from '../generated/api-client/fn/eval/eval-train-and-score-result';
+import { indicatorScoreHistory } from '../generated/api-client/fn/eval/indicator-score-history';
+import { labelingStatusIndicator } from '../generated/api-client/fn/eval/labeling-status-indicator';
+import { exampleSortById } from '../generated/api-client/fn/media-server/example-sort-by-id';
+import { exampleSortOrigin } from '../generated/api-client/fn/media-server/example-sort-origin';
+import { exampleSortServer } from '../generated/api-client/fn/media-server/example-sort-server';
+import { serverMediaFileFromMediaId } from '../generated/api-client/fn/media-server/server-media-file-from-media-id';
+import { listServerMediaFiles } from '../generated/api-client/fn/media-server/list-server-media-files';
 
 @Injectable({ providedIn: 'root' })
 export class SortingApiService {
@@ -59,71 +59,71 @@ export class SortingApiService {
   private config = inject(ApiConfiguration);
 
   sort(params: { text: string }): Observable<SortResponse> {
-    return apiSortPost(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
+    return sortClips(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
   }
 
   /** Kick off a learned-sort training job.  The response will be ``done``
    *  immediately when the cached signature matches; otherwise the caller
    *  must poll {@link getLearnedSortResult} with the returned ``job_id``. */
   learnedSort(): Observable<LearnedSortResponse> {
-    return apiLearnedSortPost(this.http, this.config.rootUrl, { body: {} }).pipe(map((r) => r.body));
+    return learnedSort(this.http, this.config.rootUrl, { body: {} }).pipe(map((r) => r.body));
   }
 
   /** Poll for a learned-sort job's completion. */
   getLearnedSortResult(jobId: string): Observable<LearnedSortResponse> {
-    return apiLearnedSortResultGet(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
+    return learnedSortResult(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
       map((r) => r.body),
     );
   }
 
   /** Cancel an in-flight learned-sort job. */
   cancelLearnedSort(jobId: string): Observable<LearnedSortCancelResponse> {
-    return apiLearnedSortCancelJobIdPost(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
+    return cancelLearnedSort(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
       map((r) => r.body),
     );
   }
 
   getVotes(): Observable<VotesResponse> {
-    return apiVotesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getVotes(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   clearVotes(): Observable<OkResponse> {
-    return apiVotesClearPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return clearVotesRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getInclusion(): Observable<InclusionResponse> {
-    return apiInclusionGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getInclusionRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   setInclusion(value: number): Observable<InclusionResponse> {
-    return apiInclusionPost(this.http, this.config.rootUrl, { body: { inclusion: value } }).pipe(
+    return setInclusionRoute(this.http, this.config.rootUrl, { body: { inclusion: value } }).pipe(
       map((r) => r.body),
     );
   }
 
   getSafeThresholds(): Observable<SafeThresholdsResponse> {
-    return apiSafeThresholdsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getSafeThresholdsRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   setSafeThresholds(value: boolean): Observable<SafeThresholdsResponse> {
-    return apiSafeThresholdsPost(this.http, this.config.rootUrl, {
+    return setSafeThresholdsRoute(this.http, this.config.rootUrl, {
       body: { safe_thresholds: value },
     }).pipe(map((r) => r.body));
   }
 
   exportLabels(goodsOnly?: boolean, options?: { enrich?: boolean }): Observable<LabelsExportResponse> {
-    return apiLabelsExportGet(this.http, this.config.rootUrl, {
+    return exportLabels(this.http, this.config.rootUrl, {
       goods_only: goodsOnly || undefined,
       enrich: options?.enrich || undefined,
     }).pipe(map((r) => r.body));
   }
 
   importLabels(data: LabelsImportRequest): Observable<LabelsImportResponse> {
-    return apiLabelsImportPost(this.http, this.config.rootUrl, { body: data }).pipe(map((r) => r.body));
+    return importLabels(this.http, this.config.rootUrl, { body: data }).pipe(map((r) => r.body));
   }
 
   fillFromSort(request: FillFromSortRequest): Observable<FillFromSortResponse> {
-    return apiLabelsFillFromSortPost(this.http, this.config.rootUrl, { body: request }).pipe(
+    return fillLabelsFromSort(this.http, this.config.rootUrl, { body: request }).pipe(
       map((r) => r.body),
     );
   }
@@ -141,14 +141,14 @@ export class SortingApiService {
   }
 
   getServerMediaFiles(): Observable<ServerMediaListResponse> {
-    return apiServerMediaFilesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return listServerMediaFiles(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   exampleSortServer(params: {
     filename: string;
     crop_params?: Record<string, unknown>;
   }): Observable<ExampleSortResponse> {
-    return apiExampleSortServerPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return exampleSortServer(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
@@ -158,7 +158,7 @@ export class SortingApiService {
     key: string;
     crop_params?: Record<string, unknown>;
   }): Observable<ExampleSortResponse> {
-    return apiExampleSortOriginPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return exampleSortOrigin(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
@@ -170,7 +170,7 @@ export class SortingApiService {
     media_id: number;
     crop_params?: Record<string, unknown>;
   }): Observable<ExampleSortResponse> {
-    return apiExampleSortByIdPost(this.http, this.config.rootUrl, { body: params }).pipe(
+    return exampleSortById(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
   }
@@ -181,7 +181,7 @@ export class SortingApiService {
     media_id: number;
     crop_params?: Record<string, unknown>;
   }): Observable<ServerMediaUploadResponse> {
-    return apiServerMediaFilesFromMediaIdPost(this.http, this.config.rootUrl, {
+    return serverMediaFileFromMediaId(this.http, this.config.rootUrl, {
       body: params,
     }).pipe(map((r) => r.body));
   }
@@ -210,11 +210,11 @@ export class SortingApiService {
   }
 
   getTextsortSuggestions(): Observable<TextsortSuggestionsResponse> {
-    return apiTextsortSuggestionsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return getTextsortSuggestionsRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   addTextsortSuggestion(text: string): Observable<OkResponse> {
-    return apiTextsortSuggestionsPost(this.http, this.config.rootUrl, { body: { text } }).pipe(
+    return addTextsortSuggestionRoute(this.http, this.config.rootUrl, { body: { text } }).pipe(
       map((r) => r.body),
     );
   }
@@ -228,13 +228,13 @@ export class SortingApiService {
   }
 
   getLabelingStatus(): Observable<LabelingStatusResponse> {
-    return apiLabelingStatusGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return labelingStatusIndicator(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getIndicatorScoreHistory(
     metric: 'smart' | 'stable' | 'diverse',
   ): Observable<IndicatorScoreHistoryResponse> {
-    return apiIndicatorScoreHistoryGet(this.http, this.config.rootUrl, { metric }).pipe(
+    return indicatorScoreHistory(this.http, this.config.rootUrl, { metric }).pipe(
       map((r) => r.body),
     );
   }
@@ -251,27 +251,27 @@ export class SortingApiService {
     if (scores) {
       return this.http.post<DiversityTreeNextResponse>('/api/diversity-tree/next', { scores, threshold });
     }
-    return apiDiversityTreeNextGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return diversityTreeNextGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Kick off an eval train-and-score job.  Like {@link learnedSort}, the
    *  response will be ``done`` immediately on a cache hit; otherwise poll
    *  {@link getEvalTrainAndScoreResult}. */
   trainAndScore(metric: 'smart' | 'stable' | 'diverse'): Observable<EvalTrainAndScoreResponse> {
-    return apiEvalTrainAndScorePost(this.http, this.config.rootUrl, { body: { metric } }).pipe(
+    return evalTrainAndScore(this.http, this.config.rootUrl, { body: { metric } }).pipe(
       map((r) => r.body),
     );
   }
 
   getEvalTrainAndScoreResult(jobId: string): Observable<EvalTrainAndScoreResponse> {
-    return apiEvalTrainAndScoreResultGet(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
+    return evalTrainAndScoreResult(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
       map((r) => r.body),
     );
   }
 
   /** Cancel an in-flight eval train-and-score job. */
   cancelEvalTrainAndScore(jobId: string): Observable<EvalTrainAndScoreCancelResponse> {
-    return apiEvalTrainAndScoreCancelJobIdPost(this.http, this.config.rootUrl, {
+    return cancelEvalTrainAndScore(this.http, this.config.rootUrl, {
       job_id: jobId,
     }).pipe(map((r) => r.body));
   }

--- a/vtsearch/openapi_postprocess.py
+++ b/vtsearch/openapi_postprocess.py
@@ -1,0 +1,94 @@
+"""Post-processing for the flask-smorest OpenAPI spec.
+
+flask-smorest / apispec do not populate ``operationId`` by default, so
+``ng-openapi-gen`` has to synthesize method names from the path + method
+when generating the TypeScript client. That produces names like
+``apiDetectorsRegistryDatasetIdLabelsetSourceMoveFilePost`` that churn
+on every URL rename.
+
+:func:`assign_operation_ids` walks the live Flask URL map, matches each
+rule to its view function, and writes ``operationId = view_func.__name__``
+into the spec. It is wired up in ``app.py`` by wrapping
+``api.spec.to_dict`` so both the live ``/api/openapi.json`` endpoint and
+the ``scripts/dump_openapi.py`` snapshot dumper see the post-processed
+result.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+
+_FLASK_PARAM_RE = re.compile(r"<(?:[^:>]+:)?([^>]+)>")
+
+
+def _flask_to_openapi_path(rule: str) -> str:
+    """Convert a Flask rule (``/foo/<int:bar>``) to OpenAPI (``/foo/{bar}``)."""
+    return _FLASK_PARAM_RE.sub(r"{\1}", rule)
+
+
+def assign_operation_ids(app: Flask, spec: dict[str, Any]) -> None:
+    """Mutate ``spec`` to assign an ``operationId`` to every operation.
+
+    The id is the Flask view function's ``__name__``. When two operations
+    in the spec map to the same view function (a single view registered
+    under several routes, like ``/dashboard`` and ``/label`` sharing
+    ``angular_routes``), we disambiguate by appending the HTTP method and,
+    if that is still not unique, a 1-based index in sorted (path, method)
+    order — so the assignment is deterministic and snapshot-stable across
+    runs.
+    """
+    paths = spec.get("paths")
+    if not paths:
+        return
+
+    # Map every (openapi_path, method) operation in the spec to its
+    # Flask view function name.
+    op_to_view: dict[tuple[str, str], str] = {}
+    for rule in app.url_map.iter_rules():
+        view_func = app.view_functions.get(rule.endpoint)
+        if view_func is None:
+            continue
+        op_path = _flask_to_openapi_path(rule.rule)
+        if op_path not in paths:
+            continue
+        rule_methods = (rule.methods or set()) - {"HEAD", "OPTIONS"}
+        for method in rule_methods:
+            op_method = method.lower()
+            if op_method in paths[op_path]:
+                op_to_view[(op_path, op_method)] = view_func.__name__
+
+    # Group operations by view function so we can detect collisions and
+    # disambiguate deterministically.
+    by_view: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for op_key, name in op_to_view.items():
+        by_view[name].append(op_key)
+
+    for name, op_keys in by_view.items():
+        if len(op_keys) == 1:
+            op_path, op_method = op_keys[0]
+            paths[op_path][op_method]["operationId"] = name
+            continue
+
+        # Multiple operations share this view function. First try
+        # appending the HTTP method; if methods alone don't disambiguate
+        # (same view bound to several paths under the same method), fall
+        # back to a 1-based index in sorted order.
+        op_keys_sorted = sorted(op_keys)
+        method_counts: dict[str, int] = defaultdict(int)
+        for _, m in op_keys_sorted:
+            method_counts[m] += 1
+
+        per_method_index: dict[str, int] = defaultdict(int)
+        for op_path, op_method in op_keys_sorted:
+            if method_counts[op_method] == 1:
+                op_id = f"{name}_{op_method}"
+            else:
+                per_method_index[op_method] += 1
+                op_id = f"{name}_{op_method}_{per_method_index[op_method]}"
+            paths[op_path][op_method]["operationId"] = op_id

--- a/vtsearch/openapi_postprocess.py
+++ b/vtsearch/openapi_postprocess.py
@@ -32,9 +32,7 @@ def _flask_to_openapi_path(rule: str) -> str:
     return _FLASK_PARAM_RE.sub(r"{\1}", rule)
 
 
-def _map_spec_ops_to_view_names(
-    app: Flask, paths: dict[str, Any]
-) -> dict[tuple[str, str], str]:
+def _map_spec_ops_to_view_names(app: Flask, paths: dict[str, Any]) -> dict[tuple[str, str], str]:
     """Return ``{(openapi_path, method_lower): view_func.__name__}``."""
     op_to_view: dict[tuple[str, str], str] = {}
     for rule in app.url_map.iter_rules():
@@ -52,9 +50,7 @@ def _map_spec_ops_to_view_names(
     return op_to_view
 
 
-def _operation_ids_for_view(
-    name: str, op_keys: list[tuple[str, str]]
-) -> dict[tuple[str, str], str]:
+def _operation_ids_for_view(name: str, op_keys: list[tuple[str, str]]) -> dict[tuple[str, str], str]:
     """Assign deterministic operationIds for a set of ops sharing a view.
 
     Single-operation views keep the bare ``name``. Collisions get a
@@ -76,9 +72,7 @@ def _operation_ids_for_view(
             assigned[(op_path, op_method)] = f"{name}_{op_method}"
         else:
             per_method_index[op_method] += 1
-            assigned[(op_path, op_method)] = (
-                f"{name}_{op_method}_{per_method_index[op_method]}"
-            )
+            assigned[(op_path, op_method)] = f"{name}_{op_method}_{per_method_index[op_method]}"
     return assigned
 
 

--- a/vtsearch/openapi_postprocess.py
+++ b/vtsearch/openapi_postprocess.py
@@ -32,6 +32,56 @@ def _flask_to_openapi_path(rule: str) -> str:
     return _FLASK_PARAM_RE.sub(r"{\1}", rule)
 
 
+def _map_spec_ops_to_view_names(
+    app: Flask, paths: dict[str, Any]
+) -> dict[tuple[str, str], str]:
+    """Return ``{(openapi_path, method_lower): view_func.__name__}``."""
+    op_to_view: dict[tuple[str, str], str] = {}
+    for rule in app.url_map.iter_rules():
+        view_func = app.view_functions.get(rule.endpoint)
+        if view_func is None:
+            continue
+        op_path = _flask_to_openapi_path(rule.rule)
+        if op_path not in paths:
+            continue
+        rule_methods = (rule.methods or set()) - {"HEAD", "OPTIONS"}
+        for method in rule_methods:
+            op_method = method.lower()
+            if op_method in paths[op_path]:
+                op_to_view[(op_path, op_method)] = view_func.__name__
+    return op_to_view
+
+
+def _operation_ids_for_view(
+    name: str, op_keys: list[tuple[str, str]]
+) -> dict[tuple[str, str], str]:
+    """Assign deterministic operationIds for a set of ops sharing a view.
+
+    Single-operation views keep the bare ``name``. Collisions get a
+    ``_{method}`` suffix; if multiple ops share both view and method,
+    they additionally get a 1-based index in sorted order.
+    """
+    if len(op_keys) == 1:
+        return {op_keys[0]: name}
+
+    op_keys_sorted = sorted(op_keys)
+    method_counts: dict[str, int] = defaultdict(int)
+    for _, m in op_keys_sorted:
+        method_counts[m] += 1
+
+    assigned: dict[tuple[str, str], str] = {}
+    per_method_index: dict[str, int] = defaultdict(int)
+    for op_path, op_method in op_keys_sorted:
+        if method_counts[op_method] == 1:
+            assigned[(op_path, op_method)] = f"{name}_{op_method}"
+        else:
+            per_method_index[op_method] += 1
+            assigned[(op_path, op_method)] = (
+                f"{name}_{op_method}_{per_method_index[op_method]}"
+            )
+    return assigned
+
+
 def assign_operation_ids(app: Flask, spec: dict[str, Any]) -> None:
     """Mutate ``spec`` to assign an ``operationId`` to every operation.
 
@@ -47,48 +97,12 @@ def assign_operation_ids(app: Flask, spec: dict[str, Any]) -> None:
     if not paths:
         return
 
-    # Map every (openapi_path, method) operation in the spec to its
-    # Flask view function name.
-    op_to_view: dict[tuple[str, str], str] = {}
-    for rule in app.url_map.iter_rules():
-        view_func = app.view_functions.get(rule.endpoint)
-        if view_func is None:
-            continue
-        op_path = _flask_to_openapi_path(rule.rule)
-        if op_path not in paths:
-            continue
-        rule_methods = (rule.methods or set()) - {"HEAD", "OPTIONS"}
-        for method in rule_methods:
-            op_method = method.lower()
-            if op_method in paths[op_path]:
-                op_to_view[(op_path, op_method)] = view_func.__name__
+    op_to_view = _map_spec_ops_to_view_names(app, paths)
 
-    # Group operations by view function so we can detect collisions and
-    # disambiguate deterministically.
     by_view: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for op_key, name in op_to_view.items():
         by_view[name].append(op_key)
 
     for name, op_keys in by_view.items():
-        if len(op_keys) == 1:
-            op_path, op_method = op_keys[0]
-            paths[op_path][op_method]["operationId"] = name
-            continue
-
-        # Multiple operations share this view function. First try
-        # appending the HTTP method; if methods alone don't disambiguate
-        # (same view bound to several paths under the same method), fall
-        # back to a 1-based index in sorted order.
-        op_keys_sorted = sorted(op_keys)
-        method_counts: dict[str, int] = defaultdict(int)
-        for _, m in op_keys_sorted:
-            method_counts[m] += 1
-
-        per_method_index: dict[str, int] = defaultdict(int)
-        for op_path, op_method in op_keys_sorted:
-            if method_counts[op_method] == 1:
-                op_id = f"{name}_{op_method}"
-            else:
-                per_method_index[op_method] += 1
-                op_id = f"{name}_{op_method}_{per_method_index[op_method]}"
+        for (op_path, op_method), op_id in _operation_ids_for_view(name, op_keys).items():
             paths[op_path][op_method]["operationId"] = op_id


### PR DESCRIPTION
## Summary

Adds automatic `operationId` assignment to the OpenAPI spec by matching each endpoint to its Flask view function name. This replaces the synthesized method names (e.g., `apiDetectorsRegistryDatasetIdRenamePut`) that `ng-openapi-gen` was generating from path + HTTP method, which churn on every URL rename.

## Changes

- **`vtsearch/openapi_postprocess.py`** (new): Post-processing module that walks the Flask URL map, matches each route to its view function, and assigns `operationId = view_func.__name__` to the OpenAPI spec. Handles collisions (multiple operations sharing the same view) by appending `_{method}` and, if needed, a 1-based index.

- **`app.py`**: Wraps `api.spec.to_dict()` to apply `assign_operation_ids()` before returning the spec. This ensures both the live `/api/openapi.json` endpoint and the `dump_openapi.py` snapshot dumper see the post-processed result.

- **`frontend/openapi.json`**: Regenerated snapshot with explicit `operationId` fields on all operations (e.g., `"operationId": "index"`, `"operationId": "get_achievements"`).

- **Frontend service files** (detectors-api, datasets-api, sorting-api, medias-api, settings-api, achievements, auth, settings-io, exporters, label-importers, recent-sessions, file-browser): Updated imports to use the new camelCase function names generated by `ng-openapi-gen` from the operationIds (e.g., `apiAutoDetectPost` → `autoDetect`, `apiDetectorsGet` → `listDetectors`).

## Implementation Details

- The post-processing is applied lazily (only when `spec.to_dict()` is called), so blueprints registered after the wrapper is installed are picked up automatically.
- Collision handling ensures deterministic, snapshot-stable operationId assignment: single-operation views keep the bare name; multi-operation views get method suffixes; ties are broken by sorted (path, method) order.
- The change is backwards-compatible with existing code paths — the wrapper is transparent to callers of `api.spec.to_dict()`.

https://claude.ai/code/session_01KcaS41EVKamQbL8bhYcPK7