### PR TITLE
demo importer chart: fix M/L item counts to match loader

### DIFF
--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -96,9 +96,13 @@ def _calculate_demo_num_files(dataset_info: dict) -> int:
     slice_frac_start = dataset_info.get("slice_frac_start")
 
     if slice_frac_start is not None:
-        frac_end = dataset_info.get("slice_frac_end") or 1.0
+        # Mirror vtscore.media.base.demo_slice: floor each endpoint independently
+        # so the count matches what the loader actually produces.
         base_per_cat = items_per_category if items_per_category > 0 else 40
-        per_cat = int(base_per_cat * (frac_end - slice_frac_start))
+        frac_end = dataset_info.get("slice_frac_end")
+        start = int(base_per_cat * slice_frac_start)
+        end = int(base_per_cat * frac_end) if frac_end is not None else base_per_cat
+        per_cat = end - start
     else:
         slice_start = dataset_info.get("slice_start", 0)
         slice_end = dataset_info.get("slice_end")


### PR DESCRIPTION
## Summary

The Demo Dataset Importer's chart shows a `# Media` column whose value was computed as
`num_categories × int(items_per_category × (frac_end − frac_start))`. The actual loader
slices each category with `demo_slice()` (`vtscore/media/base.py:161`), which floors each
endpoint independently:

```python
start = int(N * frac_start)
end   = int(N * frac_end)
items[start:end]
```

`int(a − b) ≤ int(a) − int(b)`, so for any `M` or `L` split where the two floors land on
different integers, the chart was undercounting by exactly one item per category.

Concretely (`N` = `items_per_category`, fractions `0, 1/7, 3/7, 7/7`):

| id | N | cats | chart # (before) | actual # | Δ |
|---|---|---|---|---|---|
| esc50_m | 40 | 50 | 550 | 600 | +50 |
| esc50_l | 40 | 50 | 1100 | 1150 | +50 |
| caltech101_l | 86 | 25 | 1225 | 1250 | +25 |
| food101_m | 1000 | 101 | 28,785 | 28,886 | +101 |
| food101_l | 1000 | 101 | 57,671 | 57,772 | +101 |
| stanford_dogs_m | 171 | 120 | 5760 | 5880 | +120 |
| stanford_dogs_l | 171 | 120 | 11,640 | 11,760 | +120 |
| places365_l | 100 | 365 | 20,805 | 21,170 | +365 |
| 20newsgroups_l | 950 | 15 | 8130 | 8145 | +15 |
| ucf101_m | 132 | 10 | 370 | 380 | +10 |
| ucf101_l | 132 | 10 | 750 | 760 | +10 |

S and A rows already agreed and are unchanged.

`_calculate_demo_num_files()` now mirrors `demo_slice()` exactly.

### Caveat (not fixed here)

`items_per_category` is a per-category *cap*, not the real count, for sources where
individual categories have fewer items than the cap (Caltech-101's `cougar_face` has only
~70 photos vs. cap 86, UCF-101 categories vary, etc.). For those datasets the chart's
number is still an upper bound; making it match reality would require actually loading
each demo once and caching the count. Out of scope for this PR.

## Test plan
- [x] `./run-tests.sh datasets` — 563 passed, 2 skipped
- [ ] Sanity-check the Demo Dataset Importer UI shows the new numbers


---
_Generated by [Claude Code](https://claude.ai/code/session_01K72PTcWN2fDttLao49tmac)_