### PR TITLE
Fold clipper picker into source-specs column as native row's Details button

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -17,7 +17,9 @@
     [nativeType]="nativeType"
     [typeLabels]="typeLabels"
     [specs]="sourceSpecs"
+    [clippers]="clippers"
     (specsChange)="onSourceSpecsChange($event)"
+    (clipperChooserRequested)="onClipperClick()"
   ></vt-source-specs-picker>
 }
 
@@ -49,13 +51,12 @@
   }
 }
 
-@if (clippers.length > 1 && showClipperPicker) {
-  <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+@if (showStandaloneClipperButton) {
   <button
     class="btn btn--secondary clipper-btn"
     (click)="onClipperClick()"
-    title="Choose a MediaClipper to segment or trim media before embedding"
+    title="Choose how to pre-process media before embedding (e.g. clip into shorter segments)"
   >
-    Use MediaClipper: {{ clipperDisplayName }}
+    Details: {{ clipperDisplayName }}
   </button>
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -18,7 +18,9 @@ import { SourceSpecsPickerComponent } from '../source-specs-picker/source-specs-
  *  Include media picker is gated strictly by the toggle.
  *
  *  The clipper chooser modal lives at the parent level (one instance
- *  shared across all flows), so clicking the "Use MediaClipper" button
+ *  shared across all flows), so clicking the clipper "Details" button
+ *  — either the native row's button inside the source-specs column, or
+ *  the standalone fallback button rendered below the Advanced block —
  *  emits :prop:`clipperChooserRequested` and the parent opens it.
  */
 @Component({
@@ -59,12 +61,15 @@ export class ImportAdvancedComponent {
   @Output() selectedEmbedderChange = new EventEmitter<string>();
 
   /** Current clipper selection (one-way).  Changes flow through the
-   *  parent's clipper chooser modal — clicking the "Use MediaClipper"
-   *  button emits :prop:`clipperChooserRequested` and the parent
-   *  updates this input after the chooser settles. */
+   *  parent's clipper chooser modal — clicking either the native row's
+   *  Details button or the standalone fallback Details button emits
+   *  :prop:`clipperChooserRequested` and the parent updates this input
+   *  after the chooser settles. */
   @Input() selectedClipper = '';
 
-  /** Fired when the user clicks the clipper button — parent opens its
+  /** Fired when the user clicks either the native row's Details
+   *  button (inside the source-specs column) or the standalone
+   *  Details fallback below the Advanced block — parent opens its
    *  shared clipper chooser modal. */
   @Output() clipperChooserRequested = new EventEmitter<void>();
 
@@ -110,6 +115,22 @@ export class ImportAdvancedComponent {
    *  has picked a non-default clipper. */
   get showClipperPicker(): boolean {
     return this.advancedOpen || !this.isDefaultClipperSelected;
+  }
+
+  /** Whether to render the standalone clipper "Details" button below
+   *  the Advanced block.  When the source-specs column is visible
+   *  (Advanced open AND ``showSourceSpecs`` true), the native row in
+   *  the column hosts its own Details button, so the standalone one
+   *  would be redundant.  In every other case where the user should be
+   *  able to reach the clipper chooser — Advanced collapsed but a
+   *  non-default clipper is in effect, or importers with no
+   *  source-specs column at all (demo / non-multi-media form) — we
+   *  fall back to this standalone button so the override stays visible
+   *  and the chooser stays reachable. */
+  get showStandaloneClipperButton(): boolean {
+    if (this.clippers.length <= 1) return false;
+    if (!this.showClipperPicker) return false;
+    return !(this.advancedOpen && this.showSourceSpecs);
   }
 
   /** Embedders flagged ``is_default`` for the active media type — shown

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
@@ -1,16 +1,32 @@
 <div class="ssp">
-  <label class="ssp-row ssp-row--native" title="Include files of the dataset's native media type directly, without any conversion.">
-    <input
-      type="checkbox"
-      class="ssp-checkbox"
-      [checked]="isNativeChecked()"
-      (change)="toggleNative($any($event.target).checked)"
-    />
-    <span class="ssp-row-label">
-      <strong>{{ labelFor(nativeType) }}</strong>
-      <span class="ssp-native-tag">native</span>
-    </span>
-  </label>
+  <div class="ssp-row ssp-row--native">
+    <label
+      class="ssp-row-main"
+      title="Include files of the dataset's native media type directly, without any conversion."
+    >
+      <input
+        type="checkbox"
+        class="ssp-checkbox"
+        [checked]="isNativeChecked()"
+        (change)="toggleNative($any($event.target).checked)"
+      />
+      <span class="ssp-row-label">
+        <strong>{{ labelFor(nativeType) }}</strong>
+        <span class="ssp-native-tag">native</span>
+      </span>
+    </label>
+
+    @if (hasNativeDetails()) {
+      <button
+        type="button"
+        class="advanced-toggle ssp-details-toggle"
+        (click)="onNativeDetailsClick()"
+        title="Choose how to pre-process media before embedding (e.g. clip into shorter segments)."
+      >
+        Details ▸
+      </button>
+    }
+  </div>
 
   @for (st of nonNativeSourceTypes; track st) {
     <div class="ssp-row">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -13,21 +13,12 @@
   display: contents;
 }
 
-.ssp-row--native {
-  // Native row spans both columns (no Advanced opener on the right).
-  grid-column: 1 / -1;
-}
-
-.ssp-row-main,
-.ssp-row--native {
+.ssp-row-main {
   display: inline-flex;
   align-items: center;
   gap: var(--space-md);
   cursor: pointer;
   padding: var(--space-2xs) 0;
-}
-
-.ssp-row-main {
   grid-column: 1;
 }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -2,16 +2,19 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { ConverterInfo, SourceSpec } from '../../../../models/api.models';
+import { ClipperInfo, ConverterInfo, SourceSpec } from '../../../../models/api.models';
 
 /** Checkbox column for choosing which source media types feed a
  *  multi-media import.  The native type sits at the top (always
  *  included by default, no converter); each other source type with at
  *  least one converter to the native type appears as a checkbox with a
  *  "Details ▸" opener for picking among converters (when there are
- *  multiple) and editing their params.  The picker itself lives inside
- *  the outer importer's "Advanced" section, so a nested "Advanced"
- *  label here would read as "Advanced inside Advanced". */
+ *  multiple) and editing their params.  The native row also gets its
+ *  own "Details ▸" button when there is more than one MediaClipper to
+ *  pick between — clicking it asks the parent to open the shared
+ *  clipper-chooser modal.  The picker itself lives inside the outer
+ *  importer's "Advanced" section, so a nested "Advanced" label here
+ *  would read as "Advanced inside Advanced". */
 @Component({
   selector: 'vt-source-specs-picker',
   standalone: true,
@@ -32,7 +35,16 @@ export class SourceSpecsPickerComponent implements OnChanges {
   /** Map of type_id → human-readable label.  Falls back to the type_id
    *  when a label is missing. */
   @Input() typeLabels: Record<string, string> = {};
+  /** Clippers available for the native media type.  Drives the native
+   *  row's "Details" button — shown only when there is more than one
+   *  clipper to pick between (same gate as the legacy standalone
+   *  Clipper section).  An empty list means "no clipper choice", and
+   *  the Details button is suppressed. */
+  @Input() clippers: ClipperInfo[] = [];
   @Output() specsChange = new EventEmitter<SourceSpec[]>();
+  /** Fired when the user clicks the native row's "Details" button.
+   *  The parent opens the shared clipper-chooser modal in response. */
+  @Output() clipperChooserRequested = new EventEmitter<void>();
 
   /** Per-source-type draft so the user can configure a converter via
    *  the Details panel *before* checking the box.  Edits made while
@@ -90,6 +102,19 @@ export class SourceSpecsPickerComponent implements OnChanges {
   toggleDetails(sourceType: string): void {
     if (this.detailsOpenSet.has(sourceType)) this.detailsOpenSet.delete(sourceType);
     else this.detailsOpenSet.add(sourceType);
+  }
+
+  /** True iff the native row's Details button should be rendered:
+   *  there has to be more than one clipper for the user to pick
+   *  between.  Same gate as the legacy standalone Clipper section. */
+  hasNativeDetails(): boolean {
+    return this.clippers.length > 1;
+  }
+
+  /** Click handler for the native row's Details button — bubbles up to
+   *  the parent, which opens the shared clipper-chooser modal. */
+  onNativeDetailsClick(): void {
+    this.clipperChooserRequested.emit();
   }
 
   currentConverterName(sourceType: string): string {


### PR DESCRIPTION
## Summary
- Users didn't recognise the word "Clipper" sitting at the bottom of the dataset-importer Advanced section. The pre-processing step now lives where it belongs — on the **native media-type row of the source-specs column** — as a `Details ▸` button identical in affordance to the converter `Details` buttons on the non-native rows. Every row in the column now carries at most one `Details` button, and the word "Clipper" is gone from the picker UI.
- The standalone fallback button is kept for the cases the column doesn't cover (Advanced collapsed with a non-default clipper still selected; importers with no source-specs column — demo, non-multi-media form), but the label is renamed from `Clipper` / `Use MediaClipper: X` to `Details: X` to stay consistent.

## What changed
- `SourceSpecsPickerComponent` gained a `clippers` input and a `clipperChooserRequested` output. The native row was restructured to use the same `(label, optional Details button)` grid pattern as non-native rows.
- `ImportAdvancedComponent` passes clippers through to the picker, re-emits the native Details click as `clipperChooserRequested`, and gates the standalone fallback via a new `showStandaloneClipperButton` getter that hides it whenever the column is visible.
- SCSS: dropped the `grid-column: 1 / -1` override on `.ssp-row--native` so the native row participates in the same two-column grid as the rest.

## Test plan
- [x] `cd frontend && npm run build:prod` — clean build, no warnings.
- [ ] Manual: open Add Dataset → Server Folder, expand Advanced. Native row should have a `Details ▸` button on the right; clicking it opens the clipper-chooser modal. No "Clipper" header/button below the column.
- [ ] Manual: collapse Advanced after picking a non-default clipper — the standalone `Details: <clipper>` fallback button should appear so the override stays visible/reachable.
- [ ] Manual: demo importer flow — the standalone `Details: <clipper>` button still appears since there's no column.

https://claude.ai/code/session_01TS7t614drSBBpVwAZkV2f5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TS7t614drSBBpVwAZkV2f5)_