### PR TITLE
Restructure Demo DatasetImporter to match other importer flows

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -16,6 +16,8 @@
     [activeDemoTab]="activeTab"
     (activeDemoTabChange)="selectDemoTabWithEmbedder($event)"
     [demoCols]="demoCols"
+    [showDemoMediaTypeTabs]="false"
+    [selectedDemoName]="selectedDemo?.name || ''"
     (demoSelected)="selectDemo($event)"
     [sfPathInputValue]="sfPathInputValue"
     (sfPathInputValueChange)="sfPathInputValue = $event"
@@ -25,36 +27,48 @@
     [lfFolderName]="lfFolderName"
     (lfFilesDropped)="lfOnFilesDropped($event)"
   >
-    <ng-container demoExtras>
-      @if (activeTab) {
+    <ng-container demoBefore>
+      <vt-import-config
+        mediaTypeFieldId="demo-media-type"
+        [mediaType]="activeTab"
+        (mediaTypeChange)="selectDemoTabWithEmbedder($event)"
+        [mediaTypeOptions]="demoTabs"
+        [mediaTypeOptionLabels]="mediaTypeLabels"
+        [mediaTypeOptionIcons]="demoMediaTypeIcons"
+      ></vt-import-config>
+    </ng-container>
+
+    <ng-container demoAfter>
+      @if (selectedDemo) {
         <div class="form-group">
           <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
           <input
             id="demo-dataset-name"
             type="text"
             class="form-input"
-            [(ngModel)]="demoDatasetName"
+            [ngModel]="demoDatasetName"
+            (ngModelChange)="onDemoDatasetNameInput($event)"
             placeholder="Leave blank to use the demo's name"
           />
         </div>
-      }
 
-      @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
-        <div class="form-group form-group--section">
-          <vt-import-advanced
-            [availableConverters]="[]"
-            [nativeType]="''"
-            [typeLabels]="mediaTypeLabels"
-            [embedders]="demoEmbedders"
-            [clippers]="demoClippers"
-            [showSourceSpecs]="false"
-            [sourceSpecs]="[]"
-            [selectedEmbedder]="selectedDemoEmbedder"
-            (selectedEmbedderChange)="onDemoEmbedderChange($event)"
-            [selectedClipper]="selectedDemoClipper"
-            (clipperChooserRequested)="openClipperChooser('demo')"
-          ></vt-import-advanced>
-        </div>
+        @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
+          <div class="form-group form-group--section">
+            <vt-import-advanced
+              [availableConverters]="[]"
+              [nativeType]="''"
+              [typeLabels]="mediaTypeLabels"
+              [embedders]="demoEmbedders"
+              [clippers]="demoClippers"
+              [showSourceSpecs]="false"
+              [sourceSpecs]="[]"
+              [selectedEmbedder]="selectedDemoEmbedder"
+              (selectedEmbedderChange)="onDemoEmbedderChange($event)"
+              [selectedClipper]="selectedDemoClipper"
+              (clipperChooserRequested)="openClipperChooser('demo')"
+            ></vt-import-advanced>
+          </div>
+        }
       }
     </ng-container>
 
@@ -383,6 +397,13 @@
           Import
         }
       </button>
+    </div>
+  }
+
+  @if (activePickerView === 'demo' && selectedImporter) {
+    <div class="form-actions" modal-footer>
+      <button class="btn btn--secondary" (click)="close()">Cancel</button>
+      <button class="btn btn--primary" (click)="submitDemo()" [disabled]="!selectedDemo">Import</button>
     </div>
   }
   <vt-clipper-chooser

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -506,7 +506,7 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.demoCols.sortAsc).toBeTrue();
   });
 
-  it('should emit demoSelected and close on demo selection', () => {
+  it('should record the demo selection without submitting on row click', () => {
     flushImporters();
     spyOn(component.demoSelected, 'emit');
     spyOn(component.closed, 'emit');
@@ -514,26 +514,58 @@ describe('DatasetImporterModalComponent', () => {
     openAndFlushDemoPicker();
 
     component.selectDemo(mockDemos[0] as any);
+    expect(component.selectedDemo).toBe(mockDemos[0] as any);
+    // Auto-populates the Dataset Name from the chosen demo's label.
+    expect(component.demoDatasetName).toBe(mockDemos[0].label);
+    // No emit/close until the Import footer button is clicked.
+    expect(component.demoSelected.emit).not.toHaveBeenCalled();
+    expect(component.closed.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit demoSelected and close when submitDemo is called', () => {
+    flushImporters();
+    spyOn(component.demoSelected, 'emit');
+    spyOn(component.closed, 'emit');
+
+    openAndFlushDemoPicker();
+
+    component.selectDemo(mockDemos[0] as any);
+    component.submitDemo();
     expect(component.demoSelected.emit).toHaveBeenCalled();
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render the demo tab bar but no rows until a media-type tab is clicked', () => {
+  it('should hide the demo tab bar in favor of a dropdown above the grid', () => {
     flushImporters();
     openAndFlushDemoPicker();
 
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
 
-    const tabs = el.querySelectorAll('.demo-tab');
-    expect(tabs.length).toBe(2);
+    // The inner media-type tabs are replaced by a <vt-import-config>
+    // dropdown — so no .demo-tab buttons render in this modal anymore.
+    expect(el.querySelectorAll('.demo-tab').length).toBe(0);
 
-    // No tab auto-selected → no rows rendered yet.
+    // No media type picked yet → no rows.
     expect(el.querySelectorAll('.demo-row').length).toBe(0);
 
     selectDemoTabAndFlush('audio', mockEmbedders);
     fixture.detectChanges();
     expect(el.querySelectorAll('.demo-row').length).toBe(1);
+  });
+
+  it('should clear the row selection when the media type changes', () => {
+    flushImporters();
+    openAndFlushDemoPicker();
+    selectDemoTabAndFlush('audio', mockEmbedders);
+
+    component.selectDemo(mockDemos[0] as any);
+    expect(component.selectedDemo).not.toBeNull();
+    expect(component.demoDatasetName).toBe(mockDemos[0].label);
+
+    selectDemoTabAndFlush('image', mockImageEmbedders);
+    expect(component.selectedDemo).toBeNull();
+    expect(component.demoDatasetName).toBe('');
   });
 
   it('should get correct tab label from media types', () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -66,6 +66,13 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Optional user-supplied dataset name for demo imports.  Empty means
    *  "use the demo entry's label". */
   demoDatasetName = '';
+  /** Whether the user has manually edited :prop:`demoDatasetName` (so we
+   *  stop auto-overwriting it when a different demo row is picked). */
+  private demoDatasetNameDirty = false;
+  /** Currently-selected demo row.  Clicking a row sets this; the Import
+   *  button in the footer then commits the selection.  ``null`` means
+   *  nothing is selected yet, so the Import button is disabled. */
+  selectedDemo: DemoDataset | null = null;
 
   // Demo table column metadata + controller. Mirrors the Dashboard datagrid:
   // percentage widths summing to 100, draggable column reorder, click-to-sort
@@ -580,6 +587,8 @@ export class DatasetImporterModalComponent implements OnInit {
     this.demoTabs = [];
     this.activeTab = '';
     this.demoDatasetName = '';
+    this.demoDatasetNameDirty = false;
+    this.selectedDemo = null;
 
     this.datasetsApi.getMediaTypes().subscribe({
       next: (res) => {
@@ -823,7 +832,42 @@ export class DatasetImporterModalComponent implements OnInit {
     return this.allEmbedders.filter((e) => e.media_type_id === this.activeTab);
   }
 
+  /** Cached map of ``type_id`` → icon string for the demo media-type
+   *  dropdown.  Parallel to :prop:`mediaTypeOptionIcons` (which is keyed
+   *  by ``folder_import_name``); the demo flow uses ``type_id`` so we
+   *  expose a separate map keyed accordingly. */
+  private _demoIconsSource: MediaTypeInfo[] | null = null;
+  private _demoIconsCache: Record<string, string> = {};
+  get demoMediaTypeIcons(): Record<string, string> {
+    if (this._demoIconsSource !== this.mediaTypes) {
+      const out: Record<string, string> = {};
+      for (const mt of this.mediaTypes) {
+        if (mt.icon) out[mt.type_id] = mt.icon;
+      }
+      this._demoIconsCache = out;
+      this._demoIconsSource = this.mediaTypes;
+    }
+    return this._demoIconsCache;
+  }
+
+  /** Click handler for a row in the demo grid.  Records the selection
+   *  and auto-populates the Dataset Name input (unless the user has
+   *  manually edited it).  The actual import is deferred to
+   *  :meth:`submitDemo`, which the Import footer button calls. */
   selectDemo(demo: DemoDataset): void {
+    this.selectedDemo = demo;
+    if (!this.demoDatasetNameDirty) {
+      this.demoDatasetName = demo.label || '';
+    }
+  }
+
+  /** Commit the currently-selected demo: emit ``demoSelected`` so the
+   *  dashboard kicks off the demo load, then close the modal.  Bound to
+   *  the Import footer button; disabled in the template until a row is
+   *  selected. */
+  submitDemo(): void {
+    const demo = this.selectedDemo;
+    if (!demo) return;
     const userName = (this.demoDatasetName || '').trim();
     this.demoSelected.emit({
       ...demo,
@@ -834,8 +878,22 @@ export class DatasetImporterModalComponent implements OnInit {
     this.closed.emit();
   }
 
+  /** Called when the user types into the demo Dataset Name input.  Marks
+   *  it as dirty so subsequent row picks don't overwrite the user's
+   *  value. */
+  onDemoDatasetNameInput(value: string): void {
+    this.demoDatasetName = value;
+    this.demoDatasetNameDirty = true;
+  }
+
   selectDemoTabWithEmbedder(tab: string): void {
     this.selectDemoTab(tab);
+    // Switching media type clears any prior row selection and resets the
+    // auto-populated Dataset Name so the next row pick can fill it in.
+    this.selectedDemo = null;
+    if (!this.demoDatasetNameDirty) {
+      this.demoDatasetName = '';
+    }
     // Reset embedder selection for the new tab
     const embedders = this.allEmbedders.filter((e) => e.media_type_id === tab);
     this.demoEmbedder = embedders.length > 0 ? embedders[0].name : '';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -45,21 +45,23 @@
     } @else if (demos.length === 0) {
       <p class="empty-state">{{ demoEmptyText }}</p>
     } @else {
-      <div class="demo-tab-bar">
-        @for (tab of demoTabs; track tab) {
-          <button
-            class="demo-tab"
-            [class.active]="activeDemoTab === tab"
-            (click)="activeDemoTabChange.emit(tab)"
-            [title]="'Filter demos by media type: ' + getDemoTabText(tab)"
-          >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabText(tab) }}</button>
+      @if (showDemoMediaTypeTabs) {
+        <div class="demo-tab-bar">
+          @for (tab of demoTabs; track tab) {
+            <button
+              class="demo-tab"
+              [class.active]="activeDemoTab === tab"
+              (click)="activeDemoTabChange.emit(tab)"
+              [title]="'Filter demos by media type: ' + getDemoTabText(tab)"
+            >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabText(tab) }}</button>
+          }
+        </div>
+        @if (!activeDemoTab) {
+          <p class="tab-bar-hint">{{ demoNoTabHint }}</p>
         }
-      </div>
-      @if (!activeDemoTab) {
-        <p class="tab-bar-hint">{{ demoNoTabHint }}</p>
       }
 
-      <ng-content select="[demoExtras]"></ng-content>
+      <ng-content select="[demoBefore]"></ng-content>
 
       @if (activeDemoTab && demoCols) {
         <div class="demo-content-area">
@@ -91,6 +93,7 @@
                 <tr
                   class="demo-row"
                   [class.ready]="demo.status === 'ready'"
+                  [class.selected]="selectedDemoName === demo.name"
                   [class.disabled]="demoRowDisabled(demo)"
                   role="button"
                   tabindex="0"
@@ -125,6 +128,8 @@
           </table>
         </div>
       }
+
+      <ng-content select="[demoAfter]"></ng-content>
     }
   </div>
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -33,9 +33,12 @@ import { ManagedColumns } from '../../../../utils/managed-columns';
  *  parent projects those into named content slots so the visual order
  *  on each flow stays unchanged:
  *
- *  - ``[demoExtras]`` — sits between the demo media-type tabs and the
- *    demo table (Add Dataset uses it for the Dataset Name + Advanced
- *    block; New Detector leaves it empty).
+ *  - ``[demoBefore]`` — sits between the demo media-type tabs and the
+ *    demo table (Add Dataset uses it to project a media-type dropdown
+ *    that replaces the inner tabs; New Detector leaves it empty).
+ *  - ``[demoAfter]`` — sits below the demo table (Add Dataset uses it
+ *    for the Dataset Name + Advanced block; New Detector leaves it
+ *    empty).
  *  - ``[sfBefore]`` / ``[sfAfter]`` — sit above/below the typed path
  *    input on the server-folder flow.
  *  - ``[lfBefore]`` / ``[lfAfter]`` — sit above/below the dropzone on
@@ -116,6 +119,18 @@ export class SourcePickerComponent {
   @Input() demoRowDisabledFn: ((demo: DemoDataset) => boolean) | null = null;
   /** Optional formatter for the ``title`` attribute on each demo row. */
   @Input() demoRowTitleFn: ((demo: DemoDataset) => string) | null = null;
+
+  /** When ``true`` (default) the inner media-type tab bar renders above
+   *  the demo table.  Callers that want to render their own media-type
+   *  picker (e.g. the Add Dataset modal, which uses a dropdown to match
+   *  the other importer flows) set this to ``false`` and project their
+   *  widget into the ``[demoBefore]`` slot. */
+  @Input() showDemoMediaTypeTabs = true;
+
+  /** Name of the currently-selected demo row.  Used to highlight the
+   *  selected row when the parent treats row clicks as a selection (not
+   *  an immediate submit).  Empty string disables the highlight. */
+  @Input() selectedDemoName = '';
 
   // === Server folder source view ===
 

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -198,6 +198,11 @@
 
 .demo-row {
   &.ready .col-name { color: var(--color-good); }
+  &.selected {
+    background: var(--bg-selected, var(--bg-hover));
+    box-shadow: inset 3px 0 0 0 var(--accent);
+    &:hover { background: var(--bg-selected, var(--bg-hover)); }
+  }
 }
 
 .badge-ready, .badge-embedding, .badge-download {


### PR DESCRIPTION
## Summary

The Demo DatasetImporter had a UI that didn't match the other DatasetImporter flows: media-type **tabs** above the form, then Dataset Name + Advanced *above* the grid, and a grid where clicking a row submitted immediately.

Restructured it to mirror the other flows:

1. **Dataset MediaType pulldown** (`vt-import-config`, same widget the server-folder / local-folder flows use)
2. **Grid of demos** — click selects a row, doesn't submit
3. **Dataset Name** — auto-populates from the chosen demo's `label`, editable
4. **Advanced** — collapsed by default, only renders when there's something to configure (multiple embedders or clippers)
5. **Cancel / Import** — standard footer buttons; Import is disabled until a row is selected

## Implementation notes

- `vt-source-picker` grows two new content slots (`[demoBefore]`, `[demoAfter]`) and a `showDemoMediaTypeTabs` input (default `true`, so the New Detector modal's tab UI is unchanged). The old `[demoExtras]` slot had a single consumer and was removed.
- Selected demo row gets a left-rail + muted background highlight via a new `[selectedDemoName]` input on `vt-source-picker`.
- Switching the media-type dropdown clears the row selection and resets the auto-populated Dataset Name (unless the user has typed one).
- Two existing spec cases updated to cover the new select-then-submit flow; two new cases cover the cleared-selection-on-tab-change behavior and the absence of the inner tab bar.

## Test plan

- [x] `./run-tests.sh core` — 589 passed (includes frontend `npm run build:prod`)
- [ ] Manual verification in browser: open Add Dataset → Demo, pick media type from dropdown, click a row, confirm Dataset Name auto-fills, expand Advanced, click Import

https://claude.ai/code/session_01EMFUNpYNKkZQuR2vdGcrn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMFUNpYNKkZQuR2vdGcrn9)_