### PR TITLE
Replace DIY server file browser with plain typed-path inputs

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -199,11 +199,13 @@
             </label>
 
             @if (field.field_type === 'server_path') {
-              <vt-file-browser
-                [value]="formValues[field.key] || ''"
+              <input
+                [id]="'field-' + field.key"
+                type="text"
+                class="form-input"
+                [ngModel]="formValues[field.key] || ''"
+                (ngModelChange)="formOnServerPathSelected(field.key, $event)"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
-                [extensions]="field.accept || ''"
-                (pathSelected)="formOnServerPathSelected(field.key, $event)"
               />
             } @else if (field.field_type === 'file') {
               <input
@@ -625,22 +627,8 @@
           (blur)="sfApplyPathInput()"
         />
         <p class="info-text">
-          Type or paste any folder path on the server, or browse below.
-          Press <kbd>Enter</kbd> to jump the browser to a typed path.
+          Type or paste any folder path on the server. The path is verified when you submit.
         </p>
-        <vt-folder-browser
-          [browse]="sfBrowseFn"
-          [showFiles]="false"
-          [initialPath]="sfPickerInitialPath"
-          emptyMessage="(No subfolders here.)"
-          (pathChange)="sfOnPathChange($event)"
-        ></vt-folder-browser>
-        @if (sfAbsolutePath) {
-          <div class="sf-selected-banner">
-            <span class="sf-selected-label">Selected folder:</span>
-            <code class="sf-selected-value">{{ sfAbsolutePath }}</code>
-          </div>
-        }
       </div>
 
       <div class="form-group">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,14 +1,7 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
-import {
-  FolderBrowserBrowseFn,
-  FolderBrowserComponent,
-} from '../../folder-browser/folder-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
@@ -21,7 +14,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, FolderBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, SourceSpecsPickerComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, SourceSpecsPickerComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -130,10 +123,10 @@ export class DatasetImporterModalComponent implements OnInit {
    *  instead of running the embedding model for matching uploaded files. */
   lfVectorsFile: File | null = null;
 
-  // Server folder browser state.  The directory listing itself lives
-  // inside the embedded <vt-folder-browser>; the parent only caches the
-  // resolved path so the Import button can submit the right folder and
-  // the dataset-name / detection helpers can use it.
+  // Server folder picker state. The user types an absolute server path; we
+  // split it into ``sfBrowseRootPath`` (always ``/`` here) and ``sfBrowsePath``
+  // (the typed path with the leading slash stripped) so the existing
+  // detection / submit / dataset-name helpers keep working unchanged.
   sfBrowsePath = '';
   sfBrowseRootPath = '';
   sfBrowseError = '';
@@ -156,52 +149,6 @@ export class DatasetImporterModalComponent implements OnInit {
    *  ``(source_type, converter|null, params)`` triple — see
    *  ``docs/plans/multi-media-import.md``. */
   sfSourceSpecs: SourceSpec[] = [];
-
-  /** Initial sub-path passed to ``<vt-folder-browser>``. Bound to its
-   *  ``[initialPath]`` input so we can imperatively navigate the picker
-   *  (e.g. when the user types a path into the editable input above). */
-  sfPickerInitialPath = '';
-
-  /** True once we've consumed the backend-suggested ``default_path`` on
-   *  the first browse response. Subsequent navigations to the root stay
-   *  at the root instead of bouncing back to the default. */
-  private sfDefaultPathConsumed = false;
-
-  /** Browse function for the embedded ``<vt-folder-browser>``.  Folder
-   *  importer mode — files are hidden because the user is picking a
-   *  folder to import, not a file inside it.
-   *
-   *  Uses the ``server_fs`` source so the picker can navigate the whole
-   *  server filesystem (single-user mode) or the user's data dir
-   *  (multi-user mode) — matching what the ``server_folder`` importer
-   *  actually accepts at runtime. The very first response carries a
-   *  ``default_path`` (typically the server user's home dir); we follow
-   *  it once with a second request so the picker opens there instead of
-   *  at ``/``. */
-  readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles('server_fs', path).pipe(
-      switchMap((res) => {
-        if (!path && !this.sfDefaultPathConsumed && res.default_path) {
-          this.sfDefaultPathConsumed = true;
-          const defaultPath = res.default_path;
-          return this.datasetsApi.browseMediaFiles('server_fs', defaultPath).pipe(
-            map((res2) => ({
-              directories: res2.directories || [],
-              files: [],
-              rootPath: res2.root_path,
-              currentPath: defaultPath,
-            })),
-          );
-        }
-        if (!path) this.sfDefaultPathConsumed = true;
-        return of({
-          directories: res.directories || [],
-          files: [],
-          rootPath: res.root_path,
-          currentPath: path,
-        });
-      }),
-    );
 
   /** Auto-detect result for the local-folder / local-files picker.  Set
    *  after the user picks files; ``null`` when no detection has been run
@@ -498,7 +445,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.formDatasetNameDirty = true;
   }
 
-  /** Called when the user picks a server path via ``vt-file-browser``.
+  /** Called when the user types into a ``server_path`` form field.
    *  Updates the form value and re-derives the dataset name when the
    *  user hasn't typed one yet. */
   formOnServerPathSelected(key: string, path: string): void {
@@ -1215,8 +1162,6 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfRecursive = this.readRecursiveDefault(this.selectedImporter);
     this.sfDatasetName = '';
     this.sfDatasetNameDirty = false;
-    this.sfPickerInitialPath = '';
-    this.sfDefaultPathConsumed = false;
     this.sfPathInputValue = '';
 
     // Load media type options from the folder importer's fields
@@ -1235,59 +1180,39 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfLoadEmbedders(this.sfMediaType);
     this.sfLoadClippers(this.sfMediaType);
     this.sfResetSourceSpecs();
-    // The embedded <vt-folder-browser> loads itself on init.
   }
 
-  /** Path-change handler wired to ``<vt-folder-browser>``.  The browser
-   *  itself owns directory navigation; the parent reacts to each
-   *  successful load by refreshing the auto-detected dataset name and
-   *  re-running media-type detection. */
-  sfOnPathChange(evt: { path: string; rootPath: string }): void {
-    this.sfBrowsePath = evt.path;
-    this.sfBrowseRootPath = evt.rootPath;
+  /** Current value of the editable absolute-path input. Two-way bound to
+   *  the typed path input; ``sfApplyPathInput`` splits it into the
+   *  ``sfBrowseRootPath`` / ``sfBrowsePath`` pair the submit + detection
+   *  helpers already consume. */
+  sfPathInputValue = '';
+
+  /** Apply the value typed into the absolute-path input. The path is not
+   *  verified here — the server validates it on submit. */
+  sfApplyPathInput(): void {
+    const raw = (this.sfPathInputValue || '').trim();
+    if (!raw) {
+      this.sfBrowsePath = '';
+      this.sfBrowseRootPath = '';
+      this.sfBrowseError = '';
+      this.sfDetection = null;
+      if (!this.sfDatasetNameDirty) {
+        this.sfDatasetName = '';
+      }
+      return;
+    }
+    // Treat the typed value as an absolute server path. Anchor the root
+    // at "/" and put the rest into sfBrowsePath so sfAbsolutePath returns
+    // the user-typed value verbatim.
+    const rel = raw.replace(/^\/+/, '').replace(/\/+$/, '');
+    this.sfBrowseRootPath = '/';
+    this.sfBrowsePath = rel;
     this.sfBrowseError = '';
-    // Mirror the picker's location into the editable input so the user
-    // sees the same absolute path they'd be typing.
-    this.sfPathInputValue = this.sfAbsolutePath;
     if (!this.sfDatasetNameDirty) {
       this.sfDatasetName = this.sfDerivedDatasetName();
     }
     this.sfRunDetection();
-  }
-
-  /** Current value of the editable absolute-path input.  Two-way bound to
-   *  the ``<input>`` above the folder browser; pushed into the picker
-   *  when the user presses Enter or the input blurs.  Updated to mirror
-   *  the picker's location after every navigation. */
-  sfPathInputValue = '';
-
-  /** Apply the value typed into the absolute-path input by jumping the
-   *  embedded folder browser to that directory.  Computes a relative
-   *  path against the current browse root and pushes it into the
-   *  ``initialPath`` input, which the browser observes via ngOnChanges. */
-  sfApplyPathInput(): void {
-    const raw = (this.sfPathInputValue || '').trim();
-    if (!raw) {
-      this.sfPickerInitialPath = '';
-      return;
-    }
-    const root = this.sfBrowseRootPath || '/';
-    let rel = raw;
-    if (raw.startsWith(root)) {
-      rel = raw.slice(root.length);
-    } else if (root === '/' && raw.startsWith('/')) {
-      rel = raw.slice(1);
-    }
-    // Normalize: drop leading slashes, collapse trailing slashes.
-    rel = rel.replace(/^\/+/, '').replace(/\/+$/, '');
-    // Force a re-fire even if the same path is re-applied by toggling
-    // through a sentinel value.  ngOnChanges only fires on value change.
-    if (rel === this.sfPickerInitialPath) {
-      this.sfPickerInitialPath = '';
-      setTimeout(() => (this.sfPickerInitialPath = rel), 0);
-    } else {
-      this.sfPickerInitialPath = rel;
-    }
   }
 
   /** Token guarding overlapping detection responses for the sf-* picker.

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -167,11 +167,12 @@
                   </label>
 
                   @if (field.field_type === 'server_path') {
-                    <vt-file-browser
-                      [value]="labelImporterValues[field.key] || ''"
+                    <input
+                      [id]="'nmm-' + field.key"
+                      type="text"
+                      class="form-input"
+                      [(ngModel)]="labelImporterValues[field.key]"
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
-                      [extensions]="field.accept || ''"
-                      (pathSelected)="labelImporterValues[field.key] = $event"
                     />
                   } @else if (field.field_type === 'file') {
                     <input
@@ -410,33 +411,53 @@
         </div>
       }
 
-      <!-- Demo file browser: appears after picking a demo from the table. -->
+      <!-- Demo file picker: appears after picking a demo from the table. -->
       @if (activePickerView === 'demo' && selectedImporter && demoFileBrowsing) {
         <div class="server-folder-browser">
           <button class="btn btn--secondary btn--sm back-btn" (click)="backToDemoTable()" title="Return to the demo list">&larr; Back to demo list</button>
-          <vt-folder-browser
-            [browse]="demoBrowseFn"
-            [rootLabel]="demoFileBrowseLabel"
-            [busy]="demoFileLoading"
-            emptyMessage="No media files found in this directory."
-            (confirm)="selectDemoFile($event)"
-          ></vt-folder-browser>
+          <label class="form-label" for="demo-path-input">Path to a media file in <strong>{{ demoFileBrowseLabel }}</strong></label>
+          <input
+            id="demo-path-input"
+            type="text"
+            class="form-input"
+            placeholder="path/to/file"
+            [(ngModel)]="demoTypedPath"
+            (keydown.enter)="submitDemoTypedPath(); $event.preventDefault()"
+          />
+          <button
+            type="button"
+            class="btn btn--primary"
+            [disabled]="demoFileLoading || !demoTypedPath.trim()"
+            (click)="submitDemoTypedPath()"
+          >
+            @if (demoFileLoading) { Loading… } @else { Load }
+          </button>
+          @if (demoTypedPathError) {
+            <p class="error-text">{{ demoTypedPathError }}</p>
+          }
         </div>
       }
 
-      <!-- Server folder browser: lists files alongside directories so the
-           user can pick one to use as an example. -->
+      <!-- Server folder picker: user types an absolute server path. -->
       @if (activePickerView === 'server_folder' && selectedImporter) {
         <div class="server-folder-browser">
-          <label class="form-label">Browse server folders</label>
-          <vt-folder-browser
-            [browse]="sfBrowseFn"
-            [showPathFooter]="true"
-            [busy]="sfFileSelecting"
-            emptyMessage="No subdirectories or media files in this folder."
-            (confirm)="sfSelectFile($event)"
-          ></vt-folder-browser>
-
+          <label class="form-label" for="sf-example-path-input">Path to a media file on the server</label>
+          <input
+            id="sf-example-path-input"
+            type="text"
+            class="form-input"
+            placeholder="/absolute/server/path/to/file"
+            [(ngModel)]="sfTypedPath"
+            (keydown.enter)="submitSfTypedPath(); $event.preventDefault()"
+          />
+          <button
+            type="button"
+            class="btn btn--primary"
+            [disabled]="sfFileSelecting || !sfTypedPath.trim()"
+            (click)="submitSfTypedPath()"
+          >
+            @if (sfFileSelecting) { Loading… } @else { Load }
+          </button>
           @if (sfBrowseError) {
             <p class="error-text">{{ sfBrowseError }}</p>
           }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,16 +1,8 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
-import {
-  FolderBrowserBrowseFn,
-  FolderBrowserComponent,
-  FolderBrowserFileEntry,
-} from '../../folder-browser/folder-browser.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -37,7 +29,7 @@ type TrainedSubView = 'picker' | 'form';
 @Component({
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FileBrowserComponent, FolderBrowserComponent, MediaCropModalComponent, DropZoneComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -142,63 +134,18 @@ export class NewDetectorModalComponent implements OnInit {
     { initialSort: 'num_files', storageKey: NewDetectorModalComponent.DEMO_COL_ORDER_KEY },
   );
 
-  // --- Demo file browser (shown after picking a demo from the table) ---
+  // --- Demo example-media picker (shown after picking a demo from the table) ---
   demoFileBrowsing = false;
   demoFileBrowseSource = '';
   demoFileBrowseLabel = '';
   demoFileLoading = false;
+  demoTypedPath = '';
+  demoTypedPathError = '';
 
-  // --- Server folder browser (mirrors the Add Dataset browser but
-  //     lists files too so the user can pick one as an example). ---
+  // --- Server example-media picker. Path is validated when submitted. ---
   sfBrowseError = '';
   sfFileSelecting = false;
-
-  /** Browse fn for the embedded ``<vt-folder-browser>`` in the demo
-   *  file picker.  Uses the demo-scoped source (``demo:<name>``). */
-  readonly demoBrowseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles(this.demoFileBrowseSource, path).pipe(
-      map((res) => ({
-        directories: res.directories || [],
-        files: res.files || [],
-        rootPath: res.root_path,
-        currentPath: path,
-      })),
-    );
-
-  /** True once we've consumed the backend-suggested ``default_path`` on
-   *  the first browse response. Subsequent navigations to the root stay
-   *  at the root instead of bouncing back to the default. */
-  private sfDefaultPathConsumed = false;
-
-  /** Browse fn for the embedded ``<vt-folder-browser>`` in the server
-   *  folder picker.  Lists both folders and files (filtered server-side
-   *  to known media extensions). Uses the ``server_fs`` source so the
-   *  user can browse anywhere readable by the server; first response
-   *  redirects to the suggested home directory. */
-  readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles('server_fs', path).pipe(
-      switchMap((res) => {
-        if (!path && !this.sfDefaultPathConsumed && res.default_path) {
-          this.sfDefaultPathConsumed = true;
-          const defaultPath = res.default_path;
-          return this.datasetsApi.browseMediaFiles('server_fs', defaultPath).pipe(
-            map((res2) => ({
-              directories: res2.directories || [],
-              files: res2.files || [],
-              rootPath: res2.root_path,
-              currentPath: defaultPath,
-            })),
-          );
-        }
-        if (!path) this.sfDefaultPathConsumed = true;
-        return of({
-          directories: res.directories || [],
-          files: res.files || [],
-          rootPath: res.root_path,
-          currentPath: path,
-        });
-      }),
-    );
+  sfTypedPath = '';
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -555,64 +502,76 @@ export class NewDetectorModalComponent implements OnInit {
     this.demoFileBrowsing = true;
     this.demoFileBrowseSource = `demo:${demo.name}`;
     this.demoFileBrowseLabel = demo.label;
+    this.demoTypedPath = '';
+    this.demoTypedPathError = '';
   }
 
-  /** Confirm handler for the demo file browser. */
-  selectDemoFile(entry: FolderBrowserFileEntry): void {
+  /** Submit the typed demo-relative path. Server validates and returns
+   *  the materialised filename for the example sort. */
+  submitDemoTypedPath(): void {
+    const raw = (this.demoTypedPath || '').trim();
+    if (!raw) return;
     this.demoFileLoading = true;
-    this.datasetsApi.selectBrowsedFile(this.demoFileBrowseSource, entry.path).subscribe({
+    this.demoTypedPathError = '';
+    this.datasetsApi.selectBrowsedFile(this.demoFileBrowseSource, raw).subscribe({
       next: (res) => {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
-        this.exampleDisplay = res.original_name || entry.name;
+        this.exampleDisplay = res.original_name || raw;
         this.exampleMediaType = this.activeDemoTab || this.mediaType;
         this.exampleThumbFailed = false;
         this.pendingText = '';
         this.demoFileLoading = false;
         this.view = 'main';
       },
-      error: () => {
-        this.error = 'Failed to select file';
+      error: (err) => {
+        this.demoTypedPathError = err?.error?.message || 'Path not found in this demo.';
         this.demoFileLoading = false;
       },
     });
   }
 
-  /** Return to the demo table from the demo file browser. */
+  /** Return to the demo table from the demo example-media picker. */
   backToDemoTable(): void {
     this.demoFileBrowsing = false;
     this.demoFileBrowseSource = '';
     this.demoFileBrowseLabel = '';
+    this.demoTypedPath = '';
+    this.demoTypedPathError = '';
   }
 
-  // --- Server folder browser (with file selection) ---
+  // --- Server example-media (typed path) ---
 
   private resetServerFolderState(): void {
     this.sfBrowseError = '';
     this.sfFileSelecting = false;
-    this.sfDefaultPathConsumed = false;
+    this.sfTypedPath = '';
   }
 
   private openServerFolderBrowser(): void {
     this.resetServerFolderState();
   }
 
-  /** Confirm handler for the server folder browser. */
-  sfSelectFile(entry: FolderBrowserFileEntry): void {
+  /** Submit the typed absolute server path. Server validates and returns
+   *  the materialised filename for the example sort. */
+  submitSfTypedPath(): void {
+    const raw = (this.sfTypedPath || '').trim();
+    if (!raw) return;
     this.sfFileSelecting = true;
-    this.datasetsApi.selectBrowsedFile('server_fs', entry.path).subscribe({
+    this.sfBrowseError = '';
+    this.datasetsApi.selectBrowsedFile('server_fs', raw).subscribe({
       next: (res) => {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
-        this.exampleDisplay = res.original_name || entry.name;
-        this.exampleMediaType = this.mediaType || this.mediaTypeFromFilename(entry.name);
+        this.exampleDisplay = res.original_name || raw;
+        this.exampleMediaType = this.mediaType || this.mediaTypeFromFilename(raw);
         this.exampleThumbFailed = false;
         this.pendingText = '';
         this.sfFileSelecting = false;
         this.view = 'main';
       },
-      error: () => {
-        this.sfBrowseError = 'Failed to select file';
+      error: (err) => {
+        this.sfBrowseError = err?.error?.message || 'Path not found on the server.';
         this.sfFileSelecting = false;
       },
     });

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -165,11 +165,12 @@
                 </label>
 
                 @if (field.field_type === 'server_path') {
-                  <vt-file-browser
-                    [value]="formValues[field.key] || ''"
+                  <input
+                    [id]="'field-' + field.key"
+                    type="text"
+                    class="form-input"
+                    [(ngModel)]="formValues[field.key]"
                     [placeholder]="field.placeholder || field.description || field.label || field.key"
-                    [extensions]="field.accept || ''"
-                    (pathSelected)="formValues[field.key] = $event"
                   />
                 } @else if (field.field_type === 'password') {
                   <input

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
@@ -26,7 +25,7 @@ export interface ColumnDef {
 @Component({
   selector: 'vt-export-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -76,11 +76,12 @@
             </label>
 
             @if (field.field_type === 'server_path') {
-              <vt-file-browser
-                [value]="formValues[field.key] || ''"
+              <input
+                [id]="'lif-' + field.key"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
-                [extensions]="field.accept || ''"
-                (pathSelected)="formValues[field.key] = $event"
               />
             } @else if (field.field_type === 'file') {
               <input

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { MediasApiService } from '../../../services/medias-api.service';
@@ -15,7 +14,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-label-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
   templateUrl: './label-importer-modal.component.html',
   styleUrl: './label-importer-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -42,19 +42,33 @@
         }
       }
 
-      <!-- File browser (recursive directory navigation) -->
+      <!-- Typed path for example media -->
       @if (mediaPickerView === 'file-browser') {
         <div class="file-browser-step">
           @if (selectedSource?.name === 'demo') {
             <button class="btn btn--secondary btn--sm back-btn" (click)="backFromFileBrowser()" title="Return to the demo list">&larr; Back to demo list</button>
           }
-          <vt-folder-browser
-            [browse]="browseFn"
-            [rootLabel]="browseSourceLabel"
-            [busy]="fileLoading"
-            emptyMessage="No media files found in this directory."
-            (confirm)="onFileConfirmed($event)"
-          ></vt-folder-browser>
+          <p class="picker-instructions">
+            Enter a path to a media file in <strong>{{ browseSourceLabel }}</strong>:
+          </p>
+          <input
+            type="text"
+            class="form-input"
+            placeholder="path/to/file"
+            [(ngModel)]="typedPath"
+            (keydown.enter)="submitTypedPath(); $event.preventDefault()"
+          />
+          <button
+            type="button"
+            class="btn btn--primary"
+            [disabled]="fileLoading || !typedPath.trim()"
+            (click)="submitTypedPath()"
+          >
+            @if (fileLoading) { Loading… } @else { Load }
+          </button>
+          @if (typedPathError) {
+            <p class="error-text">{{ typedPathError }}</p>
+          }
         </div>
       }
     </div>

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -1,13 +1,8 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { map } from 'rxjs/operators';
+import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
-import {
-  FolderBrowserBrowseFn,
-  FolderBrowserComponent,
-  FolderBrowserFileEntry,
-} from '../../folder-browser/folder-browser.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
@@ -29,7 +24,7 @@ type MediaPickerView = 'sources' | 'browse-items' | 'file-browser';
 @Component({
   selector: 'vt-load-sort-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent, IconComponent, FolderBrowserComponent, MediaCropModalComponent, DetectorSwatchComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DetectorSwatchComponent],
   templateUrl: './load-sort-modal.component.html',
   styleUrl: './load-sort-modal.component.scss',
 })
@@ -52,23 +47,14 @@ export class LoadSortModalComponent implements OnInit {
   browseItems: BrowseItem[] = [];
   browseLoading = false;
 
-  // File browser state (for demo & folder drill-down)
+  // Typed-path state for the example-media picker (demo & folder drill-down).
+  // The user types a path relative to the picked source; the server validates
+  // it when the form is submitted.
   browseSource = '';
   browseSourceLabel = '';
   fileLoading = false;
-
-  /** Browse fn for the embedded ``<vt-folder-browser>``.  Routes through
-   *  ``/api/browse-media-files`` with whichever source the user picked
-   *  (``demo:<name>`` or ``folder``). */
-  readonly browseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.datasetsApi.browseMediaFiles(this.browseSource, path).pipe(
-      map((res) => ({
-        directories: res.directories || [],
-        files: res.files || [],
-        rootPath: res.root_path,
-        currentPath: path,
-      })),
-    );
+  typedPath = '';
+  typedPathError = '';
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -253,31 +239,37 @@ export class LoadSortModalComponent implements OnInit {
     this.mediaPickerView = 'file-browser';
     this.browseSource = source;
     this.browseSourceLabel = label;
+    this.typedPath = '';
+    this.typedPathError = '';
   }
 
-  /** Back-arrow handler for the file-browser view — returns to the
+  /** Back-arrow handler for the typed-path view — returns to the
    *  source-listing step that opened it (demo list / saved-datasets
    *  list). */
   backFromFileBrowser(): void {
     this.mediaPickerView = this.selectedSource?.name === 'demo' ? 'browse-items' : 'sources';
     this.browseSource = '';
     this.browseSourceLabel = '';
+    this.typedPath = '';
+    this.typedPathError = '';
   }
 
-  /** Confirm handler for the file browser — materialises the picked
-   *  file via ``/api/browse-media-files/select`` and kicks off an
-   *  example sort. */
-  onFileConfirmed(entry: FolderBrowserFileEntry): void {
+  /** Submit the typed path to ``/api/browse-media-files/select`` and
+   *  kick off an example sort. The server validates the path. */
+  submitTypedPath(): void {
+    const raw = (this.typedPath || '').trim();
+    if (!raw) return;
+    this.typedPathError = '';
     this.fileLoading = true;
-    this.datasetsApi.selectBrowsedFile(this.browseSource, entry.path).subscribe({
+    this.datasetsApi.selectBrowsedFile(this.browseSource, raw).subscribe({
       next: (res) => {
         this.fileLoading = false;
         this.showMediaPicker = false;
         this.loadServerMedia(res.filename);
       },
-      error: () => {
-        this.error = 'Failed to select file';
+      error: (err) => {
         this.fileLoading = false;
+        this.typedPathError = err?.error?.message || 'Path not found on the server.';
       },
     });
   }

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -76,48 +76,26 @@
       }
 
       @if (fileBrowsing) {
-        <div class="breadcrumbs">
-          @for (seg of browsePath; track $index) {
-            @if ($index > 0) { <span class="breadcrumb-sep">/</span> }
-            @if ($index < browsePath.length - 1) {
-              <button class="breadcrumb-link" (click)="navigateBreadcrumb($index)">{{ seg }}</button>
-            } @else {
-              <span class="breadcrumb-current">{{ seg }}</span>
-            }
-          }
-        </div>
-
-        @if (fileLoading) {
-          <p class="empty-state">Loading...</p>
-        }
-
-        @if (!fileLoading && browseEntries.length > 0) {
-          <div class="browse-list">
-            @for (entry of browseEntries; track entry.path) {
-              @if (entry.isDir) {
-                <button class="browse-item browse-dir" (click)="enterDirectory(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="folder"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                </button>
-              } @else {
-                <button class="browse-item browse-file" (click)="selectFile(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="file-text"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                  @if (entry.size_bytes != null) {
-                    <span class="entry-size">{{ formatSize(entry.size_bytes) }}</span>
-                  }
-                </button>
-              }
-            }
-          </div>
-        }
-
-        @if (!fileLoading && browseEntries.length === 0) {
-          <p class="empty-state">No media files found in this directory.</p>
+        <p class="picker-instructions">
+          Enter a path to a media file in <strong>{{ browseSourceLabel }}</strong>:
+        </p>
+        <input
+          type="text"
+          class="form-input"
+          placeholder="path/to/file"
+          [(ngModel)]="typedPath"
+          (keydown.enter)="submitTypedPath(); $event.preventDefault()"
+        />
+        <button
+          type="button"
+          class="btn btn--primary"
+          [disabled]="fileLoading || !typedPath.trim()"
+          (click)="submitTypedPath()"
+        >
+          @if (fileLoading) { Loading… } @else { Load }
+        </button>
+        @if (typedPathError) {
+          <p class="error-text">{{ typedPathError }}</p>
         }
       }
 

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
@@ -12,14 +12,6 @@ interface BrowseItem {
   display: string;
 }
 
-interface BrowseEntry {
-  name: string;
-  path: string;
-  size_bytes?: number;
-  modified_at?: string;
-  isDir: boolean;
-}
-
 export interface ResortResult {
   action: 'new-example';
   type: 'text' | 'media';
@@ -53,10 +45,11 @@ export class ResortPromptModalComponent {
   browseItems: BrowseItem[] = [];
   browseLoading = false;
   browseSource = '';
-  browsePath: string[] = [];
-  browseEntries: BrowseEntry[] = [];
+  browseSourceLabel = '';
   fileBrowsing = false;
   fileLoading = false;
+  typedPath = '';
+  typedPathError = '';
 
   constructor(
     private datasetsApi: DatasetsApiService,
@@ -82,9 +75,10 @@ export class ResortPromptModalComponent {
     this.selectedSource = null;
     this.browseItems = [];
     this.fileBrowsing = false;
-    this.browseEntries = [];
-    this.browsePath = [];
     this.browseSource = '';
+    this.browseSourceLabel = '';
+    this.typedPath = '';
+    this.typedPathError = '';
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
         this.mediaSources = (res.importers || []).filter(
@@ -142,56 +136,24 @@ export class ResortPromptModalComponent {
   private startFileBrowsing(source: string, label: string): void {
     this.fileBrowsing = true;
     this.browseSource = source;
-    this.browsePath = [label];
-    this.loadDirectory('');
+    this.browseSourceLabel = label;
+    this.typedPath = '';
+    this.typedPathError = '';
   }
 
-  private loadDirectory(relPath: string): void {
+  submitTypedPath(): void {
+    const raw = (this.typedPath || '').trim();
+    if (!raw) return;
     this.fileLoading = true;
-    this.browseEntries = [];
-    this.datasetsApi.browseMediaFiles(this.browseSource, relPath).subscribe({
-      next: (res) => {
-        const entries: BrowseEntry[] = [];
-        for (const d of res.directories || []) {
-          entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
-        }
-        for (const f of res.files || []) {
-          entries.push({ name: f.name, path: f.path, size_bytes: f.size_bytes, modified_at: f.modified_at, isDir: false });
-        }
-        this.browseEntries = entries;
-        this.fileLoading = false;
-      },
-      error: () => { this.fileLoading = false; },
-    });
-  }
-
-  enterDirectory(entry: BrowseEntry): void {
-    this.browsePath.push(entry.name);
-    this.loadDirectory(entry.path);
-  }
-
-  navigateBreadcrumb(index: number): void {
-    if (index === 0) {
-      this.fileBrowsing = false;
-      this.browseEntries = [];
-      this.browsePath = [];
-      return;
-    }
-    this.browsePath = this.browsePath.slice(0, index + 1);
-    const relPath = this.browsePath.slice(1).join('/');
-    this.loadDirectory(relPath);
-  }
-
-  selectFile(entry: BrowseEntry): void {
-    this.fileLoading = true;
-    this.datasetsApi.selectBrowsedFile(this.browseSource, entry.path).subscribe({
+    this.typedPathError = '';
+    this.datasetsApi.selectBrowsedFile(this.browseSource, raw).subscribe({
       next: (res) => {
         this.fileLoading = false;
         this.newExample.emit({ action: 'new-example', type: 'media', value: res.filename });
       },
-      error: () => {
-        this.error = 'Failed to select file';
+      error: (err) => {
         this.fileLoading = false;
+        this.typedPathError = err?.error?.message || 'Path not found on the server.';
       },
     });
   }
@@ -209,13 +171,6 @@ export class ResortPromptModalComponent {
       },
     });
     input.value = '';
-  }
-
-  formatSize(bytes?: number): string {
-    if (bytes == null) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
   backToPrompt(): void {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -40,11 +40,12 @@
             </label>
 
             @if (field.field_type === 'server_path') {
-              <vt-file-browser
-                [value]="formValues[field.key] || ''"
+              <input
+                [id]="'sef-' + field.key"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
-                [extensions]="field.accept || ''"
-                (pathSelected)="formValues[field.key] = $event"
               />
             } @else if (field.field_type === 'select') {
               <select

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
@@ -14,7 +13,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-settings-exporter-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
   templateUrl: './settings-exporter-modal.component.html',
   styleUrl: './settings-exporter-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -40,11 +40,12 @@
             </label>
 
             @if (field.field_type === 'server_path') {
-              <vt-file-browser
-                [value]="formValues[field.key] || ''"
+              <input
+                [id]="'sif-' + field.key"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
-                [extensions]="field.accept || ''"
-                (pathSelected)="formValues[field.key] = $event"
               />
             } @else if (field.field_type === 'file') {
               <input

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
-import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
@@ -13,7 +12,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-settings-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
   templateUrl: './settings-importer-modal.component.html',
   styleUrl: './settings-importer-modal.component.scss',
 })


### PR DESCRIPTION
## Summary

The custom server filesystem browser (`vt-file-browser` / `vt-folder-browser`) was awkward to use. Every place that mounted it now renders a plain text input the user types a path into; the server validates the path on submit and surfaces an inline error if it's missing or invalid.

## Affected flows

- **Dataset import modal**: `server_path` importer fields and the `server_folder` picker now use typed paths.
- **New-detector modal**: example-media picker for demos and server folders.
- **Resort prompt modal**: media-example picker.
- **Load-sort modal**: example-media picker.
- **Export modal**, **settings importer/exporter modals**, **label importer modal**: any importer field declared as `server_path`.

The `vt-file-browser`, `vt-folder-browser`, `FileBrowserApiService`, and the `/api/browse` backend (with its tests) are left in place as dead code so we can revisit the design later.

## Test plan

- [x] `./run-tests.sh` passes (4196 passed, 1 skipped, 2 xpassed)
- [x] Frontend `npm run build:prod` passes (run as part of the `core` group)
- [x] ruff / codespell / deptry / pip-audit / pyright / OpenAPI snapshot clean
- [ ] Manual: open Add Dataset → server_folder, type a valid path, submit → dataset loads
- [ ] Manual: open Add Dataset → server_folder, type a bogus path, submit → server validation error surfaces
- [ ] Manual: New Detector → Browse Media → server folder, type a media path → example loads
- [ ] Manual: New Detector → Browse Media → demo, type a media path → example loads
- [ ] Manual: Resort prompt → Browse Media → typed path → example loads
- [ ] Manual: Settings exporter/importer modal with a `server_path` field → plain input + submit works


---
_Generated by [Claude Code](https://claude.ai/code/session_014SNs4zkgzgzvovob5idyyW)_