### PR TITLE
Fix dashboard column divider growing by 2px on every click

### DIFF
--- a/frontend/src/app/utils/managed-columns.ts
+++ b/frontend/src/app/utils/managed-columns.ts
@@ -212,8 +212,14 @@ export class ManagedColumns<TCol extends string = string> {
     const prevColWidth = ths[colIndex].style.width;
     ths[colIndex].style.width = '0px';
 
+    // `tbody > *` rather than `tbody tr`: dashboard rows are Angular custom
+    // elements (`<vt-dataset-card>`, `<vt-detector-card>`) with `:host {
+    // display: table-row }`, so they participate in table layout but don't
+    // match the `tr` selector. Querying for `tr` returned zero rows, so this
+    // method fell through to the `maxPx = ths[colIndex].offsetWidth` fallback
+    // and the `+ 2` below grew the column by 2px on every click.
     let maxPx = 0;
-    const rows = tableEl.querySelectorAll('tbody tr');
+    const rows = tableEl.querySelectorAll('tbody > *');
     rows.forEach((row) => {
       const cell = row.children[colIndex] as HTMLElement | undefined;
       if (!cell || cell.hasAttribute('colspan')) return;


### PR DESCRIPTION
## Summary

Clicking the divider between two columns in the Dashboard's Datasets/Detectors tables was supposed to auto-fit the left column to its content width. Instead, it inched the column ~2px to the right on every click, eventually jamming the right column against its neighbor.

Root cause: `autoSizeColumn` in `frontend/src/app/utils/managed-columns.ts` measured content width via `tableEl.querySelectorAll('tbody tr')`, but the dashboard tables don't use `<tr>` for body rows — they use `<vt-dataset-card>` / `<vt-detector-card>` Angular custom elements with `:host { display: table-row }`. Those participate in table layout but don't match the `tr` selector, so the query returned zero rows. The method fell through to the `maxPx = ths[colIndex].offsetWidth` fallback, and the `Math.max(30, maxPx + 2)` padding fudge then grew the column by 2px on each click. (The same code works fine in the importer/new-detector picker tables because those use real `<tr>`s.)

Fix: query `tbody > *` instead. That matches any direct child of `<tbody>` regardless of tag, so card-style row components measure correctly. The existing `!cell || cell.hasAttribute('colspan')` skip already handles the loading-task rows, so no extra logic is needed.

## Test plan

- [x] `./run-tests.sh core` — all 589 tests pass, frontend TypeScript build succeeds
- [ ] Manual: load the Dashboard with at least one dataset and one detector; click (don't drag) the divider between two columns; verify the left column auto-fits to its content width instead of inching right
- [ ] Manual: drag the divider; verify dragging still works and the click-to-auto-fit threshold (>3px) still distinguishes drag from click

---
_Generated by [Claude Code](https://claude.ai/code/session_016XcvTqJgvHtW3i5SqQJLrd)_