### PR TITLE
frontend: extract &lt;vt-import-config&gt; (Checkpoint 2)

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 Checkpoint 1 shipped.** The remaining checkpoints of #1
-and items #2–#6 are scoped but not started.
+Status: **#1 Checkpoints 1 and 2 shipped.** Checkpoints 3–5 of #1 and
+items #2–#6 are scoped but not started.
 
 ## What shipped
 
@@ -18,6 +18,27 @@ and items #2–#6 are scoped but not started.
   Parent .ts dropped from 1814 → 1668 lines; template from 669 → 545
   lines. **Initial bundle went from 540 kB → 526.40 kB** (gzip
   136.35 kB), back under the previous (525 kB) warning threshold.
+- **#1 Checkpoint 2** (`d1d3e2d7`): extracted `<vt-import-config>` —
+  the output media-type select + auto-detection hint chip — from the
+  `sf` and `lf` flows. The block was inlined twice with identical
+  markup (same label, same select shape, same `.detection-hint`
+  rendering) and only the bound state and field id differing. Both
+  call sites now consume `<vt-import-config>`, and the
+  `.detection-hint` rule moved out of the parent SCSS into the new
+  component. The parent gains a `mediaTypeOptionLabels` cache
+  (folder_import_name → label) so the child does not need
+  `MediaTypeInfo`. Template dropped from 545 → 529 lines; .ts grew
+  slightly (1668 → 1687) for the cache getter + import. **Lazy
+  `dataset-importer-modal-component` chunk dropped 78.96 kB →
+  77.64 kB raw** (15.99 → 15.76 kB gzip). Initial bundle unchanged at
+  526.40 kB — the modal is `@defer`-loaded, so all gains land in the
+  lazy chunk.
+  Wrapping `<vt-import-advanced>` inside the new component (the
+  plan's optional collapse) turned out to be infeasible without a UX
+  re-order: the source widget (folder browser / dropzone) and the
+  recursive checkbox sit between the media-type select and the
+  Advanced block in both flows. Kept the scope to just the media-type
+  + hint block; Advanced stays in its current position.
 
 ## Why
 
@@ -124,14 +145,19 @@ touching the cross-modal picker chrome):
    `<vt-import-advanced>` — the Advanced ▾ block (Include media +
    Embedder + Clipper). Migrated all four call sites (`sf`, `lf`,
    `form`, `demo`) in `dataset-importer-modal` to use it.
-2. **Checkpoint 2**: Extract `<vt-import-config>` (media-type select +
-   detection hint, optionally wrapping `<vt-import-advanced>` so the
-   whole config form is one widget). Migrate the `sf` / `lf` flows to
-   it. The dataset-name input and folder-path widget stay in the
-   parent — only the configuration form is extracted.
+2. **Checkpoint 2 (shipped, `d1d3e2d7`)**: Extracted
+   `<vt-import-config>` — the output media-type select + detection
+   hint chip. Migrated the `sf` and `lf` flows in
+   `dataset-importer-modal` to use it. Scope stayed at just the
+   media-type widget (not the optional collapse-with-Advanced) because
+   the source widget and recursive checkbox sit between media-type and
+   Advanced in the template — a wrap would have forced a UX re-order.
 3. **Checkpoint 3**: Migrate the `form` flow to `<vt-import-config>`
    (where applicable — the generic form's media-type lives inside the
-   importer's `fields[]`, so this may end up partial).
+   importer's `fields[]`, so this may end up partial; the form flow
+   does not currently render the detection hint, so the wider option
+   may just be inlining `<vt-import-config>` with a static
+   `detectionHint=""`).
 4. **Checkpoint 4**: Extract `<vt-source-picker>` (the importer-tab /
    sub-tab chrome + demo table + server-folder typed path + local
    dropzone). Migrate `dataset-importer-modal` to consume it.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -347,22 +347,14 @@
         />
       </div>
 
-      <div class="form-group">
-        <label class="form-label" for="lf-media-type" title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type.">Dataset MediaType</label>
-        <select
-          id="lf-media-type"
-          class="form-select"
-          [ngModel]="lfMediaType"
-          (ngModelChange)="lfOnMediaTypeChange($event)"
-        >
-          @for (opt of lfMediaTypeOptions; track opt) {
-            <option [value]="opt">{{ getMediaTypeOptionLabel(opt) }}</option>
-          }
-        </select>
-        @if (detectionHint(lfDetection); as hint) {
-          <p class="detection-hint">{{ hint }}</p>
-        }
-      </div>
+      <vt-import-config
+        mediaTypeFieldId="lf-media-type"
+        [mediaType]="lfMediaType"
+        (mediaTypeChange)="lfOnMediaTypeChange($event)"
+        [mediaTypeOptions]="lfMediaTypeOptions"
+        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [detectionHint]="detectionHint(lfDetection)"
+      ></vt-import-config>
 
       <div class="form-group form-group--section">
         @if (lfPickerKind === 'folder') {
@@ -459,22 +451,14 @@
         />
       </div>
 
-      <div class="form-group">
-        <label class="form-label" for="sf-media-type" title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type.">Dataset MediaType</label>
-        <select
-          id="sf-media-type"
-          class="form-select"
-          [ngModel]="sfMediaType"
-          (ngModelChange)="sfOnMediaTypeChange($event)"
-        >
-          @for (opt of sfMediaTypeOptions; track opt) {
-            <option [value]="opt">{{ getMediaTypeOptionLabel(opt) }}</option>
-          }
-        </select>
-        @if (detectionHint(sfDetection); as hint) {
-          <p class="detection-hint">{{ hint }}</p>
-        }
-      </div>
+      <vt-import-config
+        mediaTypeFieldId="sf-media-type"
+        [mediaType]="sfMediaType"
+        (mediaTypeChange)="sfOnMediaTypeChange($event)"
+        [mediaTypeOptions]="sfMediaTypeOptions"
+        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [detectionHint]="detectionHint(sfDetection)"
+      ></vt-import-config>
 
       <div class="sf-browse-section">
         <label class="form-label" for="sf-path-input">Folder to import</label>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -52,21 +52,11 @@
 .server-folder-browser { gap: var(--space-lg); }
 .sf-browse-section { gap: var(--space-sm); }
 
-// Detection hint shown below the output-media-type dropdown after the
-// modal samples the picked folder / files.  Subtle chip so it informs
-// without distracting from the form.
-.detection-hint {
-  margin: var(--space-sm) 0 0;
-  font-size: var(--font-sm);
-  line-height: 1.35;
-  color: var(--text-muted);
-  font-style: italic;
-}
-
-// `.advanced-toggle`, `.clipper-btn`, and `.license-warning` live inside
-// `<vt-import-advanced>` (which encapsulates the styles).  The
-// surrounding `.form-group--section` rule below provides the vertical
-// gap above the Advanced block.
+// `.detection-hint` lives inside `<vt-import-config>` (which
+// encapsulates its own styles).  `.advanced-toggle`, `.clipper-btn`,
+// and `.license-warning` likewise live inside `<vt-import-advanced>`.
+// The surrounding `.form-group--section` rule above provides the
+// vertical gap above the Advanced block.
 
 
 // Multi-media import UI lives in

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,6 +6,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { ImportAdvancedComponent } from './import-advanced/import-advanced.component';
+import { ImportConfigComponent } from './import-config/import-config.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
@@ -14,7 +15,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, ImportAdvancedComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, ImportAdvancedComponent, ImportConfigComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -792,6 +793,24 @@ export class DatasetImporterModalComponent implements OnInit {
       this._typeLabelsSource = this.mediaTypes;
     }
     return this._typeLabelsCache;
+  }
+
+  /** Cached map of ``folder_import_name`` → human label, rebuilt only
+   *  when ``mediaTypes`` is reassigned.  Feeds the media-type dropdown
+   *  inside :component:`ImportConfigComponent` so the parent does not
+   *  need to pass a per-render label function. */
+  private _optionLabelsSource: MediaTypeInfo[] | null = null;
+  private _optionLabelsCache: Record<string, string> = {};
+  get mediaTypeOptionLabels(): Record<string, string> {
+    if (this._optionLabelsSource !== this.mediaTypes) {
+      const out: Record<string, string> = {};
+      for (const mt of this.mediaTypes) {
+        if (mt.folder_import_name) out[mt.folder_import_name] = mt.name.trim();
+      }
+      this._optionLabelsCache = out;
+      this._optionLabelsSource = this.mediaTypes;
+    }
+    return this._optionLabelsCache;
   }
 
   getTabIcon(mediaType: string): string {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
@@ -1,0 +1,20 @@
+<div class="form-group">
+  <label
+    class="form-label"
+    [for]="mediaTypeFieldId"
+    title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type."
+  >Dataset MediaType</label>
+  <select
+    [id]="mediaTypeFieldId"
+    class="form-select"
+    [ngModel]="mediaType"
+    (ngModelChange)="mediaTypeChange.emit($event)"
+  >
+    @for (opt of mediaTypeOptions; track opt) {
+      <option [value]="opt">{{ optionLabel(opt) }}</option>
+    }
+  </select>
+  @if (detectionHint) {
+    <p class="detection-hint">{{ detectionHint }}</p>
+  }
+</div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
@@ -1,0 +1,18 @@
+// Styles previously inlined in the parent component for the
+// media-type select + detection hint chip — moved here when the two
+// adjacent form groups were collapsed into <vt-import-config>.
+
+:host {
+  display: contents;
+}
+
+// Detection hint shown below the output-media-type dropdown after the
+// modal samples the picked folder / files.  Subtle chip so it informs
+// without distracting from the form.
+.detection-hint {
+  margin: var(--space-sm) 0 0;
+  font-size: var(--font-sm);
+  line-height: 1.35;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -1,0 +1,57 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+/** Output-media-type select + auto-detection hint chip shared by the
+ *  server-folder (``sf``) and local-folder/local-files (``lf``) flows
+ *  of the Add Dataset modal.  The two flows had identical markup for
+ *  this block — same label text, same widget shape, same hint
+ *  rendering — with only the bound state and field id differing.
+ *
+ *  The dataset-name input, the source-side widget (folder path /
+ *  dropzone), the recursive checkbox, and the Advanced ▾ block stay
+ *  in the parent.  Wrapping the Advanced block here is tempting but
+ *  rules out by the template structure: the source widget and
+ *  recursive toggle sit between the media-type select and the
+ *  Advanced block, so collapsing into one child would force a
+ *  re-order of the flow.
+ */
+@Component({
+  selector: 'vt-import-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './import-config.component.html',
+  styleUrl: './import-config.component.scss',
+})
+export class ImportConfigComponent {
+  /** ``id`` / ``for`` value for the rendered media-type select.  Each
+   *  call site supplies a unique value so the modal does not contain
+   *  duplicate ids when multiple flows are present in the DOM. */
+  @Input() mediaTypeFieldId = 'import-config-media-type';
+
+  /** Two-way bound output media type (folder_import_name, e.g.
+   *  ``"images"``).  Parent reloads embedders/clippers/source-specs on
+   *  every change. */
+  @Input() mediaType = '';
+  @Output() mediaTypeChange = new EventEmitter<string>();
+
+  /** ``folder_import_name`` values to show in the dropdown — same list
+   *  the importer's ``media_type`` field declares as ``options``. */
+  @Input() mediaTypeOptions: string[] = [];
+
+  /** Map of ``folder_import_name`` → human label.  Parent computes this
+   *  once from the ``/api/media-types`` response. */
+  @Input() mediaTypeOptionLabels: Record<string, string> = {};
+
+  /** Pre-formatted hint string from
+   *  :meth:`DatasetImporterModalComponent.detectionHint`.  Empty hides
+   *  the chip entirely. */
+  @Input() detectionHint = '';
+
+  /** Label for an option in the media-type dropdown.  Falls back to the
+   *  option value when no label is supplied (e.g. the parent's
+   *  ``mediaTypes`` list has not loaded yet). */
+  optionLabel(opt: string): string {
+    return this.mediaTypeOptionLabels[opt] || opt;
+  }
+}


### PR DESCRIPTION
## Summary

Checkpoint 2 of the [frontend-bundle-organization plan](../blob/dev/docs/plans/frontend-bundle-organization.md). Extracts the output media-type select + auto-detection hint chip into a standalone `<vt-import-config>` component, in the same shape as the existing `<vt-import-advanced>`.

The block was inlined twice in `dataset-importer-modal.component.html` — once for the server-folder (`sf-*`) flow and once for the local-folder / local-files (`lf-*`) flow — with identical markup (same label text, same `.detection-hint` rendering) and only the bound state and field id differing. Both call sites now consume `<vt-import-config>`.

- New: `frontend/src/app/components/dashboard/dataset-importer-modal/import-config/`
- Parent template dropped from 545 → 529 lines.
- Parent .ts grew slightly (1668 → 1687) for a `mediaTypeOptionLabels` cache getter (folder_import_name → label) so the child does not need to import `MediaTypeInfo`.
- `.detection-hint` style moved out of the parent SCSS into the new component.
- **Lazy `dataset-importer-modal-component` chunk: 78.96 kB → 77.64 kB raw** (15.99 → 15.76 kB gzip). Initial bundle unchanged at 526.40 kB — the modal is `@defer`-loaded, so all gains land in the lazy chunk.

### Scope note

The plan suggested optionally wrapping `<vt-import-advanced>` inside `<vt-import-config>` so the whole config form is one widget. That turned out to be infeasible without a UX re-order: the source widget (folder browser / dropzone) and the recursive checkbox both sit between the media-type select and the Advanced block in the existing templates. Kept the scope to just the media-type + detection-hint block; Advanced stays in its current position. The plan doc is updated to record this constraint.

## Test plan

- [x] `./run-tests.sh core` (frontend build check + Python core suite): 589/589 pass
- [x] `./run-tests.sh` (full suite): 4199/4200 pass (1 skipped, 2 xpassed)
- [x] `npm run build:prod`: clean, no new warnings; initial bundle 526.40 kB (gzip 136.38 kB), under the 540 kB warning threshold


---
_Generated by [Claude Code](https://claude.ai/code/session_01JCx1UuwAEC8s6xNRcjdJBs)_