### PR TITLE
Hide "Include media" inside Advanced in every DatasetImporter

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -310,25 +310,22 @@
         <p class="info-text">This importer requires no additional configuration.</p>
       }
 
-      @if (selectedImporter.multi_media) {
-        <div class="form-group">
-          <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
-          <vt-source-specs-picker
-            [availableConverters]="formAvailableConverters"
-            [nativeType]="formOutputTypeId"
-            [typeLabels]="mediaTypeLabels"
-            [specs]="formSourceSpecs"
-            (specsChange)="onFormSpecsChange($event)"
-          ></vt-source-specs-picker>
-        </div>
-      }
-
-      @if (availableEmbedders.length > 1 || availableClippers.length > 1) {
+      @if (selectedImporter.multi_media || availableEmbedders.length > 1 || availableClippers.length > 1) {
         <div class="form-group form-group--section">
           @if (showAdvancedToggle('form')) {
-            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
+            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: included media types, embedding model, and pre-processing clipper">
               Advanced {{ advancedOpen ? '▴' : '▾' }}
             </button>
+          }
+          @if (advancedOpen && selectedImporter.multi_media) {
+            <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+            <vt-source-specs-picker
+              [availableConverters]="formAvailableConverters"
+              [nativeType]="formOutputTypeId"
+              [typeLabels]="mediaTypeLabels"
+              [specs]="formSourceSpecs"
+              (specsChange)="onFormSpecsChange($event)"
+            ></vt-source-specs-picker>
           }
           @if (availableEmbedders.length > 1 && showEmbedderPicker('form')) {
             <label class="form-label" for="field-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
@@ -421,17 +418,6 @@
         }
       </div>
 
-      <div class="form-group">
-        <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
-        <vt-source-specs-picker
-          [availableConverters]="lfAvailableConverters"
-          [nativeType]="lfOutputTypeId"
-          [typeLabels]="mediaTypeLabels"
-          [specs]="lfSourceSpecs"
-          (specsChange)="onLfSpecsChange($event)"
-        ></vt-source-specs-picker>
-      </div>
-
       <div class="form-group form-group--section">
         @if (lfPickerKind === 'folder') {
           <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
@@ -496,47 +482,55 @@
         </div>
       }
 
-      @if (lfEmbedders.length > 1 || lfClippers.length > 1) {
-        <div class="form-group form-group--section">
-          @if (showAdvancedToggle('lf')) {
-            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
-              Advanced {{ advancedOpen ? '▴' : '▾' }}
-            </button>
-          }
-          @if (lfEmbedders.length > 1 && showEmbedderPicker('lf')) {
-            <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
-            <select
-              id="lf-embedder"
-              class="form-select"
-              [(ngModel)]="lfSelectedEmbedder"
-            >
-              @if (recommendedEmbedders(lfEmbedders).length > 0) {
-                <optgroup label="Recommended">
-                  @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
-                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                  }
-                </optgroup>
-              }
-              @if (advancedEmbedders(lfEmbedders).length > 0) {
-                <optgroup label="Advanced ▾">
-                  @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
-                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                  }
-                </optgroup>
-              }
-            </select>
-            @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
-              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+      <div class="form-group form-group--section">
+        @if (showAdvancedToggle('lf')) {
+          <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: included media types, embedding model, and pre-processing clipper">
+            Advanced {{ advancedOpen ? '▴' : '▾' }}
+          </button>
+        }
+        @if (advancedOpen) {
+          <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+          <vt-source-specs-picker
+            [availableConverters]="lfAvailableConverters"
+            [nativeType]="lfOutputTypeId"
+            [typeLabels]="mediaTypeLabels"
+            [specs]="lfSourceSpecs"
+            (specsChange)="onLfSpecsChange($event)"
+          ></vt-source-specs-picker>
+        }
+        @if (lfEmbedders.length > 1 && showEmbedderPicker('lf')) {
+          <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
+          <select
+            id="lf-embedder"
+            class="form-select"
+            [(ngModel)]="lfSelectedEmbedder"
+          >
+            @if (recommendedEmbedders(lfEmbedders).length > 0) {
+              <optgroup label="Recommended">
+                @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                }
+              </optgroup>
             }
+            @if (advancedEmbedders(lfEmbedders).length > 0) {
+              <optgroup label="Advanced ▾">
+                @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                }
+              </optgroup>
+            }
+          </select>
+          @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
+            <div class="license-warning" role="note">⚠ {{ notice }}</div>
           }
-          @if (lfClippers.length > 1 && showClipperPicker('lf')) {
-            <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-            <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
-              Use MediaClipper: {{ clipperDisplayName('lf') }}
-            </button>
-          }
-        </div>
-      }
+        }
+        @if (lfClippers.length > 1 && showClipperPicker('lf')) {
+          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
+            Use MediaClipper: {{ clipperDisplayName('lf') }}
+          </button>
+        }
+      </div>
 
       @if (lfError) {
         <p class="error-text">{{ lfError }}</p>
@@ -588,17 +582,6 @@
         }
       </div>
 
-      <div class="form-group">
-        <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
-        <vt-source-specs-picker
-          [availableConverters]="sfAvailableConverters"
-          [nativeType]="sfOutputTypeId"
-          [typeLabels]="mediaTypeLabels"
-          [specs]="sfSourceSpecs"
-          (specsChange)="onSfSpecsChange($event)"
-        ></vt-source-specs-picker>
-      </div>
-
       <div class="sf-browse-section">
         <label class="form-label" for="sf-path-input">Folder to import</label>
         <input
@@ -624,47 +607,55 @@
         </label>
       </div>
 
-      @if (sfEmbedders.length > 1 || sfClippers.length > 1) {
-        <div class="form-group form-group--section">
-          @if (showAdvancedToggle('sf')) {
-            <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: embedding model and pre-processing clipper">
-              Advanced {{ advancedOpen ? '▴' : '▾' }}
-            </button>
-          }
-          @if (sfEmbedders.length > 1 && showEmbedderPicker('sf')) {
-            <label class="form-label" for="sf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
-            <select
-              id="sf-embedder"
-              class="form-select"
-              [(ngModel)]="sfSelectedEmbedder"
-            >
-              @if (recommendedEmbedders(sfEmbedders).length > 0) {
-                <optgroup label="Recommended">
-                  @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
-                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                  }
-                </optgroup>
-              }
-              @if (advancedEmbedders(sfEmbedders).length > 0) {
-                <optgroup label="Advanced ▾">
-                  @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
-                    <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
-                  }
-                </optgroup>
-              }
-            </select>
-            @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
-              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+      <div class="form-group form-group--section">
+        @if (showAdvancedToggle('sf')) {
+          <button type="button" class="advanced-toggle" (click)="toggleAdvanced()" [attr.aria-expanded]="advancedOpen" title="Show advanced options: included media types, embedding model, and pre-processing clipper">
+            Advanced {{ advancedOpen ? '▴' : '▾' }}
+          </button>
+        }
+        @if (advancedOpen) {
+          <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
+          <vt-source-specs-picker
+            [availableConverters]="sfAvailableConverters"
+            [nativeType]="sfOutputTypeId"
+            [typeLabels]="mediaTypeLabels"
+            [specs]="sfSourceSpecs"
+            (specsChange)="onSfSpecsChange($event)"
+          ></vt-source-specs-picker>
+        }
+        @if (sfEmbedders.length > 1 && showEmbedderPicker('sf')) {
+          <label class="form-label" for="sf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
+          <select
+            id="sf-embedder"
+            class="form-select"
+            [(ngModel)]="sfSelectedEmbedder"
+          >
+            @if (recommendedEmbedders(sfEmbedders).length > 0) {
+              <optgroup label="Recommended">
+                @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                }
+              </optgroup>
             }
+            @if (advancedEmbedders(sfEmbedders).length > 0) {
+              <optgroup label="Advanced ▾">
+                @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+                }
+              </optgroup>
+            }
+          </select>
+          @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
+            <div class="license-warning" role="note">⚠ {{ notice }}</div>
           }
-          @if (sfClippers.length > 1 && showClipperPicker('sf')) {
-            <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-            <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
-              Use MediaClipper: {{ clipperDisplayName('sf') }}
-            </button>
-          }
-        </div>
-      }
+        }
+        @if (sfClippers.length > 1 && showClipperPicker('sf')) {
+          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
+            Use MediaClipper: {{ clipperDisplayName('sf') }}
+          </button>
+        }
+      </div>
 
       @if (sfBrowseError) {
         <p class="error-text">{{ sfBrowseError }}</p>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1657,11 +1657,24 @@ export class DatasetImporterModalComponent implements OnInit {
     return this.advancedOpen || !this.isDefaultEmbedderSelected(context);
   }
 
+  /** Whether the given context's Advanced section also contains an
+   *  "Include media" block. The lf/sf views always have one; the generic
+   *  form has one when the importer is ``multi_media``. The demo picker
+   *  never has one. */
+  private contextHasIncludeMedia(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    if (context === 'form') return !!this.selectedImporter?.multi_media;
+    return context === 'lf' || context === 'sf';
+  }
+
   /** Whether the "Advanced ▾" toggle button should be rendered in the
-   *  given context. Only meaningful when both selections are at defaults;
-   *  otherwise the pickers are already visible and the button would be
+   *  given context. The Include media block lives inside Advanced, so
+   *  whenever the context has one the toggle must stay visible — it's the
+   *  only way to reach Include media. Otherwise we only show the toggle
+   *  when both embedder and clipper are at defaults; if either is
+   *  overridden the pickers are already visible and the button would be
    *  redundant. */
   showAdvancedToggle(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    if (this.contextHasIncludeMedia(context)) return true;
     return this.isDefaultEmbedderSelected(context) && this.isDefaultClipperSelected(context);
   }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
@@ -27,23 +27,23 @@
         <span class="ssp-row-label">{{ labelFor(st) }}</span>
       </label>
 
-      @if (hasAdvanced(st)) {
+      @if (hasDetails(st)) {
         <button
           type="button"
-          class="advanced-toggle ssp-advanced-toggle"
-          (click)="toggleAdvanced(st)"
-          [attr.aria-expanded]="isAdvancedOpen(st)"
+          class="advanced-toggle ssp-details-toggle"
+          (click)="toggleDetails(st)"
+          [attr.aria-expanded]="isDetailsOpen(st)"
           [title]="convertersFor(st).length > 1 ? 'Choose a converter and tune its options.' : 'Tune converter options.'"
         >
-          Advanced {{ isAdvancedOpen(st) ? '▾' : '▸' }}
+          Details {{ isDetailsOpen(st) ? '▾' : '▸' }}
         </button>
       }
 
-      @if (isAdvancedOpen(st)) {
-        <div class="ssp-advanced-panel">
+      @if (isDetailsOpen(st)) {
+        <div class="ssp-details-panel">
           @if (convertersFor(st).length > 1) {
-            <label class="ssp-advanced-field">
-              <span class="ssp-advanced-field-label">Converter:</span>
+            <label class="ssp-details-field">
+              <span class="ssp-details-field-label">Converter:</span>
               <select
                 class="form-select ssp-converter-select"
                 [ngModel]="currentConverterName(st)"
@@ -58,8 +58,8 @@
 
           @if (currentConverter(st); as conv) {
             @for (f of conv.fields || []; track f.key) {
-              <label class="ssp-advanced-field">
-                <span class="ssp-advanced-field-label">{{ f.label || f.key }}:</span>
+              <label class="ssp-details-field">
+                <span class="ssp-details-field-label">{{ f.label || f.key }}:</span>
                 @if (f.field_type === 'select') {
                   <select
                     class="form-select"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -53,13 +53,13 @@
   line-height: 1.3;
 }
 
-.ssp-advanced-toggle {
+.ssp-details-toggle {
   justify-self: end;
   white-space: nowrap;
   grid-column: 2;
 }
 
-.ssp-advanced-panel {
+.ssp-details-panel {
   grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
@@ -70,14 +70,14 @@
   margin-bottom: 2px;
 }
 
-.ssp-advanced-field {
+.ssp-details-field {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: .85rem;
 }
 
-.ssp-advanced-field-label {
+.ssp-details-field-label {
   color: var(--text-muted, #555);
 }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -7,9 +7,11 @@ import { ConverterInfo, SourceSpec } from '../../../../models/api.models';
 /** Checkbox column for choosing which source media types feed a
  *  multi-media import.  The native type sits at the top (always
  *  included by default, no converter); each other source type with at
- *  least one converter to the native type appears as a checkbox with an
- *  "Advanced ▸" opener for picking among converters (when there are
- *  multiple) and editing their params. */
+ *  least one converter to the native type appears as a checkbox with a
+ *  "Details ▸" opener for picking among converters (when there are
+ *  multiple) and editing their params.  The picker itself lives inside
+ *  the outer importer's "Advanced" section, so a nested "Advanced"
+ *  label here would read as "Advanced inside Advanced". */
 @Component({
   selector: 'vt-source-specs-picker',
   standalone: true,
@@ -33,15 +35,15 @@ export class SourceSpecsPickerComponent implements OnChanges {
   @Output() specsChange = new EventEmitter<SourceSpec[]>();
 
   /** Per-source-type draft so the user can configure a converter via
-   *  the Advanced panel *before* checking the box.  Edits made while
+   *  the Details panel *before* checking the box.  Edits made while
    *  unchecked are preserved here and applied on check. */
   private drafts = new Map<string, SourceSpec>();
-  private advancedOpenSet = new Set<string>();
+  private detailsOpenSet = new Set<string>();
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['nativeType'] && !changes['nativeType'].firstChange) {
       this.drafts.clear();
-      this.advancedOpenSet.clear();
+      this.detailsOpenSet.clear();
     }
     for (const s of this.specs) {
       if (s.converter !== null) this.drafts.set(s.source_type, s);
@@ -72,22 +74,22 @@ export class SourceSpecsPickerComponent implements OnChanges {
     return this.availableConverters.filter((c) => c.source_type === sourceType);
   }
 
-  /** True iff the Advanced opener should be rendered for *sourceType*:
+  /** True iff the Details opener should be rendered for *sourceType*:
    *  either multiple converters to pick between, or at least one
    *  user-editable field on the (single) converter. */
-  hasAdvanced(sourceType: string): boolean {
+  hasDetails(sourceType: string): boolean {
     const cs = this.convertersFor(sourceType);
     if (cs.length > 1) return true;
     return !!(cs[0]?.fields?.length);
   }
 
-  isAdvancedOpen(sourceType: string): boolean {
-    return this.advancedOpenSet.has(sourceType);
+  isDetailsOpen(sourceType: string): boolean {
+    return this.detailsOpenSet.has(sourceType);
   }
 
-  toggleAdvanced(sourceType: string): void {
-    if (this.advancedOpenSet.has(sourceType)) this.advancedOpenSet.delete(sourceType);
-    else this.advancedOpenSet.add(sourceType);
+  toggleDetails(sourceType: string): void {
+    if (this.detailsOpenSet.has(sourceType)) this.detailsOpenSet.delete(sourceType);
+    else this.detailsOpenSet.add(sourceType);
   }
 
   currentConverterName(sourceType: string): string {


### PR DESCRIPTION
## Summary

- In every DatasetImporter (generic form, local folder/files, server folder), the "Include media" column now lives inside the existing **Advanced** section alongside the embedder/clipper pickers — so the main form shows only the required questions by default.
- The Advanced toggle now always renders for `multi_media` importers (and for the lf/sf flows, which always have an Include media block), so the user can still reach it even when the embedder/clipper are at their defaults.
- The per-converter opener inside `source-specs-picker` is renamed from **Advanced** to **Details**, since "Advanced inside Advanced" was confusing once Include media became part of the outer Advanced section. Internal names (`detailsOpenSet`, `isDetailsOpen`, `toggleDetails`, `hasDetails`, `.ssp-details-*` classes) were renamed to match.

## Test plan

- [x] `npm run build:prod` — clean, no warnings
- [x] `./run-tests.sh core` — 589 passed (includes the frontend build check)
- [ ] Manual: open the dataset importer modal in each tab and confirm:
  - Required questions are visible by default; clicking **Advanced** reveals Include media + Embedder + Clipper.
  - For a multi-media importer, the per-source-type opener inside the picker reads **Details ▸** instead of Advanced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PS2DW2cN76Txet3Df5Mh4y)_