### PR TITLE
Fix Include-media column drift in dataset importer

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -27,6 +27,10 @@
   padding: 2px 0;
 }
 
+.ssp-row-main {
+  grid-column: 1;
+}
+
 .ssp-checkbox {
   margin: 0;
   flex-shrink: 0;
@@ -52,6 +56,7 @@
 .ssp-advanced-toggle {
   justify-self: end;
   white-space: nowrap;
+  grid-column: 2;
 }
 
 .ssp-advanced-panel {


### PR DESCRIPTION
## Summary

The "Include media" checkbox column in the Add Dataset modal was rendering broken: with the native type (e.g. Image) at top, subsequent rows like Document/Video could land side-by-side instead of stacking vertically, and stray "Advanced ▶" buttons wrapped to their own rows.

Root cause: the source-specs picker is a 2-column CSS grid (`1fr auto`) with each `.ssp-row` using `display: contents` so the inner label/button drop straight into the grid. When a non-native row lacked an Advanced opener (e.g. Document has converters with no editable fields), only one child was emitted for that row, leaving the column-2 slot empty. Grid auto-placement then filled that empty slot with the next row's checkbox label — Video popped up next to Document, and the following Advanced button wrapped underneath.

Fix: explicitly pin `.ssp-row-main` to `grid-column: 1` and `.ssp-advanced-toggle` to `grid-column: 2` so each source type stays on its own row regardless of which rows render the Advanced opener.

## Test plan
- [ ] Open Add Dataset → Server tab on a folder that triggers no native media detection.
- [ ] Verify Image (native), Audio, Document, Video each appear on their own row, left-aligned.
- [ ] Verify each row's "Advanced ▶" (when present) sits at the far right of that row.
- [ ] Toggle Advanced on a row and confirm the expanded panel still spans full width below.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GghAAP6mJ4EjgvT4JRnCFN)_