### PR TITLE
Tooltip on locked achievement tier explaining why

### DIFF
--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -20,7 +20,10 @@
         <div class="achievement-info">
           <div class="achievement-head">
             <span class="achievement-name">{{ row.name }}</span>
-            <span class="achievement-tier" [attr.data-tier-idx]="row.tier_idx">{{ row.tierName }}</span>
+            <span
+              class="achievement-tier"
+              [attr.data-tier-idx]="row.tier_idx"
+              [title]="row.lockReason || null">{{ row.tierName }}</span>
             @if (row.id === 'docs_read') {
               <button
                 type="button"

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -80,6 +80,7 @@
   &[data-tier-idx="1"] { color: #d9d9d9; }
   &[data-tier-idx="2"] { color: #f0c419; }
   &[data-tier-idx="3"] { color: #f5f6fa; }
+  &[data-tier-idx="-1"] { cursor: help; }
 }
 
 .achievement-desc {

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
 import { AchievementsService } from '../../services/achievements.service';
+import { SettingsStateService } from '../../services/settings-state.service';
 import type { AchievementEntry } from '../../generated/api-client/models/achievement-entry';
 import type { AchievementState } from '../../generated/api-client/models/achievement-state';
 import type { DocEntry } from '../../generated/api-client/models/doc-entry';
@@ -16,6 +17,7 @@ interface AchievementRow extends AchievementEntry {
   prevThreshold: number;
   progressPct: number;
   progressLabel: string;
+  lockReason: string;
 }
 
 @Component({
@@ -40,13 +42,23 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   submitting = false;
 
   private destroy$ = new Subject<void>();
+  private disableAchievements = false;
+  private lastState: AchievementState | null = null;
 
-  constructor(private achievements: AchievementsService) {}
+  constructor(
+    private achievements: AchievementsService,
+    private settingsState: SettingsStateService,
+  ) {}
 
   ngOnInit(): void {
-    this.achievements.state
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((state) => this.applyState(state));
+    this.achievements.state.pipe(takeUntil(this.destroy$)).subscribe((state) => {
+      this.lastState = state;
+      this.applyState(state);
+    });
+    this.settingsState.settings$.pipe(takeUntil(this.destroy$)).subscribe((s) => {
+      this.disableAchievements = !!s?.disable_achievements;
+      if (this.lastState) this.applyState(this.lastState);
+    });
     this.achievements.refresh();
   }
 
@@ -119,6 +131,22 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
       prevThreshold,
       progressPct,
       progressLabel,
+      lockReason: a.tier_idx === -1 ? this.lockReason(a) : '',
     };
+  }
+
+  private lockReason(a: AchievementEntry): string {
+    if (this.disableAchievements) {
+      return 'Achievements are disabled in Settings — counters are frozen at zero.';
+    }
+    const firstTier = a.tiers[0];
+    const base = `${a.counter.toLocaleString()} so far — reach ${firstTier.toLocaleString()} to unlock Bronze.`;
+    if (a.id === 'datasets_loaded' && a.counter === 0) {
+      return `${base} Demo and synthetic dataset loads don't count.`;
+    }
+    if (a.id === 'docs_read') {
+      return `${base} Find the code phrase at the bottom of a doc page and paste it in below.`;
+    }
+    return base;
   }
 }


### PR DESCRIPTION
## Summary
- Hovering the "Locked" tier badge in the achievements tab now shows a tooltip with the specific reason it's locked.
- Picks the message based on context: `disable_achievements` toggle is on (counters frozen at zero), demo/synthetic loads don't count toward "Datasets Loaded", docs reader needs a code phrase, or just the current counter vs Bronze threshold.
- `cursor: help` on the locked badge so it's discoverable.

## Test plan
- [ ] Open the achievements modal with a fresh user and hover "Locked" on each row — tooltip explains the gap to Bronze.
- [ ] Enable "Disable achievements" in Settings, reopen the tab, hover "Locked" — tooltip says counters are frozen.
- [ ] Hover an unlocked tier (Bronze/Silver/etc) — no tooltip.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGsw8sm9R4aqKRXYxXH8qR)_