### PR TITLE
Specialise New Detector example labels to the chosen media type

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -111,10 +111,10 @@
               </div>
             </div>
             <div class="example-col">
-              <label class="col-label">Media Example</label>
-              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">Browse Media...</button>
+              <label class="col-label">{{ exampleColumnLabel }}</label>
+              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">{{ browseMediaLabel }}</button>
               <vt-drop-zone
-                label="Drop a media file here"
+                [label]="dropMediaLabel"
                 sublabel="or click to upload from this computer"
                 [disabled]="hasPendingText"
                 (filesSelected)="onLocalFileDropped($event)"
@@ -487,7 +487,7 @@
             </p>
           } @else {
             <vt-drop-zone
-              label="Drop a media file here to use as example"
+              [label]="dropMediaLabel + ' to use as example'"
               sublabel="or click to browse"
               (filesSelected)="onLocalFileDropped($event)"
             ></vt-drop-zone>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -866,6 +866,30 @@ export class NewDetectorModalComponent implements OnInit {
     return typeId;
   }
 
+  /** "Image Example", "Audio Example", "Media Example" as a fallback. */
+  get exampleColumnLabel(): string {
+    const name = this.mediaType ? this.getMediaTypeLabel(this.mediaType) : '';
+    return `${name || 'Media'} Example`;
+  }
+
+  /** "Browse Images...", "Browse Audio...", "Browse Media..." as a fallback. */
+  get browseMediaLabel(): string {
+    const name = this.mediaType ? this.getMediaTypeLabel(this.mediaType) : '';
+    if (!name) return 'Browse Media...';
+    // audio and text don't take a plural -s in this context.
+    const uncountable = this.mediaType === 'audio' || this.mediaType === 'text';
+    return `Browse ${uncountable ? name : name + 's'}...`;
+  }
+
+  /** "Drop an image file here", "Drop a video file here", etc. */
+  get dropMediaLabel(): string {
+    const name = this.mediaType ? this.getMediaTypeLabel(this.mediaType) : '';
+    if (!name) return 'Drop a media file here';
+    const lower = name.toLowerCase();
+    const article = /^[aeiou]/.test(lower) ? 'an' : 'a';
+    return `Drop ${article} ${lower} file here`;
+  }
+
   getMediaTypeIcon(typeId: string): string {
     const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
     return mt?.icon || '';


### PR DESCRIPTION
## Summary
- The New Detector modal's example column header, browse button, and drop-zone hint now reflect the media type picked in the dropdown right above them.
- For `image`: "Image Example" / "Browse Images..." / "Drop an image file here". For `audio`: "Browse Audio..." (uncountable). For `video` / `document` / `text`: pluralised + correct "a"/"an" article. Falls back to the previous "Media" wording if no type is set.
- Applies to both drop zones in the modal (the inline one on the main form and the one inside the local-files picker).

## Test plan
- [x] `npm run build:prod` builds cleanly with no new warnings.
- [ ] Open the New Detector modal and step through each media type in the dropdown; verify the example column header, the Browse button, and the drop-zone label update each time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5Ex5Msm19XnyKkmkaG1zj)_