### PR TITLE
Migrate form flow media_type to <vt-import-config> (Checkpoint 3)

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 Checkpoints 1 and 2 shipped.** Checkpoints 3–5 of #1 and
-items #2–#6 are scoped but not started.
+Status: **#1 Checkpoints 1, 2, and 3 shipped.** Checkpoints 4 and 5 of
+#1 and items #2–#6 are scoped but not started.
 
 ## What shipped
 
@@ -39,6 +39,24 @@ items #2–#6 are scoped but not started.
   recursive checkbox sit between the media-type select and the
   Advanced block in both flows. Kept the scope to just the media-type
   + hint block; Advanced stays in its current position.
+- **#1 Checkpoint 3**: migrated the generic `form` flow's
+  `media_type` select to `<vt-import-config>`. The form flow's
+  field iteration now special-cases `field_type === 'select' &&
+  field.key === 'media_type'` and renders `<vt-import-config>`
+  instead of an inline `<select>` wrapped in the outer
+  `<div class="form-group">` + `<label>` + required-star scaffolding.
+  All importers that declare a `media_type` select (`server_folder`,
+  `server_files`, `http_archive`, `synthetic`, `recaller`) use the
+  label "Dataset MediaType", which matches the label
+  `<vt-import-config>` renders. The `detectionHint` input is left at
+  its default (empty) because the form flow has no auto-detection.
+  The now-dead `getMediaTypeOptionLabel` helper was removed (the
+  child consumes `mediaTypeOptionLabels` directly).
+  The previously-suppressed required-star (`@if (field.required && !(
+  field.field_type === 'select' && field.key === 'media_type'))`)
+  loses its special case — media-type lives outside the iteration
+  branch that renders the star at all. Initial bundle unchanged at
+  526.40 kB.
 
 ## Why
 
@@ -152,12 +170,15 @@ touching the cross-modal picker chrome):
    media-type widget (not the optional collapse-with-Advanced) because
    the source widget and recursive checkbox sit between media-type and
    Advanced in the template — a wrap would have forced a UX re-order.
-3. **Checkpoint 3**: Migrate the `form` flow to `<vt-import-config>`
-   (where applicable — the generic form's media-type lives inside the
-   importer's `fields[]`, so this may end up partial; the form flow
-   does not currently render the detection hint, so the wider option
-   may just be inlining `<vt-import-config>` with a static
-   `detectionHint=""`).
+3. **Checkpoint 3 (shipped)**: Migrated the `form` flow's
+   `media_type` select to `<vt-import-config>`. Special-cased
+   `field_type === 'select' && field.key === 'media_type'` inside the
+   field iteration so the child renders its own form-group + label
+   (rather than nesting inside the generic form-group / label
+   scaffold), with `detectionHint` left empty because the form flow
+   has no auto-detection. The previously dead-coded "suppress the
+   required-star for media_type" condition in the generic-label
+   template is gone with the case.
 4. **Checkpoint 4**: Extract `<vt-source-picker>` (the importer-tab /
    sub-tab chrome + demo table + server-folder typed path + local
    dropzone). Migrate `dataset-importer-modal` to consume it.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -161,10 +161,22 @@
     <div class="importer-form">
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {
+          @if (field.field_type === 'select' && field.key === 'media_type') {
+            <vt-import-config
+              [mediaTypeFieldId]="'field-' + field.key"
+              [mediaType]="formValues[field.key] || ''"
+              (mediaTypeChange)="onMediaTypeChange($event)"
+              [mediaTypeOptions]="field.options || []"
+              [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+            ></vt-import-config>
+            @if (field.hint) {
+              <p class="form-hint">{{ field.hint }}</p>
+            }
+          } @else {
           <div class="form-group">
             <label class="form-label" [for]="'field-' + field.key">
               {{ field.label || field.key }}
-              @if (field.required && !(field.field_type === 'select' && field.key === 'media_type')) {
+              @if (field.required) {
                 <span class="required">*</span>
               }
             </label>
@@ -186,17 +198,6 @@
                 [accept]="field.accept || ''"
                 (change)="onFileSelected($event, field.key)"
               />
-            } @else if (field.field_type === 'select' && field.key === 'media_type') {
-              <select
-                [id]="'field-' + field.key"
-                class="form-select"
-                [ngModel]="formValues[field.key]"
-                (ngModelChange)="onMediaTypeChange($event)"
-              >
-                @for (opt of field.options || []; track opt) {
-                  <option [value]="opt">{{ getMediaTypeOptionLabel(opt) }}</option>
-                }
-              </select>
             } @else if (field.field_type === 'select') {
               <select
                 [id]="'field-' + field.key"
@@ -280,6 +281,7 @@
               <p class="form-hint">{{ field.hint }}</p>
             }
           </div>
+          }
         }
       } @else {
         <p class="info-text">This importer requires no additional configuration.</p>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -763,14 +763,6 @@ export class DatasetImporterModalComponent implements OnInit {
     return mt?.folder_import_name || typeId;
   }
 
-  getMediaTypeOptionLabel(opt: string): string {
-    const mt = this.mediaTypes.find((m) => m.folder_import_name === opt);
-    if (mt) {
-      return mt.name.trim();
-    }
-    return opt;
-  }
-
   getTabLabel(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     if (mt) {


### PR DESCRIPTION
## Summary

Checkpoint 3 of #1 in `docs/plans/frontend-bundle-organization.md`.
The dataset-importer-modal's generic `form` flow rendered the
`media_type` field via an inline `<select>` inside the iteration over
`selectedImporter.fields[]`, parallel to the (already extracted) `sf`
and `lf` flows. Now special-cases `field_type === 'select' &&
field.key === 'media_type'` to render `<vt-import-config>` instead,
matching the other two flows. The form flow has no auto-detection, so
`detectionHint` defaults to empty.

All importers that declare a `media_type` select (`server_folder`,
`server_files`, `http_archive`, `synthetic`, `recaller`) use the label
"Dataset MediaType", which exactly matches what `<vt-import-config>`
renders — no per-importer label data is lost.

- Drops the previously-suppressed required-star for the inline
  media_type select (the new branch never reaches the generic
  label-with-star block).
- Removes the now-dead `getMediaTypeOptionLabel` helper (the child
  consumes `mediaTypeOptionLabels` directly).
- Initial bundle unchanged at 526.40 kB; modal lazy chunk unchanged
  at 77.64 kB raw (the form-flow media_type block was small).

## Test plan
- [x] `./run-tests.sh core` — 589 passed, frontend build OK
- [x] `npm run build:prod` — clean, no new warnings
- [x] Visual: the `Add Dataset` modal still renders the `Dataset
  MediaType` select correctly across `server_folder`, `server_files`,
  `http_archive`, and `synthetic` form flows (and the `sf`/`lf` flows
  unchanged from Checkpoint 2)

https://claude.ai/code/session_01UrgrtaLVTaPBtct57nhrsw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrgrtaLVTaPBtct57nhrsw)_