### PR TITLE
Silence transformers bos/eos vocab-range warning on model loads

### DIFF
--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -347,6 +347,57 @@ class TestSetupLogging:
             setup_logging()
 
 
+class TestTransformersVocabTokenFilter:
+    """Filter installed by setup_logging() drops only the bos/eos/pad
+    vocab-range warning from transformers; everything else passes through."""
+
+    def test_drops_bos_token_warning(self):
+        stream = io.StringIO()
+        try:
+            setup_logging(level="DEBUG", fmt="text", stream=stream)
+            logging.getLogger("transformers.configuration_utils").warning(
+                "Model config: bos_token_id must be `None` or an integer within "
+                "the vocabulary (between 0 and 31999), got 49406."
+            )
+            assert stream.getvalue() == ""
+        finally:
+            setup_logging()
+
+    def test_drops_eos_token_warning_on_descendant_logger(self):
+        stream = io.StringIO()
+        try:
+            setup_logging(level="DEBUG", fmt="text", stream=stream)
+            logging.getLogger("transformers.models.clap.configuration_clap").warning(
+                "Model config: eos_token_id must be `None` or an integer within "
+                "the vocabulary (between 0 and 31999), got 49407."
+            )
+            assert stream.getvalue() == ""
+        finally:
+            setup_logging()
+
+    def test_unrelated_transformers_warning_passes_through(self):
+        stream = io.StringIO()
+        try:
+            setup_logging(level="DEBUG", fmt="text", stream=stream)
+            logging.getLogger("transformers").warning("some other thing happened")
+            assert "some other thing happened" in stream.getvalue()
+        finally:
+            setup_logging()
+
+    def test_non_transformers_logger_with_matching_text_passes_through(self):
+        """Filter is scoped to transformers loggers so it can't accidentally
+        eat a same-shaped message logged from elsewhere."""
+        stream = io.StringIO()
+        try:
+            setup_logging(level="DEBUG", fmt="text", stream=stream)
+            logging.getLogger("vtsearch.test").warning(
+                "bos_token_id must be `None` or an integer within the vocabulary..."
+            )
+            assert "bos_token_id" in stream.getvalue()
+        finally:
+            setup_logging()
+
+
 class TestRequestIdHelper:
     def test_new_request_id_is_unique(self):
         ids = {new_request_id() for _ in range(100)}

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import time
 import uuid
@@ -229,6 +230,29 @@ class TextFormatter(logging.Formatter):
         return base
 
 
+_VOCAB_TOKEN_WARN_RE = re.compile(
+    r"(bos|eos|pad)_token_id must be `None` or an integer within the vocabulary"
+)
+
+
+class _TransformersVocabTokenFilter(logging.Filter):
+    """Drop transformers' bos/eos/pad token-out-of-vocab warnings.
+
+    CLIP-derived models (CLAP, X-CLIP, plain CLIP) carry CLIP's 49406/49407
+    BOS/EOS tokens against a 32k sentencepiece vocab in a sibling text
+    sub-config. transformers logs a config-validation warning on every load;
+    the mismatch is harmless and there's nothing for the user to fix.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not record.name.startswith("transformers"):
+            return True
+        try:
+            return _VOCAB_TOKEN_WARN_RE.search(record.getMessage()) is None
+        except Exception:
+            return True
+
+
 def setup_logging(
     level: str | None = None,
     fmt: str | None = None,
@@ -255,6 +279,7 @@ def setup_logging(
     handler = logging.StreamHandler(stream or sys.stderr)
     handler.setFormatter(formatter)
     handler.addFilter(ContextFilter())
+    handler.addFilter(_TransformersVocabTokenFilter())
 
     root = logging.getLogger()
     for existing in list(root.handlers):
@@ -266,6 +291,7 @@ def setup_logging(
     logging.getLogger("werkzeug").setLevel(logging.ERROR)
     logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
     logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
+
 
 
 def new_request_id() -> str:


### PR DESCRIPTION
## What

Suppress the noisy transformers warnings that fire on every CLAP / X-CLIP / CLIP model load:

```
Model config: bos_token_id must be `None` or an integer within the vocabulary (between 0 and 31999), got 49406. This may result in unexpected behavior.
Model config: eos_token_id must be `None` or an integer within the vocabulary (between 0 and 31999), got 49407. ...
```

## Why

CLIP-derived models (CLAP, X-CLIP, plain CLIP) carry CLIP's `bos_token_id=49406` / `eos_token_id=49407` against a 32k sentencepiece vocab in a sibling text sub-config. transformers' config validation flags the mismatch on every model load, but it's benign — these ids are only used by the CLIP text encoder, which has its own larger vocab. Nothing to fix on our side; just noise.

## How

Add `_TransformersVocabTokenFilter` to `vtsearch/logging_config.py` and install it on the root logging handler from `setup_logging()`. The filter:

- Matches only `transformers*` logger names (so an unrelated module logging a similar string isn't accidentally swallowed).
- Drops only the bos/eos/pad-token vocab-range warning pattern; all other transformers warnings pass through.
- Lives on the handler rather than on `getLogger("transformers")` so it catches records from descendant loggers like `transformers.configuration_utils` (Python logger filters don't propagate to descendants).

## Tests

`tests/core/test_structured_logging.py` gains 4 cases verifying the filter drops the warning, drops it on descendant loggers, lets other transformers warnings through, and doesn't swallow a same-shaped message logged from a non-transformers logger.

`./run-tests.sh core` (logging subset) — 24/24 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr1DHQ5mraSsSZahxwYXxR)_