### PR TITLE
Fix demo-dataset import showing no UI feedback until refresh

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -146,6 +146,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private knownDetectorIds = new Set<string>();
   private completedTaskIds = new Set<string>();
   private completedModelTaskIds = new Set<string>();
+  /** Task IDs we've been told to expect (via an HTTP response) but haven't
+   *  yet observed in the SSE `loading-tasks` stream. Polling refuses to bail
+   *  while this set is non-empty, even if the stream currently shows no
+   *  active tasks — otherwise a fast load (e.g. pre-embedded demo dataset)
+   *  whose HTTP response wins the race against the SSE event would stop
+   *  polling before the task ever shows up, leaving the dashboard stale
+   *  until the user refreshes. */
+  private awaitedTaskIds = new Set<string>();
   private datasetPollingActive = false;
   private detectorPollingActive = false;
   /** Dataset IDs we've already asked the backend to preload an embedder
@@ -816,7 +824,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   loadDataset(dataset: DatasetRegistryEntry): void {
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
-      next: () => this.startProgressPolling(),
+      next: (response) => this.startProgressPolling(response.task_id),
     });
   }
 
@@ -948,8 +956,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const userName = (extras.dataset_name || '').trim();
     if (userName) params['dataset_name'] = userName;
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
-      next: () => {
-        this.startProgressPolling();
+      next: (response) => {
+        this.startProgressPolling(response.task_id);
       },
     });
   }
@@ -1005,7 +1013,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Progress polling ---
 
-  startProgressPolling(onComplete?: () => void): void {
+  startProgressPolling(awaitTaskId?: string, onComplete?: () => void): void {
+    // Register any task we've been told to expect.  See the
+    // `awaitedTaskIds` field comment for why this is needed.
+    if (awaitTaskId) {
+      this.awaitedTaskIds.add(awaitTaskId);
+    }
     // If polling is already active, don't restart — the existing loop
     // already covers all tasks.  This avoids clearing completedTaskIds
     // and losing track of tasks that just finished.
@@ -1019,6 +1032,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.polling$), takeUntil(this.destroy$))
       .subscribe({
         next: (tasks: LoadingTask[]) => {
+          // Any task we were waiting for has now shown up in the SSE
+          // stream — drop it from the awaited set so the bail-out check
+          // below can fire as soon as the stream goes quiet.
+          for (const t of tasks) {
+            this.awaitedTaskIds.delete(t.task_id);
+          }
+
           // Separate active from finished. Failed tasks are surfaced
           // globally by SseErrorRouterService → ToastService; we just
           // keep them in the inline list so the row still shows the
@@ -1045,8 +1065,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
           this.datasetState.setLoading(active.length > 0);
 
-          if (active.length === 0) {
-            // No more active tasks — stop polling
+          if (active.length === 0 && this.awaitedTaskIds.size === 0) {
+            // No more active tasks and no awaited task pending — stop
+            // polling.
             this.polling$.next();
             this.datasetPollingActive = false;
             // Refresh unless we just did (justFinished already triggered it)


### PR DESCRIPTION
## Summary

Selecting a fast-loading demo dataset (e.g. a pre-embedded image one) closed the importer modal but produced no progress UI and no dataset row — only a manual page refresh revealed that the load had succeeded.

## Root cause

`handleDemoSelected` POSTs `/api/dataset/load-demo` and only starts polling once the response arrives. The HTTP response and the SSE `loading-tasks` event travel on separate connections (`/api/dataset/load-demo` vs `/api/events`), so for a fast load the HTTP reply wins the race. When `startProgressPolling` then subscribes to `progressEvents.loadingTasks$`, the `BehaviorSubject` still holds the stale empty list. The subscriber sees `active.length === 0`, stops polling, and calls `datasetState.refresh()` *before* the background task has registered the dataset — so the registry call returns nothing and no further refresh ever fires.

`loadDataset` (re-loading a registered dataset) shares the same race.

## Fix

Plumb the `task_id` returned by `/api/dataset/load-demo` and `/api/datasets/registry/{id}/load` into `startProgressPolling` and track it in a new `awaitedTaskIds` set. Polling refuses to bail out while that set is non-empty, even on an initially empty `loadingTasks$` snapshot. Finished tasks linger in `LoadingTasksTracker.list_tasks` for 5 seconds, so the awaited task is guaranteed to surface on the SSE stream even if the subscription is established after the load completes — at which point the normal active/idle bookkeeping fires `datasetState.refresh()` and the row appears.

## Test plan

- [x] `./run-tests.sh` — 4154 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean
- [ ] Manual: open Demo Dataset Importer, select a pre-embedded image dataset, confirm a loading row appears and the dataset shows up without needing to refresh

https://claude.ai/code/session_013BJZw2U7ZPMNpKB88HC7XJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013BJZw2U7ZPMNpKB88HC7XJ)_