### PR TITLE
Add media-type icons to MediaType dropdown; move Dataset Name above Advanced

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -168,6 +168,7 @@
               (mediaTypeChange)="onMediaTypeChange($event)"
               [mediaTypeOptions]="field.options || []"
               [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+              [mediaTypeOptionIcons]="mediaTypeOptionIcons"
             ></vt-import-config>
             @if (field.hint) {
               <p class="form-hint">{{ field.hint }}</p>
@@ -337,24 +338,13 @@
         </p>
       }
 
-      <div class="form-group">
-        <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
-        <input
-          id="lf-dataset-name"
-          type="text"
-          class="form-input"
-          [ngModel]="lfDatasetName"
-          (ngModelChange)="lfOnDatasetNameInput($event)"
-          placeholder="Leave blank to use a default name"
-        />
-      </div>
-
       <vt-import-config
         mediaTypeFieldId="lf-media-type"
         [mediaType]="lfMediaType"
         (mediaTypeChange)="lfOnMediaTypeChange($event)"
         [mediaTypeOptions]="lfMediaTypeOptions"
         [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [mediaTypeOptionIcons]="mediaTypeOptionIcons"
         [detectionHint]="detectionHint(lfDetection)"
       ></vt-import-config>
 
@@ -403,6 +393,18 @@
         </div>
       }
 
+      <div class="form-group">
+        <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
+        <input
+          id="lf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="lfDatasetName"
+          (ngModelChange)="lfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
+      </div>
+
       <div class="form-group form-group--section">
         <vt-import-advanced
           [availableConverters]="lfAvailableConverters"
@@ -441,24 +443,13 @@
 
   @if (activePickerView === 'server_folder' && selectedImporter) {
     <div class="server-folder-browser">
-      <div class="form-group">
-        <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
-        <input
-          id="sf-dataset-name"
-          type="text"
-          class="form-input"
-          [ngModel]="sfDatasetName"
-          (ngModelChange)="sfOnDatasetNameInput($event)"
-          placeholder="Leave blank to use a default name"
-        />
-      </div>
-
       <vt-import-config
         mediaTypeFieldId="sf-media-type"
         [mediaType]="sfMediaType"
         (mediaTypeChange)="sfOnMediaTypeChange($event)"
         [mediaTypeOptions]="sfMediaTypeOptions"
         [mediaTypeOptionLabels]="mediaTypeOptionLabels"
+        [mediaTypeOptionIcons]="mediaTypeOptionIcons"
         [detectionHint]="detectionHint(sfDetection)"
       ></vt-import-config>
 
@@ -485,6 +476,18 @@
           />
           Include subfolders
         </label>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
+        <input
+          id="sf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="sfDatasetName"
+          (ngModelChange)="sfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
       </div>
 
       <div class="form-group form-group--section">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -805,6 +805,24 @@ export class DatasetImporterModalComponent implements OnInit {
     return this._optionLabelsCache;
   }
 
+  /** Cached map of ``folder_import_name`` → icon string (emoji or SVG
+   *  type name from :class:`MediaTypeInfo.icon`), rebuilt only when
+   *  ``mediaTypes`` is reassigned.  Feeds the per-option icon shown in
+   *  the media-type dropdown inside :component:`ImportConfigComponent`. */
+  private _optionIconsSource: MediaTypeInfo[] | null = null;
+  private _optionIconsCache: Record<string, string> = {};
+  get mediaTypeOptionIcons(): Record<string, string> {
+    if (this._optionIconsSource !== this.mediaTypes) {
+      const out: Record<string, string> = {};
+      for (const mt of this.mediaTypes) {
+        if (mt.folder_import_name && mt.icon) out[mt.folder_import_name] = mt.icon;
+      }
+      this._optionIconsCache = out;
+      this._optionIconsSource = this.mediaTypes;
+    }
+    return this._optionIconsCache;
+  }
+
   getTabIcon(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     return mt?.icon || '';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
@@ -4,16 +4,42 @@
     [for]="mediaTypeFieldId"
     title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type."
   >Dataset MediaType</label>
-  <select
-    [id]="mediaTypeFieldId"
-    class="form-select"
-    [ngModel]="mediaType"
-    (ngModelChange)="mediaTypeChange.emit($event)"
-  >
-    @for (opt of mediaTypeOptions; track opt) {
-      <option [value]="opt">{{ optionLabel(opt) }}</option>
+  <div class="media-type-dropdown" [class.open]="open">
+    <button
+      type="button"
+      [id]="mediaTypeFieldId"
+      class="form-select media-type-trigger"
+      [attr.aria-haspopup]="'listbox'"
+      [attr.aria-expanded]="open"
+      (click)="toggle()"
+    >
+      <span class="media-type-trigger-content">
+        @if (iconFor(mediaType)) {
+          <vt-icon [icon]="iconFor(mediaType)" [size]="16"></vt-icon>
+        }
+        <span class="media-type-trigger-label">{{ optionLabel(mediaType) }}</span>
+      </span>
+      <span class="media-type-chevron" aria-hidden="true">▾</span>
+    </button>
+    @if (open) {
+      <ul class="media-type-options" role="listbox">
+        @for (opt of mediaTypeOptions; track opt) {
+          <li
+            class="media-type-option"
+            role="option"
+            [class.selected]="opt === mediaType"
+            [attr.aria-selected]="opt === mediaType"
+            (click)="select(opt)"
+          >
+            @if (iconFor(opt)) {
+              <vt-icon [icon]="iconFor(opt)" [size]="16"></vt-icon>
+            }
+            <span class="media-type-option-label">{{ optionLabel(opt) }}</span>
+          </li>
+        }
+      </ul>
     }
-  </select>
+  </div>
   @if (detectionHint) {
     <p class="detection-hint">{{ detectionHint }}</p>
   }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
@@ -16,3 +16,83 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+// Custom button + listbox dropdown for the media-type "select".  We
+// don't use a native ``<select>`` because ``<option>`` elements cannot
+// host markup, and we want each row to show the media type's SVG icon
+// alongside its label.  The trigger inherits ``.form-select`` so it
+// matches the visual weight of the rest of the form's inputs.
+.media-type-dropdown {
+  position: relative;
+}
+
+.media-type-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  text-align: left;
+  font: inherit;
+  // ``.form-select`` already supplies padding/border/radius/background.
+}
+
+.media-type-trigger-content {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.media-type-trigger-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.media-type-chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  transition: transform 0.15s ease;
+}
+
+.media-type-dropdown.open .media-type-chevron {
+  transform: rotate(180deg);
+}
+
+.media-type-options {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: var(--space-xs) 0;
+  list-style: none;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  max-height: 260px;
+  overflow-y: auto;
+  z-index: var(--z-dropdown, 50);
+}
+
+.media-type-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: var(--font-md);
+
+  &:hover {
+    background: var(--bg-subtle);
+  }
+
+  &.selected {
+    background: var(--bg-subtle);
+    font-weight: var(--weight-medium);
+  }
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -1,6 +1,7 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { IconComponent } from '../../../icon/icon.component';
 
 /** Output-media-type select + auto-detection hint chip shared by the
  *  server-folder (``sf``) and local-folder/local-files (``lf``) flows
@@ -15,16 +16,21 @@ import { FormsModule } from '@angular/forms';
  *  recursive toggle sit between the media-type select and the
  *  Advanced block, so collapsing into one child would force a
  *  re-order of the flow.
+ *
+ *  The "select" is implemented as a custom button + popup listbox so
+ *  each option can show the media type's SVG icon (rendered via
+ *  ``<vt-icon>``) alongside its label — native ``<option>`` elements
+ *  cannot host markup.
  */
 @Component({
   selector: 'vt-import-config',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, IconComponent],
   templateUrl: './import-config.component.html',
   styleUrl: './import-config.component.scss',
 })
 export class ImportConfigComponent {
-  /** ``id`` / ``for`` value for the rendered media-type select.  Each
+  /** ``id`` value for the rendered media-type trigger button.  Each
    *  call site supplies a unique value so the modal does not contain
    *  duplicate ids when multiple flows are present in the DOM. */
   @Input() mediaTypeFieldId = 'import-config-media-type';
@@ -43,15 +49,57 @@ export class ImportConfigComponent {
    *  once from the ``/api/media-types`` response. */
   @Input() mediaTypeOptionLabels: Record<string, string> = {};
 
+  /** Map of ``folder_import_name`` → icon string (emoji or named SVG
+   *  type from :class:`MediaTypeInfo.icon`).  When empty for a given
+   *  option, the row renders label-only. */
+  @Input() mediaTypeOptionIcons: Record<string, string> = {};
+
   /** Pre-formatted hint string from
    *  :meth:`DatasetImporterModalComponent.detectionHint`.  Empty hides
    *  the chip entirely. */
   @Input() detectionHint = '';
+
+  /** Whether the custom dropdown is currently expanded. */
+  open = false;
+
+  constructor(private hostEl: ElementRef<HTMLElement>) {}
 
   /** Label for an option in the media-type dropdown.  Falls back to the
    *  option value when no label is supplied (e.g. the parent's
    *  ``mediaTypes`` list has not loaded yet). */
   optionLabel(opt: string): string {
     return this.mediaTypeOptionLabels[opt] || opt;
+  }
+
+  /** Icon string for an option (emoji or :class:`IconComponent` type
+   *  name).  Empty hides the icon for that row. */
+  iconFor(opt: string): string {
+    return this.mediaTypeOptionIcons[opt] || '';
+  }
+
+  toggle(): void {
+    this.open = !this.open;
+  }
+
+  select(opt: string): void {
+    this.open = false;
+    if (opt !== this.mediaType) {
+      this.mediaTypeChange.emit(opt);
+    }
+  }
+
+  /** Close the popup when the user clicks outside the host element. */
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.open) return;
+    const target = event.target as Node | null;
+    if (target && this.hostEl.nativeElement.contains(target)) return;
+    this.open = false;
+  }
+
+  /** Close on Escape so keyboard users can dismiss the popup. */
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.open) this.open = false;
   }
 }

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -763,16 +763,18 @@ class TestImporterMetadata:
         assert keys.index("media_type") < keys.index("path")
 
     def test_every_importer_exposes_dataset_name_field(self, client):
-        """Every importer's serialised field list begins with a non-required
+        """Every importer's serialised field list ends with a non-required
         ``dataset_name`` text field so the user can override the auto-generated
-        display name."""
+        display name.  The field sits last so that a user filling the form
+        top-down has already entered the source fields that feed the
+        auto-derived default by the time they reach it."""
         resp = client.get("/api/dataset/importers")
         data = resp.get_json()
         assert data["importers"], "expected at least one importer"
         for imp in data["importers"]:
             keys = [f["key"] for f in imp["fields"]]
-            assert keys[0] == "dataset_name", f"{imp['name']} missing dataset_name field at index 0"
-            ds_field = imp["fields"][0]
+            assert keys[-1] == "dataset_name", f"{imp['name']} missing dataset_name field at last index"
+            ds_field = imp["fields"][-1]
             assert ds_field["field_type"] == "text"
             assert ds_field["required"] is False
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -355,7 +355,7 @@ class TestImporterDatasetName:
 
         return Imp()
 
-    def test_to_dict_prepends_dataset_name_field(self):
+    def test_to_dict_appends_dataset_name_field(self):
         from vtscore.datasets.importers.base import (
             DATASET_NAME_FIELD_KEY,
             DatasetImporter,
@@ -372,13 +372,13 @@ class TestImporterDatasetName:
                 pass
 
         d = Imp().to_dict()
-        assert d["fields"][0]["key"] == DATASET_NAME_FIELD_KEY
-        assert d["fields"][0]["required"] is False
-        assert d["fields"][0]["field_type"] == "text"
-        assert d["fields"][1]["key"] == "path"
+        assert d["fields"][0]["key"] == "path"
+        assert d["fields"][-1]["key"] == DATASET_NAME_FIELD_KEY
+        assert d["fields"][-1]["required"] is False
+        assert d["fields"][-1]["field_type"] == "text"
 
     def test_class_fields_attribute_unchanged_by_to_dict(self):
-        """to_dict() prepends dataset_name only on the serialised payload —
+        """to_dict() appends dataset_name only on the serialised payload —
         the class-level ``fields`` attribute remains as the developer wrote it."""
         from vtscore.datasets.importers.base import DatasetImporter, ImporterField
 

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -205,12 +205,13 @@ PickerView = str  # one of: "form", "demo", "server_folder", "local"
 
 
 # Synthetic per-importer field that lets the user pick a name for the new
-# dataset.  Injected at the front of every importer's serialised field list
-# in :meth:`DatasetImporter.to_dict`, so the frontend renders it generically
-# without each subclass having to duplicate the declaration.  Routed through
-# the per-plugin marshmallow schema as a regular field (see
-# :func:`vtsearch.routes._shared.validate_plugin_args`) and read downstream
-# by :meth:`DatasetImporter.resolve_display_name`.
+# dataset.  Appended to the end of every importer's serialised field list
+# in :meth:`DatasetImporter.to_dict` (just before the Advanced section in
+# the UI), so users filling the form top-down have already entered the
+# fields that feed the auto-derived default name by the time they reach
+# it.  Routed through the per-plugin marshmallow schema as a regular field
+# (see :func:`vtsearch.routes._shared.validate_plugin_args`) and read
+# downstream by :meth:`DatasetImporter.resolve_display_name`.
 DATASET_NAME_FIELD_KEY = "dataset_name"
 
 
@@ -329,7 +330,7 @@ class DatasetImporter(PluginBase):
         d["picker_view"] = self.picker_view
         d["category"] = self.category
         d["multi_media"] = self.multi_media
-        d["fields"] = [_dataset_name_field().to_dict()] + d["fields"]
+        d["fields"] = d["fields"] + [_dataset_name_field().to_dict()]
         return d
 
     def default_display_name(self, field_values: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

Two small UX improvements to the Add Dataset (importer) modal:

- **Icons in the "Dataset MediaType" pulldown.** Each option now shows the media type's SVG icon to the left of its label (audio, image, video, text, document, …). Native `<option>` elements can't host markup, so `<vt-import-config>` replaces the `<select>` with a custom button + listbox styled to match `form-select`. The icon string already flows through `MediaTypeInfo.icon` from `/api/media-types`; a new `mediaTypeOptionIcons` getter on the parent component maps `folder_import_name → icon` and is passed alongside the existing `mediaTypeOptionLabels`.
- **"Dataset Name" moved to the last entry before Advanced.** Previously the field was prepended to every importer's serialised field list, which placed it at the top of the form. Now `DatasetImporter.to_dict()` appends it instead, and the local-folder / server-folder views also render the input just above their Advanced section. This way a user filling the form top-down has already entered the source fields that feed the auto-derived default by the time they reach the override input.

Test assertions in `tests/datasets/test_datasets.py` and `tests_lib/io/test_importers.py` were updated to expect the field at the last index instead of the first.

## Test plan
- [x] `./run-tests.sh` — 4199 passed, 1 skipped
- [x] `npm run build:prod` — clean build, no warnings
- [ ] Open the Add Dataset modal and confirm each MediaType option shows its icon, the trigger shows the selected icon, and clicking outside / pressing Escape closes the popup
- [ ] Confirm "Dataset Name" appears as the last field above the Advanced toggle in the form view, the local-folder view, and the server-folder view


---
_Generated by [Claude Code](https://claude.ai/code/session_01RknNRvFCxqiQFyQMgnvd8F)_