### PR TITLE
Redesign multi-media importer source-specs UI

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -556,7 +556,7 @@ class DXImporter(DatasetImporter):
     name = "dx"
     multi_media = True
     fields = [
-        ImporterField(key="media_type", label="Output Media Type", field_type="select", ...),
+        ImporterField(key="media_type", label="Dataset MediaType", field_type="select", ...),
         ImporterField(key="dataset_id", ..., required=True),
     ]
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -313,65 +313,15 @@
       }
 
       @if (selectedImporter.multi_media) {
-        <div class="form-group sf-source-specs">
-          <label class="form-label" title="Each row declares one source type to pull into the dataset. A row with no converter is included directly; a row with a converter is read in its source type and converted to the output type.">Include media</label>
-          @for (spec of formSourceSpecs; let i = $index; track i) {
-            <div class="sf-spec-row">
-              @if (spec.converter === null) {
-                <span class="sf-spec-direct">Include {{ spec.source_type }} files directly</span>
-              } @else {
-                <span class="sf-spec-label">Also include</span>
-                <select
-                  class="form-select sf-spec-converter"
-                  [ngModel]="spec.converter"
-                  (ngModelChange)="formOnConverterChange(i, $event)"
-                >
-                  @for (c of formAvailableConverters; track c.name) {
-                    <option [value]="c.name">{{ c.display_name || c.name }}</option>
-                  }
-                </select>
-                @if (formConverterFor(i); as converter) {
-                  @for (f of converter.fields || []; track f.key) {
-                    <label class="sf-spec-param">
-                      {{ f.label || f.key }}:
-                      @if (f.field_type === 'select') {
-                        <select
-                          class="form-select sf-spec-param-input"
-                          [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                          (ngModelChange)="formOnConverterParamChange(i, f.key, $event)"
-                        >
-                          @for (opt of f.options || []; track opt) {
-                            <option [value]="opt">{{ opt }}</option>
-                          }
-                        </select>
-                      } @else if (f.field_type === 'number') {
-                        <input
-                          type="number"
-                          class="form-input sf-spec-param-input"
-                          [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                          [attr.min]="f.min || null"
-                          [attr.max]="f.max || null"
-                          [attr.step]="f.step || null"
-                          (ngModelChange)="formOnConverterParamChange(i, f.key, $event)"
-                        />
-                      } @else {
-                        <input
-                          [type]="f.field_type === 'password' ? 'password' : f.field_type === 'email' ? 'email' : f.field_type === 'url' ? 'url' : 'text'"
-                          class="form-input sf-spec-param-input"
-                          [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                          (ngModelChange)="formOnConverterParamChange(i, f.key, $event)"
-                        />
-                      }
-                    </label>
-                  }
-                }
-              }
-              <button class="btn btn--secondary sf-spec-remove" (click)="formRemoveSpec(i)" title="Remove this row">×</button>
-            </div>
-          }
-          @if (formAvailableConverters.length > 0) {
-            <button class="btn btn--secondary sf-spec-add" (click)="formAddConverterRow()">+ Add converter</button>
-          }
+        <div class="form-group">
+          <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+          <vt-source-specs-picker
+            [availableConverters]="formAvailableConverters"
+            [nativeType]="formOutputTypeId"
+            [typeLabels]="mediaTypeLabels"
+            [specs]="formSourceSpecs"
+            (specsChange)="onFormSpecsChange($event)"
+          ></vt-source-specs-picker>
         </div>
       }
 
@@ -459,7 +409,7 @@
       </div>
 
       <div class="form-group">
-        <label class="form-label" for="lf-media-type" title="The type of media files the dataset ends up holding. Converters below can pull in other source types and convert them to this output type.">Output Media Type</label>
+        <label class="form-label" for="lf-media-type" title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type.">Dataset MediaType</label>
         <select
           id="lf-media-type"
           class="form-select"
@@ -475,65 +425,15 @@
         }
       </div>
 
-      <div class="form-group sf-source-specs">
-        <label class="form-label" title="Each row declares one source type to pull into the dataset. A row with no converter is included directly; a row with a converter is read in its source type and converted to the output type.">Include media</label>
-        @for (spec of lfSourceSpecs; let i = $index; track i) {
-          <div class="sf-spec-row">
-            @if (spec.converter === null) {
-              <span class="sf-spec-direct">Include {{ spec.source_type }} files directly</span>
-            } @else {
-              <span class="sf-spec-label">Also include</span>
-              <select
-                class="form-select sf-spec-converter"
-                [ngModel]="spec.converter"
-                (ngModelChange)="lfOnConverterChange(i, $event)"
-              >
-                @for (c of lfAvailableConverters; track c.name) {
-                  <option [value]="c.name">{{ c.display_name || c.name }}</option>
-                }
-              </select>
-              @if (lfConverterFor(i); as converter) {
-                @for (f of converter.fields || []; track f.key) {
-                  <label class="sf-spec-param">
-                    {{ f.label || f.key }}:
-                    @if (f.field_type === 'select') {
-                      <select
-                        class="form-select sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        (ngModelChange)="lfOnConverterParamChange(i, f.key, $event)"
-                      >
-                        @for (opt of f.options || []; track opt) {
-                          <option [value]="opt">{{ opt }}</option>
-                        }
-                      </select>
-                    } @else if (f.field_type === 'number') {
-                      <input
-                        type="number"
-                        class="form-input sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        [attr.min]="f.min || null"
-                        [attr.max]="f.max || null"
-                        [attr.step]="f.step || null"
-                        (ngModelChange)="lfOnConverterParamChange(i, f.key, $event)"
-                      />
-                    } @else {
-                      <input
-                        [type]="f.field_type === 'password' ? 'password' : f.field_type === 'email' ? 'email' : f.field_type === 'url' ? 'url' : 'text'"
-                        class="form-input sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        (ngModelChange)="lfOnConverterParamChange(i, f.key, $event)"
-                      />
-                    }
-                  </label>
-                }
-              }
-            }
-            <button class="btn btn--secondary sf-spec-remove" (click)="lfRemoveSpec(i)" title="Remove this row">×</button>
-          </div>
-        }
-        @if (lfAvailableConverters.length > 0) {
-          <button class="btn btn--secondary sf-spec-add" (click)="lfAddConverterRow()">+ Add converter</button>
-        }
+      <div class="form-group">
+        <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+        <vt-source-specs-picker
+          [availableConverters]="lfAvailableConverters"
+          [nativeType]="lfOutputTypeId"
+          [typeLabels]="mediaTypeLabels"
+          [specs]="lfSourceSpecs"
+          (specsChange)="onLfSpecsChange($event)"
+        ></vt-source-specs-picker>
       </div>
 
       <div class="form-group form-group--section">
@@ -689,7 +589,7 @@
       </div>
 
       <div class="form-group">
-        <label class="form-label" for="sf-media-type" title="The type of media files the dataset ends up holding. Converters below can pull in other source types and convert them to this output type.">Output Media Type</label>
+        <label class="form-label" for="sf-media-type" title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type.">Dataset MediaType</label>
         <select
           id="sf-media-type"
           class="form-select"
@@ -705,65 +605,15 @@
         }
       </div>
 
-      <div class="form-group sf-source-specs">
-        <label class="form-label" title="Each row declares one source type to pull into the dataset. A row with no converter is included directly; a row with a converter is read in its source type and converted to the output type.">Include media</label>
-        @for (spec of sfSourceSpecs; let i = $index; track i) {
-          <div class="sf-spec-row">
-            @if (spec.converter === null) {
-              <span class="sf-spec-direct">Include {{ spec.source_type }} files directly</span>
-            } @else {
-              <span class="sf-spec-label">Also include</span>
-              <select
-                class="form-select sf-spec-converter"
-                [ngModel]="spec.converter"
-                (ngModelChange)="sfOnConverterChange(i, $event)"
-              >
-                @for (c of sfAvailableConverters; track c.name) {
-                  <option [value]="c.name">{{ c.display_name || c.name }}</option>
-                }
-              </select>
-              @if (sfConverterFor(i); as converter) {
-                @for (f of converter.fields || []; track f.key) {
-                  <label class="sf-spec-param">
-                    {{ f.label || f.key }}:
-                    @if (f.field_type === 'select') {
-                      <select
-                        class="form-select sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        (ngModelChange)="sfOnConverterParamChange(i, f.key, $event)"
-                      >
-                        @for (opt of f.options || []; track opt) {
-                          <option [value]="opt">{{ opt }}</option>
-                        }
-                      </select>
-                    } @else if (f.field_type === 'number') {
-                      <input
-                        type="number"
-                        class="form-input sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        [attr.min]="f.min || null"
-                        [attr.max]="f.max || null"
-                        [attr.step]="f.step || null"
-                        (ngModelChange)="sfOnConverterParamChange(i, f.key, $event)"
-                      />
-                    } @else {
-                      <input
-                        [type]="f.field_type === 'password' ? 'password' : f.field_type === 'email' ? 'email' : f.field_type === 'url' ? 'url' : 'text'"
-                        class="form-input sf-spec-param-input"
-                        [ngModel]="spec.params[f.key] ?? f.default ?? ''"
-                        (ngModelChange)="sfOnConverterParamChange(i, f.key, $event)"
-                      />
-                    }
-                  </label>
-                }
-              }
-            }
-            <button class="btn btn--secondary sf-spec-remove" (click)="sfRemoveSpec(i)" title="Remove this row">×</button>
-          </div>
-        }
-        @if (sfAvailableConverters.length > 0) {
-          <button class="btn btn--secondary sf-spec-add" (click)="sfAddConverterRow()">+ Add converter</button>
-        }
+      <div class="form-group">
+        <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+        <vt-source-specs-picker
+          [availableConverters]="sfAvailableConverters"
+          [nativeType]="sfOutputTypeId"
+          [typeLabels]="mediaTypeLabels"
+          [specs]="sfSourceSpecs"
+          (specsChange)="onSfSpecsChange($event)"
+        ></vt-source-specs-picker>
       </div>
 
       <div class="sf-browse-section">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -124,43 +124,5 @@
 }
 
 
-// Multi-media import: per-source-spec row.  Each row is either an
-// "include directly" label or an "Also include … via <converter>" with
-// inline param inputs.  See docs/plans/multi-media-import.md.
-.sf-source-specs {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-
-  .sf-spec-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding: 4px 0;
-  }
-
-  .sf-spec-direct {
-    font-style: italic;
-    color: var(--text-muted, #666);
-  }
-
-  .sf-spec-converter { min-width: 180px; }
-
-  .sf-spec-param {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: .85rem;
-
-    .sf-spec-param-input { width: 70px; }
-  }
-
-  .sf-spec-remove {
-    margin-left: auto;
-    padding: 0 6px;
-    line-height: 1;
-  }
-
-  .sf-spec-add { align-self: flex-start; }
-}
+// Multi-media import UI lives in
+// ``<vt-source-specs-picker>`` (see source-specs-picker.component.scss).

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -11,6 +11,7 @@ import {
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
+import { SourceSpecsPickerComponent } from './source-specs-picker/source-specs-picker.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
@@ -19,7 +20,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, FolderBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, FolderBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, SourceSpecsPickerComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -817,6 +818,22 @@ export class DatasetImporterModalComponent implements OnInit {
     return mediaType;
   }
 
+  /** Cached map of type_id → human label, rebuilt only when
+   *  ``mediaTypes`` is reassigned.  Passed to
+   *  ``<vt-source-specs-picker>`` so its child change-detection sees a
+   *  stable input reference. */
+  private _typeLabelsSource: MediaTypeInfo[] | null = null;
+  private _typeLabelsCache: Record<string, string> = {};
+  get mediaTypeLabels(): Record<string, string> {
+    if (this._typeLabelsSource !== this.mediaTypes) {
+      const out: Record<string, string> = {};
+      for (const mt of this.mediaTypes) out[mt.type_id] = mt.name.trim();
+      this._typeLabelsCache = out;
+      this._typeLabelsSource = this.mediaTypes;
+    }
+    return this._typeLabelsCache;
+  }
+
   getTabIcon(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     return mt?.icon || '';
@@ -1485,180 +1502,40 @@ export class DatasetImporterModalComponent implements OnInit {
       : [];
   }
 
-  /** Compute the params dict pre-filled with a converter's declared
-   *  field defaults — used when adding a new converter row. */
-  private defaultConverterParams(converter: ConverterInfo): Record<string, string> {
-    const params: Record<string, string> = {};
-    for (const f of converter.fields || []) {
-      params[f.key] = String(f.default ?? '');
-    }
-    return params;
-  }
+  // Per-view native-type ids and converter lists fed to
+  // ``<vt-source-specs-picker>``.  Local uploads stream to the
+  // server-side temp dir and re-enter ``server_folder.run()`` — so
+  // ``lf`` uses the same converter list as ``sf``.
 
-  /** Append a converter row to *specs*; returns the new list. */
-  private addConverterRowTo(specs: SourceSpec[], converters: ConverterInfo[]): SourceSpec[] {
-    if (converters.length === 0) return specs;
-    const first = converters[0];
-    return [
-      ...specs,
-      {
-        source_type: first.source_type,
-        converter: first.name,
-        params: this.defaultConverterParams(first),
-      },
-    ];
-  }
-
-  /** Drop the row at *index* from *specs*; returns the new list. */
-  private removeSpecFrom(specs: SourceSpec[], index: number): SourceSpec[] {
-    return specs.filter((_, i) => i !== index);
-  }
-
-  /** Change the converter on row *index*; returns the new list. */
-  private changeConverterIn(
-    specs: SourceSpec[],
-    index: number,
-    converterName: string,
-    converters: ConverterInfo[],
-  ): SourceSpec[] {
-    const converter = converters.find((c) => c.name === converterName);
-    if (!converter) return specs;
-    const next = [...specs];
-    next[index] = {
-      source_type: converter.source_type,
-      converter: converter.name,
-      params: this.defaultConverterParams(converter),
-    };
-    return next;
-  }
-
-  /** Set a single converter param on row *index*; returns the new list. */
-  private setParamOn(specs: SourceSpec[], index: number, key: string, value: string): SourceSpec[] {
-    const row = specs[index];
-    if (!row) return specs;
-    const next = [...specs];
-    next[index] = { ...row, params: { ...row.params, [key]: value } };
-    return next;
-  }
-
-  /** Look up the converter metadata for a spec row. */
-  private converterFor(spec: SourceSpec, converters: ConverterInfo[]): ConverterInfo | null {
-    if (!spec || !spec.converter) return null;
-    return converters.find((c) => c.name === spec.converter) || null;
-  }
-
-  // -- sf-* (server_folder picker) ------------------------------------
-
-  private sfOutputTypeId(): string {
-    return this.toTypeId(this.sfMediaType);
-  }
-
+  get sfOutputTypeId(): string { return this.toTypeId(this.sfMediaType); }
   get sfAvailableConverters(): ConverterInfo[] {
-    return this.availableConvertersFor('server_folder', this.sfOutputTypeId());
+    return this.availableConvertersFor('server_folder', this.sfOutputTypeId);
   }
-
   private sfResetSourceSpecs(): void {
-    this.sfSourceSpecs = this.defaultSpecListFor(this.sfOutputTypeId());
+    this.sfSourceSpecs = this.defaultSpecListFor(this.sfOutputTypeId);
   }
+  onSfSpecsChange(specs: SourceSpec[]): void { this.sfSourceSpecs = specs; }
 
-  sfAddConverterRow(): void {
-    this.sfSourceSpecs = this.addConverterRowTo(this.sfSourceSpecs, this.sfAvailableConverters);
-  }
-
-  sfRemoveSpec(index: number): void {
-    this.sfSourceSpecs = this.removeSpecFrom(this.sfSourceSpecs, index);
-  }
-
-  sfOnConverterChange(index: number, converterName: string): void {
-    this.sfSourceSpecs = this.changeConverterIn(
-      this.sfSourceSpecs, index, converterName, this.sfAvailableConverters,
-    );
-  }
-
-  sfOnConverterParamChange(index: number, key: string, value: string): void {
-    this.sfSourceSpecs = this.setParamOn(this.sfSourceSpecs, index, key, value);
-  }
-
-  sfConverterFor(index: number): ConverterInfo | null {
-    return this.converterFor(this.sfSourceSpecs[index], this.sfAvailableConverters);
-  }
-
-  // -- lf-* (local picker — folder or files) --------------------------
-  //
-  // Local uploads stream to the server-side temp dir and re-enter
-  // server_folder.run() — so the converter list is the same one
-  // server_folder advertises in its to_dict().
-
-  private lfOutputTypeId(): string {
-    return this.toTypeId(this.lfMediaType);
-  }
-
+  get lfOutputTypeId(): string { return this.toTypeId(this.lfMediaType); }
   get lfAvailableConverters(): ConverterInfo[] {
-    return this.availableConvertersFor('server_folder', this.lfOutputTypeId());
+    return this.availableConvertersFor('server_folder', this.lfOutputTypeId);
   }
-
   private lfResetSourceSpecs(): void {
-    this.lfSourceSpecs = this.defaultSpecListFor(this.lfOutputTypeId());
+    this.lfSourceSpecs = this.defaultSpecListFor(this.lfOutputTypeId);
   }
+  onLfSpecsChange(specs: SourceSpec[]): void { this.lfSourceSpecs = specs; }
 
-  lfAddConverterRow(): void {
-    this.lfSourceSpecs = this.addConverterRowTo(this.lfSourceSpecs, this.lfAvailableConverters);
-  }
-
-  lfRemoveSpec(index: number): void {
-    this.lfSourceSpecs = this.removeSpecFrom(this.lfSourceSpecs, index);
-  }
-
-  lfOnConverterChange(index: number, converterName: string): void {
-    this.lfSourceSpecs = this.changeConverterIn(
-      this.lfSourceSpecs, index, converterName, this.lfAvailableConverters,
-    );
-  }
-
-  lfOnConverterParamChange(index: number, key: string, value: string): void {
-    this.lfSourceSpecs = this.setParamOn(this.lfSourceSpecs, index, key, value);
-  }
-
-  lfConverterFor(index: number): ConverterInfo | null {
-    return this.converterFor(this.lfSourceSpecs[index], this.lfAvailableConverters);
-  }
-
-  // -- form-* (generic form view, e.g. server_files) ------------------
-
-  private formOutputTypeId(): string {
+  get formOutputTypeId(): string {
     return this.toTypeId(String(this.formValues['media_type'] || ''));
   }
-
   get formAvailableConverters(): ConverterInfo[] {
     if (!this.selectedImporter) return [];
-    return this.availableConvertersFor(this.selectedImporter.name, this.formOutputTypeId());
+    return this.availableConvertersFor(this.selectedImporter.name, this.formOutputTypeId);
   }
-
   resetFormSourceSpecs(): void {
-    this.formSourceSpecs = this.defaultSpecListFor(this.formOutputTypeId());
+    this.formSourceSpecs = this.defaultSpecListFor(this.formOutputTypeId);
   }
-
-  formAddConverterRow(): void {
-    this.formSourceSpecs = this.addConverterRowTo(this.formSourceSpecs, this.formAvailableConverters);
-  }
-
-  formRemoveSpec(index: number): void {
-    this.formSourceSpecs = this.removeSpecFrom(this.formSourceSpecs, index);
-  }
-
-  formOnConverterChange(index: number, converterName: string): void {
-    this.formSourceSpecs = this.changeConverterIn(
-      this.formSourceSpecs, index, converterName, this.formAvailableConverters,
-    );
-  }
-
-  formOnConverterParamChange(index: number, key: string, value: string): void {
-    this.formSourceSpecs = this.setParamOn(this.formSourceSpecs, index, key, value);
-  }
-
-  formConverterFor(index: number): ConverterInfo | null {
-    return this.converterFor(this.formSourceSpecs[index], this.formAvailableConverters);
-  }
+  onFormSpecsChange(specs: SourceSpec[]): void { this.formSourceSpecs = specs; }
 
   private sfLoadEmbedders(mediaType: string): void {
     if (!mediaType) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
@@ -1,0 +1,98 @@
+<div class="ssp">
+  <label class="ssp-row ssp-row--native" title="Include files of the dataset's native media type directly, without any conversion.">
+    <input
+      type="checkbox"
+      class="ssp-checkbox"
+      [checked]="isNativeChecked()"
+      (change)="toggleNative($any($event.target).checked)"
+    />
+    <span class="ssp-row-label">
+      <strong>{{ labelFor(nativeType) }}</strong>
+      <span class="ssp-native-tag">native</span>
+    </span>
+  </label>
+
+  @for (st of nonNativeSourceTypes; track st) {
+    <div class="ssp-row">
+      <label
+        class="ssp-row-main"
+        [title]="'Pull in ' + labelFor(st) + ' files and convert them to ' + labelFor(nativeType) + '.'"
+      >
+        <input
+          type="checkbox"
+          class="ssp-checkbox"
+          [checked]="isNonNativeChecked(st)"
+          (change)="toggleNonNative(st, $any($event.target).checked)"
+        />
+        <span class="ssp-row-label">{{ labelFor(st) }}</span>
+      </label>
+
+      @if (hasAdvanced(st)) {
+        <button
+          type="button"
+          class="advanced-toggle ssp-advanced-toggle"
+          (click)="toggleAdvanced(st)"
+          [attr.aria-expanded]="isAdvancedOpen(st)"
+          [title]="convertersFor(st).length > 1 ? 'Choose a converter and tune its options.' : 'Tune converter options.'"
+        >
+          Advanced {{ isAdvancedOpen(st) ? '▾' : '▸' }}
+        </button>
+      }
+
+      @if (isAdvancedOpen(st)) {
+        <div class="ssp-advanced-panel">
+          @if (convertersFor(st).length > 1) {
+            <label class="ssp-advanced-field">
+              <span class="ssp-advanced-field-label">Converter:</span>
+              <select
+                class="form-select ssp-converter-select"
+                [ngModel]="currentConverterName(st)"
+                (ngModelChange)="setConverter(st, $event)"
+              >
+                @for (c of convertersFor(st); track c.name) {
+                  <option [value]="c.name">{{ c.display_name || c.name }}</option>
+                }
+              </select>
+            </label>
+          }
+
+          @if (currentConverter(st); as conv) {
+            @for (f of conv.fields || []; track f.key) {
+              <label class="ssp-advanced-field">
+                <span class="ssp-advanced-field-label">{{ f.label || f.key }}:</span>
+                @if (f.field_type === 'select') {
+                  <select
+                    class="form-select"
+                    [ngModel]="paramValue(st, f.key) ?? f.default ?? ''"
+                    (ngModelChange)="setParam(st, f.key, $event)"
+                  >
+                    @for (opt of f.options || []; track opt) {
+                      <option [value]="opt">{{ opt }}</option>
+                    }
+                  </select>
+                } @else if (f.field_type === 'number') {
+                  <input
+                    type="number"
+                    class="form-input ssp-num-input"
+                    [ngModel]="paramValue(st, f.key) ?? f.default ?? ''"
+                    [attr.min]="$any(f).min ?? null"
+                    [attr.max]="$any(f).max ?? null"
+                    [attr.step]="$any(f).step ?? null"
+                    (ngModelChange)="setParam(st, f.key, $event)"
+                  />
+                } @else {
+                  <input
+                    [type]="f.field_type === 'password' ? 'password' : f.field_type === 'email' ? 'email' : f.field_type === 'url' ? 'url' : 'text'"
+                    class="form-input"
+                    [ngModel]="paramValue(st, f.key) ?? f.default ?? ''"
+                    (ngModelChange)="setParam(st, f.key, $event)"
+                  />
+                }
+              </label>
+            }
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -1,0 +1,85 @@
+// Source-specs picker — column of checkboxes for choosing which media
+// types feed a multi-media import.  See SourceSpecsPickerComponent.
+
+.ssp {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  row-gap: 4px;
+  column-gap: 12px;
+}
+
+.ssp-row {
+  display: contents;
+}
+
+.ssp-row--native {
+  // Native row spans both columns (no Advanced opener on the right).
+  grid-column: 1 / -1;
+}
+
+.ssp-row-main,
+.ssp-row--native {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.ssp-checkbox {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.ssp-row-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.ssp-native-tag {
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--text-muted, #888);
+  border: 1px solid var(--border, #d0d0d0);
+  border-radius: 3px;
+  padding: 0 4px;
+  line-height: 1.3;
+}
+
+.ssp-advanced-toggle {
+  justify-self: end;
+  white-space: nowrap;
+}
+
+.ssp-advanced-panel {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0 8px 28px;  // align with checkbox label text
+  border-bottom: 1px dashed var(--border, #e0e0e0);
+  margin-bottom: 2px;
+}
+
+.ssp-advanced-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: .85rem;
+}
+
+.ssp-advanced-field-label {
+  color: var(--text-muted, #555);
+}
+
+.ssp-converter-select {
+  min-width: 180px;
+}
+
+.ssp-num-input {
+  width: 80px;
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -1,0 +1,173 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { ConverterInfo, SourceSpec } from '../../../../models/api.models';
+
+/** Checkbox column for choosing which source media types feed a
+ *  multi-media import.  The native type sits at the top (always
+ *  included by default, no converter); each other source type with at
+ *  least one converter to the native type appears as a checkbox with an
+ *  "Advanced ▸" opener for picking among converters (when there are
+ *  multiple) and editing their params. */
+@Component({
+  selector: 'vt-source-specs-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './source-specs-picker.component.html',
+  styleUrl: './source-specs-picker.component.scss',
+})
+export class SourceSpecsPickerComponent implements OnChanges {
+  /** All converters whose ``target_type`` matches the current native
+   *  type.  Comes from the importer's ``to_dict()`` payload. */
+  @Input() availableConverters: ConverterInfo[] = [];
+  /** Native media type id (e.g. ``"image"``) — the dataset's output
+   *  type.  The native checkbox represents "include direct files of
+   *  this type, no conversion". */
+  @Input() nativeType = '';
+  /** Two-way bound source-spec list submitted to the importer. */
+  @Input() specs: SourceSpec[] = [];
+  /** Map of type_id → human-readable label.  Falls back to the type_id
+   *  when a label is missing. */
+  @Input() typeLabels: Record<string, string> = {};
+  @Output() specsChange = new EventEmitter<SourceSpec[]>();
+
+  /** Per-source-type draft so the user can configure a converter via
+   *  the Advanced panel *before* checking the box.  Edits made while
+   *  unchecked are preserved here and applied on check. */
+  private drafts = new Map<string, SourceSpec>();
+  private advancedOpenSet = new Set<string>();
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['nativeType'] && !changes['nativeType'].firstChange) {
+      this.drafts.clear();
+      this.advancedOpenSet.clear();
+    }
+    for (const s of this.specs) {
+      if (s.converter !== null) this.drafts.set(s.source_type, s);
+    }
+  }
+
+  get nonNativeSourceTypes(): string[] {
+    const set = new Set<string>();
+    for (const c of this.availableConverters) {
+      if (c.source_type !== this.nativeType) set.add(c.source_type);
+    }
+    return Array.from(set).sort();
+  }
+
+  labelFor(sourceType: string): string {
+    return this.typeLabels[sourceType] || sourceType;
+  }
+
+  isNativeChecked(): boolean {
+    return this.specs.some((s) => s.source_type === this.nativeType && s.converter === null);
+  }
+
+  isNonNativeChecked(sourceType: string): boolean {
+    return this.specs.some((s) => s.source_type === sourceType && s.converter !== null);
+  }
+
+  convertersFor(sourceType: string): ConverterInfo[] {
+    return this.availableConverters.filter((c) => c.source_type === sourceType);
+  }
+
+  /** True iff the Advanced opener should be rendered for *sourceType*:
+   *  either multiple converters to pick between, or at least one
+   *  user-editable field on the (single) converter. */
+  hasAdvanced(sourceType: string): boolean {
+    const cs = this.convertersFor(sourceType);
+    if (cs.length > 1) return true;
+    return !!(cs[0]?.fields?.length);
+  }
+
+  isAdvancedOpen(sourceType: string): boolean {
+    return this.advancedOpenSet.has(sourceType);
+  }
+
+  toggleAdvanced(sourceType: string): void {
+    if (this.advancedOpenSet.has(sourceType)) this.advancedOpenSet.delete(sourceType);
+    else this.advancedOpenSet.add(sourceType);
+  }
+
+  currentConverterName(sourceType: string): string {
+    return this.getDraft(sourceType).converter || '';
+  }
+
+  currentConverter(sourceType: string): ConverterInfo | null {
+    const name = this.currentConverterName(sourceType);
+    return this.availableConverters.find((c) => c.name === name) || null;
+  }
+
+  paramValue(sourceType: string, key: string): string | number | null {
+    const v = this.getDraft(sourceType).params[key];
+    return v === undefined ? null : v;
+  }
+
+  toggleNative(checked: boolean): void {
+    const others = this.specs.filter((s) => !(s.source_type === this.nativeType && s.converter === null));
+    if (checked) {
+      this.specsChange.emit([{ source_type: this.nativeType, converter: null, params: {} }, ...others]);
+    } else {
+      this.specsChange.emit(others);
+    }
+  }
+
+  toggleNonNative(sourceType: string, checked: boolean): void {
+    const others = this.specs.filter((s) => !(s.source_type === sourceType && s.converter !== null));
+    if (checked) {
+      this.specsChange.emit([...others, { ...this.getDraft(sourceType) }]);
+    } else {
+      this.specsChange.emit(others);
+    }
+  }
+
+  setConverter(sourceType: string, converterName: string): void {
+    const c = this.availableConverters.find((x) => x.name === converterName);
+    if (!c) return;
+    const draft: SourceSpec = {
+      source_type: sourceType,
+      converter: c.name,
+      params: this.defaultParams(c),
+    };
+    this.drafts.set(sourceType, draft);
+    if (this.isNonNativeChecked(sourceType)) {
+      this.specsChange.emit(this.specs.map((s) =>
+        (s.source_type === sourceType && s.converter !== null) ? { ...draft } : s
+      ));
+    }
+  }
+
+  setParam(sourceType: string, key: string, value: string | number | null): void {
+    const draft = this.getDraft(sourceType);
+    const updated: SourceSpec = { ...draft, params: { ...draft.params, [key]: value } };
+    this.drafts.set(sourceType, updated);
+    if (this.isNonNativeChecked(sourceType)) {
+      this.specsChange.emit(this.specs.map((s) =>
+        (s.source_type === sourceType && s.converter !== null) ? { ...updated } : s
+      ));
+    }
+  }
+
+  private getDraft(sourceType: string): SourceSpec {
+    let draft = this.drafts.get(sourceType);
+    if (!draft) {
+      const c = this.convertersFor(sourceType)[0];
+      draft = {
+        source_type: sourceType,
+        converter: c?.name ?? null,
+        params: c ? this.defaultParams(c) : {},
+      };
+      this.drafts.set(sourceType, draft);
+    }
+    return draft;
+  }
+
+  private defaultParams(c: ConverterInfo): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const f of c.fields || []) {
+      out[f.key] = String(f.default ?? '');
+    }
+    return out;
+  }
+}

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -203,7 +203,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         ),
         ImporterField(
             key="media_type",
-            label="Output Media Type",
+            label="Dataset MediaType",
             field_type="select",
             description="Type of media files contained in the archive.",
             default="audio",

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -175,7 +175,7 @@ class ReCallerDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="media_type",
-            label="Output Media Type",
+            label="Dataset MediaType",
             field_type="select",
             options=all_folder_names(),
             default="audio",

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -213,7 +213,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="media_type",
-            label="Output Media Type",
+            label="Dataset MediaType",
             field_type="select",
             description=(
                 "Type of media files the dataset ends up holding.  When source "

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -223,7 +223,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="media_type",
-            label="Output Media Type",
+            label="Dataset MediaType",
             field_type="select",
             description="Type of media files the dataset ends up holding.",
             default="audio",

--- a/vtscore/datasets/importers/synthetic/__init__.py
+++ b/vtscore/datasets/importers/synthetic/__init__.py
@@ -50,7 +50,7 @@ class SyntheticDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="media_type",
-            label="Output Media Type",
+            label="Dataset MediaType",
             field_type="select",
             description="What kind of media to generate.",
             options=_SUPPORTED_MEDIA_TYPES,

--- a/vtscore/datasets/media_type_detection.py
+++ b/vtscore/datasets/media_type_detection.py
@@ -1,6 +1,6 @@
 """Sample a folder of files and guess which media type dominates.
 
-Used by the import modal to pre-fill the "Output Media Type" dropdown and
+Used by the import modal to pre-fill the "Dataset MediaType" dropdown and
 auto-populate :class:`~vtscore.datasets.importers.base.SourceSpec` rows
 based on what's actually in the folder, instead of making the user pick
 blindly.


### PR DESCRIPTION
## Summary

Replaces the variable-length "+ Add converter" row list in the dataset importer with a fixed column of checkboxes generated from the converter registry.

- The native media type (the one picked in **Dataset MediaType**) sits at the top, pre-checked, with a `native` tag.
- Every source type `M` for which a converter `M2N` exists appears below as its own checkbox.
- Each non-native row has an `Advanced ▸` opener that reveals the converter chooser (only shown when there's more than one `M2N`) and the converter's per-field params. Edits made via Advanced while the box is unchecked are remembered and applied when the user checks the box.

The picker is extracted into a new `<vt-source-specs-picker>` standalone component shared by the form / lf / sf views, replacing three near-identical inline blocks in `dataset-importer-modal.component.html`.

Also renamed the **"Output Media Type"** label to **"Dataset MediaType"** across every `multi_media` importer (`server_folder`, `server_files`, `http_archive`, `recaller`, `synthetic`) and the two hardcoded labels in the lf/sf views.

## Test plan

- [x] `./run-tests.sh` — 4197 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean, no warnings
- [ ] Manual: open the importer modal → server-folder picker, confirm the column of checkboxes, native row pre-checked, Advanced opener works for non-native rows with multiple converters and with single-converter+params
- [ ] Manual: local-files picker (`lf` view) — same checks
- [ ] Manual: form view (e.g. `http_archive`) — same checks


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGXawUD9sKbYS9WYYhiNjJ)_