### PR TITLE
Pin progress-bar ETA to the right of the bar

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -107,6 +107,9 @@
                           [max]="task.total"
                           [indeterminate]="taskIsIndeterminate(task)"
                         />
+                        @if (info.eta) {
+                          <span class="progress-eta">{{ info.eta }}</span>
+                        }
                         <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
                       </div>
                     </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -197,6 +197,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .progress-eta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
 }
 
 .dashboard-progress {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -50,6 +50,9 @@
           [max]="loadingTask.total"
           [indeterminate]="taskIsIndeterminate"
         />
+        @if (taskProgressInfo.eta) {
+          <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
+        }
         <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel this dataset load">Cancel</button>
       </div>
     </div>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -293,6 +293,13 @@ td.select-col {
     flex: 1;
   }
 
+  .progress-eta {
+    font-size: var(--font-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
   .btn--cancel {
     flex-shrink: 0;
     cursor: pointer;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -151,7 +151,7 @@ export class DatasetCardComponent implements OnChanges {
 
   get taskProgressInfo(): ProgressHeader {
     const task = this.loadingTask;
-    if (!task) return { header: '', subtitle: '', detail: '' };
+    if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
     return formatProgressHeader(task, 'dataset', task.embedder);
   }
 

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -49,6 +49,9 @@
           [max]="loadingTask.total"
           [indeterminate]="taskIsIndeterminate()"
         />
+        @if (taskProgressInfo.eta) {
+          <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
+        }
         <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel loading">Cancel</button>
       </div>
     </div>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -193,6 +193,13 @@ td.actions-col {
     flex: 1;
   }
 
+  .progress-eta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
   .btn--cancel {
     flex-shrink: 0;
     cursor: pointer;

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -185,7 +185,7 @@ export class DetectorCardComponent implements OnChanges {
 
   get taskProgressInfo(): ProgressHeader {
     const task = this.loadingTask;
-    if (!task) return { header: '', subtitle: '', detail: '' };
+    if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
     return formatProgressHeader(task, 'detector', task.embedder);
   }
 }

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -55,7 +55,9 @@ export function formatEta(seconds: number | null | undefined): string {
 export function formatProgressMessage(
   progress: ProgressEvent | null | undefined,
   defaultMessage = '',
+  options: { includeEta?: boolean } = {},
 ): string {
+  const { includeEta = true } = options;
   const prog = progress ?? {};
   let msg = prog.message || defaultMessage;
   const step = prog.step;
@@ -74,9 +76,11 @@ export function formatProgressMessage(
       msg = msg ? `${fraction} ${msg}` : fraction;
     }
   }
-  const eta = formatEta(prog.eta_seconds);
-  if (eta) {
-    msg = msg ? `${msg} · ${eta}` : eta;
+  if (includeEta) {
+    const eta = formatEta(prog.eta_seconds);
+    if (eta) {
+      msg = msg ? `${msg} · ${eta}` : eta;
+    }
   }
   return msg;
 }
@@ -101,11 +105,16 @@ export function isProgressIndeterminate(
  *   - ``subtitle``: a plain-English one-liner explaining what the phase actually does.
  *   - ``detail``: the original message + ``(current/total)`` counts, with the
  *     redundant ``[Step S/T]`` prefix stripped (the header conveys the phase).
+ *     The ETA tail is omitted here — it is returned separately as ``eta`` so the
+ *     UI can pin it to the right of the progress bar where it stays visible
+ *     even when a long file path ellipsizes the detail.
+ *   - ``eta``: the bare ``~Xs left`` chip, or empty when no estimate is available.
  */
 export interface ProgressHeader {
   header: string;
   subtitle: string;
   detail: string;
+  eta: string;
 }
 
 /** Which load flow this progress event belongs to. */
@@ -223,6 +232,7 @@ export function formatProgressHeader(
   }
 
   const header = phase ? `${what} · ${phase}` : what;
-  const detail = stripStepPrefix(formatProgressMessage(progress));
-  return { header, subtitle, detail };
+  const detail = stripStepPrefix(formatProgressMessage(progress, '', { includeEta: false }));
+  const eta = formatEta(prog.eta_seconds);
+  return { header, subtitle, detail, eta };
 }


### PR DESCRIPTION
## Summary

Previously the ETA chip (e.g. `~2m 19s left`) lived at the tail of the combined status message — `"Embedding bonsai/image_0015.jpg · ~2m 19s left"` — so when a long file path tripped the 240px ellipsis on `.progress-msg` the ETA was the first thing to disappear. The most informative piece for "is this almost done?" was getting clipped on every long path.

This change splits `eta` out of `formatProgressMessage` into its own `ProgressHeader` field and renders it as a `<span class="progress-eta">` after `<vt-progress-bar>` in the three progress-row sites:

- dashboard loading-task row (orphan tasks, before the dataset row appears)
- `vt-dataset-card` inline loading progress
- `vt-detector-card` inline loading progress

Status text still ellipsizes on the left, the bar still grows to fill the middle, and the ETA stays pinned on the right.

## Layout

Before:
```
[Embedding bonsai/image_0015.jpg · ~2m 19s left…] [████████░░░░░░░░] [Cancel]
                                  ^^^^^^^^^^^^ clipped by ellipsis
```

After:
```
[Embedding bonsai/image_0015.jpg] [████████░░░░░░░░] [~2m 19s left] [Cancel]
```

## Test plan

- [x] `./run-tests.sh` — 4196 passed, 1 skipped, 0 failures
- [x] `npm run build:prod` — clean, no errors or warnings
- [ ] Visual check: long file path no longer hides the ETA chip


---
_Generated by [Claude Code](https://claude.ai/code/session_01VK4J3UNvVTjHVij4gK3e85)_