### PR TITLE
Bump ws to 8.20.1 to clear npm audit advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12000,9 +12000,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Bumps `ws` 8.20.0 → 8.20.1 in `frontend/package-lock.json` via `npm audit fix` to clear [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (uninitialized memory disclosure).
- Dev-server-only dependency; does not affect the production bundle in `static/` or the deployed Flask app.

## Remaining advisories (not fixed here)
- `webpack-dev-server` <=5.2.3 ([GHSA-79cf-xcqc-c78w](https://github.com/advisories/GHSA-79cf-xcqc-c78w)) — moderate, no upstream fix available, pulled in transitively by `@angular-devkit/build-angular`. Only relevant when running `npm start`.

## Test plan
- [ ] `cd frontend && npm audit` shows the `ws` advisory gone (2 moderate remain, both `webpack-dev-server`).
- [ ] `cd frontend && npm run build:prod` still builds cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn8qBhGyUqrX31JzPJ5Pj9)_