### PR TITLE
Add stepped progress output to install scripts

### DIFF
--- a/scripts/_progress.sh
+++ b/scripts/_progress.sh
@@ -1,0 +1,70 @@
+# Sourced helper: structured step/progress output for install scripts.
+#
+# Usage:
+#   source "$SCRIPT_DIR/_progress.sh"
+#   vts_progress_init <total_steps> "Banner title"
+#   vts_progress_step "Doing the thing"
+#   ...work...
+#   vts_progress_step "Doing the next thing"
+#   ...work...
+#   vts_progress_done "All done"
+#
+# Each step prints a header like:
+#   [2/4] (0:00:12 elapsed) Doing the next thing
+# followed by an underline.  Colors are emitted only when stdout is a TTY.
+
+if [ -t 1 ]; then
+    _VTS_BOLD="$(printf '\033[1m')"
+    _VTS_CYAN="$(printf '\033[36m')"
+    _VTS_GREEN="$(printf '\033[32m')"
+    _VTS_DIM="$(printf '\033[2m')"
+    _VTS_RESET="$(printf '\033[0m')"
+else
+    _VTS_BOLD=""
+    _VTS_CYAN=""
+    _VTS_GREEN=""
+    _VTS_DIM=""
+    _VTS_RESET=""
+fi
+
+_VTS_TOTAL=0
+_VTS_CURRENT=0
+_VTS_START=0
+
+_vts_elapsed() {
+    local now elapsed h m s
+    now=$(date +%s)
+    elapsed=$((now - _VTS_START))
+    h=$((elapsed / 3600))
+    m=$(((elapsed % 3600) / 60))
+    s=$((elapsed % 60))
+    printf '%d:%02d:%02d' "$h" "$m" "$s"
+}
+
+vts_progress_init() {
+    _VTS_TOTAL="$1"
+    _VTS_CURRENT=0
+    _VTS_START=$(date +%s)
+    local title="$2"
+    local bar
+    bar=$(printf '%.0s=' $(seq 1 ${#title}))
+    printf '\n%s%s%s%s\n' "$_VTS_BOLD" "$_VTS_CYAN" "$title" "$_VTS_RESET"
+    printf '%s%s%s\n\n' "$_VTS_CYAN" "$bar" "$_VTS_RESET"
+}
+
+vts_progress_step() {
+    _VTS_CURRENT=$((_VTS_CURRENT + 1))
+    local msg="$1"
+    local header
+    header="[${_VTS_CURRENT}/${_VTS_TOTAL}]"
+    printf '\n%s%s%s %s(%s elapsed)%s %s%s%s\n' \
+        "$_VTS_BOLD" "$header" "$_VTS_RESET" \
+        "$_VTS_DIM" "$(_vts_elapsed)" "$_VTS_RESET" \
+        "$_VTS_BOLD" "$msg" "$_VTS_RESET"
+}
+
+vts_progress_done() {
+    local msg="$1"
+    printf '\n%s%s✓ %s (total: %s)%s\n\n' \
+        "$_VTS_BOLD" "$_VTS_GREEN" "$msg" "$(_vts_elapsed)" "$_VTS_RESET"
+}

--- a/scripts/install-cpu.sh
+++ b/scripts/install-cpu.sh
@@ -13,26 +13,27 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-echo "Installing VTSearch CPU dependencies..."
+# Shared progress-printing helpers.
+# shellcheck source=_progress.sh
+source "$SCRIPT_DIR/_progress.sh"
 
-# Bail out early if the active Python is too old.  pyproject.toml requires
-# >=3.10, but pip only enforces it partway through resolution, after a slow
-# and confusing failure path.  Check up front instead.
+vts_progress_init 4 "Installing VTSearch CPU dependencies"
+
+vts_progress_step "Checking Python version (>= 3.10)"
 source "$SCRIPT_DIR/_check-python.sh"
 
-# Ensure pip/setuptools/wheel are recent enough to resolve modern wheel-only
-# packages.  Stale pips (e.g. 21.x) have a weaker resolver and will fall back
-# to building ancient sdists from source, which then fails for lack of
-# `bdist_wheel`.
-pip install --upgrade pip setuptools wheel -q
+vts_progress_step "Upgrading pip / setuptools / wheel"
+pip install --upgrade pip setuptools wheel --progress-bar on
 
-pip install -r "$REPO_ROOT/requirements/base.txt" -q
+vts_progress_step "Installing runtime + dev dependencies (this may take several minutes)"
+pip install -r "$REPO_ROOT/requirements/base.txt" --progress-bar on
 
-# Wire up the pre-commit git hook (no-op if not in a git checkout
-# or if .pre-commit-config.yaml is absent).
+vts_progress_step "Wiring up pre-commit git hook"
 if [ -d "$REPO_ROOT/.git" ] && [ -f "$REPO_ROOT/.pre-commit-config.yaml" ]; then
     (cd "$REPO_ROOT" && pre-commit install --install-hooks) || \
         echo "warning: pre-commit install failed; run it manually to enable git hooks"
+else
+    echo "  (skipped: no git checkout or .pre-commit-config.yaml)"
 fi
 
-echo "CPU dependencies installed successfully."
+vts_progress_done "CPU dependencies installed successfully"

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -18,35 +18,29 @@ EXTRA_INDEX="https://download.pytorch.org/whl/${CUDA_TAG}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-echo "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})..."
+# Shared progress-printing helpers.
+# shellcheck source=_progress.sh
+source "$SCRIPT_DIR/_progress.sh"
 
-# Bail out early if the active Python is too old.  pyproject.toml requires
-# >=3.10, but pip only enforces it partway through resolution, after a slow
-# and confusing failure path.  Check up front instead.
+vts_progress_init 4 "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})"
+
+vts_progress_step "Checking Python version (>= 3.10)"
 source "$SCRIPT_DIR/_check-python.sh"
 
-# Step 0: Ensure pip/setuptools/wheel are recent enough to resolve modern
-# wheel-only packages.  Stale pips (e.g. 21.x) have a weaker resolver and
-# will fall back to building ancient sdists from source, which then fails
-# for lack of `bdist_wheel`.
-echo "Upgrading pip / setuptools / wheel..."
-pip install --upgrade pip setuptools wheel -q
+vts_progress_step "Upgrading pip / setuptools / wheel"
+pip install --upgrade pip setuptools wheel --progress-bar on
 
-# Step 1: Pre-install packages that the PyTorch index may serve as source
-# tarballs.  --only-binary ensures we get pre-built wheels from PyPI.
-echo "Pre-installing binary-only wheels (numpy, scipy)..."
+vts_progress_step "Pre-installing binary-only wheels (numpy, scipy) from PyPI"
 pip install --only-binary :all: \
   --index-url https://pypi.org/simple \
   "numpy" \
   "scipy" \
-  -q
+  --progress-bar on
 
-# Step 2: Install runtime + dev deps and the vtsearch package (editable)
-# via pyproject.toml. requirements/gpu.txt is just `-e .[dev]`.
-echo "Installing all dependencies..."
+vts_progress_step "Installing all dependencies via ${EXTRA_INDEX} (this may take several minutes)"
 pip install --extra-index-url "$EXTRA_INDEX" \
   --prefer-binary \
   -r "$REPO_ROOT/requirements/gpu.txt" \
-  -q
+  --progress-bar on
 
-echo "GPU dependencies installed successfully."
+vts_progress_done "GPU dependencies installed successfully"


### PR DESCRIPTION
## Summary
- New `scripts/_progress.sh` helper that prints `[N/M] (elapsed) Title` step headers (with color when stdout is a TTY) and a final ✓ summary with total runtime
- `install-cpu.sh` and `install-gpu.sh` now wrap each phase (python check, pip upgrade, dependency install, etc.) in a numbered step, so the user sees what's happening instead of staring at a silent terminal
- Dropped pip's `-q` flag and passed `--progress-bar on`, so pip's native per-package download progress bars surface during the long install phases

## Test plan
- [x] `bash -n scripts/install-cpu.sh` / `bash -n scripts/install-gpu.sh` syntax-check clean
- [x] Smoke-tested `_progress.sh` end-to-end to confirm the header / elapsed-time / done-banner rendering
- [ ] Manual: run `bash scripts/install-cpu.sh` in a fresh venv and confirm the new step headers and pip progress bars appear

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmuU8oHozmBsCMtLLtW2ng)_