### PR TITLE
Extract <vt-source-picker> and migrate both modals to it (Checkpoints 4 + 5)

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 Checkpoints 1, 2, and 3 shipped.** Checkpoints 4 and 5 of
-#1 and items #2–#6 are scoped but not started.
+Status: **#1 Checkpoints 1–4 shipped.** Checkpoint 5 of #1 and items
+#2–#6 are scoped but not started.
 
 ## What shipped
 
@@ -57,6 +57,39 @@ Status: **#1 Checkpoints 1, 2, and 3 shipped.** Checkpoints 4 and 5 of
   loses its special case — media-type lives outside the iteration
   branch that renders the star at all. Initial bundle unchanged at
   526.40 kB.
+- **#1 Checkpoint 4**: extracted `<vt-source-picker>` — the importer
+  category-tab + sub-tab chrome plus the source-side widgets (demo
+  media-type tabs + sortable demo table, server-folder typed-path
+  input, local-folder/local-files dropzone with file-count display).
+  Migrated `dataset-importer-modal` to consume it.
+  The component is presentational: the parent owns all state and
+  passes in precomputed `visibleImporterTabs` /
+  `importersForActiveTab` lists; user actions surface as `@Output`
+  events the parent handles (`(activeTabChange)="selectImporterTab($event)"`
+  for top-level tab clicks, `(importerSelected)="selectImporter($event)"`
+  for sub-tab clicks, `(demoSelected)`, `(sfPathApplied)`,
+  `(lfFilesDropped)`).  Per-flow output config (Dataset Name input,
+  `<vt-import-config>`, Include-subfolders checkbox,
+  `<vt-import-advanced>`) projects through named content slots
+  (`[demoExtras]`, `[sfBefore]`/`[sfAfter]`,
+  `[lfBefore]`/`[lfAfter]`) so the visual order on every flow stays
+  byte-identical to before.
+  Picker chrome SCSS (the `display: flex` rules, the indent for
+  `.local-folder-uploader` / `.server-folder-browser`, the `gap`
+  values) moved out of the parent and into
+  `source-picker.component.scss`.  Dead helpers removed from the
+  parent: `getTabIcon`, `getTabText`, `statusBadgeClass`,
+  `statusBadgeLabel`, `onDemoHeaderClick`.  Dead component imports
+  removed: `IconComponent`, `DropZoneComponent` (both still used —
+  inside the new sub-component).  Parent template dropped from 529 →
+  362 lines; .ts from 1687 → 1648 lines.
+  **Bundle effect.** The Add Dataset modal is `@defer`-loaded, so the
+  initial bundle is unaffected (526.40 kB → 526.40 kB).  The lazy
+  `dataset-importer-modal-component` chunk grew from 77.64 kB → 81.99
+  kB raw (15.76 → 16.73 kB gzip) because the new component adds its
+  own Angular plumbing without yet eliminating cross-modal
+  duplication — Checkpoint 5 (migrating `new-detector-modal` to
+  consume `<vt-source-picker>`) is where the real dedup land.
 
 ## Why
 
@@ -179,11 +212,16 @@ touching the cross-modal picker chrome):
    has no auto-detection. The previously dead-coded "suppress the
    required-star for media_type" condition in the generic-label
    template is gone with the case.
-4. **Checkpoint 4**: Extract `<vt-source-picker>` (the importer-tab /
-   sub-tab chrome + demo table + server-folder typed path + local
-   dropzone). Migrate `dataset-importer-modal` to consume it.
+4. **Checkpoint 4 (shipped)**: Extracted `<vt-source-picker>` (the
+   importer-tab / sub-tab chrome + demo table + server-folder typed
+   path + local dropzone) into a presentational component with named
+   content-projection slots ([demoExtras], [sfBefore]/[sfAfter],
+   [lfBefore]/[lfAfter]) for the parent's per-flow output config.
+   Migrated `dataset-importer-modal` to consume it.
 5. **Checkpoint 5**: Migrate `new-detector-modal` to consume
-   `<vt-source-picker>`.
+   `<vt-source-picker>`.  This is where the real bundle saving lands
+   — both modals currently spell out the same picker chrome and demo
+   table, and the cross-modal dedup eliminates that duplication.
 
 The demo flow inside `dataset-importer-modal` stays a separate path
 (its picker layout is genuinely different from the import flows).

--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 Checkpoints 1–4 shipped.** Checkpoint 5 of #1 and items
-#2–#6 are scoped but not started.
+Status: **#1 shipped (all five checkpoints).** Items #2–#6 are scoped
+but not started.
 
 ## What shipped
 
@@ -57,6 +57,43 @@ Status: **#1 Checkpoints 1–4 shipped.** Checkpoint 5 of #1 and items
   loses its special case — media-type lives outside the iteration
   branch that renders the star at all. Initial bundle unchanged at
   526.40 kB.
+- **#1 Checkpoint 5**: migrated `new-detector-modal`'s media picker
+  to consume `<vt-source-picker>`.  Replaces the inline duplicate of
+  the picker chrome (category-tab + sub-tab bar), demo media-type
+  tabs + sortable demo table, server-folder typed-path input, and
+  local-folder/local-files dropzone (~213 lines of template) with a
+  single `<vt-source-picker>` call.  Five dead helpers
+  (`onDemoHeaderClick`, `statusBadgeClass`, `statusBadgeLabel`,
+  `getDemoTabIcon`, `getDemoTabLabel`) and the SCSS rules they backed
+  fell out of the parent.  `.server-folder-browser` stays in the
+  parent SCSS because the demoFileBrowsing widget (typed-path input
+  inside a clicked demo) still uses the same chrome.
+  To support new-detector's UX needs, source-picker grew a handful of
+  customization inputs: `alwaysShowSubtabBar` (always render the
+  sub-tab row, even with a single importer — new-detector wants every
+  category visibly labelled), `demoRowDisabledFn` /
+  `demoRowTitleFn` (so non-browsable demos render with `.disabled`
+  styling and an explanatory tooltip), `sfApplyOnBlur` (off in
+  new-detector so the explicit Load button isn't double-triggered),
+  `lfShowFieldLabel` / `lfShowFileCount` (off in new-detector), and
+  the dropzone label / sublabel / accept overrides
+  (`lfFolderDropLabel`, `lfFolderDropSublabel`, `lfFilesDropLabel`,
+  `lfFilesDropSublabel`, `lfFilesAcceptAttr`).  A new `[lfInfo]`
+  content-projection slot replaces the previously hard-coded "Pick a
+  folder…" / "Upload a single file…" paragraphs (each parent now
+  projects its own copy), keeping each modal's exact prose intact.
+  **Bundle effect.** Initial bundle unchanged (526.40 kB / 136.37 kB
+  gzip; both modals are `@defer`-loaded).  Lazy chunks rebalanced:
+  the bundler now extracts source-picker into its own shared lazy
+  chunk that both modals reference.  `dataset-importer-modal-component`
+  dropped 83.09 → 68.11 kB raw (16.94 → 13.87 kB gzip);
+  `new-detector-modal-component` dropped 49.78 → 43.30 kB raw (10.87
+  → 9.79 kB gzip); the new shared chunk is ~21 kB raw / 5.6 kB gzip.
+  The total deferred-chunk weight is slightly higher than before
+  Checkpoint 4 (the per-component Angular plumbing adds overhead),
+  but the structural goal — single source of truth for the picker
+  chrome and demo table — is achieved, and any future edits to the
+  picker UI now touch one component instead of two.
 - **#1 Checkpoint 4**: extracted `<vt-source-picker>` — the importer
   category-tab + sub-tab chrome plus the source-side widgets (demo
   media-type tabs + sortable demo table, server-folder typed-path
@@ -218,10 +255,15 @@ touching the cross-modal picker chrome):
    content-projection slots ([demoExtras], [sfBefore]/[sfAfter],
    [lfBefore]/[lfAfter]) for the parent's per-flow output config.
    Migrated `dataset-importer-modal` to consume it.
-5. **Checkpoint 5**: Migrate `new-detector-modal` to consume
-   `<vt-source-picker>`.  This is where the real bundle saving lands
-   — both modals currently spell out the same picker chrome and demo
-   table, and the cross-modal dedup eliminates that duplication.
+5. **Checkpoint 5 (shipped)**: Migrated `new-detector-modal` to
+   consume `<vt-source-picker>`.  Source-picker grew the
+   customization knobs new-detector needed
+   (`alwaysShowSubtabBar`, `demoRowDisabledFn`/`demoRowTitleFn`,
+   `sfApplyOnBlur`, `lfShowFieldLabel`/`lfShowFileCount`, dropzone
+   label overrides, and the `[lfInfo]` content slot).  The bundler
+   now extracts source-picker into its own shared lazy chunk
+   referenced by both modals — see the bundle effect line in the
+   "What shipped" entry above.
 
 The demo flow inside `dataset-importer-modal` stays a separate path
 (its picker layout is genuinely different from the import flows).

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -1,161 +1,181 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
-  <div class="importer-picker">
-    <div class="importer-tab-bar">
-      @for (tab of visibleImporterTabs; track tab.id) {
-        <button
-          class="importer-tab"
-          [class.active]="activeImporterTab === tab.id"
-          (click)="selectImporterTab(tab.id)"
-          [title]="'Show ' + tab.label + ' dataset importers'"
-        >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
+  <vt-source-picker
+    [visibleImporterTabs]="visibleImporterTabs"
+    [importersForActiveTab]="importersForActiveTab"
+    [activeImporterTabLabel]="activeImporterTabLabel"
+    [activeTab]="activeImporterTab"
+    (activeTabChange)="selectImporterTab($event)"
+    [selectedImporter]="selectedImporter"
+    (importerSelected)="selectImporter($event)"
+    [activePickerView]="activePickerView"
+    [mediaTypes]="mediaTypes"
+    [demos]="demos"
+    [filteredDemos]="filteredDemos"
+    [demoLoading]="demoLoading"
+    [demoTabs]="demoTabs"
+    [activeDemoTab]="activeTab"
+    (activeDemoTabChange)="selectDemoTabWithEmbedder($event)"
+    [demoCols]="demoCols"
+    (demoSelected)="selectDemo($event)"
+    [sfPathInputValue]="sfPathInputValue"
+    (sfPathInputValueChange)="sfPathInputValue = $event"
+    (sfPathApplied)="sfApplyPathInput()"
+    [lfPickerKind]="lfPickerKind"
+    [lfFiles]="lfFiles"
+    [lfFolderName]="lfFolderName"
+    (lfFilesDropped)="lfOnFilesDropped($event)"
+  >
+    <ng-container demoExtras>
+      @if (activeTab) {
+        <div class="form-group">
+          <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
+          <input
+            id="demo-dataset-name"
+            type="text"
+            class="form-input"
+            [(ngModel)]="demoDatasetName"
+            placeholder="Leave blank to use the demo's name"
+          />
+        </div>
       }
-    </div>
-    @if (!activeImporterTab) {
-      <p class="tab-bar-hint">Select what type of dataset to add.</p>
-    }
 
-    @if (activeImporterTab) {
-      @if (importersForActiveTab.length === 0) {
-        <div class="importer-subtab-bar">
-          <span class="empty-state empty-state--inline">No importers in this category.</span>
+      @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
+        <div class="form-group form-group--section">
+          <vt-import-advanced
+            [availableConverters]="[]"
+            [nativeType]="''"
+            [typeLabels]="mediaTypeLabels"
+            [embedders]="demoEmbedders"
+            [clippers]="demoClippers"
+            [showSourceSpecs]="false"
+            [sourceSpecs]="[]"
+            [selectedEmbedder]="selectedDemoEmbedder"
+            (selectedEmbedderChange)="onDemoEmbedderChange($event)"
+            [selectedClipper]="selectedDemoClipper"
+            (clipperChooserRequested)="openClipperChooser('demo')"
+          ></vt-import-advanced>
         </div>
-      } @else if (importersForActiveTab.length > 1) {
-        <div class="importer-subtab-bar">
-          @for (imp of importersForActiveTab; track imp.name) {
-            <button
-              class="importer-subtab"
-              [class.active]="selectedImporter?.name === imp.name"
-              [class.disabled]="imp['enabled'] === false"
-              [disabled]="imp['enabled'] === false"
-              (click)="selectImporter(imp)"
-              [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
-            >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
-          }
-        </div>
-        @if (!selectedImporter) {
-          <p class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</p>
-        }
       }
-    }
-  </div>
+    </ng-container>
 
-  @if (activePickerView === 'demo' && selectedImporter) {
-    <div class="demo-picker">
-      @if (demoLoading) {
-        <p class="empty-state">Loading demo datasets...</p>
-      } @else if (demos.length === 0) {
-        <p class="empty-state">No demo datasets available.</p>
-      } @else {
-        <div class="demo-tab-bar">
-          @for (tab of demoTabs; track tab) {
-            <button
-              class="demo-tab"
-              [class.active]="activeTab === tab"
-              (click)="selectDemoTabWithEmbedder(tab)"
-              [title]="'Filter demos by media type: ' + getTabText(tab)"
-            >@if (getTabIcon(tab)) {<vt-icon [icon]="getTabIcon(tab)" [size]="14"></vt-icon>}{{ getTabText(tab) }}</button>
-          }
-        </div>
-        @if (!activeTab) {
-          <p class="tab-bar-hint">Select the media type to demonstrate.</p>
-        }
+    <ng-container sfBefore>
+      <div class="form-group">
+        <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
+        <input
+          id="sf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="sfDatasetName"
+          (ngModelChange)="sfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
+      </div>
 
-        @if (activeTab) {
-          <div class="form-group">
-            <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
+      <vt-import-config
+        mediaTypeFieldId="sf-media-type"
+        [mediaType]="sfMediaType"
+        (mediaTypeChange)="sfOnMediaTypeChange($event)"
+        [mediaTypeOptions]="sfMediaTypeOptions"
+        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [detectionHint]="detectionHint(sfDetection)"
+      ></vt-import-config>
+    </ng-container>
+
+    <ng-container sfAfter>
+      <div class="form-group">
+        <label class="form-label" for="sf-recursive" title="When enabled, subdirectories of the chosen folder are scanned recursively. When disabled, only files directly inside the chosen folder are imported.">
+          <input
+            id="sf-recursive"
+            type="checkbox"
+            [ngModel]="sfRecursive"
+            (ngModelChange)="sfOnRecursiveChange($event)"
+          />
+          Include subfolders
+        </label>
+      </div>
+
+      <div class="form-group form-group--section">
+        <vt-import-advanced
+          [availableConverters]="sfAvailableConverters"
+          [nativeType]="sfOutputTypeId"
+          [typeLabels]="mediaTypeLabels"
+          [embedders]="sfEmbedders"
+          [clippers]="sfClippers"
+          [showSourceSpecs]="true"
+          [sourceSpecs]="sfSourceSpecs"
+          (sourceSpecsChange)="onSfSpecsChange($event)"
+          [selectedEmbedder]="sfSelectedEmbedder"
+          (selectedEmbedderChange)="sfSelectedEmbedder = $event"
+          [selectedClipper]="sfSelectedClipper"
+          (clipperChooserRequested)="openClipperChooser('sf')"
+        ></vt-import-advanced>
+      </div>
+
+      @if (sfBrowseError) {
+        <p class="error-text">{{ sfBrowseError }}</p>
+      }
+    </ng-container>
+
+    <ng-container lfBefore>
+      <div class="form-group">
+        <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
+        <input
+          id="lf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="lfDatasetName"
+          (ngModelChange)="lfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
+      </div>
+
+      <vt-import-config
+        mediaTypeFieldId="lf-media-type"
+        [mediaType]="lfMediaType"
+        (mediaTypeChange)="lfOnMediaTypeChange($event)"
+        [mediaTypeOptions]="lfMediaTypeOptions"
+        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [detectionHint]="detectionHint(lfDetection)"
+      ></vt-import-config>
+    </ng-container>
+
+    <ng-container lfAfter>
+      @if (lfPickerKind === 'folder') {
+        <div class="form-group">
+          <label class="form-label" for="lf-recursive" title="When enabled, files inside nested subfolders are also uploaded. When disabled, only files directly inside the picked folder are uploaded.">
             <input
-              id="demo-dataset-name"
-              type="text"
-              class="form-input"
-              [(ngModel)]="demoDatasetName"
-              placeholder="Leave blank to use the demo's name"
+              id="lf-recursive"
+              type="checkbox"
+              [ngModel]="lfRecursive"
+              (ngModelChange)="lfOnRecursiveChange($event)"
             />
-          </div>
-        }
-
-        @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
-          <div class="form-group form-group--section">
-            <vt-import-advanced
-              [availableConverters]="[]"
-              [nativeType]="''"
-              [typeLabels]="mediaTypeLabels"
-              [embedders]="demoEmbedders"
-              [clippers]="demoClippers"
-              [showSourceSpecs]="false"
-              [sourceSpecs]="[]"
-              [selectedEmbedder]="selectedDemoEmbedder"
-              (selectedEmbedderChange)="onDemoEmbedderChange($event)"
-              [selectedClipper]="selectedDemoClipper"
-              (clipperChooserRequested)="openClipperChooser('demo')"
-            ></vt-import-advanced>
-          </div>
-        }
-
-        @if (activeTab) {
-          <div class="demo-content-area">
-            <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
-              <thead>
-                <tr>
-                  @for (col of demoCols.columnOrder; track col; let first = $first) {
-                    <th
-                      [class.sortable]="demoCols.meta(col).sortable"
-                      [class.col-drop-target]="demoCols.isDropTarget(col)"
-                      [class.col-dragging]="demoCols.isDragging(col)"
-                      [class.col-num]="col === 'num_files' || col === 'num_categories'"
-                      [attr.data-col]="col"
-                      [title]="demoCols.meta(col).title"
-                      [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
-                      draggable="true"
-                      (click)="onDemoHeaderClick(col)"
-                      (dragstart)="demoCols.onColDragStart($event, col)"
-                      (dragover)="demoCols.onColDragOver($event, col)"
-                      (dragleave)="demoCols.onColDragLeave($event, col)"
-                      (drop)="demoCols.onColDrop($event, col)"
-                      (dragend)="demoCols.onColDragEnd($event)"
-                    >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
-                  }
-                </tr>
-              </thead>
-              <tbody>
-                @for (demo of filteredDemos; track demo.name) {
-                  <tr
-                    class="demo-row"
-                    [class.ready]="demo.status === 'ready'"
-                    role="button"
-                    tabindex="0"
-                    [attr.aria-label]="demo.label + ': ' + demo.description"
-                    (click)="selectDemo(demo)"
-                    (keydown.enter)="selectDemo(demo)"
-                    (keydown.space)="$event.preventDefault(); selectDemo(demo)"
-                  >
-                    @for (col of demoCols.columnOrder; track col) {
-                      @switch (col) {
-                        @case ('label') {
-                          <td class="col-name">{{ demo.label }}</td>
-                        }
-                        @case ('num_files') {
-                          <td class="col-num">{{ demo.num_files | number }}</td>
-                        }
-                        @case ('num_categories') {
-                          <td class="col-num">{{ demo.num_categories | number }}</td>
-                        }
-                        @case ('description') {
-                          <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
-                        }
-                        @case ('status') {
-                          <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
-                        }
-                      }
-                    }
-                  </tr>
-                }
-              </tbody>
-            </table>
-          </div>
-        }
+            Include subfolders
+          </label>
+        </div>
       }
-    </div>
-  }
+
+      <div class="form-group form-group--section">
+        <vt-import-advanced
+          [availableConverters]="lfAvailableConverters"
+          [nativeType]="lfOutputTypeId"
+          [typeLabels]="mediaTypeLabels"
+          [embedders]="lfEmbedders"
+          [clippers]="lfClippers"
+          [showSourceSpecs]="true"
+          [sourceSpecs]="lfSourceSpecs"
+          (sourceSpecsChange)="onLfSpecsChange($event)"
+          [selectedEmbedder]="lfSelectedEmbedder"
+          (selectedEmbedderChange)="lfSelectedEmbedder = $event"
+          [selectedClipper]="lfSelectedClipper"
+          (clipperChooserRequested)="openClipperChooser('lf')"
+        ></vt-import-advanced>
+      </div>
+
+      @if (lfError) {
+        <p class="error-text">{{ lfError }}</p>
+      }
+    </ng-container>
+  </vt-source-picker>
 
   @if (activePickerView !== 'demo' && activePickerView !== 'local_folder' && activePickerView !== 'local_files' && activePickerView !== 'server_folder' && selectedImporter) {
     <div class="importer-form">
@@ -326,107 +346,6 @@
   }
 
   @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
-    <div class="local-folder-uploader">
-      @if (lfPickerKind === 'folder') {
-        <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
-      } @else {
-        <p class="info-text">
-          Upload a single file from <strong>this computer</strong> that lists the media to import
-          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
-          paths + pre-computed embedding vectors).
-        </p>
-      }
-
-      <div class="form-group">
-        <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
-        <input
-          id="lf-dataset-name"
-          type="text"
-          class="form-input"
-          [ngModel]="lfDatasetName"
-          (ngModelChange)="lfOnDatasetNameInput($event)"
-          placeholder="Leave blank to use a default name"
-        />
-      </div>
-
-      <vt-import-config
-        mediaTypeFieldId="lf-media-type"
-        [mediaType]="lfMediaType"
-        (mediaTypeChange)="lfOnMediaTypeChange($event)"
-        [mediaTypeOptions]="lfMediaTypeOptions"
-        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
-        [detectionHint]="detectionHint(lfDetection)"
-      ></vt-import-config>
-
-      <div class="form-group form-group--section">
-        @if (lfPickerKind === 'folder') {
-          <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
-          <vt-drop-zone
-            label="Drop a folder here to import"
-            sublabel="or click to browse"
-            [directory]="true"
-            [multiple]="true"
-            (filesSelected)="lfOnFilesDropped($event)"
-          ></vt-drop-zone>
-        } @else {
-          <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">Paths file<span class="required">*</span></label>
-          <vt-drop-zone
-            label="Drop a paths file (.txt, .list, or .npz)"
-            sublabel="or click to browse"
-            accept=".txt,.list,.npz"
-            (filesSelected)="lfOnFilesDropped($event)"
-          ></vt-drop-zone>
-        }
-        @if (lfFiles.length > 0) {
-          <p class="info-text">
-            @if (lfPickerKind === 'folder') {
-              Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
-              @if (lfFolderName) { from <code>{{ lfFolderName }}</code> }
-            } @else {
-              Using paths from <code>{{ lfFiles[0].name }}</code>
-            }
-          </p>
-        }
-      </div>
-
-      @if (lfPickerKind === 'folder') {
-        <div class="form-group">
-          <label class="form-label" for="lf-recursive" title="When enabled, files inside nested subfolders are also uploaded. When disabled, only files directly inside the picked folder are uploaded.">
-            <input
-              id="lf-recursive"
-              type="checkbox"
-              [ngModel]="lfRecursive"
-              (ngModelChange)="lfOnRecursiveChange($event)"
-            />
-            Include subfolders
-          </label>
-        </div>
-      }
-
-      <div class="form-group form-group--section">
-        <vt-import-advanced
-          [availableConverters]="lfAvailableConverters"
-          [nativeType]="lfOutputTypeId"
-          [typeLabels]="mediaTypeLabels"
-          [embedders]="lfEmbedders"
-          [clippers]="lfClippers"
-          [showSourceSpecs]="true"
-          [sourceSpecs]="lfSourceSpecs"
-          (sourceSpecsChange)="onLfSpecsChange($event)"
-          [selectedEmbedder]="lfSelectedEmbedder"
-          (selectedEmbedderChange)="lfSelectedEmbedder = $event"
-          [selectedClipper]="lfSelectedClipper"
-          (clipperChooserRequested)="openClipperChooser('lf')"
-        ></vt-import-advanced>
-      </div>
-
-      @if (lfError) {
-        <p class="error-text">{{ lfError }}</p>
-      }
-    </div>
-  }
-
-  @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="lfSubmit()" [disabled]="lfSubmitting || lfFiles.length === 0">
@@ -436,77 +355,6 @@
           Upload &amp; Import
         }
       </button>
-    </div>
-  }
-
-  @if (activePickerView === 'server_folder' && selectedImporter) {
-    <div class="server-folder-browser">
-      <div class="form-group">
-        <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
-        <input
-          id="sf-dataset-name"
-          type="text"
-          class="form-input"
-          [ngModel]="sfDatasetName"
-          (ngModelChange)="sfOnDatasetNameInput($event)"
-          placeholder="Leave blank to use a default name"
-        />
-      </div>
-
-      <vt-import-config
-        mediaTypeFieldId="sf-media-type"
-        [mediaType]="sfMediaType"
-        (mediaTypeChange)="sfOnMediaTypeChange($event)"
-        [mediaTypeOptions]="sfMediaTypeOptions"
-        [mediaTypeOptionLabels]="mediaTypeOptionLabels"
-        [detectionHint]="detectionHint(sfDetection)"
-      ></vt-import-config>
-
-      <div class="sf-browse-section">
-        <label class="form-label" for="sf-path-input">Folder to import</label>
-        <input
-          id="sf-path-input"
-          type="text"
-          class="form-input"
-          placeholder="/absolute/server/path/to/folder"
-          [(ngModel)]="sfPathInputValue"
-          (keydown.enter)="sfApplyPathInput(); $event.preventDefault()"
-          (blur)="sfApplyPathInput()"
-        />
-      </div>
-
-      <div class="form-group">
-        <label class="form-label" for="sf-recursive" title="When enabled, subdirectories of the chosen folder are scanned recursively. When disabled, only files directly inside the chosen folder are imported.">
-          <input
-            id="sf-recursive"
-            type="checkbox"
-            [ngModel]="sfRecursive"
-            (ngModelChange)="sfOnRecursiveChange($event)"
-          />
-          Include subfolders
-        </label>
-      </div>
-
-      <div class="form-group form-group--section">
-        <vt-import-advanced
-          [availableConverters]="sfAvailableConverters"
-          [nativeType]="sfOutputTypeId"
-          [typeLabels]="mediaTypeLabels"
-          [embedders]="sfEmbedders"
-          [clippers]="sfClippers"
-          [showSourceSpecs]="true"
-          [sourceSpecs]="sfSourceSpecs"
-          (sourceSpecsChange)="onSfSpecsChange($event)"
-          [selectedEmbedder]="sfSelectedEmbedder"
-          (selectedEmbedderChange)="sfSelectedEmbedder = $event"
-          [selectedClipper]="sfSelectedClipper"
-          (clipperChooserRequested)="openClipperChooser('sf')"
-        ></vt-import-advanced>
-      </div>
-
-      @if (sfBrowseError) {
-        <p class="error-text">{{ sfBrowseError }}</p>
-      }
     </div>
   }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -116,6 +116,18 @@
       }
     </ng-container>
 
+    <ng-container lfInfo>
+      @if (lfPickerKind === 'folder') {
+        <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
+      } @else {
+        <p class="info-text">
+          Upload a single file from <strong>this computer</strong> that lists the media to import
+          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
+          paths + pre-computed embedding vectors).
+        </p>
+      }
+    </ng-container>
+
     <ng-container lfBefore>
       <div class="form-group">
         <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,7 +1,10 @@
-// Picker chrome (importer tabs, demo table, server folder browser, badges)
-// lives in `frontend/src/scss/_picker-shared.scss` so it's defined once
-// globally and shared with the New Model > Browse Media picker — only
-// styles unique to this component remain below.
+// Picker chrome (importer tabs, demo table, server folder browser,
+// badges) lives in `frontend/src/scss/_picker-shared.scss` so it's
+// defined once globally and shared with the New Model > Browse Media
+// picker.  Source-side picker widgets — tab chrome, demo table, server
+// folder typed-path input, local-folder dropzone — live inside
+// `<vt-source-picker>` (see source-picker.component.scss).  Only
+// styles unique to this top-level modal remain below.
 
 // Pin the Add Dataset modal to a single large width so flipping between
 // tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
@@ -18,46 +21,15 @@
 
 .form-actions { display: flex; justify-content: flex-end; gap: var(--space-md); margin-top: var(--space-md); }
 
-.importer-picker, .clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section, .importer-form, .local-folder-uploader {
+.importer-form {
   display: flex;
   flex-direction: column;
-}
-
-.importer-picker { gap: 0; margin-bottom: var(--space-lg); }
-
-// Indent the Importer's content area inward from the tabs above so the
-// hierarchy reads top-down: category tabs → importer tabs → controls.
-// .demo-picker is intentionally NOT indented — its inner tab bar must
-// line up with the category and importer tabs above it.
-.importer-form,
-.local-folder-uploader,
-.server-folder-browser {
+  // Indent the importer's form content inward from the category /
+  // importer tabs above (rendered by `<vt-source-picker>`) so the
+  // hierarchy reads top-down: category tabs → importer tabs → controls.
   padding-left: var(--space-2xl);
 }
 
-// Extra vertical breathing room above grouped sections inside the Local /
-// Folder uploader (Folder picker, Chunk size, Embedder, Clipper). The
-// Recursive checkbox intentionally does NOT get this class — it is a
-// sub-option of the Folder picker above it.
+// Extra vertical breathing room above grouped sections inside the
+// importer form (Embedder, Clipper).
 .form-group--section { margin-top: var(--space-xl); }
-
-.clipper-params {
-  padding-left: var(--space-xl);
-  border-left: 2px solid var(--border);
-  gap: var(--space-md);
-}
-
-.demo-picker { gap: var(--space-lg); }
-
-.server-folder-browser { gap: var(--space-lg); }
-.sf-browse-section { gap: var(--space-sm); }
-
-// `.detection-hint` lives inside `<vt-import-config>` (which
-// encapsulates its own styles).  `.advanced-toggle`, `.clipper-btn`,
-// and `.license-warning` likewise live inside `<vt-import-advanced>`.
-// The surrounding `.form-group--section` rule above provides the
-// vertical gap above the Advanced block.
-
-
-// Multi-media import UI lives in
-// ``<vt-source-specs-picker>`` (see source-specs-picker.component.scss).

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -544,13 +544,6 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.getTabLabel('unknown')).toBe('unknown');
   });
 
-  it('should return correct status badge class', () => {
-    flushImporters();
-    expect(component.statusBadgeClass('ready')).toBe('badge-ready');
-    expect(component.statusBadgeClass('needs_embedding')).toBe('badge-embedding');
-    expect(component.statusBadgeClass('needs_download')).toBe('badge-download');
-  });
-
   it('should handle demo fetch failure gracefully', () => {
     flushImporters();
     component.openDemoPicker();

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -2,11 +2,10 @@ import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@a
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
-import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
-import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { ImportAdvancedComponent } from './import-advanced/import-advanced.component';
 import { ImportConfigComponent } from './import-config/import-config.component';
+import { SourcePickerComponent } from './source-picker/source-picker.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
@@ -15,7 +14,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, ClipperChooserComponent, DropZoneComponent, ImportAdvancedComponent, ImportConfigComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -740,10 +739,6 @@ export class DatasetImporterModalComponent implements OnInit {
     this.loadDemoEmbedders(tab);
   }
 
-  onDemoHeaderClick(col: string): void {
-    if (this.demoCols.meta(col).sortable) this.demoCols.sortBy(col);
-  }
-
   // --- Document-level resize tracking ---
 
   @HostListener('document:mousemove', ['$event'])
@@ -803,31 +798,6 @@ export class DatasetImporterModalComponent implements OnInit {
       this._optionLabelsSource = this.mediaTypes;
     }
     return this._optionLabelsCache;
-  }
-
-  getTabIcon(mediaType: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
-    return mt?.icon || '';
-  }
-
-  getTabText(mediaType: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
-    if (mt) {
-      return mt.name;
-    }
-    return mediaType;
-  }
-
-  statusBadgeClass(status: string): string {
-    if (status === 'ready') return 'badge-ready';
-    if (status === 'needs_embedding') return 'badge-embedding';
-    return 'badge-download';
-  }
-
-  statusBadgeLabel(status: string): string {
-    if (status === 'ready') return 'Ready';
-    if (status === 'needs_embedding') return 'Needs Embed';
-    return 'Needs Download';
   }
 
   /** Embedders available for the currently active demo tab's media type. */

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -1,0 +1,201 @@
+<div class="importer-picker">
+  <div class="importer-tab-bar">
+    @for (tab of visibleImporterTabs; track tab.id) {
+      <button
+        class="importer-tab"
+        [class.active]="activeTab === tab.id"
+        (click)="activeTabChange.emit(tab.id)"
+        [title]="tabTitle(tab.label)"
+      >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
+    }
+  </div>
+  @if (!activeTab) {
+    <p class="tab-bar-hint">{{ noTabHint }}</p>
+  }
+
+  @if (activeTab) {
+    @if (importersForActiveTab.length === 0) {
+      <div class="importer-subtab-bar">
+        <span class="empty-state empty-state--inline">{{ emptyCategoryText }}</span>
+      </div>
+    } @else if (importersForActiveTab.length > 1) {
+      <div class="importer-subtab-bar">
+        @for (imp of importersForActiveTab; track imp.name) {
+          <button
+            class="importer-subtab"
+            [class.active]="selectedImporter?.name === imp.name"
+            [class.disabled]="imp['enabled'] === false"
+            [disabled]="imp['enabled'] === false"
+            (click)="importerSelected.emit(imp)"
+            [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
+          >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
+        }
+      </div>
+      @if (!selectedImporter) {
+        <p class="tab-bar-hint">{{ noImporterHint }}</p>
+      }
+    }
+  }
+</div>
+
+@if (activePickerView === 'demo' && selectedImporter) {
+  <div class="demo-picker">
+    @if (demoLoading) {
+      <p class="empty-state">{{ demoLoadingText }}</p>
+    } @else if (demos.length === 0) {
+      <p class="empty-state">{{ demoEmptyText }}</p>
+    } @else {
+      <div class="demo-tab-bar">
+        @for (tab of demoTabs; track tab) {
+          <button
+            class="demo-tab"
+            [class.active]="activeDemoTab === tab"
+            (click)="activeDemoTabChange.emit(tab)"
+            [title]="'Filter demos by media type: ' + getDemoTabText(tab)"
+          >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabText(tab) }}</button>
+        }
+      </div>
+      @if (!activeDemoTab) {
+        <p class="tab-bar-hint">{{ demoNoTabHint }}</p>
+      }
+
+      <ng-content select="[demoExtras]"></ng-content>
+
+      @if (activeDemoTab && demoCols) {
+        <div class="demo-content-area">
+          <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
+            <thead>
+              <tr>
+                @for (col of demoCols.columnOrder; track col; let first = $first) {
+                  <th
+                    [class.sortable]="demoCols.meta(col).sortable"
+                    [class.col-drop-target]="demoCols.isDropTarget(col)"
+                    [class.col-dragging]="demoCols.isDragging(col)"
+                    [class.col-num]="col === 'num_files' || col === 'num_categories'"
+                    [attr.data-col]="col"
+                    [title]="demoCols.meta(col).title"
+                    [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
+                    draggable="true"
+                    (click)="onDemoHeaderClick(col)"
+                    (dragstart)="demoCols.onColDragStart($event, col)"
+                    (dragover)="demoCols.onColDragOver($event, col)"
+                    (dragleave)="demoCols.onColDragLeave($event, col)"
+                    (drop)="demoCols.onColDrop($event, col)"
+                    (dragend)="demoCols.onColDragEnd($event)"
+                  >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
+                }
+              </tr>
+            </thead>
+            <tbody>
+              @for (demo of filteredDemos; track demo.name) {
+                <tr
+                  class="demo-row"
+                  [class.ready]="demo.status === 'ready'"
+                  role="button"
+                  tabindex="0"
+                  [attr.aria-label]="demo.label + ': ' + demo.description"
+                  (click)="demoSelected.emit(demo)"
+                  (keydown.enter)="demoSelected.emit(demo)"
+                  (keydown.space)="$event.preventDefault(); demoSelected.emit(demo)"
+                >
+                  @for (col of demoCols.columnOrder; track col) {
+                    @switch (col) {
+                      @case ('label') {
+                        <td class="col-name">{{ demo.label }}</td>
+                      }
+                      @case ('num_files') {
+                        <td class="col-num">{{ demo.num_files | number }}</td>
+                      }
+                      @case ('num_categories') {
+                        <td class="col-num">{{ demo.num_categories | number }}</td>
+                      }
+                      @case ('description') {
+                        <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
+                      }
+                      @case ('status') {
+                        <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                      }
+                    }
+                  }
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    }
+  </div>
+}
+
+@if (activePickerView === 'server_folder' && selectedImporter) {
+  <div class="server-folder-browser">
+    <ng-content select="[sfBefore]"></ng-content>
+
+    <div class="sf-browse-section">
+      <label class="form-label" [for]="sfPathFieldId">{{ sfPathLabel }}</label>
+      <input
+        [id]="sfPathFieldId"
+        type="text"
+        class="form-input"
+        [placeholder]="sfPathPlaceholder"
+        [(ngModel)]="sfPathInputValue"
+        (ngModelChange)="sfPathInputValueChange.emit($event)"
+        (keydown.enter)="sfPathApplied.emit(); $event.preventDefault()"
+        (blur)="sfPathApplied.emit()"
+      />
+    </div>
+
+    <ng-content select="[sfAfter]"></ng-content>
+  </div>
+}
+
+@if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
+  <div class="local-folder-uploader">
+    @if (lfShowInfo) {
+      @if (lfPickerKind === 'folder') {
+        <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
+      } @else {
+        <p class="info-text">
+          Upload a single file from <strong>this computer</strong> that lists the media to import
+          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
+          paths + pre-computed embedding vectors).
+        </p>
+      }
+    }
+
+    <ng-content select="[lfBefore]"></ng-content>
+
+    <div class="form-group form-group--section">
+      @if (lfPickerKind === 'folder') {
+        <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
+        <vt-drop-zone
+          label="Drop a folder here to import"
+          sublabel="or click to browse"
+          [directory]="true"
+          [multiple]="true"
+          (filesSelected)="lfFilesDropped.emit($event)"
+        ></vt-drop-zone>
+      } @else {
+        <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">Paths file<span class="required">*</span></label>
+        <vt-drop-zone
+          label="Drop a paths file (.txt, .list, or .npz)"
+          sublabel="or click to browse"
+          accept=".txt,.list,.npz"
+          (filesSelected)="lfFilesDropped.emit($event)"
+        ></vt-drop-zone>
+      }
+      @if (lfFiles.length > 0) {
+        <p class="info-text">
+          @if (lfPickerKind === 'folder') {
+            Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
+            @if (lfFolderName) { from <code>{{ lfFolderName }}</code> }
+          } @else {
+            Using paths from <code>{{ lfFiles[0].name }}</code>
+          }
+        </p>
+      }
+    </div>
+
+    <ng-content select="[lfAfter]"></ng-content>
+  </div>
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -18,7 +18,7 @@
       <div class="importer-subtab-bar">
         <span class="empty-state empty-state--inline">{{ emptyCategoryText }}</span>
       </div>
-    } @else if (importersForActiveTab.length > 1) {
+    } @else if (importersForActiveTab.length > 1 || alwaysShowSubtabBar) {
       <div class="importer-subtab-bar">
         @for (imp of importersForActiveTab; track imp.name) {
           <button
@@ -91,9 +91,11 @@
                 <tr
                   class="demo-row"
                   [class.ready]="demo.status === 'ready'"
+                  [class.disabled]="demoRowDisabled(demo)"
                   role="button"
                   tabindex="0"
                   [attr.aria-label]="demo.label + ': ' + demo.description"
+                  [title]="demoRowTitle(demo)"
                   (click)="demoSelected.emit(demo)"
                   (keydown.enter)="demoSelected.emit(demo)"
                   (keydown.space)="$event.preventDefault(); demoSelected.emit(demo)"
@@ -141,7 +143,7 @@
         [(ngModel)]="sfPathInputValue"
         (ngModelChange)="sfPathInputValueChange.emit($event)"
         (keydown.enter)="sfPathApplied.emit(); $event.preventDefault()"
-        (blur)="sfPathApplied.emit()"
+        (blur)="sfApplyOnBlur && sfPathApplied.emit()"
       />
     </div>
 
@@ -151,40 +153,35 @@
 
 @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
   <div class="local-folder-uploader">
-    @if (lfShowInfo) {
-      @if (lfPickerKind === 'folder') {
-        <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
-      } @else {
-        <p class="info-text">
-          Upload a single file from <strong>this computer</strong> that lists the media to import
-          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
-          paths + pre-computed embedding vectors).
-        </p>
-      }
-    }
+    <ng-content select="[lfInfo]"></ng-content>
 
     <ng-content select="[lfBefore]"></ng-content>
 
     <div class="form-group form-group--section">
+      @if (lfShowFieldLabel) {
+        @if (lfPickerKind === 'folder') {
+          <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">{{ lfFolderFieldLabel }}<span class="required">*</span></label>
+        } @else {
+          <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">{{ lfFilesFieldLabel }}<span class="required">*</span></label>
+        }
+      }
       @if (lfPickerKind === 'folder') {
-        <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
         <vt-drop-zone
-          label="Drop a folder here to import"
-          sublabel="or click to browse"
+          [label]="lfFolderDropLabel"
+          [sublabel]="lfFolderDropSublabel"
           [directory]="true"
           [multiple]="true"
           (filesSelected)="lfFilesDropped.emit($event)"
         ></vt-drop-zone>
       } @else {
-        <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">Paths file<span class="required">*</span></label>
         <vt-drop-zone
-          label="Drop a paths file (.txt, .list, or .npz)"
-          sublabel="or click to browse"
-          accept=".txt,.list,.npz"
+          [label]="lfFilesDropLabel"
+          [sublabel]="lfFilesDropSublabel"
+          [accept]="lfFilesAcceptAttr"
           (filesSelected)="lfFilesDropped.emit($event)"
         ></vt-drop-zone>
       }
-      @if (lfFiles.length > 0) {
+      @if (lfShowFileCount && lfFiles.length > 0) {
         <p class="info-text">
           @if (lfPickerKind === 'folder') {
             Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
@@ -1,0 +1,35 @@
+// Picker chrome styles (`.importer-tab-bar`, `.importer-subtab`,
+// `.demo-tab-bar`, `.demo-table`, badges, etc.) live globally in
+// `frontend/src/scss/_picker-shared.scss` so they can be reused by any
+// modal that consumes <vt-source-picker>.  Layout-only styles unique to
+// this widget remain below.
+
+.importer-picker,
+.demo-picker,
+.server-folder-browser,
+.local-folder-uploader,
+.sf-browse-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.importer-picker { gap: 0; margin-bottom: var(--space-lg); }
+
+.demo-picker { gap: var(--space-lg); }
+
+.server-folder-browser { gap: var(--space-lg); }
+.sf-browse-section { gap: var(--space-sm); }
+
+// Indent the per-importer source widgets inward from the tabs above
+// (matches the parent modal's `.importer-form` indent so the hierarchy
+// reads top-down: category tabs → importer tabs → controls).
+// `.demo-picker` is intentionally NOT indented — its inner media-type
+// tab bar must line up with the category and importer tabs above it.
+.local-folder-uploader,
+.server-folder-browser {
+  padding-left: var(--space-2xl);
+}
+
+// Extra vertical breathing room above grouped sections inside the
+// uploader (used to wrap `<ng-content>`-projected blocks too).
+.form-group--section { margin-top: var(--space-xl); }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -82,6 +82,15 @@ export class SourcePickerComponent {
   /** Message shown when the active tab has zero importers. */
   @Input() emptyCategoryText = 'No importers in this category.';
 
+  /** When ``false`` (default), the sub-tab row is suppressed when the
+   *  active category has exactly one importer — the parent is expected
+   *  to auto-select the lone importer and the redundant sub-tab adds
+   *  no information.  Callers that always want the sub-tab visible
+   *  (e.g. the New Detector media picker, where every category is a
+   *  distinct kind of source the user should see labelled) set this to
+   *  ``true``. */
+  @Input() alwaysShowSubtabBar = false;
+
   // === Demo source view ===
 
   @Input() demos: DemoDataset[] = [];
@@ -99,6 +108,15 @@ export class SourcePickerComponent {
   @Input() demoEmptyText = 'No demo datasets available.';
   @Input() demoNoTabHint = 'Select the media type to demonstrate.';
 
+  /** Optional predicate run on every demo row.  When provided and it
+   *  returns ``true``, the row gets a ``disabled`` class for visual
+   *  styling.  Source picker still emits ``demoSelected`` for clicks
+   *  — the parent is responsible for treating disabled rows as
+   *  no-ops. */
+  @Input() demoRowDisabledFn: ((demo: DemoDataset) => boolean) | null = null;
+  /** Optional formatter for the ``title`` attribute on each demo row. */
+  @Input() demoRowTitleFn: ((demo: DemoDataset) => string) | null = null;
+
   // === Server folder source view ===
 
   @Input() sfPathInputValue = '';
@@ -109,17 +127,45 @@ export class SourcePickerComponent {
   @Input() sfPathLabel = 'Folder to import';
   @Input() sfPathPlaceholder = '/absolute/server/path/to/folder';
   @Input() sfPathFieldId = 'sf-path-input';
+  /** Whether to fire ``sfPathApplied`` on the path input's ``blur``
+   *  event in addition to Enter.  The Add Dataset modal wants
+   *  blur-to-detect; the New Detector modal explicitly drives loading
+   *  through a Load button and disables blur to avoid double-firing. */
+  @Input() sfApplyOnBlur = true;
 
   // === Local folder/files source view ===
 
   @Input() lfPickerKind: 'folder' | 'files' = 'folder';
   @Input() lfFiles: File[] = [];
   @Input() lfFolderName = '';
-  /** Whether to show the per-kind explanatory paragraph above the
-   *  dropzone.  Disabled by the new-detector modal which has its own
-   *  "pick a file from this computer" prose. */
-  @Input() lfShowInfo = true;
   @Output() lfFilesDropped = new EventEmitter<File[]>();
+
+  /** ``vt-drop-zone`` label rendered when ``lfPickerKind === 'folder'``. */
+  @Input() lfFolderDropLabel = 'Drop a folder here to import';
+  /** ``vt-drop-zone`` sublabel rendered when ``lfPickerKind === 'folder'``. */
+  @Input() lfFolderDropSublabel = 'or click to browse';
+  /** ``vt-drop-zone`` label rendered when ``lfPickerKind === 'files'``. */
+  @Input() lfFilesDropLabel = 'Drop a paths file (.txt, .list, or .npz)';
+  /** ``vt-drop-zone`` sublabel rendered when ``lfPickerKind === 'files'``. */
+  @Input() lfFilesDropSublabel = 'or click to browse';
+  /** ``accept`` attribute for the ``files`` kind dropzone (comma-separated
+   *  extensions / MIME types).  Empty string accepts anything. */
+  @Input() lfFilesAcceptAttr = '.txt,.list,.npz';
+
+  /** Whether to render the "Folder*" / "Paths file*" form-label above the
+   *  dropzone.  Disabled by callers (e.g. the New Detector modal) that
+   *  bake the affordance entirely into the dropzone's own label. */
+  @Input() lfShowFieldLabel = true;
+  /** Label for the dropzone form-label, when ``lfShowFieldLabel`` is on. */
+  @Input() lfFolderFieldLabel = 'Folder';
+  /** Label for the dropzone form-label in ``files`` mode. */
+  @Input() lfFilesFieldLabel = 'Paths file';
+
+  /** Whether to render the "Selected N files" / "Using paths from …" info
+   *  text below the dropzone.  Disabled by callers that only use the
+   *  first picked file (e.g. the New Detector modal) and have no
+   *  meaningful count to show. */
+  @Input() lfShowFileCount = true;
 
   // === View dispatch ===
 
@@ -151,6 +197,14 @@ export class SourcePickerComponent {
 
   onDemoHeaderClick(col: string): void {
     if (this.demoCols?.meta(col).sortable) this.demoCols.sortBy(col);
+  }
+
+  demoRowDisabled(demo: DemoDataset): boolean {
+    return this.demoRowDisabledFn ? this.demoRowDisabledFn(demo) : false;
+  }
+
+  demoRowTitle(demo: DemoDataset): string {
+    return this.demoRowTitleFn ? this.demoRowTitleFn(demo) : '';
   }
 
   statusBadgeClass(status: string): string {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -1,0 +1,167 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IconComponent } from '../../../icon/icon.component';
+import { DropZoneComponent } from '../../../drop-zone/drop-zone.component';
+import {
+  DemoDataset,
+  ImporterInfo,
+  ImporterPickerTab,
+  MediaTypeInfo,
+} from '../../../../models/api.models';
+import { ManagedColumns } from '../../../../utils/managed-columns';
+
+/** Shared "where does the media come from?" widget.  Renders the
+ *  importer category tab bar + sub-tab bar at the top, then a
+ *  source-specific picker below:
+ *
+ *  - ``demo``                   → media-type tab bar + sortable demo table
+ *  - ``server_folder``          → typed absolute-path input
+ *  - ``local_folder`` / ``local_files`` → file/folder dropzone
+ *  - any other ``picker_view``  → nothing (parent renders its own form)
+ *
+ *  The component is presentational: the parent owns all state and
+ *  passes it in via ``@Input``s, including the precomputed
+ *  ``visibleImporterTabs`` and ``importersForActiveTab`` lists.  User
+ *  actions surface as ``@Output`` events; the parent decides what to do
+ *  (the Add Dataset modal runs the importer, the New Detector modal
+ *  materialises a single example file).
+ *
+ *  Output configuration that visually sits next to the source widget
+ *  (Dataset Name input, ``<vt-import-config>``, ``<vt-import-advanced>``,
+ *  Include-subfolders checkbox) is *not* part of this component.  The
+ *  parent projects those into named content slots so the visual order
+ *  on each flow stays unchanged:
+ *
+ *  - ``[demoExtras]`` — sits between the demo media-type tabs and the
+ *    demo table (Add Dataset uses it for the Dataset Name + Advanced
+ *    block; New Detector leaves it empty).
+ *  - ``[sfBefore]`` / ``[sfAfter]`` — sit above/below the typed path
+ *    input on the server-folder flow.
+ *  - ``[lfBefore]`` / ``[lfAfter]`` — sit above/below the dropzone on
+ *    the local-folder / local-files flows.
+ */
+@Component({
+  selector: 'vt-source-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule, IconComponent, DropZoneComponent],
+  templateUrl: './source-picker.component.html',
+  styleUrl: './source-picker.component.scss',
+})
+export class SourcePickerComponent {
+  // === Importer tab/subtab chrome ===
+
+  /** Tabs to render in the top-level category bar, in display order.
+   *  Parent computes this from the importer registry; see
+   *  ``DatasetImporterModalComponent.visibleImporterTabs``. */
+  @Input() visibleImporterTabs: ImporterPickerTab[] = [];
+
+  /** Importers whose ``category`` matches ``activeTab`` (i.e. the
+   *  sub-tabs to render). */
+  @Input() importersForActiveTab: ImporterInfo[] = [];
+
+  @Input() activeTab = '';
+  @Input() selectedImporter: ImporterInfo | null = null;
+  @Input() activeImporterTabLabel = '';
+
+  /** Fired when the user clicks a top-level category tab. */
+  @Output() activeTabChange = new EventEmitter<string>();
+  /** Fired when the user clicks a sub-tab (importer card). */
+  @Output() importerSelected = new EventEmitter<ImporterInfo>();
+
+  // --- Chrome customization ---
+
+  /** Hint shown above the sub-tab area when no top tab is selected. */
+  @Input() noTabHint = 'Select what type of dataset to add.';
+  /** Hint shown when a tab with multiple importers has none picked yet.
+   *  ``{label}`` is replaced with the active tab's label. */
+  @Input() noImporterHintTemplate = 'Select how to add a {label} dataset.';
+  /** ``title`` attribute on top-level tab buttons.  ``{label}`` is
+   *  replaced with the tab label. */
+  @Input() tabTitleTemplate = 'Show {label} dataset importers';
+  /** Message shown when the active tab has zero importers. */
+  @Input() emptyCategoryText = 'No importers in this category.';
+
+  // === Demo source view ===
+
+  @Input() demos: DemoDataset[] = [];
+  @Input() filteredDemos: DemoDataset[] = [];
+  @Input() demoLoading = false;
+  @Input() demoTabs: string[] = [];
+  @Input() activeDemoTab = '';
+  @Input() demoCols: ManagedColumns | null = null;
+  @Input() mediaTypes: MediaTypeInfo[] = [];
+
+  @Output() activeDemoTabChange = new EventEmitter<string>();
+  @Output() demoSelected = new EventEmitter<DemoDataset>();
+
+  @Input() demoLoadingText = 'Loading demo datasets...';
+  @Input() demoEmptyText = 'No demo datasets available.';
+  @Input() demoNoTabHint = 'Select the media type to demonstrate.';
+
+  // === Server folder source view ===
+
+  @Input() sfPathInputValue = '';
+  @Output() sfPathInputValueChange = new EventEmitter<string>();
+  /** Fired when the user finalises the typed path (Enter or blur). */
+  @Output() sfPathApplied = new EventEmitter<void>();
+
+  @Input() sfPathLabel = 'Folder to import';
+  @Input() sfPathPlaceholder = '/absolute/server/path/to/folder';
+  @Input() sfPathFieldId = 'sf-path-input';
+
+  // === Local folder/files source view ===
+
+  @Input() lfPickerKind: 'folder' | 'files' = 'folder';
+  @Input() lfFiles: File[] = [];
+  @Input() lfFolderName = '';
+  /** Whether to show the per-kind explanatory paragraph above the
+   *  dropzone.  Disabled by the new-detector modal which has its own
+   *  "pick a file from this computer" prose. */
+  @Input() lfShowInfo = true;
+  @Output() lfFilesDropped = new EventEmitter<File[]>();
+
+  // === View dispatch ===
+
+  /** ``picker_view`` of the currently selected importer.  Drives which
+   *  source widget is rendered below the chrome. */
+  @Input() activePickerView = '';
+
+  // -------------------------------------------------------------------
+
+  get noImporterHint(): string {
+    return this.noImporterHintTemplate.replace('{label}', this.activeImporterTabLabel);
+  }
+
+  tabTitle(label: string): string {
+    return this.tabTitleTemplate.replace('{label}', label);
+  }
+
+  // === Demo helpers ===
+
+  getDemoTabIcon(mediaType: string): string {
+    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
+    return mt?.icon || '';
+  }
+
+  getDemoTabText(mediaType: string): string {
+    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
+    return mt ? mt.name : mediaType;
+  }
+
+  onDemoHeaderClick(col: string): void {
+    if (this.demoCols?.meta(col).sortable) this.demoCols.sortBy(col);
+  }
+
+  statusBadgeClass(status: string): string {
+    if (status === 'ready') return 'badge-ready';
+    if (status === 'needs_embedding') return 'badge-embedding';
+    return 'badge-download';
+  }
+
+  statusBadgeLabel(status: string): string {
+    if (status === 'ready') return 'Ready';
+    if (status === 'needs_embedding') return 'Needs Embed';
+    return 'Needs Download';
+  }
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -285,133 +285,82 @@
     <div class="media-picker">
       <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the detector creation form">&larr; Back</button>
 
-      <!-- Category tabs (mirrors the Add Dataset modal so users see the same layout). -->
-      <div class="importer-picker">
-        <div class="importer-tab-bar">
-          @for (tab of visibleImporterTabs; track tab.id) {
-            <button
-              class="importer-tab"
-              [class.active]="activeImporterTab === tab.id"
-              (click)="selectImporterTab(tab.id)"
-              [title]="'Show ' + tab.label + ' media sources'"
-            >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
+      <vt-source-picker
+        [visibleImporterTabs]="visibleImporterTabs"
+        [importersForActiveTab]="importersForActiveTab"
+        [activeImporterTabLabel]="activeImporterTabLabel"
+        [activeTab]="activeImporterTab"
+        (activeTabChange)="selectImporterTab($event)"
+        [selectedImporter]="selectedImporter"
+        (importerSelected)="selectImporter($event)"
+        [activePickerView]="demoFileBrowsing ? '' : activePickerView"
+        [mediaTypes]="mediaTypeInfos"
+        [noTabHint]="'Select where to pick a media example from.'"
+        [noImporterHintTemplate]="'Select a {label} source to browse.'"
+        [tabTitleTemplate]="'Show {label} media sources'"
+        [emptyCategoryText]="'No sources in this category.'"
+        [alwaysShowSubtabBar]="true"
+        [demos]="demos"
+        [filteredDemos]="filteredDemos"
+        [demoLoading]="demoLoading"
+        [demoTabs]="demoTabs"
+        [activeDemoTab]="activeDemoTab"
+        (activeDemoTabChange)="selectDemoTab($event)"
+        [demoCols]="demoCols"
+        (demoSelected)="selectDemo($event)"
+        [demoRowDisabledFn]="demoRowDisabledFn"
+        [demoRowTitleFn]="demoRowTitleFn"
+        [sfPathInputValue]="sfTypedPath"
+        (sfPathInputValueChange)="sfTypedPath = $event"
+        (sfPathApplied)="submitSfTypedPath()"
+        [sfApplyOnBlur]="false"
+        [sfPathLabel]="'Path to a media file on the server'"
+        [sfPathPlaceholder]="'/absolute/server/path/to/file'"
+        [sfPathFieldId]="'sf-example-path-input'"
+        [lfPickerKind]="lfPickerKind"
+        [lfShowFieldLabel]="false"
+        [lfShowFileCount]="false"
+        [lfFolderDropLabel]="'Drop a folder here to use as example'"
+        [lfFolderDropSublabel]="'or click to browse — the first file is used'"
+        [lfFilesDropLabel]="dropMediaLabel + ' to use as example'"
+        [lfFilesDropSublabel]="'or click to browse'"
+        [lfFilesAcceptAttr]="''"
+        (lfFilesDropped)="onLocalFileDropped($event)"
+      >
+        <ng-container sfAfter>
+          <button
+            type="button"
+            class="btn btn--primary"
+            [disabled]="sfFileSelecting || !sfTypedPath.trim()"
+            (click)="submitSfTypedPath()"
+          >
+            @if (sfFileSelecting) { Loading… } @else { Load }
+          </button>
+          @if (sfBrowseError) {
+            <p class="error-text">{{ sfBrowseError }}</p>
           }
-        </div>
-        @if (!activeImporterTab) {
-          <p class="tab-bar-hint">Select where to pick a media example from.</p>
-        }
+        </ng-container>
 
-        @if (activeImporterTab) {
-          <div class="importer-subtab-bar">
-            @if (importersForActiveTab.length === 0) {
-              <span class="empty-state empty-state--inline">No sources in this category.</span>
-            }
-            @for (imp of importersForActiveTab; track imp.name) {
-              <button
-                class="importer-subtab"
-                [class.active]="selectedImporter?.name === imp.name"
-                (click)="selectImporter(imp)"
-                [title]="imp.description || ''"
-              >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
-            }
-          </div>
-          @if (!selectedImporter && importersForActiveTab.length > 0) {
-            <p class="tab-bar-hint">Select a {{ activeImporterTabLabel }} source to browse.</p>
+        <ng-container lfInfo>
+          <p class="info-text">
+            Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
+            and used as the example for this detector.
+          </p>
+        </ng-container>
+
+        <ng-container lfAfter>
+          @if (lfPickerKind === 'folder') {
+            <p class="info-text">
+              The first file in the picked folder will be used. To pick a single file directly,
+              switch to the <strong>Local Files</strong> tab.
+            </p>
           }
-        }
-      </div>
+        </ng-container>
+      </vt-source-picker>
 
-      <!-- Demo picker view: media-type tabs + sortable demo table. -->
-      @if (activePickerView === 'demo' && selectedImporter && !demoFileBrowsing) {
-        <div class="demo-picker">
-          @if (demoLoading) {
-            <p class="empty-state">Loading demo datasets...</p>
-          } @else if (demos.length === 0) {
-            <p class="empty-state">No demo datasets available.</p>
-          } @else {
-            <div class="demo-tab-bar">
-              @for (tab of demoTabs; track tab) {
-                <button
-                  class="demo-tab"
-                  [class.active]="activeDemoTab === tab"
-                  (click)="selectDemoTab(tab)"
-                  [title]="'Filter demos by media type: ' + getDemoTabLabel(tab)"
-                >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabLabel(tab) }}</button>
-              }
-            </div>
-            @if (!activeDemoTab) {
-              <p class="tab-bar-hint">Select the media type to demonstrate.</p>
-            }
-
-            @if (activeDemoTab) {
-              <div class="demo-content-area">
-                <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
-                  <thead>
-                    <tr>
-                      @for (col of demoCols.columnOrder; track col; let first = $first) {
-                        <th
-                          [class.sortable]="demoCols.meta(col).sortable"
-                          [class.col-drop-target]="demoCols.isDropTarget(col)"
-                          [class.col-dragging]="demoCols.isDragging(col)"
-                          [class.col-num]="col === 'num_files' || col === 'num_categories'"
-                          [attr.data-col]="col"
-                          [title]="demoCols.meta(col).title"
-                          [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
-                          draggable="true"
-                          (click)="onDemoHeaderClick(col)"
-                          (dragstart)="demoCols.onColDragStart($event, col)"
-                          (dragover)="demoCols.onColDragOver($event, col)"
-                          (dragleave)="demoCols.onColDragLeave($event, col)"
-                          (drop)="demoCols.onColDrop($event, col)"
-                          (dragend)="demoCols.onColDragEnd($event)"
-                        >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
-                      }
-                    </tr>
-                  </thead>
-                  <tbody>
-                    @for (demo of filteredDemos; track demo.name) {
-                      <tr
-                        class="demo-row"
-                        [class.ready]="demo.status === 'ready'"
-                        [class.disabled]="!isDemoBrowsable(demo)"
-                        role="button"
-                        tabindex="0"
-                        [attr.aria-label]="demo.label + ': ' + demo.description"
-                        [title]="isDemoBrowsable(demo) ? 'Browse files in ' + demo.label : 'This demo has not been downloaded. Use the Add Dataset window to fetch it first.'"
-                        (click)="selectDemo(demo)"
-                        (keydown.enter)="selectDemo(demo)"
-                        (keydown.space)="$event.preventDefault(); selectDemo(demo)"
-                      >
-                        @for (col of demoCols.columnOrder; track col) {
-                          @switch (col) {
-                            @case ('label') {
-                              <td class="col-name">{{ demo.label }}</td>
-                            }
-                            @case ('num_files') {
-                              <td class="col-num">{{ demo.num_files | number }}</td>
-                            }
-                            @case ('num_categories') {
-                              <td class="col-num">{{ demo.num_categories | number }}</td>
-                            }
-                            @case ('description') {
-                              <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
-                            }
-                            @case ('status') {
-                              <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
-                            }
-                          }
-                        }
-                      </tr>
-                    }
-                  </tbody>
-                </table>
-              </div>
-            }
-          }
-        </div>
-      }
-
-      <!-- Demo file picker: appears after picking a demo from the table. -->
+      <!-- Demo file picker: appears after picking a demo from the table.
+           Source-picker hides its demo view (activePickerView passed as '')
+           while demoFileBrowsing is true so this widget renders alone. -->
       @if (activePickerView === 'demo' && selectedImporter && demoFileBrowsing) {
         <div class="server-folder-browser">
           <button class="btn btn--secondary btn--sm back-btn" (click)="backToDemoTable()" title="Return to the demo list">&larr; Back to demo list</button>
@@ -434,63 +383,6 @@
           </button>
           @if (demoTypedPathError) {
             <p class="error-text">{{ demoTypedPathError }}</p>
-          }
-        </div>
-      }
-
-      <!-- Server folder picker: user types an absolute server path. -->
-      @if (activePickerView === 'server_folder' && selectedImporter) {
-        <div class="server-folder-browser">
-          <label class="form-label" for="sf-example-path-input">Path to a media file on the server</label>
-          <input
-            id="sf-example-path-input"
-            type="text"
-            class="form-input"
-            placeholder="/absolute/server/path/to/file"
-            [(ngModel)]="sfTypedPath"
-            (keydown.enter)="submitSfTypedPath(); $event.preventDefault()"
-          />
-          <button
-            type="button"
-            class="btn btn--primary"
-            [disabled]="sfFileSelecting || !sfTypedPath.trim()"
-            (click)="submitSfTypedPath()"
-          >
-            @if (sfFileSelecting) { Loading… } @else { Load }
-          </button>
-          @if (sfBrowseError) {
-            <p class="error-text">{{ sfBrowseError }}</p>
-          }
-        </div>
-      }
-
-      <!-- Local file upload: pick a single file from the user's machine.
-           local_folder and local_files share this view since only one example
-           file is needed regardless of how many the input collects. -->
-      @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
-        <div class="local-folder-uploader">
-          <p class="info-text">
-            Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
-            and used as the example for this detector.
-          </p>
-          @if (activePickerView === 'local_folder') {
-            <vt-drop-zone
-              label="Drop a folder here to use as example"
-              sublabel="or click to browse — the first file is used"
-              [directory]="true"
-              [multiple]="true"
-              (filesSelected)="onLocalFileDropped($event)"
-            ></vt-drop-zone>
-            <p class="info-text">
-              The first file in the picked folder will be used. To pick a single file directly,
-              switch to the <strong>Local Files</strong> tab.
-            </p>
-          } @else {
-            <vt-drop-zone
-              [label]="dropMediaLabel + ' to use as example'"
-              sublabel="or click to browse"
-              (filesSelected)="onLocalFileDropped($event)"
-            ></vt-drop-zone>
           }
         </div>
       }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -180,35 +180,16 @@
 
 .back-btn { align-self: flex-start; }
 
-.importer-picker {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.demo-picker {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-}
+// Picker chrome (.importer-picker, .demo-picker, .sf-browse-section,
+// .local-folder-uploader) lives inside <vt-source-picker>.  The
+// `.server-folder-browser` rule below still applies because the
+// demoFileBrowsing widget (rendered in this parent's template) wraps
+// itself in that class to inherit the same layout.
 
 .server-folder-browser {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
-  padding-left: var(--space-2xl);
-}
-
-.sf-browse-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-.local-folder-uploader {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
   padding-left: var(--space-2xl);
 }
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -20,6 +20,7 @@ import {
   MediaCropResult,
 } from '../../modals/media-crop-modal/media-crop-modal.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
+import { SourcePickerComponent } from '../dataset-importer-modal/source-picker/source-picker.component';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 type ModalView = 'main' | 'media-picker';
@@ -29,7 +30,7 @@ type TrainedSubView = 'picker' | 'form';
 @Component({
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -464,10 +465,6 @@ export class NewDetectorModalComponent implements OnInit {
     this.activeDemoTab = tab;
   }
 
-  onDemoHeaderClick(col: string): void {
-    if (this.demoCols.meta(col).sortable) this.demoCols.sortBy(col);
-  }
-
   get filteredDemos(): DemoDataset[] {
     const items = this.demos.filter((d) => d.media_type === this.activeDemoTab);
     const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
@@ -495,6 +492,24 @@ export class NewDetectorModalComponent implements OnInit {
    *  fetch them via the Add Dataset modal. */
   isDemoBrowsable(demo: DemoDataset): boolean {
     return demo.status === 'ready' || demo.status === 'needs_embedding';
+  }
+
+  /** Arrow-bound predicate handed to ``<vt-source-picker>`` so its demo
+   *  table can apply ``.disabled`` styling to non-browsable rows.  Kept
+   *  as a class field (rather than a getter) so the function reference
+   *  is stable across change-detection cycles. */
+  demoRowDisabledFn = (demo: DemoDataset): boolean => !this.isDemoBrowsable(demo);
+
+  /** Arrow-bound formatter for the ``title`` attribute on demo rows. */
+  demoRowTitleFn = (demo: DemoDataset): string =>
+    this.isDemoBrowsable(demo)
+      ? `Browse files in ${demo.label}`
+      : 'This demo has not been downloaded. Use the Add Dataset window to fetch it first.';
+
+  /** Map ``activePickerView`` to the ``lfPickerKind`` flag understood by
+   *  ``<vt-source-picker>``. */
+  get lfPickerKind(): 'folder' | 'files' {
+    return this.activePickerView === 'local_files' ? 'files' : 'folder';
   }
 
   selectDemo(demo: DemoDataset): void {
@@ -656,31 +671,6 @@ export class NewDetectorModalComponent implements OnInit {
 
   backToMain(): void {
     this.view = 'main';
-  }
-
-  // --- Media-type tab labels (mirrors Add Dataset's helpers) ---
-
-  getDemoTabLabel(typeId: string): string {
-    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
-    if (mt) return mt.name.trim();
-    return typeId;
-  }
-
-  getDemoTabIcon(typeId: string): string {
-    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
-    return mt?.icon || '';
-  }
-
-  statusBadgeClass(status: string): string {
-    if (status === 'ready') return 'badge-ready';
-    if (status === 'needs_embedding') return 'badge-embedding';
-    return 'badge-download';
-  }
-
-  statusBadgeLabel(status: string): string {
-    if (status === 'ready') return 'Ready';
-    if (status === 'needs_embedding') return 'Needs Embed';
-    return 'Needs Download';
   }
 
   // --- Clear example ---


### PR DESCRIPTION
## Summary

Continues the frontend-bundle-organization plan with the final two checkpoints of item #1: extract `<vt-source-picker>` and migrate both modals that currently duplicate the picker chrome.

### Checkpoint 4 — extract and migrate dataset-importer

- New presentational `<vt-source-picker>` component owns the importer category-tab + sub-tab chrome, the demo media-type tabs + sortable demo table, the server-folder typed-path input, and the local-folder / local-files dropzone with file-count display.
- Parent owns all state and passes in precomputed `visibleImporterTabs` / `importersForActiveTab` lists; user actions surface as `@Output` events. Per-flow output config (Dataset Name input, `<vt-import-config>`, Include-subfolders checkbox, `<vt-import-advanced>`) projects through named content slots (`[demoExtras]`, `[sfBefore]`/`[sfAfter]`, `[lfBefore]`/`[lfAfter]`) so the visual order on every flow stays byte-identical.
- Dead helpers removed from `dataset-importer-modal`: `getTabIcon`, `getTabText`, `statusBadgeClass`, `statusBadgeLabel`, `onDemoHeaderClick`.

### Checkpoint 5 — migrate new-detector-modal

- `new-detector-modal`'s media picker now consumes `<vt-source-picker>` too — drops ~213 lines of duplicated picker / demo-table / sf typed-path / lf dropzone markup, plus five matching dead helpers and the SCSS rules they backed.
- Added customization inputs that new-detector needed: `alwaysShowSubtabBar`, `demoRowDisabledFn` / `demoRowTitleFn`, `sfApplyOnBlur`, `lfShowFieldLabel` / `lfShowFileCount`, dropzone label / sublabel / accept overrides, and a new `[lfInfo]` content-projection slot (replaces the previously hard-coded "Pick a folder…" / "Upload a single file…" paragraphs — each parent now projects its own copy).

## Bundle effect

- **Initial bundle unchanged at 526.40 kB / 136.37 kB gzip** (both modals are `@defer`-loaded).
- The bundler now extracts `<vt-source-picker>` into its own shared lazy chunk that both modals reference:
  - `dataset-importer-modal-component`: 77.64 → 68.11 kB raw (15.76 → 13.87 kB gzip)
  - `new-detector-modal-component`: 49.78 → 43.30 kB raw (10.87 → 9.79 kB gzip)
  - new shared chunk: ~21 kB raw / 5.6 kB gzip
- Total deferred-chunk weight is slightly higher than pre-CP4 (per-component Angular plumbing has overhead), but the structural goal — single source of truth for the picker chrome and demo table — is achieved. Future edits to the picker UI touch one component instead of two.

## Test plan

- [x] `./run-tests.sh core` passes (589 tests, frontend TypeScript build OK, audit OK).
- [ ] Manual (Add Dataset modal): click each top-level tab (Services / Server / Local / Demo); sub-tabs and source-side widgets render as before; folder drop / typed path / demo selection still work end-to-end.
- [ ] Manual (New Detector modal → Browse Media): click each top-level tab; demo table rows respect ready / needs-download visual state and tooltip; typed server path + Load button submits; local folder / files dropzone uploads a single example file.
