### PR TITLE
Trim redundant text in dataset importer modal

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -103,9 +103,6 @@
                   </optgroup>
                 }
               </select>
-              @if (selectedEmbedderRawId(selectedDemoEmbedder, demoEmbedders); as rawId) {
-                <small class="embedder-raw-id">{{ rawId }}</small>
-              }
               @if (licenseNoticeFor(selectedDemoEmbedder, demoEmbedders); as notice) {
                 <div class="license-warning" role="note">⚠ {{ notice }}</div>
               }
@@ -355,9 +352,6 @@
                 </optgroup>
               }
             </select>
-            @if (selectedEmbedderRawId(selectedEmbedder, availableEmbedders); as rawId) {
-              <small class="embedder-raw-id">{{ rawId }}</small>
-            }
             @if (licenseNoticeFor(selectedEmbedder, availableEmbedders); as notice) {
               <div class="license-warning" role="note">⚠ {{ notice }}</div>
             }
@@ -393,9 +387,9 @@
   @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
     <div class="local-folder-uploader">
       @if (lfPickerKind === 'folder') {
-        <p class="info-text">Pick a folder on <strong>this computer</strong> (the machine your browser is running on). Its contents will be uploaded to the server and embedded into a new dataset. If you have already embedded your media, you can <strong>optionally</strong> attach a <code>.npz</code> archive of pre-computed vectors below to skip re-embedding.</p>
+        <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
       } @else {
-        <p class="info-text">Pick one or more files on <strong>this computer</strong> (the machine your browser is running on). They will be uploaded to the server and embedded into a new dataset. If you have already embedded your media, you can <strong>optionally</strong> attach a <code>.npz</code> archive of pre-computed vectors below to skip re-embedding.</p>
+        <p class="info-text">Pick one or more files on <strong>this computer</strong> (running your browser).</p>
       }
 
       <div class="form-group">
@@ -531,9 +525,6 @@
                 </optgroup>
               }
             </select>
-            @if (selectedEmbedderRawId(lfSelectedEmbedder, lfEmbedders); as rawId) {
-              <small class="embedder-raw-id">{{ rawId }}</small>
-            }
             @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
               <div class="license-warning" role="note">⚠ {{ notice }}</div>
             }
@@ -619,9 +610,6 @@
           (keydown.enter)="sfApplyPathInput(); $event.preventDefault()"
           (blur)="sfApplyPathInput()"
         />
-        <p class="info-text">
-          Type or paste any folder path on the server. The path is verified when you submit.
-        </p>
       </div>
 
       <div class="form-group">
@@ -665,9 +653,6 @@
                 </optgroup>
               }
             </select>
-            @if (selectedEmbedderRawId(sfSelectedEmbedder, sfEmbedders); as rawId) {
-              <small class="embedder-raw-id">{{ rawId }}</small>
-            }
             @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
               <div class="license-warning" role="note">⚠ {{ notice }}</div>
             }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -113,15 +113,6 @@
   font-style: italic;
 }
 
-.embedder-raw-id {
-  display: block;
-  margin-top: 2px;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
-  font-size: .75rem;
-  color: var(--text-muted, #888);
-  line-height: 1.2;
-}
-
 .license-warning {
   margin-top: 6px;
   padding: 6px 10px;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -865,20 +865,6 @@ export class DatasetImporterModalComponent implements OnInit {
     return embedder.display_name || embedder.name;
   }
 
-  /**
-   * Raw registry ID for the currently-selected embedder, used as a secondary
-   * ``<small>`` line under the picker so power users can still see it. Returns
-   * an empty string when the display name equals the raw name (no need to
-   * repeat it) or when no embedder is selected.
-   */
-  selectedEmbedderRawId(name: string, list: EmbedderInfo[]): string {
-    if (!name) return '';
-    const found = list.find((e) => e.name === name);
-    if (!found) return '';
-    const label = found.display_name || found.name;
-    return label === found.name ? '' : found.name;
-  }
-
   selectDemo(demo: DemoDataset): void {
     const userName = (this.demoDatasetName || '').trim();
     this.demoSelected.emit({


### PR DESCRIPTION
## Summary
- Remove the "Type or paste any folder path on the server…" help text under the server-folder path input.
- Shorten the local-folder / local-files info paragraphs to a single line: "Pick a folder on **this computer** (running your browser)." (and the parallel files variant).
- Drop the raw-id `<small>` line that echoed the selected embedder's registry ID under every Advanced → Embedder pulldown (4 occurrences: demo, form, local_folder, server_folder views). Also removed the now-unused `selectedEmbedderRawId()` method and `.embedder-raw-id` SCSS rule.

## Test plan
- [x] `npm run build:prod` succeeds with no warnings
- [ ] Open each dataset importer (demo, server folder, local folder, local files, generic form-based) and confirm the deleted text is gone and the Embedder pulldown no longer has a duplicate name line under it

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFx9YsMJgeUu2c7nL49FqS)_