### PR TITLE
Drop 'Computing one X vector per file' progress subtitle

### DIFF
--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -173,10 +173,6 @@ export function formatProgressHeader(
     }
   } else if (status === 'embedding') {
     phase = 'embedding files';
-    const pretty = prettifyEmbedder(embedder);
-    subtitle = pretty
-      ? `Computing one ${pretty} vector per file. Time depends on dataset size and hardware.`
-      : 'Computing one vector per file. Time depends on dataset size and hardware.';
   } else if (status === 'loading' && /embedding model/i.test(message)) {
     phase = 'embedding model';
     const pretty = prettifyEmbedder(embedder);


### PR DESCRIPTION
## Summary
- Remove the "Computing one ${pretty} vector per file. Time depends on dataset size and hardware." subtitle from the embedding-files phase in `formatProgressHeader`.
- The phase header ("Loading dataset · embedding files") already conveys what's happening, so the subtitle was just bloat on the progress bar.

## Test plan
- [ ] Load a dataset and confirm the progress card during the embedding phase no longer renders the extra subtitle line.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrgFDqmeg5ZDBd2hfXSrnw)_