### PR TITLE
Split label-view.component.ts into directive + service + factory

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,7 @@
 # Frontend bundle organization
 
-Status: **#1 shipped (all five checkpoints). #2 shipped.** Items #3–#6
-are scoped but not started.
+Status: **#1 shipped (all five checkpoints). #2 shipped. #3 shipped.**
+Items #4–#6 are scoped but not started.
 
 ## What shipped
 
@@ -152,6 +152,69 @@ are scoped but not started.
   component dedup.  Bundle size was not the goal of this checkpoint —
   the structural goal (clear ownership of modal state and polling, a
   smaller dashboard shell) is what shipped.
+- **#3 Split `label-view.component.ts`**: extracted three focused
+  units out of the coordinator component to drop it from 1196 → 1071
+  lines.
+  - **`PanelResizeDirective`** (`vtPanelResize`) folds the two
+    near-identical 50-line divider drag handlers (left + right
+    mousedown / mousemove / mouseup) into a single standalone
+    directive bound to each divider in the template.  The directive
+    runs mousemove outside the Angular zone (matching the previous
+    inline behaviour) and emits a `widthChange` per move plus one
+    `resizeEnd` on release; the component receives those events and
+    handles side-specific concerns (auto-uncollapse on left, grid
+    snap on release, save-to-settings) in two small handlers per
+    side.  The four bound handler properties
+    (`boundMouseMove` / `boundMouseUp` / `boundRightMouseMove` /
+    `boundRightMouseUp`), the two `dragging` flags, the `NgZone`
+    injection, and the four `document.removeEventListener` calls in
+    `ngOnDestroy` all leave the parent.
+  - **`LabelViewPanelStateService`** owns the six per-media-type
+    preference dicts (`viewModeLeftDict`, `gridIconSizeLeftDict`,
+    `focusModeLeftDict`, `focusModeRightDict`, `panelPxLeftDict`,
+    `panelPxRightDict`) and the active `currentMediaType` pointer.
+    The component reads getters off the service (`viewModeLeft`,
+    `gridGoalWidthLeft`, `focusModeLeft`, `focusModeRight`) in the
+    template, hands fresh settings blobs to
+    `panelState.loadFromSettings()`, and calls
+    `panelState.savePanelPx(side, px)` after a drag releases.  The
+    `loadSettings()` body shrunk from a six-key cascade with
+    duplicate type-guards down to a single `loadFromSettings` call
+    plus an `applyPanelPx()` re-clamp.  The service is component-
+    scoped (provided in the component's `providers`) so it resets
+    cleanly between test instances.
+  - **`buildMediaContextMenuItems(mediaType)`** factory replaces the
+    ~30-line inline switch on `cropAble` inside
+    `onMediaContextRequest`.  The factory lives next to the
+    component so audio/image-specific menu items stay near the
+    flow that consumes them.
+  - **What we did NOT do** (deviations from the plan, noted so the
+    next contributor doesn't try and back them out):
+    - **`applyPanelPx` stays in the component.**  The plan suggested
+      a "panel-px ↔ panel-pct conversion utility module", but the
+      existing code already stores raw px (the `panel_pct_*`
+      settings-key names are a misnomer from an earlier draft).
+      The remaining `applyPanelPx` helper clamps stored widths
+      against current layout bounds (which needs `LEFT_MIN` /
+      `RIGHT_MIN` / `DIVIDER_TOTAL` / `CENTER_MIN` plus the live
+      `leftWidth` / `rightWidth` / `autopilotCollapsed` state),
+      so pulling it out would force the component to pass all that
+      state in on every call — a wash.  The service owns the
+      per-media-type dicts; the clamping math stays where the
+      constants live.
+    - **`MediaContextMenuComponent` itself was not rebuilt.**  The
+      plan mentioned moving the configuration data "into a small
+      per-flow factory", which is exactly what
+      `buildMediaContextMenuItems` does.  No structural change to
+      the rendering component was needed.
+  **Bundle effect.** Initial bundle unchanged at 527.25 kB raw /
+  136.46 kB gzip — label-view is a lazy-loaded route, so all gains
+  land in its chunk.  Lazy `label-view-component` chunk dropped from
+  ~58 kB → 55.72 kB raw (12.44 kB gzip) as the four divider-drag
+  handlers and the inline dict-loading cascade were replaced with
+  smaller delegations.  Structural goal — three focused files
+  (directive, service, pure factory) instead of one 1200-line
+  coordinator — is what shipped.
 - **#1 Checkpoint 4**: extracted `<vt-source-picker>` — the importer
   category-tab + sub-tab chrome plus the source-side widgets (demo
   media-type tabs + sortable demo table, server-folder typed-path
@@ -354,7 +417,7 @@ After: `DashboardComponent` is roughly a layout + selection +
 button-wiring component, with each domain concern owned by its
 service or card component.
 
-### #3 — Split `label-view.component.ts`
+### #3 — Split `label-view.component.ts` (shipped — see "What shipped")
 
 Goal: shrink the coordinator component (1196 lines, ~50 fields,
 ~160 methods). Existing section dividers: divider drag (left),

--- a/frontend/src/app/components/label-view/label-view-panel-state.service.ts
+++ b/frontend/src/app/components/label-view/label-view-panel-state.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import type { AppSettings } from '../../generated/api-client/models/app-settings';
+import { SettingsStateService } from '../../services/settings-state.service';
+import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+
+type ViewMode = 'grid' | 'list';
+type FocusMode = 'click' | 'hover';
+
+/**
+ * Per-media-type panel display preferences for `vt-label-view`.
+ *
+ * Tracks the six dicts (left view mode, left grid icon size, left/right focus
+ * mode, left/right saved panel widths) that used to live inline on
+ * `LabelViewComponent` and exposes them as computed getters keyed on the
+ * currently-active media type.  `loadFromSettings` hydrates the dicts from
+ * the loaded `AppSettings` blob; `savePanelPx` persists a width change for
+ * the active media type back through `SettingsStateService`.
+ *
+ * The component still owns the layout math and the CSS-var writes — this
+ * service only owns the per-media-type lookup tables and the persistence
+ * round-trip.
+ */
+@Injectable()
+export class LabelViewPanelStateService {
+  private viewModeLeftDict: Record<string, ViewMode> = {};
+  private gridIconSizeLeftDict: Record<string, string> = {};
+  private focusModeLeftDict: Record<string, FocusMode> = {};
+  private focusModeRightDict: Record<string, FocusMode> = {};
+  private panelPxLeftDict: Record<string, number> = {};
+  private panelPxRightDict: Record<string, number> = {};
+
+  private _currentMediaType = '';
+
+  constructor(private settingsState: SettingsStateService) {}
+
+  setMediaType(mediaType: string): void {
+    this._currentMediaType = mediaType;
+  }
+
+  get currentMediaType(): string {
+    return this._currentMediaType;
+  }
+
+  get viewModeLeft(): ViewMode {
+    return this.viewModeLeftDict[this._currentMediaType] ?? 'list';
+  }
+
+  get gridGoalWidthLeft(): number {
+    return iconSizeToGoalWidth(this.gridIconSizeLeftDict[this._currentMediaType] ?? 'M');
+  }
+
+  get focusModeLeft(): FocusMode {
+    return this.focusModeLeftDict[this._currentMediaType] ?? 'click';
+  }
+
+  get focusModeRight(): FocusMode {
+    return this.focusModeRightDict[this._currentMediaType] ?? 'click';
+  }
+
+  /** Saved width for `side` at the current media type, or null if none. */
+  getPanelPx(side: 'left' | 'right'): number | null {
+    const dict = side === 'left' ? this.panelPxLeftDict : this.panelPxRightDict;
+    return dict[this._currentMediaType] ?? null;
+  }
+
+  /** Persist `px` for the active media type. No-op if media type is empty. */
+  savePanelPx(side: 'left' | 'right', px: number): void {
+    if (!this._currentMediaType) return;
+    const dict = side === 'left' ? this.panelPxLeftDict : this.panelPxRightDict;
+    dict[this._currentMediaType] = px;
+    const key = side === 'left' ? 'panel_pct_left' : 'panel_pct_right';
+    this.settingsState.update({ [key]: { ...dict } }).subscribe();
+  }
+
+  loadFromSettings(settings: AppSettings): void {
+    const vm = settings.view_mode_left;
+    if (vm && typeof vm === 'object') this.viewModeLeftDict = vm as Record<string, ViewMode>;
+    const gs = settings.grid_icon_size_left;
+    if (gs && typeof gs === 'object') this.gridIconSizeLeftDict = gs as Record<string, string>;
+    const fl = settings.focus_mode_left;
+    if (fl && typeof fl === 'object') this.focusModeLeftDict = fl as Record<string, FocusMode>;
+    const fr = settings.focus_mode_right;
+    if (fr && typeof fr === 'object') this.focusModeRightDict = fr as Record<string, FocusMode>;
+    const pl = settings.panel_pct_left;
+    if (pl && typeof pl === 'object') this.panelPxLeftDict = pl as Record<string, number>;
+    const pr = settings.panel_pct_right;
+    if (pr && typeof pr === 'object') this.panelPxRightDict = pr as Record<string, number>;
+  }
+}

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -48,7 +48,14 @@
   </div>
   <div
     class="divider-left"
-    (mousedown)="onDividerMouseDown($event)"
+    vtPanelResize="left"
+    [layoutEl]="layoutRef.nativeElement"
+    [minWidth]="leftMin"
+    [opposingWidth]="rightWidth"
+    [centerMin]="CENTER_MIN"
+    [dividerTotal]="DIVIDER_TOTAL"
+    (widthChange)="onLeftWidthChange($event)"
+    (resizeEnd)="onLeftResizeEnd($event)"
   ></div>
   <div class="panel-center">
     <vt-center-panel
@@ -58,7 +65,14 @@
   </div>
   <div
     class="divider-right"
-    (mousedown)="onRightDividerMouseDown($event)"
+    vtPanelResize="right"
+    [layoutEl]="layoutRef.nativeElement"
+    [minWidth]="RIGHT_MIN"
+    [opposingWidth]="leftWidth"
+    [centerMin]="CENTER_MIN"
+    [dividerTotal]="DIVIDER_TOTAL"
+    (widthChange)="onRightWidthChange($event)"
+    (resizeEnd)="onRightResizeEnd($event)"
   ></div>
   <div class="panel-right">
     <vt-right-panel

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -33,7 +33,10 @@ import { ResortPromptModalComponent, ResortResult } from '../modals/resort-promp
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import type { LearnedSortResponse } from '../../generated/api-client/models/learned-sort-response';
 import { formatProgressMessage } from '../../utils/format-progress';
-import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+import { PanelResizeDirective } from './panel-resize.directive';
+import { LabelViewPanelStateService } from './label-view-panel-state.service';
+import { buildMediaContextMenuItems } from './media-context-menu-items';
 
 @Component({
   selector: 'vt-label-view',
@@ -47,7 +50,9 @@ import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/gr
     ResortPromptModalComponent,
     MediaContextMenuComponent,
     MediaCropModalComponent,
+    PanelResizeDirective,
   ],
+  providers: [LabelViewPanelStateService],
   templateUrl: './label-view.component.html',
   styleUrl: './label-view.component.scss',
 })
@@ -61,22 +66,18 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  back to cid-based vote display. */
   trainableModelName: string | null = null;
   labelingStatus: LabelingStatusResponse | null = null;
-  viewModeLeft: 'grid' | 'list' = 'list';
-  gridGoalWidthLeft: number = 80;
-  focusModeLeft: 'click' | 'hover' = 'click';
-  focusModeRight: 'click' | 'hover' = 'click';
-  private viewModeLeftDict: Record<string, 'grid' | 'list'> = {};
-  private gridIconSizeLeftDict: Record<string, string> = {};
-  private focusModeLeftDict: Record<string, 'click' | 'hover'> = {};
-  private focusModeRightDict: Record<string, 'click' | 'hover'> = {};
-  private panelPxLeftDict: Record<string, number> = {};
-  private panelPxRightDict: Record<string, number> = {};
-  private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
   autopilotCollapsed = false;
   autopilotEnabled = true;
   progressModalMetric: ProgressMetric | null = null;
+
+  // Per-media-type panel preferences (view mode, grid size, focus mode, saved
+  // widths) live on `panelState`; the template reads getters on it directly.
+  get viewModeLeft(): 'grid' | 'list' { return this.panelState.viewModeLeft; }
+  get gridGoalWidthLeft(): number { return this.panelState.gridGoalWidthLeft; }
+  get focusModeLeft(): 'click' | 'hover' { return this.panelState.focusModeLeft; }
+  get focusModeRight(): 'click' | 'hover' { return this.panelState.focusModeRight; }
 
   // Re-sort prompt state
   showResortPrompt = false;
@@ -90,12 +91,12 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     return Math.round(this.resortNextThreshold * 1.5);
   }
 
-  private readonly COLLAPSED_WIDTH = 48;
+  readonly COLLAPSED_WIDTH = 48;
   private savedLeftWidth = 260;
-  private readonly LEFT_MIN = 180;
-  private readonly RIGHT_MIN = 150;
-  private readonly CENTER_MIN = 100;
-  private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
+  readonly LEFT_MIN = 180;
+  readonly RIGHT_MIN = 150;
+  readonly CENTER_MIN = 100;
+  readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private scoringProgressPoll$: Subscription | null = null;
@@ -112,19 +113,12 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private rehydrateLearnedSub?: Subscription;
   private autopilotTextSortPending = false;
   private autopilotMediaSortPending = false;
-  private dragging = false;
-  private draggingRight = false;
-  private boundMouseMove = this.onMouseMove.bind(this);
-  private boundMouseUp = this.onMouseUp.bind(this);
-  private boundRightMouseMove = this.onRightMouseMove.bind(this);
-  private boundRightMouseUp = this.onRightMouseUp.bind(this);
 
   constructor(
     private sortingApi: SortingApiService,
     private detectorsApi: DetectorsApiService,
     private mediasApi: MediasApiService,
     private datasetsApi: DatasetsApiService,
-    private ngZone: NgZone,
     private labelSession: LabelSessionService,
     public mediaState: MediaStateService,
     public voteState: VoteStateService,
@@ -135,6 +129,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private progressEvents: ProgressEventsService,
     private newThingFlows: NewThingFlowsService,
     private toast: ToastService,
+    public panelState: LabelViewPanelStateService,
   ) {}
 
   ngOnInit(): void {
@@ -174,13 +169,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe((medias) => {
         if (medias.length > 0) {
           const newType = medias[0].type;
-          if (newType !== this.currentMediaType) {
-            this.currentMediaType = newType;
-            this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
-            this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
-            this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
-            this.applyPanelPx(newType);
+          if (newType !== this.panelState.currentMediaType) {
+            this.panelState.setMediaType(newType);
+            this.applyPanelPx();
           }
         }
         if (this.autopilotTextSortPending && medias.length > 0) {
@@ -267,87 +258,47 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.stopPolling();
-    document.removeEventListener('mousemove', this.boundMouseMove);
-    document.removeEventListener('mouseup', this.boundMouseUp);
-    document.removeEventListener('mousemove', this.boundRightMouseMove);
-    document.removeEventListener('mouseup', this.boundRightMouseUp);
   }
 
   // --- Divider drag ---
 
-  onDividerMouseDown(event: MouseEvent): void {
-    event.preventDefault();
-    this.dragging = true;
-    this.ngZone.runOutsideAngular(() => {
-      document.addEventListener('mousemove', this.boundMouseMove);
-      document.addEventListener('mouseup', this.boundMouseUp);
-    });
+  /** Min width the left panel can shrink to right now — autopilot-collapsed
+   *  state lets the user drag down to a thin sliver. */
+  get leftMin(): number {
+    return this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
   }
 
-  private onMouseMove(event: MouseEvent): void {
-    if (!this.dragging) return;
-    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
-    let newWidth = event.clientX - layoutRect.left;
-    const minWidth = this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
-    const leftMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
-    newWidth = Math.max(minWidth, Math.min(leftMax, newWidth));
-    this.ngZone.run(() => {
-      if (this.autopilotCollapsed && newWidth >= this.LEFT_MIN) {
-        this.autopilotCollapsed = false;
-        this.settingsState.update({ hide_autopilot: false }).subscribe();
-      }
-      this.leftWidth = newWidth;
-      this.layoutRef.nativeElement.style.setProperty('--left-width', `${newWidth}px`);
-    });
+  onLeftWidthChange(width: number): void {
+    if (this.autopilotCollapsed && width >= this.LEFT_MIN) {
+      this.autopilotCollapsed = false;
+      this.settingsState.update({ hide_autopilot: false }).subscribe();
+    }
+    this.leftWidth = width;
+    this.layoutRef.nativeElement.style.setProperty('--left-width', `${width}px`);
   }
 
-  private onMouseUp(): void {
-    this.dragging = false;
-    document.removeEventListener('mousemove', this.boundMouseMove);
-    document.removeEventListener('mouseup', this.boundMouseUp);
+  onLeftResizeEnd(width: number): void {
+    this.leftWidth = width;
     const leftPanelEl = this.layoutRef.nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
     if (leftPanelEl) {
       const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth);
       if (snapped !== null) {
-        const minWidth = this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
         const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
-        const clamped = Math.max(minWidth, Math.min(leftMax, snapped));
-        this.ngZone.run(() => {
-          this.leftWidth = clamped;
-          this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
-        });
+        const clamped = Math.max(this.leftMin, Math.min(leftMax, snapped));
+        this.leftWidth = clamped;
+        this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
       }
     }
-    this.savePanelPx('left');
+    this.panelState.savePanelPx('left', this.leftWidth);
   }
 
-  // --- Right divider drag ---
-
-  onRightDividerMouseDown(event: MouseEvent): void {
-    event.preventDefault();
-    this.draggingRight = true;
-    this.ngZone.runOutsideAngular(() => {
-      document.addEventListener('mousemove', this.boundRightMouseMove);
-      document.addEventListener('mouseup', this.boundRightMouseUp);
-    });
+  onRightWidthChange(width: number): void {
+    this.rightWidth = width;
+    this.layoutRef.nativeElement.style.setProperty('--right-width', `${width}px`);
   }
 
-  private onRightMouseMove(event: MouseEvent): void {
-    if (!this.draggingRight) return;
-    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
-    let newWidth = layoutRect.right - event.clientX;
-    const rightMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
-    newWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, newWidth));
-    this.ngZone.run(() => {
-      this.rightWidth = newWidth;
-      this.layoutRef.nativeElement.style.setProperty('--right-width', `${newWidth}px`);
-    });
-  }
-
-  private onRightMouseUp(): void {
-    this.draggingRight = false;
-    document.removeEventListener('mousemove', this.boundRightMouseMove);
-    document.removeEventListener('mouseup', this.boundRightMouseUp);
+  onRightResizeEnd(width: number): void {
+    this.rightWidth = width;
     const rightPanelEl = this.layoutRef.nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
     if (rightPanelEl) {
       const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth);
@@ -355,13 +306,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
         const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
         const clamped = Math.max(this.RIGHT_MIN, Math.min(rightMax, snapped));
-        this.ngZone.run(() => {
-          this.rightWidth = clamped;
-          this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
-        });
+        this.rightWidth = clamped;
+        this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
       }
     }
-    this.savePanelPx('right');
+    this.panelState.savePanelPx('right', this.rightWidth);
   }
 
   // --- Data loading ---
@@ -372,47 +321,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((settings) => {
         if (!settings) return;
-        const dict = settings.view_mode_left;
-        if (dict && typeof dict === 'object') {
-          this.viewModeLeftDict = dict as Record<string, 'grid' | 'list'>;
-          if (this.currentMediaType) {
-            this.viewModeLeft = this.viewModeLeftDict[this.currentMediaType] ?? 'list';
-          }
-        }
-        const sizeDict = settings.grid_icon_size_left;
-        if (sizeDict && typeof sizeDict === 'object') {
-          this.gridIconSizeLeftDict = sizeDict as Record<string, string>;
-          if (this.currentMediaType) {
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[this.currentMediaType] ?? 'M');
-          }
-        }
-        const fmLeft = settings.focus_mode_left;
-        if (fmLeft && typeof fmLeft === 'object') {
-          this.focusModeLeftDict = fmLeft as Record<string, 'click' | 'hover'>;
-          if (this.currentMediaType) {
-            this.focusModeLeft = this.focusModeLeftDict[this.currentMediaType] ?? 'click';
-          }
-        }
-        const fmRight = settings.focus_mode_right;
-        if (fmRight && typeof fmRight === 'object') {
-          this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
-          if (this.currentMediaType) {
-            this.focusModeRight = this.focusModeRightDict[this.currentMediaType] ?? 'click';
-          }
-        }
-        const pplDict = settings.panel_pct_left;
-        if (pplDict && typeof pplDict === 'object') {
-          this.panelPxLeftDict = pplDict as Record<string, number>;
-          if (this.currentMediaType) {
-            this.applyPanelPx(this.currentMediaType);
-          }
-        }
-        const pprDict = settings.panel_pct_right;
-        if (pprDict && typeof pprDict === 'object') {
-          this.panelPxRightDict = pprDict as Record<string, number>;
-          if (this.currentMediaType) {
-            this.applyPanelPx(this.currentMediaType);
-          }
+        this.panelState.loadFromSettings(settings);
+        if (this.panelState.currentMediaType) {
+          this.applyPanelPx();
         }
         if (settings.autopilot_enabled != null) {
           this.autopilotEnabled = settings.autopilot_enabled;
@@ -720,37 +631,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onMediaContextRequest(event: { id: number; x: number; y: number }): void {
     const media = this.mediaState.medias.find((m) => m.id === event.id);
-    const mediaType = media?.type ?? '';
-    const cropAble = mediaType === 'audio' || mediaType === 'image';
-
-    const items: MediaContextMenuItem[] = [
-      {
-        id: 'sort',
-        label: 'Sort by similarity to this',
-        title: 'Sort all loaded items by similarity to this item, using its existing embedding.',
-      },
-    ];
-    if (cropAble) {
-      items.push({
-        id: 'crop-sort',
-        label: 'Crop, then sort by similarity…',
-        title: 'Open the crop tool to pick a sub-region, then sort by similarity.',
-      });
-    }
-    items.push({
-      id: 'seed',
-      label: 'Use as detector seed',
-      title: 'Open the New Detector form with this item pre-selected as the example.',
-    });
-    if (cropAble) {
-      items.push({
-        id: 'crop-seed',
-        label: 'Crop, then use as detector seed…',
-        title: 'Open the crop tool to pick a sub-region, then seed a new detector.',
-      });
-    }
-
-    this.contextMenuItems = items;
+    this.contextMenuItems = buildMediaContextMenuItems(media?.type ?? '');
     this.contextMenuMediaId = event.id;
     this.contextMenuX = event.x;
     this.contextMenuY = event.y;
@@ -1116,26 +997,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.showResortPrompt = false;
   }
 
-  // --- Panel percentage helpers ---
+  // --- Panel width helpers ---
 
-  private savePanelPx(side: 'left' | 'right'): void {
-    if (!this.currentMediaType) return;
-    const px = side === 'left' ? this.leftWidth : this.rightWidth;
-    const key = side === 'left' ? 'panel_pct_left' : 'panel_pct_right';
-    const dict = side === 'left' ? this.panelPxLeftDict : this.panelPxRightDict;
-    dict[this.currentMediaType] = px;
-    this.settingsState.update({ [key]: { ...dict } }).subscribe();
-  }
-
-  private applyPanelPx(mediaType: string): void {
+  /** Apply the panel widths saved for the active media type, clamping against
+   *  the current layout bounds. Called when the media type changes or when
+   *  fresh per-media-type settings come in. */
+  private applyPanelPx(): void {
     const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width || 1200;
-    const leftPx = this.panelPxLeftDict[mediaType];
+    const leftPx = this.panelState.getPanelPx('left');
     if (leftPx != null && !this.autopilotCollapsed) {
       const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
       this.leftWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx));
       this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     }
-    const rightPx = this.panelPxRightDict[mediaType];
+    const rightPx = this.panelState.getPanelPx('right');
     if (rightPx != null) {
       const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
       this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx));

--- a/frontend/src/app/components/label-view/media-context-menu-items.ts
+++ b/frontend/src/app/components/label-view/media-context-menu-items.ts
@@ -1,0 +1,38 @@
+import type { MediaContextMenuItem } from '../left-panel/media-item/media-context-menu.component';
+
+/**
+ * Build the right-click context-menu items for a media item in
+ * `vt-label-view`.  The crop variants are only emitted for media types
+ * whose viewer can produce a sub-region selection (`audio` spectrograms
+ * and `image` raster regions).
+ */
+export function buildMediaContextMenuItems(mediaType: string): MediaContextMenuItem[] {
+  const cropAble = mediaType === 'audio' || mediaType === 'image';
+  const items: MediaContextMenuItem[] = [
+    {
+      id: 'sort',
+      label: 'Sort by similarity to this',
+      title: 'Sort all loaded items by similarity to this item, using its existing embedding.',
+    },
+  ];
+  if (cropAble) {
+    items.push({
+      id: 'crop-sort',
+      label: 'Crop, then sort by similarity…',
+      title: 'Open the crop tool to pick a sub-region, then sort by similarity.',
+    });
+  }
+  items.push({
+    id: 'seed',
+    label: 'Use as detector seed',
+    title: 'Open the New Detector form with this item pre-selected as the example.',
+  });
+  if (cropAble) {
+    items.push({
+      id: 'crop-seed',
+      label: 'Crop, then use as detector seed…',
+      title: 'Open the crop tool to pick a sub-region, then seed a new detector.',
+    });
+  }
+  return items;
+}

--- a/frontend/src/app/components/label-view/panel-resize.directive.ts
+++ b/frontend/src/app/components/label-view/panel-resize.directive.ts
@@ -1,0 +1,91 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  NgZone,
+  OnDestroy,
+  Output,
+} from '@angular/core';
+
+/**
+ * Handles a vertical-divider drag for a flanking panel inside `vt-label-view`.
+ *
+ * The parent owns the panel widths; this directive translates mouse motion on
+ * the divider into a stream of width values for the side it is bound to,
+ * clamped to the available space. Listeners run outside Angular while the user
+ * is dragging — only the per-move emission re-enters the zone — so the
+ * mousemove handler does not trigger a full change-detection pass on every
+ * pixel.
+ *
+ * Inputs:
+ *   - `[vtPanelResize]` — `'left'` or `'right'`; controls which edge of the
+ *     layout the new width is measured from.
+ *   - `[layoutEl]` — the layout container whose bounding rect defines the
+ *     drag bounds.
+ *   - `[minWidth]` / `[opposingWidth]` / `[centerMin]` / `[dividerTotal]` —
+ *     clamping inputs. Width is constrained to
+ *     `[minWidth, layoutWidth - dividerTotal - centerMin - opposingWidth]`.
+ *
+ * Outputs:
+ *   - `(widthChange)` fires on every mousemove with the new width.
+ *   - `(resizeEnd)` fires once on mouseup with the final width, after which
+ *     the parent typically snaps to a grid-column boundary and persists.
+ */
+@Directive({
+  selector: '[vtPanelResize]',
+  standalone: true,
+})
+export class PanelResizeDirective implements OnDestroy {
+  @Input('vtPanelResize') side: 'left' | 'right' = 'left';
+  @Input({ required: true }) layoutEl!: HTMLElement;
+  @Input() minWidth = 100;
+  @Input() opposingWidth = 0;
+  @Input() centerMin = 100;
+  @Input() dividerTotal = 16;
+
+  @Output() widthChange = new EventEmitter<number>();
+  @Output() resizeEnd = new EventEmitter<number>();
+
+  @HostBinding('class.dragging') dragging = false;
+
+  private boundMove = this.onMouseMove.bind(this);
+  private boundUp = this.onMouseUp.bind(this);
+  private lastWidth = 0;
+
+  constructor(private host: ElementRef<HTMLElement>, private ngZone: NgZone) {}
+
+  @HostListener('mousedown', ['$event'])
+  onMouseDown(event: MouseEvent): void {
+    event.preventDefault();
+    this.dragging = true;
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('mousemove', this.boundMove);
+      document.addEventListener('mouseup', this.boundUp);
+    });
+  }
+
+  ngOnDestroy(): void {
+    document.removeEventListener('mousemove', this.boundMove);
+    document.removeEventListener('mouseup', this.boundUp);
+  }
+
+  private onMouseMove(event: MouseEvent): void {
+    if (!this.dragging) return;
+    const rect = this.layoutEl.getBoundingClientRect();
+    const raw = this.side === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
+    const max = rect.width - this.dividerTotal - this.centerMin - this.opposingWidth;
+    const width = Math.max(this.minWidth, Math.min(max, raw));
+    this.lastWidth = width;
+    this.ngZone.run(() => this.widthChange.emit(width));
+  }
+
+  private onMouseUp(): void {
+    this.dragging = false;
+    document.removeEventListener('mousemove', this.boundMove);
+    document.removeEventListener('mouseup', this.boundUp);
+    this.ngZone.run(() => this.resizeEnd.emit(this.lastWidth));
+  }
+}


### PR DESCRIPTION
## Summary

Implements item **#3** of `docs/plans/frontend-bundle-organization.md`
(Split `label-view.component.ts`). The coordinator component drops
from **1196 → 1071 lines**, with three focused units pulled out into
sibling files.

- **`PanelResizeDirective` (`vtPanelResize`)** — replaces the two
  near-identical ~50-line divider drag handlers (left + right
  mousedown / mousemove / mouseup) with a single standalone
  directive bound to each divider. Runs mousemove outside the
  Angular zone (matching prior behaviour) and emits `widthChange`
  per move plus one `resizeEnd` on release. The parent receives
  those events and handles side-specific concerns (auto-uncollapse
  on left, grid snap on release, save-to-settings) in two small
  handlers per side.
- **`LabelViewPanelStateService`** — owns the six per-media-type
  preference dicts (`viewModeLeftDict`, `gridIconSizeLeftDict`,
  `focusModeLeftDict`, `focusModeRightDict`, `panelPxLeftDict`,
  `panelPxRightDict`) and the active media-type pointer. The
  component reads getters on the service in the template and calls
  `loadFromSettings()` / `savePanelPx()` from its existing flows.
  Provided in the component's `providers` so it resets cleanly
  between test instances.
- **`buildMediaContextMenuItems(mediaType)`** — pure factory that
  replaces the inline `cropAble` switch inside
  `onMediaContextRequest`.

`applyPanelPx` stays in the component because it needs the live
layout state to clamp against; the service owns the dicts, the
component owns the math. See the "What we did NOT do" subsection in
the plan for the full rationale.

## Bundle effect

Initial bundle unchanged at **527.25 kB raw / 136.46 kB gzip**
(label-view is a lazy-loaded route). Lazy `label-view-component`
chunk slimmed slightly. Structural goal — three focused files
(directive, service, pure factory) instead of one 1200-line
coordinator — is what shipped.

## Test plan

- [x] `cd frontend && npm run build:prod` — builds cleanly, no
  warnings, initial bundle unchanged.
- [x] `npx tsc -p tsconfig.spec.json --noEmit` — spec files
  typecheck cleanly.
- [x] `./run-tests.sh core` — 589/589 pass (includes ruff,
  codespell, deptry, frontend TypeScript build, frontend npm audit).
- [ ] Manual: drag the left divider; confirm it auto-uncollapses
  past `LEFT_MIN`, snaps to grid columns on release, and persists
  per media type.
- [ ] Manual: drag the right divider; confirm it clamps against
  `RIGHT_MIN` / opposing-panel width and persists per media type.
- [ ] Manual: right-click a media item; confirm crop variants only
  appear for `audio` / `image`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017ebvFDAKcqt9dV5Y55CZWa)_