### PR TITLE
Move converter invocation into the framework + add bulk-fetch hook

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -266,8 +266,9 @@ IMPORTER = S3Importer()
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
-| `run()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | Populate `medias` in-place with loaded data |
-| `list_records()` + `fetch_record()` | see [Bulk-record hooks](#bulk-record-hooks) | Per-record / bulk-record split that mirrors `MediaEmbedder`. The default `run()` lists records, hands them all to `fetch_records_bulk()`, and assigns IDs |
+| `run()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | Populate `medias` in-place with loaded data. Override for full control (e.g. folder-shaped importers that delegate to `run_converters_on_folder()`) |
+| `fetch_source_media()` | `(spec: SourceSpec, field_values: dict, thin: bool = False) -> Iterator[dict]` | **Recommended for multi-source-type service importers.** Yield raw media dicts of `spec.source_type`. The framework loops `effective_source_specs()` and runs each spec's converter on the yielded media — subclasses never invoke converters themselves. See [Multi-media imports](#multi-media-imports) |
+| `list_records()` + `fetch_record()` | see [Bulk-record hooks](#bulk-record-hooks) | Per-record / bulk-record split for **single-source-type** service importers. The default `fetch_source_media()` delegates to these |
 
 **Optional overrides:**
 
@@ -529,8 +530,7 @@ every import is declared there. They are picked up the next time you run
 
 Importers that want to pull in **multiple source media types** (e.g.
 "images, plus videos converted to images, plus documents converted to
-images") set the class attribute `multi_media = True` and iterate
-`self.effective_source_specs(field_values)` inside `run()`.
+images") set the class attribute `multi_media = True`.
 
 A `SourceSpec` (defined in `vtscore.datasets.importers.base`) is:
 
@@ -545,34 +545,55 @@ SourceSpec(
 `effective_source_specs()` reads the user's `source_specs` form value
 (either a Python list or a JSON-encoded string), validates it against
 the converter registry, and returns the typed list.  Each spec where
-`converter is None` is a "include directly" row — the importer fetches
+`converter is None` is a "include directly" row — the framework ingests
 files of `source_type` straight into the dataset.  Each spec where
-`converter` is set asks the importer to fetch files of `source_type` and
-pass them through that converter (with `spec.params`) to produce media
-of the dataset's output type.
+`converter` is set asks the framework to take files of `source_type`
+from the importer and pass them through that converter (with
+`spec.params`) to produce media of the dataset's output type.
+
+**The framework drives the conversion, not your importer.**  Your job
+is just to **yield raw source-type media** for whatever `SourceSpec`
+the framework hands you — override `fetch_source_media(spec,
+field_values, thin)`.  The default `run()` on `DatasetImporter` loops
+`effective_source_specs()`, calls `fetch_source_media()` once per spec,
+and runs the spec's converter on every yielded media itself.
+Subclasses **never** call `get_converter()` or `converter.convert()`
+directly.
 
 ```python
 class DXImporter(DatasetImporter):
     name = "dx"
     multi_media = True
     fields = [
-        ImporterField(key="media_type", label="Dataset MediaType", field_type="select", ...),
+        ImporterField(key="media_type", label="Output Media Type", field_type="select", ...),
         ImporterField(key="dataset_id", ..., required=True),
     ]
 
-    def run(self, field_values, medias, thin=False):
-        from vtscore.converters import get_converter
+    def fetch_source_media(self, spec, field_values, thin=False):
+        """Yield raw media dicts of spec.source_type — one per upstream record.
 
-        for spec in self.effective_source_specs(field_values):
-            for record in self._dx_list(spec.source_type, field_values):
-                raw = self._dx_fetch(record, spec.source_type, field_values)
-                if spec.converter is None:
-                    self._add(medias, raw)
-                else:
-                    converter = get_converter(spec.converter)
-                    for out in converter.convert(raw, spec.params):
-                        self._add(medias, out)
+        The framework owns the SourceSpec loop and converter invocation.
+        This method is called once per spec; when spec.converter is set
+        the framework runs converter.convert(raw, spec.params) on every
+        yielded dict before storing it.
+        """
+        for record in self._dx_list(spec.source_type, field_values):
+            yield self._dx_fetch(record, spec.source_type, field_values)
 ```
+
+That's the entire integration.  If `DX` ever supports listing across
+multiple types in one call, the importer can override `run()` directly
+(or build records once in a cache and have `fetch_source_media()` slice
+into it by `spec.source_type`).
+
+**`fetch_source_media` vs the per-record hooks.**  For service-style
+importers that pull a **single source type** per import,
+`list_records()` + `fetch_record()` (and optionally
+`_fetch_records_bulk_impl()` for batched fetches) remain the simplest
+hooks — see [Bulk-record hooks](#bulk-record-hooks).  The default
+`fetch_source_media()` delegates to them, so single-spec importers keep
+working without touching the new hook.  Override
+`fetch_source_media()` once you need to dispatch by `spec.source_type`.
 
 **Legacy / shim path.** Importers that have **not** flipped
 `multi_media` still work as before: they declare a single `media_type`
@@ -581,7 +602,7 @@ post-processes the imported folder through
 `run_converters_on_folder()`.  Legacy importers can also call
 `effective_source_specs()` — it synthesises an equivalent list from the
 classic `media_type` + `converters` fields, so a legacy importer can
-migrate its `run()` to iterate specs before changing its form schema.
+migrate to the new iteration style before changing its form schema.
 
 See [`docs/plans/multi-media-import.md`](plans/multi-media-import.md) for
 the full design and migration checklist.

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -260,15 +260,74 @@ class S3Importer(DatasetImporter):
 IMPORTER = S3Importer()
 ```
 
+### Choosing your override point
+
+`DatasetImporter` offers four override points, from simplest to
+fullest-control.  **Hooks 1–3 leave conversion and ingestion to the
+framework** — you never call `get_converter()`, never invoke
+`converter.convert()`, never assign media IDs, never set default
+origins.  Only hook 4 takes that responsibility back.
+
+```
+Does your backend serve media one record at a time, with one media
+type per query?
+│
+├─ Yes, and the importer only ever pulls one media type per import.
+│  └─→ Hook 1: list_records() + fetch_record()
+│       Simplest split — return opaque record handles, then convert
+│       each to a media dict. Default fetch_source_media() delegates
+│       here, so the spec list is invisible to you. Best for
+│       single-source-type service importers (e.g. "pull all rows
+│       from this table").
+│
+├─ Yes, and the importer can pull different media types per spec
+│  (e.g. one query for images, another for videos).
+│  └─→ Hook 2: fetch_source_media(spec, ...)
+│       Framework loops effective_source_specs() and calls you once
+│       per spec. You yield raw media dicts of spec.source_type;
+│       framework runs spec.converter on each. Best for service-style
+│       multi-media importers (e.g. ReCaller).
+│
+├─ No — one upstream call returns mixed source types in a single
+│  response, and you want to make it only once.
+│  └─→ Hook 3: fetch_all_source_media(specs, ...)
+│       Framework calls you once with the full spec list. You make
+│       the one upstream call and yield (spec, raw_media) pairs,
+│       tagging each record with the spec it satisfies. Framework
+│       still runs converters and ingests.
+│
+└─ Neither — the data is folder-shaped (already on disk, or staged
+   there after download) and you want to delegate to the folder
+   loader / converter runner.
+   └─→ Hook 4: run()
+        Full control. You own the medias dict, ID assignment,
+        origin, and conversion. Typical body: stage files to a temp
+        dir, call load_dataset_from_folder() for direct specs, call
+        run_converters_on_folder() for converter specs. The four
+        in-tree folder importers (server_folder, server_files,
+        local_folder, local_files) all use this hook.
+```
+
+**Single-spec rule of thumb:** if your importer always pulls exactly
+one media type per import (no per-source-type fan-out), use hook 1 and
+ignore `SourceSpec` entirely.  The default `fetch_source_media()`
+threads through to it without you knowing the spec exists.
+
+**Multi-spec rule of thumb:** if the user can pick multiple source
+types in one import, use hook 2 unless making N upstream calls is
+actively wasteful — in which case use hook 3.  Both leave conversion
+to the framework.
+
 ### DatasetImporter class reference
 
-**Required to implement (pick one approach):**
+**Required to implement (pick one — see [Choosing your override point](#choosing-your-override-point)):**
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
-| `run()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | Populate `medias` in-place with loaded data. Override for full control (e.g. folder-shaped importers that delegate to `run_converters_on_folder()`) |
-| `fetch_source_media()` | `(spec: SourceSpec, field_values: dict, thin: bool = False) -> Iterator[dict]` | **Recommended for multi-source-type service importers.** Yield raw media dicts of `spec.source_type`. The framework loops `effective_source_specs()` and runs each spec's converter on the yielded media — subclasses never invoke converters themselves. See [Multi-media imports](#multi-media-imports) |
-| `list_records()` + `fetch_record()` | see [Bulk-record hooks](#bulk-record-hooks) | Per-record / bulk-record split for **single-source-type** service importers. The default `fetch_source_media()` delegates to these |
+| `list_records()` + `fetch_record()` | see [Bulk-record hooks](#bulk-record-hooks) | **Hook 1.** Per-record / bulk-record split for **single-source-type** service importers. Default `fetch_source_media()` delegates to these |
+| `fetch_source_media()` | `(spec: SourceSpec, field_values: dict, thin: bool = False) -> Iterator[dict]` | **Hook 2.** Per-spec fetch for **multi-source-type** service importers. Yield raw media dicts of `spec.source_type`; framework runs `spec.converter` on each. See [Multi-media imports](#multi-media-imports) |
+| `fetch_all_source_media()` | `(specs: list[SourceSpec], field_values: dict, thin: bool = False) -> Iterator[tuple[SourceSpec, dict]]` | **Hook 3.** Bulk fetch for service-style importers whose backend returns mixed source types in one call. Yield `(spec, raw_media)` pairs; framework runs converters and ingests. Default delegates to `fetch_source_media()` per spec. See [Multi-media imports](#multi-media-imports) |
+| `run()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | **Hook 4.** Full control — populate `medias` in-place yourself. Used by folder-shaped importers that delegate to `load_dataset_from_folder()` and `run_converters_on_folder()` |
 
 **Optional overrides:**
 
@@ -552,13 +611,17 @@ from the importer and pass them through that converter (with
 `spec.params`) to produce media of the dataset's output type.
 
 **The framework drives the conversion, not your importer.**  Your job
-is just to **yield raw source-type media** for whatever `SourceSpec`
-the framework hands you — override `fetch_source_media(spec,
-field_values, thin)`.  The default `run()` on `DatasetImporter` loops
-`effective_source_specs()`, calls `fetch_source_media()` once per spec,
-and runs the spec's converter on every yielded media itself.
-Subclasses **never** call `get_converter()` or `converter.convert()`
-directly.
+is just to **yield raw source-type media**; the framework runs each
+spec's converter and ingests the result.  Subclasses **never** call
+`get_converter()` or `converter.convert()` directly.
+
+You pick one of two fetch hooks depending on how your backend is
+shaped.
+
+#### Hook 2 — per-spec fetch (`fetch_source_media`)
+
+When the backend serves one media type per query.  The framework
+loops `effective_source_specs()` and calls you once per spec.
 
 ```python
 class DXImporter(DatasetImporter):
@@ -572,28 +635,50 @@ class DXImporter(DatasetImporter):
     def fetch_source_media(self, spec, field_values, thin=False):
         """Yield raw media dicts of spec.source_type — one per upstream record.
 
-        The framework owns the SourceSpec loop and converter invocation.
-        This method is called once per spec; when spec.converter is set
-        the framework runs converter.convert(raw, spec.params) on every
-        yielded dict before storing it.
+        Called once per spec. When spec.converter is set the framework
+        runs converter.convert(raw, spec.params) on every yielded dict
+        before storing it.
         """
         for record in self._dx_list(spec.source_type, field_values):
             yield self._dx_fetch(record, spec.source_type, field_values)
 ```
 
-That's the entire integration.  If `DX` ever supports listing across
-multiple types in one call, the importer can override `run()` directly
-(or build records once in a cache and have `fetch_source_media()` slice
-into it by `spec.source_type`).
+That's the entire integration — no `run()`, no converter calls, no
+spec loop.
 
-**`fetch_source_media` vs the per-record hooks.**  For service-style
-importers that pull a **single source type** per import,
-`list_records()` + `fetch_record()` (and optionally
-`_fetch_records_bulk_impl()` for batched fetches) remain the simplest
-hooks — see [Bulk-record hooks](#bulk-record-hooks).  The default
-`fetch_source_media()` delegates to them, so single-spec importers keep
-working without touching the new hook.  Override
-`fetch_source_media()` once you need to dispatch by `spec.source_type`.
+#### Hook 3 — bulk fetch (`fetch_all_source_media`)
+
+When one upstream call returns mixed source types in a single
+response and you want to make it only once.  The framework calls you
+once with the full spec list; you yield `(spec, raw_media)` pairs.
+
+```python
+class DXImporter(DatasetImporter):
+    name = "dx"
+    multi_media = True
+    fields = [...]
+
+    def fetch_all_source_media(self, specs, field_values, thin=False):
+        """One upstream call covers every spec; tag each record with
+        the spec it satisfies. Framework still owns converter dispatch
+        and ingestion.
+        """
+        wanted_types = {spec.source_type for spec in specs}
+        records = self._dx_fetch_everything(field_values, types=wanted_types)
+
+        # Bucket by type, then walk specs to preserve user-submitted order.
+        by_type: dict[str, list[dict]] = {}
+        for rec in records:
+            by_type.setdefault(rec["media_type"], []).append(rec)
+
+        for spec in specs:
+            for rec in by_type.get(spec.source_type, []):
+                yield spec, self._dx_to_media_dict(rec, spec.source_type)
+```
+
+The default `fetch_all_source_media()` just loops
+`fetch_source_media()` per spec, so importers using hook 2 see no
+behavioural change.
 
 **Legacy / shim path.** Importers that have **not** flipped
 `multi_media` still work as before: they declare a single `media_type`

--- a/docs/plans/multi-media-import.md
+++ b/docs/plans/multi-media-import.md
@@ -292,6 +292,30 @@ the docs example showed a `DXImporter` calling
   videos converted to images + documents converted to images, with the
   framework running each converter.
 
+## What shipped (bulk-fetch escape hatch)
+
+Service-style importers had only one framework-driven fetch shape:
+`fetch_source_media(spec)` called once per spec.  That works when the
+backend serves one media type per query, but it forces N upstream calls
+when a single query naturally returns mixed types.  Adding a second
+fetch hook for that case:
+
+- New optional hook on `DatasetImporter`:
+  `fetch_all_source_media(specs, field_values, thin=False) -> Iterator[tuple[SourceSpec, dict]]`.
+  Override this when one upstream call covers every spec — yield
+  `(spec, raw_media)` pairs and the framework handles converter
+  dispatch and ingestion exactly as it does for the per-spec hook.
+- The base-class `run()` now calls `fetch_all_source_media()` once
+  instead of looping `fetch_source_media()` itself.  The default
+  `fetch_all_source_media()` delegates to `fetch_source_media()` per
+  spec, so existing per-spec importers see no behavioural change.
+- Converter lookups in `run()` are cached per-spec so a bulk importer
+  that interleaves specs across yields doesn't re-resolve the same
+  converter on every pair.
+- Subclasses still never call `get_converter()` themselves — the
+  framework owns conversion and ingestion regardless of which fetch
+  hook is overridden.
+
 ## What shipped (latest round)
 
 Flipped `multi_media = True` on the last six in-tree importers so the

--- a/docs/plans/multi-media-import.md
+++ b/docs/plans/multi-media-import.md
@@ -1,6 +1,8 @@
 # Multi-media importing
 
-Status: every in-tree importer now sets `multi_media=True`.  Shim
+Status: every in-tree importer now sets `multi_media=True`, and the
+framework now owns conversion — importers yield raw source-type media
+and the base-class `run()` runs each spec's converter itself.  Shim
 removal is the next step but is **blocked on external extensions** (see
 "Open follow-ups" at the bottom).
 
@@ -259,6 +261,36 @@ When migrating an importer to `multi_media=True`:
   in `dataset-importer-modal.component.ts`.
 - Tests covering the new code path, the shim, and the `multi_media`
   flag on all migrated importers.
+
+## What shipped (framework-driven conversion)
+
+Earlier rounds left importers to drive the converter loop themselves —
+the docs example showed a `DXImporter` calling
+`get_converter(spec.converter).convert(raw, spec.params)` inside its
+`run()`.  That leak is now closed:
+
+- New hook on `DatasetImporter`:
+  `fetch_source_media(spec, field_values, thin=False) -> Iterator[dict]`.
+  Subclasses yield raw media of `spec.source_type` and never touch the
+  converter registry.
+- The base-class `run()` now loops `effective_source_specs()`, calls
+  `fetch_source_media()` once per spec, and runs
+  `converter.convert(raw, spec.params)` itself when the spec declares a
+  converter.  IDs and default origins are assigned by the framework
+  exactly as before.
+- The default `fetch_source_media()` delegates to
+  `list_records()` + `fetch_records_bulk()`, so single-source-type
+  service importers (which only ever pull one type per import) keep
+  working without the new hook.
+- The DX docs example was rewritten to use the new hook and no longer
+  shows manual `get_converter()` calls.
+- `recaller` migrated to be truly multi-source-type-aware: its old
+  `list_records` / `fetch_record` / `_fetch_records_bulk_impl` trio was
+  replaced by a single `fetch_source_media()` that filters
+  `_rc_fetch_results` by `spec.source_type`.  A user can now build a
+  single ReCaller-backed dataset that pulls in (say) images directly +
+  videos converted to images + documents converted to images, with the
+  framework running each converter.
 
 ## What shipped (latest round)
 

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -135,9 +135,17 @@ class LabelSet:
 ```python
 class DatasetImporter(PluginBase):
     """Abstract base for a dataset importer. Subclasses declare `fields` (a list of
-    PluginField) and implement `run(field_values, progress_callback) -> iterable of
-    (Media, embedding)`. Multi-media importers set `multi_media = True` and iterate
-    `self.effective_source_specs(field_values)` to fan out across source types."""
+    PluginField) and override one of four hooks to populate medias:
+
+    - `list_records()` + `fetch_record()` — single-source-type service importer.
+    - `fetch_source_media(spec, ...)` — multi-source-type service importer with
+      one query per spec.
+    - `fetch_all_source_media(specs, ...)` — multi-source-type service importer
+      with one upstream call covering every spec; yields (spec, raw_media) pairs.
+    - `run()` — folder-shaped or full-control importer.
+
+    Multi-media importers set `multi_media = True`. The framework owns conversion
+    and ingestion for hooks 1–3 — subclasses never call `get_converter()`."""
 
 ImporterField = PluginField
 """Alias kept for clarity at import sites; identical to vtscore.plugins.PluginField."""

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -792,29 +792,35 @@ class TestImporterBulkHooks:
             imp.run({}, {})
 
 
-class TestReCallerBulkOverride:
-    """ReCaller is the worked example — verify its hooks return the same
-    media dicts whether the per-item or bulk path is used."""
+class TestReCallerMultiMedia:
+    """ReCaller is the worked example of a multi-source-type service importer.
 
-    def _stub_apis(self, monkeypatch):
+    Verifies ``fetch_source_media(spec, ...)`` filters records by
+    ``spec.source_type`` and that the framework's default :meth:`run`
+    drives converter calls so the importer doesn't need to.
+    """
+
+    def _stub_apis(self, monkeypatch, *, media_types=None):
         import numpy as np
 
         from vtscore.datasets.importers import recaller as rc
 
+        if media_types is None:
+            media_types = ["audio"] * 3
         results = [
             {
                 "contentID": f"C{i}",
                 "mediaID": f"M{i}",
                 "media_url": f"http://pw/{i}",
-                "media_type": "audio",
+                "media_type": mt,
                 "md5": f"md5_{i}",
             }
-            for i in range(3)
+            for i, mt in enumerate(media_types)
         ]
         monkeypatch.setattr(rc, "_rc_fetch_results", lambda _q: list(results))
 
         rng = np.random.default_rng(42)
-        embeddings = {f"M{i}": rng.standard_normal(8).astype(np.float32) for i in range(3)}
+        embeddings = {f"M{i}": rng.standard_normal(8).astype(np.float32) for i in range(len(results))}
         monkeypatch.setattr(
             rc,
             "_dw_get_embedding",
@@ -823,25 +829,49 @@ class TestReCallerBulkOverride:
         monkeypatch.setattr(rc, "_pw_fetch_media", lambda url: f"bytes-for-{url}".encode())
         return results
 
-    def test_per_item_and_bulk_paths_agree(self, monkeypatch):
+    def test_fetch_source_media_filters_by_source_type(self, monkeypatch):
+        from vtscore.datasets.importers.base import SourceSpec
         from vtscore.datasets.importers.recaller import ReCallerDatasetImporter
 
-        records = self._stub_apis(monkeypatch)
-        field_values = {"query_id": "Q1", "media_type": "audio"}
-
+        self._stub_apis(monkeypatch, media_types=["audio", "image", "audio"])
         imp = ReCallerDatasetImporter()
-        per_item = [imp.fetch_record(r, field_values, thin=True) for r in records]
-        bulk = imp._fetch_records_bulk_impl(records, field_values, thin=True)
 
-        assert len(per_item) == len(bulk) == 3
-        for a, b in zip(per_item, bulk):
-            assert a is not None and b is not None
-            assert a["filename"] == b["filename"]
-            assert a["origin"] == b["origin"]
-            assert a["custom_metadata"] == b["custom_metadata"]
-            assert (a["embedding"] == b["embedding"]).all()
+        audio_yields = list(
+            imp.fetch_source_media(
+                SourceSpec(source_type="audio", converter=None, params={}),
+                {"query_id": "Q1", "media_type": "audio"},
+                thin=True,
+            )
+        )
+        assert [m["filename"] for m in audio_yields] == ["C0", "C2"]
+        assert all(m["type"] == "audio" for m in audio_yields)
 
-    def test_run_uses_bulk_override(self, monkeypatch):
+        image_yields = list(
+            imp.fetch_source_media(
+                SourceSpec(source_type="image", converter=None, params={}),
+                {"query_id": "Q1", "media_type": "audio"},
+                thin=True,
+            )
+        )
+        assert [m["filename"] for m in image_yields] == ["C1"]
+        assert image_yields[0]["type"] == "image"
+
+    def test_fetch_source_media_requires_query_id(self, monkeypatch):
+        from vtscore.datasets.importers.base import SourceSpec
+        from vtscore.datasets.importers.recaller import ReCallerDatasetImporter
+
+        self._stub_apis(monkeypatch)
+        imp = ReCallerDatasetImporter()
+        with pytest.raises(ValueError, match="query ID"):
+            list(
+                imp.fetch_source_media(
+                    SourceSpec(source_type="audio", converter=None, params={}),
+                    {"query_id": "", "media_type": "audio"},
+                    thin=True,
+                )
+            )
+
+    def test_default_run_ingests_direct_spec(self, monkeypatch):
         from vtscore.datasets.importers.recaller import ReCallerDatasetImporter
 
         self._stub_apis(monkeypatch)
@@ -853,6 +883,65 @@ class TestReCallerBulkOverride:
         for i in (1, 2, 3):
             assert medias[i]["origin"]["params"]["contentID"] == f"C{i - 1}"
             assert medias[i]["origin"]["params"]["mediaID"] == f"M{i - 1}"
+
+    def test_default_run_drives_converter_per_spec(self, monkeypatch):
+        """Framework calls converter.convert(); importer never does."""
+        import json
+
+        from vtscore.datasets.importers.recaller import ReCallerDatasetImporter
+
+        # Mix of audio (direct) and video (must go through video2image).
+        self._stub_apis(monkeypatch, media_types=["image", "video", "image"])
+
+        # Stub video2image to return a deterministic 2-frame expansion.
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+        observed_params: list[dict] = []
+
+        def fake_convert(media, params):
+            observed_params.append(dict(params))
+            return [
+                {
+                    "type": "image",
+                    "filename": f"{media['filename']}_frame_{k}.png",
+                    "media_bytes": None,
+                    "media_path": None,
+                    "media_url": media.get("media_url"),
+                    "embedding": media["embedding"],
+                    "embedder": media["embedder"],
+                    "md5": f"{media['md5']}_{k}",
+                    "duration": 0,
+                    "category": "",
+                    "file_size": 0,
+                }
+                for k in range(2)
+            ]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = ReCallerDatasetImporter()
+        medias: dict = {}
+        source_specs = json.dumps(
+            [
+                {"source_type": "image", "converter": None, "params": {}},
+                {"source_type": "video", "converter": "video2image", "params": {"n_clips": "2"}},
+            ]
+        )
+        imp.run(
+            {"query_id": "Q1", "media_type": "image", "source_specs": source_specs},
+            medias,
+            thin=True,
+        )
+
+        # Two image records (direct) + one video record × 2 frames = 4 medias.
+        assert len(medias) == 4
+        types = sorted(m["type"] for m in medias.values())
+        assert types == ["image", "image", "image", "image"]
+        # The framework, not the importer, called video2image.convert with
+        # the spec's params.
+        assert observed_params == [{"n_clips": "2"}]
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -451,8 +451,6 @@ class DatasetImporter(PluginBase):
             Exception: Any exception propagates to the route handler, which
                 stores it in the progress tracker as an error message.
         """
-        from vtscore.converters import get_converter  # noqa: PLC0415
-
         default_origin = self.build_origin(field_values)
         next_id = 1
 
@@ -462,26 +460,12 @@ class DatasetImporter(PluginBase):
             specs = []
 
         if specs:
-            converter_cache: dict[str, Any] = {}
-            for spec, raw in self.fetch_all_source_media(specs, field_values, thin=thin):
-                if raw is None:
-                    continue
-                if spec.converter is None:
-                    outs = [raw]
-                else:
-                    converter = converter_cache.get(spec.converter)
-                    if converter is None:
-                        converter = get_converter(spec.converter)
-                        converter_cache[spec.converter] = converter
-                    outs = converter.convert(raw, spec.params)
-                for media in outs:
-                    if media is None:
-                        continue
-                    media["id"] = next_id
-                    media.setdefault("origin", default_origin)
-                    media.setdefault("origin_name", media.get("filename") or str(next_id))
-                    medias[next_id] = media
-                    next_id += 1
+            next_id = self._ingest_spec_stream(
+                self.fetch_all_source_media(specs, field_values, thin=thin),
+                medias,
+                default_origin,
+                next_id,
+            )
             return
 
         # Fallback: no spec set could be resolved.  Use the per-record hooks
@@ -498,6 +482,46 @@ class DatasetImporter(PluginBase):
             media.setdefault("origin_name", media.get("filename") or str(next_id))
             medias[next_id] = media
             next_id += 1
+
+    def _ingest_spec_stream(
+        self,
+        stream: Iterator[tuple[SourceSpec, dict[str, Any]]],
+        medias: dict,
+        default_origin: dict[str, Any],
+        next_id: int,
+    ) -> int:
+        """Convert+ingest each ``(spec, raw)`` pair from *stream* into *medias*.
+
+        Resolves each spec's converter once and caches it across pairs so
+        a bulk importer that interleaves specs doesn't re-resolve on
+        every yield.  Returns the next available media id.
+        """
+        from vtscore.converters import get_converter  # noqa: PLC0415
+
+        converter_cache: dict[str, Any] = {}
+        for spec, raw in stream:
+            if raw is None:
+                continue
+            if spec.converter is None:
+                outs = [raw]
+            else:
+                converter = converter_cache.get(spec.converter)
+                if converter is None:
+                    resolved = get_converter(spec.converter)
+                    if resolved is None:
+                        raise ValueError(f"Unknown converter: {spec.converter!r}")
+                    converter = resolved
+                    converter_cache[spec.converter] = converter
+                outs = converter.convert(raw, spec.params)
+            for media in outs:
+                if media is None:
+                    continue
+                media["id"] = next_id
+                media.setdefault("origin", default_origin)
+                media.setdefault("origin_name", media.get("filename") or str(next_id))
+                medias[next_id] = media
+                next_id += 1
+        return next_id
 
     # ------------------------------------------------------------------
     # Multi-media source hooks

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -386,17 +386,41 @@ class DatasetImporter(PluginBase):
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Perform the import, populating *medias* in-place.
 
-        Subclasses can override either this method directly (full control over
-        the import flow) **or** the per-record / bulk-record hooks:
-        :meth:`list_records`, :meth:`fetch_record`, and optionally
-        :meth:`_fetch_records_bulk_impl` for batched fetches.  When the hooks
-        are implemented, the default :meth:`run` here lists the records, hands
-        them all to :meth:`fetch_records_bulk` in one call (so subclasses that
-        override the bulk impl can issue concurrent / batched I/O), and stores
-        each returned media dict in *medias* with sequential integer IDs
-        starting at 1.  The default per-media origin is filled in from
-        :meth:`build_origin` when the importer's :meth:`fetch_record` did not
-        set its own.
+        Subclasses pick one of three override points, in order of increasing
+        control:
+
+        1. :meth:`fetch_source_media` — yield raw source-type media one record
+           at a time.  The framework loops over each
+           :class:`SourceSpec` produced by :meth:`effective_source_specs`,
+           runs the spec's converter (when one is set) on every yielded
+           media, and ingests the results.  This is the recommended hook for
+           service-style importers: subclasses never call
+           :func:`~vtscore.converters.get_converter` themselves.
+        2. :meth:`list_records` + :meth:`fetch_record` (and optionally
+           :meth:`_fetch_records_bulk_impl` for batched fetches) — a
+           single-spec convenience for service importers that only pull one
+           source type.  The default :meth:`fetch_source_media` delegates to
+           these hooks, so single-spec importers can keep using the
+           per-record split without thinking about specs.
+        3. :meth:`run` directly — full control.  Folder-shaped importers
+           override this and delegate to
+           :func:`~vtscore.converters.runner.run_converters_on_folder`.
+
+        Default flow:
+
+        - When :meth:`effective_source_specs` resolves to one or more specs,
+          iterate them: for each spec, call :meth:`fetch_source_media` and
+          (when ``spec.converter`` is set) pass each yielded media through
+          ``converter.convert(raw, spec.params)`` before assigning IDs.
+        - When :meth:`effective_source_specs` cannot resolve (no
+          ``media_type`` declared and no legacy ``converters`` field — i.e.
+          a bare service importer), fall back to the
+          :meth:`list_records` + :meth:`fetch_records_bulk` path with no
+          conversion.
+
+        IDs are assigned as sequential integers starting at 1.  The default
+        per-media origin is filled in from :meth:`build_origin` when the
+        media dict did not already set one.
 
         Args:
             field_values: Mapping of :attr:`ImporterField.key` → value.
@@ -410,16 +434,45 @@ class DatasetImporter(PluginBase):
                 saves memory for CLI workflows that only need embeddings.
 
         Raises:
-            NotImplementedError: If neither :meth:`run` nor the
-                :meth:`list_records` + :meth:`fetch_record` hooks are
+            NotImplementedError: If neither :meth:`run`, :meth:`fetch_source_media`,
+                nor the :meth:`list_records` + :meth:`fetch_record` hooks are
                 implemented by the subclass.
             Exception: Any exception propagates to the route handler, which
                 stores it in the progress tracker as an error message.
         """
-        records = self.list_records(field_values)
-        fetched = self.fetch_records_bulk(records, field_values, thin=thin)
+        from vtscore.converters import get_converter  # noqa: PLC0415
+
         default_origin = self.build_origin(field_values)
         next_id = 1
+
+        try:
+            specs = self.effective_source_specs(field_values)
+        except ValueError:
+            specs = []
+
+        if specs:
+            for spec in specs:
+                converter = get_converter(spec.converter) if spec.converter else None
+                for raw in self.fetch_source_media(spec, field_values, thin=thin):
+                    if raw is None:
+                        continue
+                    outs = converter.convert(raw, spec.params) if converter is not None else [raw]
+                    for media in outs:
+                        if media is None:
+                            continue
+                        media["id"] = next_id
+                        media.setdefault("origin", default_origin)
+                        media.setdefault("origin_name", media.get("filename") or str(next_id))
+                        medias[next_id] = media
+                        next_id += 1
+            return
+
+        # Fallback: no spec set could be resolved.  Use the per-record hooks
+        # directly with no conversion.  This path keeps the
+        # list_records/fetch_record API working for importers that don't
+        # declare a media_type / source_specs schema (e.g. tests).
+        records = self.list_records(field_values)
+        fetched = self.fetch_records_bulk(records, field_values, thin=thin)
         for media in fetched:
             if media is None:
                 continue
@@ -430,14 +483,72 @@ class DatasetImporter(PluginBase):
             next_id += 1
 
     # ------------------------------------------------------------------
+    # Multi-media source hook
+    # ------------------------------------------------------------------
+    #
+    # The recommended override point for service-style importers that want
+    # to support multiple source types in one import.  The framework drives
+    # both the spec iteration *and* the converter loop, so subclasses never
+    # call :func:`vtscore.converters.get_converter` themselves — they just
+    # yield raw media of ``spec.source_type`` and let
+    # :meth:`run` apply the converter.
+
+    def fetch_source_media(
+        self,
+        spec: SourceSpec,
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield raw media dicts of ``spec.source_type``.
+
+        For multi-source-type importers (service-style importers that mix
+        e.g. images + videos in one import), override this method.  The
+        framework calls it once per :class:`SourceSpec` returned by
+        :meth:`effective_source_specs`; if the spec declares a converter,
+        the framework runs ``converter.convert(raw, spec.params)`` on every
+        yielded media before storing it.  Subclasses never invoke
+        converters themselves.
+
+        Each yielded dict should already match the shape expected of media
+        of ``spec.source_type`` (so a video spec yields ``type="video"``
+        dicts with ``media_bytes`` / ``media_path``; the framework hands
+        them to the converter which produces e.g. ``type="image"`` dicts).
+        Yield nothing if the spec resolves to zero records.
+
+        Default implementation: delegates to
+        :meth:`list_records` + :meth:`fetch_records_bulk`, ignoring *spec*.
+        This keeps the legacy single-spec hooks (``list_records`` +
+        ``fetch_record``) working for importers that only pull one source
+        type per import.
+
+        Args:
+            spec: The :class:`SourceSpec` row being fetched.  ``source_type``
+                is the canonical type id (e.g. ``"image"``, ``"video"``).
+            field_values: The same mapping passed to :meth:`run`.
+            thin: When ``True``, skip downloading raw bytes — yield media
+                dicts with ``media_url`` / ``media_path`` instead of
+                ``media_bytes``.
+
+        Yields:
+            Raw source-type media dicts.  ``id`` and ``origin`` may be
+            omitted — :meth:`run` assigns IDs and falls back to
+            :meth:`build_origin` for unset origins.
+        """
+        del spec  # default impl is single-spec
+        records = self.list_records(field_values)
+        fetched = self.fetch_records_bulk(records, field_values, thin=thin)
+        for media in fetched:
+            if media is not None:
+                yield media
+
+    # ------------------------------------------------------------------
     # Per-record / bulk-record hooks
     # ------------------------------------------------------------------
     #
-    # Subclasses implementing a service-style importer (one that fetches
-    # records from a remote source) can override these instead of writing
-    # ``run()`` from scratch.  The split mirrors :class:`MediaEmbedder`:
-    # implement the per-item method and you get a working importer; override
-    # the bulk hook to batch the I/O when the source supports it.
+    # Convenience hooks for service-style importers that pull a single
+    # source type per import.  The default :meth:`fetch_source_media`
+    # delegates here.  Multi-source-type importers should override
+    # :meth:`fetch_source_media` directly instead.
 
     def list_records(self, field_values: dict[str, Any]) -> list[Any]:
         """Return the opaque list of records to import.

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -386,32 +386,42 @@ class DatasetImporter(PluginBase):
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Perform the import, populating *medias* in-place.
 
-        Subclasses pick one of three override points, in order of increasing
-        control:
+        Subclasses pick one of four override points, in order of increasing
+        control.  Hooks 1–3 leave conversion and ingestion to the framework;
+        only hook 4 takes that responsibility back.
 
         1. :meth:`fetch_source_media` — yield raw source-type media one record
-           at a time.  The framework loops over each
-           :class:`SourceSpec` produced by :meth:`effective_source_specs`,
-           runs the spec's converter (when one is set) on every yielded
-           media, and ingests the results.  This is the recommended hook for
-           service-style importers: subclasses never call
-           :func:`~vtscore.converters.get_converter` themselves.
-        2. :meth:`list_records` + :meth:`fetch_record` (and optionally
+           at a time, for one :class:`SourceSpec` at a time.  The framework
+           loops over each spec produced by :meth:`effective_source_specs`,
+           calls this method per spec, runs the spec's converter (when one is
+           set) on every yielded media, and ingests the results.  This is the
+           recommended hook for service-style importers whose backend
+           naturally serves one media type per query.
+        2. :meth:`fetch_all_source_media` — yield ``(spec, raw_media)`` pairs
+           for **all** specs in one pass.  Override this when one upstream
+           call returns mixed source types and you want to make it just once
+           (e.g. a service whose query returns "everything that matched" with
+           a per-record type tag).  The framework still runs converters and
+           ingests; subclasses never call
+           :func:`~vtscore.converters.get_converter` themselves.  The default
+           implementation delegates to :meth:`fetch_source_media` per spec,
+           so importers using hook 1 don't need to know this hook exists.
+        3. :meth:`list_records` + :meth:`fetch_record` (and optionally
            :meth:`_fetch_records_bulk_impl` for batched fetches) — a
            single-spec convenience for service importers that only pull one
            source type.  The default :meth:`fetch_source_media` delegates to
            these hooks, so single-spec importers can keep using the
            per-record split without thinking about specs.
-        3. :meth:`run` directly — full control.  Folder-shaped importers
+        4. :meth:`run` directly — full control.  Folder-shaped importers
            override this and delegate to
            :func:`~vtscore.converters.runner.run_converters_on_folder`.
 
         Default flow:
 
         - When :meth:`effective_source_specs` resolves to one or more specs,
-          iterate them: for each spec, call :meth:`fetch_source_media` and
-          (when ``spec.converter`` is set) pass each yielded media through
-          ``converter.convert(raw, spec.params)`` before assigning IDs.
+          call :meth:`fetch_all_source_media` once and pass each yielded
+          ``(spec, raw)`` pair through ``spec.converter`` (when set) before
+          assigning IDs and storing the result in *medias*.
         - When :meth:`effective_source_specs` cannot resolve (no
           ``media_type`` declared and no legacy ``converters`` field — i.e.
           a bare service importer), fall back to the
@@ -434,8 +444,9 @@ class DatasetImporter(PluginBase):
                 saves memory for CLI workflows that only need embeddings.
 
         Raises:
-            NotImplementedError: If neither :meth:`run`, :meth:`fetch_source_media`,
-                nor the :meth:`list_records` + :meth:`fetch_record` hooks are
+            NotImplementedError: If none of :meth:`run`,
+                :meth:`fetch_all_source_media`, :meth:`fetch_source_media`,
+                or the :meth:`list_records` + :meth:`fetch_record` hooks are
                 implemented by the subclass.
             Exception: Any exception propagates to the route handler, which
                 stores it in the progress tracker as an error message.
@@ -451,20 +462,26 @@ class DatasetImporter(PluginBase):
             specs = []
 
         if specs:
-            for spec in specs:
-                converter = get_converter(spec.converter) if spec.converter else None
-                for raw in self.fetch_source_media(spec, field_values, thin=thin):
-                    if raw is None:
+            converter_cache: dict[str, Any] = {}
+            for spec, raw in self.fetch_all_source_media(specs, field_values, thin=thin):
+                if raw is None:
+                    continue
+                if spec.converter is None:
+                    outs = [raw]
+                else:
+                    converter = converter_cache.get(spec.converter)
+                    if converter is None:
+                        converter = get_converter(spec.converter)
+                        converter_cache[spec.converter] = converter
+                    outs = converter.convert(raw, spec.params)
+                for media in outs:
+                    if media is None:
                         continue
-                    outs = converter.convert(raw, spec.params) if converter is not None else [raw]
-                    for media in outs:
-                        if media is None:
-                            continue
-                        media["id"] = next_id
-                        media.setdefault("origin", default_origin)
-                        media.setdefault("origin_name", media.get("filename") or str(next_id))
-                        medias[next_id] = media
-                        next_id += 1
+                    media["id"] = next_id
+                    media.setdefault("origin", default_origin)
+                    media.setdefault("origin_name", media.get("filename") or str(next_id))
+                    medias[next_id] = media
+                    next_id += 1
             return
 
         # Fallback: no spec set could be resolved.  Use the per-record hooks
@@ -483,15 +500,65 @@ class DatasetImporter(PluginBase):
             next_id += 1
 
     # ------------------------------------------------------------------
-    # Multi-media source hook
+    # Multi-media source hooks
     # ------------------------------------------------------------------
     #
-    # The recommended override point for service-style importers that want
-    # to support multiple source types in one import.  The framework drives
-    # both the spec iteration *and* the converter loop, so subclasses never
-    # call :func:`vtscore.converters.get_converter` themselves — they just
-    # yield raw media of ``spec.source_type`` and let
-    # :meth:`run` apply the converter.
+    # Two override points for service-style importers.  In both cases the
+    # framework drives the converter loop and ingestion, so subclasses
+    # never call :func:`vtscore.converters.get_converter` themselves —
+    # they just yield raw media of the appropriate ``spec.source_type``.
+    #
+    # Pick :meth:`fetch_source_media` when the backend serves one media
+    # type per query (the framework loops it across specs for you).
+    # Pick :meth:`fetch_all_source_media` when a single upstream call
+    # returns mixed source types and you want to make it only once.
+
+    def fetch_all_source_media(
+        self,
+        specs: list[SourceSpec],
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> Iterator[tuple[SourceSpec, dict[str, Any]]]:
+        """Yield ``(spec, raw_media)`` pairs for every spec the user picked.
+
+        This is the bulk-fetch escape hatch for importers whose backend
+        returns mixed source types in a single upstream call (e.g. one
+        query that yields both images and videos, with a per-record type
+        tag).  Override this to issue that one call, then yield each
+        record paired with the :class:`SourceSpec` it satisfies — the
+        framework handles converter dispatch and ingestion exactly as it
+        does for :meth:`fetch_source_media`.
+
+        For per-spec importers (the common case — one query per source
+        type), override :meth:`fetch_source_media` instead; the default
+        implementation of this method loops it for you.
+
+        Each yielded ``raw_media`` dict must match the shape expected of
+        media of ``spec.source_type`` (so a video spec yields
+        ``type="video"`` dicts with ``media_bytes`` / ``media_path``; the
+        framework hands them to the spec's converter, which produces
+        e.g. ``type="image"`` dicts).  ``id`` and ``origin`` may be
+        omitted — :meth:`run` assigns IDs and falls back to
+        :meth:`build_origin` for unset origins.
+
+        Args:
+            specs: The full list of :class:`SourceSpec` rows resolved
+                from *field_values*, in the user's submitted order.
+            field_values: The same mapping passed to :meth:`run`.
+            thin: When ``True``, skip downloading raw bytes — yield media
+                dicts with ``media_url`` / ``media_path`` instead of
+                ``media_bytes``.
+
+        Yields:
+            ``(spec, raw_media)`` tuples.  ``spec`` must be one of the
+            entries in *specs* (the framework uses its ``converter`` and
+            ``params`` to dispatch).
+        """
+        for spec in specs:
+            for raw in self.fetch_source_media(spec, field_values, thin=thin):
+                if raw is None:
+                    continue
+                yield spec, raw
 
     def fetch_source_media(
         self,

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -1,16 +1,35 @@
 """ReCaller dataset importer — import media from a ReCaller query.
 
-Given a ReCaller *queryID* and a *mediaType*, this importer:
+Given a ReCaller *queryID* and an output media type, this importer pulls
+the matching results from ReCaller, downloads their bytes via PullWrest
+(PW), and fetches their pre-computed embeddings via DataWrest (DW).  MD5
+hashes come straight from ReCaller — no local recalculation.
 
-1. Calls ReCaller to fetch all results for the query.
-2. Filters results to the requested media type.
-3. Uses PullWrest (PW) to download media files (skipped in thin mode).
-4. Uses DataWrest (DW) to obtain pre-computed embeddings and embedder name.
-5. Uses the MD5 hashes supplied by ReCaller (no local recalculation).
+Multi-media imports
+-------------------
+ReCaller is a :attr:`~DatasetImporter.multi_media` importer: a single
+import can pull in **multiple source types** in one go and let the
+framework convert each to the dataset's output type.  The user picks
+the output media type plus a list of :class:`SourceSpec` rows in the
+modal, e.g.::
 
-Each media item receives a **per-media origin** keyed by ``contentID``
-(not the ephemeral ``queryID``), so labels can round-trip through Holder
-and back::
+    output_type = "image"
+    source_specs = [
+        {"source_type": "image",    "converter": None,           "params": {}},
+        {"source_type": "video",    "converter": "video2image",  "params": {"n_clips": "30"}},
+        {"source_type": "document", "converter": "document2image", "params": {}},
+    ]
+
+The importer's job is to yield raw source-type media — one dict per
+ReCaller record matching ``spec.source_type`` — from
+:meth:`~ReCallerDatasetImporter.fetch_source_media`.  The framework
+loops the spec list and, when the spec has a converter, runs
+``converter.convert(raw, spec.params)`` on every yielded media before
+storing it.  This importer **never** invokes a converter itself.
+
+Each ingested media receives a **per-media origin** keyed by
+``contentID`` (not the ephemeral ``queryID``), so labels can round-trip
+through Holder and back::
 
     {
         "importer": "recaller",
@@ -36,22 +55,17 @@ downloading the actual media.
 
 Bulk fetch
 ----------
-This importer overrides
-:meth:`~vtscore.datasets.importers.base.DatasetImporter._fetch_records_bulk_impl`
-to issue DataWrest embedding lookups and PullWrest media-byte downloads
-concurrently via a thread pool.  The per-record :meth:`fetch_record` is
-kept as a serial fallback (and as the simplest possible reference
-implementation).  Importers built on top of this base get the same
-per-record / bulk-record split: implement :meth:`fetch_record` for a
-working baseline, override :meth:`_fetch_records_bulk_impl` when the
-backing service can be batched.
+:meth:`~ReCallerDatasetImporter.fetch_source_media` issues all DataWrest
+embedding lookups and PullWrest media-byte downloads for a spec
+concurrently via a thread pool, then yields the assembled media dicts in
+the original ReCaller order.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtscore.media import all_folder_names
 
 
@@ -61,24 +75,26 @@ from vtscore.media import all_folder_names
 # ---------------------------------------------------------------------------
 
 
-def _rc_list_queries(media_type: str) -> list[str]:
-    """Call ReCaller and return the list of query IDs for *media_type*.
+def _rc_list_queries(output_type: str) -> list[str]:
+    """Call ReCaller and return the list of query IDs scoped by *output_type*.
 
     Used to populate the ``query_id`` dropdown dynamically once the user
-    picks a media type.  Each entry is a ReCaller queryID string.
+    picks an output media type.  Each entry is a ReCaller queryID string.
+    A query may contain records of any media type; *output_type* is used
+    to narrow the listing to queries the user is likely to import for.
     """
     raise NotImplementedError("TODO: implement ReCaller list-queries API client")
 
 
 def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
-    """Call ReCaller and return the result list for *query_id*.
+    """Call ReCaller and return every result for *query_id*.
 
     Each result dict should have at least::
 
         {
             "contentID": str,
             "mediaID": str,
-            "media_type": str,   # e.g. "audio", "image"
+            "media_type": str,   # e.g. "audio", "image", "video", "document"
             "media_url": str,    # PullWrest-resolvable URL
             "md5": str,          # hex digest from ReCaller
             ...                  # any other RC fields
@@ -106,7 +122,7 @@ def _pw_fetch_media(media_url: str) -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# Media-dict assembly (shared by per-item and bulk paths)
+# Media-dict assembly
 # ---------------------------------------------------------------------------
 
 
@@ -158,7 +174,7 @@ def _build_media(
 
 
 class ReCallerDatasetImporter(DatasetImporter):
-    """Import a dataset from a ReCaller query."""
+    """Import a dataset from a ReCaller query, with multi-source-type support."""
 
     name = "recaller"
     display_name = "ReCaller Query"
@@ -166,20 +182,15 @@ class ReCallerDatasetImporter(DatasetImporter):
     icon = "\U0001f50d"  # magnifying glass
     hidden_from_picker = True  # flip to False once API clients are implemented
     category = "services"
-    # ReCaller queries return a single ``media_type`` selected by the
-    # user — the import flow does not pull in additional source types
-    # via converters.  Flag set to keep the in-tree importer set
-    # uniformly off the legacy shim; the existing ``list_records``
-    # implementation reads ``field_values["media_type"]`` directly.
     multi_media = True
     fields = [
         ImporterField(
             key="media_type",
-            label="Dataset MediaType",
+            label="Output Media Type",
             field_type="select",
             options=all_folder_names(),
             default="audio",
-            description="Only results matching this media type will be imported.",
+            description="The media type this dataset will hold.  Source-type rows below specify which ReCaller record types to pull in and how to convert them to this output type.",
         ),
         ImporterField(
             key="query_id",
@@ -192,86 +203,66 @@ class ReCallerDatasetImporter(DatasetImporter):
     ]
 
     def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[str]:
-        """Populate ``query_id`` from ReCaller, scoped by the picked media type."""
+        """Populate ``query_id`` from ReCaller, scoped by the output type."""
         if field_key == "query_id":
-            media_type = current_values.get("media_type") or "audio"
-            return list(_rc_list_queries(media_type))
+            output_type = current_values.get("media_type") or "audio"
+            return list(_rc_list_queries(output_type))
         return super().get_field_options(field_key, current_values)
 
     # The dataset-level origin (queryID) is NOT useful for provenance —
-    # each media gets its own origin keyed by contentID via fetch_record.
+    # each media gets its own origin keyed by contentID via _build_media.
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         return {"importer": self.name, "params": {}}
 
     # ------------------------------------------------------------------
-    # Bulk import hooks
+    # Multi-media source hook
     # ------------------------------------------------------------------
 
-    def list_records(self, field_values: dict[str, Any]) -> list[dict[str, Any]]:
+    def fetch_source_media(
+        self,
+        spec: SourceSpec,
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield raw ReCaller records matching ``spec.source_type``.
+
+        Filters :func:`_rc_fetch_results` by ``media_type ==
+        spec.source_type`` and batches DataWrest + PullWrest calls
+        concurrently via a thread pool.  Yields :func:`_build_media`
+        dicts in ReCaller's result order.
+
+        The framework owns conversion: when the caller's :class:`SourceSpec`
+        carries a converter, :meth:`DatasetImporter.run` passes each
+        yielded media through ``converter.convert(raw, spec.params)``
+        before assigning an ID and storing it.
+        """
         query_id = (field_values.get("query_id") or "").strip()
         if not query_id:
             raise ValueError("A query ID is required.")
-        media_type = field_values.get("media_type", "audio")
 
         all_results = _rc_fetch_results(query_id)
-        results = [r for r in all_results if r.get("media_type") == media_type]
+        results = [r for r in all_results if r.get("media_type") == spec.source_type]
         if not results:
-            raise ValueError(f"No results of type '{media_type}' found for query '{query_id}'.")
-        return results
+            return
 
-    def fetch_record(
-        self,
-        record: dict[str, Any],
-        field_values: dict[str, Any],
-        thin: bool = False,
-    ) -> dict[str, Any]:
-        """Fetch a single ReCaller record into a media dict.
+        from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
 
-        Per-item path: one DataWrest call for the embedding plus (in
-        non-thin mode) one PullWrest call for the bytes.  Override
-        :meth:`_fetch_records_bulk_impl` to batch these across many
-        records concurrently.
-        """
-        media_type = field_values.get("media_type", "audio")
-        embedding_info = _dw_get_embedding(record["mediaID"])
-        media_bytes = None if thin else _pw_fetch_media(record["media_url"])
-        return _build_media(record, media_type, embedding_info, media_bytes, self.name)
+        from vtscore.concurrency.progress import update_progress  # noqa: PLC0415
 
-    def _fetch_records_bulk_impl(
-        self,
-        records: list[dict[str, Any]],
-        field_values: dict[str, Any],
-        thin: bool = False,
-    ) -> list[dict[str, Any] | None]:
-        """Concurrent bulk fetch.
-
-        Issues all DataWrest embedding lookups and PullWrest media-byte
-        downloads in parallel via a thread pool, then assembles the media
-        dicts in the original order.  Each record still goes through
-        :func:`_build_media`, so the per-item shape stays identical to
-        :meth:`fetch_record`.
-        """
-        from concurrent.futures import ThreadPoolExecutor
-
-        from vtscore.concurrency.progress import update_progress
-
-        media_type = field_values.get("media_type", "audio")
-        total = len(records)
-        update_progress("loading", f"Fetching {total} ReCaller records…", 0, total)
+        total = len(results)
+        update_progress("loading", f"Fetching {total} {spec.source_type} records…", 0, total)
 
         max_workers = min(16, max(1, total))
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
-            embed_infos = list(pool.map(lambda r: _dw_get_embedding(r["mediaID"]), records))
+            embed_infos = list(pool.map(lambda r: _dw_get_embedding(r["mediaID"]), results))
             if thin:
                 byte_blobs: list[bytes | None] = [None] * total
             else:
-                byte_blobs = list(pool.map(lambda r: _pw_fetch_media(r["media_url"]), records))
+                byte_blobs = list(pool.map(lambda r: _pw_fetch_media(r["media_url"]), results))
 
-        results: list[dict[str, Any] | None] = []
-        for i, (rec, ei, mb) in enumerate(zip(records, embed_infos, byte_blobs)):
+        for i, (rec, ei, mb) in enumerate(zip(results, embed_infos, byte_blobs)):
             update_progress("loading", f"Importing {i + 1} of {total}…", i + 1, total)
-            results.append(_build_media(rec, media_type, ei, mb, self.name))
-        return results
+            yield _build_media(rec, spec.source_type, ei, mb, self.name)
 
     def origin_display(self, origin: dict[str, Any]) -> str:
         content_id = origin.get("params", {}).get("contentID", "")

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -156,9 +156,8 @@ from origins.
 
 An importer that wants to pull in multiple source media types in one
 shot — e.g. images, plus videos converted to images, plus documents
-converted to images — sets the class attribute `multi_media = True`
-and iterates `self.effective_source_specs(field_values)` inside
-`run()`. Each `SourceSpec` ([`vtscore/datasets/importers/base.py:67`](../../datasets/importers/base.py))
+converted to images — sets the class attribute `multi_media = True`.
+Each `SourceSpec` ([`vtscore/datasets/importers/base.py:67`](../../datasets/importers/base.py))
 is `(source_type, converter, params)`:
 
 - `converter is None` means "include directly" — fetch files of
@@ -166,12 +165,41 @@ is `(source_type, converter, params)`:
 - `converter is set` means "fetch files of `source_type`, then pass
   them through the named converter with `params`".
 
+**The framework owns conversion and ingestion.** Subclasses never
+call `get_converter()` or `converter.convert()` themselves — they
+just yield raw source-type media, and the framework runs each spec's
+converter on it before assigning IDs and storing the result.
+
+### Choosing your override point
+
+`DatasetImporter` exposes four override points. Pick the simplest
+one that fits your backend:
+
+| When your backend looks like… | Override |
+|------------------------------|----------|
+| One query, one media type per import (no per-source-type fan-out) | `list_records()` + `fetch_record()` |
+| Different query per media type — framework loops specs for you | `fetch_source_media(spec, ...)` |
+| One query that returns mixed types in one response | `fetch_all_source_media(specs, ...)` |
+| Folder-shaped (already on disk; delegates to `load_dataset_from_folder()` / `run_converters_on_folder()`) | `run()` directly |
+
+The first three hooks all hand back raw source-type media; the
+framework runs converters and ingests.  Only `run()` gives up that
+help in exchange for full control.  The built-in `server_folder`
+importer is the canonical `run()`-shaped example; `recaller` is the
+canonical `fetch_source_media()`-shaped example.
+
+The default `fetch_source_media()` delegates to `list_records()` +
+`fetch_record()`, and the default `fetch_all_source_media()`
+delegates to `fetch_source_media()` per spec — so each hook is a
+strict generalisation of the one above it.  You can also call
+`self.effective_source_specs(field_values)` directly from any of
+these (or from a custom `run()`) to inspect the resolved spec list.
+
 Legacy importers (`multi_media = False`) can still call
 `effective_source_specs()` — it synthesises an equivalent list from
 the classic `media_type` + comma-separated `converters` form fields,
 so you can migrate the body of `run()` before touching the form
-schema. The built-in `server_folder` importer is a good migration
-reference.
+schema.
 
 ## Reporting progress
 

--- a/vtscore/docs/packages/datasets.md
+++ b/vtscore/docs/packages/datasets.md
@@ -276,17 +276,38 @@ entry-point group; built-ins win on name clashes. See
 `source_specs` form value: a list of
 `SourceSpec(source_type, converter, params)` rows that fan one import
 out across several source media types, each optionally run through a
-named `MediaConverter`. Inside `run()`, call
-`self.effective_source_specs(field_values)`; for legacy
-(`multi_media = False`) importers the same helper synthesises an
-equivalent list from the legacy `media_type` + comma-separated
-`converters` form fields.
+named `MediaConverter`. The framework owns conversion and ingestion —
+subclasses never call `get_converter()` themselves.
 
-**Per-record hooks.** For service-style importers (HTTP API,
-database) override `list_records` + `fetch_record` instead of writing
-`run()` from scratch. The default `run()` lists, batches into
-`fetch_records_bulk`, and assigns sequential IDs / origins. Override
-`_fetch_records_bulk_impl` for batched / concurrent I/O.
+**Importer override points** (pick one, simplest first):
+
+1. `list_records()` + `fetch_record()` — single-source-type service
+   importer. Default `fetch_source_media()` delegates here.
+2. `fetch_source_media(spec, ...)` — multi-source-type service
+   importer where the backend serves one type per query. Framework
+   calls you once per spec; you yield raw source-type media dicts.
+3. `fetch_all_source_media(specs, ...)` — multi-source-type service
+   importer where one upstream call returns mixed types. Framework
+   calls you once with the full spec list; you yield
+   `(spec, raw_media)` pairs. Default delegates to
+   `fetch_source_media()` per spec.
+4. `run()` — folder-shaped importers that own the medias dict
+   directly (typical body: stage files, call
+   `load_dataset_from_folder()` + `run_converters_on_folder()`).
+
+For hooks 1–3 the framework also assigns sequential IDs, fills
+`media["origin"]` from `build_origin()`, and runs each spec's
+converter on the yielded raw media before storing the result.
+
+**Per-record hooks (`list_records` / `fetch_record`).** Hook 1's
+bulk variant `_fetch_records_bulk_impl` lets you replace the per-item
+loop with batched / concurrent I/O.
+
+For legacy (`multi_media = False`) importers,
+`effective_source_specs()` synthesises an equivalent spec list from
+the legacy `media_type` + comma-separated `converters` form fields,
+so a legacy `run()` can migrate to the new iteration style before
+touching its form schema.
 
 **Resolving back to a file.** Importers whose media is reachable on
 disk **must** override `resolve_file(origin, origin_name, filename) ->


### PR DESCRIPTION
## Summary

Multi-media service importers no longer call `get_converter().convert()` themselves — the framework owns the SourceSpec loop *and* the conversion. Importers just yield raw source-type media; the base-class `run()` runs the spec's converter on every yielded dict.

This PR ships two related changes to the importer override surface:

1. **Per-spec fetch hook** (`fetch_source_media`) for service importers whose backend serves one media type per query.
2. **Bulk-fetch escape hatch** (`fetch_all_source_media`) for service importers whose backend returns mixed source types in one upstream call.

Both are framework-driven — subclasses never call `get_converter()` or `converter.convert()` themselves regardless of which they pick.

## What changed

- **New `DatasetImporter.fetch_source_media(spec, field_values, thin)` hook.** Yield raw media of `spec.source_type`. The framework runs `converter.convert(raw, spec.params)` itself when the spec declares a converter.
- **New `DatasetImporter.fetch_all_source_media(specs, field_values, thin)` hook.** Yield `(spec, raw_media)` pairs for every spec in one pass — for importers whose backend serves mixed source types in a single response. Default impl delegates to `fetch_source_media()` per spec, so per-spec importers are unaffected.
- **Default `fetch_source_media()` delegates to `list_records()` + `fetch_records_bulk()`.** Single-source-type service importers keep working without touching the new hooks.
- **`run()` body refactored** to call `fetch_all_source_media()` once instead of looping per spec. Converter lookups are cached across pairs so a bulk importer interleaving specs doesn't re-resolve on every yield.
- **ReCaller migrated to be truly multi-source-type-aware.** Its `list_records` / `fetch_record` / `_fetch_records_bulk_impl` trio is replaced by a single `fetch_source_media()` that filters `_rc_fetch_results` by `spec.source_type`. A user can now build one ReCaller-backed dataset that mixes (say) images directly + videos converted to images + documents converted to images, with the framework driving every converter.
- **Docs restructured around the four override points.** `EXTENDING-plugins.md` gains a "Choosing your override point" decision tree that enumerates the options and the branching logic — so authors can find the right hook from a single read. The same decision table is mirrored in `vtscore/docs/extending/dataset-importers.md` and `vtscore/docs/packages/datasets.md`. `docs/vtscore-api.md` and the multi-media-import plan are updated to match.

## The four override points (from simplest to fullest-control)

| Hook | When to use |
|------|-------------|
| `list_records()` + `fetch_record()` | Single-source-type service importer |
| `fetch_source_media(spec, ...)` | Multi-source-type service importer, one query per spec |
| `fetch_all_source_media(specs, ...)` | Multi-source-type service importer, one query covers all specs |
| `run()` | Folder-shaped importers; full control |

Hooks 1–3 leave conversion and ingestion to the framework. Only `run()` takes that responsibility back.

## Breaking change

ReCaller no longer exposes `fetch_record` / `_fetch_records_bulk_impl`. No in-tree code subclassed ReCaller specifically, so this only affects out-of-tree extensions that did — those must migrate to `fetch_source_media()`.

## Test plan

- [x] `./run-tests.sh io datasets converters` — 1444 passed, 1 skipped
- [x] `./run-tests.sh` (full suite) — 4201 passed, 1 skipped, 2 xpassed
- [x] New tests in `tests_lib/io/test_importers.py::TestReCallerMultiMedia` cover: per-spec filtering, missing-query-id error, default `run()` ingesting a direct spec, and default `run()` driving converter calls on a mixed image + video→image source-spec list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdxDLqPwkFHkJaito6mQ5M)_