### PR TITLE
Split Local Files into paths-file flow; drop pre-computed from Local Folder

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -6059,9 +6059,40 @@
         ]
       }
     },
+    "/api/dataset/import-local-files": {
+      "post": {
+        "description": "The browser picks a single file (a ``.txt`` / ``.list`` with one\nserver-side media path per line, or a ``.npz`` archive that also\nsupplies pre-computed embedding vectors) and POSTs it as the\nmultipart field ``paths_file``.  We stream it to a server-side\ntemporary directory and then delegate to the regular\n:mod:`server_files` importer for resolution and embedding.  The\ntemp directory is removed once the importer finishes (success or\nfailure).",
+        "operationId": "import_local_files",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetLoadStartedResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Multipart body is missing the ``paths_file`` field, is missing ``media_type``, or carries malformed ``clipper_params``."
+          },
+          "500": {
+            "description": "The server_files importer is unavailable."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Import a paths file uploaded from the user's *browser* machine.",
+        "tags": [
+          "datasets_load"
+        ]
+      }
+    },
     "/api/dataset/import-local-folder": {
       "post": {
-        "description": "The browser uses ``<input type=\"file\" webkitdirectory>`` to let the\nuser pick a directory; each selected ``File`` is appended to the\nmultipart body under the key ``\"files\"`` with its ``webkitRelativePath``\nas the multipart filename.  We stream each file to a temporary\ndirectory on the server (preserving sub-directory structure) and then\ndelegate to the regular folder importer to do the actual scanning,\nembedding, and dataset registration.  The temp directory is removed\nonce the importer finishes (success or failure).\n\nLocal-files uploads may additionally include a ``vectors_file`` form\nfield carrying a ``.npz`` archive of pre-computed embedding vectors\nkeyed by uploaded-file name (basename or relative path).  Files\nwhose name matches an NPZ key reuse the supplied vector instead of\nrunning the embedding model.",
+        "description": "The browser uses ``<input type=\"file\" webkitdirectory>`` to let the\nuser pick a directory; each selected ``File`` is appended to the\nmultipart body under the key ``\"files\"`` with its ``webkitRelativePath``\nas the multipart filename.  We stream each file to a temporary\ndirectory on the server (preserving sub-directory structure) and then\ndelegate to the regular folder importer to do the actual scanning,\nembedding, and dataset registration.  The temp directory is removed\nonce the importer finishes (success or failure).",
         "operationId": "import_local_folder",
         "responses": {
           "200": {
@@ -6075,7 +6106,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Multipart body is missing the ``files`` field, has no valid files, is missing ``media_type``, or carries malformed ``clipper_params`` / ``vectors_file``."
+            "description": "Multipart body is missing the ``files`` field, has no valid files, is missing ``media_type``, or carries malformed ``clipper_params``."
           },
           "500": {
             "description": "The server_folder importer is unavailable."

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -386,7 +386,11 @@
       @if (lfPickerKind === 'folder') {
         <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
       } @else {
-        <p class="info-text">Pick one or more files on <strong>this computer</strong> (running your browser).</p>
+        <p class="info-text">
+          Upload a single file from <strong>this computer</strong> that lists the media to import
+          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
+          paths + pre-computed embedding vectors).
+        </p>
       }
 
       <div class="form-group">
@@ -429,41 +433,22 @@
             (filesSelected)="lfOnFilesDropped($event)"
           ></vt-drop-zone>
         } @else {
-          <label class="form-label" title="Choose one or more files on your local machine. Each selected file will be uploaded.">Files<span class="required">*</span></label>
+          <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">Paths file<span class="required">*</span></label>
           <vt-drop-zone
-            label="Drop files here to import"
+            label="Drop a paths file (.txt, .list, or .npz)"
             sublabel="or click to browse"
-            [multiple]="true"
+            accept=".txt,.list,.npz"
             (filesSelected)="lfOnFilesDropped($event)"
           ></vt-drop-zone>
         }
         @if (lfFiles.length > 0) {
           <p class="info-text">
-            Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
-            @if (lfFolderName && lfPickerKind === 'folder') { from <code>{{ lfFolderName }}</code> }
-          </p>
-        }
-      </div>
-
-      <div class="form-group form-group--section">
-        <label
-          class="form-label"
-          for="lf-vectors-input"
-          title="Optional .npz archive of pre-computed embedding vectors. Each entry's filename must match an uploaded file (by basename or relative path) for its vector to be reused. Skipped files are embedded normally on the server."
-        >
-          Pre-computed embeddings (optional)
-        </label>
-        <input
-          id="lf-vectors-input"
-          type="file"
-          class="form-input"
-          accept=".npz"
-          (change)="lfOnVectorsFileSelected($event)"
-        />
-        @if (lfVectorsFile) {
-          <p class="info-text">
-            Using vectors from <code>{{ lfVectorsFile.name }}</code>
-            <button type="button" class="btn btn--secondary btn--sm" (click)="lfClearVectorsFile()">Remove</button>
+            @if (lfPickerKind === 'folder') {
+              Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
+              @if (lfFolderName) { from <code>{{ lfFolderName }}</code> }
+            } @else {
+              Using paths from <code>{{ lfFiles[0].name }}</code>
+            }
           </p>
         }
       </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -279,7 +279,7 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.expectOne(req => req.url === '/api/browse-media-files').flush({ directories: [], files: [], root_path: '' });
   });
 
-  it('should set activePickerView=local_files (multi-file picker) when the Local Files sub-tab is clicked', () => {
+  it('should set activePickerView=local_files (paths-file picker) when the Local Files sub-tab is clicked', () => {
     flushImporters();
     const localFiles = component.importers.find((i) => i.name === 'local_files')!;
     component.selectImporter(localFiles);
@@ -322,6 +322,33 @@ describe('DatasetImporterModalComponent', () => {
     const body = req.request.body as FormData;
     expect(body.get('media_type')).toBe('audio');
     expect(body.getAll('files').length).toBe(1);
+    req.flush({ ok: true });
+
+    expect(component.lfSubmitting).toBeFalse();
+    expect(component.importStarted.emit).toHaveBeenCalled();
+  });
+
+  it('should POST uploaded paths file via importLocalFiles', () => {
+    flushImporters();
+    spyOn(component.importStarted, 'emit');
+
+    const localFiles = component.importers.find((i) => i.name === 'local_files')!;
+    component.selectImporter(localFiles);
+    httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
+    httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
+
+    const pathsFile = new File(['/a.wav\n/b.wav\n'], 'list.txt');
+    component.lfFiles = [pathsFile];
+    component.lfMediaType = 'audio';
+    component.lfSubmit();
+
+    const req = httpMock.expectOne('/api/dataset/import-local-files');
+    expect(req.request.method).toBe('POST');
+    const body = req.request.body as FormData;
+    expect(body.get('media_type')).toBe('audio');
+    const uploaded = body.get('paths_file') as File;
+    expect(uploaded.name).toBe('list.txt');
+    expect(body.get('files')).toBeNull();
     req.flush({ ok: true });
 
     expect(component.lfSubmitting).toBeFalse();

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -118,10 +118,6 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Whether the user has manually edited :prop:`lfDatasetName` (so we stop
    *  auto-overwriting it from the picked folder name). */
   private lfDatasetNameDirty = false;
-  /** Optional .npz file of pre-computed embedding vectors (Local Folder /
-   *  Local Files).  When set, the upload endpoint reuses these vectors
-   *  instead of running the embedding model for matching uploaded files. */
-  lfVectorsFile: File | null = null;
 
   // Server folder picker state. The user types an absolute server path; we
   // split it into ``sfBrowseRootPath`` (always ``/`` here) and ``sfBrowsePath``
@@ -902,7 +898,6 @@ export class DatasetImporterModalComponent implements OnInit {
     this.lfPickerKind = resolved?.name === 'local_files' ? 'files' : 'folder';
     this.lfFiles = [];
     this.lfDetection = null;
-    this.lfVectorsFile = null;
     this.lfError = '';
     this.lfSubmitting = false;
     this.lfRecursive = this.readRecursiveDefault(resolved);
@@ -934,6 +929,17 @@ export class DatasetImporterModalComponent implements OnInit {
     if (files.length === 0) {
       this.lfFiles = [];
       this.lfDetection = null;
+      return;
+    }
+    // Local Files uploads a single paths file (not media), so type detection
+    // doesn't apply — the user picks the media type explicitly.
+    if (this.lfPickerKind === 'files') {
+      this.lfFiles = [files[0]];
+      this.lfDetection = null;
+      this.lfError = '';
+      if (!this.lfDatasetNameDirty) {
+        this.lfDatasetName = this.lfDerivedDatasetName();
+      }
       return;
     }
     this.lfFiles = files;
@@ -979,16 +985,6 @@ export class DatasetImporterModalComponent implements OnInit {
     if (sourceSpecs) {
       this.lfSourceSpecs = sourceSpecs;
     }
-  }
-
-  lfOnVectorsFileSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    this.lfVectorsFile = input.files && input.files.length > 0 ? input.files[0] : null;
-    this.lfError = '';
-  }
-
-  lfClearVectorsFile(): void {
-    this.lfVectorsFile = null;
   }
 
   /** Derive a default dataset name from the currently picked files / folder.
@@ -1071,16 +1067,26 @@ export class DatasetImporterModalComponent implements OnInit {
 
   lfSubmit(): void {
     if (this.lfFiles.length === 0) {
-      this.lfError = 'Please select a folder to upload.';
+      this.lfError = this.lfPickerKind === 'files'
+        ? 'Please select a paths file to upload.'
+        : 'Please select a folder to upload.';
       return;
     }
 
+    if (this.lfPickerKind === 'files') {
+      this.lfSubmitFiles();
+      return;
+    }
+    this.lfSubmitFolder();
+  }
+
+  private lfSubmitFolder(): void {
     // When recursion is disabled in folder mode, drop any files that live
     // inside subdirectories of the picked folder.  ``webkitRelativePath``
     // looks like ``"top/file.wav"`` for top-level entries and
     // ``"top/sub/file.wav"`` for files inside a subdirectory.
     let filesToUpload = this.lfFiles;
-    if (this.lfPickerKind === 'folder' && !this.lfRecursive) {
+    if (!this.lfRecursive) {
       filesToUpload = this.lfFiles.filter((file) => {
         const rel = ((file as any).webkitRelativePath as string | undefined) || '';
         return rel.split('/').length <= 2;
@@ -1097,27 +1103,12 @@ export class DatasetImporterModalComponent implements OnInit {
     const formData = new FormData();
     formData.append('media_type', this.lfMediaType);
     formData.append('recursive', this.lfRecursive ? 'true' : 'false');
-    const lfName = (this.lfDatasetName || '').trim();
-    if (lfName) {
-      formData.append('dataset_name', lfName);
-    }
-    if (this.lfSelectedEmbedder) {
-      formData.append('embedder', this.lfSelectedEmbedder);
-    }
-    if (this.lfSelectedClipper) {
-      formData.append('clipper', this.lfSelectedClipper);
-      if (this.lfClipperParams.length > 0 && Object.keys(this.lfClipperParamValues).length > 0) {
-        formData.append('clipper_params', JSON.stringify(this.lfClipperParamValues));
-      }
-    }
+    this.lfAppendCommonFormFields(formData);
     for (const file of filesToUpload) {
       const rel = (file as any).webkitRelativePath as string | undefined;
       // Browsers only populate webkitRelativePath when the input has the
       // `webkitdirectory` attribute; fall back to the file's own name.
       formData.append('files', file, rel && rel.length > 0 ? rel : file.name);
-    }
-    if (this.lfVectorsFile) {
-      formData.append('vectors_file', this.lfVectorsFile, this.lfVectorsFile.name);
     }
     if (this.lfSourceSpecs.length > 0) {
       // Multipart form fields are flat strings; encode as JSON.
@@ -1134,6 +1125,47 @@ export class DatasetImporterModalComponent implements OnInit {
         this.lfError = err.error?.error || 'Upload failed';
       },
     });
+  }
+
+  private lfSubmitFiles(): void {
+    this.lfSubmitting = true;
+    this.lfError = '';
+
+    const pathsFile = this.lfFiles[0];
+    const formData = new FormData();
+    formData.append('media_type', this.lfMediaType);
+    formData.append('paths_file', pathsFile, pathsFile.name);
+    this.lfAppendCommonFormFields(formData);
+    if (this.lfSourceSpecs.length > 0) {
+      formData.append('source_specs', JSON.stringify(this.lfSourceSpecs));
+    }
+
+    this.datasetsApi.importLocalFiles(formData).subscribe({
+      next: () => {
+        this.lfSubmitting = false;
+        this.importStarted.emit();
+      },
+      error: (err) => {
+        this.lfSubmitting = false;
+        this.lfError = err.error?.error || 'Upload failed';
+      },
+    });
+  }
+
+  private lfAppendCommonFormFields(formData: FormData): void {
+    const lfName = (this.lfDatasetName || '').trim();
+    if (lfName) {
+      formData.append('dataset_name', lfName);
+    }
+    if (this.lfSelectedEmbedder) {
+      formData.append('embedder', this.lfSelectedEmbedder);
+    }
+    if (this.lfSelectedClipper) {
+      formData.append('clipper', this.lfSelectedClipper);
+      if (this.lfClipperParams.length > 0 && Object.keys(this.lfClipperParamValues).length > 0) {
+        formData.append('clipper_params', JSON.stringify(this.lfClipperParamValues));
+      }
+    }
   }
 
   // --- Server folder browser ---

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -197,6 +197,14 @@ export class DatasetsApiService {
     return this.http.post<DatasetLoadStartedResponse>('/api/dataset/import-local-folder', formData);
   }
 
+  /** Multipart upload — the caller builds the FormData with a single
+   *  ``paths_file`` (txt list or npz archive), ``media_type``, optional
+   *  ``embedder`` / ``clipper`` / ``clipper_params`` / ``source_specs``.
+   *  See {@link importLocalFolder} for why this stays on plain HttpClient. */
+  importLocalFiles(formData: FormData): Observable<DatasetLoadStartedResponse> {
+    return this.http.post<DatasetLoadStartedResponse>('/api/dataset/import-local-files', formData);
+  }
+
   loadDemo(name: string, params?: Record<string, string>): Observable<DatasetLoadStartedResponse> {
     const body: DatasetLoadDemoRequest = { name, ...params };
     return loadDemoDatasetRoute(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -7,10 +7,10 @@ staging dir and run through the regular folder loader, but the loader
 skips re-embedding for files whose names appear in the supplied
 ``content_vectors`` map.
 
-The ``/api/dataset/import-local-folder`` endpoint additionally accepts
-an optional ``vectors_file`` multipart form field (a ``.npz`` archive
-keyed by uploaded-file name) so users can attach pre-computed vectors
-to a browser-side multi-file upload.
+The ``/api/dataset/import-local-files`` endpoint is the browser-upload
+equivalent of ``server_files``: the user POSTs a single ``paths_file``
+(a ``.txt`` of paths or a ``.npz`` of paths + vectors) and the server
+runs the regular ``server_files`` importer over the uploaded file.
 """
 
 from __future__ import annotations
@@ -237,33 +237,34 @@ class TestServerFilesNpzRunsEndToEnd:
 
 
 # ---------------------------------------------------------------------------
-# /api/dataset/import-local-folder: vectors_file npz alongside media files
+# /api/dataset/import-local-files: paths_file upload delegates to server_files
 # ---------------------------------------------------------------------------
 
 
-class TestLocalUploadVectorsFile:
-    """The /api/dataset/import-local-folder endpoint parses the optional
-    ``vectors_file`` npz and hands the resulting ``{filename: vector}``
-    map to the server_folder importer via its ``content_vectors``
-    attribute.  The background task runner is stubbed so the test can
-    invoke the importer's ``load_fn`` synchronously and inspect the
-    importer's state at the moment it would have been called."""
+class TestImportLocalFilesEndpoint:
+    """The /api/dataset/import-local-files endpoint accepts a single
+    uploaded ``paths_file`` (txt list or npz archive) and runs the
+    ``server_files`` importer over the saved copy on the server.  The
+    background task runner is stubbed so the test can invoke the
+    importer's ``load_fn`` synchronously and inspect the field_values
+    that the importer would have been called with."""
 
     @staticmethod
     def _stub_run_and_observe(observed: dict):
-        """Build a ``_run_origin_load_in_background`` stub that sniffs the
-        server_folder importer's ``content_vectors`` at the moment the
-        load function would call into the importer.  Works for both the
-        chunked and non-chunked dispatch paths."""
         from vtscore.datasets.importers import get_importer
 
         def _fake_run(load_fn, origin, **kwargs):
-            importer = get_importer("server_folder")
+            importer = get_importer("server_files")
             assert importer is not None
+            observed["origin"] = origin
+            observed["kwargs"] = kwargs
 
             def _sniff(field_values, medias=None, thin=False):
-                observed["content_vectors"] = dict(importer.content_vectors or {})
-                # Return an empty generator for the chunked path.
+                observed["field_values"] = dict(field_values)
+                # Snapshot the uploaded paths_file's bytes before the loader
+                # tears down the temp dir.
+                pf = Path(field_values["paths_file"])
+                observed["paths_file_bytes"] = pf.read_bytes()
                 return iter(())
 
             with (
@@ -271,24 +272,75 @@ class TestLocalUploadVectorsFile:
                 patch.object(importer, "run_chunked", side_effect=_sniff),
             ):
                 load_fn({})
-            return "task-fake-npz"
+            return "task-fake-local-files"
 
         return _fake_run
 
-    def test_upload_with_vectors_file_populates_importer_content_vectors(self, client, tmp_path, monkeypatch):
-        from vtscore.datasets.importers import get_importer
+    def test_no_paths_file_returns_400(self, client):
+        resp = client.post(
+            "/api/dataset/import-local-files",
+            data={"media_type": "audio"},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "paths file" in resp.get_json()["message"].lower()
 
+    def test_missing_media_type_returns_400(self, client):
+        resp = client.post(
+            "/api/dataset/import-local-files",
+            data={"paths_file": (io.BytesIO(b"/a.wav\n"), "list.txt")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "media_type" in resp.get_json()["message"]
+
+    def test_uploads_txt_paths_file_and_starts_load(self, client, tmp_path, monkeypatch):
         monkeypatch.setattr(
             "vtsearch.routes.datasets.load.LOCAL_UPLOADS_DIR",
             tmp_path / "uploads",
         )
 
-        vec = np.full(384, 3.5, dtype=np.float32)
+        observed: dict = {}
+        with patch(
+            "vtsearch.routes.datasets.load._run_origin_load_in_background",
+            side_effect=self._stub_run_and_observe(observed),
+        ):
+            resp = client.post(
+                "/api/dataset/import-local-files",
+                data={
+                    "media_type": "audio",
+                    "paths_file": (io.BytesIO(b"/a.wav\n/b.wav\n"), "list.txt"),
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["task_id"] == "task-fake-local-files"
+
+        # The uploaded paths file was saved with its original suffix
+        # (so the server_files importer dispatches on extension).
+        assert observed["field_values"]["paths_file"].endswith(".txt")
+        assert observed["paths_file_bytes"] == b"/a.wav\n/b.wav\n"
+        # Origin is synthetic (the temp paths_file is about to be deleted)
+        # so reload-from-origin is naturally disabled.
+        assert observed["origin"]["importer"] == "server_files"
+        assert observed["origin"]["params"]["paths_file"] == "<browser_upload>"
+        assert observed["origin"]["params"]["media_type"] == "audio"
+
+    def test_uploads_npz_paths_file_preserves_suffix(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.load.LOCAL_UPLOADS_DIR",
+            tmp_path / "uploads",
+        )
+
+        # A real npz so the suffix-based reader dispatch is meaningful.
         npz_bytes_io = io.BytesIO()
         np.savez(
             npz_bytes_io,
-            filenames=np.array(["clip.wav"]),
-            vectors=np.stack([vec]),
+            filenames=np.array(["/a.wav"]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
         )
         npz_bytes_io.seek(0)
 
@@ -298,66 +350,13 @@ class TestLocalUploadVectorsFile:
             side_effect=self._stub_run_and_observe(observed),
         ):
             resp = client.post(
-                "/api/dataset/import-local-folder",
+                "/api/dataset/import-local-files",
                 data={
                     "media_type": "audio",
-                    "files": (io.BytesIO(b"AAA"), "clip.wav"),
-                    "vectors_file": (npz_bytes_io, "vectors.npz"),
+                    "paths_file": (npz_bytes_io, "list.npz"),
                 },
                 content_type="multipart/form-data",
             )
 
         assert resp.status_code == 200, resp.get_data(as_text=True)
-        # The npz was parsed and forwarded to the importer.
-        assert "clip.wav" in observed["content_vectors"]
-        np.testing.assert_array_equal(observed["content_vectors"]["clip.wav"], vec)
-
-        # After the load returns, content_vectors is restored so the
-        # next upload doesn't inherit stale vectors.
-        assert get_importer("server_folder").content_vectors == {}
-
-    def test_upload_without_vectors_file_leaves_importer_unchanged(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.load.LOCAL_UPLOADS_DIR",
-            tmp_path / "uploads",
-        )
-
-        observed: dict = {}
-        with patch(
-            "vtsearch.routes.datasets.load._run_origin_load_in_background",
-            side_effect=self._stub_run_and_observe(observed),
-        ):
-            resp = client.post(
-                "/api/dataset/import-local-folder",
-                data={
-                    "media_type": "audio",
-                    "files": (io.BytesIO(b"AAA"), "clip.wav"),
-                },
-                content_type="multipart/form-data",
-            )
-
-        assert resp.status_code == 200, resp.get_data(as_text=True)
-        # With no npz attached, the importer's content_vectors stays
-        # empty for the run.
-        assert observed["content_vectors"] == {}
-
-    def test_upload_rejects_invalid_vectors_file(self, client, tmp_path, monkeypatch):
-        """A bogus ``vectors_file`` is rejected up front with a 400."""
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.load.LOCAL_UPLOADS_DIR",
-            tmp_path / "uploads",
-        )
-        bogus = io.BytesIO(b"not really a npz archive")
-        resp = client.post(
-            "/api/dataset/import-local-folder",
-            data={
-                "media_type": "audio",
-                "files": (io.BytesIO(b"RIFF...."), "clip.wav"),
-                "vectors_file": (bogus, "broken.npz"),
-            },
-            content_type="multipart/form-data",
-        )
-        assert resp.status_code == 400
-        body = resp.get_json()
-        # flask-smorest error envelope: ``message`` (not ``error``).
-        assert "vectors_file" in body["message"].lower()
+        assert observed["field_values"]["paths_file"].endswith(".npz")

--- a/vtscore/datasets/importers/local_files/__init__.py
+++ b/vtscore/datasets/importers/local_files/__init__.py
@@ -1,24 +1,18 @@
-"""Local-files importer placeholder — drives the browser-side multi-file upload card.
+"""Local-files importer placeholder — drives the browser-side paths-file upload card.
 
-Like :mod:`local_folder`, this importer's ``run()`` is **never invoked**:
-the browser POSTs a multipart body to ``/api/dataset/import-local-folder``
-which streams the uploaded media files into a server-side temp directory
-and then delegates to the regular :mod:`server_folder` importer for
-scanning and embedding.
+The actual upload flow does **not** invoke this importer's ``run()``.
+The browser POSTs a multipart body to ``/api/dataset/import-local-files``
+carrying a single ``paths_file`` (a UTF-8 text file listing one
+server-side media path per line, or a ``.npz`` archive that also
+supplies pre-computed embedding vectors).  The endpoint saves the
+uploaded file to a server-side temp location and then delegates to the
+regular :mod:`server_files` importer for resolution, symlinking, and
+embedding.
 
-The only difference between the Local Folder and Local Files cards is
-the browser-side input: Local Folder uses ``<input type="file"
-webkitdirectory>`` (a single directory pick), while Local Files uses
-``<input type="file" multiple>`` (one or more individual file picks).
-Both flows deliver the same multipart shape to the same upload
-endpoint.
-
-The Local Files card additionally accepts an optional ``vectors_file``
-form input — a ``.npz`` archive containing pre-computed embedding
-vectors keyed by uploaded-file name.  Files whose name matches an NPZ
-key reuse the supplied vector and skip the embedding model, which lets
-users import media they have already embedded offline without
-re-embedding it on the server.
+The card is the browser-upload equivalent of Server Files.  Use it when
+you have a list of media paths (or a NumPy archive of pre-computed
+vectors) on your laptop that you'd like to feed to the server without
+typing the file's absolute server path by hand.
 """
 
 from __future__ import annotations
@@ -29,38 +23,38 @@ from vtscore.datasets.importers.base import DatasetImporter
 
 
 class LocalFilesDatasetImporter(DatasetImporter):
-    """Placeholder for the browser-side multi-file upload card.
+    """Placeholder for the browser-side single-file paths upload card.
 
     The card opens the modal's ``"local_files"`` view (see
-    :attr:`picker_view`), which uses
-    ``<input type="file" multiple>`` to let the user pick one or more
-    individual files on the **browser machine** and POSTs them to
-    ``/api/dataset/import-local-folder`` — the server then runs the
-    regular :mod:`server_folder` importer over the upload temp dir.
+    :attr:`picker_view`), which uses a single-file ``<input type="file">``
+    accepting ``.txt`` / ``.list`` / ``.npz`` and POSTs it to
+    ``/api/dataset/import-local-files`` — the server then runs the
+    regular :mod:`server_files` importer over the uploaded paths file.
     """
 
     name = "local_files"
     display_name = "Files"
     description = (
-        "Upload one or more individual media files from this computer (your browser machine) "
-        "to the server.  Optionally include a .npz archive of pre-computed embedding vectors "
-        "to skip re-embedding for media you have already embedded offline."
+        "Upload a single file from this computer (your browser machine) that lists the media "
+        "to import: a UTF-8 text file with one server-side path per line, or a .npz archive "
+        "that also supplies pre-computed embedding vectors."
     )
     icon = "\U0001f4c4"  # 📄 — falls back to a generic file icon
     ui_mode = "custom"
     picker_view = "local_files"
     category = "local"
-    # The upload flow delegates to server_folder, which already
-    # participates in the multi-media flow.  See LocalFolderDatasetImporter
-    # for the same flag and the upload-route plumbing.
+    # The upload flow delegates to server_files, which already
+    # participates in the multi-media flow.  Surfacing the flag here
+    # lets the frontend render the "Include media" repeater for this
+    # picker too.
     multi_media = True
     fields = []
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         raise NotImplementedError(
             "LocalFilesDatasetImporter is browser-only. "
-            "POST to /api/dataset/import-local-folder for the upload flow, "
-            "or use the regular `server_folder` importer for server-side directories."
+            "POST to /api/dataset/import-local-files for the upload flow, "
+            "or use the regular `server_files` importer for server-side paths files."
         )
 
 

--- a/vtscore/datasets/importers/local_folder/__init__.py
+++ b/vtscore/datasets/importers/local_folder/__init__.py
@@ -10,6 +10,12 @@ This importer exists so that the dataset-importer modal can be fully
 data-driven — the picker reads :attr:`display_name`, :attr:`description`,
 :attr:`icon`, and :attr:`picker_view` from the registry instead of
 hard-coding "Local Folder" markup in HTML.
+
+Pre-computed embedding vectors are intentionally **not** supported by
+the folder card.  Users who want to attach pre-computed vectors to a
+browser-side upload should use the Local Files card instead — it takes
+a single ``.npz`` (or ``.txt``) paths file, which is the natural
+delivery mechanism for vectors keyed by filename.
 """
 
 from __future__ import annotations

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -14,7 +14,7 @@ not available) keep their HTTP codes (400 / 500) with the standard
 handler intercepts — see plan doc).
 
 Routes whose request body is multipart (``import-local-folder``,
-``load-file``) or whose success body is a binary stream (``export``)
+``import-local-files``, ``load-file``) or whose success body is a binary stream (``export``)
 omit ``@arguments`` and declare error responses via ``alt_response`` —
 same pattern as ``add-to-pile`` / ``server-media-files/upload`` /
 ``server-media-files/<f>/thumbnail`` in ``media/list.py`` and
@@ -26,7 +26,6 @@ import json
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any
 
 from flask import request, send_file
 from flask_smorest import Blueprint, abort
@@ -86,33 +85,6 @@ def _save_uploaded_files_to_temp(files, upload_dir: Path) -> int:
     return saved
 
 
-def _read_optional_vectors_file(upload_dir: Path) -> dict[str, Any]:
-    """Parse the optional ``vectors_file`` multipart field, if present.
-
-    Returns the {filename: vector} mapping (possibly empty).  Removes the
-    temporary .npz once it's parsed.  Aborts 400 if the file is malformed
-    (after cleaning up *upload_dir*).
-    """
-    storage = request.files.get("vectors_file")
-    if not storage or not storage.filename:
-        return {}
-
-    from vtscore.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
-
-    npz_path = upload_dir / "__vtsearch_vectors__.npz"
-    try:
-        storage.save(npz_path)
-        return dict(read_npz_filenames_and_vectors(npz_path))
-    except Exception as exc:
-        shutil.rmtree(upload_dir, ignore_errors=True)
-        abort(400, message=f"Invalid vectors_file: {exc}")
-    finally:
-        try:
-            npz_path.unlink()
-        except FileNotFoundError:
-            pass
-
-
 def _build_local_folder_field_values(form, upload_dir: Path, clipper_params: dict | None) -> dict:
     """Translate the multipart form into the importer's field_values dict."""
     field_values: dict = {
@@ -150,7 +122,7 @@ def _extract_clipper_config(field_values: dict) -> tuple[str, dict | None, list[
     return clipper_name, clipper_params, chain_steps
 
 
-def _make_local_folder_loader(importer, field_values: dict, upload_dir: Path, content_vectors: dict, media_type: str):
+def _make_local_folder_loader(importer, field_values: dict, upload_dir: Path, media_type: str):
     """Build the ``target_medias -> None`` task that the importer will run."""
     from vtscore.datasets.load_pipeline import auto_chunk_size, consume_chunks_into
 
@@ -158,17 +130,12 @@ def _make_local_folder_loader(importer, field_values: dict, upload_dir: Path, co
     chunk_size = auto_chunk_size(media_type) if use_chunked else 0
 
     def _load(target_medias):
-        previous_vectors = importer.content_vectors
-        if content_vectors:
-            importer.content_vectors = content_vectors
         try:
             if use_chunked:
                 consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size))
             else:
                 importer.run(field_values, target_medias)
         finally:
-            if content_vectors:
-                importer.content_vectors = previous_vectors
             shutil.rmtree(upload_dir, ignore_errors=True)
 
     return _load
@@ -180,8 +147,7 @@ def _make_local_folder_loader(importer, field_values: dict, upload_dir: Path, co
     400,
     description=(
         "Multipart body is missing the ``files`` field, has no valid files, is "
-        "missing ``media_type``, or carries malformed ``clipper_params`` / "
-        "``vectors_file``."
+        "missing ``media_type``, or carries malformed ``clipper_params``."
     ),
 )
 @datasets_load_bp.alt_response(500, description="The server_folder importer is unavailable.")
@@ -196,12 +162,6 @@ def import_local_folder():
     delegate to the regular folder importer to do the actual scanning,
     embedding, and dataset registration.  The temp directory is removed
     once the importer finishes (success or failure).
-
-    Local-files uploads may additionally include a ``vectors_file`` form
-    field carrying a ``.npz`` archive of pre-computed embedding vectors
-    keyed by uploaded-file name (basename or relative path).  Files
-    whose name matches an NPZ key reuse the supplied vector instead of
-    running the embedding model.
     """
     files = request.files.getlist("files")
     if not files:
@@ -229,8 +189,6 @@ def import_local_folder():
         shutil.rmtree(upload_dir, ignore_errors=True)
         abort(400, message="No valid files in upload")
 
-    content_vectors = _read_optional_vectors_file(upload_dir)
-
     field_values = _build_local_folder_field_values(request.form, upload_dir, clipper_params)
 
     # Origin is intentionally synthetic — the on-disk path is a temp dir we
@@ -242,12 +200,103 @@ def import_local_folder():
     }
 
     clipper_name, clipper_params_out, chain_steps = _extract_clipper_config(field_values)
-    loader = _make_local_folder_loader(importer, field_values, upload_dir, content_vectors, media_type)
+    loader = _make_local_folder_loader(importer, field_values, upload_dir, media_type)
 
     from vtsearch.auth import get_current_user
     from vtscore.datasets.load_pipeline import _normalize_media_type
 
     dataset_name = (request.form.get("dataset_name") or "").strip() or "Local folder upload"
+    task_id = _run_origin_load_in_background(
+        loader,
+        origin,
+        name=dataset_name,
+        clipper=clipper_name,
+        clipper_params=clipper_params_out,
+        chain_steps=chain_steps,
+        embedder=field_values.get("embedder", ""),
+        created_by=get_current_user(),
+        media_type=_normalize_media_type(media_type),
+    )
+    return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
+
+
+@datasets_load_bp.route("/api/dataset/import-local-files", methods=["POST"])
+@datasets_load_bp.response(200, DatasetLoadStartedResponseSchema)
+@datasets_load_bp.alt_response(
+    400,
+    description=(
+        "Multipart body is missing the ``paths_file`` field, is missing "
+        "``media_type``, or carries malformed ``clipper_params``."
+    ),
+)
+@datasets_load_bp.alt_response(500, description="The server_files importer is unavailable.")
+def import_local_files():
+    """Import a paths file uploaded from the user's *browser* machine.
+
+    The browser picks a single file (a ``.txt`` / ``.list`` with one
+    server-side media path per line, or a ``.npz`` archive that also
+    supplies pre-computed embedding vectors) and POSTs it as the
+    multipart field ``paths_file``.  We stream it to a server-side
+    temporary directory and then delegate to the regular
+    :mod:`server_files` importer for resolution and embedding.  The
+    temp directory is removed once the importer finishes (success or
+    failure).
+    """
+    storage = request.files.get("paths_file")
+    if not storage or not storage.filename:
+        abort(400, message="No paths file uploaded")
+
+    importer = get_importer("server_files")
+    if importer is None:
+        abort(500, message="server_files importer not available")
+
+    media_type = (request.form.get("media_type") or "").strip()
+    if not media_type:
+        abort(400, message="Missing required field: 'media_type'")
+
+    clipper_params = _parse_clipper_params(request.form.get("clipper_params") or "")
+
+    LOCAL_UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    upload_dir = Path(tempfile.mkdtemp(prefix="local_files_", dir=LOCAL_UPLOADS_DIR))
+    # Preserve the suffix so the importer picks the right reader (.txt vs .npz).
+    suffix = Path(storage.filename).suffix
+    paths_file = upload_dir / f"paths_file{suffix}"
+    try:
+        storage.save(paths_file)
+    except Exception:
+        shutil.rmtree(upload_dir, ignore_errors=True)
+        raise
+
+    field_values: dict = {
+        "media_type": media_type,
+        "paths_file": str(paths_file),
+    }
+    for key in ("embedder", "source_specs"):
+        val = (request.form.get(key) or "").strip()
+        if val:
+            field_values[key] = val
+    clipper = (request.form.get("clipper") or "").strip()
+    if clipper:
+        field_values["clipper"] = clipper
+        if clipper_params is not None:
+            field_values["clipper_params"] = clipper_params
+
+    # Origin is intentionally synthetic — the on-disk paths file is in a temp
+    # dir we are about to delete, so storing it on each media would be
+    # misleading and ``can_reload_from_origin`` would (correctly) refuse to
+    # reload.
+    origin = {
+        "importer": "server_files",
+        "params": {"paths_file": "<browser_upload>", "media_type": media_type},
+    }
+
+    clipper_name, clipper_params_out, chain_steps = _extract_clipper_config(field_values)
+    loader = _make_local_folder_loader(importer, field_values, upload_dir, media_type)
+
+    from vtsearch.auth import get_current_user
+    from vtscore.datasets.load_pipeline import _normalize_media_type
+
+    dataset_name = (request.form.get("dataset_name") or "").strip() or "Local files upload"
     task_id = _run_origin_load_in_background(
         loader,
         origin,


### PR DESCRIPTION
## Summary

- **Local Folder** no longer shows a "Pre-computed embeddings (optional)" `.npz` picker. That affordance only makes sense paired with a list of filenames the vectors can be keyed against, which now lives entirely on the Local Files card. The `vectors_file` form field is removed from `/api/dataset/import-local-folder` as well.
- **Local Files** is now the browser-upload equivalent of Server Files: a single drop zone for one paths file (`.txt`/`.list` or `.npz` of paths + pre-computed vectors). A new `/api/dataset/import-local-files` endpoint saves the upload (preserving suffix so the importer dispatches on extension) and runs the existing `server_files` importer in the background.
- Embedder / clipper / source-specs stay behind the Advanced toggle, so the required fields stay uncrowded.

## Test plan

- [x] `./run-tests.sh` — 4199 passed, 1 skipped
- [x] `./run-tests.sh io` — covers the new `TestImportLocalFilesEndpoint` (missing field validation, txt + npz suffix preservation, synthetic origin shape)
- [x] `./run-tests.sh core` — frontend `build:prod` typechecks the rewritten modal
- [ ] Manual UI smoke: open the importer modal, confirm the Local Folder card has no "Pre-computed embeddings" section, and Local Files presents a single paths-file drop zone with Advanced collapsing the embedder/clipper rows.

https://claude.ai/code/session_01Kgx8onmVytoty9VxGwTsMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgx8onmVytoty9VxGwTsMc)_