### PR TITLE
Trim Stable/Smart/Diverse indicator tooltips

### DIFF
--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -65,20 +65,17 @@ export class ProgressIndicatorsComponent {
 
   get smartTooltip(): string {
     const meaning = 'Smart: the model fits your votes consistently.';
-    const legend = 'Green when error cost has leveled off, yellow when still improving, red when more votes are needed.';
-    return this.smartSubtext ? `${meaning} ${this.smartSubtext}. ${legend}` : `${meaning} ${legend}`;
+    return this.smartSubtext ? `${meaning} ${this.smartSubtext}.` : meaning;
   }
 
   get stableTooltip(): string {
     const meaning = 'Stable: predictions stopped shifting between retrains.';
-    const legend = 'Green when predictions have settled, yellow when still shifting, red when more votes are needed.';
-    return this.stableSubtext ? `${meaning} ${this.stableSubtext}. ${legend}` : `${meaning} ${legend}`;
+    return this.stableSubtext ? `${meaning} ${this.stableSubtext}.` : meaning;
   }
 
   get spanTooltip(): string {
     const meaning = 'Diverse: your votes cover the dataset broadly.';
-    const legend = 'Green when you have sampled from all major clusters, yellow when some regions remain unexplored, red when coverage data is unavailable.';
-    return this.spanSubtext ? `${meaning} Level ${this.spanSubtext}. ${legend}` : `${meaning} ${legend}`;
+    return this.spanSubtext ? `${meaning} Level ${this.spanSubtext}.` : meaning;
   }
 
   onClick(name: string): void {


### PR DESCRIPTION
## Summary
- Drop the color-code legend ("Green when…, yellow when…, red when…") from the Smart, Stable, and Diverse labeling-indicator tooltips
- Hover text now just describes the metric (plus the live subtext when available — Cost / Flips / Level)

The legends were too long for a hover affordance and pushed real content off-screen.

## Test plan
- [ ] Hover each labeling indicator (Smart, Stable, Diverse) and confirm the tooltip is short and only describes the metric
- [ ] Existing spec assertions still pass (they only check the meaning + subtext, not the dropped legend)

https://claude.ai/code/session_01UkXt5cZZnpwbuvnBLs8QVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkXt5cZZnpwbuvnBLs8QVf)_