### PR TITLE
Upgrade pip/setuptools/wheel at start of install scripts

### DIFF
--- a/scripts/_check-python.sh
+++ b/scripts/_check-python.sh
@@ -1,0 +1,34 @@
+# Sourced helper: aborts the calling script if the active Python is < 3.10.
+# Uses `command -v python || python3` so it works both inside and outside a venv.
+
+_vts_py="$(command -v python || command -v python3 || true)"
+if [ -z "$_vts_py" ]; then
+    echo "ERROR: no python interpreter found on PATH." >&2
+    exit 1
+fi
+
+if ! "$_vts_py" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; then
+    _vts_ver="$("$_vts_py" --version 2>&1)"
+    cat >&2 <<EOF
+ERROR: VTSearch requires Python 3.10+, but '$_vts_py' is $_vts_ver.
+
+Upgrade Python, then create a fresh venv before re-running this script:
+
+  Amazon Linux 2023 / RHEL / Fedora:   sudo dnf install python3.11
+  Ubuntu / Debian:                     sudo apt install python3.11
+                                       (older Ubuntu may need the deadsnakes PPA)
+  macOS (Homebrew):                    brew install python@3.11
+
+Then:
+
+  deactivate 2>/dev/null || true
+  rm -rf venv
+  python3.11 -m venv venv
+  source venv/bin/activate
+
+See docs/SETUP.md for full instructions.
+EOF
+    exit 1
+fi
+
+unset _vts_py _vts_ver

--- a/scripts/install-cpu.sh
+++ b/scripts/install-cpu.sh
@@ -15,6 +15,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "Installing VTSearch CPU dependencies..."
 
+# Ensure pip/setuptools/wheel are recent enough to resolve modern wheel-only
+# packages.  Stale pips (e.g. 21.x) have a weaker resolver and will fall back
+# to building ancient sdists from source, which then fails for lack of
+# `bdist_wheel`.
+pip install --upgrade pip setuptools wheel -q
+
 pip install -r "$REPO_ROOT/requirements/base.txt" -q
 
 # Wire up the pre-commit git hook (no-op if not in a git checkout

--- a/scripts/install-cpu.sh
+++ b/scripts/install-cpu.sh
@@ -15,6 +15,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "Installing VTSearch CPU dependencies..."
 
+# Bail out early if the active Python is too old.  pyproject.toml requires
+# >=3.10, but pip only enforces it partway through resolution, after a slow
+# and confusing failure path.  Check up front instead.
+source "$SCRIPT_DIR/_check-python.sh"
+
 # Ensure pip/setuptools/wheel are recent enough to resolve modern wheel-only
 # packages.  Stale pips (e.g. 21.x) have a weaker resolver and will fall back
 # to building ancient sdists from source, which then fails for lack of

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -20,6 +20,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})..."
 
+# Bail out early if the active Python is too old.  pyproject.toml requires
+# >=3.10, but pip only enforces it partway through resolution, after a slow
+# and confusing failure path.  Check up front instead.
+source "$SCRIPT_DIR/_check-python.sh"
+
 # Step 0: Ensure pip/setuptools/wheel are recent enough to resolve modern
 # wheel-only packages.  Stale pips (e.g. 21.x) have a weaker resolver and
 # will fall back to building ancient sdists from source, which then fails

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -20,6 +20,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})..."
 
+# Step 0: Ensure pip/setuptools/wheel are recent enough to resolve modern
+# wheel-only packages.  Stale pips (e.g. 21.x) have a weaker resolver and
+# will fall back to building ancient sdists from source, which then fails
+# for lack of `bdist_wheel`.
+echo "Upgrading pip / setuptools / wheel..."
+pip install --upgrade pip setuptools wheel -q
+
 # Step 1: Pre-install packages that the PyTorch index may serve as source
 # tarballs.  --only-binary ensures we get pre-built wheels from PyPI.
 echo "Pre-installing binary-only wheels (numpy, scipy)..."


### PR DESCRIPTION
## Summary

- Adds `pip install --upgrade pip setuptools wheel` as the first step of both `scripts/install-cpu.sh` and `scripts/install-gpu.sh`.
- Prevents a confusing failure on stale venvs (e.g. pip 21.3.1) where the old resolver picks an ancient `protobuf` sdist, which then pulls in `google-apputils` and dies with `error: invalid command 'bdist_wheel'`.

## Why

On a fresh venv with modern pip everything works because unpinned `protobuf` resolves to a recent wheel-only release. On a stale venv, the old resolver instead picks a very old `protobuf` release whose `setup.py` requires `google-apputils` (Python-2-era, no wheel), and the build fails because `wheel`/`bdist_wheel` isn't available in the build env. Upgrading pip/setuptools/wheel up front sidesteps the whole class of problem.

## Test plan

- [ ] Re-run `bash scripts/install-gpu.sh` on a venv that previously failed with the `protobuf` / `google-apputils` / `bdist_wheel` error and confirm it now installs cleanly.
- [ ] Re-run `bash scripts/install-cpu.sh` on a fresh venv and confirm no regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bep1AJRPFX8piM2kpciiYE)_