### PR TITLE
Fix duplicate Name column and shifted body cells in dashboard grids

### DIFF
--- a/frontend/src/app/services/dashboard-columns.service.ts
+++ b/frontend/src/app/services/dashboard-columns.service.ts
@@ -21,8 +21,12 @@ export type DetectorColumn =
   | 'detector_loaded'
   | 'actions';
 
+// `name` is pinned at the far left and `actions` at the far right; both are
+// rendered explicitly by the Dashboard template, so they are excluded from the
+// reorderable middle-column defaults. (Leaving `name` in here produced a
+// duplicate Name header and shifted every body cell one column to the right,
+// leaving the Actions column with no body cells.)
 const DATASET_COLUMNS_DEFAULT: DatasetColumn[] = [
-  'name',
   'media_type',
   'num_items',
   'created_at',
@@ -32,7 +36,6 @@ const DATASET_COLUMNS_DEFAULT: DatasetColumn[] = [
 ];
 
 const DETECTOR_COLUMNS_DEFAULT: DetectorColumn[] = [
-  'name',
   'media_type',
   'num_training',
   'autodetect',


### PR DESCRIPTION
## Summary

The My Datasets / Detectors grids on the dashboard rendered the header row as `Name, Name, Type, # Items, Created, Loaded, Actions` — the Name column appeared twice, every other column was shifted one slot to the right relative to the body cells, and the Actions column had no body cells under it (the visible "gap").

**Root cause:** when `DashboardColumnsService` was extracted from `DashboardComponent` in commit `3a2a8636`, the reorderable-middle-column defaults (`DATASET_COLUMNS_DEFAULT`, `DETECTOR_COLUMNS_DEFAULT`) were copied with `'name'` accidentally included. But the dashboard template renders the Name column as a hardcoded `<th>` *before* the `@for (col of visibleDatasetColumns; …)` loop — so iterating over an order that still contained `'name'` emitted a second "Name" header. The dataset-card / detector-card body templates have no `'name'` case in their `@switch`, so each row was one `<td>` short, shifting every visible column one slot left under the headers.

**Fix:** drop `'name'` from both default arrays so it's rendered exactly once (via the pinned header). `ManagedColumns.normalizeColumnOrder` filters unknown columns from stored orders, so existing users with `'name'` saved in their `localStorage` column order get cleaned up automatically on next load — no migration needed.

## Test plan

- [x] `npm run build:prod` succeeds with no warnings
- [ ] Open the dashboard: header row reads `☐, Name, Type, # Items, Created, Loaded, Actions` (single Name)
- [ ] Body cells line up under their headers; Actions column has buttons in every row
- [ ] Same check on the Detectors grid (header should read `☐, Name, Type, # Training, Autorun?, Last Trained, Created, Loaded?, Actions`)
- [ ] Drag-reorder still works on middle columns and survives a reload

https://claude.ai/code/session_01DYhzdG2N7Q6GPmmbs7ZgZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhzdG2N7Q6GPmmbs7ZgZt)_