### PR TITLE
Fix invisible hover colors from fallbacks to undefined CSS vars

### DIFF
--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -5,7 +5,7 @@
   gap: 0.75rem;
   margin: 0 0 0.75rem;
   padding: 0.6rem 0.9rem;
-  background: var(--surface-alt, rgba(255, 255, 255, 0.04));
+  background: var(--bg-subtle);
   border-radius: 6px;
 }
 
@@ -42,7 +42,7 @@
   align-items: center;
   gap: 1rem;
   padding: 0.75rem;
-  background: var(--surface-alt, rgba(255, 255, 255, 0.04));
+  background: var(--bg-subtle);
   border-radius: 6px;
 }
 
@@ -73,7 +73,7 @@
   letter-spacing: 0.04em;
   padding: 0.05rem 0.4rem;
   border-radius: 3px;
-  background: var(--surface, rgba(255, 255, 255, 0.08));
+  background: var(--bg-hover);
   color: var(--text-muted, #888);
 
   &[data-tier-idx="0"] { color: #cd7f32; }
@@ -98,7 +98,7 @@
 .achievement-progress-track {
   flex: 1;
   height: 6px;
-  background: var(--surface, rgba(255, 255, 255, 0.08));
+  background: var(--bg-hover);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -121,20 +121,20 @@
   font-size: 0.75rem;
   padding: 0.1rem 0.5rem;
   border-radius: 3px;
-  background: var(--surface, rgba(255, 255, 255, 0.08));
+  background: var(--bg-hover);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
   color: inherit;
   cursor: pointer;
 
   &:hover {
-    background: var(--surface-hover, rgba(255, 255, 255, 0.12));
+    background: var(--bg-hover);
   }
 }
 
 .docs-panel {
   margin-top: 0.6rem;
   padding: 0.6rem 0.75rem;
-  background: var(--surface, rgba(255, 255, 255, 0.06));
+  background: var(--bg-subtle);
   border-radius: 4px;
 }
 
@@ -196,7 +196,7 @@
   padding: 0.25rem 0.5rem;
   border-radius: 3px;
   border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
-  background: var(--surface-alt, rgba(0, 0, 0, 0.2));
+  background: var(--bg-subtle);
   color: inherit;
 }
 

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -37,8 +37,8 @@
   padding: 6px 10px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg, transparent);
-  color: var(--text, inherit);
+  background: var(--bg-surface);
+  color: var(--text-primary);
   font-size: .95rem;
 
   &:focus {
@@ -101,7 +101,7 @@
     background: rgba(255, 180, 0, .12);
 
     .col-type {
-      color: var(--warn, #c47a00);
+      color: var(--text-warning);
       font-weight: 600;
     }
   }
@@ -118,13 +118,13 @@
   border-radius: 4px;
 
   &:hover {
-    color: var(--danger, #c43a3a);
+    color: var(--color-bad);
     background: var(--bg-subtle);
   }
 }
 
 .mismatch-warning {
-  color: var(--warn, #c47a00);
+  color: var(--text-warning);
   font-style: italic;
 }
 
@@ -136,13 +136,13 @@
 
 .warn-text {
   margin: 0;
-  color: var(--warn, #c47a00);
+  color: var(--text-warning);
   font-size: .85rem;
 }
 
 .error-text {
   margin: 0;
-  color: var(--danger, #c43a3a);
+  color: var(--color-bad);
   font-size: .85rem;
 }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -67,8 +67,8 @@
   color: var(--text-muted, #666);
   cursor: pointer;
 
-  &:hover { color: var(--text, #222); text-decoration: underline; }
-  &:focus-visible { outline: 2px solid var(--focus, #4a90e2); outline-offset: 2px; }
+  &:hover { color: var(--text-primary); text-decoration: underline; }
+  &:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 }
 
 .server-folder-browser { gap: 12px; }
@@ -94,7 +94,7 @@
   .sf-selected-value {
     font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
     word-break: break-all;
-    color: var(--text, #222);
+    color: var(--text-primary);
   }
 }
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -157,7 +157,7 @@
   object-fit: cover;
   border-radius: var(--radius-sm, 4px);
   flex-shrink: 0;
-  background: var(--bg, #fff);
+  background: var(--bg-subtle);
 }
 
 .example-label {


### PR DESCRIPTION
## Summary

Several SCSS files referenced CSS custom properties that don't exist in `_variables.scss` (`--text`, `--bg`, `--warn`, `--danger`, `--focus`, `--surface*`) and supplied **hard-coded** color fallbacks. The most visible symptom: the `Advanced` toggle in the dataset importer modal turned near-black on hover (`var(--text, #222)`) and vanished into the dark-mode body background.

Audited the whole tree and swapped each broken reference to a defined theme token, so the color now follows the active theme instead of falling back to a fixed value.

### Fixes by file

| File | Was | Now |
|---|---|---|
| `dataset-importer-modal.scss` | `var(--text, #222)` ×2, `var(--focus, #4a90e2)` | `var(--text-primary)`, `var(--accent)` |
| `combine-datasets-modal.scss` | `var(--text, inherit)`, `var(--bg, transparent)`, `var(--warn, #c47a00)` ×4, `var(--danger, #c43a3a)` ×2 | `var(--text-primary)`, `var(--bg-surface)`, `var(--text-warning)`, `var(--color-bad)` |
| `new-detector-modal.scss` | `var(--bg, #fff)` | `var(--bg-subtle)` |
| `achievements-tab.scss` | `var(--surface*, rgba(255,255,255,…))` ×8 | `var(--bg-subtle)` / `var(--bg-hover)` |

Other undefined-var refs in the codebase (`--bg-active`, `--bg-disabled`, `--bg-elevated`, `--bg-error-subtle`, `--bg-input`, `--accent-highlight-hover-bg`) already chain to a defined token via `var(…, var(…))` fallback, so they degrade correctly in both themes — left alone.

## Test plan

- [x] `npm run build:prod` succeeds with no warnings
- [ ] Hover "Advanced" in the dataset importer modal in dark, light, and highviz themes — text should remain readable
- [ ] Open Combine Datasets modal — name input, warn/danger badges, mismatch warning all render correctly in each theme
- [ ] Open New Detector modal — example thumbnails no longer render a white square in dark mode
- [ ] Open Achievements tab — tiles/rows/progress bars/docs panel render correctly in light mode (previously the rgba(255,255,255,…) fallbacks could blend into the light background)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KsE3ouU3piLSU9WhPHnGG1)_