### PR TITLE
Split dashboard.component.ts into focused services (plan #2)

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 shipped (all five checkpoints).** Items #2–#6 are scoped
-but not started.
+Status: **#1 shipped (all five checkpoints). #2 shipped.** Items #3–#6
+are scoped but not started.
 
 ## What shipped
 
@@ -94,6 +94,64 @@ but not started.
   but the structural goal — single source of truth for the picker
   chrome and demo table — is achieved, and any future edits to the
   picker UI now touch one component instead of two.
+- **#2 Split `dashboard.component.ts`**: extracted two focused
+  services from the page-shell god component.  Dashboard dropped
+  1419 → 1175 lines.
+  - **`DashboardModalsService`** consolidates the six row-action /
+    selection-action modal states (combine-datasets, combine-detectors,
+    label-exporter, label-importer, find-results, dataset-stats).  Each
+    modal now has a single source of truth with `openX()` / `closeX()`
+    methods; template `@if` blocks read directly off
+    `modals.x.open` / `modals.x.payload`.  Replaces six parallel
+    `xModalOpen` boolean + `xPayload` field pairs and their open/close
+    glue scattered through the component.  Importer / new-detector
+    flows continue to live on `NewThingFlowsService` because they're
+    also opened from the top-bar context pulldowns — the new service
+    only owns dashboard-local modals.
+  - **`DashboardLoadingTasksService`** owns the per-task loading lists
+    (`loadingTasks` for datasets, `detectorLoadingTasks` for
+    detectors), the polling subscriptions, and the bookkeeping for
+    `awaitedTaskIds` / `completedTaskIds` / `completedModelTaskIds`.
+    Polling auto-resumes on construction whenever the SSE stream
+    shows an active task, replacing the dashboard's bespoke
+    `resumeActivePolling` and two `startProgressPolling` methods.
+    `inlineTaskMap`, `orphanLoadingTasks`, `getInlineTask`,
+    `getInlineDetectorTask`, and the cancel / dismiss helpers move
+    with the state.
+  - **DatasetStateService cleanup**: removed the now-dead
+    `loadingTasksSubject` / `loadingTasks$` / `setLoadingTasks` /
+    `loadingTasks` surface — nobody read it after the polling moved.
+  - **What we did NOT do** (deviation from the original plan, noted
+    here so the next contributor doesn't try and back it out):
+    - **Row actions stay on the dashboard, not on cards.** The plan
+      suggested pushing per-row handlers (rename / delete / load /
+      unload / security / export / addLabels) into
+      `DatasetCardComponent` / `DetectorCardComponent`.  Each handler
+      is 1-15 lines of API + dialog glue, and pushing them in would
+      require the card components to inject `DatasetsApiService`,
+      `DetectorsApiService`, `VtDialogService`, and
+      `DatasetStateService` — coupling presentation to backend +
+      dialog system.  Cards stay presentational; the dashboard keeps
+      the thin glue methods.  Extracting them into yet another service
+      was also rejected: they have a single caller (the dashboard
+      template) so the move would just shuffle names without making
+      the code more reusable.
+    - **Column resize / drag-reorder forwarding stays in the
+      component.** The two `@HostListener('document:mousemove')` /
+      `('document:mouseup')` methods can't move to a service (host
+      listeners need to live on a `@Component` / `@Directive`).  The
+      actual logic already lives in `ManagedColumns` /
+      `DashboardColumnsService`; the dashboard's contribution is two
+      lines of "forward to both managers" — already minimal.
+  **Bundle effect.** Initial bundle essentially unchanged
+  (527.48 kB → 527.25 kB raw, 136.49 kB → 136.47 kB gzip — both
+  modals are `@defer`-loaded so service code is in the dashboard's
+  lazy chunk).  Lazy `dashboard-component` chunk grew from
+  129.71 → 131.61 kB raw (22.57 → 22.82 kB gzip) because the service
+  plumbing adds Angular DI overhead without yet enabling cross-
+  component dedup.  Bundle size was not the goal of this checkpoint —
+  the structural goal (clear ownership of modal state and polling, a
+  smaller dashboard shell) is what shipped.
 - **#1 Checkpoint 4**: extracted `<vt-source-picker>` — the importer
   category-tab + sub-tab chrome plus the source-side widgets (demo
   media-type tabs + sortable demo table, server-folder typed-path
@@ -268,7 +326,7 @@ touching the cross-modal picker chrome):
 The demo flow inside `dataset-importer-modal` stays a separate path
 (its picker layout is genuinely different from the import flows).
 
-### #2 — Split `dashboard.component.ts`
+### #2 — Split `dashboard.component.ts` (shipped — see "What shipped")
 
 Goal: shrink the page-shell god component (1419 lines, ~200 methods).
 Section dividers in the file already document the boundaries:

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -14,7 +14,7 @@
       </div>
     </div>
 
-    @if (!registryLoaded && datasets.length === 0 && orphanLoadingTasks.length === 0) {
+    @if (!registryLoaded && datasets.length === 0 && loadingTasksSvc.orphanLoadingTasks.length === 0) {
       <ul class="dashboard-skeleton-list" aria-busy="true" aria-label="Loading datasets">
         @for (_ of skeletonRows; track $index) {
           <li class="dashboard-skeleton-row">
@@ -25,7 +25,7 @@
           </li>
         }
       </ul>
-    } @else if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
+    } @else if (datasets.length === 0 && loadingTasksSvc.orphanLoadingTasks.length === 0 && !loading) {
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
@@ -77,7 +77,7 @@
             </tr>
           </thead>
           <tbody>
-            @for (task of orphanLoadingTasks; track task.task_id) {
+            @for (task of loadingTasksSvc.orphanLoadingTasks; track task.task_id) {
               <tr class="loading-task-row" [class.loading-task-error]="!!task.error">
                 <td class="select-col"></td>
                 <td>
@@ -87,7 +87,7 @@
                   @if (task.error) {
                     <div class="loading-task-progress loading-task-failed">
                       <span class="error-msg">Failed: {{ task.error }}</span>
-                      <button class="btn btn--cancel btn--sm" (click)="dismissLoadingTask(task.task_id)" title="Dismiss this error">Dismiss</button>
+                      <button class="btn btn--cancel btn--sm" (click)="loadingTasksSvc.dismissLoadingTask(task.task_id)" title="Dismiss this error">Dismiss</button>
                     </div>
                   } @else {
                     @let info = taskProgressInfo(task);
@@ -110,7 +110,7 @@
                         @if (info.eta) {
                           <span class="progress-eta">{{ info.eta }}</span>
                         }
-                        <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
+                        <button class="btn btn--cancel btn--sm" (click)="loadingTasksSvc.cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
                       </div>
                     </div>
                   }
@@ -125,8 +125,8 @@
                 [columnOrder]="visibleDatasetColumns"
                 [selected]="isDatasetSelected(dataset.id)"
                 [dimmed]="isLoading && !isDatasetSelected(dataset.id)"
-                [loadingTask]="getInlineTask(dataset.id)"
-                [statsOpen]="statsModalOpen && statsDatasetId === dataset.id"
+                [loadingTask]="loadingTasksSvc.getInlineTask(dataset.id)"
+                [statsOpen]="modals.stats.open && modals.stats.datasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId === dataset.id"
                 (rowClick)="!isLoading && toggleDatasetSelection(dataset.id, $event)"
                 (checkboxToggle)="!isLoading && toggleDatasetCheckbox(dataset.id)"
@@ -135,8 +135,8 @@
                 (delete)="deleteDataset(dataset)"
                 (load)="loadDataset(dataset)"
                 (security)="editDatasetSecurity(dataset)"
-                (cancelTask)="cancelLoadingTask($event)"
-                (dismissTask)="dismissLoadingTask($event)"
+                (cancelTask)="loadingTasksSvc.cancelLoadingTask($event)"
+                (dismissTask)="loadingTasksSvc.dismissLoadingTask($event)"
               />
             }
           </tbody>
@@ -249,9 +249,9 @@
                 [columnOrder]="visibleDetectorColumns"
                 [selected]="isDetectorSelected(detector.id)"
                 [dimmed]="isLoading && !isDetectorSelected(detector.id)"
-                [loadingTask]="getInlineDetectorTask(detector.id)"
+                [loadingTask]="loadingTasksSvc.getInlineDetectorTask(detector.id)"
                 [deleteConfirmOpen]="deletingDetectorId === detector.id"
-                [addLabelsOpen]="addLabelsModalOpen && addLabelsDetectorId === detector.id"
+                [addLabelsOpen]="modals.addLabels.open && modals.addLabels.detectorId === detector.id"
                 (rowClick)="!isLoading && toggleDetectorSelection(detector.id, $event)"
                 (checkboxToggle)="!isLoading && toggleDetectorCheckbox(detector.id)"
                 (rename)="renameDetector(detector, $event)"
@@ -261,8 +261,8 @@
                 (export)="openExportModal(detector)"
                 (addLabels)="openAddLabelsModal(detector)"
                 (autorunToggle)="toggleAutorun(detector, $event)"
-                (cancelTask)="cancelDetectorLoadingTask($event)"
-                (dismissTask)="dismissDetectorLoadingTask($event)"
+                (cancelTask)="loadingTasksSvc.cancelDetectorLoadingTask($event)"
+                (dismissTask)="loadingTasksSvc.dismissDetectorLoadingTask($event)"
               />
             }
           </tbody>
@@ -335,50 +335,50 @@
   </div>
 </div>
 
-@if (combineModalOpen) {
+@if (modals.combineDatasets.open) {
   <vt-combine-datasets-modal
-    [datasets]="combineModalDatasets"
-    (closed)="closeCombineModal()"
+    [datasets]="modals.combineDatasets.datasets"
+    (closed)="modals.closeCombineDatasets()"
     (combineStarted)="onCombineStarted()"
   />
 }
 
-@if (combineDetectorsModalOpen) {
+@if (modals.combineDetectors.open) {
   <vt-combine-detectors-modal
     [sources]="combineSelectedDetectorSources"
     [existingNames]="allDetectorNames"
-    (closed)="closeCombineDetectorsModal()"
+    (closed)="modals.closeCombineDetectors()"
     (created)="onDetectorsCombined($event)"
   />
 }
 
-@if (exportModalOpen) {
+@if (modals.export.open) {
   <vt-label-exporter-modal
-    [customTitle]="'Export Labelset: ' + exportDetectorName"
-    (closed)="closeExportModal()"
-    (exportComplete)="closeExportModal()"
+    [customTitle]="'Export Labelset: ' + modals.export.detectorName"
+    (closed)="modals.closeExport()"
+    (exportComplete)="modals.closeExport()"
   />
 }
 
-@if (addLabelsModalOpen) {
+@if (modals.addLabels.open) {
   <vt-label-importer-modal
-    [targetModelName]="addLabelsDetectorName"
-    (closed)="closeAddLabelsModal()"
+    [targetModelName]="modals.addLabels.detectorName"
+    (closed)="modals.closeAddLabels()"
     (imported)="onAddLabelsImported()"
   />
 }
 
-@if (findResultsOpen) {
+@if (modals.findResults.open) {
   <vt-autodetect-results-modal
-    [data]="findResultsData"
-    (closed)="closeFindResults()"
+    [data]="modals.findResults.data"
+    (closed)="modals.closeFindResults()"
   />
 }
 
-@if (statsModalOpen) {
+@if (modals.stats.open) {
   <vt-dataset-stats-modal
-    [datasetId]="statsDatasetId"
-    [datasetName]="statsDatasetName"
-    (closed)="closeStatsModal()"
+    [datasetId]="modals.stats.datasetId"
+    [datasetName]="modals.stats.datasetName"
+    (closed)="modals.closeStats()"
   />
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -5,17 +5,17 @@ import { EMPTY, Subject, timer } from 'rxjs';
 import { catchError, filter, switchMap, take, takeUntil } from 'rxjs/operators';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
-import { ProgressEventsService } from '../../services/progress-events.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
-import { ActiveContextService } from '../../services/active-context.service';
 import { ContextSwitchService } from '../../services/context-switch.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
-import { AchievementsService } from '../../services/achievements.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, DemoDataset, LoadingTask, DetectorRegistryEntry, ImporterInfo, ProgressEvent } from '../../models/api.models';
+import { DashboardModalsService } from '../../services/dashboard-modals.service';
+import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
+import { DatasetRegistryEntry, DemoDataset, DetectorRegistryEntry, ImporterInfo, LoadingTask, ProgressEvent } from '../../models/api.models';
+import { ProgressEventsService } from '../../services/progress-events.service';
 import {
   ProgressHeader,
   formatProgressHeader,
@@ -76,31 +76,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
   progressTotal = 0;
   progressIndeterminate = false;
 
-  loadingTasks: LoadingTask[] = [];
-  detectorLoadingTasks: LoadingTask[] = [];
-
   importerClosing = false;
   /** Visible importers (i.e. ``hidden_from_picker !== true``), fetched
    *  once on init so the welcome banner can detect Services-tab
    *  importers without waiting for the modal to open. */
   visibleImporters: ImporterInfo[] = [];
-  combineModalOpen = false;
-  /** Datasets passed into the Combine modal when it opens. */
-  combineModalDatasets: DatasetRegistryEntry[] = [];
   newDetectorClosing = false;
-  combineDetectorsModalOpen = false;
-  exportModalOpen = false;
-  exportDetectorName = '';
-  addLabelsModalOpen = false;
-  addLabelsDetectorName = '';
-  findResultsOpen = false;
-  findResultsData: AutoDetectResultsData = { results: {} };
-  statsModalOpen = false;
-  statsDatasetId = '';
-  statsDatasetName = '';
   deletingDatasetId = '';
   deletingDetectorId = '';
-  addLabelsDetectorId = '';
   trainAfterModelCreation = false;
   /** Mirrors the user's click intent so the Train/Find button icons
    *  can waggle while the `activeContextGuard` waits between click and
@@ -139,23 +122,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   private destroy$ = new Subject<void>();
-  private polling$ = new Subject<void>();
-  private detectorPolling$ = new Subject<void>();
   private findPolling$ = new Subject<void>();
   private knownDatasetIds = new Set<string>();
   private knownDetectorIds = new Set<string>();
-  private completedTaskIds = new Set<string>();
-  private completedModelTaskIds = new Set<string>();
-  /** Task IDs we've been told to expect (via an HTTP response) but haven't
-   *  yet observed in the SSE `loading-tasks` stream. Polling refuses to bail
-   *  while this set is non-empty, even if the stream currently shows no
-   *  active tasks — otherwise a fast load (e.g. pre-embedded demo dataset)
-   *  whose HTTP response wins the race against the SSE event would stop
-   *  polling before the task ever shows up, leaving the dashboard stale
-   *  until the user refreshes. */
-  private awaitedTaskIds = new Set<string>();
-  private datasetPollingActive = false;
-  private detectorPollingActive = false;
   /** Dataset IDs we've already asked the backend to preload an embedder
    *  for this session. The backend dedupes against already-loaded
    *  embedders, but tracking here avoids hammering the network as the
@@ -174,12 +143,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private dialog: VtDialogService,
     private labelSession: LabelSessionService,
     public datasetState: DatasetStateService,
-    private activeContext: ActiveContextService,
     private contextSwitch: ContextSwitchService,
     private authService: AuthService,
     private topBarState: TopBarStateService,
     private newThingFlows: NewThingFlowsService,
-    private achievements: AchievementsService,
+    public modals: DashboardModalsService,
+    public loadingTasksSvc: DashboardLoadingTasksService,
     private progressEvents: ProgressEventsService,
     columnsService: DashboardColumnsService,
   ) {
@@ -241,7 +210,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.pushTopBarLabels();
       });
     this.refresh();
-    this.resumeActivePolling();
     this.startDiskUsagePolling();
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
@@ -336,18 +304,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       });
   }
 
-  /** Check for in-progress loading tasks (e.g. after a page reload) and start watching. */
-  private resumeActivePolling(): void {
-    // SSE pushes the initial snapshot the moment we connect, so the first
-    // event on each channel tells us whether there's anything in flight.
-    this.progressEvents.loadingTasks$
-      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')), take(1), takeUntil(this.destroy$))
-      .subscribe(() => this.startProgressPolling());
-    this.progressEvents.detectorLoadingTasks$
-      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')), take(1), takeUntil(this.destroy$))
-      .subscribe(() => this.startDetectorProgressPolling());
-  }
-
   // --- Column resize / drag-reorder ---
   //
   // The actual logic lives in `ManagedColumns`. We just forward document-level
@@ -370,10 +326,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-    this.polling$.next();
-    this.polling$.complete();
-    this.detectorPolling$.next();
-    this.detectorPolling$.complete();
     this.findPolling$.next();
     this.findPolling$.complete();
   }
@@ -401,28 +353,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   get progressMessage(): string {
     return this.datasetState.progressMessage;
-  }
-
-  /** Map dataset_id → LoadingTask for tasks that match an existing dataset row. */
-  get inlineTaskMap(): Map<string, LoadingTask> {
-    const map = new Map<string, LoadingTask>();
-    const datasetIds = new Set(this.datasets.map((d) => d.id));
-    for (const task of this.loadingTasks) {
-      if (task.dataset_id && datasetIds.has(task.dataset_id)) {
-        map.set(task.dataset_id, task);
-      }
-    }
-    return map;
-  }
-
-  /** Loading tasks that have no matching dataset row (new imports, etc.). */
-  get orphanLoadingTasks(): LoadingTask[] {
-    const datasetIds = new Set(this.datasets.map((d) => d.id));
-    return this.loadingTasks.filter((t) => !t.dataset_id || !datasetIds.has(t.dataset_id));
-  }
-
-  getInlineTask(datasetId: string): LoadingTask | undefined {
-    return this.inlineTaskMap.get(datasetId);
   }
 
   refresh(): void {
@@ -518,18 +448,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
   combineSelectedDatasets(): void {
     const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
     if (targets.length < 2) return;
-    this.combineModalDatasets = targets;
-    this.combineModalOpen = true;
-  }
-
-  closeCombineModal(): void {
-    this.combineModalOpen = false;
-    this.combineModalDatasets = [];
+    this.modals.openCombineDatasets(targets);
   }
 
   onCombineStarted(): void {
-    this.closeCombineModal();
-    this.startProgressPolling();
+    this.modals.closeCombineDatasets();
+    this.loadingTasksSvc.startProgressPolling();
   }
 
   /**
@@ -712,15 +636,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   openCombineDetectorsModal(): void {
     if (!this.combineSelectedDetectorsEnabled) return;
-    this.combineDetectorsModalOpen = true;
-  }
-
-  closeCombineDetectorsModal(): void {
-    this.combineDetectorsModalOpen = false;
+    this.modals.openCombineDetectors();
   }
 
   onDetectorsCombined(newName: string): void {
-    this.combineDetectorsModalOpen = false;
+    this.modals.closeCombineDetectors();
     // The new model will appear via the datasets$/detectors$ subscription's
     // new-id auto-select logic; nothing more to do besides refreshing.
     this.datasetState.refresh();
@@ -774,15 +694,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   showDatasetStats(dataset: DatasetRegistryEntry): void {
-    this.statsDatasetId = dataset.id;
-    this.statsDatasetName = dataset.name;
-    this.statsModalOpen = true;
-  }
-
-  closeStatsModal(): void {
-    this.statsModalOpen = false;
-    this.statsDatasetId = '';
-    this.statsDatasetName = '';
+    this.modals.openStats(dataset.id, dataset.name);
   }
 
   // --- Model actions ---
@@ -821,13 +733,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   loadDataset(dataset: DatasetRegistryEntry): void {
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
-      next: (response) => this.startProgressPolling(response.task_id),
+      next: (response) => this.loadingTasksSvc.startProgressPolling(response.task_id),
     });
   }
 
   loadDetector(model: DetectorRegistryEntry): void {
     this.detectorsApi.loadDetector(model.id).subscribe({
-      next: () => this.startDetectorProgressPolling(),
+      next: () => this.loadingTasksSvc.startDetectorProgressPolling(),
     });
   }
 
@@ -837,40 +749,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  getInlineDetectorTask(modelId: string): LoadingTask | undefined {
-    return this.detectorLoadingTasks.find((t) => t.detector_id === modelId);
-  }
-
   toggleAutorun(model: DetectorRegistryEntry, autorun: boolean): void {
     this.detectorsApi.setAutorun(model.id, autorun).subscribe({
       next: () => this.datasetState.refresh(),
     });
   }
 
-  // --- Export modal ---
+  // --- Export / Add-Labels modal openers (state lives on DashboardModalsService) ---
 
   openExportModal(model: DetectorRegistryEntry): void {
-    this.exportDetectorName = model.name;
-    this.exportModalOpen = true;
+    this.modals.openExport(model.name);
   }
-
-  closeExportModal(): void {
-    this.exportModalOpen = false;
-    this.exportDetectorName = '';
-  }
-
-  // --- Add Labels modal ---
 
   openAddLabelsModal(model: DetectorRegistryEntry): void {
-    this.addLabelsDetectorId = model.id;
-    this.addLabelsDetectorName = model.name;
-    this.addLabelsModalOpen = true;
-  }
-
-  closeAddLabelsModal(): void {
-    this.addLabelsModalOpen = false;
-    this.addLabelsDetectorId = '';
-    this.addLabelsDetectorName = '';
+    this.modals.openAddLabels(model.id, model.name);
   }
 
   onAddLabelsImported(): void {
@@ -888,7 +780,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     for (const m of this.detectors) {
       if (m.media_type) types.add(m.media_type);
     }
-    for (const t of this.loadingTasks) {
+    for (const t of this.loadingTasksSvc.loadingTasks) {
       if (t.media_type && !t.error) types.add(t.media_type);
     }
     return types.size === 1 ? [...types][0] : '';
@@ -901,7 +793,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       const emb = d['embedder'] as string;
       if (emb) embedders.add(emb);
     }
-    for (const t of this.loadingTasks) {
+    for (const t of this.loadingTasksSvc.loadingTasks) {
       if (t.embedder && !t.error) embedders.add(t.embedder);
     }
     return embedders.size === 1 ? [...embedders][0] : '';
@@ -933,7 +825,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private handleImportStarted(): void {
     this.importerClosing = true;
-    this.startProgressPolling();
+    this.loadingTasksSvc.startProgressPolling();
   }
 
   private handleDemoSelected(demo: DemoDataset): void {
@@ -954,7 +846,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (userName) params['dataset_name'] = userName;
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
       next: (response) => {
-        this.startProgressPolling(response.task_id);
+        this.loadingTasksSvc.startProgressPolling(response.task_id);
       },
     });
   }
@@ -972,7 +864,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (loaded?.media_type) return loaded.media_type;
     // Fall back to in-progress loading tasks when no dataset is fully loaded yet.
     const loadingTypes = new Set(
-      this.loadingTasks.filter((t) => t.media_type && !t.error).map((t) => t.media_type!),
+      this.loadingTasksSvc.loadingTasks.filter((t) => t.media_type && !t.error).map((t) => t.media_type!),
     );
     return loadingTypes.size === 1 ? [...loadingTypes][0] : '';
   }
@@ -992,134 +884,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsApi.cancelIngest().subscribe();
   }
 
-  cancelLoadingTask(taskId: string): void {
-    this.datasetsApi.cancelTask(taskId).subscribe();
+  // --- Loading-task helpers (used by the orphan-task row template) ---
+
+  taskProgressInfo(task: LoadingTask): ProgressHeader {
+    return formatProgressHeader(task, 'dataset', task.embedder);
   }
 
-  dismissLoadingTask(taskId: string): void {
-    this.loadingTasks = this.loadingTasks.filter((t) => t.task_id !== taskId);
-  }
-
-  cancelDetectorLoadingTask(taskId: string): void {
-    this.detectorsApi.cancelDetectorLoadingTask(taskId).subscribe();
-  }
-
-  dismissDetectorLoadingTask(taskId: string): void {
-    this.detectorLoadingTasks = this.detectorLoadingTasks.filter((t) => t.task_id !== taskId);
-  }
-
-  // --- Progress polling ---
-
-  startProgressPolling(awaitTaskId?: string, onComplete?: () => void): void {
-    // Register any task we've been told to expect.  See the
-    // `awaitedTaskIds` field comment for why this is needed.
-    if (awaitTaskId) {
-      this.awaitedTaskIds.add(awaitTaskId);
-    }
-    // If polling is already active, don't restart — the existing loop
-    // already covers all tasks.  This avoids clearing completedTaskIds
-    // and losing track of tasks that just finished.
-    if (this.datasetPollingActive) {
-      return;
-    }
-    this.datasetPollingActive = true;
-    this.completedTaskIds.clear();
-
-    this.progressEvents.loadingTasks$
-      .pipe(takeUntil(this.polling$), takeUntil(this.destroy$))
-      .subscribe({
-        next: (tasks: LoadingTask[]) => {
-          // Any task we were waiting for has now shown up in the SSE
-          // stream — drop it from the awaited set so the bail-out check
-          // below can fire as soon as the stream goes quiet.
-          for (const t of tasks) {
-            this.awaitedTaskIds.delete(t.task_id);
-          }
-
-          // Separate active from finished. Failed tasks are surfaced
-          // globally by SseErrorRouterService → ToastService; we just
-          // keep them in the inline list so the row still shows the
-          // dashed loading bar with the error text.
-          const active = tasks.filter((t) => t.status !== 'idle');
-          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
-          const failed = errored.filter((t) => t.error !== 'Cancelled');
-
-          this.loadingTasks = [...active, ...failed];
-          this.datasetState.setLoadingTasks(active);
-
-          // Detect tasks that just completed successfully so we can
-          // refresh the registry immediately (not only when ALL finish).
-          const justFinished = tasks.filter(
-            (t) => t.status === 'idle' && !t.error && !this.completedTaskIds.has(t.task_id),
-          );
-          for (const t of justFinished) {
-            this.completedTaskIds.add(t.task_id);
-          }
-          if (justFinished.length > 0) {
-            this.datasetState.refresh();
-            this.achievements.refresh();
-          }
-
-          this.datasetState.setLoading(active.length > 0);
-
-          if (active.length === 0 && this.awaitedTaskIds.size === 0) {
-            // No more active tasks and no awaited task pending — stop
-            // polling.
-            this.polling$.next();
-            this.datasetPollingActive = false;
-            // Refresh unless we just did (justFinished already triggered it)
-            if (justFinished.length === 0) {
-              this.datasetState.refresh();
-            }
-            if (onComplete && failed.length === 0) {
-              onComplete();
-            }
-          }
-        },
-      });
-  }
-
-  startDetectorProgressPolling(onComplete?: () => void): void {
-    if (this.detectorPollingActive) {
-      return;
-    }
-    this.detectorPollingActive = true;
-    this.completedModelTaskIds.clear();
-
-    this.progressEvents.detectorLoadingTasks$
-      .pipe(takeUntil(this.detectorPolling$), takeUntil(this.destroy$))
-      .subscribe({
-        next: (tasks: LoadingTask[]) => {
-          const active = tasks.filter((t) => t.status !== 'idle');
-          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
-          const failed = errored.filter((t) => t.error !== 'Cancelled');
-
-          this.detectorLoadingTasks = [...active, ...failed];
-
-          // Detect tasks that just completed successfully
-          const justFinished = tasks.filter(
-            (t) => t.status === 'idle' && !t.error && !this.completedModelTaskIds.has(t.task_id),
-          );
-          for (const t of justFinished) {
-            this.completedModelTaskIds.add(t.task_id);
-          }
-          if (justFinished.length > 0) {
-            this.datasetState.refresh();
-            this.achievements.refresh();
-          }
-
-          if (active.length === 0) {
-            this.detectorPolling$.next();
-            this.detectorPollingActive = false;
-            if (justFinished.length === 0) {
-              this.datasetState.refresh();
-            }
-            if (onComplete && failed.length === 0) {
-              onComplete();
-            }
-          }
-        },
-      });
+  taskIsIndeterminate(task: LoadingTask): boolean {
+    return isProgressIndeterminate(task);
   }
 
   // --- Sorting ---
@@ -1382,7 +1154,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           }
         }
 
-        this.findResultsData = {
+        this.modals.openFindResults({
           media_type: response.media_type || 'unknown',
           detectors_run: detectorNames.length,
           results: detectorResults,
@@ -1390,9 +1162,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           datasets: response.datasets || [],
           multiple_datasets: response.multiple_datasets || false,
           multiple_detectors: response.multiple_detectors || false,
-        } as AutoDetectResultsData;
-
-        this.findResultsOpen = true;
+        });
       },
       error: () => {
         this.stopFindProgressPolling();
@@ -1401,19 +1171,5 @@ export class DashboardComponent implements OnInit, OnDestroy {
         // Global error interceptor surfaces the failure in the banner.
       },
     });
-  }
-
-  closeFindResults(): void {
-    this.findResultsOpen = false;
-  }
-
-  // --- Loading task helpers ---
-
-  taskProgressInfo(task: LoadingTask): ProgressHeader {
-    return formatProgressHeader(task, 'dataset', task.embedder);
-  }
-
-  taskIsIndeterminate(task: LoadingTask): boolean {
-    return isProgressIndeterminate(task);
   }
 }

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -1,0 +1,229 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
+import { LoadingTask } from '../models/api.models';
+import { AchievementsService } from './achievements.service';
+import { DatasetStateService } from './dataset-state.service';
+import { DatasetsApiService } from './datasets-api.service';
+import { DetectorsApiService } from './detectors-api.service';
+import { ProgressEventsService } from './progress-events.service';
+
+/**
+ * Owns the Dashboard's per-task loading-row state and the bookkeeping
+ * that drives the "poll until everything settles, then refresh"
+ * behaviour. Lifted out of `DashboardComponent` so the dashboard is a
+ * thinner layout/wiring shell — it reads the published lists, listens
+ * for completion side effects, and forwards user clicks (cancel /
+ * dismiss) here.
+ *
+ * Bookkeeping responsibilities, all of which used to live inline on the
+ * Dashboard component:
+ *  - Demux the raw SSE stream into "currently active" + "errored but
+ *    not yet dismissed" rows, so the dashboard table can keep failed
+ *    rows visible with the dashed loading bar + Dismiss button.
+ *  - Track `awaitedTaskIds` for tasks whose HTTP response landed
+ *    before the SSE stream caught up, so we don't bail out of polling
+ *    before they're observed.
+ *  - Track `completedTaskIds` / `completedModelTaskIds` so we can fire
+ *    `datasetState.refresh()` + `achievements.refresh()` the moment a
+ *    task finishes (not only when the whole batch is idle).
+ *  - Drive `datasetState.setLoading()` based on active dataset tasks.
+ */
+@Injectable({ providedIn: 'root' })
+export class DashboardLoadingTasksService {
+  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
+  private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
+
+  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
+  readonly detectorLoadingTasks$ = this.detectorLoadingTasksSubject.asObservable();
+
+  private polling$ = new Subject<void>();
+  private detectorPolling$ = new Subject<void>();
+
+  private awaitedTaskIds = new Set<string>();
+  private completedTaskIds = new Set<string>();
+  private completedModelTaskIds = new Set<string>();
+  private datasetPollingActive = false;
+  private detectorPollingActive = false;
+
+  constructor(
+    private progressEvents: ProgressEventsService,
+    private datasetsApi: DatasetsApiService,
+    private detectorsApi: DetectorsApiService,
+    private datasetState: DatasetStateService,
+    private achievements: AchievementsService,
+  ) {
+    // SSE pushes the initial snapshot on connect, so the first event on
+    // each channel tells us whether there's anything in flight — auto-
+    // resume polling without the dashboard having to coordinate it.
+    this.progressEvents.loadingTasks$
+      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')))
+      .subscribe(() => this.startProgressPolling());
+    this.progressEvents.detectorLoadingTasks$
+      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')))
+      .subscribe(() => this.startDetectorProgressPolling());
+  }
+
+  get loadingTasks(): LoadingTask[] {
+    return this.loadingTasksSubject.value;
+  }
+
+  get detectorLoadingTasks(): LoadingTask[] {
+    return this.detectorLoadingTasksSubject.value;
+  }
+
+  /** Map dataset_id → LoadingTask for tasks that match an existing dataset row. */
+  get inlineTaskMap(): Map<string, LoadingTask> {
+    const map = new Map<string, LoadingTask>();
+    const datasetIds = new Set(this.datasetState.datasets.map((d) => d.id));
+    for (const task of this.loadingTasks) {
+      if (task.dataset_id && datasetIds.has(task.dataset_id)) {
+        map.set(task.dataset_id, task);
+      }
+    }
+    return map;
+  }
+
+  /** Loading tasks that have no matching dataset row (new imports, etc.). */
+  get orphanLoadingTasks(): LoadingTask[] {
+    const datasetIds = new Set(this.datasetState.datasets.map((d) => d.id));
+    return this.loadingTasks.filter((t) => !t.dataset_id || !datasetIds.has(t.dataset_id));
+  }
+
+  getInlineTask(datasetId: string): LoadingTask | undefined {
+    return this.inlineTaskMap.get(datasetId);
+  }
+
+  getInlineDetectorTask(modelId: string): LoadingTask | undefined {
+    return this.detectorLoadingTasks.find((t) => t.detector_id === modelId);
+  }
+
+  startProgressPolling(awaitTaskId?: string, onComplete?: () => void): void {
+    // Register any task we've been told to expect.  See the field
+    // comment on `awaitedTaskIds` for why this is needed.
+    if (awaitTaskId) {
+      this.awaitedTaskIds.add(awaitTaskId);
+    }
+    // If polling is already active, don't restart — the existing loop
+    // already covers all tasks.  This avoids clearing completedTaskIds
+    // and losing track of tasks that just finished.
+    if (this.datasetPollingActive) {
+      return;
+    }
+    this.datasetPollingActive = true;
+    this.completedTaskIds.clear();
+
+    this.progressEvents.loadingTasks$
+      .pipe(takeUntil(this.polling$))
+      .subscribe({
+        next: (tasks: LoadingTask[]) => {
+          // Any task we were waiting for has now shown up in the SSE
+          // stream — drop it from the awaited set so the bail-out check
+          // below can fire as soon as the stream goes quiet.
+          for (const t of tasks) {
+            this.awaitedTaskIds.delete(t.task_id);
+          }
+
+          // Separate active from finished. Failed tasks are surfaced
+          // globally by SseErrorRouterService → ToastService; we just
+          // keep them in the inline list so the row still shows the
+          // dashed loading bar with the error text.
+          const active = tasks.filter((t) => t.status !== 'idle');
+          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
+          const failed = errored.filter((t) => t.error !== 'Cancelled');
+
+          this.loadingTasksSubject.next([...active, ...failed]);
+
+          // Detect tasks that just completed successfully so we can
+          // refresh the registry immediately (not only when ALL finish).
+          const justFinished = tasks.filter(
+            (t) => t.status === 'idle' && !t.error && !this.completedTaskIds.has(t.task_id),
+          );
+          for (const t of justFinished) {
+            this.completedTaskIds.add(t.task_id);
+          }
+          if (justFinished.length > 0) {
+            this.datasetState.refresh();
+            this.achievements.refresh();
+          }
+
+          this.datasetState.setLoading(active.length > 0);
+
+          if (active.length === 0 && this.awaitedTaskIds.size === 0) {
+            // No more active tasks and no awaited task pending — stop
+            // polling.
+            this.polling$.next();
+            this.datasetPollingActive = false;
+            // Refresh unless we just did (justFinished already triggered it)
+            if (justFinished.length === 0) {
+              this.datasetState.refresh();
+            }
+            if (onComplete && failed.length === 0) {
+              onComplete();
+            }
+          }
+        },
+      });
+  }
+
+  startDetectorProgressPolling(onComplete?: () => void): void {
+    if (this.detectorPollingActive) {
+      return;
+    }
+    this.detectorPollingActive = true;
+    this.completedModelTaskIds.clear();
+
+    this.progressEvents.detectorLoadingTasks$
+      .pipe(takeUntil(this.detectorPolling$))
+      .subscribe({
+        next: (tasks: LoadingTask[]) => {
+          const active = tasks.filter((t) => t.status !== 'idle');
+          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
+          const failed = errored.filter((t) => t.error !== 'Cancelled');
+
+          this.detectorLoadingTasksSubject.next([...active, ...failed]);
+
+          // Detect tasks that just completed successfully
+          const justFinished = tasks.filter(
+            (t) => t.status === 'idle' && !t.error && !this.completedModelTaskIds.has(t.task_id),
+          );
+          for (const t of justFinished) {
+            this.completedModelTaskIds.add(t.task_id);
+          }
+          if (justFinished.length > 0) {
+            this.datasetState.refresh();
+            this.achievements.refresh();
+          }
+
+          if (active.length === 0) {
+            this.detectorPolling$.next();
+            this.detectorPollingActive = false;
+            if (justFinished.length === 0) {
+              this.datasetState.refresh();
+            }
+            if (onComplete && failed.length === 0) {
+              onComplete();
+            }
+          }
+        },
+      });
+  }
+
+  cancelLoadingTask(taskId: string): void {
+    this.datasetsApi.cancelTask(taskId).subscribe();
+  }
+
+  dismissLoadingTask(taskId: string): void {
+    this.loadingTasksSubject.next(this.loadingTasks.filter((t) => t.task_id !== taskId));
+  }
+
+  cancelDetectorLoadingTask(taskId: string): void {
+    this.detectorsApi.cancelDetectorLoadingTask(taskId).subscribe();
+  }
+
+  dismissDetectorLoadingTask(taskId: string): void {
+    this.detectorLoadingTasksSubject.next(
+      this.detectorLoadingTasks.filter((t) => t.task_id !== taskId),
+    );
+  }
+}

--- a/frontend/src/app/services/dashboard-modals.service.ts
+++ b/frontend/src/app/services/dashboard-modals.service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AutoDetectResultsData, DatasetRegistryEntry } from '../models/api.models';
+
+export interface CombineDatasetsState {
+  open: boolean;
+  datasets: DatasetRegistryEntry[];
+}
+
+export interface CombineDetectorsState {
+  open: boolean;
+}
+
+export interface ExportState {
+  open: boolean;
+  detectorName: string;
+}
+
+export interface AddLabelsState {
+  open: boolean;
+  detectorId: string;
+  detectorName: string;
+}
+
+export interface FindResultsState {
+  open: boolean;
+  data: AutoDetectResultsData;
+}
+
+export interface StatsState {
+  open: boolean;
+  datasetId: string;
+  datasetName: string;
+}
+
+/**
+ * Singleton owner of the Dashboard's row-action and selection-action
+ * modal states. Lifting these out of `DashboardComponent` keeps the
+ * dashboard a thinner layout/wiring shell — opening any of these modals
+ * is `modals.openX(...)`, closing is `modals.closeX()`, and the modal
+ * `@if` blocks in the template read directly off `modals.x.open`.
+ *
+ * The dataset-importer and new-detector flows stay on
+ * `NewThingFlowsService` (they're opened from places other than the
+ * dashboard too — e.g. the top-bar context pulldowns).
+ */
+@Injectable({ providedIn: 'root' })
+export class DashboardModalsService {
+  private readonly combineDatasetsSubject = new BehaviorSubject<CombineDatasetsState>({
+    open: false,
+    datasets: [],
+  });
+  private readonly combineDetectorsSubject = new BehaviorSubject<CombineDetectorsState>({
+    open: false,
+  });
+  private readonly exportSubject = new BehaviorSubject<ExportState>({
+    open: false,
+    detectorName: '',
+  });
+  private readonly addLabelsSubject = new BehaviorSubject<AddLabelsState>({
+    open: false,
+    detectorId: '',
+    detectorName: '',
+  });
+  private readonly findResultsSubject = new BehaviorSubject<FindResultsState>({
+    open: false,
+    data: { results: {} },
+  });
+  private readonly statsSubject = new BehaviorSubject<StatsState>({
+    open: false,
+    datasetId: '',
+    datasetName: '',
+  });
+
+  readonly combineDatasets$ = this.combineDatasetsSubject.asObservable();
+  readonly combineDetectors$ = this.combineDetectorsSubject.asObservable();
+  readonly export$ = this.exportSubject.asObservable();
+  readonly addLabels$ = this.addLabelsSubject.asObservable();
+  readonly findResults$ = this.findResultsSubject.asObservable();
+  readonly stats$ = this.statsSubject.asObservable();
+
+  get combineDatasets(): CombineDatasetsState {
+    return this.combineDatasetsSubject.value;
+  }
+
+  get combineDetectors(): CombineDetectorsState {
+    return this.combineDetectorsSubject.value;
+  }
+
+  get export(): ExportState {
+    return this.exportSubject.value;
+  }
+
+  get addLabels(): AddLabelsState {
+    return this.addLabelsSubject.value;
+  }
+
+  get findResults(): FindResultsState {
+    return this.findResultsSubject.value;
+  }
+
+  get stats(): StatsState {
+    return this.statsSubject.value;
+  }
+
+  openCombineDatasets(datasets: DatasetRegistryEntry[]): void {
+    this.combineDatasetsSubject.next({ open: true, datasets });
+  }
+
+  closeCombineDatasets(): void {
+    this.combineDatasetsSubject.next({ open: false, datasets: [] });
+  }
+
+  openCombineDetectors(): void {
+    this.combineDetectorsSubject.next({ open: true });
+  }
+
+  closeCombineDetectors(): void {
+    this.combineDetectorsSubject.next({ open: false });
+  }
+
+  openExport(detectorName: string): void {
+    this.exportSubject.next({ open: true, detectorName });
+  }
+
+  closeExport(): void {
+    this.exportSubject.next({ open: false, detectorName: '' });
+  }
+
+  openAddLabels(detectorId: string, detectorName: string): void {
+    this.addLabelsSubject.next({ open: true, detectorId, detectorName });
+  }
+
+  closeAddLabels(): void {
+    this.addLabelsSubject.next({ open: false, detectorId: '', detectorName: '' });
+  }
+
+  openFindResults(data: AutoDetectResultsData): void {
+    this.findResultsSubject.next({ open: true, data });
+  }
+
+  closeFindResults(): void {
+    this.findResultsSubject.next({ open: false, data: { results: {} } });
+  }
+
+  openStats(datasetId: string, datasetName: string): void {
+    this.statsSubject.next({ open: true, datasetId, datasetName });
+  }
+
+  closeStats(): void {
+    this.statsSubject.next({ open: false, datasetId: '', datasetName: '' });
+  }
+}

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject, forkJoin, of } from 'rxjs';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
-import { DatasetRegistryEntry, LoadingTask, DetectorRegistryEntry } from '../models/api.models';
+import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
 import { DatasetsApiService } from './datasets-api.service';
 import { DetectorsApiService } from './detectors-api.service';
 
@@ -9,7 +9,6 @@ import { DetectorsApiService } from './detectors-api.service';
 export class DatasetStateService implements OnDestroy {
   private readonly datasetsSubject = new BehaviorSubject<DatasetRegistryEntry[]>([]);
   private readonly detectorsSubject = new BehaviorSubject<DetectorRegistryEntry[]>([]);
-  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
   private readonly loadingSubject = new BehaviorSubject<boolean>(false);
   private readonly progressMessageSubject = new BehaviorSubject<string>('');
   /** Last registry-fetch error, or null if the most recent fetch
@@ -28,7 +27,6 @@ export class DatasetStateService implements OnDestroy {
 
   readonly datasets$ = this.datasetsSubject.asObservable();
   readonly detectors$ = this.detectorsSubject.asObservable();
-  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
   readonly loading$ = this.loadingSubject.asObservable();
   readonly progressMessage$ = this.progressMessageSubject.asObservable();
   readonly error$ = this.errorSubject.asObservable();
@@ -84,14 +82,6 @@ export class DatasetStateService implements OnDestroy {
     return this.detectorsSubject.value;
   }
 
-  get loadingTasks(): LoadingTask[] {
-    return this.loadingTasksSubject.value;
-  }
-
-  setLoadingTasks(tasks: LoadingTask[]): void {
-    this.loadingTasksSubject.next(tasks);
-  }
-
   get loading(): boolean {
     return this.loadingSubject.value;
   }
@@ -123,7 +113,6 @@ export class DatasetStateService implements OnDestroy {
   clear(): void {
     this.datasetsSubject.next([]);
     this.detectorsSubject.next([]);
-    this.loadingTasksSubject.next([]);
     this.loadingSubject.next(false);
     this.progressMessageSubject.next('');
     this.errorSubject.next(null);


### PR DESCRIPTION
## Summary

Continues `docs/plans/frontend-bundle-organization.md` with item **#2 (Split `dashboard.component.ts`)**. The page-shell god component drops 1419 → 1175 lines by extracting two focused services with clear, single-purpose responsibilities. Plan doc updated with a "What shipped" entry that includes explicit notes on the deviations from the original plan.

- **`DashboardModalsService`** — single source of truth for the six row-action / selection-action modal states (combine-datasets, combine-detectors, label-exporter, label-importer, find-results, dataset-stats). Replaces six parallel `xModalOpen` + `xPayload` field pairs and their open/close glue. Template `@if` blocks now read directly off `modals.x.open`. Importer / new-detector flows stay on `NewThingFlowsService` because they're also opened from the top-bar context pulldowns.
- **`DashboardLoadingTasksService`** — owns the per-task loading lists, the polling subscriptions, and the `awaitedTaskIds` / `completedTaskIds` / `completedModelTaskIds` bookkeeping. Polling auto-resumes on construction whenever the SSE stream shows an active task, replacing the dashboard's bespoke `resumeActivePolling` and two `startProgressPolling` methods. `inlineTaskMap`, `orphanLoadingTasks`, `getInlineTask`, `getInlineDetectorTask`, and the cancel / dismiss helpers move with the state.
- **`DatasetStateService`** cleanup — dropped the dead `loadingTasksSubject` / `loadingTasks$` / `setLoadingTasks` surface (nobody read it after the polling moved).

## What we did NOT do (and why)

The original plan suggested **pushing row actions into the card components** and **moving column-resize forwarding out of the dashboard**. Both were rejected and the reasoning is recorded in the plan doc so the next contributor sees it:

- **Row actions stay on the dashboard.** Pushing rename / delete / load / unload / security / export / addLabels into `DatasetCardComponent` / `DetectorCardComponent` would require the cards to inject `DatasetsApiService`, `DetectorsApiService`, `VtDialogService`, and `DatasetStateService` — coupling presentation to backend + dialog. Cards stay presentational. Extracting the handlers into another service was also rejected: they have a single caller (the dashboard template), so the move would just shuffle names without making anything more reusable.
- **Column resize / drag-reorder forwarding stays in the component.** The two `@HostListener('document:mousemove')` / `('document:mouseup')` methods can't move to a service. The actual logic already lives in `ManagedColumns` / `DashboardColumnsService`; the dashboard's contribution is two lines of "forward to both managers", which is already minimal.

## Bundle effect

Bundle size was not the goal of this checkpoint (the goal was clarity / maintainability), and the numbers reflect that:

- Initial bundle: 527.48 kB → 527.25 kB raw (136.49 → 136.47 kB gzip) — essentially unchanged. Both modals are `@defer`-loaded so the new service code lives in the lazy chunk.
- Lazy `dashboard-component` chunk: 129.71 → 131.61 kB raw (22.57 → 22.82 kB gzip) — slightly larger because the service plumbing adds Angular DI overhead without yet enabling cross-component dedup.

## Test plan

- [x] `./run-tests.sh` — full suite passes (4201 passed, 1 skipped, 2 xpassed)
- [x] `./run-tests.sh core` — ruff / codespell / deptry / pip-audit / pyright / OpenAPI snapshot / frontend `build:prod` / frontend `audit` all green
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: open dashboard, open each of the 6 modals, kick off a dataset load and a detector load, verify polling resumes correctly after page reload while a load is in flight (not exercised in this remote session — no browser available)

https://claude.ai/code/session_014fAp2GdK6cvM4y8neCTnr6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fAp2GdK6cvM4y8neCTnr6)_