### PR TITLE
Fix blank-image / cid-name regressions after lazy-media-listing refactor

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -33,16 +33,22 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
 
   private audioCtx: AudioContext | null = null;
   private viewReady = false;
+  // See ImageViewerComponent.lastMediaId: the `media` input reference changes
+  // whenever the metadata cache hydrates; without this guard, every cache
+  // refresh would re-`loadAudio()` and snap playback back to t=0.
+  private lastMediaId: number | null = null;
 
   constructor(private activeContext: ActiveContextService) {}
 
   ngAfterViewInit(): void {
     this.viewReady = true;
+    if (this.media) this.lastMediaId = this.media.id;
     this.loadAudio();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
+    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
+      this.lastMediaId = this.media.id;
       this.audioSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/audio`);
       if (this.viewReady) {
         this.loadAudio();

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -12,11 +12,15 @@ export class DocumentViewerComponent implements OnChanges {
   @Input() media!: Media;
 
   mediaSrc = '';
+  // See ImageViewerComponent.lastMediaId — keep the iframe stable across
+  // metadata-enrichment ngOnChanges cycles for the same id.
+  private lastMediaId: number | null = null;
 
   constructor(private activeContext: ActiveContextService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
+    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
+      this.lastMediaId = this.media.id;
       this.mediaSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/media`);
     }
   }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -64,6 +64,30 @@ describe('ImageViewerComponent', () => {
     expect(component.imageReady).toBeFalse();
   });
 
+  // Regression: when MediaMetadataCacheService hydrates the stub into a
+  // fully-typed Media for the same id, MediaStateService.selectedMedia returns
+  // a *new reference*, which used to retrigger this ngOnChanges body. That
+  // flipped `imageReady` back to false while leaving `imageSrc` unchanged, so
+  // Angular's property binding skipped the DOM write and no fresh (load) event
+  // fired — leaving the canvas hidden behind `visibility: hidden`. The id
+  // guard keeps the loaded state stable across enrichment events.
+  it('should not reset imageReady when the media reference changes but id is the same', () => {
+    component.media = mockMedia;
+    component.ngOnChanges({
+      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
+    });
+    component.onImageLoad();
+    expect(component.imageReady).toBeTrue();
+
+    // Same id, new object reference (typical metadata-cache enrichment).
+    const enriched: Media = { ...mockMedia, filename: 'real-name.png' };
+    component.media = enriched;
+    component.ngOnChanges({
+      media: { currentValue: enriched, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
+    });
+    expect(component.imageReady).toBeTrue();
+  });
+
   it('should show image on error to avoid stuck black screen', () => {
     component.media = mockMedia;
     component.ngOnChanges({

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -55,6 +55,13 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   zoom = 1;
   rotation = 0;
   zoomLabel = '1×';
+  // Track the id of the media we last reset for. The `media` input reference
+  // changes whenever `MediaMetadataCacheService` hydrates richer metadata for
+  // the same id; re-running ngOnChanges for those enrichments would clobber
+  // `imageReady=true` back to false and — since `imageSrc` is the same string
+  // — Angular wouldn't re-fire the `<img>` load event, leaving the canvas
+  // permanently hidden behind `visibility: hidden`.
+  private lastMediaId: number | null = null;
 
   // Region voting state (v2 of the patch-embedder plan, UI only — see docs/plans/patch-embedder.md).
   regionBox: RegionBox | null = null;
@@ -91,7 +98,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
+    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
+      this.lastMediaId = this.media.id;
       this.imageReady = false;
       this.imageSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
       this.resetView();

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -14,11 +14,15 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
 
   text = 'Loading...';
   private sub: Subscription | null = null;
+  // See ImageViewerComponent.lastMediaId — avoid re-fetching the text payload
+  // every time the metadata cache hydrates a new reference for the same id.
+  private lastMediaId: number | null = null;
 
   constructor(private mediasApi: MediasApiService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
+    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
+      this.lastMediaId = this.media.id;
       this.loadText();
     }
   }

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -22,11 +22,16 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   videoError = false;
 
   private clipCheckInterval: ReturnType<typeof setInterval> | null = null;
+  // See ImageViewerComponent.lastMediaId — guards against metadata-enrichment
+  // ngOnChanges cycles rebuilding videoSrc (and yanking playback) for the
+  // same id.
+  private lastMediaId: number | null = null;
 
   constructor(private activeContext: ActiveContextService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
+    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
+      this.lastMediaId = this.media.id;
       this.videoError = false;
       this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
     }

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MediaListComponent } from './media-list.component';
 import { Media } from '../../../models/api.models';
+import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 
 describe('MediaListComponent', () => {
   let component: MediaListComponent;
@@ -94,5 +95,21 @@ describe('MediaListComponent', () => {
     component.threshold = 0.5;
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.media-threshold-line')).toBeTruthy();
+  });
+
+  // Regression: small datasets used to never prefetch metadata, so the list
+  // displayed ``#284`` placeholders forever — names only filled in when the
+  // user clicked an item. Without virtual scroll active, every row is in the
+  // DOM, so every row is visible and should hydrate eagerly.
+  it('eagerly prefetches metadata for every row when virtual scroll is off', () => {
+    const cache = TestBed.inject(MediaMetadataCacheService);
+    const spy = spyOn(cache, 'ensureLoaded');
+    component.medias = mockMedias;
+    component.ngOnChanges({
+      medias: { currentValue: mockMedias, previousValue: [], firstChange: false, isFirstChange: () => false },
+    });
+    expect(spy).toHaveBeenCalled();
+    const ids = spy.calls.mostRecent().args[0] as number[];
+    expect(ids).toEqual([1, 2, 3]);
   });
 });

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -252,13 +252,27 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   /**
    * Ask the metadata cache to prefetch items around the currently visible
-   * viewport range.  This is a no-op when all metadata is already cached
-   * (small datasets) or when virtual scrolling is not active.
+   * viewport range.
+   *
+   * When the list is short enough to skip virtual scrolling (or we're in
+   * grid mode), every item is rendered into the DOM, so every item is
+   * "visible" — prefetch the lot. Without this, small datasets keep
+   * showing ``#284`` placeholders forever because the only other hydration
+   * trigger is an explicit click via ``selectMedia()``.
+   *
+   * ``MediaMetadataCacheService.ensureLoaded()`` already de-dupes
+   * already-cached and already-pending ids, so calling it on every
+   * rebuild is cheap.
    */
   private prefetchVisibleMetadata(): void {
-    if (!this.useVirtualScroll || !this.virtualViewport) return;
     const total = this.cachedOrderedItems.length;
     if (total === 0) return;
+
+    if (!this.useVirtualScroll || !this.virtualViewport) {
+      const ids = this.cachedOrderedItems.map((item) => item.media.id);
+      this.metadataCache.ensureLoaded(ids);
+      return;
+    }
 
     const viewportEl = this.virtualViewport.elementRef.nativeElement;
     const viewportHeight = viewportEl.clientHeight || 600;


### PR DESCRIPTION
## Summary

Two related regressions from the `/api/medias/ids` lazy-metadata refactor (#bd02837a):

**1. Autopilot showed a permanently blank image on a freshly-loaded dataset.** `MediaStateService.selectedMedia` returns the cached, enriched media as soon as the batch fetch lands, which produces a *new object reference for the same id*. The center-panel viewers all re-ran their `ngOnChanges` body on every reference change. For `image-viewer` specifically this reset `imageReady = false` while re-assigning `imageSrc` to the *same URL string* — Angular skips the DOM write when the bound value is unchanged, so no fresh `(load)` event fires and the `<img>` stays at `visibility: hidden` indefinitely. Clicking off-and-back appeared to "fix" it because by then the cache was warm: the first ngOnChanges saw the enriched media and nothing clobbered `imageReady` afterwards.

The same bug latently affected the other viewers — audio/video would yank playback back to t=0 on every cache refresh; text-viewer re-fetched the paragraph; document-viewer rebuilt the iframe URL.

Fix: guard every viewer on `media.id !== lastMediaId`, the same pattern `media-item.component` already uses.

**2. Manual mode showed `#284`-style placeholders forever on small datasets.** `MediaListComponent.prefetchVisibleMetadata()` only ran when virtual scroll was active (>500 items in list mode). For smaller datasets and grid mode every row sits in the DOM but metadata never auto-loaded — names only filled in when the user clicked each item individually. Fix: in the non-virtual path, prefetch every row's metadata; the cache already de-dupes already-loaded ids so repeated calls are cheap.

## Test plan
- [x] `./run-tests.sh core` (includes frontend `build:prod` typecheck) — 583 passed
- [x] Added regression spec: `image-viewer.spec` asserts `imageReady` stays `true` when only the reference changes
- [x] Added regression spec: `media-list.spec` asserts `ensureLoaded` is called with every row id when virtual scroll is off
- [ ] Manual: load a demo image dataset and confirm autopilot renders the first item immediately, and the manual list shows real filenames without clicking

---
_Generated by [Claude Code](https://claude.ai/code/session_011ByS7cBrQndpeoPqbyVyHU)_