### PR TITLE
Stop double-printing the count in archive-extract progress messages

### DIFF
--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -313,7 +313,7 @@ def _download_and_extract(  # noqa: C901
                 total = len(members)
                 for i, member in enumerate(members):
                     if i % 100 == 0 or i == total - 1:
-                        on_progress("downloading", f"Extracting {dataset_name} ({i + 1}/{total})...", i + 1, total)
+                        on_progress("downloading", f"Extracting {dataset_name}...", i + 1, total)
                     # Guard against path traversal in zip entries
                     member_path = Path(temp_extract) / member
                     if not str(member_path.resolve()).startswith(str(Path(temp_extract).resolve())):

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -99,7 +99,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
                 if i % 100 == 0 or i == total:
                     on_progress(
                         "downloading",
-                        f"Extracting Caltech-101 zip ({i}/{total})...",
+                        "Extracting Caltech-101 zip...",
                         i,
                         total,
                     )
@@ -118,7 +118,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
                     if i % 100 == 0 or i == total - 1:
                         on_progress(
                             "downloading",
-                            f"Extracting 101_ObjectCategories ({i + 1}/{total})...",
+                            "Extracting 101_ObjectCategories...",
                             i + 1,
                             total,
                         )

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -171,7 +171,7 @@ def download_bbc_news(  # noqa: C901
                         if i % 100 == 0 or i == total - 1:
                             on_progress(
                                 "downloading",
-                                f"Extracting BBC News dataset ({i + 1}/{total})...",
+                                "Extracting BBC News dataset...",
                                 i + 1,
                                 total,
                             )


### PR DESCRIPTION
## Why

The dataset-extraction progress bar was showing the count twice:

```
(9,123/9,248) Extracting 101_ObjectCategories (9123/9248)...
```

The frontend's `formatProgressMessage` (`frontend/src/app/utils/format-progress.ts:69`) already prepends `(current/total)` from the numeric `current`/`total` fields whenever both are set. The four archive-extract call sites were *also* embedding the same count inside the message string, producing the duplicate.

## Fix

Drop the redundant `({i+1}/{total})` from the message in:

- `vtscore/datasets/downloader/core.py:316` (generic zip extract)
- `vtscore/datasets/downloader/images.py:102` (Caltech-101 zip)
- `vtscore/datasets/downloader/images.py:121` (101_ObjectCategories tarball)
- `vtscore/datasets/downloader/text.py:174` (BBC News zip)

The numeric `current` / `total` arguments are unchanged, so the progress bar still gets exact counts — only the prose duplicate goes away. Other `Extracting <varname>...` messages (HMDB51/KTH category names, http_archive member names) were already free of redundant counts.

After:

```
(9,123/9,248) Extracting 101_ObjectCategories...
```


---
_Generated by [Claude Code](https://claude.ai/code/session_0192Ynv8ifpDeBxQZJ2eCnd3)_