### PR TITLE
Fix tall thumbnails breaking grid squares in label list

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -98,6 +98,8 @@ h3 {
     width: 100%;
     height: auto;
     aspect-ratio: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
## Summary

In the Goods/Bads label list grid view, tall images (e.g. a flamingo portrait) rendered much taller than their square grid cell, breaking row alignment.

The `.vote-thumbnail-wrap` is a flex item inside `.vote-entry-grid` (a column flex container). In grid mode it sets `width: 100%; height: auto; aspect-ratio: 1` to render a square. But as a flex item it has the default `min-height: auto`, which for items containing a replaced element like `<img>` resolves to the image's intrinsic content size — so a tall image pushed the wrapper taller than the square, overriding the `aspect-ratio` constraint.

Fix: set `min-height: 0` (and `overflow: hidden` as belt-and-braces) on the grid-mode wrapper so `aspect-ratio: 1` actually wins.

## Test plan
- [ ] Open the right panel, switch the Goods/Bads list into grid view
- [ ] Confirm tall portraits (e.g. flamingo) now fit inside the square cell, letterboxed by `object-fit: contain`, with no row-height blowout
- [ ] Confirm wide / square thumbnails are unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_017P729QKW59zv9XykFScpmE)_