### PR TITLE
Match dataset empty-state styling to detector list

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -26,9 +26,7 @@
         }
       </ul>
     } @else if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
-      <div class="welcome-banner">
-        <p class="welcome-banner-text">Welcome! Load data with '+' to get started.</p>
-      </div>
+      <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
         <table class="dash-table" [class.table-fixed]="datasetCols.tableFixed">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -304,25 +304,6 @@
   padding: 6px 4px;
 }
 
-.welcome-banner {
-  flex: 1 1 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 24px;
-  text-align: center;
-
-  .welcome-banner-text {
-    color: var(--text-primary);
-    margin: 0;
-    max-width: 480px;
-    line-height: 1.45;
-  }
-}
-
 .dashboard-actions {
   flex-shrink: 0;
   display: flex;

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -396,13 +396,13 @@ describe('DashboardComponent', () => {
     expect(component.importerModalOpen).toBeFalse();
   });
 
-  it('should render welcome banner when no datasets', () => {
+  it('should render empty state when no datasets', () => {
     flushInitialRequests();
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
-    const banner = el.querySelector('.welcome-banner');
-    expect(banner).toBeTruthy();
-    expect(banner?.textContent || '').toContain("Welcome! Load data with '+' to get started.");
+    const empty = el.querySelector('.empty-state');
+    expect(empty).toBeTruthy();
+    expect(empty?.textContent || '').toContain('No datasets yet. Click + to add one.');
   });
 
   it('should render dataset table when datasets exist', () => {


### PR DESCRIPTION
## Summary
- The dataset welcome banner ("Welcome! Load data with '+' to get started.") was a large centered element while the detector list used a small italic muted "No detectors yet. Click + to add one." line.
- Switch the dataset empty view to the shared `.empty-state` style with the parallel "No datasets yet. Click + to add one." copy so the two read as a matched pair.
- Drop the now-unused `.welcome-banner` SCSS and update the dashboard spec.

## Test plan
- [x] `npm run build:prod` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_018RnMHRMQ5W1MdBoE8C3XP7)_