### PR TITLE
importer modal: fold Embedder into the Advanced section

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -74,12 +74,17 @@
         }
 
         @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
-          <div class="demo-embedder-row">
-            @if (demoEmbedders.length > 1) {
-              <label class="form-label" for="demo-embedder" title="Embedding model used to compute vector representations of each media item">Embedder:</label>
+          <div class="form-group form-group--section">
+            @if (showAdvancedToggle('demo')) {
+              <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
+                Advanced {{ advancedOpen ? '▴' : '▾' }}
+              </button>
+            }
+            @if (demoEmbedders.length > 1 && showEmbedderPicker('demo')) {
+              <label class="form-label" for="demo-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
               <select
                 id="demo-embedder"
-                class="form-select form-select--inline"
+                class="form-select"
                 [ngModel]="selectedDemoEmbedder"
                 (ngModelChange)="onDemoEmbedderChange($event)"
               >
@@ -101,21 +106,15 @@
               @if (selectedEmbedderRawId(selectedDemoEmbedder, demoEmbedders); as rawId) {
                 <small class="embedder-raw-id">{{ rawId }}</small>
               }
-            }
-            @if (licenseNoticeFor(selectedDemoEmbedder, demoEmbedders); as notice) {
-              <div class="license-warning" role="note">⚠ {{ notice }}</div>
-            }
-            @if (demoClippers.length > 1) {
-              @if (isDefaultClipperSelected('demo')) {
-                <button type="button" class="advanced-toggle advanced-toggle--inline" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
-                  Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
-                </button>
+              @if (licenseNoticeFor(selectedDemoEmbedder, demoEmbedders); as notice) {
+                <div class="license-warning" role="note">⚠ {{ notice }}</div>
               }
-              @if (showClipperPicker('demo')) {
-                <button class="btn btn--secondary btn--sm clipper-btn" (click)="openClipperChooser('demo')" title="Choose a MediaClipper to segment or trim media before embedding">
-                  Clipper: {{ clipperDisplayName('demo') }}
-                </button>
-              }
+            }
+            @if (demoClippers.length > 1 && showClipperPicker('demo')) {
+              <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+              <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('demo')" title="Choose a MediaClipper to segment or trim media before embedding">
+                Use MediaClipper: {{ clipperDisplayName('demo') }}
+              </button>
             }
           </div>
         }
@@ -327,46 +326,43 @@
         </div>
       }
 
-      @if (availableEmbedders.length > 1) {
-        <div class="form-group">
-          <label class="form-label" for="field-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
-          <select
-            id="field-embedder"
-            class="form-select"
-            [(ngModel)]="selectedEmbedder"
-          >
-            @if (recommendedEmbedders(availableEmbedders).length > 0) {
-              <optgroup label="Recommended">
-                @for (embedder of recommendedEmbedders(availableEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-            @if (advancedEmbedders(availableEmbedders).length > 0) {
-              <optgroup label="Advanced ▾">
-                @for (embedder of advancedEmbedders(availableEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-          </select>
-          @if (selectedEmbedderRawId(selectedEmbedder, availableEmbedders); as rawId) {
-            <small class="embedder-raw-id">{{ rawId }}</small>
-          }
-          @if (licenseNoticeFor(selectedEmbedder, availableEmbedders); as notice) {
-            <div class="license-warning" role="note">⚠ {{ notice }}</div>
-          }
-        </div>
-      }
-
-      @if (availableClippers.length > 1) {
-        <div class="form-group">
-          @if (isDefaultClipperSelected('form')) {
-            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
-              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+      @if (availableEmbedders.length > 1 || availableClippers.length > 1) {
+        <div class="form-group form-group--section">
+          @if (showAdvancedToggle('form')) {
+            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
+              Advanced {{ advancedOpen ? '▴' : '▾' }}
             </button>
           }
-          @if (showClipperPicker('form')) {
+          @if (availableEmbedders.length > 1 && showEmbedderPicker('form')) {
+            <label class="form-label" for="field-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
+            <select
+              id="field-embedder"
+              class="form-select"
+              [(ngModel)]="selectedEmbedder"
+            >
+              @if (recommendedEmbedders(availableEmbedders).length > 0) {
+                <optgroup label="Recommended">
+                  @for (embedder of recommendedEmbedders(availableEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+              @if (advancedEmbedders(availableEmbedders).length > 0) {
+                <optgroup label="Advanced ▾">
+                  @for (embedder of advancedEmbedders(availableEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+            </select>
+            @if (selectedEmbedderRawId(selectedEmbedder, availableEmbedders); as rawId) {
+              <small class="embedder-raw-id">{{ rawId }}</small>
+            }
+            @if (licenseNoticeFor(selectedEmbedder, availableEmbedders); as notice) {
+              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+            }
+          }
+          @if (availableClippers.length > 1 && showClipperPicker('form')) {
             <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
             <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('form')" title="Choose a MediaClipper to segment or trim media before embedding">
               Use MediaClipper: {{ clipperDisplayName('form') }}
@@ -506,46 +502,43 @@
         </div>
       }
 
-      @if (lfEmbedders.length > 1) {
+      @if (lfEmbedders.length > 1 || lfClippers.length > 1) {
         <div class="form-group form-group--section">
-          <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
-          <select
-            id="lf-embedder"
-            class="form-select"
-            [(ngModel)]="lfSelectedEmbedder"
-          >
-            @if (recommendedEmbedders(lfEmbedders).length > 0) {
-              <optgroup label="Recommended">
-                @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-            @if (advancedEmbedders(lfEmbedders).length > 0) {
-              <optgroup label="Advanced ▾">
-                @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-          </select>
-          @if (selectedEmbedderRawId(lfSelectedEmbedder, lfEmbedders); as rawId) {
-            <small class="embedder-raw-id">{{ rawId }}</small>
-          }
-          @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
-            <div class="license-warning" role="note">⚠ {{ notice }}</div>
-          }
-        </div>
-      }
-
-      @if (lfClippers.length > 1) {
-        <div class="form-group form-group--section">
-          @if (isDefaultClipperSelected('lf')) {
-            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
-              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+          @if (showAdvancedToggle('lf')) {
+            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
+              Advanced {{ advancedOpen ? '▴' : '▾' }}
             </button>
           }
-          @if (showClipperPicker('lf')) {
+          @if (lfEmbedders.length > 1 && showEmbedderPicker('lf')) {
+            <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
+            <select
+              id="lf-embedder"
+              class="form-select"
+              [(ngModel)]="lfSelectedEmbedder"
+            >
+              @if (recommendedEmbedders(lfEmbedders).length > 0) {
+                <optgroup label="Recommended">
+                  @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+              @if (advancedEmbedders(lfEmbedders).length > 0) {
+                <optgroup label="Advanced ▾">
+                  @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+            </select>
+            @if (selectedEmbedderRawId(lfSelectedEmbedder, lfEmbedders); as rawId) {
+              <small class="embedder-raw-id">{{ rawId }}</small>
+            }
+            @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
+              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+            }
+          }
+          @if (lfClippers.length > 1 && showClipperPicker('lf')) {
             <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
             <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
               Use MediaClipper: {{ clipperDisplayName('lf') }}
@@ -643,46 +636,43 @@
         </label>
       </div>
 
-      @if (sfEmbedders.length > 1) {
-        <div class="form-group">
-          <label class="form-label" for="sf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
-          <select
-            id="sf-embedder"
-            class="form-select"
-            [(ngModel)]="sfSelectedEmbedder"
-          >
-            @if (recommendedEmbedders(sfEmbedders).length > 0) {
-              <optgroup label="Recommended">
-                @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-            @if (advancedEmbedders(sfEmbedders).length > 0) {
-              <optgroup label="Advanced ▾">
-                @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                }
-              </optgroup>
-            }
-          </select>
-          @if (selectedEmbedderRawId(sfSelectedEmbedder, sfEmbedders); as rawId) {
-            <small class="embedder-raw-id">{{ rawId }}</small>
-          }
-          @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
-            <div class="license-warning" role="note">⚠ {{ notice }}</div>
-          }
-        </div>
-      }
-
-      @if (sfClippers.length > 1) {
-        <div class="form-group">
-          @if (isDefaultClipperSelected('sf')) {
-            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
-              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+      @if (sfEmbedders.length > 1 || sfClippers.length > 1) {
+        <div class="form-group form-group--section">
+          @if (showAdvancedToggle('sf')) {
+            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
+              Advanced {{ advancedOpen ? '▴' : '▾' }}
             </button>
           }
-          @if (showClipperPicker('sf')) {
+          @if (sfEmbedders.length > 1 && showEmbedderPicker('sf')) {
+            <label class="form-label" for="sf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
+            <select
+              id="sf-embedder"
+              class="form-select"
+              [(ngModel)]="sfSelectedEmbedder"
+            >
+              @if (recommendedEmbedders(sfEmbedders).length > 0) {
+                <optgroup label="Recommended">
+                  @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+              @if (advancedEmbedders(sfEmbedders).length > 0) {
+                <optgroup label="Advanced ▾">
+                  @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
+                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                  }
+                </optgroup>
+              }
+            </select>
+            @if (selectedEmbedderRawId(sfSelectedEmbedder, sfEmbedders); as rawId) {
+              <small class="embedder-raw-id">{{ rawId }}</small>
+            }
+            @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
+              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+            }
+          }
+          @if (sfClippers.length > 1 && showClipperPicker('sf')) {
             <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
             <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
               Use MediaClipper: {{ clipperDisplayName('sf') }}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -50,24 +50,14 @@
 
 .demo-picker { gap: 12px; }
 
-.demo-embedder-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-
-  .form-label { margin: 0; font-size: .85rem; white-space: nowrap; }
-  .form-select--inline { width: auto; min-width: 140px; }
-  .form-select { max-width: 200px; }
-}
-
 .clipper-btn {
   text-align: left;
   white-space: nowrap;
 }
 
-// Phase 3 of smart-clipper-defaults: the clipper picker hides behind a
-// subtle "Advanced ▾" link. Designed to disappear into the surrounding
-// form so users who don't need the override aren't distracted by it.
+// The embedder + clipper pickers hide behind a single subtle "Advanced ▾"
+// link below the required fields. Designed to disappear into the
+// surrounding form so users who don't need overrides aren't distracted.
 .advanced-toggle {
   align-self: flex-start;
   background: transparent;
@@ -79,10 +69,6 @@
 
   &:hover { color: var(--text, #222); text-decoration: underline; }
   &:focus-visible { outline: 2px solid var(--focus, #4a90e2); outline-offset: 2px; }
-}
-
-.advanced-toggle--inline {
-  margin-left: 4px;
 }
 
 .server-folder-browser { gap: 12px; }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -172,11 +172,11 @@ export class DatasetImporterModalComponent implements OnInit {
   clipperChooserContext: 'form' | 'demo' | 'sf' | 'lf' = 'form';
   clipperChooserClippers: ClipperInfo[] = [];
 
-  // Phase 3 of smart-clipper-defaults: the clipper picker is hidden
-  // behind an "Advanced" toggle by default. When the user has picked a
-  // non-default clipper, the picker is always visible regardless of
-  // this flag (so they can see and re-edit their selection).
-  clipperAdvancedOpen = false;
+  // Embedder + clipper pickers live behind a single "Advanced" toggle so
+  // they don't crowd the required fields. When the user has picked a
+  // non-default value for either, that picker stays visible regardless
+  // of this flag (so they can see and re-edit their selection).
+  advancedOpen = false;
 
   constructor(
     private datasetsApi: DatasetsApiService,
@@ -1633,15 +1633,54 @@ export class DatasetImporterModalComponent implements OnInit {
     return clippers.length > 0 && clippers[0].name === selected;
   }
 
+  /** Whether the currently-selected embedder is one the registry flags
+   *  ``is_default`` for the active media type. Used to decide whether the
+   *  Advanced section can stay collapsed — if the user (or saved settings)
+   *  picked a non-default, we keep the picker visible. */
+  isDefaultEmbedderSelected(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    let embedders: EmbedderInfo[];
+    let selected: string;
+    if (context === 'form') {
+      embedders = this.availableEmbedders;
+      selected = this.selectedEmbedder;
+    } else if (context === 'demo') {
+      embedders = this.demoEmbedders;
+      selected = this.selectedDemoEmbedder;
+    } else if (context === 'sf') {
+      embedders = this.sfEmbedders;
+      selected = this.sfSelectedEmbedder;
+    } else {
+      embedders = this.lfEmbedders;
+      selected = this.lfSelectedEmbedder;
+    }
+    if (!selected) return true;
+    const found = embedders.find((e) => e.name === selected);
+    return !!found?.is_default;
+  }
+
   /** Whether the clipper picker should be visible in the given context.
    *  True when the Advanced section is expanded or when a non-default
    *  clipper is selected. */
   showClipperPicker(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
-    return this.clipperAdvancedOpen || !this.isDefaultClipperSelected(context);
+    return this.advancedOpen || !this.isDefaultClipperSelected(context);
   }
 
-  toggleClipperAdvanced(): void {
-    this.clipperAdvancedOpen = !this.clipperAdvancedOpen;
+  /** Whether the embedder picker should be visible in the given context.
+   *  Same semantics as ``showClipperPicker`` but for the embedder. */
+  showEmbedderPicker(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    return this.advancedOpen || !this.isDefaultEmbedderSelected(context);
+  }
+
+  /** Whether the "Advanced ▾" toggle button should be rendered in the
+   *  given context. Only meaningful when both selections are at defaults;
+   *  otherwise the pickers are already visible and the button would be
+   *  redundant. */
+  showAdvancedToggle(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    return this.isDefaultEmbedderSelected(context) && this.isDefaultClipperSelected(context);
+  }
+
+  toggleAdvanced(): void {
+    this.advancedOpen = !this.advancedOpen;
   }
 
   sfSubmit(): void {


### PR DESCRIPTION
## Summary

- Move the Embedder picker into the existing **Advanced** expandable section alongside the Clipper picker, in every variant of the Add-Dataset modal (Demo, Services form, Server folder, Local folder/files).
- Place that Advanced section below the required questions so an "Advanced ▾" toggle no longer appears in the middle of the form.
- The section auto-expands when a non-default embedder *or* non-default clipper is already selected, so saved overrides stay visible without an extra click.

## Why

The embedder was rendered next to / above the required fields with an inline "Advanced ▾" affordance for the clipper. That put the toggle in the middle of the flow even though the embedder is itself an advanced choice. Folding both behind a single Advanced toggle below the required fields keeps the form tidy without losing access to either control.

## Note on the "siglip" line

The small grey `siglip` shown under the dropdown is the embedder's raw registry ID — `selectedEmbedderRawId()` renders it whenever an embedder's `display_name` differs from its `name`, "so power users can still see it" (per the existing comment in the component). It is intentional and unchanged by this PR; it just no longer shows by default because the picker is now collapsed.

## Test plan

- [x] `npm run build:prod` — clean (no warnings).
- [ ] Manually verify each importer variant (demo / services form / server_folder / local_folder / local_files) shows a single "Advanced ▾" toggle below the required fields, and that clicking it reveals both Embedder and Clipper pickers.
- [ ] Verify that selecting a non-default embedder or clipper keeps that picker visible on next open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LNawQemzwvX9FfN7i5rwoN)_