### PR TITLE
style: design-token sweep + style-guide + section-rhythm utility

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,340 @@
+# VTSearch Frontend Style Guide
+
+This is the canonical reference for visual styling in the Angular frontend. **All component SCSS must use the tokens and classes defined here** — raw `px`/`rem` values for padding, margins, gaps, font sizes, border radii, and transition durations are not allowed. Hex color literals are not allowed. The shared classes in `frontend/src/scss/_components.scss` are the source of truth for buttons, form fields, modals, and typography; one-off restyling of these elements is not allowed.
+
+The frontend is **desktop-only**. There are no responsive breakpoints, touch-targeted controls, or mobile layouts to design for.
+
+---
+
+## 1. Design tokens
+
+Tokens live in `frontend/src/scss/_variables.scss` as CSS custom properties on `:root` (with overrides on `[data-theme="light"]` and `[data-theme="highviz"]`). Reference them with `var(--name)`. **Never hardcode a value that has a token.**
+
+### 1.1 Spacing — `--space-*`
+
+Use the spacing scale for `padding`, `margin`, `gap`, and similar layout offsets. The scale is sized so each step roughly doubles, giving clear visual rhythm without dozens of arbitrary increments.
+
+| Token         | Value     | When to use |
+|---------------|-----------|-------------|
+| `--space-2xs` | 0.125rem (2px) | Badge inner padding, hairline offsets |
+| `--space-xs`  | 0.25rem (4px)  | Tight icon/text gaps, list-item gaps |
+| `--space-sm`  | 0.375rem (6px) | Default button gap, small padding |
+| `--space-md`  | 0.5rem (8px)   | Standard toolbar/header gap, default control padding |
+| `--space-lg`  | 0.75rem (12px) | Card padding, table cell padding |
+| `--space-xl`  | 1rem (16px)    | Section padding, modal-body bottom margin |
+| `--space-2xl` | 1.5rem (24px)  | Modal-content padding, page-section spacing |
+
+**Rounding rule:** any hardcoded `5px`/`7px`/`10px`/`14px`/`20px` value not produced by a token is a smell. Round to the nearest token; tiny visual shifts (1–3px) are acceptable in exchange for a consistent rhythm.
+
+### 1.2 Font sizes — `--font-*`
+
+| Token         | Value      | When to use |
+|---------------|------------|-------------|
+| `--font-2xs`  | 0.7rem     | Badges, tiny meta text |
+| `--font-xs`   | 0.75rem    | Table headers, captions, subtitle rows |
+| `--font-sm`   | 0.8rem     | Form labels, secondary helper text |
+| `--font-md`   | 0.85rem    | **Default** for body UI text, buttons, inputs, tables |
+| `--font-lg`   | 0.9rem     | Card titles, prominent secondary headings |
+| `--font-xl`   | 1rem       | `<h3>`, section headers |
+| `--font-2xl`  | 1.1rem     | `<h2>`, modal titles |
+| `--font-3xl`  | 1.4rem     | `<h1>`, page-level header, modal-close glyph |
+
+There are no other font sizes. `0.78rem`, `0.83rem`, `0.95rem`, `12px`, `13px`, etc. are all violations — they collapse into the table above.
+
+### 1.3 Font weights — `--weight-*`
+
+Use these named weights, not raw numbers. The semantic mapping is enforced so a casual reader can tell *what role* an element has just from its weight.
+
+| Token              | Value | When to use |
+|--------------------|-------|-------------|
+| `--weight-regular` | 400   | Body copy, table cells, descriptions, info text |
+| `--weight-medium`  | 500   | Form labels, table headers, subtitles |
+| `--weight-semibold`| 600   | Card titles, active tab labels, names in lists, anything that should "pop" without screaming |
+
+There is no `--weight-bold` (700). If you find yourself wanting `font-weight: 700`, you're either reaching for size (use a larger heading) or you're styling around the layout (fix the layout). The one exception is the `<strong>` tag itself, which the browser styles bold by default.
+
+### 1.4 Border radius — `--radius-*`
+
+| Token          | Value  | When to use |
+|----------------|--------|-------------|
+| `--radius-sm`  | 3px    | Badges, scroll thumbs, small chips |
+| `--radius-md`  | 4px    | **Default** for buttons, inputs, panels |
+| `--radius-lg`  | 6px    | Cards, importer/exporter tiles |
+| `--radius-xl`  | 8px    | Modals, prominent surfaces |
+| `--radius-pill`| 999px  | Pill-shaped progress tracks, status pills |
+
+`50%` is fine for circular avatars. Anything else (`2px`, `10px`, `1px`) is a violation.
+
+### 1.5 Colors
+
+All colors are theme-aware CSS variables defined in `_variables.scss`. There are dark (default), light, and high-contrast themes. **Hex literals in component SCSS are not allowed** — using one means the component will not respond to theme changes, which is a bug.
+
+Canonical roles:
+
+- **Text:** `--text-primary` (default), `--text-secondary` (subtitles), `--text-muted` (hints), `--text-dim`, `--text-placeholder`
+- **Surface:** `--bg-body`, `--bg-surface` (cards, modal), `--bg-panel` (side panels), `--bg-subtle` (input bg, recessed sections), `--bg-hover`
+- **Borders:** `--border` (default), `--border-secondary` (emphasis), `--border-subtle` (table row dividers)
+- **Accent:** `--accent` (primary), `--accent-hover`, `--accent-light`, `--accent-highlight-bg`, `--accent-highlight-border`
+- **Status:** `--color-good` (success/green), `--color-bad` (error/red), `--text-warning`, `--badge-embedding`
+- **Status rows (red/yellow/green sets):** `--status-{color}-{border|dot|label|sub}`
+- **Per-detector accent:** `--detector-accent`, `--detector-accent-bg` (driven by `--detector-hue` set inline on the component)
+
+If you need a color that does not exist, add it to all three theme blocks in `_variables.scss` — don't introduce a hex literal "just this once."
+
+### 1.6 Transitions — `--transition-*`
+
+| Token               | Value  | When to use |
+|---------------------|--------|-------------|
+| `--transition-fast` | 0.1s   | Hover backgrounds where the cursor moves quickly |
+| `--transition-base` | 0.15s  | **Default** for color/border/background changes |
+| `--transition-slow` | 0.3s   | Progress fills, width animations, opacity reveals |
+
+`0.2s`, `0.4s`, and other ad-hoc durations should be rounded to one of these. `prefers-reduced-motion` overrides all three globally (see `styles.scss`).
+
+### 1.7 Shadows — `--shadow-*`
+
+| Token         | When to use |
+|---------------|-------------|
+| `--shadow-sm` | Subtle lift (tooltip, popover) |
+| `--shadow-md` | Toasts, floating buttons |
+| `--shadow-lg` | Modals |
+
+All three resolve through `--shadow-dropdown` so they auto-tint per theme.
+
+### 1.8 Z-index — `--z-*`
+
+| Token                | Value  | Used by |
+|----------------------|--------|---------|
+| `--z-base`           | 1      | Normal in-flow content |
+| `--z-elevated`       | 10     | Sticky table headers, raised tiles |
+| `--z-sticky`         | 100    | App header, sticky toolbars |
+| `--z-modal-backdrop` | 1000   | Modal overlay |
+| `--z-modal`          | 1001   | Modal content |
+| `--z-burger-menu`    | 2000   | Dropdown menus that must clear modals |
+| `--z-toast`          | 5000   | Toast notifications |
+| `--z-login`          | 9999   | Login gate |
+
+Never use a raw z-index. If you need a new layer, add a token.
+
+---
+
+## 2. Shared component classes
+
+All these live in `frontend/src/scss/_components.scss` and are global. Apply them via `class="..."` in templates. **Do not redeclare these styles in component SCSS** — extend with a child selector if needed (e.g. `.progress-row .btn--cancel { ... }` to scope a specific layout).
+
+### 2.1 Typography
+
+Use the right tag for the role; the global rules will style it correctly.
+
+```html
+<h1>Page header</h1>          <!-- 1.4rem semibold -->
+<h2>Modal / section title</h2><!-- 1.1rem semibold -->
+<h3>Sub-section</h3>          <!-- 1rem semibold -->
+<h4>Minor group label</h4>    <!-- 0.9rem medium -->
+```
+
+Headings have `margin: 0`. Add spacing via the parent's flex `gap` or `margin-bottom` on the heading using a `--space-*` token. **Do not set `font-size`/`font-weight` to make a smaller tag look like a bigger one.**
+
+Text utility classes (use directly on `<p>` / `<span>`):
+
+| Class           | What it is |
+|-----------------|------------|
+| `.info-text`    | Body helper text — secondary color, default font-size |
+| `.error-text`   | Red error message |
+| `.success-text` | Green success message |
+| `.status-text`  | Inline status / secondary message |
+| `.empty-state`  | Centered "no items" message, padded |
+
+### 2.2 Buttons
+
+The full taxonomy is `.btn` plus optional variant + optional size. Always start with `.btn`:
+
+```html
+<button class="btn">Default outline</button>
+<button class="btn btn--primary">Commit / Save</button>
+<button class="btn btn--secondary">Secondary action</button>
+<button class="btn btn--danger">Delete</button>
+<button class="btn btn--cancel">Cancel</button>
+<button class="btn btn--sm">Compact</button>
+<button class="btn btn--primary btn--sm">Compact primary</button>
+<button class="btn btn--xs">Inline mini</button>
+<button class="btn btn--icon-square">+</button>
+```
+
+Rules:
+
+- **Default size** for prominent actions (modal footers, top-of-panel actions).
+- **`.btn--sm`** for inline actions inside cards and rows.
+- **`.btn--xs`** for the densest tables / inline edit rows.
+- **`.btn--cancel`** for low-weight cancel/close affordances next to progress bars.
+- **`.btn--icon-square`** for square plus/icon buttons (28×28).
+- **Do not write per-component `padding` / `font-size` / `border-radius` on a button.** Every "small button" implementation in component SCSS that bypassed this taxonomy has been removed.
+
+### 2.3 Forms
+
+```html
+<label class="form-label">Dataset name</label>
+<input class="form-input" />
+<select class="form-select">...</select>
+<p class="form-hint">JSON, CSV, or NPZ accepted.</p>
+```
+
+- `.form-input` and `.form-select` share padding, border, focus state. They sit on `--bg-subtle` so they read as "input wells."
+- `.form-label` is `--font-sm`, `--weight-medium`, `--text-primary` — visually heavier than helper text so it reads as a header above its input.
+- `.form-hint` (used for plugin-field `hint` strings) is muted monospace.
+- `.required` marks required fields with `--color-bad`.
+
+Focus state is provided globally by `:focus-visible { outline: 2px solid var(--accent); }`. Inputs additionally swap their border to `--accent` on focus. **Do not override focus styling per component.**
+
+### 2.4 Modals
+
+The modal framework is the standard markup pattern; copy it.
+
+```html
+<div class="modal-backdrop">
+  <div class="modal-content">
+    <header class="modal-header">
+      <h2>Title</h2>
+      <button class="modal-close">×</button>
+    </header>
+    <div class="modal-body">
+      <!-- content -->
+    </div>
+    <footer class="modal-footer">
+      <button class="btn">Cancel</button>
+      <button class="btn btn--primary">Save</button>
+    </footer>
+  </div>
+</div>
+```
+
+Spacing inside modals:
+- `.modal-content` already has `padding: var(--space-2xl)` — **do not** add a wrapping `padding` div.
+- `.modal-header`, `.modal-body` already have `margin-bottom: var(--space-xl)` — **do not** add it again.
+- `.modal-footer` has `gap: var(--space-md)` between buttons.
+- The modal-content uses `--shadow-lg` and `--radius-xl`.
+
+#### Back vs Cancel
+
+This pattern is **mandatory** for any modal with an outer→inner view (importer picker → importer form, exporter picker → exporter form, new-detector → media picker, etc.). See CLAUDE.md for the canonical writeup. Short version:
+
+- **`← Back`** (top-left of inner view, `.back-btn`) — navigates to the previous view without committing the step. Use it any time the user is "going back" to a parent view, including from a child modal.
+- **`Cancel`** (footer, `.btn`) — abandons the whole dialog. Use it only at the leaves of a flow.
+
+The canonical back-button markup:
+
+```html
+<button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to ...">
+  &larr; Back
+</button>
+```
+
+### 2.5 Importer / exporter pickers
+
+The shared classes `.importer-picker` / `.importer-card` / `.importer-name` / `.importer-desc` / `.importer-form` / `.form-group` / `.required` cover the dataset importer modal, label importer modal, settings importer/exporter modals, exporter modal, and new-detector picker. **Don't duplicate the card/tile look** — apply the shared classes and the cards will pick up consistent padding, gap, hover, and radius.
+
+### 2.6 Tabs (`.importer-tab-bar` / `.importer-tab`)
+
+Tab strips inside modals use the shared classes in `_picker-shared.scss`. Subclasses (`.importer-subtab`, `.demo-tab`, etc.) extend the base via SCSS `@extend`. Active state: accent color, accent underline, `--weight-semibold`.
+
+### 2.7 Tables
+
+Two near-identical table classes share most styling:
+
+- **`.dash-table`** (`_data-table.scss`) — dashboard grids, with pinned select/actions columns.
+- **`.demo-table`** (`_picker-shared.scss`) — picker tables (demo, labels, etc.).
+
+Both use `--font-md` cells, `--font-xs` uppercase headers, `--space-sm var(--space-md)` cell padding. **Do not invent a new table class** — extend one of these with a row state if needed.
+
+### 2.8 Badges
+
+Use the shared `.badge-ready` / `.badge-embedding` / `.badge-download` classes (`_picker-shared.scss`) for status badges. They share padding, font-size, and radius. If you need a new badge variant, add it next to those rules and reuse the same dimensions.
+
+### 2.9 Layout
+
+The 3-panel grid lives in `_layout.scss`. Panels have `padding: var(--space-xl)` and theme-aware borders. Inside a panel, prefer flex with a `--space-md` or `--space-lg` gap.
+
+---
+
+## 3. Patterns and conventions
+
+### 3.1 Flex gaps
+
+Pick the gap from the spacing scale that matches the visual density:
+
+- **Tight inline rows** (icon + label, related controls): `gap: var(--space-xs)` or `var(--space-sm)`
+- **Standard toolbars / button groups**: `gap: var(--space-md)`
+- **Card-to-card / section-to-section**: `gap: var(--space-lg)` or `var(--space-xl)`
+
+Within one feature, **use the same gap for the same visual pattern**. If a header has `gap: var(--space-md)` between title and actions, every similar header should use the same value.
+
+### 3.2 Alignment
+
+`align-items: center` is the default in horizontal flex rows. Justify-content choices:
+
+- `justify-content: flex-end` — button rows, modal footers, action columns.
+- `justify-content: space-between` — title + close/action header pairs.
+- `justify-content: center` — empty states, single-item centered layouts.
+
+### 3.3 Focus and disabled states
+
+Don't write per-component focus / disabled CSS. The base classes handle both:
+
+- `:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }` (global)
+- `.btn:disabled { opacity: 0.5; cursor: not-allowed; }`
+- `.form-input:focus { border-color: var(--accent); }`
+
+### 3.4 Per-detector hue
+
+Components that should tint themselves by detector identity bind an inline style:
+
+```html
+<div class="detector-card" [style.--detector-hue]="detectorHue(detector.name)">
+  ...
+</div>
+```
+
+Then reference `var(--detector-accent)` and `var(--detector-accent-bg)` in the SCSS. The hue is theme-resolved — in highviz it falls back to the global accent so the high-contrast yellow isn't diluted.
+
+### 3.5 Theme overrides inside a component
+
+Avoid them. The right answer is almost always "use a theme variable." If a component genuinely needs a per-theme tweak (rare), wrap the override in `[data-theme="light"]` or `[data-theme="highviz"]` and add a comment explaining why a token-based solution didn't work.
+
+---
+
+## 4. Anti-patterns (do not do these)
+
+1. **Hardcoded `px` / `rem` for padding, margin, gap.** Pick a `--space-*` token.
+2. **Hardcoded font sizes.** Pick a `--font-*` token. `0.78rem`, `0.95rem`, `13px` are all violations.
+3. **Hex colors in component SCSS.** Pick a theme variable; add one to all three theme blocks if it doesn't exist yet.
+4. **Per-component button styles.** Use `.btn` + variant + size modifier. Never restyle a `.btn`'s padding/font-size/radius from a component.
+5. **Custom focus / disabled / hover styling that overrides the base.** Extend the base, don't replace it.
+6. **`font-weight: 700` / `bold`.** Use `--weight-semibold` (600) or rethink the layout.
+7. **Restyling an `<h1>`/`<h2>` to look like a different heading.** Use the right tag.
+8. **Wrapping a modal's body in a div with extra padding.** `.modal-content` already pads.
+9. **Inventing a new table class.** Extend `.dash-table` or `.demo-table`.
+10. **`transition: all <duration>` with a custom duration.** Use `var(--transition-base)`.
+11. **Cancel as a Back button (or vice versa).** See §2.4.
+12. **Designing for mobile.** Desktop only.
+
+---
+
+## 5. Adding new shared styles
+
+When you have a pattern that recurs (the third time you copy similar SCSS from one component to another), promote it to `_components.scss` (general shared) or `_picker-shared.scss` (importer/exporter/picker domain) or `_data-table.scss` (tables). Don't let the same "kind of thing" diverge across components — that's how the codebase ends up with three "small buttons" that all look slightly different.
+
+When you add a new token:
+- Add it under the matching scale in `_variables.scss` (all three theme blocks if it's color-bearing).
+- Document it here.
+- Use it everywhere it applies.
+
+---
+
+## 6. References
+
+- `frontend/src/scss/_variables.scss` — every design token.
+- `frontend/src/scss/_components.scss` — buttons, forms, modals, headings, info/error/success text.
+- `frontend/src/scss/_picker-shared.scss` — importer/exporter tabs, picker table, badges.
+- `frontend/src/scss/_data-table.scss` — dashboard table.
+- `frontend/src/scss/_layout.scss` — 3-panel grid.
+- `CLAUDE.md` — Back vs Cancel rules, desktop-only scope.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -258,6 +258,42 @@ The 3-panel grid lives in `_layout.scss`. Panels have `padding: var(--space-xl)`
 
 ## 3. Patterns and conventions
 
+### 3.0 Vertical rhythm — titles belong to the content BELOW them
+
+When a panel or modal stacks multiple labelled sections, the gap between a section's title and its content must be **smaller** than the gap between that content and the next section's title. Equal-spaced gaps make titles look like they belong to the section above:
+
+```
+WRONG                            RIGHT
+Section A                        Section A
+[24px gap — equal]               [8px gap — small]
+content A content A              content A content A
+[24px gap — equal]               [24px gap — LARGER]
+Section B                        Section B
+[24px gap — equal]               [8px gap — small]
+content B content B              content B content B
+```
+
+How to achieve the right rhythm:
+
+- **Asymmetric heading margins.** Inside a section container, give the section title (h3/h4 or a `.section-title` element) `margin-top: var(--space-2xl)` and `margin-bottom: var(--space-sm)`, with `:first-child { margin-top: 0 }`. The shared `.section-title` utility class in `_components.scss` does exactly this — use it when you have a panel that stacks sections (no extra flex gap needed).
+- **Or use container padding + flex gap.** If each section lives in its own bordered panel (like the dashboard sections or `.vote-section` in the label list), the panel padding plus container `gap` already produces the right rhythm; no heading margin needed.
+- **Do not** use a flex container's `gap` to do all the spacing and leave headings with `margin: 0`. That produces equal gaps everywhere and breaks the hierarchy.
+
+If you're authoring a settings-style modal with several h3 sub-sections inside one panel, the canonical pattern is:
+
+```scss
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);          // in-section rhythm
+
+  h3 {
+    margin: var(--space-xl) 0 0; // larger top, no bottom (flex gap handles below)
+    &:first-child { margin-top: 0; }
+  }
+}
+```
+
 ### 3.1 Flex gaps
 
 Pick the gap from the spacing scale that matches the visual density:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -45,7 +45,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "525kB",
+                  "maximumWarning": "540kB",
                   "maximumError": "1MB"
                 },
                 {

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
@@ -22,23 +22,23 @@
 
 // Color themes — currentColor is consumed by both the ring SVG and the inner icon.
 .tier-bronze {
-  color: #cd7f32;
+  color: #cd7f32; // achievement-tier intrinsic color, not theme-aware
 }
 
 .tier-silver {
-  color: #d9d9d9;
+  color: #d9d9d9; // achievement-tier intrinsic color, not theme-aware
 }
 
 .tier-gold {
-  color: #f0c419;
+  color: #f0c419; // achievement-tier intrinsic color, not theme-aware
 }
 
 .tier-platinum {
-  color: #f5f6fa;
+  color: #f5f6fa; // achievement-tier intrinsic color, not theme-aware
   filter: drop-shadow(0 0 4px rgba(245, 246, 250, 0.45));
 }
 
 .tier-locked {
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   opacity: 0.55;
 }

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.scss
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.scss
@@ -1,24 +1,24 @@
 .unlock-body {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
-  padding: 0.5rem 0 1rem;
+  gap: var(--space-2xl);
+  padding: var(--space-md) 0 var(--space-xl);
 }
 
 .unlock-text {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-xs);
 }
 
 .unlock-title {
   margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
+  font-size: var(--font-2xl);
+  font-weight: var(--weight-semibold);
 }
 
 .unlock-message {
   margin: 0;
-  color: var(--text-muted, #888);
-  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-size: var(--font-lg);
 }

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -2,30 +2,30 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
-  margin: 0 0 0.75rem;
-  padding: 0.6rem 0.9rem;
+  gap: var(--space-lg);
+  margin: 0 0 var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
   background: var(--bg-subtle);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
 }
 
 .achievements-total-label {
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
 }
 
 .achievements-total-value {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--accent, #4aa3ff);
+  font-size: var(--font-3xl);
+  font-weight: var(--weight-semibold);
+  color: var(--accent);
 }
 
 .achievements-intro {
-  margin: 0 0 1rem;
-  color: var(--text-muted, #888);
-  font-size: 0.9rem;
+  margin: 0 0 var(--space-xl);
+  color: var(--text-muted);
+  font-size: var(--font-lg);
 }
 
 .achievements-list {
@@ -34,16 +34,16 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-lg);
 }
 
 .achievement-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem;
+  gap: var(--space-xl);
+  padding: var(--space-lg);
   background: var(--bg-subtle);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
 }
 
 .achievement-row--locked {
@@ -58,71 +58,71 @@
 .achievement-head {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
-  margin-bottom: 0.15rem;
+  gap: var(--space-md);
+  margin-bottom: var(--space-2xs);
 }
 
 .achievement-name {
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-xl);
 }
 
 .achievement-tier {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding: 0.05rem 0.4rem;
-  border-radius: 3px;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
   background: var(--bg-hover);
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
 
-  &[data-tier-idx="0"] { color: #cd7f32; }
-  &[data-tier-idx="1"] { color: #d9d9d9; }
-  &[data-tier-idx="2"] { color: #f0c419; }
-  &[data-tier-idx="3"] { color: #f5f6fa; }
+  &[data-tier-idx="0"] { color: #cd7f32; } // achievement-tier intrinsic color, not theme-aware
+  &[data-tier-idx="1"] { color: #d9d9d9; } // achievement-tier intrinsic color, not theme-aware
+  &[data-tier-idx="2"] { color: #f0c419; } // achievement-tier intrinsic color, not theme-aware
+  &[data-tier-idx="3"] { color: #f5f6fa; } // achievement-tier intrinsic color, not theme-aware
   &[data-tier-idx="-1"] { cursor: help; }
 }
 
 .achievement-desc {
-  margin: 0 0 0.35rem;
-  font-size: 0.83rem;
-  color: var(--text-muted, #888);
+  margin: 0 0 var(--space-xs);
+  font-size: var(--font-sm);
+  color: var(--text-muted);
 }
 
 .achievement-progress {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-md);
 }
 
 .achievement-progress-track {
   flex: 1;
   height: 6px;
   background: var(--bg-hover);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   overflow: hidden;
 }
 
 .achievement-progress-fill {
   height: 100%;
-  background: var(--accent, #4aa3ff);
+  background: var(--accent);
   border-radius: inherit;
-  transition: width 0.3s ease;
+  transition: width var(--transition-slow) ease;
 }
 
 .achievement-progress-label {
-  font-size: 0.78rem;
-  color: var(--text-muted, #888);
+  font-size: var(--font-xs);
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
 .docs-expand-toggle {
   margin-left: auto;
-  font-size: 0.75rem;
-  padding: 0.1rem 0.5rem;
-  border-radius: 3px;
+  font-size: var(--font-xs);
+  padding: var(--space-2xs) var(--space-md);
+  border-radius: var(--radius-sm);
   background: var(--bg-hover);
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--border);
   color: inherit;
   cursor: pointer;
 
@@ -132,36 +132,36 @@
 }
 
 .docs-panel {
-  margin-top: 0.6rem;
-  padding: 0.6rem 0.75rem;
+  margin-top: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   background: var(--bg-subtle);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .docs-list {
   list-style: none;
-  margin: 0 0 0.6rem;
+  margin: 0 0 var(--space-md);
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-xs);
 }
 
 .docs-list-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  gap: var(--space-md);
+  font-size: var(--font-md);
 }
 
 .docs-list-item--read {
-  color: var(--accent, #4aa3ff);
+  color: var(--accent);
 }
 
 .docs-list-status {
   width: 1rem;
   text-align: center;
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 
 .docs-list-link {
@@ -174,39 +174,39 @@
 }
 
 .docs-list-path {
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
   font-family: var(--font-mono, monospace);
-  font-size: 0.78rem;
+  font-size: var(--font-xs);
 }
 
 .docs-phrase-form {
   display: flex;
-  gap: 0.4rem;
+  gap: var(--space-xs);
   align-items: center;
 }
 
 .docs-phrase-label {
-  font-size: 0.78rem;
-  color: var(--text-muted, #888);
+  font-size: var(--font-xs);
+  color: var(--text-muted);
 }
 
 .docs-phrase-input {
   flex: 1;
-  font-size: 0.85rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 3px;
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  font-size: var(--font-md);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
   background: var(--bg-subtle);
   color: inherit;
 }
 
 .docs-phrase-submit {
-  font-size: 0.78rem;
-  padding: 0.25rem 0.7rem;
-  border-radius: 3px;
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
-  background: var(--accent, #4aa3ff);
-  color: #fff;
+  font-size: var(--font-xs);
+  padding: var(--space-xs) var(--space-lg);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: var(--btn-primary-text);
   cursor: pointer;
 
   &:disabled {
@@ -216,10 +216,10 @@
 }
 
 .docs-phrase-status {
-  margin: 0.4rem 0 0;
-  font-size: 0.8rem;
+  margin: var(--space-xs) 0 0;
+  font-size: var(--font-sm);
 
-  &[data-kind="success"] { color: var(--accent, #4aa3ff); }
-  &[data-kind="already"] { color: var(--text-muted, #888); }
-  &[data-kind="wrong"]   { color: #ff7676; }
+  &[data-kind="success"] { color: var(--accent); }
+  &[data-kind="already"] { color: var(--text-muted); }
+  &[data-kind="wrong"]   { color: var(--color-bad); }
 }

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.scss
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   width: 100%;
-  gap: 10px;
+  gap: var(--space-md);
 }
 
 .waveform-swipe-wrapper {
@@ -37,7 +37,7 @@
 .waveform-canvas {
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-xl);
   background: var(--bg-surface);
 }
 

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -15,14 +15,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  padding: 2px 4px;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-xs);
   overflow: hidden;
 
   &.empty {
     justify-content: center;
     color: var(--text-placeholder);
-    font-size: 1rem;
+    font-size: var(--font-xl);
   }
 }
 
@@ -67,13 +67,13 @@
 .image-view-controls {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-lg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-surface);
   opacity: 0.7;
-  transition: opacity 0.2s;
+  transition: opacity var(--transition-base);
   flex-shrink: 0;
 
   &:hover {
@@ -84,11 +84,11 @@
 .ivc-btn {
   background: none;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   cursor: pointer;
-  padding: 2px 8px;
-  font-size: 1rem;
+  padding: var(--space-2xs) var(--space-md);
+  font-size: var(--font-xl);
 
   &:hover {
     background: var(--bg-hover);
@@ -99,7 +99,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 2px 6px;
+  padding: var(--space-2xs) var(--space-sm);
   line-height: 1;
 
   &.active {
@@ -126,7 +126,7 @@
 }
 
 .ivc-zoom-label {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-secondary);
   min-width: 3em;
 }
@@ -153,18 +153,18 @@
 .metadata-toggle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
   width: 100%;
-  padding: 2px 4px;
+  padding: var(--space-2xs) var(--space-xs);
   border: none;
   border-top: 1px solid var(--border);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  transition: color 0.15s;
+  transition: color var(--transition-base);
   outline: none;
 
   &:hover {
@@ -173,45 +173,45 @@
 }
 
 .metadata-toggle-icon {
-  font-size: 0.6rem;
-  transition: transform 0.2s;
+  font-size: var(--font-2xs);
+  transition: transform var(--transition-base);
 }
 
 .metadata-toggle-label {
-  font-size: 0.7rem;
+  font-size: var(--font-2xs);
 }
 
 // Metadata grid
 .metadata-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 8px;
+  gap: var(--space-md);
   width: 100%;
-  padding: 2px 0;
+  padding: var(--space-2xs) 0;
 }
 
 .metadata-item {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2xs);
 }
 
 .metadata-label {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .metadata-value {
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   color: var(--text-primary);
   word-break: break-all;
 }
 
 .metadata-md5 {
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
 }
 
 // Sticky-armed-state hint banner for the bad-vote-with-box discard flow
@@ -220,24 +220,24 @@
 .bad-confirm-hint {
   flex-shrink: 0;
   width: 100%;
-  padding: 4px 8px;
+  padding: var(--space-xs) var(--space-md);
   border: 1px solid rgba(255, 110, 110, 0.5);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: rgba(255, 110, 110, 0.08);
   color: var(--text-primary);
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   text-align: center;
 }
 
 .undo-toast {
   flex-shrink: 0;
   width: 100%;
-  padding: 4px 8px;
-  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.15));
-  border-radius: 4px;
-  background: var(--bg-subtle, rgba(0, 0, 0, 0.4));
+  padding: var(--space-xs) var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
   color: var(--text-primary);
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   text-align: center;
   animation: undo-toast-fade 2s ease-out;
 }

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.scss
@@ -20,5 +20,5 @@
   max-height: 100%;
   object-fit: contain;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-xl);
 }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -23,7 +23,7 @@
   width: 100%;
   height: 100%;
   object-fit: contain;
-  border-radius: 8px;
+  border-radius: var(--radius-xl);
   user-select: none;
   -webkit-user-drag: none;
 

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.scss
@@ -10,9 +10,9 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 16px;
+  padding: var(--space-xl);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-xl);
   background: var(--bg-surface);
   white-space: pre-wrap;
   line-height: 1.6;

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.scss
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.scss
@@ -32,7 +32,7 @@
   font-size: var(--font-lg);
 
   .error-icon {
-    font-size: 2em;
+    font-size: var(--font-3xl);
     color: var(--text-warning);
   }
 }

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.scss
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.scss
@@ -29,7 +29,7 @@
   padding: var(--space-2xl);
   color: var(--text-muted);
   text-align: center;
-  font-size: 0.9em;
+  font-size: var(--font-lg);
 
   .error-icon {
     font-size: 2em;

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -10,9 +10,9 @@
 .vote-hint {
   flex-shrink: 0;
   width: 100%;
-  padding: 2px 0 4px;
+  padding: var(--space-2xs) 0 var(--space-xs);
   color: var(--text-muted);
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   text-align: center;
   opacity: 0.7;
   pointer-events: none;
@@ -20,26 +20,26 @@
 
 .vote-buttons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-lg);
   justify-content: center;
-  padding: 2px 0;
+  padding: var(--space-2xs) 0;
   flex-shrink: 0;
 }
 
 button {
   min-width: 120px;
-  padding: 8px 24px;
+  padding: var(--space-md) var(--space-2xl);
   border: 2px solid;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  font-weight: 500;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-xl);
+  font-weight: var(--weight-medium);
   cursor: pointer;
   background: transparent;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-sm);
   line-height: 1;
 
   // Remove focus ring from mouse clicks; keep it for keyboard navigation.
@@ -55,7 +55,7 @@ button {
 }
 
 vt-icon.icon-spinning {
-  animation: icon-spin-cw 0.3s ease-in-out;
+  animation: icon-spin-cw var(--transition-slow) ease-in-out;
 }
 
 .btn-good {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
@@ -11,14 +11,14 @@
   gap: var(--space-xs);
   width: 100%;
   min-width: 0;
-  padding: var(--space-xs) 0.5rem;
+  padding: var(--space-xs) var(--space-md);
   background: var(--header-btn-bg);
   border: 1px solid var(--header-btn-border);
   border-radius: var(--radius-md);
   color: var(--header-text);
   font-size: var(--font-sm);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   white-space: nowrap;
 
   &:hover,
@@ -30,7 +30,7 @@
   .trigger-label {
     flex: 0 0 auto;
     color: var(--header-text-dim);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 
   .trigger-swatch {
@@ -53,20 +53,20 @@
   .trigger-caret {
     flex: 0 0 auto;
     color: var(--header-text-dim);
-    font-size: 0.7rem;
+    font-size: var(--font-2xs);
   }
 }
 
 .pulldown-menu {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + var(--space-xs));
   left: 0;
   min-width: 100%;
   max-width: 480px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 12px var(--shadow-dropdown);
+  box-shadow: var(--shadow-md);
   z-index: var(--z-burger-menu);
   display: flex;
   flex-direction: column;
@@ -109,7 +109,7 @@
     border: 1px solid var(--color-bad);
     border-radius: var(--radius-sm);
     color: var(--color-bad);
-    padding: 2px 8px;
+    padding: var(--space-2xs) var(--space-md);
     font-size: var(--font-xs);
     cursor: pointer;
 
@@ -142,7 +142,7 @@
 
   &.is-active {
     background: var(--accent-highlight-bg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
 
     &.is-focused,
     &:hover {

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
@@ -1,12 +1,12 @@
 .clipper-chooser {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .clipper-tab-bar {
   display: flex;
-  gap: 4px;
+  gap: var(--space-xs);
   width: 100%;
   border-bottom: 2px solid var(--border);
 }
@@ -14,15 +14,15 @@
 .clipper-tab {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 8px 16px;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl);
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
+  color: var(--text-secondary);
+  font-size: var(--font-md);
   cursor: pointer;
-  transition: all .15s;
+  transition: all var(--transition-base);
   margin-bottom: -2px;
   white-space: nowrap;
 
@@ -34,31 +34,31 @@
   &.active {
     color: var(--accent);
     border-bottom-color: var(--accent);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 }
 
 .clipper-tab-content {
   min-height: 80px;
-  padding: 4px 0;
+  padding: var(--space-xs) 0;
 }
 
 .clipper-description {
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .82rem;
-  margin: 0 0 8px;
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
+  margin: 0 0 var(--space-md);
 }
 
 .no-settings {
   color: var(--text-muted);
-  font-size: .85rem;
+  font-size: var(--font-md);
   font-style: italic;
-  padding: 8px 0;
+  padding: var(--space-md) 0;
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
 }

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -8,67 +8,67 @@
 .combine-modal-body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .combine-intro {
   margin: 0;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .9rem;
+  color: var(--text-secondary);
+  font-size: var(--font-lg);
   line-height: 1.4;
 }
 
 .name-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: .9rem;
+  gap: var(--space-xs);
+  font-size: var(--font-lg);
 }
 
 .name-label {
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .8rem;
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
   text-transform: uppercase;
   letter-spacing: .04em;
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 
 .name-input {
-  padding: 6px 10px;
+  padding: var(--space-sm) var(--space-md);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--bg-surface);
   color: var(--text-primary);
-  font-size: .95rem;
+  font-size: var(--font-xl);
 
   &:focus {
     outline: none;
-    border-color: var(--accent, #4a8edb);
+    border-color: var(--accent);
   }
 }
 
 .combine-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: .9rem;
+  font-size: var(--font-lg);
 
   th, td {
-    padding: 8px 10px;
+    padding: var(--space-md) var(--space-md);
     border-bottom: 1px solid var(--border);
     text-align: left;
     vertical-align: middle;
   }
 
   thead th {
-    font-weight: 600;
-    color: var(--text-secondary, var(--text-muted));
-    font-size: .8rem;
+    font-weight: var(--weight-semibold);
+    color: var(--text-secondary);
+    font-size: var(--font-sm);
     text-transform: uppercase;
     letter-spacing: .04em;
   }
 
   tfoot td {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     border-top: 2px solid var(--border);
     border-bottom: none;
     background: var(--bg-subtle);
@@ -84,7 +84,7 @@
 
     vt-icon {
       vertical-align: middle;
-      margin-right: 4px;
+      margin-right: var(--space-xs);
     }
   }
 
@@ -94,7 +94,7 @@
   }
 
   .dataset-name {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 
   tbody tr.row-mismatch {
@@ -102,7 +102,7 @@
 
     .col-type {
       color: var(--text-warning);
-      font-weight: 600;
+      font-weight: var(--weight-semibold);
     }
   }
 }
@@ -110,12 +110,12 @@
 .row-remove-btn {
   background: none;
   border: none;
-  font-size: 1.1rem;
+  font-size: var(--font-2xl);
   line-height: 1;
-  color: var(--text-secondary, var(--text-muted));
+  color: var(--text-secondary);
   cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-md);
 
   &:hover {
     color: var(--color-bad);
@@ -130,24 +130,24 @@
 
 .info-text {
   margin: 0;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
+  color: var(--text-secondary);
+  font-size: var(--font-md);
 }
 
 .warn-text {
   margin: 0;
   color: var(--text-warning);
-  font-size: .85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   margin: 0;
   color: var(--color-bad);
-  font-size: .85rem;
+  font-size: var(--font-md);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-md);
 }

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
@@ -1,7 +1,7 @@
 .combine-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
   width: 480px;
   max-width: 100%;
 }
@@ -9,13 +9,13 @@
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .col-label {
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--text-secondary, var(--text-muted));
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-md);
+  color: var(--text-secondary);
 }
 
 .required {
@@ -23,15 +23,15 @@
 }
 
 .info-text {
-  margin: 4px 0 0;
+  margin: var(--space-xs) 0 0;
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
-  margin: 4px 0 0;
+  margin: var(--space-xs) 0 0;
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .source-list {
@@ -40,11 +40,11 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
   max-height: 240px;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
 }
 
@@ -52,8 +52,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 6px 12px;
+  gap: var(--space-lg);
+  padding: var(--space-sm) var(--space-lg);
   border-bottom: 1px solid var(--border);
 
   &:last-child {
@@ -62,8 +62,8 @@
 }
 
 .source-name {
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-lg);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -74,15 +74,15 @@
 .source-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
   flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
 }
 
 .meta-pill {
-  padding: 2px 6px;
-  border-radius: 10px;
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-pill);
   background: var(--bg-hover);
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -1,8 +1,8 @@
 .dashboard-view {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
+  gap: var(--space-2xl);
+  padding: var(--space-2xl);
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
@@ -16,7 +16,7 @@
   min-height: 0;
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: var(--space-md);
   align-items: stretch;
 }
 
@@ -28,8 +28,8 @@
   flex-direction: column;
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 16px;
+  border-radius: var(--radius-xl);
+  padding: var(--space-xl);
 }
 
 .dashboard-side-actions {
@@ -37,8 +37,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 4px 0;
+  gap: var(--space-xs);
+  padding: var(--space-xs) 0;
 }
 
 .side-action-btn {
@@ -47,12 +47,12 @@
   // Dimmer than --text-primary; hover snaps back to full brightness.
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 6px;
-  border-radius: 4px;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover:not(:disabled) {
     color: var(--text-primary);
@@ -76,12 +76,12 @@
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover:not(:disabled) {
     background: var(--btn-icon-hover-bg);
@@ -111,53 +111,33 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
 }
 
 .dashboard-section-title {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: var(--font-xl);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-}
-
-// Shared .btn--cancel base (used in progress, error, and loading-task rows)
-.btn--cancel {
-  flex-shrink: 0;
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 2px 8px;
-  border-radius: 4px;
+  gap: var(--space-sm);
 }
 
 .dashboard-progress,
 .loading-task-progress {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
 
   .progress-msg {
-    font-size: 0.8rem;
+    font-size: var(--font-sm);
     color: var(--text-muted);
     white-space: nowrap;
   }
 
   vt-progress-bar {
     flex: 1;
-  }
-
-  .btn--cancel {
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
   }
 }
 
@@ -166,40 +146,40 @@
 .loading-task-progress:has(.progress-context) {
   flex-direction: column;
   align-items: stretch;
-  gap: 4px;
+  gap: var(--space-xs);
 
   .progress-context {
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: var(--space-2xs);
   }
 
   .progress-header {
-    font-size: 0.85rem;
+    font-size: var(--font-md);
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 
   .progress-subtitle {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     color: var(--text-muted);
   }
 
   .progress-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-md);
   }
 
   .progress-msg {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     max-width: 240px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .progress-eta {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     color: var(--text-muted);
     white-space: nowrap;
     flex-shrink: 0;
@@ -212,35 +192,6 @@
 
 .dashboard-section-actions {
   margin-left: auto;
-}
-
-.btn--sm {
-  padding: 2px 10px;
-  font-size: 1rem;
-  min-width: 28px;
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  .plus-icon {
-    display: inline-block;
-    line-height: 1;
-
-    &.plus-open {
-      animation: plus-spin-open 0.3s ease-in-out forwards;
-    }
-
-    &.plus-close {
-      animation: plus-spin-open 0.3s ease-in-out reverse forwards;
-    }
-  }
-}
-
-@keyframes plus-spin-open {
-  0% { transform: rotate(0deg); }
-  50% { transform: rotate(22.5deg); }
-  100% { transform: rotate(45deg); }
 }
 
 .dashboard-grid {
@@ -256,7 +207,7 @@
 // Loading task rows — per-dataset progress bars inline in the table
 .loading-task-row {
   .loading-task-name {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
     color: var(--text-primary);
     white-space: nowrap;
     overflow: hidden;
@@ -264,7 +215,7 @@
   }
 
   .loading-task-progress .progress-msg {
-    font-size: 0.78rem;
+    font-size: var(--font-xs);
     flex-shrink: 0;
     max-width: 300px;
     overflow: hidden;
@@ -278,7 +229,7 @@
   .loading-task-failed {
     .error-msg {
       flex: 1;
-      font-size: 0.8rem;
+      font-size: var(--font-sm);
       color: var(--error-text);
     }
   }
@@ -289,7 +240,7 @@
   min-height: 0;
   color: var(--text-muted);
   text-align: center;
-  padding: 24px;
+  padding: var(--space-2xl);
   font-style: italic;
 }
 
@@ -298,34 +249,34 @@
   min-height: 0;
   list-style: none;
   margin: 0;
-  padding: 4px 12px;
+  padding: var(--space-xs) var(--space-lg);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-md);
 }
 
 .dashboard-skeleton-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 6px 4px;
+  gap: var(--space-lg);
+  padding: var(--space-sm) var(--space-xs);
 }
 
 .dashboard-actions {
   flex-shrink: 0;
   display: flex;
-  gap: 12px;
+  gap: var(--space-lg);
   justify-content: center;
   position: relative;
 
   .btn {
     min-width: 120px;
-    padding: 10px 24px;
-    font-size: 1rem;
+    padding: var(--space-md) var(--space-2xl);
+    font-size: var(--font-xl);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
+    gap: var(--space-sm);
 
     // Keep full opacity on the active loading button (waggling icon)
     // even though it's disabled to block new clicks.
@@ -351,12 +302,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
   width: 220px;
 }
 
 .btn-disabled-reason {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-muted);
   font-style: italic;
   height: 1.2em;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -1,7 +1,7 @@
 :host {
   display: table-row;
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 
   &:hover {
     background: var(--bg-hover);
@@ -63,18 +63,18 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
 
   .pencil-active {
-    animation: pencil-rotate-open 0.3s ease-in-out forwards;
+    animation: pencil-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .pencil-inactive {
-    animation: pencil-rotate-close 0.3s ease-in-out forwards;
+    animation: pencil-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -104,14 +104,14 @@ td.actions-col {
 
 .inline-edit {
   width: 140px;
-  padding: 2px var(--space-sm);
+  padding: var(--space-2xs) var(--space-sm);
   font-size: var(--font-md);
 }
 
 .type-cell {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-sm);
 }
 
 .type-icon {
@@ -137,16 +137,11 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
-}
-
-.btn--xs {
-  padding: 1px var(--space-sm);
-  font-size: var(--font-xs);
 }
 
 .security-btn {
@@ -159,7 +154,7 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover:not(.disabled) {
     background: var(--btn-icon-hover-bg);
@@ -181,18 +176,18 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
 
   .pie-active {
-    animation: icon-rotate-open 0.3s ease-in-out forwards;
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .pie-inactive {
-    animation: icon-rotate-close 0.3s ease-in-out forwards;
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -206,7 +201,7 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     color: var(--color-bad);
@@ -214,11 +209,11 @@ td.actions-col {
   }
 
   .trash-active {
-    animation: icon-rotate-open 0.3s ease-in-out forwards;
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .trash-inactive {
-    animation: icon-rotate-close 0.3s ease-in-out forwards;
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -226,7 +221,7 @@ td.actions-col {
 // the checkbox in each row lines up under the master checkbox.
 td.select-col {
   width: 36px;
-  padding-left: 8px;
+  padding-left: var(--space-md);
   padding-right: 0;
   text-align: center;
   overflow: visible;
@@ -242,7 +237,7 @@ td.select-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
@@ -254,18 +249,18 @@ td.select-col {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 4px;
+  gap: var(--space-xs);
 
   .progress-context {
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: var(--space-2xs);
   }
 
   .progress-header {
     font-size: var(--font-sm);
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 
   .progress-subtitle {
@@ -300,22 +295,6 @@ td.select-col {
     flex-shrink: 0;
   }
 
-  .btn--cancel {
-    flex-shrink: 0;
-    cursor: pointer;
-    font-size: var(--font-xs);
-    padding: 2px var(--space-md);
-    border-radius: var(--radius-md);
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
-  }
-
   &.inline-loading-failed {
     flex-direction: row;
     align-items: center;
@@ -324,17 +303,6 @@ td.select-col {
       flex: 1;
       font-size: var(--font-sm);
       color: var(--error-text);
-    }
-
-    .btn--cancel {
-      background: transparent;
-      color: var(--error-text);
-      border: 1px solid var(--error-border);
-
-      &:hover {
-        background: var(--error-border);
-        color: var(--btn-filled-text);
-      }
     }
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -16,15 +16,14 @@
   }
 }
 
-.btn--sm { padding: 2px 10px; font-size: .85rem; }
-.form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+.form-actions { display: flex; justify-content: flex-end; gap: var(--space-md); margin-top: var(--space-md); }
 
 .importer-picker, .clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section, .importer-form, .local-folder-uploader {
   display: flex;
   flex-direction: column;
 }
 
-.importer-picker { gap: 0; margin-bottom: 12px; }
+.importer-picker { gap: 0; margin-bottom: var(--space-lg); }
 
 // Indent the Importer's content area inward from the tabs above so the
 // hierarchy reads top-down: category tabs → importer tabs → controls.
@@ -33,22 +32,22 @@
 .importer-form,
 .local-folder-uploader,
 .server-folder-browser {
-  padding-left: 20px;
+  padding-left: var(--space-2xl);
 }
 
 // Extra vertical breathing room above grouped sections inside the Local /
 // Folder uploader (Folder picker, Chunk size, Embedder, Clipper). The
 // Recursive checkbox intentionally does NOT get this class — it is a
 // sub-option of the Folder picker above it.
-.form-group--section { margin-top: 16px; }
+.form-group--section { margin-top: var(--space-xl); }
 
 .clipper-params {
-  padding-left: 16px;
+  padding-left: var(--space-xl);
   border-left: 2px solid var(--border);
-  gap: 8px;
+  gap: var(--space-md);
 }
 
-.demo-picker { gap: 12px; }
+.demo-picker { gap: var(--space-lg); }
 
 .clipper-btn {
   text-align: left;
@@ -62,7 +61,7 @@
   align-self: flex-start;
   background: transparent;
   border: none;
-  padding: 2px 0;
+  padding: var(--space-2xs) 0;
   font-size: var(--font-sm);
   color: var(--text-muted);
   cursor: pointer;
@@ -71,8 +70,8 @@
   &:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 }
 
-.server-folder-browser { gap: 12px; }
-.sf-browse-section { gap: 6px; }
+.server-folder-browser { gap: var(--space-lg); }
+.sf-browse-section { gap: var(--space-sm); }
 
 // Embedder licence warning shown under the picker when the chosen
 // embedder reports a license_notice (today: real-EUPE under FAIR
@@ -82,7 +81,7 @@
 // modal samples the picked folder / files.  Subtle chip so it informs
 // without distracting from the form.
 .detection-hint {
-  margin: 6px 0 0;
+  margin: var(--space-sm) 0 0;
   font-size: var(--font-sm);
   line-height: 1.35;
   color: var(--text-muted);
@@ -90,8 +89,8 @@
 }
 
 .license-warning {
-  margin-top: 6px;
-  padding: 6px 10px;
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-md);
   background: rgba(255, 196, 0, 0.12);
   border: 1px solid rgba(255, 196, 0, 0.4);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -5,8 +5,8 @@
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  row-gap: 4px;
-  column-gap: 12px;
+  row-gap: var(--space-xs);
+  column-gap: var(--space-lg);
 }
 
 .ssp-row {
@@ -22,9 +22,9 @@
 .ssp-row--native {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
   cursor: pointer;
-  padding: 2px 0;
+  padding: var(--space-2xs) 0;
 }
 
 .ssp-row-main {
@@ -39,17 +39,17 @@
 .ssp-row-label {
   display: inline-flex;
   align-items: baseline;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .ssp-native-tag {
-  font-size: .7rem;
+  font-size: var(--font-2xs);
   text-transform: uppercase;
   letter-spacing: .04em;
-  color: var(--text-muted, #888);
-  border: 1px solid var(--border, #d0d0d0);
-  border-radius: 3px;
-  padding: 0 4px;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-xs);
   line-height: 1.3;
 }
 
@@ -64,21 +64,21 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  padding: 6px 0 8px 28px;  // align with checkbox label text
-  border-bottom: 1px dashed var(--border, #e0e0e0);
-  margin-bottom: 2px;
+  gap: var(--space-lg);
+  padding: var(--space-sm) 0 var(--space-md) 28px;  // align with checkbox label text
+  border-bottom: 1px dashed var(--border);
+  margin-bottom: var(--space-2xs);
 }
 
 .ssp-details-field {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: .85rem;
+  gap: var(--space-sm);
+  font-size: var(--font-md);
 }
 
 .ssp-details-field-label {
-  color: var(--text-muted, #555);
+  color: var(--text-muted);
 }
 
 .ssp-converter-select {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -1,7 +1,7 @@
 :host {
   display: table-row;
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 
   &:hover {
     background: var(--bg-hover);
@@ -23,7 +23,7 @@
 }
 
 td {
-  padding: 6px 10px;
+  padding: var(--space-sm) var(--space-md);
   white-space: nowrap;
   vertical-align: middle;
   border-bottom: 1px solid var(--border-subtle);
@@ -39,14 +39,14 @@ td.actions-col {
 .name-cell {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .actions-cell {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .edit-btn {
@@ -54,23 +54,23 @@ td.actions-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
 
   .pencil-active {
-    animation: pencil-rotate-open 0.3s ease-in-out forwards;
+    animation: pencil-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .pencil-inactive {
-    animation: pencil-rotate-close 0.3s ease-in-out forwards;
+    animation: pencil-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -100,14 +100,14 @@ td.actions-col {
 
 .inline-edit {
   width: 140px;
-  padding: 2px 6px;
-  font-size: 0.83rem;
+  padding: var(--space-2xs) var(--space-sm);
+  font-size: var(--font-md);
 }
 
 .type-cell {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-sm);
 }
 
 .type-icon {
@@ -121,7 +121,7 @@ td.actions-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
+  padding: var(--space-xs);
 }
 
 .load-action,
@@ -130,21 +130,16 @@ td.actions-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
-}
-
-.btn--xs {
-  padding: 1px 6px;
-  font-size: 0.75rem;
 }
 
 // Inline loading progress (replaces data columns while loading). Mirrors the
@@ -154,33 +149,33 @@ td.actions-col {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 4px;
+  gap: var(--space-xs);
 
   .progress-context {
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: var(--space-2xs);
   }
 
   .progress-header {
-    font-size: 0.85rem;
+    font-size: var(--font-md);
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 
   .progress-subtitle {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     color: var(--text-muted);
   }
 
   .progress-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-md);
   }
 
   .progress-msg {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     color: var(--text-muted);
     white-space: nowrap;
     flex-shrink: 0;
@@ -194,26 +189,10 @@ td.actions-col {
   }
 
   .progress-eta {
-    font-size: 0.75rem;
+    font-size: var(--font-xs);
     color: var(--text-muted);
     white-space: nowrap;
     flex-shrink: 0;
-  }
-
-  .btn--cancel {
-    flex-shrink: 0;
-    cursor: pointer;
-    font-size: 0.75rem;
-    padding: 2px 8px;
-    border-radius: 4px;
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
   }
 
   &.loading-task-failed {
@@ -222,19 +201,8 @@ td.actions-col {
 
     .error-msg {
       flex: 1;
-      font-size: 0.85rem;
+      font-size: var(--font-md);
       color: var(--error-text);
-    }
-
-    .btn--cancel {
-      background: transparent;
-      color: var(--error-text);
-      border: 1px solid var(--error-border);
-
-      &:hover {
-        background: var(--error-border);
-        color: var(--btn-filled-text);
-      }
     }
   }
 }
@@ -244,23 +212,23 @@ td.actions-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
 
   .cap-active {
-    animation: icon-rotate-open 0.3s ease-in-out forwards;
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .cap-inactive {
-    animation: icon-rotate-close 0.3s ease-in-out forwards;
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -269,12 +237,12 @@ td.actions-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);
@@ -286,12 +254,12 @@ td.actions-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     color: var(--color-bad);
@@ -299,11 +267,11 @@ td.actions-col {
   }
 
   .trash-active {
-    animation: icon-rotate-open 0.3s ease-in-out forwards;
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
   }
 
   .trash-inactive {
-    animation: icon-rotate-close 0.3s ease-in-out forwards;
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
   }
 }
 
@@ -311,7 +279,7 @@ td.actions-col {
 // the checkbox in each row lines up under the master checkbox.
 td.select-col {
   width: 36px;
-  padding-left: 8px;
+  padding-left: var(--space-md);
   padding-right: 0;
   text-align: center;
   overflow: visible;
@@ -322,12 +290,12 @@ td.select-col {
   border: none;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover {
     background: var(--btn-icon-hover-bg);

--- a/frontend/src/app/components/dashboard/disk-usage/disk-usage.component.scss
+++ b/frontend/src/app/components/dashboard/disk-usage/disk-usage.component.scss
@@ -12,11 +12,11 @@
   width: 220px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .disk-usage-label {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -27,20 +27,20 @@
   height: 8px;
   background: var(--bg-elevated, rgba(127, 127, 127, 0.2));
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .disk-usage-fill {
   height: 100%;
-  background: var(--accent, #4caf50);
-  transition: width 0.4s ease, background-color 0.3s ease;
+  background: var(--accent);
+  transition: width var(--transition-slow) ease, background-color var(--transition-slow) ease;
 }
 
 .disk-usage-bar.warn .disk-usage-fill {
-  background: #f0a020;
+  background: var(--text-warning);
 }
 
 .disk-usage-bar.critical .disk-usage-fill {
-  background: #d04030;
+  background: var(--color-bad);
 }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -20,22 +20,22 @@
 
 .tab-bar {
   display: flex;
-  gap: 4px;
+  gap: var(--space-xs);
   border-bottom: 1px solid var(--border);
-  margin-bottom: 12px;
+  margin-bottom: var(--space-lg);
 }
 
 .tab-btn {
   background: none;
   border: none;
-  padding: 8px 16px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  padding: var(--space-md) var(--space-xl);
+  font-size: var(--font-lg);
+  font-weight: var(--weight-medium);
   color: var(--text-muted);
   cursor: pointer;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base);
 
   &:hover { color: var(--text-primary); }
 
@@ -48,19 +48,19 @@
 .importer-form-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xs);
 }
 
 .importer-form-title {
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-xl);
 }
 
 .new-detector-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
   width: 480px;
   max-width: 100%;
 }
@@ -68,44 +68,44 @@
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .required { color: var(--color-bad); }
 
 .info-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 // Two-column layout for text vs media example input
 .example-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  margin-top: 4px;
+  gap: var(--space-xl);
+  margin-top: var(--space-xs);
 }
 
 .example-col {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .col-label {
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--text-secondary, var(--text-muted));
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-md);
+  color: var(--text-secondary);
 }
 
 .text-input-row {
   display: flex;
-  gap: 6px;
+  gap: var(--space-sm);
   align-items: center;
 
   .form-input {
@@ -123,7 +123,7 @@
 // so use a more compact padding than the standalone version inside the media
 // picker — the column is short and we don't want it to dwarf the text input.
 .example-col vt-drop-zone ::ng-deep .drop-zone {
-  padding: 14px 12px;
+  padding: var(--space-lg) var(--space-lg);
 }
 .example-col vt-drop-zone ::ng-deep .drop-zone-icon {
   width: 22px;
@@ -131,17 +131,17 @@
 }
 
 // Single example display
-.example-display { margin-top: 4px; }
+.example-display { margin-top: var(--space-xs); }
 
 .example-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
-  margin-top: 4px;
+  margin-top: var(--space-xs);
 }
 
 .example-icon {
@@ -155,7 +155,7 @@
   width: 40px;
   height: 40px;
   object-fit: cover;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   background: var(--bg-subtle);
 }
@@ -166,7 +166,7 @@
   white-space: nowrap;
   flex: 1;
   min-width: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
 }
 
 // Media picker view container
@@ -175,15 +175,10 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .back-btn { align-self: flex-start; }
-
-.btn--sm {
-  padding: 2px 10px;
-  font-size: .85rem;
-}
 
 .importer-picker {
   display: flex;
@@ -194,27 +189,27 @@
 .demo-picker {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .server-folder-browser {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding-left: 20px;
+  gap: var(--space-lg);
+  padding-left: var(--space-2xl);
 }
 
 .sf-browse-section {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .local-folder-uploader {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding-left: 20px;
+  gap: var(--space-md);
+  padding-left: var(--space-2xl);
 }
 
 // --- Trained-tab importer cards (label-importer picker) ---
@@ -222,21 +217,21 @@
 .source-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .importer-card {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 10px 14px;
+  gap: var(--space-2xs);
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
   color: var(--text-primary);
   cursor: pointer;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--transition-base), background var(--transition-base);
 
   &:hover {
     border-color: var(--accent);
@@ -245,29 +240,29 @@
 }
 
 .importer-name {
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-lg);
 }
 
-.importer-icon { margin-right: 4px; }
+.importer-icon { margin-right: var(--space-xs); }
 
 .importer-desc {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
 .empty-state {
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
   text-align: center;
-  padding: 16px 0;
+  padding: var(--space-xl) 0;
 }
 
 // Media-type field row: dropdown + optional unlock button.
 .media-type-row {
   display: flex;
   align-items: stretch;
-  gap: 6px;
+  gap: var(--space-sm);
 
   .custom-select { flex: 1; min-width: 0; }
 }
@@ -276,13 +271,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
+  padding: 0 var(--space-md);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 6px);
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
   color: var(--text-muted);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
 
   &:hover {
     color: var(--text-primary);
@@ -314,13 +309,13 @@
 .select-option-content {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .select-arrow {
   flex-shrink: 0;
   opacity: 0.6;
-  transition: transform 0.15s;
+  transition: transform var(--transition-base);
 
   .custom-select.open & { transform: rotate(180deg); }
 }
@@ -331,32 +326,32 @@
   left: 0;
   right: 0;
   z-index: var(--z-elevated);
-  margin-top: 2px;
+  margin-top: var(--space-2xs);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-primary, var(--bg-subtle));
-  box-shadow: 0 4px 12px var(--shadow-dropdown);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
 }
 
 .custom-select-option {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-md) var(--space-lg);
   border: none;
   background: none;
   color: var(--text-primary);
   cursor: pointer;
   text-align: left;
   font-size: inherit;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 
   &:hover { background: var(--bg-hover); }
 
   &.selected {
     background: var(--bg-active, var(--bg-hover));
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 }

--- a/frontend/src/app/components/dialog-host/dialog-host.component.scss
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.scss
@@ -2,10 +2,10 @@
 .dialog-message {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-md);
 }
 
 .form-input {
   width: 100%;
-  margin-top: 8px;
+  margin-top: var(--space-md);
 }

--- a/frontend/src/app/components/drop-zone/drop-zone.component.scss
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.scss
@@ -3,14 +3,14 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 22px 16px;
+  gap: var(--space-sm);
+  padding: var(--space-2xl) var(--space-xl);
   border: 2px dashed var(--border-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-xl);
   background: var(--bg-subtle);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  transition: border-color var(--transition-base), background var(--transition-base), color var(--transition-base);
   text-align: center;
   user-select: none;
 
@@ -49,14 +49,14 @@
 
 .drop-zone-label {
   margin: 0;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: var(--font-lg);
+  font-weight: var(--weight-medium);
   pointer-events: none;
 }
 
 .drop-zone-sublabel {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: var(--font-xs);
   color: var(--text-muted);
   pointer-events: none;
 }

--- a/frontend/src/app/components/file-browser/file-browser.component.scss
+++ b/frontend/src/app/components/file-browser/file-browser.component.scss
@@ -1,12 +1,12 @@
 .file-browser-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .file-browser-input-row {
   display: flex;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .file-browser-input {
@@ -16,17 +16,17 @@
 
 .file-browser-browse-btn {
   white-space: nowrap;
-  padding: 4px 12px;
-  font-size: 0.85rem;
+  padding: var(--space-xs) var(--space-lg);
+  font-size: var(--font-md);
 }
 
 // Outer chrome around the embedded folder-browser panel. The list,
 // breadcrumb, and rows themselves are styled by vt-folder-browser.
 .file-browser-panel {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
-  padding: 6px 8px;
+  padding: var(--space-sm) var(--space-md);
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -28,7 +28,7 @@
     left: 2px;
     width: 4px;
     background: var(--border);
-    transition: background 0.15s;
+    transition: background var(--transition-base);
   }
 
   &:hover::after,
@@ -63,7 +63,7 @@
     left: 2px;
     width: 4px;
     background: var(--border);
-    transition: background 0.15s;
+    transition: background var(--transition-base);
   }
 
   &:hover::after,

--- a/frontend/src/app/components/folder-browser/folder-browser.component.scss
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.scss
@@ -6,7 +6,7 @@
 .vfb {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
   min-width: 0;
 }
 
@@ -17,8 +17,8 @@
 .vfb-breadcrumbs {
   display: flex;
   align-items: center;
-  gap: 2px;
-  font-size: .8rem;
+  gap: var(--space-2xs);
+  font-size: var(--font-sm);
   flex-wrap: wrap;
 }
 
@@ -27,15 +27,15 @@
   border: none;
   color: var(--accent);
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: .8rem;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
 
   &:hover { background: var(--bg-subtle); }
 
   &.active {
     color: var(--text-primary);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     cursor: default;
     &:hover { background: none; }
   }
@@ -43,7 +43,7 @@
 
 .vfb-crumb-sep {
   color: var(--text-muted);
-  font-size: .75rem;
+  font-size: var(--font-xs);
 }
 
 // ---------------------------------------------------------------------
@@ -52,7 +52,7 @@
 
 .vfb-list {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   max-height: 320px;
   overflow-y: auto;
   outline: none;
@@ -72,17 +72,17 @@
 .vfb-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-lg);
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
-  z-index: 1;
-  font-size: .72rem;
+  z-index: var(--z-base);
+  font-size: var(--font-2xs);
   text-transform: uppercase;
   letter-spacing: .03em;
-  color: var(--text-secondary, var(--text-muted));
+  color: var(--text-secondary);
   user-select: none;
 }
 
@@ -107,24 +107,24 @@
 .vfb-sort-ind {
   display: inline-block;
   width: 1em;
-  font-size: .7rem;
+  font-size: var(--font-2xs);
 }
 
 // Rows are buttons so they're keyboard-and-screen-reader-friendly.
 .vfb-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
   width: 100%;
-  padding: 6px 12px;
+  padding: var(--space-sm) var(--space-lg);
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-subtle, var(--border));
+  border-bottom: 1px solid var(--border-subtle);
   cursor: pointer;
   text-align: left;
   color: var(--text-primary);
-  font-size: .85rem;
-  transition: background .12s;
+  font-size: var(--font-md);
+  transition: background var(--transition-fast);
 
   &:last-child { border-bottom: none; }
   &:hover:not(:disabled) { background: var(--bg-subtle); }
@@ -137,7 +137,7 @@
   &:hover { background: var(--bg-hover); }
 }
 
-.vfb-row--dir .vfb-name { font-weight: 500; }
+.vfb-row--dir .vfb-name { font-weight: var(--weight-medium); }
 .vfb-row--up { color: var(--text-muted); }
 
 .vfb-icon {
@@ -160,7 +160,7 @@
   width: 110px;
   flex-shrink: 0;
   color: var(--text-muted);
-  font-size: .75rem;
+  font-size: var(--font-xs);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -170,24 +170,24 @@
   width: 70px;
   flex-shrink: 0;
   color: var(--text-muted);
-  font-size: .75rem;
+  font-size: var(--font-xs);
   text-align: right;
   white-space: nowrap;
 }
 
 .vfb-empty {
   margin: 0;
-  padding: 16px;
+  padding: var(--space-xl);
   text-align: center;
-  font-size: .85rem;
+  font-size: var(--font-md);
   color: var(--text-muted);
 }
 
 .vfb-error {
   margin: 0;
-  padding: 12px;
+  padding: var(--space-lg);
   color: var(--color-bad);
-  font-size: .85rem;
+  font-size: var(--font-md);
 }
 
 // ---------------------------------------------------------------------
@@ -197,22 +197,22 @@
 .vfb-path-footer {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 2px;
+  gap: var(--space-sm);
+  margin-top: var(--space-2xs);
 }
 
 .vfb-path-label {
-  font-size: .8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .vfb-path-value {
-  font-size: .8rem;
-  color: var(--text-secondary, var(--text-muted));
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
   background: var(--bg-subtle);
-  padding: 3px 8px;
-  border-radius: 3px;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -28,7 +28,7 @@
     left: 2px;
     width: 4px;
     background: var(--border);
-    transition: background 0.15s;
+    transition: background var(--transition-base);
   }
 
   &:hover::after,
@@ -62,7 +62,7 @@
     left: 2px;
     width: 4px;
     background: var(--border);
-    transition: background 0.15s;
+    transition: background var(--transition-base);
   }
 
   &:hover::after,

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -1,11 +1,11 @@
 .autopilot-panel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 
   &.collapsed {
     align-items: center;
-    padding: 4px 0;
+    padding: var(--space-xs) 0;
     gap: 0;
   }
 }
@@ -13,7 +13,7 @@
 .autopilot-active {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .autopilot-header {
@@ -24,13 +24,13 @@
 .collapse-toggle {
   background: none;
   border: 1px solid var(--border);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 0.7rem;
-  padding: 2px 5px;
+  font-size: var(--font-2xs);
+  padding: var(--space-2xs) var(--space-sm);
   line-height: 1;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base);
 
   &:hover {
     color: var(--text-primary);
@@ -41,15 +41,15 @@
 .autopilot-steps {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .ap-step {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 4px;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
 
   &.active {
     background: var(--accent-highlight-bg);
@@ -85,8 +85,8 @@
 
 .ap-check {
   color: var(--color-good);
-  font-size: 0.85rem;
-  font-weight: bold;
+  font-size: var(--font-md);
+  font-weight: var(--weight-semibold);
 }
 
 .ap-dot {
@@ -104,22 +104,22 @@
 .ap-step-content {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2xs);
 }
 
 .ap-step-label {
-  font-size: 0.82rem;
+  font-size: var(--font-sm);
   color: var(--text-primary);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   cursor: help;
 }
 
 .ap-step-detail {
-  font-size: 0.72rem;
+  font-size: var(--font-2xs);
   color: var(--text-muted);
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
   white-space: nowrap;
 }
 
@@ -145,8 +145,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 4px 0;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
 }
 
 .collapsed-step {
@@ -166,8 +166,8 @@
   &.active {
     background: var(--accent-highlight-bg);
     border: 1px solid var(--accent-highlight-border);
-    border-radius: 3px;
-    padding: 4px 2px;
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-2xs);
   }
 
   &.future {
@@ -176,9 +176,9 @@
 }
 
 .collapsed-step-number {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 
   &.struck {
     text-decoration: line-through;
@@ -189,9 +189,9 @@
 .collapsed-step-label {
   writing-mode: vertical-rl;
   text-orientation: mixed;
-  font-size: 0.72rem;
+  font-size: var(--font-2xs);
   color: var(--text-primary);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   letter-spacing: 0.5px;
   white-space: nowrap;
 }

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
@@ -1,11 +1,11 @@
 .inclusion-selector {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 .inclusion-label {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-secondary);
   white-space: nowrap;
 }
@@ -13,12 +13,12 @@
 
 input[type="number"] {
   width: 56px;
-  padding: 2px 4px;
-  font-size: 0.8rem;
+  padding: var(--space-2xs) var(--space-xs);
+  font-size: var(--font-sm);
   color: var(--text-primary);
   background: var(--bg-secondary, transparent);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   text-align: center;
   outline: none;
 

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -25,9 +25,9 @@
 }
 
 .dataset-name {
-  padding: 6px 8px 4px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  padding: var(--space-sm) var(--space-md) var(--space-xs);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -44,13 +44,13 @@
 
 .left-tab {
   flex: 1;
-  padding: 8px 12px;
+  padding: var(--space-md) var(--space-lg);
   border: none;
   background: var(--bg-panel);
   color: var(--text-secondary);
   cursor: pointer;
-  font-size: 0.85rem;
-  transition: background 0.15s, color 0.15s;
+  font-size: var(--font-md);
+  transition: background var(--transition-base), color var(--transition-base);
 
   &:focus-visible {
     outline: none;
@@ -91,11 +91,11 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: 4px;
-  gap: 4px;
+  padding: var(--space-xs);
+  gap: var(--space-xs);
 
   &.collapsed {
-    padding: 4px 4px;
+    padding: var(--space-xs) var(--space-xs);
     align-items: center;
   }
 }
@@ -108,16 +108,16 @@
 .images-header {
   display: flex;
   align-items: center;
-  padding: 0 4px;
+  padding: 0 var(--space-xs);
   flex-shrink: 0;
 }
 
 .images-header-title {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   letter-spacing: 0.05em;
   margin: 0;
   color: var(--text-secondary);
-  font-weight: normal;
+  font-weight: var(--weight-regular);
 }
 
 .view-controls-slot {

--- a/frontend/src/app/components/left-panel/media-item/media-context-menu.component.scss
+++ b/frontend/src/app/components/left-panel/media-item/media-context-menu.component.scss
@@ -6,7 +6,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: var(--space-xs) 0;
-  box-shadow: 0 8px 24px var(--shadow-dropdown);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.scss
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.scss
@@ -5,7 +5,7 @@
   padding: var(--space-xs) var(--space-md);
   cursor: pointer;
   border-radius: var(--radius-sm);
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
   min-height: 28px;
 
   &:hover {
@@ -95,7 +95,7 @@
   position: absolute;
   box-sizing: border-box;
   border: 1px solid rgba(255, 224, 102, 0.9);
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   pointer-events: none;
   // Inner dark halo keeps the yellow stroke readable on light thumbnails.
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35) inset;
@@ -113,7 +113,7 @@
     border-radius: var(--radius-sm);
     background: var(--bg-surface);
     color: var(--text-muted);
-    font-size: 1.5rem;
+    font-size: var(--font-3xl);
   }
 }
 
@@ -143,7 +143,7 @@
 }
 
 .media-name-grid {
-  font-size: 0.65rem;
+  font-size: var(--font-2xs);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -15,8 +15,8 @@
   &.grid-layout {
     display: grid;
     grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
-    gap: 4px;
-    padding: 4px;
+    gap: var(--space-xs);
+    padding: var(--space-xs);
     align-content: start;
     justify-content: start;
   }
@@ -30,9 +30,9 @@
 .media-threshold-line {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 8px;
-  margin: 2px 0;
+  gap: var(--space-sm);
+  padding: var(--space-2xs) var(--space-md);
+  margin: var(--space-2xs) 0;
 
   .grid-layout & {
     grid-column: 1 / -1;
@@ -49,7 +49,7 @@
 }
 
 .threshold-label {
-  font-size: 0.65rem;
+  font-size: var(--font-2xs);
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -59,9 +59,9 @@
 .empty-list {
   color: var(--text-muted);
   text-align: center;
-  padding: 24px;
+  padding: var(--space-2xl);
   font-style: italic;
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .media-list-skeleton {
@@ -70,14 +70,14 @@
   // real rows doesn't cause a layout shift.
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 4px 8px;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-md);
 
   &.grid-layout {
     display: grid;
     grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
-    gap: 4px;
-    padding: 4px;
+    gap: var(--space-xs);
+    padding: var(--space-xs);
     align-content: start;
     justify-content: start;
   }

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -1,6 +1,6 @@
 .progress-check-bar {
   display: flex;
-  gap: 2px;
+  gap: var(--space-2xs);
   align-items: stretch;
   min-height: 26px;
   flex-wrap: wrap;
@@ -12,10 +12,10 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 3px 6px;
+  gap: var(--space-sm);
+  padding: var(--space-2xs) var(--space-sm);
   border: 1px solid var(--indicator-border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--bg-panel);
   min-width: 0;
 
@@ -23,28 +23,10 @@
     flex: 1;
     min-width: 0;
   }
-
-  // Match the .btn--cancel.btn--sm pattern used by dataset / detector cards —
-  // small grey pill next to the running progress bar.
-  .btn--cancel {
-    flex-shrink: 0;
-    cursor: pointer;
-    font-size: 0.7rem;
-    padding: 1px 8px;
-    border-radius: 4px;
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
-  }
 }
 
 .sort-overlay-status {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
@@ -56,13 +38,13 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  padding: 3px 2px;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-2xs);
   border: 1px solid var(--indicator-border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--bg-panel);
   cursor: pointer;
-  transition: border-color 0.2s;
+  transition: border-color var(--transition-base);
   min-width: 0;
 
   &:hover {
@@ -115,9 +97,9 @@
 }
 
 .indicator-label {
-  font-size: 0.7rem;
+  font-size: var(--font-2xs);
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   line-height: 1;
   overflow-wrap: break-word;
   word-break: break-all;

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
@@ -2,20 +2,20 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px 8px;
+  gap: var(--space-xs) var(--space-md);
 }
 
 .sort-label {
   color: var(--text-secondary);
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
 }
 
 .sort-radio {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  font-size: 0.8rem;
+  gap: var(--space-2xs);
+  font-size: var(--font-sm);
   color: var(--text-secondary);
   cursor: pointer;
 
@@ -26,6 +26,6 @@
 
   &.active {
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 }

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
@@ -14,13 +14,13 @@
 .sort-label {
   color: var(--text-secondary);
   font-size: var(--font-sm);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .sort-radio {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--space-2xs);
   font-size: var(--font-sm);
   color: var(--text-secondary);
   cursor: pointer;
@@ -32,7 +32,7 @@
 
   &.active {
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
 }
 
@@ -58,7 +58,7 @@
   flex: 1;
   min-width: 0;
   font-size: var(--font-sm);
-  padding: 5px var(--space-md);
+  padding: var(--space-sm) var(--space-md);
 }
 
 .text-sort-btn {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
@@ -22,26 +22,26 @@
 .stripe-dot {
   position: absolute;
   height: 2px;
-  border-radius: 1px;
+  border-radius: var(--radius-sm);
 
   &.good {
     background: var(--color-good);
     left: 50%;
-    right: 2px;
+    right: var(--space-2xs);
   }
 
   &.bad {
     background: var(--color-bad);
-    left: 2px;
+    left: var(--space-2xs);
     right: 50%;
   }
 
   &.selected {
     background: var(--accent);
     height: 3px;
-    left: 4px;
-    right: 4px;
-    z-index: 1;
+    left: var(--space-xs);
+    right: var(--space-xs);
+    z-index: var(--z-base);
   }
 }
 

--- a/frontend/src/app/components/login/login.component.scss
+++ b/frontend/src/app/components/login/login.component.scss
@@ -12,7 +12,7 @@
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  padding: 2.5rem 2rem;
+  padding: var(--space-2xl) var(--space-2xl);
   width: 340px;
   max-width: 90vw;
   text-align: center;
@@ -27,7 +27,7 @@
 h2 {
   color: var(--text-primary);
   margin: 0 0 var(--space-xs);
-  font-size: 1.5rem;
+  font-size: var(--font-3xl);
 }
 
 .login-subtitle {
@@ -50,7 +50,7 @@ input {
   color: var(--text-primary);
   font-size: var(--font-xl);
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-base);
 
   &:focus {
     border-color: var(--accent);
@@ -69,7 +69,7 @@ button {
   color: var(--btn-primary-text);
   font-size: var(--font-xl);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--transition-base);
 
   &:hover:not(:disabled) {
     background: var(--accent-hover);

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
@@ -1,18 +1,18 @@
 .autodetect-progress {
   text-align: center;
-  padding: 2rem;
+  padding: var(--space-2xl);
 
   p {
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-xl);
   }
 
   .progress-pct {
-    margin-top: 0.5rem;
-    font-size: 0.85rem;
+    margin-top: var(--space-md);
+    font-size: var(--font-md);
     color: var(--text-secondary);
   }
 
   button {
-    margin-top: 1rem;
+    margin-top: var(--space-xl);
   }
 }

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -1,25 +1,25 @@
 .results-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  font-size: 0.85rem;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-xl);
+  font-size: var(--font-md);
 }
 
 .results-table-wrapper {
   max-height: 300px;
   overflow-y: auto;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-xl);
 }
 
 .results-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
 
   th,
   td {
-    padding: 0.35rem 0.5rem;
+    padding: var(--space-xs) var(--space-md);
     text-align: left;
     border-bottom: 1px solid var(--border-subtle);
   }
@@ -38,24 +38,24 @@
 .col-muted {
   color: var(--text-muted);
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
 }
 
 .export-controls {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-md);
 }
 
 .export-sides {
   display: flex;
-  gap: 1rem;
-  font-size: 0.85rem;
+  gap: var(--space-xl);
+  font-size: var(--font-md);
 
   label {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
+    gap: var(--space-xs);
     cursor: pointer;
   }
 }
@@ -66,13 +66,13 @@
 
 .copy-row {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-md);
   align-items: center;
   flex-wrap: wrap;
 }
 
 .export-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-md);
   justify-content: flex-end;
 }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -10,24 +10,24 @@
 .stats-table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-lg);
 
   th,
   td {
-    padding: 6px 10px;
+    padding: var(--space-sm) var(--space-md);
     text-align: left;
     border-bottom: 1px solid var(--border-subtle);
   }
 
   th {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     color: var(--text-secondary);
-    font-size: 0.85rem;
+    font-size: var(--font-md);
   }
 }
 
 .stat-label {
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   color: var(--text-secondary);
   white-space: nowrap;
 }
@@ -37,8 +37,8 @@
 }
 
 .section-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  margin: 16px 0 8px;
+  font-size: var(--font-xl);
+  font-weight: var(--weight-semibold);
+  margin: var(--space-xl) 0 var(--space-md);
   color: var(--text-primary);
 }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -36,9 +36,6 @@
   color: var(--text-primary);
 }
 
-.section-title {
-  font-size: var(--font-xl);
-  font-weight: var(--weight-semibold);
-  margin: var(--space-xl) 0 var(--space-md);
-  color: var(--text-primary);
-}
+// Section rhythm provided by the shared `.section-title` utility in
+// _components.scss (asymmetric top/bottom margins so each title binds to the
+// content BELOW it). No per-component overrides needed.

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.scss
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.scss
@@ -1,33 +1,33 @@
 .examples-sections {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: var(--space-2xl);
 }
 
 .examples-section {
   h3 {
-    margin: 0 0 0.75rem;
-    font-size: 0.95rem;
+    margin: 0 0 var(--space-lg);
+    font-size: var(--font-xl);
   }
 }
 
 .examples-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-xs);
   max-height: 250px;
   overflow-y: auto;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-md);
 }
 
 .example-card {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.35rem 0.5rem;
+  padding: var(--space-xs) var(--space-md);
   border: 1px solid var(--border-subtle);
-  border-radius: 4px;
-  font-size: 0.8rem;
+  border-radius: var(--radius-md);
+  font-size: var(--font-sm);
 }
 
 .example-label {
@@ -41,8 +41,8 @@
   border: none;
   color: var(--color-bad);
   cursor: pointer;
-  font-size: 1.1rem;
-  padding: 0 0.25rem;
+  font-size: var(--font-2xl);
+  padding: 0 var(--space-xs);
 }
 
 .add-btn {
@@ -51,6 +51,6 @@
 
 .editor-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-md);
   justify-content: flex-end;
 }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -3,17 +3,17 @@
 }
 
 .export-section {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--space-2xl);
 
   h3 {
-    margin: 0 0 0.5rem;
-    font-size: 0.95rem;
+    margin: 0 0 var(--space-md);
+    font-size: var(--font-xl);
   }
 }
 
 .preview-count {
-  font-weight: 400;
-  font-size: 0.8rem;
+  font-weight: var(--weight-regular);
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
@@ -22,14 +22,14 @@
 .column-checkboxes {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .column-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 0.85rem;
+  gap: var(--space-xs);
+  font-size: var(--font-md);
   cursor: pointer;
   user-select: none;
 
@@ -43,14 +43,14 @@
 .delimiter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .delimiter-option {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 0.85rem;
+  gap: var(--space-xs);
+  font-size: var(--font-md);
   cursor: pointer;
   user-select: none;
 
@@ -74,17 +74,17 @@
   max-height: 280px;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .export-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
 
   th,
   td {
-    padding: 4px 8px;
+    padding: var(--space-xs) var(--space-md);
     text-align: left;
     white-space: nowrap;
     overflow: hidden;
@@ -97,8 +97,8 @@
     position: sticky;
     top: 0;
     background: var(--bg-subtle);
-    font-weight: 600;
-    font-size: 0.78rem;
+    font-weight: var(--weight-semibold);
+    font-size: var(--font-xs);
     text-transform: uppercase;
     letter-spacing: 0.02em;
   }
@@ -110,12 +110,12 @@
 
 .label-good {
   color: var(--color-good);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .label-bad {
   color: var(--color-bad);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .truncated-row td {
@@ -130,7 +130,7 @@
 .export-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 // --- Export tabs ---
@@ -145,17 +145,17 @@
 .export-tab {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px 16px;
+  gap: var(--space-xs);
+  padding: var(--space-md) var(--space-xl);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   color: var(--text-muted);
   cursor: pointer;
   white-space: nowrap;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base);
 
   &:hover {
     color: var(--text-primary);
@@ -164,12 +164,12 @@
   &.active {
     color: var(--text-primary);
     border-bottom-color: var(--color-accent);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 }
 
 .tab-icon {
-  font-size: 1rem;
+  font-size: var(--font-xl);
 }
 
 .tab-icon-svg {
@@ -181,8 +181,8 @@
 .tab-content {
   border: 1px solid var(--border);
   border-top: none;
-  border-radius: 0 0 6px 6px;
-  padding: 12px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  padding: var(--space-lg);
   background: var(--bg-subtle);
 }
 
@@ -190,13 +190,13 @@
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .tab-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
   flex: 1 1 200px;
   min-width: 0;
 }
@@ -206,7 +206,7 @@
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .required {
@@ -215,29 +215,29 @@
 
 .info-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .status-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
-  margin-top: 0.5rem;
+  font-size: var(--font-md);
+  margin-top: var(--space-md);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
 }
 
 .empty-state {
   color: var(--text-muted);
   text-align: center;
-  padding: 16px;
+  padding: var(--space-xl);
 }

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -43,14 +43,14 @@
   align-items: center;
   justify-content: center;
   min-width: 1.75rem;
-  padding: 0.1rem 0.4rem;
+  padding: var(--space-2xs) var(--space-xs);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: var(--font-sm);
   color: var(--text-primary);
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   border-bottom-width: 2px;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   line-height: 1.2;
 }
 

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -1,7 +1,7 @@
 .importer-picker {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-md);
   width: 480px;
   max-width: 100%;
 }
@@ -10,14 +10,14 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  padding: 12px 16px;
+  gap: var(--space-xs);
+  padding: var(--space-lg) var(--space-xl);
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   color: var(--text-primary);
 
   &:hover {
@@ -27,41 +27,36 @@
 }
 
 .importer-name {
-  font-weight: 500;
-  font-size: 0.95rem;
+  font-weight: var(--weight-medium);
+  font-size: var(--font-xl);
 }
 
 .importer-icon {
-  margin-right: 4px;
+  margin-right: var(--space-xs);
 }
 
 .importer-desc {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
 .importer-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
   width: 480px;
   max-width: 100%;
 }
 
 .back-btn {
   align-self: flex-start;
-  margin-bottom: 4px;
-}
-
-.btn--sm {
-  padding: 2px 10px;
-  font-size: 0.85rem;
+  margin-bottom: var(--space-xs);
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .required {
@@ -70,45 +65,45 @@
 
 .info-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
 }
 
 .empty-state {
   color: var(--text-muted);
   text-align: center;
-  padding: 16px;
+  padding: var(--space-xl);
 }
 
 .add-media-section {
-  margin-top: 16px;
-  padding-top: 16px;
+  margin-top: var(--space-xl);
+  padding-top: var(--space-xl);
   border-top: 1px solid var(--border);
   width: 480px;
   max-width: 100%;
 }
 
 .add-media-heading {
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: var(--font-md);
+  font-weight: var(--weight-medium);
   color: var(--text-muted);
-  margin-bottom: 8px;
+  margin-bottom: var(--space-md);
 }
 
 .add-media-buttons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 .hidden-file-input {
@@ -117,14 +112,14 @@
 
 .btn-add-good {
   flex: 1;
-  padding: 8px 12px;
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--color-good);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: transparent;
   color: var(--color-good);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--transition-base), color var(--transition-base);
 
   &:hover:not(:disabled) {
     background: var(--color-good);
@@ -140,25 +135,25 @@
 .missing-view {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .missing-info {
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
   color: var(--text-primary);
   line-height: 1.5;
 }
 
 .btn-add-bad {
   flex: 1;
-  padding: 8px 12px;
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--color-bad);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: transparent;
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--transition-base), color var(--transition-base);
 
   &:hover:not(:disabled) {
     background: var(--color-bad);

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -1,18 +1,18 @@
 .load-sort-sections {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: var(--space-2xl);
 }
 
 .sort-section {
   h3 {
-    margin: 0 0 0.75rem;
-    font-size: 0.95rem;
+    margin: 0 0 var(--space-lg);
+    font-size: var(--font-xl);
   }
 
   h4 {
-    margin: 0.75rem 0 0.5rem;
-    font-size: 0.85rem;
+    margin: var(--space-lg) 0 var(--space-md);
+    font-size: var(--font-md);
     color: var(--text-secondary);
   }
 }
@@ -20,27 +20,27 @@
 .file-btn {
   display: inline-block;
   cursor: pointer;
-  margin-right: 0.5rem;
-  margin-bottom: 0.25rem;
+  margin-right: var(--space-md);
+  margin-bottom: var(--space-xs);
 }
 
 .file-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-xs);
   max-height: 200px;
   overflow-y: auto;
 }
 
 .file-item {
   text-align: left;
-  padding: 0.35rem 0.5rem;
+  padding: var(--space-xs) var(--space-md);
   border: 1px solid var(--border-subtle);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -53,7 +53,7 @@
 .file-item-name {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -61,9 +61,9 @@
 }
 
 .item-meta {
-  font-size: 0.7rem;
+  font-size: var(--font-2xs);
   color: var(--text-secondary);
-  margin-left: 0.5rem;
+  margin-left: var(--space-md);
 }
 
 // --- Media picker ---
@@ -73,28 +73,28 @@
 }
 
 .back-btn {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-lg);
 }
 
 .picker-instructions {
-  margin: 0 0 0.75rem;
-  font-size: 0.85rem;
+  margin: 0 0 var(--space-lg);
+  font-size: var(--font-md);
   color: var(--text-secondary);
 }
 
 .source-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-md);
 }
 
 .importer-card {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
@@ -106,37 +106,37 @@
 }
 
 .importer-name {
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: var(--font-md);
+  font-weight: var(--weight-medium);
 }
 
 .importer-icon {
-  margin-right: 0.35rem;
+  margin-right: var(--space-xs);
 }
 
 .importer-desc {
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   color: var(--text-secondary);
-  margin-top: 0.15rem;
+  margin-top: var(--space-2xs);
 }
 
 .browse-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-xs);
   max-height: 300px;
   overflow-y: auto;
 }
 
 .browse-item {
   text-align: left;
-  padding: 0.35rem 0.5rem;
+  padding: var(--space-xs) var(--space-md);
   border: 1px solid var(--border-subtle);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
   white-space: normal;
   word-break: break-word;
 
@@ -152,12 +152,12 @@
 .file-browser-step {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-md);
 }
 
 .empty-state {
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   text-align: center;
-  padding: 1rem 0;
+  padding: var(--space-xl) 0;
 }

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
@@ -1,24 +1,24 @@
 .hint {
-  font-size: 12px;
+  font-size: var(--font-xs);
   color: rgba(0, 0, 0, 0.6);
-  margin-bottom: 8px;
+  margin-bottom: var(--space-md);
 }
 
 .errorMsg {
-  color: #b00020;
-  font-size: 12px;
-  margin-bottom: 8px;
+  color: var(--color-bad);
+  font-size: var(--font-xs);
+  margin-bottom: var(--space-md);
 }
 
 .loading {
-  font-size: 12px;
+  font-size: var(--font-xs);
   color: rgba(0, 0, 0, 0.6);
-  margin: 8px 0;
+  margin: var(--space-md) 0;
 }
 
 audio {
   width: 100%;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-md);
 }
 
 canvas {
@@ -27,18 +27,18 @@ canvas {
   height: 120px;
   background: rgba(0, 0, 0, 0.04);
   border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   touch-action: none;
   user-select: none;
 }
 
 .time-readout {
   display: flex;
-  gap: 8px;
+  gap: var(--space-md);
   align-items: center;
-  margin-top: 8px;
+  margin-top: var(--space-md);
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-md);
   color: rgba(0, 0, 0, 0.7);
 
   .separator {
@@ -52,16 +52,16 @@ canvas {
 
 .actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-md);
   justify-content: flex-end;
-  margin-top: 16px;
+  margin-top: var(--space-xl);
 
   button {
-    padding: 8px 16px;
-    border-radius: 4px;
+    padding: var(--space-md) var(--space-xl);
+    border-radius: var(--radius-md);
     border: 1px solid rgba(0, 0, 0, 0.2);
     cursor: pointer;
-    font-size: 14px;
+    font-size: var(--font-lg);
     background: white;
 
     &:disabled {
@@ -70,7 +70,7 @@ canvas {
     }
 
     &.primary {
-      background: var(--accent-color, #2962ff);
+      background: var(--accent);
       color: white;
       border-color: transparent;
     }

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.scss
@@ -1,7 +1,7 @@
 .hint {
-  font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
-  margin-bottom: 8px;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  margin-bottom: var(--space-md);
   text-align: center;
 }
 
@@ -46,7 +46,7 @@
 
 .crop-box {
   position: absolute;
-  border: 2px solid #2962ff;
+  border: 2px solid var(--accent);
   box-sizing: border-box;
   cursor: move;
 }
@@ -55,7 +55,7 @@
   position: absolute;
   width: 12px;
   height: 12px;
-  background: #2962ff;
+  background: var(--accent);
   border: 2px solid white;
   border-radius: 50%;
   box-sizing: border-box;
@@ -72,21 +72,21 @@
 
 .actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-md);
   justify-content: flex-end;
-  margin-top: 16px;
+  margin-top: var(--space-xl);
 
   button {
-    padding: 8px 16px;
-    border-radius: 4px;
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    padding: var(--space-md) var(--space-xl);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
     cursor: pointer;
-    font-size: 14px;
-    background: white;
+    font-size: var(--font-lg);
+    background: var(--bg-surface);
 
     &.primary {
-      background: var(--accent-color, #2962ff);
-      color: white;
+      background: var(--accent);
+      color: var(--btn-filled-text);
       border-color: transparent;
     }
     &.cancel {

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
@@ -4,10 +4,10 @@
   justify-content: center;
   min-height: 120px;
   max-height: 50vh;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-lg);
   background: rgba(0, 0, 0, 0.04);
-  border-radius: 4px;
-  padding: 8px;
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
 }
 
 .preview img {
@@ -24,29 +24,29 @@
 
 .generic-preview {
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-md);
   color: rgba(0, 0, 0, 0.6);
 }
 
 .filename {
-  font-size: 13px;
+  font-size: var(--font-md);
   color: rgba(0, 0, 0, 0.6);
   text-align: center;
-  margin-bottom: 16px;
+  margin-bottom: var(--space-xl);
   word-break: break-all;
 }
 
 .actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-md);
   justify-content: flex-end;
 
   button {
-    padding: 8px 16px;
-    border-radius: 4px;
+    padding: var(--space-md) var(--space-xl);
+    border-radius: var(--radius-md);
     border: 1px solid rgba(0, 0, 0, 0.2);
     cursor: pointer;
-    font-size: 14px;
+    font-size: var(--font-lg);
     background: white;
 
     &:disabled {
@@ -55,7 +55,7 @@
     }
 
     &.primary {
-      background: var(--accent-color, #2962ff);
+      background: var(--accent);
       color: white;
       border-color: transparent;
     }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
@@ -1,50 +1,32 @@
 .analysis-loading {
   text-align: center;
-  padding: 2rem;
+  padding: var(--space-2xl);
 
   p {
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-xl);
   }
 }
 
 .progress-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
 
   vt-progress-bar {
     flex: 1;
   }
-
-  // Match the .btn--cancel.btn--sm pattern shared with dataset / detector
-  // cards and the sort progress bar.
-  .btn--cancel {
-    flex-shrink: 0;
-    cursor: pointer;
-    font-size: 0.7rem;
-    padding: 1px 8px;
-    border-radius: 4px;
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
-  }
 }
 
 .progress-text {
-  margin-top: 0.5rem;
-  font-size: 0.85rem;
+  margin-top: var(--space-md);
+  font-size: var(--font-md);
   color: var(--text-secondary);
 }
 
 .chart-container {
   display: flex;
   justify-content: center;
-  padding: 1rem 0;
+  padding: var(--space-xl) 0;
 
   canvas {
     max-width: 100%;

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
@@ -1,37 +1,37 @@
 .resort-prompt {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .prompt-text {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
   color: var(--text-primary);
 }
 
 .example-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  margin-top: 4px;
+  gap: var(--space-xl);
+  margin-top: var(--space-xs);
 }
 
 .example-col {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .col-label {
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--text-secondary, var(--text-muted));
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-md);
+  color: var(--text-secondary);
 }
 
 .text-input-row {
   display: flex;
-  gap: 6px;
+  gap: var(--space-sm);
   align-items: center;
 
   .form-input {
@@ -51,7 +51,7 @@
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 // Media picker view (reuses styles from new-model-modal)
@@ -60,33 +60,33 @@
 }
 
 .back-btn {
-  margin-bottom: 12px;
+  margin-bottom: var(--space-lg);
 }
 
 .picker-instructions {
-  margin: 0 0 8px;
-  font-size: 0.9rem;
+  margin: 0 0 var(--space-md);
+  font-size: var(--font-lg);
   color: var(--text-primary);
 }
 
 .source-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .importer-card {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 10px 14px;
+  gap: var(--space-2xs);
+  padding: var(--space-md) var(--space-lg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--bg-subtle);
   color: var(--text-primary);
   cursor: pointer;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--transition-base), background var(--transition-base);
 
   &:hover {
     border-color: var(--accent);
@@ -95,23 +95,23 @@
 }
 
 .importer-name {
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-lg);
 }
 
 .importer-icon {
-  margin-right: 4px;
+  margin-right: var(--space-xs);
 }
 
 .importer-desc {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
 .browse-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
   max-height: 300px;
   overflow-y: auto;
 }
@@ -119,15 +119,15 @@
 .browse-item {
   display: block;
   width: 100%;
-  padding: 6px 12px;
+  padding: var(--space-sm) var(--space-lg);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--bg-subtle);
   color: var(--text-primary);
   cursor: pointer;
   text-align: left;
-  font-size: 0.9rem;
-  transition: border-color 0.15s, background 0.15s;
+  font-size: var(--font-lg);
+  transition: border-color var(--transition-base), background var(--transition-base);
   white-space: normal;
   word-break: break-word;
 
@@ -139,18 +139,18 @@
 
 .empty-state {
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: var(--font-lg);
   text-align: center;
-  padding: 16px 0;
+  padding: var(--space-xl) 0;
 }
 
 .breadcrumbs {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 2px;
-  margin-bottom: 8px;
-  font-size: 0.85rem;
+  gap: var(--space-2xs);
+  margin-bottom: var(--space-md);
+  font-size: var(--font-md);
 }
 
 .breadcrumb-link {
@@ -158,9 +158,9 @@
   border: none;
   cursor: pointer;
   color: var(--accent);
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: 0.85rem;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-md);
 
   &:hover {
     text-decoration: underline;
@@ -174,18 +174,18 @@
 }
 
 .breadcrumb-current {
-  font-weight: 600;
-  padding: 2px 4px;
+  font-weight: var(--weight-semibold);
+  padding: var(--space-2xs) var(--space-xs);
 }
 
 .browse-dir {
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 
 .browse-file {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .entry-icon {
@@ -195,15 +195,15 @@
 .entry-date {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 0.75rem;
+  font-size: var(--font-xs);
   flex-shrink: 0;
   white-space: nowrap;
 }
 
 .entry-size {
   margin-left: 0;
-  padding-left: 0.5rem;
+  padding-left: var(--space-md);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
   flex-shrink: 0;
 }

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
@@ -1,21 +1,21 @@
 .exporter-picker {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 .exporter-card {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  padding: 12px 16px;
+  gap: var(--space-xs);
+  padding: var(--space-lg) var(--space-xl);
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   color: var(--text-primary);
 
   &:hover {
@@ -25,39 +25,34 @@
 }
 
 .exporter-name {
-  font-weight: 500;
-  font-size: 0.95rem;
+  font-weight: var(--weight-medium);
+  font-size: var(--font-xl);
 }
 
 .exporter-icon {
-  margin-right: 4px;
+  margin-right: var(--space-xs);
 }
 
 .exporter-desc {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
 .exporter-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .back-btn {
   align-self: flex-start;
-  margin-bottom: 4px;
-}
-
-.btn--sm {
-  padding: 2px 10px;
-  font-size: 0.85rem;
+  margin-bottom: var(--space-xs);
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .required {
@@ -66,23 +61,23 @@
 
 .info-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
 }
 
 .empty-state {
   color: var(--text-muted);
   text-align: center;
-  padding: 16px;
+  padding: var(--space-xl);
 }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
@@ -1,21 +1,21 @@
 .importer-picker {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 .importer-card {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  padding: 12px 16px;
+  gap: var(--space-xs);
+  padding: var(--space-lg) var(--space-xl);
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   color: var(--text-primary);
 
   &:hover {
@@ -25,39 +25,34 @@
 }
 
 .importer-name {
-  font-weight: 500;
-  font-size: 0.95rem;
+  font-weight: var(--weight-medium);
+  font-size: var(--font-xl);
 }
 
 .importer-icon {
-  margin-right: 4px;
+  margin-right: var(--space-xs);
 }
 
 .importer-desc {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   color: var(--text-muted);
 }
 
 .importer-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .back-btn {
   align-self: flex-start;
-  margin-bottom: 4px;
-}
-
-.btn--sm {
-  padding: 2px 10px;
-  font-size: 0.85rem;
+  margin-bottom: var(--space-xs);
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-xs);
 }
 
 .required {
@@ -66,23 +61,23 @@
 
 .info-text {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .error-text {
   color: var(--color-bad);
-  font-size: 0.85rem;
+  font-size: var(--font-md);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
 }
 
 .empty-state {
   color: var(--text-muted);
   text-align: center;
-  padding: 16px;
+  padding: var(--space-xl);
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -23,16 +23,16 @@
   background: none;
   border: none;
   border-left: 3px solid transparent;
-  padding: 0.6rem 0.85rem;
+  padding: var(--space-sm) var(--space-md);
   font-size: var(--font-md);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   color: var(--text-secondary);
   cursor: pointer;
   text-align: left;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  transition: color var(--transition-base), background var(--transition-base), border-color var(--transition-base);
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: var(--space-xs);
 
   &:hover {
     color: var(--text-primary);
@@ -48,16 +48,23 @@
 
 .settings-panel {
   flex: 1;
-  padding: var(--space-lg) 1.25rem;
+  padding: var(--space-lg) var(--space-xl);
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
 
+  // Section title rhythm: each h3 marks the start of a new sub-section. We
+  // want the gap from the previous section's content to be LARGER than the
+  // gap from the h3 to its own content, so the title visually belongs to
+  // what's below it. Asymmetric margins handle this; flex-gap still
+  // provides the rest of the in-section rhythm.
   h3 {
-    margin: 0;
-    font-size: 0.95rem;
+    margin: var(--space-xl) 0 0;
+    font-size: var(--font-xl);
     color: var(--text-primary);
+
+    &:first-child { margin-top: 0; }
   }
 
   h4 {
@@ -91,12 +98,12 @@
   border: none;
   border-bottom: 2px solid transparent;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
-  padding: 0.45rem 0.85rem;
+  padding: var(--space-sm) var(--space-md);
   font-size: var(--font-sm);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
 
   &:hover {
     color: var(--text-primary);
@@ -131,7 +138,7 @@
     font-size: var(--font-md);
     color: var(--text-secondary);
     border-bottom: 1px solid var(--border-color);
-    padding-bottom: 0.35rem;
+    padding-bottom: var(--space-xs);
   }
 }
 
@@ -143,17 +150,17 @@
 .toggle-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-xs);
   flex: 1;
   justify-content: center;
-  padding: 0.3rem 0.6rem;
+  padding: var(--space-xs) var(--space-sm);
   font-size: var(--font-sm);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   color: var(--text-secondary);
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+  transition: background var(--transition-base), color var(--transition-base), box-shadow var(--transition-base);
 
   &:first-child {
     border-radius: var(--radius-md) 0 0 var(--radius-md);
@@ -183,7 +190,7 @@
 
 
 .settings-tab-icon {
-  transition: transform 0.4s ease;
+  transition: transform var(--transition-slow) ease;
   transform: rotate(0deg);
 
   &--active {
@@ -211,7 +218,7 @@
   font-size: var(--font-xs);
   color: var(--text-secondary);
   opacity: 0;
-  transition: opacity 0.4s ease;
+  transition: opacity var(--transition-slow) ease;
   pointer-events: none;
   user-select: none;
 

--- a/frontend/src/app/components/progress-bar/progress-bar.component.scss
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.scss
@@ -2,15 +2,15 @@
   width: 100%;
   height: 6px;
   background: var(--bg-subtle);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
 .progress-fill {
   height: 100%;
   background: var(--accent);
-  border-radius: 3px;
-  transition: width 0.3s ease;
+  border-radius: var(--radius-sm);
+  transition: width var(--transition-slow) ease;
 
   &.indeterminate {
     width: 30% !important;

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
@@ -1,5 +1,5 @@
 .train-context-bar {
-  padding: 6px 10px;
+  padding: var(--space-sm) var(--space-md);
   border-bottom: 1px solid var(--border);
   background: var(--detector-accent-bg);
   flex-shrink: 0;
@@ -10,22 +10,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .train-context-label {
-  font-size: 0.65rem;
+  font-size: var(--font-2xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-muted);
   display: block;
   line-height: 1;
-  margin-bottom: 2px;
+  margin-bottom: var(--space-2xs);
 }
 
 .train-context-name {
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
   display: inline;
   white-space: nowrap;
@@ -35,14 +35,14 @@
 
 .train-rename-btn {
   vertical-align: middle;
-  margin-left: 4px;
-  font-size: 0.68rem;
+  margin-left: var(--space-xs);
+  font-size: var(--font-2xs);
   background: none;
   border: none;
   cursor: pointer;
   color: var(--text-muted);
-  padding: 2px 4px;
-  border-radius: 3px;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
 
   &:hover {
     color: var(--text-primary);
@@ -51,13 +51,13 @@
 }
 
 .train-rename-input {
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  padding: 1px var(--space-xs);
   width: 100%;
   max-width: 160px;
 }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -9,19 +9,19 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  padding: 12px 16px;
+  padding: var(--space-lg) var(--space-xl);
   display: flex;
   flex-direction: column;
 }
 
 h3 {
-  font-size: 0.8rem;
+  font-size: var(--font-sm);
   letter-spacing: 0.05em;
-  margin: 0 0 8px 0;
+  margin: 0 0 var(--space-md) 0;
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  font-weight: normal;
+  font-weight: var(--weight-regular);
 
   &.good {
     color: var(--color-good);
@@ -41,21 +41,21 @@ h3 {
   &.grid-layout {
     display: grid;
     grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
-    gap: 4px;
+    gap: var(--space-xs);
     align-content: start;
     justify-content: end;
   }
 }
 
 .vote-entry {
-  padding: 4px 0;
-  font-size: 0.8rem;
+  padding: var(--space-xs) 0;
+  font-size: var(--font-sm);
   cursor: pointer;
   color: var(--text-vote);
   line-height: 1.3;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
 
   &:hover {
     color: var(--text-primary);
@@ -64,7 +64,7 @@ h3 {
   &:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
   }
 }
 
@@ -72,9 +72,9 @@ h3 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4px;
-  gap: 2px;
-  border-radius: 3px;
+  padding: var(--space-xs);
+  gap: var(--space-2xs);
+  border-radius: var(--radius-sm);
 
   &:hover {
     background: var(--bg-hover);
@@ -84,14 +84,14 @@ h3 {
 .vote-entry-missing {
   outline: 1px solid var(--missing-border);
   outline-offset: -1px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
 }
 
 .vote-thumbnail-wrap {
   display: block;
   width: 28px;
   height: 28px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 
   .vote-entry-grid & {
@@ -107,7 +107,7 @@ h3 {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--bg-surface);
   display: block;
 
@@ -122,10 +122,10 @@ h3 {
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--bg-surface);
   color: var(--text-muted);
-  font-size: 1rem;
+  font-size: var(--font-xl);
   overflow: hidden;
   flex-shrink: 0;
 
@@ -133,20 +133,20 @@ h3 {
     width: 100%;
     height: auto;
     aspect-ratio: 1;
-    font-size: 1.5rem;
+    font-size: var(--font-3xl);
   }
 }
 
 .vote-name {
   display: block;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .vote-name-grid {
-  font-size: 0.65rem;
+  font-size: var(--font-2xs);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.scss
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.scss
@@ -1,14 +1,14 @@
 .label-sort-bar {
-  padding: 8px 16px;
+  padding: var(--space-md) var(--space-xl);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
   flex-shrink: 0;
 }
 
 .sort-label {
-  font-size: 0.7rem;
+  font-size: var(--font-2xs);
   color: var(--text-dim);
 }
 
@@ -25,10 +25,10 @@
 }
 
 .label-sort-select {
-  padding: 3px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-2xs) var(--space-sm);
+  font-size: var(--font-xs);
   background: var(--bg-surface);
   color: var(--text-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -15,7 +15,7 @@
 
 .import-row {
   display: flex;
-  padding: 8px 16px;
+  padding: var(--space-md) var(--space-xl);
   flex-shrink: 0;
 }
 
@@ -40,7 +40,7 @@
   align-items: center;
   justify-content: flex-start;
   flex-shrink: 0;
-  padding: 4px 12px;
+  padding: var(--space-xs) var(--space-lg);
   border-bottom: 1px solid var(--border);
 }
 
@@ -51,22 +51,22 @@
 
 .export-row {
   display: flex;
-  gap: 6px;
-  padding: 8px 16px;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl);
   flex-shrink: 0;
   border-top: 1px solid var(--border);
 }
 
 .panel-btn {
-  padding: 4px 10px;
-  font-size: 0.75rem;
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--font-xs);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--bg-surface);
   color: var(--text-secondary);
   cursor: pointer;
   white-space: nowrap;
-  transition: all 0.15s;
+  transition: all var(--transition-base);
 
   &:hover:not(:disabled) {
     background: var(--bg-hover);

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -1,12 +1,12 @@
 .toast-stack {
   position: fixed;
-  top: 12px;
+  top: var(--space-lg);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 10000;
+  z-index: var(--z-toast);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-md);
   max-width: min(720px, calc(100vw - 24px));
   width: max-content;
   pointer-events: none;
@@ -19,10 +19,10 @@
   background: var(--bg-panel);
   border: 1px solid var(--error);
   border-left: 4px solid var(--error);
-  border-radius: 6px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-md);
   line-height: 1.4;
   animation: toast-slide-in 180ms ease-out;
 
@@ -47,8 +47,8 @@
 .toast__main {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
 }
 
 .toast__icon {
@@ -65,15 +65,15 @@
 }
 
 .toast__title {
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
   color: var(--error-text);
   word-wrap: break-word;
 }
 
 .toast__detail {
-  margin-top: 2px;
+  margin-top: var(--space-2xs);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-xs);
   word-wrap: break-word;
 }
 
@@ -81,16 +81,16 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
 }
 
 .toast__btn {
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text-primary);
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 4px;
+  font-size: var(--font-xs);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-md);
   cursor: pointer;
   white-space: nowrap;
 
@@ -105,8 +105,8 @@
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -123,20 +123,20 @@
 }
 
 .toast__details {
-  padding: 0 12px 12px;
+  padding: 0 var(--space-lg) var(--space-lg);
   border-top: 1px solid var(--border-subtle);
   margin-top: -2px;
 
   dl {
     display: grid;
     grid-template-columns: max-content 1fr;
-    gap: 4px 12px;
-    margin: 10px 0 0;
-    font-size: 12px;
+    gap: var(--space-xs) var(--space-lg);
+    margin: var(--space-md) 0 0;
+    font-size: var(--font-xs);
   }
 
   dt {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     color: var(--text-muted);
   }
 
@@ -148,26 +148,26 @@
 
   code {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11.5px;
+    font-size: var(--font-xs);
   }
 }
 
 .toast__raw {
-  margin-top: 10px;
+  margin-top: var(--space-md);
 
   summary {
     cursor: pointer;
-    font-size: 12px;
+    font-size: var(--font-xs);
     color: var(--text-muted);
     user-select: none;
   }
 
   pre {
-    margin: 6px 0 0;
-    padding: 8px;
+    margin: var(--space-sm) 0 0;
+    padding: var(--space-md);
     background: var(--border-subtle);
-    border-radius: 4px;
-    font-size: 11.5px;
+    border-radius: var(--radius-md);
+    font-size: var(--font-xs);
     line-height: 1.35;
     max-height: 240px;
     overflow: auto;

--- a/frontend/src/app/components/view-controls/view-controls.component.scss
+++ b/frontend/src/app/components/view-controls/view-controls.component.scss
@@ -5,7 +5,7 @@
 .view-controls {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-md);
 }
 
 .vc-group {
@@ -24,18 +24,18 @@
   border: 1px solid var(--border);
   color: var(--text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s, border-color 0.12s, box-shadow 0.12s;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
 
   &:not(:first-child) {
     margin-left: -1px;
   }
 
   &:first-child {
-    border-radius: 3px 0 0 3px;
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
   }
 
   &:last-child {
-    border-radius: 0 3px 3px 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   }
 
   &:hover:not(:disabled):not(.vc-btn--active) {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -1,20 +1,62 @@
-// Shared component styles: buttons, forms, modals
+// Shared component styles: typography, buttons, forms, modals.
+//
+// Token usage rules (enforced by stylelint + by the conventions in
+// docs/style-guide.md):
+//   • Spacing → `var(--space-*)` only. No raw `px`/`rem` for padding/margin/gap.
+//   • Font sizes → `var(--font-*)` only.
+//   • Font weights → `var(--weight-*)` only.
+//   • Border radius → `var(--radius-*)` only.
+//   • Transition durations → `var(--transition-*)` only.
+//   • Colors → theme CSS variables only (no hex literals).
+
+// --- Typography baseline ---
+//
+// Three semantic heading roles. Components MUST use the matching tag rather
+// than restyling a smaller tag with a bigger font.
+//   h1 — page header (rarely used; reserved for top-of-app surfaces)
+//   h2 — modal/section title
+//   h3 — sub-section title within a modal/panel
+//   h4 — minor grouping label
+h1, h2, h3, h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: var(--weight-semibold);
+  line-height: 1.3;
+}
+
+h1 { font-size: var(--font-3xl); }
+h2 { font-size: var(--font-2xl); }
+h3 { font-size: var(--font-xl); }
+h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
 // --- Buttons ---
+//
+// Anatomy:
+//   .btn              — base; outline-on-surface, default size
+//   .btn--primary     — filled accent (commit action)
+//   .btn--secondary   — filled secondary (neutral action)
+//   .btn--danger      — destructive (red outline → red bg on hover)
+//   .btn--cancel      — subtle, link-weight cancel/close (no fill, small)
+//   .btn--sm          — compact size modifier
+//   .btn--xs          — inline mini size modifier (used inside table rows etc.)
+//   .btn--icon-square — square 28×28 plus/icon button
+//
+// Combine variant + size as needed: `class="btn btn--primary btn--sm"`.
 
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-sm);
-  padding: var(--space-sm) 0.875rem;  // 6px 14px — off-scale horizontal kept exact
+  padding: var(--space-sm) var(--space-lg);  // 6px 12px
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-surface);
   color: var(--text-primary);
   font-size: var(--font-md);
+  font-weight: var(--weight-regular);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
 
   &:hover {
     background: var(--bg-hover);
@@ -48,6 +90,41 @@
     &:hover {
       background: var(--bad-bg);
     }
+  }
+
+  // Compact, no-frill cancel/close. Used in progress rows, error rows, loading
+  // tasks. Sits comfortably next to a vt-progress-bar without dominating it.
+  &--cancel {
+    flex-shrink: 0;
+    padding: var(--space-2xs) var(--space-md);
+    font-size: var(--font-xs);
+    color: var(--text-secondary);
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+    }
+  }
+
+  // Size modifiers — change padding + font, keep border/colors from the variant.
+  &--sm {
+    padding: var(--space-2xs) var(--space-md);
+    font-size: var(--font-sm);
+  }
+
+  &--xs {
+    padding: 0 var(--space-sm);
+    font-size: var(--font-xs);
+    line-height: 1.6;
+  }
+
+  // Square 28×28 icon button (used for "+ add" in dashboard headers).
+  &--icon-square {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: var(--font-xl);
+    line-height: 1;
   }
 }
 
@@ -86,7 +163,7 @@
   margin-bottom: var(--space-xs);
   color: var(--text-primary);
   font-size: var(--font-sm);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 // --- Modal overlay ---
@@ -111,7 +188,7 @@
   max-width: 90vw;
   max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px var(--shadow-dropdown);
+  box-shadow: var(--shadow-lg);
 }
 
 .modal-header {
@@ -171,7 +248,7 @@
   background: var(--bg-subtle);
   cursor: pointer;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--transition-base), background var(--transition-base);
 
   &:hover {
     border-color: var(--accent);
@@ -187,7 +264,7 @@
 .importer-name,
 .exporter-name {
   font-size: var(--font-lg);
-  font-weight: 500;
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
@@ -229,7 +306,7 @@
 .back-btn {
   align-self: flex-start;
   font-size: var(--font-sm);
-  padding: var(--space-xs) 0.625rem;  // 4px 10px — off-scale horizontal kept exact
+  padding: var(--space-xs) var(--space-md);
 }
 
 .info-text {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -29,6 +29,21 @@ h2 { font-size: var(--font-2xl); }
 h3 { font-size: var(--font-xl); }
 h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
+// Section title rhythm — when a heading divides one section from the next
+// inside a single panel/modal, apply `.section-title`. The asymmetric
+// margins (large top, small bottom) make each title visually adhere to the
+// content BELOW it rather than the content ABOVE it. The first title in
+// the container resets its top margin so it sits flush with the panel edge.
+//
+// Pair this with a flex parent that uses `gap: 0` so the asymmetric margins
+// — not the flex gap — produce the spacing.
+.section-title {
+  margin-top: var(--space-2xl);
+  margin-bottom: var(--space-sm);
+
+  &:first-child { margin-top: 0; }
+}
+
 // --- Buttons ---
 //
 // Anatomy:

--- a/frontend/src/scss/_data-table.scss
+++ b/frontend/src/scss/_data-table.scss
@@ -15,10 +15,10 @@
 .dash-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.83rem;
+  font-size: var(--font-md);
 
   th, td {
-    padding: 6px 10px;
+    padding: var(--space-sm) var(--space-md);
     text-align: left;
     vertical-align: middle;
     border-bottom: 1px solid var(--border-subtle);
@@ -29,7 +29,7 @@
   // their content. Header cells must NOT clip — they host the resize
   // handle which pokes 6px to the left of the cell's edge.
   td {
-    padding: 6px 10px;
+    padding: var(--space-sm) var(--space-md);
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -45,7 +45,7 @@
   th.select-col,
   td.select-col {
     width: 36px;
-    padding-left: 8px;
+    padding-left: var(--space-md);
     padding-right: 0;
     text-align: center;
   }
@@ -72,8 +72,8 @@
     background: var(--bg-surface);
     z-index: 1;
     color: var(--text-secondary);
-    font-weight: 500;
-    font-size: 0.78rem;
+    font-weight: var(--weight-medium);
+    font-size: var(--font-xs);
     text-transform: uppercase;
     letter-spacing: 0.03em;
     user-select: none;
@@ -162,7 +162,7 @@
         width: 2px;
         background: var(--accent);
         opacity: 0.35;
-        transition: opacity 0.15s;
+        transition: opacity var(--transition-base);
       }
 
       &:hover::after {
@@ -173,7 +173,7 @@
 
   tbody tr {
     cursor: pointer;
-    transition: background 0.1s;
+    transition: background var(--transition-fast);
 
     &:hover {
       background: var(--bg-hover);

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -12,7 +12,7 @@
 .importer-tab-bar {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
   width: 100%;
   border-bottom: 2px solid var(--border);
 }
@@ -20,15 +20,15 @@
 .importer-tab {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 8px 16px;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl);
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
+  color: var(--text-secondary);
+  font-size: var(--font-md);
   cursor: pointer;
-  transition: all .15s;
+  transition: all var(--transition-base);
   margin-bottom: -2px;
   white-space: nowrap;
 
@@ -40,7 +40,7 @@
   &.active {
     color: var(--accent);
     border-bottom-color: var(--accent);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
 }
 
@@ -66,14 +66,14 @@
 // as `.detection-hint` in the dataset importer so subtle helper text reads
 // consistently across the modal.
 .tab-bar-hint {
-  margin: 8px 0 0 0;
+  margin: var(--space-md) 0 0;
   color: var(--text-muted);
   font-size: var(--font-sm);
   font-style: italic;
 }
 
 .empty-state--inline {
-  padding: 6px 10px;
+  padding: var(--space-sm) var(--space-md);
   font-size: var(--font-sm);
   color: var(--text-muted);
   font-style: italic;
@@ -98,17 +98,17 @@
 .demo-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.83rem;
+  font-size: var(--font-md);
 
   th, td {
-    padding: 6px 10px;
+    padding: var(--space-sm) var(--space-md);
     text-align: left;
     border-bottom: 1px solid var(--border-subtle);
     white-space: nowrap;
   }
 
   td {
-    padding: 6px 12px;
+    padding: var(--space-sm) var(--space-lg);
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -120,8 +120,8 @@
     background: var(--bg-surface);
     z-index: 1;
     color: var(--text-secondary);
-    font-weight: 500;
-    font-size: 0.78rem;
+    font-weight: var(--weight-medium);
+    font-size: var(--font-xs);
     text-transform: uppercase;
     letter-spacing: 0.03em;
     user-select: none;
@@ -164,7 +164,7 @@
         width: 2px;
         background: var(--accent);
         opacity: 0.35;
-        transition: opacity 0.15s;
+        transition: opacity var(--transition-base);
       }
 
       &:hover::after { opacity: 0.7; }
@@ -173,7 +173,7 @@
 
   tbody tr {
     cursor: pointer;
-    transition: background 0.1s;
+    transition: background var(--transition-fast);
 
     &:hover { background: var(--bg-hover); }
 
@@ -185,7 +185,7 @@
   }
 }
 
-.col-num { text-align: right; padding-right: 12px; }
+.col-num { text-align: right; padding-right: var(--space-lg); }
 
 .col-desc, .col-name, .col-status {
   overflow: hidden;
@@ -193,8 +193,8 @@
   white-space: nowrap;
 }
 
-.col-desc { color: var(--text-muted); font-size: 0.78rem; }
-.col-name { font-weight: 600; color: var(--text-primary); }
+.col-desc { color: var(--text-muted); font-size: var(--font-xs); }
+.col-name { font-weight: var(--weight-semibold); color: var(--text-primary); }
 
 .demo-row {
   &.ready .col-name { color: var(--color-good); }
@@ -202,10 +202,10 @@
 
 .badge-ready, .badge-embedding, .badge-download {
   display: inline-block;
-  padding: 1px 7px;
+  padding: var(--space-2xs) var(--space-sm);
   color: var(--btn-filled-text);
-  font-size: .7rem;
-  border-radius: 3px;
+  font-size: var(--font-2xs);
+  border-radius: var(--radius-sm);
 }
 
 .badge-ready { background: var(--color-good); }

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -28,6 +28,29 @@
   --radius-md: 4px;
   --radius-lg: 6px;
   --radius-xl: 8px;
+  --radius-pill: 999px;
+
+  // Font weights — semantic, not numeric
+  //   --weight-regular  → body copy, table cells, descriptions
+  //   --weight-medium   → form labels, table headers, secondary emphasis
+  //   --weight-semibold → card titles, active tabs, primary emphasis
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+
+  // Transition durations — every interactive transition picks one of these.
+  //   --transition-fast → hover/background swaps that should feel instant
+  //   --transition-base → default for color/border/background on interactive elements
+  //   --transition-slow → bars, fills, and other animations that benefit from being perceptible
+  --transition-fast: 0.1s;
+  --transition-base: 0.15s;
+  --transition-slow: 0.3s;
+
+  // Elevation / shadow scale (resolves through --shadow-dropdown so each
+  // theme tints shadows appropriately: dark/light/highviz)
+  --shadow-sm: 0 1px 2px var(--shadow-dropdown);
+  --shadow-md: 0 4px 12px var(--shadow-dropdown);
+  --shadow-lg: 0 8px 32px var(--shadow-dropdown);
 
   // Z-index scale (centralised stacking order)
   --z-base: 1;
@@ -36,6 +59,7 @@
   --z-modal-backdrop: 1000;
   --z-modal: 1001;
   --z-burger-menu: 2000;
+  --z-toast: 5000;
   --z-login: 9999;
 
   // --- Theme colors (dark, default) ---


### PR DESCRIPTION
## Summary

Codifies the frontend design system and applies it everywhere.

- **`docs/style-guide.md`** — full reference for tokens, shared classes, the vertical-rhythm rule, and anti-patterns.
- **`frontend/src/scss/_variables.scss`** — adds `--weight-*`, `--transition-*`, `--shadow-*`, `--radius-pill`, `--z-toast`.
- **`frontend/src/scss/_components.scss`** — base `h1–h4` typography rules, `.btn--sm` / `--xs` / `--cancel` / `--icon-square` shared button variants, `.section-title` utility (asymmetric top/bottom margins so titles bind to the content below).
- **SCSS sweep across every component file under `frontend/src/app/components/`** — hardcoded px/rem for spacing, font sizes, weights, radii, transitions all resolve through tokens; hex literals replaced with theme variables; redundant local `.btn--sm` / `.btn--cancel` declarations removed in favor of the shared classes.
- **`settings-modal` + `dataset-stats-modal`** — vertical-rhythm violations fixed so titles visually adhere to the content below them.
- **`frontend/angular.json`** — initial-bundle warning budget 525 → 540 kB to absorb the raw-byte cost of `var(--space-md)` vs `8px`. Gzipped transfer size unchanged at ~136 kB.

## Note

These commits already landed on `main` via PR #1644 (created and merged outside this session). This PR brings `dev` in sync.

## Test plan
- [x] `./run-tests.sh core` → 589 passed
- [x] `cd frontend && npm run build:prod` → clean, no warnings
- [ ] Spot-check the UI in a browser before relying on it


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSF5kDFQeviPk1qUzTwM8L)_