### PR TITLE
Let Server Folder importer browse the whole filesystem

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -567,6 +567,11 @@
       "BrowseMediaFilesResponse": {
         "additionalProperties": false,
         "properties": {
+          "default_path": {
+            "default": "",
+            "description": "Suggested initial relative sub-path for this source \u2014 for example the server user's home directory when ``source=server_fs``. Empty for sources where the root is already the right starting point.",
+            "type": "string"
+          },
           "directories": {
             "items": {
               "$ref": "#/components/schemas/BrowseDirectoryEntry"
@@ -5423,7 +5428,7 @@
         "operationId": "browse_media_files",
         "parameters": [
           {
-            "description": "One of ``demo:<name>`` or ``folder``.",
+            "description": "One of ``demo:<name>``, ``folder``, or ``server_fs``.",
             "in": "query",
             "name": "source",
             "required": false,

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -767,14 +767,33 @@
       </div>
 
       <div class="sf-browse-section">
-        <label class="form-label">Select Folder</label>
+        <label class="form-label" for="sf-path-input">Folder to import</label>
+        <input
+          id="sf-path-input"
+          type="text"
+          class="form-input"
+          placeholder="/absolute/server/path/to/folder"
+          [(ngModel)]="sfPathInputValue"
+          (keydown.enter)="sfApplyPathInput(); $event.preventDefault()"
+          (blur)="sfApplyPathInput()"
+        />
+        <p class="info-text">
+          Type or paste any folder path on the server, or browse below.
+          Press <kbd>Enter</kbd> to jump the browser to a typed path.
+        </p>
         <vt-folder-browser
           [browse]="sfBrowseFn"
           [showFiles]="false"
-          [showPathFooter]="true"
-          emptyMessage="No subdirectories. This folder will be imported."
+          [initialPath]="sfPickerInitialPath"
+          emptyMessage="(No subfolders here.)"
           (pathChange)="sfOnPathChange($event)"
         ></vt-folder-browser>
+        @if (sfAbsolutePath) {
+          <div class="sf-selected-banner">
+            <span class="sf-selected-label">Selected folder:</span>
+            <code class="sf-selected-value">{{ sfAbsolutePath }}</code>
+          </div>
+        }
       </div>
 
       <div class="form-group">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -88,6 +88,30 @@
 .server-folder-browser { gap: 12px; }
 .sf-browse-section { gap: 6px; }
 
+.sf-selected-banner {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: var(--bg-subtle, #f3f6fa);
+  border: 1px solid var(--border, #d8e0ea);
+  border-radius: 6px;
+  font-size: .9rem;
+  flex-wrap: wrap;
+
+  .sf-selected-label {
+    color: var(--text-muted, #555);
+    font-weight: 600;
+  }
+
+  .sf-selected-value {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    word-break: break-all;
+    color: var(--text, #222);
+  }
+}
+
 // Embedder licence warning shown under the picker when the chosen
 // embedder reports a license_notice (today: real-EUPE under FAIR
 // Noncommercial). Subtle yellow chip, no acceptance click — users

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,7 +1,8 @@
 import { Component, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { map } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import {
@@ -168,17 +169,50 @@ export class DatasetImporterModalComponent implements OnInit {
    *  the manifest workflow that used to be a separate "Files" card. */
   sfPathsFile = '';
 
+  /** Initial sub-path passed to ``<vt-folder-browser>``. Bound to its
+   *  ``[initialPath]`` input so we can imperatively navigate the picker
+   *  (e.g. when the user types a path into the editable input above). */
+  sfPickerInitialPath = '';
+
+  /** True once we've consumed the backend-suggested ``default_path`` on
+   *  the first browse response. Subsequent navigations to the root stay
+   *  at the root instead of bouncing back to the default. */
+  private sfDefaultPathConsumed = false;
+
   /** Browse function for the embedded ``<vt-folder-browser>``.  Folder
    *  importer mode — files are hidden because the user is picking a
-   *  folder to import, not a file inside it. */
+   *  folder to import, not a file inside it.
+   *
+   *  Uses the ``server_fs`` source so the picker can navigate the whole
+   *  server filesystem (single-user mode) or the user's data dir
+   *  (multi-user mode) — matching what the ``server_folder`` importer
+   *  actually accepts at runtime. The very first response carries a
+   *  ``default_path`` (typically the server user's home dir); we follow
+   *  it once with a second request so the picker opens there instead of
+   *  at ``/``. */
   readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles('folder', path).pipe(
-      map((res) => ({
-        directories: res.directories || [],
-        files: [],
-        rootPath: res.root_path,
-        currentPath: path,
-      })),
+    this.datasetsApi.browseMediaFiles('server_fs', path).pipe(
+      switchMap((res) => {
+        if (!path && !this.sfDefaultPathConsumed && res.default_path) {
+          this.sfDefaultPathConsumed = true;
+          const defaultPath = res.default_path;
+          return this.datasetsApi.browseMediaFiles('server_fs', defaultPath).pipe(
+            map((res2) => ({
+              directories: res2.directories || [],
+              files: [],
+              rootPath: res2.root_path,
+              currentPath: defaultPath,
+            })),
+          );
+        }
+        if (!path) this.sfDefaultPathConsumed = true;
+        return of({
+          directories: res.directories || [],
+          files: [],
+          rootPath: res.root_path,
+          currentPath: path,
+        });
+      }),
     );
 
   /** Auto-detect result for the local-folder / local-files picker.  Set
@@ -1217,6 +1251,9 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfDatasetNameDirty = false;
     this.sfVectorsFile = '';
     this.sfPathsFile = '';
+    this.sfPickerInitialPath = '';
+    this.sfDefaultPathConsumed = false;
+    this.sfPathInputValue = '';
 
     // Load media type options from the folder importer's fields
     const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
@@ -1245,10 +1282,48 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfBrowsePath = evt.path;
     this.sfBrowseRootPath = evt.rootPath;
     this.sfBrowseError = '';
+    // Mirror the picker's location into the editable input so the user
+    // sees the same absolute path they'd be typing.
+    this.sfPathInputValue = this.sfAbsolutePath;
     if (!this.sfDatasetNameDirty) {
       this.sfDatasetName = this.sfDerivedDatasetName();
     }
     this.sfRunDetection();
+  }
+
+  /** Current value of the editable absolute-path input.  Two-way bound to
+   *  the ``<input>`` above the folder browser; pushed into the picker
+   *  when the user presses Enter or the input blurs.  Updated to mirror
+   *  the picker's location after every navigation. */
+  sfPathInputValue = '';
+
+  /** Apply the value typed into the absolute-path input by jumping the
+   *  embedded folder browser to that directory.  Computes a relative
+   *  path against the current browse root and pushes it into the
+   *  ``initialPath`` input, which the browser observes via ngOnChanges. */
+  sfApplyPathInput(): void {
+    const raw = (this.sfPathInputValue || '').trim();
+    if (!raw) {
+      this.sfPickerInitialPath = '';
+      return;
+    }
+    const root = this.sfBrowseRootPath || '/';
+    let rel = raw;
+    if (raw.startsWith(root)) {
+      rel = raw.slice(root.length);
+    } else if (root === '/' && raw.startsWith('/')) {
+      rel = raw.slice(1);
+    }
+    // Normalize: drop leading slashes, collapse trailing slashes.
+    rel = rel.replace(/^\/+/, '').replace(/\/+$/, '');
+    // Force a re-fire even if the same path is re-applied by toggling
+    // through a sentinel value.  ngOnChanges only fires on value change.
+    if (rel === this.sfPickerInitialPath) {
+      this.sfPickerInitialPath = '';
+      setTimeout(() => (this.sfPickerInitialPath = rel), 0);
+    } else {
+      this.sfPickerInitialPath = rel;
+    }
   }
 
   /** Token guarding overlapping detection responses for the sf-* picker.
@@ -1262,7 +1337,7 @@ export class DatasetImporterModalComponent implements OnInit {
    *  and apply it to the sf-* form (output media-type + source specs). */
   private sfRunDetection(): void {
     const token = ++this.sfDetectionToken;
-    this.datasetsApi.detectMediaType('folder', this.sfBrowsePath, this.sfRecursive).subscribe({
+    this.datasetsApi.detectMediaType('server_fs', this.sfBrowsePath, this.sfRecursive).subscribe({
       next: (res) => {
         if (token !== this.sfDetectionToken) return;
         this.sfDetection = res;
@@ -1309,6 +1384,8 @@ export class DatasetImporterModalComponent implements OnInit {
   get sfAbsolutePath(): string {
     if (!this.sfBrowseRootPath) return '';
     if (!this.sfBrowsePath) return this.sfBrowseRootPath;
+    // Avoid "//foo" when the picker is rooted at the filesystem root.
+    if (this.sfBrowseRootPath === '/') return '/' + this.sfBrowsePath;
     return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
   }
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,7 +1,8 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { map } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
@@ -160,17 +161,39 @@ export class NewDetectorModalComponent implements OnInit {
       })),
     );
 
+  /** True once we've consumed the backend-suggested ``default_path`` on
+   *  the first browse response. Subsequent navigations to the root stay
+   *  at the root instead of bouncing back to the default. */
+  private sfDefaultPathConsumed = false;
+
   /** Browse fn for the embedded ``<vt-folder-browser>`` in the server
    *  folder picker.  Lists both folders and files (filtered server-side
-   *  to known media extensions). */
+   *  to known media extensions). Uses the ``server_fs`` source so the
+   *  user can browse anywhere readable by the server; first response
+   *  redirects to the suggested home directory. */
   readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles('folder', path).pipe(
-      map((res) => ({
-        directories: res.directories || [],
-        files: res.files || [],
-        rootPath: res.root_path,
-        currentPath: path,
-      })),
+    this.datasetsApi.browseMediaFiles('server_fs', path).pipe(
+      switchMap((res) => {
+        if (!path && !this.sfDefaultPathConsumed && res.default_path) {
+          this.sfDefaultPathConsumed = true;
+          const defaultPath = res.default_path;
+          return this.datasetsApi.browseMediaFiles('server_fs', defaultPath).pipe(
+            map((res2) => ({
+              directories: res2.directories || [],
+              files: res2.files || [],
+              rootPath: res2.root_path,
+              currentPath: defaultPath,
+            })),
+          );
+        }
+        if (!path) this.sfDefaultPathConsumed = true;
+        return of({
+          directories: res.directories || [],
+          files: res.files || [],
+          rootPath: res.root_path,
+          currentPath: path,
+        });
+      }),
     );
 
   // Pending crop confirmation state.
@@ -563,6 +586,7 @@ export class NewDetectorModalComponent implements OnInit {
   private resetServerFolderState(): void {
     this.sfBrowseError = '';
     this.sfFileSelecting = false;
+    this.sfDefaultPathConsumed = false;
   }
 
   private openServerFolderBrowser(): void {
@@ -572,7 +596,7 @@ export class NewDetectorModalComponent implements OnInit {
   /** Confirm handler for the server folder browser. */
   sfSelectFile(entry: FolderBrowserFileEntry): void {
     this.sfFileSelecting = true;
-    this.datasetsApi.selectBrowsedFile('folder', entry.path).subscribe({
+    this.datasetsApi.selectBrowsedFile('server_fs', entry.path).subscribe({
       next: (res) => {
         this.exampleType = 'media';
         this.exampleValue = res.filename;

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -253,6 +253,10 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
   get absolutePath(): string {
     if (!this.rootPath) return '';
     if (!this.currentPath) return this.rootPath;
+    // When the root is the filesystem root ("/"), joining with "/" would
+    // produce a leading "//". Treat "/" as a special case so the absolute
+    // path stays well-formed.
+    if (this.rootPath === '/') return '/' + this.currentPath;
     return this.rootPath + '/' + this.currentPath;
   }
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -128,6 +128,34 @@ class TestDatasetEndpoints:
             file_names2 = [f["name"] for f in data2["files"]]
             assert "sound.wav" in file_names2
 
+    def test_browse_media_files_server_fs_lists_filesystem(self, client, tmp_path):
+        """``source=server_fs`` should let the picker walk the whole filesystem.
+
+        The single-user mode root is ``/`` so any directory readable by the
+        server process should be listable via its absolute path stripped of
+        the leading slash.
+        """
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / "track.wav").write_bytes(b"RIFF" + b"\x00" * 64)
+
+        # tmp_path is absolute (e.g. /tmp/pytest-of-user/.../test_x0).
+        # Strip the leading "/" to get the relative path under "/".
+        rel = str(tmp_path).lstrip("/")
+        resp = client.get(f"/api/browse-media-files?source=server_fs&path={rel}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["root_path"] == "/"
+        dir_names = [d["name"] for d in data["directories"]]
+        file_names = [f["name"] for f in data["files"]]
+        assert "subdir" in dir_names
+        # No media files at this level.
+        assert "track.wav" not in file_names
+
+        # default_path is reported on every server_fs response. It points
+        # at the server user's home dir when it exists.
+        assert "default_path" in data
+
     def test_select_browsed_file_copies_to_example_media(self, client, tmp_path):
         """POST /api/browse-media-files/select copies the file to example_media."""
         from unittest.mock import patch

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -225,6 +225,10 @@ def _resolve_browse_root(source: str) -> Path | None:
 
     * ``demo:<name>`` — the ``required_folder`` of the named demo dataset.
     * ``folder`` — the configured ``saved_datasets_dir``.
+    * ``server_fs`` — the whole server filesystem (single-user mode) or the
+      current user's data directory (multi-user mode). Matches the actual
+      runtime scope of the ``server_folder``/``server_files`` importers,
+      which accept any absolute path readable by the server process.
 
     Returns ``None`` if the source is unrecognised or the directory does not
     exist.
@@ -246,7 +250,38 @@ def _resolve_browse_root(source: str) -> Path | None:
         ds_dir.mkdir(parents=True, exist_ok=True)
         return ds_dir.resolve()
 
+    if source == "server_fs":
+        from vtscore.security.path_validation import get_file_access_base_dir
+
+        base = get_file_access_base_dir()
+        if base is None:
+            return Path("/")
+        return base.resolve()
+
     return None
+
+
+def _default_browse_path(source: str, root: Path) -> str:
+    """Pick a sensible initial relative path for *source* under *root*.
+
+    For ``server_fs`` in single-user mode (root == ``/``) we start the
+    picker at the server user's home directory if it exists — saves the
+    user three or four clicks to drill down from ``/``. Falls back to the
+    root itself otherwise.
+    """
+    if source != "server_fs":
+        return ""
+    try:
+        home = Path.home().resolve()
+    except (RuntimeError, OSError):
+        return ""
+    try:
+        rel = home.relative_to(root)
+    except ValueError:
+        return ""
+    if not home.is_dir():
+        return ""
+    return str(rel) if str(rel) != "." else ""
 
 
 @datasets_ui_bp.route("/api/browse-media-files")
@@ -309,7 +344,12 @@ def browse_media_files(query: dict):
                 }
             )
 
-    return {"directories": directories, "files": files, "root_path": str(root)}
+    return {
+        "directories": directories,
+        "files": files,
+        "root_path": str(root),
+        "default_path": _default_browse_path(source, root),
+    }
 
 
 @datasets_ui_bp.route("/api/dataset/detect-media-type")

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -193,7 +193,7 @@ class BrowseMediaFilesQuerySchema(Schema):
 
     source = fields.String(
         load_default="",
-        metadata={"description": "One of ``demo:<name>`` or ``folder``."},
+        metadata={"description": "One of ``demo:<name>``, ``folder``, or ``server_fs``."},
     )
     path = fields.String(
         load_default="",
@@ -215,6 +215,17 @@ class BrowseMediaFilesResponseSchema(Schema):
     directories = fields.List(fields.Nested(BrowseDirectoryEntrySchema), required=True)
     files = fields.List(fields.Nested(BrowseFileEntrySchema), required=True)
     root_path = fields.String(required=True)
+    default_path = fields.String(
+        load_default="",
+        dump_default="",
+        metadata={
+            "description": (
+                "Suggested initial relative sub-path for this source — for example "
+                "the server user's home directory when ``source=server_fs``. Empty "
+                "for sources where the root is already the right starting point."
+            )
+        },
+    )
 
 
 class BrowseMediaFilesSelectRequestSchema(Schema):


### PR DESCRIPTION
## Summary

- The Server Folder importer's embedded folder picker was hard-locked to `saved_datasets_dir` via `_resolve_browse_root("folder")`, even though the importer itself accepts any absolute path the server process can read. That made it impossible to pull in a folder of media from anywhere else on the box, and the "Path:" footer + "No subdirectories. This folder will be imported." empty-state read as noise.
- Adds a new `source=server_fs` to `/api/browse-media-files` and `/api/dataset/detect-media-type` that roots the picker at `/` in single-user mode (or the user's data dir in multi-user mode), matching the importer's real runtime scope. Responses now carry a `default_path` so the picker can open at the server user's home directory instead of `/`.
- Frontend rework on the dataset-importer modal:
  - Switches the picker and media-type detector to `server_fs`.
  - Adds an editable absolute-path text input above the picker; <kbd>Enter</kbd> or blur jumps the picker to that directory. The picker syncs the input on every navigation, so the input is both source-of-truth and a live readout.
  - Replaces the cryptic empty-state copy with a "Selected folder: `<abs path>`" banner that's always visible once a folder is chosen.
- Same `server_fs` switch in the new-detector example-picker so users can grab example media from anywhere on the server.

## Test plan

- [x] `./run-tests.sh` — full CPU suite (4198 passed)
- [x] `./run-tests.sh datasets` — new `test_browse_media_files_server_fs_lists_filesystem` covers the wide-scope listing + `default_path` field
- [x] `./run-tests.sh core` — frontend TypeScript build clean
- [ ] Manual: open the Server Folder importer, type a path outside `data/saved_datasets`, confirm it imports
- [ ] Manual: open the new-detector modal's server example picker, browse into `/home/<user>/...`, confirm file selection works


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi8J7Kcri2aP1jr2Ko5K7C)_