### PR TITLE
Add Help and Achievements to the burger menu; polish shortcut sheet

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -41,6 +41,34 @@
         class="burger-item"
         role="menuitem"
         tabindex="-1"
+        (click)="onHelp()"
+        title="Show keyboard shortcuts"
+      ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.2"/>
+          <path d="M5.8 6.2a2.2 2.2 0 014.4 0c0 1.1-.8 1.5-1.5 2-.5.3-.7.7-.7 1.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+          <circle cx="8" cy="12" r="0.7" fill="currentColor"/>
+        </svg> Help</div>
+      @if (!achievementsDisabled) {
+        <div
+          class="burger-item"
+          role="menuitem"
+          tabindex="-1"
+          (click)="onAchievements()"
+          title="Achievements — your usage milestones and tier progress"
+        ><svg class="menu-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 4h12v4a6 6 0 0 1-12 0z"/>
+            <path d="M6 6H3a2 2 0 0 0 0 4h3"/>
+            <path d="M18 6h3a2 2 0 0 1 0 4h-3"/>
+            <line x1="10" y1="14" x2="10" y2="18"/>
+            <line x1="14" y1="14" x2="14" y2="18"/>
+            <rect x="7" y="18" width="10" height="3" rx="1"/>
+          </svg> Achievements</div>
+      }
+      <div
+        class="burger-item"
+        role="menuitem"
+        tabindex="-1"
         (click)="onSettings()"
         title="Open the Settings panel to configure appearance, sorting, autopilot, and autoload"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -187,6 +187,11 @@ export class AppComponent {
     this.showKeyboardHelp = false;
   }
 
+  onHelp(): void {
+    this.menuOpen = false;
+    this.showKeyboardHelp = true;
+  }
+
   onMenuKeydown(event: KeyboardEvent): void {
     const menu = event.currentTarget as HTMLElement;
     const items = Array.from(menu.querySelectorAll('[role="menuitem"]')) as HTMLElement[];

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
@@ -1,24 +1,31 @@
 <vt-modal title="Keyboard shortcuts" [open]="true" (closed)="close()">
   <div class="kbd-help">
-    @for (group of groups; track group.title) {
-      <section class="kbd-group">
-        <h3 class="kbd-group-title">{{ group.title }}</h3>
-        <ul class="kbd-list">
-          @for (sc of group.shortcuts; track sc.description) {
-            <li class="kbd-row">
-              <span class="kbd-keys">
-                @for (k of sc.keys; track k; let last = $last) {
-                  <kbd class="kbd-key">{{ k }}</kbd>
-                  @if (!last) {
-                    <span class="kbd-plus">+</span>
-                  }
-                }
-              </span>
-              <span class="kbd-desc">{{ sc.description }}</span>
-            </li>
-          }
-        </ul>
-      </section>
+    @for (section of sections; track section.header) {
+      <div class="kbd-section">
+        @if (section.header) {
+          <h2 class="kbd-section-header">{{ section.header }}</h2>
+        }
+        @for (group of section.groups; track group.title) {
+          <section class="kbd-group">
+            <h3 class="kbd-group-title">{{ group.title }}</h3>
+            <ul class="kbd-list">
+              @for (sc of group.shortcuts; track sc.description) {
+                <li class="kbd-row">
+                  <span class="kbd-keys">
+                    @for (k of sc.keys; track k; let last = $last) {
+                      <kbd class="kbd-key">{{ k }}</kbd>
+                      @if (!last) {
+                        <span class="kbd-plus">+</span>
+                      }
+                    }
+                  </span>
+                  <span class="kbd-desc">{{ sc.description }}</span>
+                </li>
+              }
+            </ul>
+          </section>
+        }
+      </div>
     }
     <p class="kbd-hint">Press <kbd class="kbd-key">?</kbd> any time to open this sheet.</p>
   </div>

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -6,6 +6,19 @@
   max-width: 560px;
 }
 
+.kbd-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.kbd-section-header {
+  margin: 0;
+  font-size: var(--font-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 .kbd-group-title {
   margin: 0 0 var(--space-sm);
   font-size: var(--font-lg);

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -12,6 +12,11 @@ interface ShortcutGroup {
   shortcuts: Shortcut[];
 }
 
+interface ShortcutSection {
+  header?: string;
+  groups: ShortcutGroup[];
+}
+
 @Component({
   selector: 'vt-keyboard-help-modal',
   standalone: true,
@@ -22,38 +27,48 @@ interface ShortcutGroup {
 export class KeyboardHelpModalComponent {
   @Output() closed = new EventEmitter<void>();
 
-  readonly groups: ShortcutGroup[] = [
+  readonly sections: ShortcutSection[] = [
     {
-      title: 'Voting',
-      shortcuts: [
-        { keys: ['→'], description: 'Vote good (👍)' },
-        { keys: ['←'], description: 'Vote bad (👎)' },
+      header: 'In the Train / Find window only',
+      groups: [
+        {
+          title: 'Voting',
+          shortcuts: [
+            { keys: ['→'], description: 'Vote good' },
+            { keys: ['←'], description: 'Vote bad' },
+          ],
+        },
+        {
+          title: 'Playback',
+          shortcuts: [
+            { keys: ['Space'], description: 'Play / pause audio or video' },
+            { keys: ['↑'], description: 'Volume up' },
+            { keys: ['↓'], description: 'Volume down' },
+          ],
+        },
+        {
+          title: 'Image viewer',
+          shortcuts: [
+            { keys: ['+'], description: 'Zoom in' },
+            { keys: ['-'], description: 'Zoom out' },
+            { keys: ['['], description: 'Rotate left' },
+            { keys: [']'], description: 'Rotate right' },
+            { keys: ['Shift', 'drag'], description: 'Draw region box (or use the Marquee button)' },
+            { keys: ['Esc'], description: 'Cancel armed vote / clear region box' },
+          ],
+        },
       ],
     },
     {
-      title: 'Playback',
-      shortcuts: [
-        { keys: ['Space'], description: 'Play / pause audio or video' },
-        { keys: ['↑'], description: 'Volume up' },
-        { keys: ['↓'], description: 'Volume down' },
-      ],
-    },
-    {
-      title: 'Image viewer',
-      shortcuts: [
-        { keys: ['+'], description: 'Zoom in' },
-        { keys: ['-'], description: 'Zoom out' },
-        { keys: ['['], description: 'Rotate left' },
-        { keys: [']'], description: 'Rotate right' },
-        { keys: ['Shift', 'drag'], description: 'Draw region box (or use the Marquee button)' },
-        { keys: ['Esc'], description: 'Cancel armed vote / clear region box' },
-      ],
-    },
-    {
-      title: 'General',
-      shortcuts: [
-        { keys: ['?'], description: 'Show this help' },
-        { keys: ['Esc'], description: 'Close modal or dropdown' },
+      header: 'Anywhere',
+      groups: [
+        {
+          title: 'General',
+          shortcuts: [
+            { keys: ['?'], description: 'Show this help' },
+            { keys: ['Esc'], description: 'Close modal or dropdown' },
+          ],
+        },
       ],
     },
   ];


### PR DESCRIPTION
## Summary
- Add **Help** to the burger menu (right under Dashboard) — opens the same keyboard-shortcuts modal as the `?` toolbar button.
- Add **Achievements** to the burger menu (right above Settings) — opens the same modal as the trophy toolbar button. Hidden when `disable_achievements` is set, matching the trophy button.
- Section the keyboard-shortcuts sheet under **"In the Train / Find window only"** vs. **"Anywhere"** so it's clear which commands are context-bound.
- Drop the 👍 / 👎 emojis from the vote descriptions.

## Test plan
- [ ] Open the burger menu — Dashboard, Help, Achievements, Settings appear in that order; Recent sessions still follow.
- [ ] Click Help → keyboard-shortcuts modal opens; click Achievements → achievements modal opens.
- [ ] With `disable_achievements` toggled on, the Achievements item is hidden (mirrors the trophy button).
- [ ] Keyboard-shortcuts modal shows the "In the Train / Find window only" header above Voting / Playback / Image viewer and "Anywhere" above General.
- [ ] Vote rows read "Vote good" / "Vote bad" with no emoji.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk9mpW5GSuhBd1x8y4NhJU)_