### PR TITLE
Route transformers library logs through root handler

### DIFF
--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -11,6 +11,7 @@ from vtsearch.logging_config import (
     ContextFilter,
     JsonFormatter,
     TextFormatter,
+    install_transformers_logging_bridge,
     new_request_id,
     setup_logging,
 )
@@ -395,6 +396,47 @@ class TestTransformersVocabTokenFilter:
             )
             assert "bos_token_id" in stream.getvalue()
         finally:
+            setup_logging()
+
+
+class TestTransformersLoggingBridge:
+    """The bridge disables transformers' default handler and re-enables
+    propagation so its records flow through our root handler (and our
+    vocab-token filter)."""
+
+    def test_bridge_disables_default_handler_and_enables_propagation(self):
+        import transformers.utils.logging as hf_logging
+
+        hf_logging._reset_library_root_logger()
+        hf_logging._configure_library_root_logger()
+        hf_root = hf_logging._get_library_root_logger()
+        try:
+            assert hf_root.propagate is False
+            assert any(isinstance(h, logging.StreamHandler) for h in hf_root.handlers)
+
+            install_transformers_logging_bridge()
+
+            assert hf_root.propagate is True
+            assert hf_root.handlers == []
+        finally:
+            hf_logging._reset_library_root_logger()
+            hf_logging._configure_library_root_logger()
+
+    def test_bridge_lets_vocab_token_warning_be_filtered(self):
+        import transformers.utils.logging as hf_logging
+
+        stream = io.StringIO()
+        try:
+            setup_logging(level="DEBUG", fmt="text", stream=stream)
+            install_transformers_logging_bridge()
+            logging.getLogger("transformers.configuration_utils").warning(
+                "Model config: bos_token_id must be `None` or an integer within "
+                "the vocabulary (between 0 and 31999), got 49406."
+            )
+            assert stream.getvalue() == ""
+        finally:
+            hf_logging._reset_library_root_logger()
+            hf_logging._configure_library_root_logger()
             setup_logging()
 
 

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -94,6 +94,12 @@ def initialize_models() -> None:
     """
     MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     ensure_torch_configured()
+    try:
+        from vtsearch.logging_config import install_transformers_logging_bridge  # noqa: PLC0415
+
+        install_transformers_logging_bridge()
+    except Exception:
+        pass
     gc.collect()
 
 

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -291,6 +291,36 @@ def setup_logging(
     logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
 
 
+
+def install_transformers_logging_bridge() -> None:
+    """Route the ``transformers`` library's logs through our root handler.
+
+    transformers configures its own stderr handler with a ``[transformers]``
+    prefix formatter and sets ``propagate=False`` on its library root logger,
+    so records from ``transformers.*`` never reach the handler installed by
+    :func:`setup_logging`. That makes our context tags and our
+    :class:`_TransformersVocabTokenFilter` ineffective for transformers' own
+    output. This bridge disables their default handler and re-enables
+    propagation so transformers records flow through our formatter and
+    filters like every other library's.
+
+    Deferred from ``setup_logging`` because importing ``transformers.utils.logging``
+    pulls in the full ``transformers`` package (~0.7s), which we don't want
+    to pay for in unit tests that stub embedders. Call once during app
+    startup before any model load — :func:`vtscore.embedding.loader.initialize_models`
+    is the canonical site.
+    """
+    try:
+        import transformers.utils.logging as hf_logging  # noqa: PLC0415
+    except Exception:
+        return
+    try:
+        hf_logging.disable_default_handler()
+        hf_logging.enable_propagation()
+    except Exception:
+        pass
+
+
 def new_request_id() -> str:
     """Generate a short request id (12 hex chars from a uuid4)."""
     return uuid.uuid4().hex[:12]

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -291,7 +291,6 @@ def setup_logging(
     logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
 
 
-
 def install_transformers_logging_bridge() -> None:
     """Route the ``transformers`` library's logs through our root handler.
 


### PR DESCRIPTION
## Summary
Add `install_transformers_logging_bridge()` to route the `transformers` library's logs through our root handler, enabling our context tags and vocab-token filter to apply to transformers' own output.

## Changes
- **New function `install_transformers_logging_bridge()`** in `vtsearch/logging_config.py`:
  - Disables transformers' default stderr handler
  - Re-enables log propagation so records flow through our root handler
  - Wrapped in exception handling to gracefully degrade if transformers is unavailable
  - Deferred from `setup_logging()` to avoid importing the full transformers package (~0.7s) in unit tests that stub embedders

- **Call site in `vtscore/embedding/loader.initialize_models()`**:
  - Invokes the bridge during app startup, before any model load
  - Wrapped in exception handling to prevent startup failures if the bridge fails

- **Test coverage** in `tests/core/test_structured_logging.py`:
  - `TestTransformersLoggingBridge` class with two tests:
    - Verifies the bridge disables the default handler and enables propagation
    - Confirms vocab-token warnings are filtered when the bridge is active

## Implementation Details
The transformers library configures its own stderr handler with a `[transformers]` prefix formatter and sets `propagate=False` on its library root logger, preventing records from reaching our handler. This bridge leverages transformers' own `disable_default_handler()` and `enable_propagation()` utilities to integrate its logs into our logging pipeline, making our filters and formatters effective for transformers' output.

https://claude.ai/code/session_01QLaMWVGV2AnNR5axHQ8yJP