### PR TITLE
Recompute clip MD5 from final bytes for single-output crop clippers

### DIFF
--- a/tests_lib/io/test_clip_reembed_bulk.py
+++ b/tests_lib/io/test_clip_reembed_bulk.py
@@ -219,6 +219,74 @@ class TestBulkClipReembedMD5UnchangedByRefactor:
             assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
 
 
+class TestSingleOutputClipperMD5Recompute:
+    """Single-output clippers that rewrite ``media_bytes`` (e.g.
+    ImageBboxClipper, ImageObjectClipper with one detection) must have
+    their MD5 rehashed from the final bytes, not inherited from the
+    parent — otherwise dedup would collapse distinct crops.
+
+    ``needs_recompute=False`` (single output, no converter) but
+    ``embedding is None`` (importer skipped embedding because a clipper
+    was specified) — the historical bug case.
+    """
+
+    def test_md5_recomputed_when_embedding_is_none_even_without_recompute_flag(self):
+        from vtscore.datasets.load_pipeline import _fixup_clip_md5_and_embeddings
+
+        parent_bytes = b"parent-image-bytes"
+        crop_bytes = b"crop-from-parent-bytes"
+        parent_md5 = hashlib.md5(parent_bytes).hexdigest()
+        expected_crop_md5 = hashlib.md5(crop_bytes).hexdigest()
+
+        # Simulates the state a single-output crop clipper leaves behind:
+        # media_bytes replaced with the crop, but md5 still carries the
+        # parent's hash via ``dict(media)``; embedding is None because the
+        # importer skipped embedding when a clipper was requested.
+        clip = {
+            "id": 1,
+            "type": "image",
+            "media_bytes": crop_bytes,
+            "md5": parent_md5,
+            "embedding": None,
+            "filename": "img.png",
+            "origin_name": "img.png",
+        }
+
+        emb = _fake_bulk_embedder()
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            _fixup_clip_md5_and_embeddings([clip], needs_recompute=[False], media_type="image")
+
+        assert clip["md5"] == expected_crop_md5, (
+            f"expected MD5 to be rehashed from crop bytes ({expected_crop_md5}), got {clip['md5']}"
+        )
+        assert clip["md5"] != parent_md5
+
+    def test_md5_recomputed_for_text_string_clips(self):
+        from vtscore.datasets.load_pipeline import _fixup_clip_md5_and_embeddings
+
+        parent_text = "the full document text"
+        clip_text = "first sentence only"
+        parent_md5 = hashlib.md5(parent_text.encode("utf-8")).hexdigest()
+        expected_clip_md5 = hashlib.md5(clip_text.encode("utf-8")).hexdigest()
+
+        clip = {
+            "id": 1,
+            "type": "text",
+            "media_string": clip_text,
+            "md5": parent_md5,
+            "embedding": None,
+            "filename": "doc.txt",
+            "origin_name": "doc.txt",
+        }
+
+        emb = _fake_bulk_embedder()
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            _fixup_clip_md5_and_embeddings([clip], needs_recompute=[False], media_type="text")
+
+        assert clip["md5"] == expected_clip_md5
+        assert clip["md5"] != parent_md5
+
+
 class TestBulkClipReembedNoTempfile:
     """The pre-refactor path wrote each clip to ``tempfile.mkstemp`` and
     called ``embed_file`` from ``vtscore.detectors.resolver`` one clip

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -394,7 +394,12 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
     - the clip has no embedding at all (import phase was skipped because a
       clipper was going to re-embed anyway).
 
-    Without the MD5 fix, all clips from the same parent would share the
+    For any clip reaching this fixup with new content bytes (audio/image/
+    text), the MD5 is always rehashed from those final bytes — including
+    single-output clippers that copy the parent dict via ``dict(media)``
+    and would otherwise carry the parent's stale MD5 forward.
+
+    Without the MD5 fix, clips from the same parent would share the
     parent's MD5 (causing ``collapse_duplicates`` to merge them).
 
     Embeddings are batched through ``embed_media_bulk`` in a single call
@@ -418,18 +423,22 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
         if content_bytes is None and not metadata_only:
             continue
 
-        if recompute:
-            if content_bytes is not None:
-                clip["md5"] = hashlib.md5(content_bytes).hexdigest()
-            else:
-                # Metadata-only clips (e.g. video): bytes unchanged but
-                # boundaries differ — create a unique MD5 by hashing the
-                # parent bytes + clip boundaries so dedup doesn't collapse
-                # distinct clips.
-                parent_bytes = clip.get("media_bytes", b"")
-                boundary_tag = f"|clip_start={clip.get('clip_start')}|clip_end={clip.get('clip_end')}"
-                combined = hashlib.md5(parent_bytes).hexdigest() + boundary_tag
-                clip["md5"] = hashlib.md5(combined.encode()).hexdigest()
+        # Always recompute MD5 from the final clip bytes whenever we're
+        # also recomputing the embedding. Any single-output clipper that
+        # rewrites media_bytes (e.g. ImageObjectClipper with one detection,
+        # ImageBboxClipper) would otherwise inherit the parent's MD5 via
+        # ``dict(media)`` and cause dedup to merge distinct crops.
+        if content_bytes is not None:
+            clip["md5"] = hashlib.md5(content_bytes).hexdigest()
+        elif recompute:
+            # Metadata-only clips (e.g. video): bytes unchanged but
+            # boundaries differ — create a unique MD5 by hashing the
+            # parent bytes + clip boundaries so dedup doesn't collapse
+            # distinct clips.
+            parent_bytes = clip.get("media_bytes", b"")
+            boundary_tag = f"|clip_start={clip.get('clip_start')}|clip_end={clip.get('clip_end')}"
+            combined = hashlib.md5(parent_bytes).hexdigest() + boundary_tag
+            clip["md5"] = hashlib.md5(combined.encode()).hexdigest()
         embed_indices.append(clip_idx)
         embed_inputs.append(_build_clip_embed_input(clip, media_type))
 


### PR DESCRIPTION
## Summary
- `_fixup_clip_md5_and_embeddings` only rehashed MD5 when `needs_recompute=True` (multi-output clipper or type-changing chain). Single-output crop clippers like `ImageObjectClipper` (with one detection) and `ImageBboxClipper` copy the parent dict via `dict(media)` and replace `media_bytes` with the crop, but the inherited MD5 then described the full parent image — letting `collapse_duplicates` merge distinct crops of the same parent.
- The user's specific concern (`vid2img → img2img_tile`) was already correct because `chain_changes_type=True` forced recompute; this fix covers the standalone single-output clipper case that wasn't.
- Always rehash from `content_bytes` when reaching the fixup branch; the video boundary-tag fallback stays gated on `recompute` (only genuine sub-items need a synthesised hash).

## Test plan
- [x] `./run-tests.sh` — 4197 passed, 1 skipped
- [x] Added regression tests in `tests_lib/io/test_clip_reembed_bulk.py` covering the `needs_recompute=False` + `embedding=None` case for both image and text clips


---
_Generated by [Claude Code](https://claude.ai/code/session_01DebykoJzvCAELgiw7vCBHM)_