### PR TITLE
Plugin form fields: header tooltips, (?) hint icon, defaults, font fix

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -223,10 +223,14 @@
             }
           } @else {
           <div class="form-group">
-            <label class="form-label" [for]="'field-' + field.key">
+            <label class="form-label" [for]="'field-' + field.key"
+              [title]="field.description || field.label || field.key">
               {{ field.label || field.key }}
               @if (field.required) {
                 <span class="required">*</span>
+              }
+              @if (field.hint) {
+                <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
               }
             </label>
 
@@ -324,10 +328,6 @@
                 [placeholder]="field.description || field.label || field.key"
                 (change)="onFormFieldChanged(field.key)"
               />
-            }
-
-            @if (field.hint) {
-              <p class="form-hint">{{ field.hint }}</p>
             }
           </div>
           }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,6 +6,7 @@ import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/cl
 import { ImportAdvancedComponent } from './import-advanced/import-advanced.component';
 import { ImportConfigComponent } from './import-config/import-config.component';
 import { SourcePickerComponent } from './source-picker/source-picker.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
@@ -14,7 +15,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent, FieldHintIconComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -370,11 +371,20 @@ export class DatasetImporterModalComponent implements OnInit {
     this.dynamicFieldError = {};
     this.formDatasetNameDirty = false;
 
-    // Pre-populate defaults
+    // Pre-populate defaults.  For select fields without an explicit default,
+    // fall back to the first option so the form is never sitting on an empty
+    // selection that the user has to actively click to populate.  Dynamic
+    // (runtime-fetched) options are handled later by ``refreshDynamicFieldOptions``.
     if (importer.fields) {
       for (const field of importer.fields) {
-        if (field.default !== undefined) {
+        if (field.default !== undefined && field.default !== '') {
           this.formValues[field.key] = field.default;
+        } else if (
+          field.field_type === 'select' &&
+          !field.dynamic_options &&
+          (field.options?.length ?? 0) > 0
+        ) {
+          this.formValues[field.key] = field.options![0];
         }
       }
     }
@@ -625,9 +635,13 @@ export class DatasetImporterModalComponent implements OnInit {
         this.demoTabs.push(mt);
       }
     }
-    // Intentionally leave ``activeTab`` blank — no media-type tab is
-    // auto-selected.  The demo table stays empty until the user clicks
-    // one of the inner tabs.
+    // Pre-select a media-type tab so the demo table shows results instead
+    // of sitting empty.  Prefer "audio" when present (matches the default
+    // for most file-list importers), otherwise pick the first tab.
+    if (!this.activeTab && this.demoTabs.length > 0) {
+      const preferred = this.demoTabs.includes('audio') ? 'audio' : this.demoTabs[0];
+      this.selectDemoTabWithEmbedder(preferred);
+    }
   }
 
   private loadDemoEmbedders(mediaType: string): void {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -164,6 +164,9 @@
                     @if (field.required) {
                       <span class="required">*</span>
                     }
+                    @if (field.hint) {
+                      <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
+                    }
                   </label>
 
                   @if (field.field_type === 'server_path') {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -30,7 +31,7 @@ type TrainedSubView = 'picker' | 'form';
 @Component({
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, FieldHintIconComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -721,7 +722,15 @@ export class NewDetectorModalComponent implements OnInit {
     this.error = '';
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
-      if (field.default) this.labelImporterValues[field.key] = field.default;
+      if (field.default) {
+        this.labelImporterValues[field.key] = field.default;
+      } else if (
+        field.field_type === 'select' &&
+        !field.dynamic_options &&
+        (field.options?.length ?? 0) > 0
+      ) {
+        this.labelImporterValues[field.key] = field.options![0];
+      }
     }
     this.trainedView = 'form';
   }

--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'vt-field-hint-icon',
+  standalone: true,
+  template: `
+    <span
+      class="field-hint-icon"
+      [title]="hint"
+      tabindex="0"
+      role="img"
+      [attr.aria-label]="ariaLabel || hint"
+    >
+      <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true" focusable="false">
+        <circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor" stroke-width="1.3" />
+        <text
+          x="8"
+          y="11.5"
+          font-size="9"
+          font-weight="600"
+          text-anchor="middle"
+          fill="currentColor"
+        >?</text>
+      </svg>
+    </span>
+  `,
+  styles: [
+    `
+      .field-hint-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: var(--space-2xs);
+        color: var(--text-muted);
+        cursor: help;
+        vertical-align: middle;
+        line-height: 1;
+      }
+      .field-hint-icon:hover,
+      .field-hint-icon:focus-visible {
+        color: var(--text-primary);
+        outline: none;
+      }
+    `,
+  ],
+})
+export class FieldHintIconComponent {
+  @Input() hint = '';
+  @Input() ariaLabel = '';
+}

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -157,10 +157,14 @@
           @if (activeTabExporterFields.length > 0) {
             @for (field of activeTabExporterFields; track field.key) {
               <div class="tab-field">
-                <label class="form-label" [for]="'field-' + field.key">
+                <label class="form-label" [for]="'field-' + field.key"
+                  [title]="field.description || field.label || field.key">
                   {{ field.label || field.key }}
                   @if (field.required) {
                     <span class="required">*</span>
+                  }
+                  @if (field.hint) {
+                    <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
                   }
                 </label>
 

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DatasetStateService } from '../../../services/dataset-state.service';
@@ -25,7 +26,7 @@ export interface ColumnDef {
 @Component({
   selector: 'vt-export-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',
 })
@@ -266,6 +267,21 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return (exporter.fields ?? []) as ImporterField[];
   }
 
+  /** Initial form value for *field*: its declared default, or the first
+   *  option when a select field has no default (so the form is never sitting
+   *  on a blank pulldown that the user has to actively populate). */
+  private defaultFor(field: ImporterField): string {
+    if (field.default) return field.default;
+    if (
+      field.field_type === 'select' &&
+      !field.dynamic_options &&
+      (field.options?.length ?? 0) > 0
+    ) {
+      return field.options![0];
+    }
+    return '';
+  }
+
   /** Apply the dynamic default filename to the filepath form field if present. */
   private applyDefaultFilename(exporter: ExporterEntry): void {
     const filepathField = this.exporterFieldsOf(exporter).find((f) => f.key === 'filepath');
@@ -288,7 +304,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     this.selectedExporter = exporter;
     this.formValues = {};
     for (const f of fields) {
-      this.formValues[f.key] = f.default || '';
+      this.formValues[f.key] = this.defaultFor(f);
     }
     this.applyDefaultFilename(exporter);
     this.error = '';
@@ -301,7 +317,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     this.selectedExporter = exporter;
     this.formValues = {};
     for (const f of this.exporterFieldsOf(exporter)) {
-      this.formValues[f.key] = f.default || '';
+      this.formValues[f.key] = this.defaultFor(f);
     }
     this.applyDefaultFilename(exporter);
     this.error = '';

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -68,10 +68,14 @@
       @if (selectedImporterFields.length > 0) {
         @for (field of selectedImporterFields; track field.key) {
           <div class="form-group">
-            <label class="form-label" [for]="'lif-' + field.key">
+            <label class="form-label" [for]="'lif-' + field.key"
+              [title]="field.description || field.label || field.key">
               {{ field.label || field.key }}
               @if (field.required) {
                 <span class="required">*</span>
+              }
+              @if (field.hint) {
+                <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
               }
             </label>
 
@@ -144,10 +148,6 @@
                 [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
               />
-            }
-
-            @if (field.hint) {
-              <p class="form-hint">{{ field.hint }}</p>
             }
           </div>
         }

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { VoteStateService } from '../../../services/vote-state.service';
@@ -14,7 +15,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-label-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
   templateUrl: './label-importer-modal.component.html',
   styleUrl: './label-importer-modal.component.scss',
 })
@@ -84,7 +85,15 @@ export class LabelImporterModalComponent implements OnInit {
     this.successMessage = '';
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
-      if (field.default) this.formValues[field.key] = field.default;
+      if (field.default) {
+        this.formValues[field.key] = field.default;
+      } else if (
+        field.field_type === 'select' &&
+        !field.dynamic_options &&
+        (field.options?.length ?? 0) > 0
+      ) {
+        this.formValues[field.key] = field.options![0];
+      }
     }
     this.view = 'form';
   }

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -32,10 +32,14 @@
       @if (selectedExporterFields.length > 0) {
         @for (field of selectedExporterFields; track field.key) {
           <div class="form-group">
-            <label class="form-label" [for]="'sef-' + field.key">
+            <label class="form-label" [for]="'sef-' + field.key"
+              [title]="field.description || field.label || field.key">
               {{ field.label || field.key }}
               @if (field.required) {
                 <span class="required">*</span>
+              }
+              @if (field.hint) {
+                <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
               }
             </label>
 

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
 import type { SettingsExporterEntry } from '../../../generated/api-client/models/settings-exporter-entry';
@@ -13,7 +14,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-settings-exporter-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
   templateUrl: './settings-exporter-modal.component.html',
   styleUrl: './settings-exporter-modal.component.scss',
 })
@@ -66,7 +67,15 @@ export class SettingsExporterModalComponent implements OnInit {
     this.successMessage = '';
     const fields = (exporter.fields ?? []) as ImporterField[];
     for (const field of fields) {
-      if (field.default) this.formValues[field.key] = field.default;
+      if (field.default) {
+        this.formValues[field.key] = field.default;
+      } else if (
+        field.field_type === 'select' &&
+        !field.dynamic_options &&
+        (field.options?.length ?? 0) > 0
+      ) {
+        this.formValues[field.key] = field.options![0];
+      }
     }
     // If the exporter has no fields, submit immediately
     if (fields.length === 0) {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -32,10 +32,14 @@
       @if (selectedImporterFields.length > 0) {
         @for (field of selectedImporterFields; track field.key) {
           <div class="form-group">
-            <label class="form-label" [for]="'sif-' + field.key">
+            <label class="form-label" [for]="'sif-' + field.key"
+              [title]="field.description || field.label || field.key">
               {{ field.label || field.key }}
               @if (field.required) {
                 <span class="required">*</span>
+              }
+              @if (field.hint) {
+                <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
               }
             </label>
 

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
 import type { SettingsImporterEntry } from '../../../generated/api-client/models/settings-importer-entry';
@@ -12,7 +13,7 @@ type ModalView = 'picker' | 'form';
 @Component({
   selector: 'vt-settings-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
   templateUrl: './settings-importer-modal.component.html',
   styleUrl: './settings-importer-modal.component.scss',
 })
@@ -69,7 +70,15 @@ export class SettingsImporterModalComponent implements OnInit {
     this.successMessage = '';
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
-      if (field.default) this.formValues[field.key] = field.default;
+      if (field.default) {
+        this.formValues[field.key] = field.default;
+      } else if (
+        field.field_type === 'select' &&
+        !field.dynamic_options &&
+        (field.options?.length ?? 0) > 0
+      ) {
+        this.formValues[field.key] = field.options![0];
+      }
     }
     this.view = 'form';
   }

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -172,12 +172,14 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 // Field header label.  Made visually distinct from `.info-text` (instruction
 // body copy) by using the primary text color and a heavier weight, so a
 // label like "Dataset Name" reads as a header above its input rather than
-// blending into surrounding paragraph text.
+// blending into surrounding paragraph text.  Sized to match `.form-input`
+// (`var(--font-md)`) so the header is never visually smaller than the value
+// the user types/picks underneath it.
 .form-label {
   display: block;
   margin-bottom: var(--space-xs);
   color: var(--text-primary);
-  font-size: var(--font-sm);
+  font-size: var(--font-md);
   font-weight: var(--weight-medium);
 }
 

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -111,10 +111,13 @@ class TestServerFilesFieldsAdvertiseNpz:
         assert ".list" in accept_exts
         assert ".npz" in accept_exts
 
-    def test_paths_file_description_mentions_npz(self):
+    def test_paths_file_hint_mentions_npz(self):
+        # The format hint (shown via the (?) icon next to the label) is where
+        # the user discovers that .npz is an accepted shape for the paths file.
+        # The shorter ``description`` covers the field's purpose only.
         imp = ServerFilesDatasetImporter()
         paths_field = next(f for f in imp.fields if f.key == "paths_file")
-        assert ".npz" in (paths_field.description or "").lower()
+        assert ".npz" in (paths_field.hint or "").lower()
 
 
 class TestServerFilesNpzPathsFile:

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -134,7 +134,8 @@ class CombineDatasetsImporter(DatasetImporter):
             key="datasets",
             label="Dataset Files",
             field_type="text",
-            description="Comma-separated paths to .pkl dataset files.",
+            description="The existing datasets to merge into one new dataset.",
+            hint="Comma-separated paths to .pkl files exported from VTSearch.",
         ),
         ImporterField(
             key="name",

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -199,7 +199,8 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             key="url",
             label="Path or URL",
             field_type="url",
-            description="URL to a publicly accessible archive (.zip, .tar.gz, .rar, \u2026) of media files.",
+            description="A publicly accessible archive of media files to download and unpack.",
+            hint="Supported archive formats: .zip, .tar, .tar.gz / .tgz, .tar.bz2, .rar.",
         ),
         ImporterField(
             key="media_type",

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -213,17 +213,14 @@ class ServerFilesDatasetImporter(DatasetImporter):
             key="paths_file",
             label="Paths file",
             field_type="server_path",
-            description=(
-                "Absolute server path to a file listing the media to import.  Either:\n"
-                " • a UTF-8 text file (.txt / .list) with one media-file or directory "
-                "path per line (lines starting with # are comments), or\n"
-                " • a NumPy archive (.npz) that holds both the media paths AND "
-                "their pre-computed embedding vectors — when provided, listed "
-                "files skip re-embedding and use the supplied vectors instead.\n"
-                "Symlinks are followed; directory entries are scanned recursively "
-                "for media files."
+            description="A file that lists the media files (or folders) to pull into the dataset.",
+            hint=(
+                "Accepted formats:\n"
+                " • .txt / .list — UTF-8 text, one path per line (lines starting with # are comments).\n"
+                " • .npz — NumPy archive of paths plus pre-computed embedding vectors;\n"
+                "   listed files skip re-embedding and use the supplied vectors.\n"
+                "Symlinks are followed; directory entries are scanned recursively for media files."
             ),
-            hint=("Accepts .txt, .list, or .npz. One path per line, or a NumPy archive of pre-computed vectors."),
             accept=".txt,.list,.npz",
         ),
     ]

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -99,10 +99,8 @@ class EmailLabelsetExporter(LabelsetExporter):
             key="from",
             label="Sender Email",
             field_type="email",
-            description=(
-                "The email address to send from. Must be on a domain you control — "
-                "MX hosts reject mail from non-existent domains."
-            ),
+            description="The email address the results will be sent from.",
+            hint=("Must be on a domain you control — most MX hosts reject mail from non-existent domains."),
             placeholder="vtsearch@your-domain.example",
         ),
         ExporterField(

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -71,11 +71,10 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",
-            description=(
-                "Absolute or relative path on the server where the CSV "
-                "results file will be written.  Parent directories are "
-                "created automatically.  Supports {YYYYMMDD-HHMMSS}, "
-                "{detector_name} and {username} templates."
+            description="Where on the server to write the CSV results file.",
+            hint=(
+                "Absolute or relative path; parent directories are created automatically.\n"
+                "Template variables: {YYYYMMDD-HHMMSS}, {detector_name}, {username}."
             ),
             placeholder=_DEFAULT_CSV_PATH,
             default=_DEFAULT_CSV_PATH,

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -53,11 +53,10 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",
-            description=(
-                "Absolute or relative path on the server where the JSON "
-                "results file will be written.  Parent directories are "
-                "created automatically.  Supports {YYYYMMDD-HHMMSS}, "
-                "{detector_name} and {username} templates."
+            description="Where on the server to write the JSON results file.",
+            hint=(
+                "Absolute or relative path; parent directories are created automatically.\n"
+                "Template variables: {YYYYMMDD-HHMMSS}, {detector_name}, {username}."
             ),
             placeholder=_DEFAULT_JSON_PATH,
             default=_DEFAULT_JSON_PATH,

--- a/vtscore/labels/importers/server_csv_file/__init__.py
+++ b/vtscore/labels/importers/server_csv_file/__init__.py
@@ -39,9 +39,7 @@ class ServerCsvLabelImporter(LabelImporter):
             key="filepath",
             label="Path or URL",
             field_type="server_path",
-            description=(
-                "Absolute or relative path to a CSV file with md5 and label columns on the server filesystem."
-            ),
+            description="A CSV file on the server holding the labels to import.",
             placeholder=f"{DATA_DIR}/labels/my_labels.csv",
             hint=(
                 "Expects columns: md5,label\n"

--- a/vtscore/labels/importers/server_json_file/__init__.py
+++ b/vtscore/labels/importers/server_json_file/__init__.py
@@ -39,7 +39,7 @@ class ServerJsonLabelImporter(LabelImporter):
             key="filepath",
             label="Path or URL",
             field_type="server_path",
-            description=("Absolute or relative path to a VTSearch labels JSON file on the server filesystem."),
+            description="A VTSearch labels JSON file on the server to import labels from.",
             placeholder=f"{DATA_DIR}/labels/my_labels.json",
             hint=(
                 "Example structure:\n"

--- a/vtscore/labels/sources/server_json_file/__init__.py
+++ b/vtscore/labels/sources/server_json_file/__init__.py
@@ -31,10 +31,8 @@ class ServerFileLabelsetSource(LabelsetSource):
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",
-            description=(
-                "Absolute or relative path to a labels JSON file on the "
-                "server.  Supports {detector_id} and {detector_name} templates."
-            ),
+            description="The JSON file on the server to sync this detector's labels with.",
+            hint=("Absolute or relative server path.  Template variables: {detector_id}, {detector_name}."),
             placeholder=f"{DATA_DIR}/labels/{{detector_name}}.labels.json",
         ),
     ]

--- a/vtsearch/settings_io/exporters/server_json_file/__init__.py
+++ b/vtsearch/settings_io/exporters/server_json_file/__init__.py
@@ -26,11 +26,8 @@ class ServerFileSettingsExporter(SettingsExporter):
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",
-            description=(
-                "Absolute or relative path on the server where the settings "
-                "JSON file will be written.  Parent directories are created "
-                "automatically."
-            ),
+            description="Where on the server to write the settings JSON file.",
+            hint="Absolute or relative path; parent directories are created automatically.",
             placeholder="data/settings_backup.json",
             default="data/settings_backup.json",
         ),

--- a/vtsearch/settings_io/importers/server_json_file/__init__.py
+++ b/vtsearch/settings_io/importers/server_json_file/__init__.py
@@ -25,7 +25,7 @@ class ServerFileSettingsImporter(SettingsImporter):
             key="filepath",
             label="Path or URL",
             field_type="server_path",
-            description="Absolute or relative path to a VTSearch settings JSON file on the server.",
+            description="A VTSearch settings JSON file on the server to load settings from.",
             placeholder="data/settings.json",
         ),
     ]

--- a/vtsearch/settings_io/sources/server_json_file/__init__.py
+++ b/vtsearch/settings_io/sources/server_json_file/__init__.py
@@ -27,9 +27,8 @@ class ServerFileSettingsSource(SettingsSource):
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",
-            description=(
-                "Absolute or relative path to a settings JSON file on the server.  Supports {username} template."
-            ),
+            description="The JSON file on the server to sync your settings with.",
+            hint="Absolute or relative server path.  Template variable: {username}.",
             placeholder="data/{username}.settings.json",
         ),
     ]


### PR DESCRIPTION
## Summary

Polishes the importer/exporter form UI across DatasetImporter, LabelImporter, SettingsImporter / Exporter, the results ExportModal, and the NewDetector trained tab.

### Header tooltips on every field

Every plugin-form field label now carries a `title` sourced from the PluginField's `description`. Previously the generic-form labels in DatasetImporter (and a few others) had no mouse-over hint at all.

### (?) icon for technical detail

When a field declares a `hint`, a small SVG `(?)` icon is rendered next to the label header (via the new shared `vt-field-hint-icon` component). Hovering the icon shows the format / template-variable detail. The visible format-hint *chip* that used to sit below the input has been removed — that content now lives in the icon's tooltip.

### Sensible defaults for pulldowns

Select fields without an explicit `default` now fall back to the **first option**, so the form never starts on a blank pulldown the user has to actively populate. The Demo Dataset picker also auto-selects a media-type tab (preferring `audio`) so the demo table is populated on open instead of sitting empty.

### Font-size fix

`.form-label` was `var(--font-sm)` (0.8rem) while `.form-input` / `.form-select` are `var(--font-md)` (0.85rem), so the value in every pulldown looked bigger than the header above it. Bumped the label to `--font-md` so they match.

### Backend: description vs. hint split

Per the rule "description says **what** the field is for, hint says **how** to fill it", I moved technical / format detail out of `description` and into `hint` for the fields where the two were tangled:

- `server_files paths_file` — the long multi-line file-format breakdown moves to `hint`; description becomes a one-liner about purpose.
- `server_csv_file` / `server_json_file` results exporters — template variables (`{YYYYMMDD-HHMMSS}`, `{detector_name}`, `{username}`) move to `hint`.
- `server_json_file` labelset source + settings source — same treatment.
- `settings_io/server_json_file` settings exporter / importer — same.
- `http_archive url` — supported archive formats move to `hint`.
- `combine_datasets datasets` — `.pkl` / comma-separated format moves to `hint`.
- `email_smtp from` — the MX / domain-control technical caveat moves to `hint`.

## Test plan

- [x] `./run-tests.sh` — full suite passes (4201 passed, 1 skipped).
- [x] Adjusted `tests/io/test_npz_dataset_import.py::test_paths_file_description_mentions_npz` → `test_paths_file_hint_mentions_npz` to follow the description/hint reshuffle.
- [ ] Manual: open the DatasetImporter and verify the generic form (e.g. http_archive, server_files) shows tooltips on labels and a (?) icon where applicable.
- [ ] Manual: confirm the demo picker opens with a populated media-type tab.
- [ ] Manual: confirm select pulldowns are pre-populated on open.


---
_Generated by [Claude Code](https://claude.ai/code/session_011mD8dmrYm8JSU1kTGhuz3p)_