### PR TITLE
Rename media dict field: type → media_type

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -413,7 +413,7 @@ def run(self, field_values, medias, thin=False):
     for i, item in enumerate(api_results, start=1):
         medias[i] = {
             "id": i,
-            "type": "audio",
+            "media_type": "audio",
             "filename": item["id"],
             "md5": item["md5"],                  # pre-computed by the service
             "embedding": item["embedding"],      # pre-computed by the service
@@ -460,7 +460,7 @@ class MyServiceImporter(DatasetImporter):
         # Default per-item path. The framework loops this when no
         # bulk override is provided. Return None to skip a record.
         return {
-            "type": "audio",
+            "media_type": "audio",
             "filename": record["id"],
             "embedding": _api.get_embedding(record["id"]),
             "media_bytes": None if thin else _api.fetch_bytes(record["url"]),
@@ -478,7 +478,7 @@ class MyServiceImporter(DatasetImporter):
             blobs = ([] if thin else
                      list(pool.map(lambda r: _api.fetch_bytes(r["url"]), records)))
         return [
-            {"type": "audio", "filename": r["id"], "embedding": e,
+            {"media_type": "audio", "filename": r["id"], "embedding": e,
              "media_bytes": (None if thin else b), "media_url": r["url"]}
             for r, e, b in zip(records, embeddings, blobs or [None] * len(records))
         ]

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -16,8 +16,8 @@ GET /api/medias/ids
 
 ```json
 [
-  { "id": 0, "type": "audio", "embedder": "clap-fused" },
-  { "id": 1, "type": "audio", "embedder": "clap-fused" }
+  { "id": 0, "media_type": "audio", "embedder": "clap-fused" },
+  { "id": 1, "media_type": "audio", "embedder": "clap-fused" }
 ]
 ```
 
@@ -44,7 +44,7 @@ are silently omitted):
 [
   {
     "id": 0,
-    "type": "audio",
+    "media_type": "audio",
     "filename": "media_0.wav",
     "md5": "abc123...",
     "custom_metadata": {

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -786,7 +786,7 @@ Cross-section interaction agents:
   reviewed and left alone: by the time it runs, its values have already
   been emptied by the existing APPEND/APPENDS/BINBYTES overrides, and
   the peek needs the dict structure intact for `len(media_dict)` /
-  `first["type"]` in the staging route. As a side-fix, the staging
+  `first["media_type"]` in the staging route. As a side-fix, the staging
   endpoint stopped silently swallowing peek failures — the response
   schema grew an `error` field carrying the exception message so the UI
   can distinguish "valid pickle with 0 medias" from "couldn't parse
@@ -1004,7 +1004,7 @@ Cross-cutting open items that don't fit any single finding above:
   (2) `BINUNICODE` / `BINUNICODE8` are not overridden, so a pickle
   with a multi-MB inline `media_string` (a long document) is still
   fully materialised during peek. A blanket override doesn't work
-  because the peek needs short unicode strings (dict keys, `"type"`
+  because the peek needs short unicode strings (dict keys, `"media_type"`
   value); a size-bounded handler (e.g. truncate over N bytes) would
   cap the worst case.
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3157,10 +3157,10 @@
           "md5": {
             "type": "string"
           },
-          "origin_name": {
+          "media_type": {
             "type": "string"
           },
-          "type": {
+          "origin_name": {
             "type": "string"
           }
         },
@@ -3169,7 +3169,7 @@
           "filename",
           "id",
           "md5",
-          "type"
+          "media_type"
         ],
         "type": "object"
       },
@@ -3182,13 +3182,13 @@
           "id": {
             "type": "integer"
           },
-          "type": {
+          "media_type": {
             "type": "string"
           }
         },
         "required": [
           "id",
-          "type"
+          "media_type"
         ],
         "type": "object"
       },

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -162,7 +162,7 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const mediaState = TestBed.inject(MediaStateService);
     spyOnProperty(mediaState, 'medias', 'get').and.returnValue([
-      { id: 1, type: 'image' },
+      { id: 1, media_type: 'image' },
     ]);
     fixture.componentInstance.isOnLabelView = true;
     fixture.componentInstance.onSettings();

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -310,7 +310,7 @@ export class AppComponent {
     if (this.isOnLabelView) {
       const medias = this.mediaState.medias;
       if (medias.length > 0) {
-        return medias[0].type;
+        return medias[0].media_type;
       }
       return '';
     }

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -9,7 +9,7 @@ describe('AudioPlayerComponent', () => {
 
   const mockMedia: Media = {
     id: 1,
-    type: 'audio',
+    media_type: 'audio',
     filename: 'test.wav',
     md5: 'abc123',
     custom_metadata: {},

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -12,7 +12,7 @@ describe('CenterPanelComponent', () => {
 
   const mockMedia: Media = {
     id: 1,
-    type: 'audio',
+    media_type: 'audio',
     filename: 'test.wav',
     md5: 'abc123',
     custom_metadata: {},
@@ -48,25 +48,25 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should show image viewer for image media', () => {
-    component.media = { ...mockMedia, type: 'image' };
+    component.media = { ...mockMedia, media_type: 'image' };
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('vt-image-viewer')).toBeTruthy();
   });
 
   it('should show video player for video media', () => {
-    component.media = { ...mockMedia, type: 'video' };
+    component.media = { ...mockMedia, media_type: 'video' };
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('vt-video-player')).toBeTruthy();
   });
 
   it('should show text viewer for text media', () => {
-    component.media = { ...mockMedia, type: 'text' };
+    component.media = { ...mockMedia, media_type: 'text' };
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('vt-text-viewer')).toBeTruthy();
   });
 
   it('should show document viewer for document media', () => {
-    component.media = { ...mockMedia, type: 'document' };
+    component.media = { ...mockMedia, media_type: 'document' };
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('vt-document-viewer')).toBeTruthy();
   });
@@ -154,7 +154,7 @@ describe('CenterPanelComponent', () => {
    * region-agnostic — see "Vote attribution → v2" in docs/plans/patch-embedder.md).
    */
   describe('vote-API contract for region_box', () => {
-    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, media_type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
@@ -218,7 +218,7 @@ describe('CenterPanelComponent', () => {
    * clears the armed state and keeps the box.
    */
   describe('sticky bad-vote-confirm armed state', () => {
-    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, media_type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -180,7 +180,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   get mediaType(): string {
-    return this.media?.type || 'audio';
+    return this.media?.media_type || 'audio';
   }
 
   get isGood(): boolean {

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -9,7 +9,7 @@ describe('DocumentViewerComponent', () => {
 
   const mockMedia: Media = {
     id: 5,
-    type: 'document',
+    media_type: 'document',
     filename: 'test.pdf',
     md5: 'mno345',
     custom_metadata: {},

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -10,7 +10,7 @@ describe('ImageViewerComponent', () => {
 
   const mockMedia: Media = {
     id: 2,
-    type: 'image',
+    media_type: 'image',
     filename: 'test.png',
     md5: 'def456',
     custom_metadata: {},

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -11,7 +11,7 @@ describe('TextViewerComponent', () => {
 
   const mockMedia: Media = {
     id: 4,
-    type: 'text',
+    media_type: 'text',
     filename: 'test.txt',
     md5: 'jkl012',
     custom_metadata: {},

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -9,7 +9,7 @@ describe('VideoPlayerComponent', () => {
 
   const mockMedia: Media = {
     id: 3,
-    type: 'video',
+    media_type: 'video',
     filename: 'test.mp4',
     md5: 'ghi789',
     custom_metadata: {},

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -86,7 +86,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((medias) => {
         if (medias.length > 0) {
-          const newType = medias[0].type;
+          const newType = medias[0].media_type;
           if (newType !== this.currentMediaType) {
             this.currentMediaType = newType;
             this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -33,8 +33,8 @@ describe('LabelViewComponent', () => {
     fixture.detectChanges();
     // Flush /api/medias
     httpMock.expectOne('/api/medias/ids').flush([
-      { id: 1, type: 'audio' },
-      { id: 2, type: 'audio' },
+      { id: 1, media_type: 'audio' },
+      { id: 2, media_type: 'audio' },
     ]);
     // Flush /api/votes (label-view + right-panel both poll)
     httpMock.match('/api/votes').forEach(req =>
@@ -265,7 +265,7 @@ describe('LabelViewComponent', () => {
     // Now trigger init which loads medias
     fixture.detectChanges();
     httpMock.expectOne('/api/medias/ids').flush([
-      { id: 1, type: 'audio' },
+      { id: 1, media_type: 'audio' },
     ]);
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -168,7 +168,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((medias) => {
         if (medias.length > 0) {
-          const newType = medias[0].type;
+          const newType = medias[0].media_type;
           if (newType !== this.panelState.currentMediaType) {
             this.panelState.setMediaType(newType);
             this.applyPanelPx();
@@ -631,7 +631,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onMediaContextRequest(event: { id: number; x: number; y: number }): void {
     const media = this.mediaState.medias.find((m) => m.id === event.id);
-    this.contextMenuItems = buildMediaContextMenuItems(media?.type ?? '');
+    this.contextMenuItems = buildMediaContextMenuItems(media?.media_type ?? '');
     this.contextMenuMediaId = event.id;
     this.contextMenuX = event.x;
     this.contextMenuY = event.y;
@@ -686,7 +686,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private openSeedNewDetector(mediaId: number, cropParams?: Record<string, unknown>): void {
     const media = this.mediaState.medias.find((m) => m.id === mediaId);
     this.newThingFlows.openNewDetector({
-      defaultMediaType: media?.type ?? '',
+      defaultMediaType: media?.media_type ?? '',
       seedMediaId: mediaId,
       seedCropParams: cropParams,
     });
@@ -695,7 +695,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private openCropOverlay(mediaId: number, action: 'sort' | 'seed'): void {
     const media = this.mediaState.getMedia(mediaId);
     if (!media) return;
-    const mediaType = media.type;
+    const mediaType = media.media_type;
     const url =
       mediaType === 'audio'
         ? this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`)

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -11,7 +11,7 @@
         </h3>
         <vt-view-controls
           side="left"
-          [currentMediaType]="medias.length > 0 ? medias[0].type : ''"
+          [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"
           class="view-controls-slot" />
 
       </div>
@@ -120,7 +120,7 @@
           </h3>
           <vt-view-controls
             side="left"
-            [currentMediaType]="medias.length > 0 ? medias[0].type : ''"
+            [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"
             class="view-controls-slot" />
         </div>
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -134,7 +134,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   private updateMediaTypeName(): void {
-    const typeId = this.medias.length > 0 ? this.medias[0].type : '';
+    const typeId = this.medias.length > 0 ? this.medias[0].media_type : '';
     if (typeId && typeId !== this.currentTypeId) {
       this.currentTypeId = typeId;
       const info = this.mediaTypeInfos.find((mt) => mt.type_id === typeId);

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -9,7 +9,7 @@ describe('MediaItemComponent', () => {
 
   const mockMedia: Media = {
     id: 1,
-    type: 'audio',
+    media_type: 'audio',
     filename: 'test.wav',
     md5: 'abc123',
     custom_metadata: {},
@@ -74,12 +74,12 @@ describe('MediaItemComponent', () => {
   });
 
   it('should show thumbnail for image type', () => {
-    component.media = { ...mockMedia, type: 'image' };
+    component.media = { ...mockMedia, media_type: 'image' };
     expect(component.thumbnailUrl).toBe('/api/medias/1/image');
   });
 
   it('should not show thumbnail for text type', () => {
-    component.media = { ...mockMedia, type: 'text' };
+    component.media = { ...mockMedia, media_type: 'text' };
     expect(component.thumbnailUrl).toBeNull();
   });
 

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -43,7 +43,7 @@ export class MediaItemComponent implements OnChanges {
 
   get thumbnailUrl(): string | null {
     if (this.thumbnailFailed) return null;
-    if (this.media.type === 'image' || this.media.type === 'video' || this.media.type === 'document' || this.media.type === 'audio') {
+    if (this.media.media_type === 'image' || this.media.media_type === 'video' || this.media.media_type === 'document' || this.media.media_type === 'audio') {
       return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
     }
     return null;
@@ -52,8 +52,8 @@ export class MediaItemComponent implements OnChanges {
   get placeholderIcon(): string | null {
     if (!this.isGrid) return null;
     if (this.thumbnailUrl) return null;
-    if (this.media.type === 'audio') return '\u266B';
-    if (this.media.type === 'text') return '\u00B6';
+    if (this.media.media_type === 'audio') return '\u266B';
+    if (this.media.media_type === 'text') return '\u00B6';
     return '\u25A1';
   }
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -10,9 +10,9 @@ describe('MediaListComponent', () => {
   let fixture: ComponentFixture<MediaListComponent>;
 
   const mockMedias: Media[] = [
-    { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
-    { id: 2, type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
-    { id: 3, type: 'audio', filename: 'c.wav', md5: 'c3', custom_metadata: {} },
+    { id: 1, media_type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
+    { id: 2, media_type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
+    { id: 3, media_type: 'audio', filename: 'c.wav', md5: 'c3', custom_metadata: {} },
   ];
 
   beforeEach(async () => {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -8,9 +8,9 @@ describe('LabelListComponent', () => {
   let fixture: ComponentFixture<LabelListComponent>;
 
   const sampleMedias: Media[] = [
-    { id: 1, type: 'audio', filename: 'song.wav', md5: 'aaa', custom_metadata: {} },
-    { id: 2, type: 'image', filename: 'photo.jpg', md5: 'bbb', custom_metadata: {} },
-    { id: 3, type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },
+    { id: 1, media_type: 'audio', filename: 'song.wav', md5: 'aaa', custom_metadata: {} },
+    { id: 2, media_type: 'image', filename: 'photo.jpg', md5: 'bbb', custom_metadata: {} },
+    { id: 3, media_type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },
   ];
 
   beforeEach(async () => {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -150,7 +150,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     const url = this.thumbnailUrl(id);
     if (url && this.thumbnailFailedUrls.has(url)) return false;
     const media = this.lookup(id);
-    return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
+    return !!media && (media.media_type === 'image' || media.media_type === 'video' || media.media_type === 'document' || media.media_type === 'audio');
   }
 
   thumbnailUrl(id: number): string {
@@ -167,8 +167,8 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     if (this.hasThumbnailUrl(id)) return null;
     const media = this.lookup(id);
     if (!media) return null;
-    if (media.type === 'audio') return '\u266B';
-    if (media.type === 'text') return '\u00B6';
+    if (media.media_type === 'audio') return '\u266B';
+    if (media.media_type === 'text') return '\u00B6';
     return '\u25A1';
   }
 

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -52,7 +52,7 @@ describe('RightPanelComponent', () => {
   }));
 
   it('should load view mode from settings on init', fakeAsync(() => {
-    component.medias = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
+    component.medias = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
     fixture.detectChanges();
     tick();
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -101,7 +101,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['medias'] && this.medias.length > 0) {
-      const newType = this.medias[0].type;
+      const newType = this.medias[0].media_type;
       if (newType !== this.currentMediaType) {
         this.currentMediaType = newType;
         this.viewMode = this.viewModeRightDict[newType] ?? 'grid';

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -9,8 +9,8 @@ describe('MediaStateService', () => {
   let httpMock: HttpTestingController;
 
   const mockMedias: Media[] = [
-    { id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} },
-    { id: 2, type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
+    { id: 1, media_type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} },
+    { id: 2, media_type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
   ];
 
   beforeEach(() => {

--- a/frontend/src/app/services/medias-api.service.spec.ts
+++ b/frontend/src/app/services/medias-api.service.spec.ts
@@ -22,7 +22,7 @@ describe('MediasApiService', () => {
   });
 
   it('getMediaIds should GET /api/medias/ids', () => {
-    const mock = [{ id: 1, type: 'audio' }, { id: 2, type: 'audio', embedder: 'clap' }];
+    const mock = [{ id: 1, media_type: 'audio' }, { id: 2, media_type: 'audio', embedder: 'clap' }];
     service.getMediaIds().subscribe(data => expect(data).toEqual(mock));
     const req = httpMock.expectOne('/api/medias/ids');
     expect(req.request.method).toBe('GET');
@@ -30,7 +30,7 @@ describe('MediasApiService', () => {
   });
 
   it('getMediasBatch should POST /api/medias/batch with ids', () => {
-    const mock = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
+    const mock = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
     service.getMediasBatch([1]).subscribe(data => expect(data).toEqual(mock));
     const req = httpMock.expectOne('/api/medias/batch');
     expect(req.request.method).toBe('POST');

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -41,7 +41,7 @@ class TestMediasContract:
             assert isinstance(item["media_type"], str)
 
     def test_batch_each_media_has_required_fields(self, client):
-        required = {"id", "type", "filename", "md5", "custom_metadata"}
+        required = {"id", "media_type", "filename", "md5", "custom_metadata"}
         for item in self._batch(client):
             assert required.issubset(item.keys()), f"Missing keys: {required - item.keys()}"
 

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -38,7 +38,7 @@ class TestMediasContract:
         assert isinstance(data, list)
         for item in data:
             assert isinstance(item["id"], int)
-            assert isinstance(item["type"], str)
+            assert isinstance(item["media_type"], str)
 
     def test_batch_each_media_has_required_fields(self, client):
         required = {"id", "type", "filename", "md5", "custom_metadata"}

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -42,7 +42,7 @@ class TestDashboardDatasetInfo:
         resp = client.get("/api/dashboard/dataset-info")
         data = resp.get_json()
         first_media = next(iter(medias.values()))
-        assert data["media_type"] == first_media.get("type", "audio")
+        assert data["media_type"] == first_media.get("media_type", "audio")
 
     def test_returns_origin_from_media(self, client):
         """Endpoint extracts origin info when medias have origin set."""
@@ -735,7 +735,7 @@ class TestFindProgress:
             emb = np.random.RandomState(i + 50).randn(512).astype(np.float32)
             ds_medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"prog_md5_{i}",
                 "filename": f"prog_{i}.wav",

--- a/tests/cli/test_chunked_id_renumber.py
+++ b/tests/cli/test_chunked_id_renumber.py
@@ -33,7 +33,7 @@ def _make_audio_media(media_id: int) -> dict:
     md5 = hashlib.md5(raw).hexdigest()
     return {
         "id": media_id,
-        "type": "audio",
+        "media_type": "audio",
         "duration": 1.0,
         "file_size": len(raw),
         "md5": md5,

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -426,7 +426,7 @@ class TestRunConvertersOnFolder:
         assert "\u2192" in media["origin_name"]
 
         # Check media type
-        assert media["type"] == "image"
+        assert media["media_type"] == "image"
 
         # Check embedding
         assert np.array_equal(media["embedding"], fake_embedding)
@@ -729,7 +729,7 @@ class TestFolderImporterWithConverters:
         # Create only a video file — no image files.
         (tmp_path / "clip.mp4").write_bytes(b"fake-video")
 
-        mock_converter_medias = {1: {"id": 1, "type": "image"}}
+        mock_converter_medias = {1: {"id": 1, "media_type": "image"}}
 
         def _fake_run_converters(
             folder, output_type, specs, medias, thin=False, recursive=True, folder_path_for_origin=""

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -703,7 +703,7 @@ class TestLoadDemoWithConverter:
         medias = {
             1: {
                 "id": 1,
-                "type": "document",
+                "media_type": "document",
                 "filename": "test.pdf",
                 "media_bytes": pdf_bytes,
                 "media_path": "",
@@ -718,7 +718,7 @@ class TestLoadDemoWithConverter:
         # Should have converted the document to image(s)
         assert len(medias) >= 1
         for m in medias.values():
-            assert m["type"] == "image"
+            assert m["media_type"] == "image"
             assert m["origin"]["importer"] == "converter"
             assert m["origin"]["params"]["converter"] == "document2image"
             assert m["origin"]["params"]["parent_importer"] == "demo"

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -312,13 +312,13 @@ class TestListMediaIds:
         assert len(data) == app_module.NUM_MEDIAS
 
     def test_stub_fields_only(self, client):
-        """Each stub carries id + type and (optionally) embedder — nothing else."""
+        """Each stub carries id + media_type and (optionally) embedder — nothing else."""
         resp = client.get("/api/medias/ids")
         data = resp.get_json()
-        allowed = {"id", "type", "embedder"}
+        allowed = {"id", "media_type", "embedder"}
         for media in data:
             assert "id" in media
-            assert "type" in media
+            assert "media_type" in media
             extra = set(media.keys()) - allowed
             assert not extra, f"unexpected heavy fields in /ids response: {extra}"
 

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -38,7 +38,7 @@ def _make_audio_clip(media_id: int, md5: str = "", filename: str = "") -> dict:
         md5 = hashlib.md5(raw).hexdigest()
     return {
         "id": media_id,
-        "type": "audio",
+        "media_type": "audio",
         "duration": 1.0,
         "file_size": 1000,
         "md5": md5,
@@ -60,7 +60,7 @@ def _make_image_clip(media_id: int, md5: str = "") -> dict:
         md5 = hashlib.md5(raw).hexdigest()
     return {
         "id": media_id,
-        "type": "image",
+        "media_type": "image",
         "duration": 0,
         "file_size": 2000,
         "md5": md5,

--- a/tests/datasets/test_creation_info.py
+++ b/tests/datasets/test_creation_info.py
@@ -97,7 +97,7 @@ class TestPickleRoundTrip:
         return {
             1: {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "duration": 1.0,
                 "file_size": 100,
                 "md5": "abc123",
@@ -129,7 +129,7 @@ class TestPickleRoundTrip:
         old_data = {
             1: {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "duration": 1.0,
                 "file_size": 100,
                 "md5": "abc123",

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1421,7 +1421,7 @@ class TestLoadFailureCleanup:
 
         target_medias[1] = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 1.0,
             "file_size": 100,
             "md5": "test-md5-c12",

--- a/tests/datasets/test_duplicates.py
+++ b/tests/datasets/test_duplicates.py
@@ -22,7 +22,7 @@ def _make_media(cid, md5="unique", origin_importer="test", filename=None, catego
     fname = filename or f"media_{cid}.wav"
     return {
         "id": cid,
-        "type": "audio",
+        "media_type": "audio",
         "duration": 1.0,
         "file_size": 100,
         "md5": md5,

--- a/tests/datasets/test_extension_scaffolds.py
+++ b/tests/datasets/test_extension_scaffolds.py
@@ -437,7 +437,7 @@ class TestEnrichedExportOriginParams:
             rng = np.random.default_rng(42)
             medias[1] = {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "md5": "enrich_test_hash",
                 "filename": "C1.wav",
                 "origin": {
@@ -492,7 +492,7 @@ class TestEnrichedExportOriginParams:
             rng = np.random.default_rng(42)
             medias[1] = {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "md5": "override_test_hash",
                 "filename": "C1.wav",
                 "origin": {

--- a/tests/datasets/test_load_stage_matrix_cache.py
+++ b/tests/datasets/test_load_stage_matrix_cache.py
@@ -76,7 +76,7 @@ class TestApplyClipperStageInvalidatesMatrix:
         for cid in (1, 2, 3):
             ctx.medias[cid] = {
                 "id": cid,
-                "type": "audio",
+                "media_type": "audio",
                 "filename": f"a_{cid}.wav",
                 "md5": f"md5_{cid}",
                 "embedding": rng.standard_normal(4).astype(np.float32),

--- a/tests/datasets/test_memory_errors.py
+++ b/tests/datasets/test_memory_errors.py
@@ -25,7 +25,7 @@ class TestClearClipsGarbageCollection:
             mock_gc.assert_called_once()
 
     def test_clear_medias_empties_dict(self):
-        medias[999] = {"id": 999, "type": "audio", "embedding": np.zeros(10)}
+        medias[999] = {"id": 999, "media_type": "audio", "embedding": np.zeros(10)}
         clear_medias()
         assert len(medias) == 0
         # Restore test medias
@@ -57,7 +57,7 @@ class TestPickleMemoryError:
         medias_data = {}
         for i in range(1, 6):
             medias_data[i] = {
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": [0.0] * 10,
                 "media_bytes": b"\x00" * 100,
                 "filename": f"clip_{i}.wav",
@@ -92,7 +92,7 @@ class TestPickleMemoryError:
 
         medias_data = {
             1: {
-                "type": "text",
+                "media_type": "text",
                 "embedding": [0.0] * 10,
                 "media_string": "hello",
                 "filename": "t.txt",
@@ -176,7 +176,7 @@ class TestCombineMemoryError:
         for name in ("a.pkl", "b.pkl"):
             medias_data = {
                 1: {
-                    "type": "audio",
+                    "media_type": "audio",
                     "embedding": [0.0] * 10,
                     "media_bytes": b"\x00" * 100,
                     "filename": f"{name}_clip.wav",

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -40,8 +40,8 @@ class TestDatasetContext:
     def test_contexts_are_independent(self):
         ctx_a = DatasetContext("a")
         ctx_b = DatasetContext("b")
-        ctx_a.medias[1] = {"id": 1, "type": "audio"}
-        ctx_b.medias[2] = {"id": 2, "type": "image"}
+        ctx_a.medias[1] = {"id": 1, "media_type": "audio"}
+        ctx_b.medias[2] = {"id": 2, "media_type": "image"}
         assert 1 in ctx_a.medias and 2 not in ctx_a.medias
         assert 2 in ctx_b.medias and 1 not in ctx_b.medias
 
@@ -115,7 +115,7 @@ class TestProxyDict:
         # The reset_state fixture creates _test_default with test medias.
         # Create a second context and switch.
         ctx2 = DatasetContext("proxy_test")
-        ctx2.medias[999] = {"id": 999, "type": "test"}
+        ctx2.medias[999] = {"id": 999, "media_type": "test"}
         register_context(ctx2)
         set_thread_dataset_context(ctx2)
 
@@ -228,7 +228,7 @@ class TestMultiDatasetSwitching:
         rng = np.random.default_rng(media_id)
         return {
             "id": media_id,
-            "type": media_type,
+            "media_type": media_type,
             "embedder": "clap",
             "duration": 1.0,
             "file_size": 100,
@@ -384,7 +384,7 @@ class TestMultiDatasetAPI:
         rng = np.random.default_rng(media_id)
         return {
             "id": media_id,
-            "type": "audio",
+            "media_type": "audio",
             "embedder": "clap",
             "duration": 1.0,
             "file_size": 100,

--- a/tests/datasets/test_pickle_safety.py
+++ b/tests/datasets/test_pickle_safety.py
@@ -186,7 +186,7 @@ class TestSafePickleRoundTrip:
         medias = {
             1: {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "duration": 1.0,
                 "file_size": 1024,
                 "md5": "abc123",
@@ -219,7 +219,7 @@ class TestSafePickleRoundTrip:
         for i in range(5):
             medias[i + 1] = {
                 "id": i + 1,
-                "type": "audio",
+                "media_type": "audio",
                 "duration": 1.0,
                 "file_size": 1024,
                 "md5": f"md5_{i}",
@@ -310,7 +310,7 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         data = {
             "medias": {
                 i: {
-                    "type": "audio",
+                    "media_type": "audio",
                     "embedding": [float(j) * 1.0001 for j in range(64)],
                     "filename": f"m_{i}.wav",
                 }
@@ -322,7 +322,7 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         media_dict = peeked["medias"]
         assert len(media_dict) == 8
         first = next(iter(media_dict.values()))
-        assert first["type"] == "audio"
+        assert first["media_type"] == "audio"
         # The whole point of the peek: embedding contents are dropped, not
         # materialised into millions of Python floats.
         assert len(first["embedding"]) == 0
@@ -336,11 +336,11 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         from vtscore.security.pickle import peek_pickle_dataset_summary
 
         big = bytearray(b"X" * 1_000_000)
-        data = {"medias": {0: {"type": "audio", "audio": big}}}
+        data = {"medias": {0: {"media_type": "audio", "audio": big}}}
         raw = pickle.dumps(data, protocol=5)
         peeked = peek_pickle_dataset_summary(io.BytesIO(raw))
 
-        assert peeked["medias"][0]["type"] == "audio"
+        assert peeked["medias"][0]["media_type"] == "audio"
         assert peeked["medias"][0]["audio"] == bytearray()
         assert len(peeked["medias"][0]["audio"]) == 0
 
@@ -356,7 +356,7 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         data = {
             "medias": {
                 i: {
-                    "type": "audio",
+                    "media_type": "audio",
                     "embedding": [float(j) * 1.0001 for j in range(512)],
                 }
                 for i in range(200)

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -37,7 +37,7 @@ def _make_dataset(ds_id, media_ids):
     for mid in media_ids:
         ctx.medias[mid] = {
             "id": mid,
-            "type": "audio",
+            "media_type": "audio",
             "embedding": rng.standard_normal(4).astype(np.float32),
         }
     register_context(ctx)
@@ -432,7 +432,7 @@ class TestRequestMissingSentinel:
             app.preprocess_request()
             ctx = get_active_context()
             with pytest.raises(RequestMissingContextError):
-                ctx.medias[42] = {"id": 42, "type": "audio"}
+                ctx.medias[42] = {"id": 42, "media_type": "audio"}
             with pytest.raises(RequestMissingContextError):
                 ctx.diversity_tree = object()
 

--- a/tests/detectors/test_clipper_workflow.py
+++ b/tests/detectors/test_clipper_workflow.py
@@ -36,7 +36,7 @@ def _make_audio_media(media_id: int, duration: float = 5.1, *, origin_path: str 
     rng = np.random.default_rng(media_id)
     return {
         "id": media_id,
-        "type": "audio",
+        "media_type": "audio",
         "filename": f"clip_{media_id}.wav",
         "media_bytes": wav,
         "duration": duration,
@@ -58,7 +58,7 @@ def _make_image_media(media_id: int, width: int = 300, height: int = 100) -> dic
     rng = np.random.default_rng(media_id + 1000)
     return {
         "id": media_id,
-        "type": "image",
+        "media_type": "image",
         "filename": f"img_{media_id}.png",
         "media_bytes": img_bytes,
         "width": width,
@@ -76,7 +76,7 @@ def _make_text_media(media_id: int, text: str = "First sentence. Second sentence
     rng = np.random.default_rng(media_id + 2000)
     return {
         "id": media_id,
-        "type": "text",
+        "media_type": "text",
         "filename": f"text_{media_id}.txt",
         "media_string": text,
         "media_bytes": text_bytes,
@@ -93,7 +93,7 @@ def _make_video_media(media_id: int, duration: float = 10.0) -> dict:
     rng = np.random.default_rng(media_id + 3000)
     return {
         "id": media_id,
-        "type": "video",
+        "media_type": "video",
         "filename": f"video_{media_id}.mp4",
         "media_bytes": fake_bytes,
         "duration": duration,
@@ -777,7 +777,7 @@ class TestClipDisplayMetadata:
         from vtscore.media import get as get_media_type
 
         mt = get_media_type("audio")
-        media = {"type": "audio", "clip_start": 0.0, "clip_end": 2.0, "clip_index": 0}
+        media = {"media_type": "audio", "clip_start": 0.0, "clip_end": 2.0, "clip_index": 0}
         meta = mt.display_metadata(media)
         assert meta["Clip Start"] == 0.0
         assert meta["Clip End"] == 2.0
@@ -787,7 +787,7 @@ class TestClipDisplayMetadata:
         from vtscore.media import get as get_media_type
 
         mt = get_media_type("image")
-        media = {"type": "image", "clip_box": [0, 0, 100, 100], "clip_index": 0}
+        media = {"media_type": "image", "clip_box": [0, 0, 100, 100], "clip_index": 0}
         meta = mt.display_metadata(media)
         assert meta["Clip Box"] == "0,0,100,100"
         assert meta["Clip Index"] == 0
@@ -796,7 +796,7 @@ class TestClipDisplayMetadata:
         from vtscore.media import get as get_media_type
 
         mt = get_media_type("video")
-        media = {"type": "video", "clip_start": 1.5, "clip_end": 4.0, "clip_index": 1}
+        media = {"media_type": "video", "clip_start": 1.5, "clip_end": 4.0, "clip_index": 1}
         meta = mt.display_metadata(media)
         assert meta["Clip Start"] == 1.5
         assert meta["Clip End"] == 4.0
@@ -806,7 +806,7 @@ class TestClipDisplayMetadata:
         from vtscore.media import get as get_media_type
 
         mt = get_media_type("text")
-        media = {"type": "text", "clip_index": 2}
+        media = {"media_type": "text", "clip_index": 2}
         meta = mt.display_metadata(media)
         assert meta["Clip Index"] == 2
 
@@ -814,7 +814,7 @@ class TestClipDisplayMetadata:
         from vtscore.media import get as get_media_type
 
         mt = get_media_type("audio")
-        media = {"type": "audio", "duration": 3.0}
+        media = {"media_type": "audio", "duration": 3.0}
         meta = mt.display_metadata(media)
         assert "Clip Start" not in meta
         assert "Clip End" not in meta

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -89,7 +89,7 @@ class TestSoundDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtscore.media.audio.clipper import SoundDefaultClipper
 
-        media = {"id": 1, "type": "audio", "media_bytes": b"fake", "duration": 3.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": b"fake", "duration": 3.0}
         result = SoundDefaultClipper().clip(media)
         assert result == [media]
 
@@ -144,7 +144,7 @@ class TestSoundTilingClipper:
         from vtscore.media.audio.clipper import SoundTilingClipper
 
         wav = generate_wav(440, 1.5)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.5}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 1.5}
         result = SoundTilingClipper(2.0).clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -153,7 +153,7 @@ class TestSoundTilingClipper:
         from vtscore.media.audio.clipper import SoundTilingClipper
 
         wav = generate_wav(440, 5.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 5.0}
         result = SoundTilingClipper(2.0).clip(media)
         # 5.0 / 2.0 = 2.5 → ceil → 3 tiles
         assert len(result) == 3
@@ -170,7 +170,7 @@ class TestSoundTilingClipper:
         from vtscore.media.audio.clipper import SoundTilingClipper
 
         wav = generate_wav(440, 9.5)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 9.5}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 9.5}
         result = SoundTilingClipper(2.0).clip(media)
         # 9.5 / 2.0 = 4.75 → round → 5 tiles
         assert len(result) == 5
@@ -182,7 +182,7 @@ class TestSoundTilingClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.audio.clipper import SoundTilingClipper
 
-        media = {"id": 1, "type": "audio", "duration": 10.0}
+        media = {"id": 1, "media_type": "audio", "duration": 10.0}
         result = SoundTilingClipper(2.0).clip(media)
         assert result == [media]
 
@@ -201,7 +201,7 @@ class TestSoundTilingClipper:
         from vtscore.media.audio.clipper import SoundTilingClipper
 
         wav = generate_wav(440, 10.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 10.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 10.0}
         # Without overlap: ceil(10/2) = 5 tiles
         result_no_overlap = SoundTilingClipper(2.0, min_overlap=0.0).clip(media)
         assert len(result_no_overlap) == 5
@@ -254,7 +254,7 @@ class TestSoundClipClipper:
         from vtscore.media.audio.clipper import SoundClipClipper
 
         wav = generate_wav(440, 5.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 5.0}
         result = SoundClipClipper(1.0, 3.5).clip(media)
         assert len(result) == 1
         clip = result[0]
@@ -270,7 +270,7 @@ class TestSoundClipClipper:
         from vtscore.media.audio.clipper import SoundClipClipper
 
         wav = generate_wav(440, 2.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.0}
         # Request a window that runs past the end — clamps.
         result = SoundClipClipper(1.0, 10.0).clip(media)
         assert len(result) == 1
@@ -280,7 +280,7 @@ class TestSoundClipClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.audio.clipper import SoundClipClipper
 
-        media = {"id": 1, "type": "audio", "duration": 3.0}
+        media = {"id": 1, "media_type": "audio", "duration": 3.0}
         result = SoundClipClipper(0.0, 1.0).clip(media)
         assert result == [media]
 
@@ -376,14 +376,14 @@ class TestSoundSilenceClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.audio.clipper import SoundSilenceClipper
 
-        media = {"id": 1, "type": "audio", "duration": 3.0}
+        media = {"id": 1, "media_type": "audio", "duration": 3.0}
         result = SoundSilenceClipper().clip(media)
         assert result == [media]
 
     def test_invalid_bytes_returns_unchanged(self):
         from vtscore.media.audio.clipper import SoundSilenceClipper
 
-        media = {"id": 1, "type": "audio", "media_bytes": b"not a wav", "duration": 1.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": b"not a wav", "duration": 1.0}
         result = SoundSilenceClipper().clip(media)
         assert result == [media]
 
@@ -399,7 +399,7 @@ class TestSoundSilenceClipper:
             generate_wav(0, 1.0),
             generate_wav(440, 1.0),
         )
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 5.0}
 
         result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.0).clip(media)
         assert len(result) == 3
@@ -422,7 +422,7 @@ class TestSoundSilenceClipper:
             generate_wav(440, 1.0),
             generate_wav(0, 0.5),
         )
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.0}
 
         result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.0).clip(media)
         assert len(result) == 1
@@ -440,7 +440,7 @@ class TestSoundSilenceClipper:
             generate_wav(440, 1.0),
             generate_wav(0, 0.5),
         )
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.0}
 
         # With 0.2 s pad, the single clip should extend ~0.2 s into the surrounding silence.
         result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.2).clip(media)
@@ -462,7 +462,7 @@ class TestSoundSilenceClipper:
             generate_wav(0, 1.0),
             generate_wav(440, 1.0),
         )
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.05}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.05}
 
         # min_clip_duration=0.3 should drop the blip but keep the 1 s tone.
         result = SoundSilenceClipper(top_db=40, min_clip_duration=0.3, pad=0.0).clip(media)
@@ -474,7 +474,7 @@ class TestSoundSilenceClipper:
         from vtscore.media.audio.clipper import SoundSilenceClipper
 
         wav = generate_wav(0, 2.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.0}
         result = SoundSilenceClipper().clip(media)
         assert result == [media]
 
@@ -521,7 +521,7 @@ class TestSoundSilenceClipper:
             return real_import(name, *args, **kwargs)
 
         wav = generate_wav(440, 1.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 1.0}
         monkeypatch.setattr(builtins, "__import__", mock_import)
         result = SoundSilenceClipper().clip(media)
         assert result == [media]
@@ -577,7 +577,7 @@ class TestSoundSpeechActivityClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.audio.clipper import SoundSpeechActivityClipper
 
-        media = {"id": 1, "type": "audio", "duration": 3.0}
+        media = {"id": 1, "media_type": "audio", "duration": 3.0}
         result = SoundSpeechActivityClipper().clip(media)
         assert result == [media]
 
@@ -589,7 +589,7 @@ class TestSoundSpeechActivityClipper:
         # Force the lazy loader to report unavailable so we never touch torch.hub.
         monkeypatch.setattr(c, "_load_model", lambda: False)
         wav = generate_wav(440, 1.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 1.0}
         result = c.clip(media)
         assert result == [media]
 
@@ -604,7 +604,7 @@ class TestSoundSpeechActivityClipper:
             generate_wav(0, 1.0),
             generate_wav(440, 1.0),
         )
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 5.0}
 
         c = SoundSpeechActivityClipper(min_clip_duration=0.1, pad=0.0)
         c._detect_speech_intervals = lambda _b: [(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)]  # pyright: ignore[reportAttributeAccessIssue]
@@ -624,7 +624,7 @@ class TestSoundSpeechActivityClipper:
         from vtscore.media.audio.clipper import SoundSpeechActivityClipper
 
         wav = generate_wav(440, 1.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 1.0}
         c = SoundSpeechActivityClipper()
         c._detect_speech_intervals = lambda _b: []  # pyright: ignore[reportAttributeAccessIssue]
         result = c.clip(media)
@@ -635,7 +635,7 @@ class TestSoundSpeechActivityClipper:
         from vtscore.media.audio.clipper import SoundSpeechActivityClipper
 
         wav = generate_wav(440, 1.0)
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.0}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 1.0}
         c = SoundSpeechActivityClipper()
         c._detect_speech_intervals = lambda _b: None  # pyright: ignore[reportAttributeAccessIssue]
         result = c.clip(media)
@@ -672,7 +672,7 @@ class TestSoundSpeechActivityClipper:
         from vtscore.media.audio.clipper import SoundSpeechActivityClipper
 
         wav = _concat_wavs(generate_wav(440, 0.05), generate_wav(0, 1.0), generate_wav(440, 1.0))
-        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.05}
+        media = {"id": 1, "media_type": "audio", "media_bytes": wav, "duration": 2.05}
 
         # Drive the post-filter directly: the 50 ms interval drops, the 1 s one stays.
         c = SoundSpeechActivityClipper(min_clip_duration=0.3, pad=0.0)
@@ -696,7 +696,7 @@ class TestVideoDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtscore.media.video.clipper import VideoDefaultClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         result = VideoDefaultClipper().clip(media)
         assert result == [media]
 
@@ -750,7 +750,7 @@ class TestVideoTilingClipper:
     def test_short_video_returned_unchanged(self):
         from vtscore.media.video.clipper import VideoTilingClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 1.5}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 1.5}
         result = VideoTilingClipper(2.0).clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -758,7 +758,7 @@ class TestVideoTilingClipper:
     def test_9_5s_produces_five_2s_tiles(self):
         from vtscore.media.video.clipper import VideoTilingClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 9.5}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 9.5}
         result = VideoTilingClipper(2.0).clip(media)
         assert len(result) == 5
         assert result[0]["clip_start"] == pytest.approx(0.0)
@@ -770,7 +770,7 @@ class TestVideoTilingClipper:
     def test_exact_multiple_duration(self):
         from vtscore.media.video.clipper import VideoTilingClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         result = VideoTilingClipper(2.0).clip(media)
         assert len(result) == 5
         # No overlap when duration is exact multiple
@@ -791,14 +791,14 @@ class TestVideoTilingClipper:
     def test_zero_duration_video_returned_unchanged(self):
         from vtscore.media.video.clipper import VideoTilingClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 0}
         result = VideoTilingClipper(2.0).clip(media)
         assert result == [media]
 
     def test_min_overlap_produces_more_tiles(self):
         from vtscore.media.video.clipper import VideoTilingClipper
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         # Without overlap: ceil(10/2) = 5 tiles
         result_no_overlap = VideoTilingClipper(2.0, min_overlap=0.0).clip(media)
         assert len(result_no_overlap) == 5
@@ -824,7 +824,7 @@ class TestImageDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtscore.media.image.clipper import ImageDefaultClipper
 
-        media = {"id": 1, "type": "image", "media_bytes": b"fake", "width": 100, "height": 100}
+        media = {"id": 1, "media_type": "image", "media_bytes": b"fake", "width": 100, "height": 100}
         result = ImageDefaultClipper().clip(media)
         assert result == [media]
 
@@ -865,7 +865,7 @@ class TestImageTilingClipper:
         from vtscore.media.image.clipper import ImageTilingClipper
 
         img_bytes = _make_image_bytes(100, 100)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 100, "height": 100}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 100, "height": 100}
         result = ImageTilingClipper().clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -877,7 +877,7 @@ class TestImageTilingClipper:
 
         # 100 x 250 image → tile_size = 100, ceil(250/100) = 3 tiles
         img_bytes = _make_image_bytes(100, 250)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 100, "height": 250}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 100, "height": 250}
         result = ImageTilingClipper().clip(media)
         assert len(result) == 3
         for tile in result:
@@ -895,7 +895,7 @@ class TestImageTilingClipper:
 
         # 300 x 100 image → tile_size = 100, 300/100 = 3 → 3 tiles
         img_bytes = _make_image_bytes(300, 100)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 300, "height": 100}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 300, "height": 100}
         result = ImageTilingClipper().clip(media)
         assert len(result) == 3
         for tile in result:
@@ -912,7 +912,7 @@ class TestImageTilingClipper:
 
         # 85 x 110 portrait: tile_size = 85, ceil(110/85) = 2 tiles
         img_bytes = _make_image_bytes(85, 110)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 85, "height": 110}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 85, "height": 110}
         result = ImageTilingClipper().clip(media)
         assert len(result) == 2
         # First tile at top, second at bottom
@@ -927,14 +927,14 @@ class TestImageTilingClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.image.clipper import ImageTilingClipper
 
-        media = {"id": 1, "type": "image", "width": 100, "height": 200}
+        media = {"id": 1, "media_type": "image", "width": 100, "height": 200}
         result = ImageTilingClipper().clip(media)
         assert result == [media]
 
     def test_missing_dimensions_returns_unchanged(self):
         from vtscore.media.image.clipper import ImageTilingClipper
 
-        media = {"id": 1, "type": "image", "media_bytes": b"fake"}
+        media = {"id": 1, "media_type": "image", "media_bytes": b"fake"}
         result = ImageTilingClipper().clip(media)
         assert result == [media]
 
@@ -972,7 +972,7 @@ class TestImageBboxClipper:
         from vtscore.media.image.clipper import ImageBboxClipper
 
         img_bytes = _make_image_bytes(200, 100)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 100}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 100}
         result = ImageBboxClipper([20, 10, 120, 90]).clip(media)
         assert len(result) == 1
         clip = result[0]
@@ -987,7 +987,7 @@ class TestImageBboxClipper:
         from vtscore.media.image.clipper import ImageBboxClipper
 
         img_bytes = _make_image_bytes(50, 50)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 50, "height": 50}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 50, "height": 50}
         # Request a box wider than the image — clamps to (0,0,50,50).
         result = ImageBboxClipper([0, 0, 200, 200]).clip(media)
         assert len(result) == 1
@@ -999,7 +999,7 @@ class TestImageBboxClipper:
     def test_no_media_bytes_returns_unchanged(self):
         from vtscore.media.image.clipper import ImageBboxClipper
 
-        media = {"id": 1, "type": "image", "width": 100, "height": 100}
+        media = {"id": 1, "media_type": "image", "width": 100, "height": 100}
         result = ImageBboxClipper([0, 0, 50, 50]).clip(media)
         assert result == [media]
 
@@ -1120,7 +1120,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         c = ImageObjectClipper()
-        media = {"id": 1, "type": "image", "width": 100, "height": 100}
+        media = {"id": 1, "media_type": "image", "width": 100, "height": 100}
         result = c.clip(media)
         assert result == [media]
 
@@ -1128,7 +1128,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         c = ImageObjectClipper()
         c._model = _make_mock_yolo([], {0: "person"})
         result = c.clip(media)
@@ -1141,7 +1141,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
             (0, 0.8, [100.0, 100.0, 180.0, 180.0]),
@@ -1164,7 +1164,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.3, [10.0, 10.0, 40.0, 40.0]),
             (0, 0.95, [50.0, 50.0, 120.0, 120.0]),
@@ -1182,7 +1182,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
             (0, 0.2, [100.0, 100.0, 180.0, 180.0]),
@@ -1197,7 +1197,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.9, [10.0, 10.0, 60.0, 60.0]),  # person
             (1, 0.85, [80.0, 80.0, 150.0, 150.0]),  # car
@@ -1215,7 +1215,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
             (1, 0.8, [80.0, 80.0, 150.0, 150.0]),
@@ -1229,7 +1229,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(400, 400)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
         # 6 detections with varying confidence; cap at 3 should keep top 3
         detections = [
             (0, 0.5, [0.0, 0.0, 20.0, 20.0]),
@@ -1251,7 +1251,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(400, 400)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
         # 100x100 box at (150,150)-(250,250) with 10% padding → expand by 10px each side
         detections = [(0, 0.9, [150.0, 150.0, 250.0, 250.0])]
         c = ImageObjectClipper(threshold=0.0, padding=0.1)
@@ -1267,7 +1267,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         # Box near the corner; aggressive padding would go negative / past edge.
         detections = [(0, 0.9, [10.0, 10.0, 50.0, 50.0])]
         c = ImageObjectClipper(threshold=0.0, padding=1.0)  # +40px each side
@@ -1285,7 +1285,7 @@ class TestImageObjectClipper:
         from vtscore.media.image.clipper import ImageObjectClipper
 
         img_bytes = _make_image_bytes(200, 200)
-        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        media = {"id": 1, "media_type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
         detections = [
             (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
             (0, 0.8, [70.0, 70.0, 120.0, 120.0]),
@@ -1311,7 +1311,7 @@ class TestTextDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtscore.media.text.clipper import TextDefaultClipper
 
-        media = {"id": 1, "type": "text", "media_string": "Hello world."}
+        media = {"id": 1, "media_type": "text", "media_string": "Hello world."}
         result = TextDefaultClipper().clip(media)
         assert result == [media]
 
@@ -1341,7 +1341,7 @@ class TestTextParagraphClipper:
     def test_single_paragraph_unchanged(self):
         from vtscore.media.text.clipper import TextParagraphClipper
 
-        media = {"id": 1, "type": "text", "media_string": "Just one paragraph here."}
+        media = {"id": 1, "media_type": "text", "media_string": "Just one paragraph here."}
         result = TextParagraphClipper().clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -1350,7 +1350,7 @@ class TestTextParagraphClipper:
         from vtscore.media.text.clipper import TextParagraphClipper
 
         text = "First paragraph.\n\nSecond paragraph.\n\nThird one."
-        media = {"id": 1, "type": "text", "media_string": text, "word_count": 6, "character_count": len(text)}
+        media = {"id": 1, "media_type": "text", "media_string": text, "word_count": 6, "character_count": len(text)}
         result = TextParagraphClipper().clip(media)
         assert len(result) == 3
         assert result[0]["media_string"] == "First paragraph."
@@ -1366,7 +1366,7 @@ class TestTextParagraphClipper:
         from vtscore.media.text.clipper import TextParagraphClipper
 
         text = "Line one.\nLine two of the same para.\n\nSecond paragraph here."
-        media = {"id": 1, "type": "text", "media_string": text}
+        media = {"id": 1, "media_type": "text", "media_string": text}
         result = TextParagraphClipper().clip(media)
         assert len(result) == 2
         assert result[0]["media_string"] == "Line one.\nLine two of the same para."
@@ -1376,7 +1376,7 @@ class TestTextParagraphClipper:
         from vtscore.media.text.clipper import TextParagraphClipper
 
         text = "Alpha.\n\n\n\nBeta.\n\n\nGamma."
-        media = {"id": 1, "type": "text", "media_string": text}
+        media = {"id": 1, "media_type": "text", "media_string": text}
         result = TextParagraphClipper().clip(media)
         assert [t["media_string"] for t in result] == ["Alpha.", "Beta.", "Gamma."]
 
@@ -1384,7 +1384,7 @@ class TestTextParagraphClipper:
         from vtscore.media.text.clipper import TextParagraphClipper
 
         text = "Para one.\r\n\r\nPara two.\r\n\r\nPara three."
-        media = {"id": 1, "type": "text", "media_string": text}
+        media = {"id": 1, "media_type": "text", "media_string": text}
         result = TextParagraphClipper().clip(media)
         assert [t["media_string"] for t in result] == ["Para one.", "Para two.", "Para three."]
 
@@ -1393,21 +1393,21 @@ class TestTextParagraphClipper:
         from vtscore.media.text.clipper import TextParagraphClipper
 
         text = "First.\n   \nSecond."
-        media = {"id": 1, "type": "text", "media_string": text}
+        media = {"id": 1, "media_type": "text", "media_string": text}
         result = TextParagraphClipper().clip(media)
         assert [t["media_string"] for t in result] == ["First.", "Second."]
 
     def test_empty_string_returns_unchanged(self):
         from vtscore.media.text.clipper import TextParagraphClipper
 
-        media = {"id": 1, "type": "text", "media_string": ""}
+        media = {"id": 1, "media_type": "text", "media_string": ""}
         result = TextParagraphClipper().clip(media)
         assert result == [media]
 
     def test_no_media_string_returns_unchanged(self):
         from vtscore.media.text.clipper import TextParagraphClipper
 
-        media = {"id": 1, "type": "text"}
+        media = {"id": 1, "media_type": "text"}
         result = TextParagraphClipper().clip(media)
         assert result == [media]
 
@@ -1445,7 +1445,7 @@ class TestTextSentenceClipper:
     def test_single_sentence_unchanged(self):
         from vtscore.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "text", "media_string": "Hello world."}
+        media = {"id": 1, "media_type": "text", "media_string": "Hello world."}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -1454,7 +1454,7 @@ class TestTextSentenceClipper:
         from vtscore.media.text.clipper import TextSentenceClipper
 
         text = "First sentence. Second sentence. Third one!"
-        media = {"id": 1, "type": "text", "media_string": text, "word_count": 7, "character_count": len(text)}
+        media = {"id": 1, "media_type": "text", "media_string": text, "word_count": 7, "character_count": len(text)}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 3
         assert result[0]["media_string"] == "First sentence."
@@ -1469,7 +1469,7 @@ class TestTextSentenceClipper:
         from vtscore.media.text.clipper import TextSentenceClipper
 
         text = "Is this a test? Yes it is! Great."
-        media = {"id": 1, "type": "text", "media_string": text}
+        media = {"id": 1, "media_type": "text", "media_string": text}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 3
         assert result[0]["media_string"] == "Is this a test?"
@@ -1479,14 +1479,14 @@ class TestTextSentenceClipper:
     def test_empty_string_returns_unchanged(self):
         from vtscore.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "text", "media_string": ""}
+        media = {"id": 1, "media_type": "text", "media_string": ""}
         result = TextSentenceClipper().clip(media)
         assert result == [media]
 
     def test_no_media_string_returns_unchanged(self):
         from vtscore.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "text"}
+        media = {"id": 1, "media_type": "text"}
         result = TextSentenceClipper().clip(media)
         assert result == [media]
 
@@ -1500,7 +1500,7 @@ class TestDocumentDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtscore.media.document.clipper import DocumentDefaultClipper
 
-        media = {"id": 1, "type": "document", "media_bytes": b"fake-pdf"}
+        media = {"id": 1, "media_type": "document", "media_bytes": b"fake-pdf"}
         result = DocumentDefaultClipper().clip(media)
         assert result == [media]
 
@@ -1555,14 +1555,14 @@ class TestVideoSceneClipper:
     def test_zero_duration_returns_unchanged(self):
         from vtscore.media.video.clipper import VideoSceneClipper
 
-        media = {"id": 1, "type": "video", "duration": 0}
+        media = {"id": 1, "media_type": "video", "duration": 0}
         result = VideoSceneClipper().clip(media)
         assert result == [media]
 
     def test_no_media_bytes_or_path_returns_unchanged(self):
         from vtscore.media.video.clipper import VideoSceneClipper
 
-        media = {"id": 1, "type": "video", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "duration": 10.0}
         result = VideoSceneClipper().clip(media)
         assert result == [media]
 
@@ -1589,7 +1589,7 @@ class TestVideoSceneClipper:
                 raise ImportError("no cv2")
             return real_import(name, *args, **kwargs)
 
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         monkeypatch.setattr(builtins, "__import__", mock_import)
         result = VideoSceneClipper().clip(media)
         assert result == [media]
@@ -1600,7 +1600,7 @@ class TestVideoSceneClipper:
         from vtscore.media.video.clipper import VideoSceneClipper
 
         monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [])
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         result = VideoSceneClipper().clip(media)
         assert result == [media]
 
@@ -1611,7 +1611,7 @@ class TestVideoSceneClipper:
 
         # Simulate two scene boundaries at 3.0s and 7.0s in a 10s video.
         monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [3.0, 7.0])
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
         result = VideoSceneClipper().clip(media)
 
         assert len(result) == 3
@@ -1642,7 +1642,7 @@ class TestVideoSceneClipper:
         from vtscore.media.video.clipper import VideoSceneClipper
 
         monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [5.0])
-        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 8.0}
+        media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 8.0}
         result = VideoSceneClipper().clip(media)
         assert len(result) == 2
         assert result[0]["clip_start"] == pytest.approx(0.0)
@@ -1666,7 +1666,7 @@ class TestVideoSceneClipper:
 
         monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", mock_detect)
 
-        media = {"id": 1, "type": "video", "media_path": str(video_file), "duration": 5.0}
+        media = {"id": 1, "media_type": "video", "media_path": str(video_file), "duration": 5.0}
         result = VideoSceneClipper().clip(media)
         assert len(result) == 2
         assert paths_seen[0] == str(video_file)
@@ -1886,21 +1886,21 @@ class TestApplyClipper:
     def test_apply_clipper_noop_for_empty_name(self):
         from vtscore.datasets.load_pipeline import _apply_clipper
 
-        clips = {1: {"id": 1, "type": "audio", "origin": {"importer": "test", "params": {}}}}
+        clips = {1: {"id": 1, "media_type": "audio", "origin": {"importer": "test", "params": {}}}}
         _apply_clipper(clips, "")
         assert len(clips) == 1
 
     def test_apply_clipper_unknown_name_noop(self):
         from vtscore.datasets.load_pipeline import _apply_clipper
 
-        clips = {1: {"id": 1, "type": "audio", "origin": {"importer": "test", "params": {}}}}
+        clips = {1: {"id": 1, "media_type": "audio", "origin": {"importer": "test", "params": {}}}}
         _apply_clipper(clips, "nonexistent_clipper")
         assert len(clips) == 1
 
     def test_apply_default_clipper_passthrough(self):
         from vtscore.datasets.load_pipeline import _apply_clipper
 
-        media = {"id": 1, "type": "audio", "media_bytes": b"fake", "origin": {"importer": "test", "params": {}}}
+        media = {"id": 1, "media_type": "audio", "media_bytes": b"fake", "origin": {"importer": "test", "params": {}}}
         clips = {1: media}
         _apply_clipper(clips, "sound_default")
         assert len(clips) == 1
@@ -1911,7 +1911,7 @@ class TestApplyClipper:
 
         media = {
             "id": 1,
-            "type": "text",
+            "media_type": "text",
             "media_string": "First sentence. Second sentence.",
             "word_count": 4,
             "character_count": 32,
@@ -2165,7 +2165,7 @@ class TestApplyClipperWithParams:
         wav = generate_wav(440, 10.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 10.0,
             "origin": {"importer": "test", "params": {}},
@@ -2182,7 +2182,7 @@ class TestApplyClipperWithParams:
         wav = generate_wav(440, 10.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 10.0,
             "origin": {"importer": "test", "params": {}},
@@ -2199,7 +2199,7 @@ class TestApplyClipperWithParams:
         wav = generate_wav(440, 10.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 10.0,
             "origin": {"importer": "test", "params": {}},
@@ -2215,7 +2215,7 @@ class TestApplyClipperWithParams:
         wav = generate_wav(440, 10.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 10.0,
             "origin": {"importer": "test", "params": {}},
@@ -2258,14 +2258,14 @@ class TestSoundAutoClipper:
     def test_resolve_for_media_short_returns_default(self):
         from vtscore.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
 
-        media = {"id": 1, "type": "audio", "duration": 5.0}
+        media = {"id": 1, "media_type": "audio", "duration": 5.0}
         resolved = SoundAutoClipper().resolve_for_media(media)
         assert isinstance(resolved, SoundDefaultClipper)
 
     def test_resolve_for_media_long_returns_tiling(self):
         from vtscore.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
 
-        media = {"id": 1, "type": "audio", "duration": 120.0}
+        media = {"id": 1, "media_type": "audio", "duration": 120.0}
         resolved = SoundAutoClipper().resolve_for_media(media)
         assert isinstance(resolved, SoundTilingClipper)
         assert resolved.duration == 10.0
@@ -2279,8 +2279,8 @@ class TestSoundAutoClipper:
         )
 
         c = SoundAutoClipper()
-        short = {"id": 1, "type": "audio", "duration": 5.0}
-        long_media = {"id": 2, "type": "audio", "duration": 120.0}
+        short = {"id": 1, "media_type": "audio", "duration": 5.0}
+        long_media = {"id": 2, "media_type": "audio", "duration": 120.0}
         assert isinstance(c.resolve_for_media(short), SoundDefaultClipper)
         assert isinstance(c.resolve_for_media(long_media), SoundTilingClipper)
 
@@ -2288,7 +2288,7 @@ class TestSoundAutoClipper:
         from vtscore.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
 
         long_wav = generate_wav(440, 5.0)
-        media = {"id": 1, "type": "audio", "media_bytes": long_wav}
+        media = {"id": 1, "media_type": "audio", "media_bytes": long_wav}
         resolved = SoundAutoClipper(threshold=3.0, tile_duration=1.0).resolve_for_media(media)
         assert isinstance(resolved, SoundTilingClipper)
 
@@ -2307,7 +2307,7 @@ class TestSoundAutoClipper:
         assert c.threshold == 5.0
         assert c.tile_duration == 3.0
         # 10s exceeds 5s threshold → tiling with 3s segments
-        resolved = c.resolve_for_media({"id": 1, "type": "audio", "duration": 10.0})
+        resolved = c.resolve_for_media({"id": 1, "media_type": "audio", "duration": 10.0})
         assert isinstance(resolved, SoundTilingClipper)
         assert resolved.duration == 3.0
 
@@ -2331,11 +2331,11 @@ class TestSoundAutoClipper:
         c = SoundAutoClipper(threshold=3.0, tile_duration=1.0)
         # Short clip → pass-through
         short_wav = generate_wav(440, 2.0)
-        short = {"id": 1, "type": "audio", "media_bytes": short_wav, "duration": 2.0}
+        short = {"id": 1, "media_type": "audio", "media_bytes": short_wav, "duration": 2.0}
         assert c.clip(short) == [short]
         # Long clip → tiled
         long_wav = generate_wav(440, 5.0)
-        long_media = {"id": 1, "type": "audio", "media_bytes": long_wav, "duration": 5.0}
+        long_media = {"id": 1, "media_type": "audio", "media_bytes": long_wav, "duration": 5.0}
         result = c.clip(long_media)
         assert len(result) > 1
 
@@ -2369,13 +2369,13 @@ class TestVideoAutoClipper:
     def test_resolve_for_media_short_returns_default(self):
         from vtscore.media.video.clipper import VideoAutoClipper, VideoDefaultClipper
 
-        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "type": "video", "duration": 10.0})
+        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "media_type": "video", "duration": 10.0})
         assert isinstance(resolved, VideoDefaultClipper)
 
     def test_resolve_for_media_long_returns_tiling(self):
         from vtscore.media.video.clipper import VideoAutoClipper, VideoTilingClipper
 
-        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "type": "video", "duration": 90.0})
+        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "media_type": "video", "duration": 90.0})
         assert isinstance(resolved, VideoTilingClipper)
         assert resolved.duration == 10.0
 
@@ -2387,8 +2387,8 @@ class TestVideoAutoClipper:
         )
 
         c = VideoAutoClipper()
-        short = {"id": 1, "type": "video", "duration": 10.0}
-        long_media = {"id": 2, "type": "video", "duration": 90.0}
+        short = {"id": 1, "media_type": "video", "duration": 10.0}
+        long_media = {"id": 2, "media_type": "video", "duration": 90.0}
         assert isinstance(c.resolve_for_media(short), VideoDefaultClipper)
         assert isinstance(c.resolve_for_media(long_media), VideoTilingClipper)
 
@@ -2404,7 +2404,7 @@ class TestVideoAutoClipper:
 
         c = VideoAutoClipper().with_params({"threshold": 4.0, "tile_duration": 2.0})
         assert c.threshold == 4.0
-        resolved = c.resolve_for_media({"id": 1, "type": "video", "duration": 10.0})
+        resolved = c.resolve_for_media({"id": 1, "media_type": "video", "duration": 10.0})
         assert isinstance(resolved, VideoTilingClipper)
         assert resolved.duration == 2.0
 
@@ -2425,7 +2425,7 @@ class TestApplyClipperResolvesAuto:
         wav = generate_wav(440, 5.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 5.0,
             "origin": {"importer": "test", "params": {}},
@@ -2444,7 +2444,7 @@ class TestApplyClipperResolvesAuto:
         wav = generate_wav(440, 60.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 60.0,
             "origin": {"importer": "test", "params": {}},
@@ -2468,14 +2468,14 @@ class TestApplyClipperResolvesAuto:
         clips = {
             1: {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "media_bytes": short_wav,
                 "duration": 2.0,
                 "origin": {"importer": "test", "params": {}},
             },
             2: {
                 "id": 2,
-                "type": "audio",
+                "media_type": "audio",
                 "media_bytes": long_wav,
                 "duration": 8.0,
                 "origin": {"importer": "test", "params": {}},
@@ -2495,7 +2495,7 @@ class TestApplyClipperResolvesAuto:
         wav = generate_wav(440, 8.0)
         media = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "media_bytes": wav,
             "duration": 8.0,
             "origin": {"importer": "test", "params": {}},
@@ -2595,7 +2595,7 @@ class TestImageFaceClipper:
 
         c = ImageFaceClipper()
         c._detector = _stub_detector([])
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         assert c.clip(media) == []
 
     def test_returns_empty_when_no_media_bytes(self):
@@ -2603,7 +2603,7 @@ class TestImageFaceClipper:
 
         c = ImageFaceClipper()
         c._detector = _stub_detector([_FakeDetection(0.9, _FakeBBox(0.1, 0.1, 0.2, 0.2))])
-        assert c.clip({"id": 1, "type": "image"}) == []
+        assert c.clip({"id": 1, "media_type": "image"}) == []
 
     def test_emits_one_clip_per_face(self):
         from vtscore.media.image.clipper import ImageFaceClipper
@@ -2615,11 +2615,11 @@ class TestImageFaceClipper:
                 _FakeDetection(0.85, _FakeBBox(0.5, 0.4, 0.2, 0.2)),
             ]
         )
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         clips = c.clip(media)
         assert len(clips) == 2
         for clip in clips:
-            assert clip["type"] == "image"
+            assert clip["media_type"] == "image"
             assert isinstance(clip["media_bytes"], bytes)
             assert clip["width"] > 0 and clip["height"] > 0
             assert clip["file_size"] == len(clip["media_bytes"])
@@ -2635,7 +2635,7 @@ class TestImageFaceClipper:
                 _FakeDetection(0.95, _FakeBBox(0.5, 0.4, 0.2, 0.2)),
             ]
         )
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         clips = c.clip(media)
         assert clips[0]["clip_index"] == 0
         assert clips[1]["clip_index"] == 1
@@ -2654,7 +2654,7 @@ class TestImageFaceClipper:
                 _FakeDetection(0.4, _FakeBBox(0.5, 0.4, 0.2, 0.2)),
             ]
         )
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         clips = c.clip(media)
         assert len(clips) == 1
 
@@ -2664,7 +2664,7 @@ class TestImageFaceClipper:
         c = ImageFaceClipper(min_size=100, padding=0.0)
         # 0.05 * 640 = 32px — below the 100px floor.
         c._detector = _stub_detector([_FakeDetection(0.95, _FakeBBox(0.1, 0.1, 0.05, 0.05))])
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         assert c.clip(media) == []
 
     def test_padding_expands_box(self):
@@ -2674,7 +2674,7 @@ class TestImageFaceClipper:
         # Face at (320,240) sized 64x64 → padded by 32px on each side → 128x128.
         # 0.5..0.5+64/640=0.6 in x; 0.5..0.5+64/480≈0.633 in y.
         c._detector = _stub_detector([_FakeDetection(0.95, _FakeBBox(0.5, 0.5, 0.1, 0.1333))])
-        media = {"id": 1, "type": "image", "media_bytes": _make_image_bytes(640, 480)}
+        media = {"id": 1, "media_type": "image", "media_bytes": _make_image_bytes(640, 480)}
         clips = c.clip(media)
         assert len(clips) == 1
         x1, y1, x2, y2 = clips[0]["clip_box"]
@@ -2690,7 +2690,7 @@ class TestImageFaceClipper:
         c._detector = _stub_detector([_FakeDetection(0.95, _FakeBBox(0.1, 0.1, 0.3, 0.3))])
         media = {
             "id": 1,
-            "type": "image",
+            "media_type": "image",
             "media_bytes": _make_image_bytes(640, 480),
             "md5": "deadbeef",
             "embedding": np.zeros(8, dtype=np.float32),

--- a/tests/detectors/test_cross_embedder_switch.py
+++ b/tests/detectors/test_cross_embedder_switch.py
@@ -42,7 +42,7 @@ def _make_snap(embedder: str) -> dict[int, dict]:
     return {
         1: {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "embedder": embedder,
             "embedding": rng.standard_normal(8).astype(np.float32),
         }

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -912,7 +912,7 @@ class TestLoadModelEndpoint:
         for cid in (a_good, a_bad):
             ctx_b.medias[cid] = {
                 "id": cid,
-                "type": "audio",
+                "media_type": "audio",
                 "embedder": "clap",
                 "md5": hashlib.md5(f"ds_b_{cid}".encode()).hexdigest(),
                 "embedding": np.zeros(512, dtype=np.float32),
@@ -1061,7 +1061,7 @@ class TestEmbedderMismatchInvalidatesStaleModel:
         for cid in a_ids[:2]:
             ctx_b.medias[cid] = {
                 "id": cid,
-                "type": "audio",
+                "media_type": "audio",
                 "embedder": "shiny-new-embedder",
                 "md5": hashlib.md5(f"h5_b_{cid}".encode()).hexdigest(),
                 "embedding": np.zeros(512, dtype=np.float32),
@@ -1864,7 +1864,7 @@ class TestLoadModelCrossDatasetResolution:
             rng = np.random.default_rng(99)
             medias[1] = {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": rng.standard_normal(512).astype(np.float32),
                 "md5": good_md5,  # same content as good_0.wav
                 "filename": "completely_different_name.wav",
@@ -1873,7 +1873,7 @@ class TestLoadModelCrossDatasetResolution:
             }
             medias[2] = {
                 "id": 2,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": rng.standard_normal(512).astype(np.float32),
                 "md5": bad_md5,  # same content as bad_0.wav
                 "filename": "another_file.wav",
@@ -1951,7 +1951,7 @@ class TestLoadModelCrossDatasetResolution:
             rng = np.random.default_rng(42)
             medias[1] = {
                 "id": 1,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": rng.standard_normal(512).astype(np.float32),
                 "md5": "totally_different_md5",
                 "filename": "shared_name.wav",

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -573,7 +573,7 @@ class TestSortRouteRejectsTextWhenUnsupported:
         try:
             medias[1] = {
                 "id": 1,
-                "type": "image",
+                "media_type": "image",
                 "filename": "x.jpg",
                 "md5": "deadbeef",
                 "embedder": "dinov3_single",

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -27,7 +27,7 @@ def _make_test_media(media_id: int, media_type: str = "audio") -> dict:
     rng = np.random.default_rng(media_id)
     return {
         "id": media_id,
-        "type": media_type,
+        "media_type": media_type,
         "embedder": "clap",
         "duration": 1.0,
         "file_size": 100,

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1285,7 +1285,7 @@ class TestRegionAwareTraining:
         return {
             "id": cid,
             "md5": f"md5-{cid:04x}",
-            "type": "image",
+            "media_type": "image",
             "embedding": cls,
             "patch_grid": grid,
         }
@@ -1313,7 +1313,7 @@ class TestRegionAwareTraining:
         media = {
             "id": 1,
             "md5": "abc",
-            "type": "image",
+            "media_type": "image",
             "embedding": np.array([1.0, 0.0, 0.0], dtype=np.float32),
         }
         vec = _training_vec_for_vote(media, (0.1, 0.2, 0.7, 0.8))

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -540,7 +540,7 @@ class TestMultiFindCrossDatasetFallback:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             target_medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"target_md5_{i}",
                 "filename": f"target_{i}.wav",
@@ -648,7 +648,7 @@ class TestMultiFindCrossDatasetFallback:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             target_medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"mt_md5_{i}",
                 "filename": f"mt_{i}.wav",
@@ -737,7 +737,7 @@ class TestMultiFindCrossDatasetFallback:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             target_medias[i] = {
                 "id": i,
-                "type": "image",
+                "media_type": "image",
                 "embedding": emb,
                 "md5": f"nr_md5_{i}",
                 "filename": f"nr_{i}.jpg",
@@ -850,7 +850,7 @@ class TestFindCheckLabels:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"cl_match_{i}",
                 "filename": f"clip_{i}.wav",
@@ -909,7 +909,7 @@ class TestFindCheckLabels:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"cl_diff_{i}",
                 "filename": f"other_{i}.wav",
@@ -995,7 +995,7 @@ class TestFindCheckLabels:
             emb = np.random.RandomState(i).randn(512).astype(np.float32)
             medias[i] = {
                 "id": i,
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": emb,
                 "md5": f"cl_part_{i}",
                 "filename": f"part_{i}.wav",

--- a/tests/fixtures/medias.py
+++ b/tests/fixtures/medias.py
@@ -78,7 +78,7 @@ def init_medias():
         fname = f"test_media_{i}.wav"
         medias[i] = {
             "id": i,
-            "type": "audio",
+            "media_type": "audio",
             "embedder": "clap",
             "frequency": freq,
             "duration": duration,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -110,7 +110,7 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id)
     return {
         "id": media_id,
-        "type": "image",
+        "media_type": "image",
         "embedder": "siglip",
         "width": 16,
         "height": 16,
@@ -135,7 +135,7 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id + 1000)
     return {
         "id": media_id,
-        "type": "text",
+        "media_type": "text",
         "embedder": "e5",
         "word_count": len(content.split()),
         "character_count": len(content),
@@ -160,7 +160,7 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id + 2000)
     return {
         "id": media_id,
-        "type": "video",
+        "media_type": "video",
         "embedder": "xclip",
         "duration": 1.0,
         "file_size": len(mp4),

--- a/tests/integration/test_multi_media_coverage.py
+++ b/tests/integration/test_multi_media_coverage.py
@@ -188,7 +188,7 @@ class TestMediasListingMultiMedia:
             data = resp.get_json()
             assert len(data) == 3
             for item in data:
-                assert item["type"] == "image"
+                assert item["media_type"] == "image"
                 assert "embedding" not in item
                 assert "media_bytes" not in item
         finally:
@@ -206,7 +206,7 @@ class TestMediasListingMultiMedia:
             data = resp.get_json()
             assert len(data) == 3
             for item in data:
-                assert item["type"] == "text"
+                assert item["media_type"] == "text"
                 assert "media_string" not in item
         finally:
             medias.clear()
@@ -223,7 +223,7 @@ class TestMediasListingMultiMedia:
             data = resp.get_json()
             assert len(data) == 3
             for item in data:
-                assert item["type"] == "video"
+                assert item["media_type"] == "video"
         finally:
             medias.clear()
             medias.update(saved)

--- a/tests/io/test_chunked_web_flow.py
+++ b/tests/io/test_chunked_web_flow.py
@@ -102,8 +102,8 @@ class _DummyChunkedImporter(DatasetImporter):
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         self.run_called = True
-        medias[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
-        medias[2] = {"id": 2, "type": "audio", "embedding": np.ones(4)}
+        medias[1] = {"id": 1, "media_type": "audio", "embedding": np.zeros(4)}
+        medias[2] = {"id": 2, "media_type": "audio", "embedding": np.ones(4)}
 
     def run_chunked(
         self,
@@ -113,8 +113,8 @@ class _DummyChunkedImporter(DatasetImporter):
     ) -> Iterator[dict[int, dict[str, Any]]]:
         self.run_chunked_called = True
         self.last_chunk_size = chunk_size
-        yield {1: {"id": 1, "type": "audio", "embedding": np.zeros(4)}}
-        yield {1: {"id": 1, "type": "audio", "embedding": np.ones(4)}}
+        yield {1: {"id": 1, "media_type": "audio", "embedding": np.zeros(4)}}
+        yield {1: {"id": 1, "media_type": "audio", "embedding": np.ones(4)}}
 
 
 class _DummyNonChunkedImporter(DatasetImporter):
@@ -131,7 +131,7 @@ class _DummyNonChunkedImporter(DatasetImporter):
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         self.run_called = True
-        medias[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
+        medias[1] = {"id": 1, "media_type": "audio", "embedding": np.zeros(4)}
 
     def run_chunked(
         self,
@@ -323,7 +323,7 @@ class TestLocalFolderRouteChunked:
 
         def _stub_run_chunked(field_values, chunk_size, thin=False):
             chunked_calls.append(chunk_size)
-            yield {1: {"id": 1, "type": "audio", "embedding": np.zeros(4), "filename": "a.wav"}}
+            yield {1: {"id": 1, "media_type": "audio", "embedding": np.zeros(4), "filename": "a.wav"}}
 
         def _stub_run(field_values, medias, thin=False):
             captured["run_called"] = True

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -255,7 +255,7 @@ class TestIngestMissingClips:
         existing_clips: dict = {
             1: {
                 "id": 1,
-                "type": "text",
+                "media_type": "text",
                 "duration": 0,
                 "file_size": 10,
                 "md5": "existing_md5",

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -955,7 +955,7 @@ class TestLabelsetSync:
 
             # Add a media item with an md5
             mid = max(medias.keys(), default=0) + 10000
-            medias[mid] = {"id": mid, "md5": "test_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "test_md5", "media_type": "audio"}
             good_votes[mid] = None
 
             sync_to_labelset_source()
@@ -1058,7 +1058,7 @@ class TestLabelsetSync:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 20000
         try:
-            medias[mid] = {"id": mid, "md5": "fake_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "fake_md5", "media_type": "audio"}
             good_votes[mid] = None
             sync_to_labelset_source()
             flush_pending_label_syncs()
@@ -1113,7 +1113,7 @@ class TestLabelsetSync:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 20100
         try:
-            medias[mid] = {"id": mid, "md5": "fake_md5_2", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "fake_md5_2", "media_type": "audio"}
             good_votes[mid] = None
             sync_to_labelset_source()
             flush_pending_label_syncs()
@@ -1412,7 +1412,7 @@ class TestLabelsetSyncDebounce:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 30000
         try:
-            medias[mid] = {"id": mid, "md5": "dbnc_block_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "dbnc_block_md5", "media_type": "audio"}
             good_votes[mid] = None
 
             t0 = time.monotonic()
@@ -1463,7 +1463,7 @@ class TestLabelsetSyncDebounce:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 30100
         try:
-            medias[mid] = {"id": mid, "md5": "dbnc_coalesce_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "dbnc_coalesce_md5", "media_type": "audio"}
             good_votes[mid] = None
 
             with patch.object(src, "save", side_effect=counting_save):
@@ -1494,8 +1494,8 @@ class TestLabelsetSyncDebounce:
         mid_a = max(medias.keys(), default=0) + 30200
         mid_b = mid_a + 1
         try:
-            medias[mid_a] = {"id": mid_a, "md5": "dbnc_a_md5", "type": "audio"}
-            medias[mid_b] = {"id": mid_b, "md5": "dbnc_b_md5", "type": "audio"}
+            medias[mid_a] = {"id": mid_a, "md5": "dbnc_a_md5", "media_type": "audio"}
+            medias[mid_b] = {"id": mid_b, "md5": "dbnc_b_md5", "media_type": "audio"}
 
             set_thread_detector_context(ctx_a)
             good_votes[mid_a] = None
@@ -1535,7 +1535,7 @@ class TestLabelsetSyncDebounce:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 30300
         try:
-            medias[mid] = {"id": mid, "md5": "dbnc_latest_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "dbnc_latest_md5", "media_type": "audio"}
             good_votes[mid] = None
             sync_to_labelset_source()
 
@@ -1569,7 +1569,7 @@ class TestLabelsetSyncDebounce:
         saved_medias = dict(medias)
         mid = max(medias.keys(), default=0) + 30400
         try:
-            medias[mid] = {"id": mid, "md5": "dbnc_reset_md5", "type": "audio"}
+            medias[mid] = {"id": mid, "md5": "dbnc_reset_md5", "media_type": "audio"}
             good_votes[mid] = None
             sync_to_labelset_source()
 

--- a/tests/sorting/test_enrich_descriptions.py
+++ b/tests/sorting/test_enrich_descriptions.py
@@ -325,14 +325,14 @@ class TestEvalTextSortEnrich:
         for _ in range(10):
             emb = cat_dir + rng.normal(0, 0.05, 16)
             emb /= np.linalg.norm(emb)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat", "media_type": "image"}
             media_id += 1
         dog_dir = np.zeros(16)
         dog_dir[1] = 1.0
         for _ in range(10):
             emb = dog_dir + rng.normal(0, 0.05, 16)
             emb /= np.linalg.norm(emb)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "dog", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "dog", "media_type": "image"}
             media_id += 1
         return medias, cat_dir, dog_dir
 

--- a/tests/sorting/test_label_sorting.py
+++ b/tests/sorting/test_label_sorting.py
@@ -164,7 +164,7 @@ class TestLabelFileSortModelSelection:
         """The endpoint should call embed_media on the embedder matching the loaded dataset,
         not hardcode embed_audio_file / CLAP."""
         # Determine the current media type from loaded test medias
-        media_type = next(iter(medias.values())).get("type", "audio")
+        media_type = next(iter(medias.values())).get("media_type", "audio")
         embedding_dim = next(iter(medias.values()))["embedding"].shape[0]
 
         # Create fake media files on disk

--- a/tests_lib/datasets/test_chunked_loading.py
+++ b/tests_lib/datasets/test_chunked_loading.py
@@ -30,7 +30,7 @@ def _make_pickle_with_base_freq(tmp_path: Path, num_clips: int, base_freq: float
         wav_bytes = _make_wav_bytes(frequency=base_freq + i * 10)
         media: dict[str, Any] = {
             "id": i,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -54,7 +54,7 @@ def _make_pickle(tmp_path: Path, num_clips: int, inline_bytes: bool = True) -> P
         wav_bytes = _make_wav_bytes(frequency=440.0 + i)
         media: dict[str, Any] = {
             "id": i,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -228,7 +228,7 @@ class TestPickleChunked:
         pkl_path = _make_pickle(tmp_path, 1)
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
         media = chunks[0][1]
-        assert media["type"] == "audio"
+        assert media["media_type"] == "audio"
         assert media["filename"] == "clip_1.wav"
         assert media["category"] == "cat_1"
 
@@ -236,7 +236,7 @@ class TestPickleChunked:
         """Image-specific fields (width, height) are preserved via the registry."""
         medias_data = {
             1: {
-                "type": "image",
+                "media_type": "image",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_bytes": b"\x89PNG fake",
                 "filename": "photo.png",
@@ -252,7 +252,7 @@ class TestPickleChunked:
         # Full mode
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         media = chunks[0][1]
-        assert media["type"] == "image"
+        assert media["media_type"] == "image"
         assert media["width"] == 640
         assert media["height"] == 480
 
@@ -266,7 +266,7 @@ class TestPickleChunked:
         """Text-specific fields (word_count, character_count) are preserved via the registry."""
         medias_data = {
             1: {
-                "type": "text",
+                "media_type": "text",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_string": "Hello world",
                 "media_bytes": b"Hello world",
@@ -283,7 +283,7 @@ class TestPickleChunked:
         # Full mode
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         media = chunks[0][1]
-        assert media["type"] == "text"
+        assert media["media_type"] == "text"
         assert media["word_count"] == 2
         assert media["character_count"] == 11
 
@@ -297,7 +297,7 @@ class TestPickleChunked:
         """Document media type loads correctly in chunked mode (previously silently failed)."""
         medias_data = {
             1: {
-                "type": "document",
+                "media_type": "document",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_bytes": b"%PDF-1.4 fake",
                 "filename": "report.pdf",
@@ -312,26 +312,26 @@ class TestPickleChunked:
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         assert len(chunks) == 1
         media = chunks[0][1]
-        assert media["type"] == "document"
+        assert media["media_type"] == "document"
         assert media["media_bytes"] == b"%PDF-1.4 fake"
 
         # Thin mode
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
         assert len(chunks) == 1
-        assert chunks[0][1]["type"] == "document"
+        assert chunks[0][1]["media_type"] == "document"
 
     def test_standard_bytes_keys_via_registry(self, tmp_path):
         """Standard media_bytes key is used for all media types."""
         medias_data = {
             1: {
-                "type": "audio",
+                "media_type": "audio",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_bytes": _make_wav_bytes(),
                 "filename": "clip.wav",
                 "category": "test",
             },
             2: {
-                "type": "image",
+                "media_type": "image",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_bytes": b"\x89PNG fake",
                 "filename": "pic.png",
@@ -345,7 +345,7 @@ class TestPickleChunked:
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         loaded = chunks[0]
         assert len(loaded) == 2
-        types = {m["type"] for m in loaded.values()}
+        types = {m["media_type"] for m in loaded.values()}
         assert types == {"audio", "image"}
 
     def test_external_dir_via_registry(self, tmp_path):
@@ -356,7 +356,7 @@ class TestPickleChunked:
 
         medias_data = {
             1: {
-                "type": "document",
+                "media_type": "document",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "filename": "report.pdf",
                 "category": "test",
@@ -370,7 +370,7 @@ class TestPickleChunked:
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         assert len(chunks) == 1
         media = chunks[0][1]
-        assert media["type"] == "document"
+        assert media["media_type"] == "document"
         assert media["media_bytes"] == b"%PDF fake content"
 
         # Thin mode — resolves media_path from document_dir
@@ -384,7 +384,7 @@ class TestPickleChunked:
         """Text media using media_string key loads correctly."""
         medias_data = {
             1: {
-                "type": "text",
+                "media_type": "text",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_string": "Some text paragraph",
                 "filename": "para.txt",
@@ -398,7 +398,7 @@ class TestPickleChunked:
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         assert len(chunks) == 1
         media = chunks[0][1]
-        assert media["type"] == "text"
+        assert media["media_type"] == "text"
         assert media["media_string"] == "Some text paragraph"
         assert media["media_bytes"] == b"Some text paragraph"
 
@@ -423,8 +423,8 @@ class TestBaseImporterChunkedDefault:
             fields: list[ImporterField] = []
 
             def run(self, field_values, medias, thin=False):
-                medias[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
-                medias[2] = {"id": 2, "type": "audio", "embedding": np.ones(4)}
+                medias[1] = {"id": 1, "media_type": "audio", "embedding": np.zeros(4)}
+                medias[2] = {"id": 2, "media_type": "audio", "embedding": np.ones(4)}
 
         imp = DummyImporter()
         assert imp.supports_chunked is False

--- a/tests_lib/datasets/test_dataset_split.py
+++ b/tests_lib/datasets/test_dataset_split.py
@@ -23,7 +23,7 @@ def _make_clips(categories: dict[str, int]) -> dict[int, dict]:
         for _ in range(count):
             medias[media_id] = {
                 "id": media_id,
-                "type": "audio",
+                "media_type": "audio",
                 "category": cat,
                 "embedding": np.zeros(4),
                 "duration": 1.0,

--- a/tests_lib/datasets/test_synthetic_importer.py
+++ b/tests_lib/datasets/test_synthetic_importer.py
@@ -274,7 +274,7 @@ class TestRunEndToEnd:
             assert m["origin"]["importer"] == "synthetic"
             assert m["origin"]["params"]["media_type"] == "audio"
             assert m["origin"]["params"]["size"] == "6"
-            assert m["type"] == "audio"
+            assert m["media_type"] == "audio"
             assert isinstance(m["filename"], str)
             assert Path(m["filename"]).suffix == ".wav"
 

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -111,7 +111,7 @@ class TestThinLoadFromPickle:
         wav_bytes = _make_wav_bytes()
         media_data: dict[str, Any] = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -159,7 +159,7 @@ class TestThinLoadFromPickle:
         pkl_path = self._make_pickle(tmp_path, inline_bytes=True)
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_pickle(pkl_path, medias, thin=True)
-        assert medias[1]["type"] == "audio"
+        assert medias[1]["media_type"] == "audio"
         assert medias[1]["filename"] == "test.wav"
         assert medias[1]["category"] == "test"
 
@@ -191,7 +191,7 @@ class TestPickleNullEmbedding:
         wav_bytes = _make_wav_bytes()
         media: dict[str, Any] = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -244,7 +244,7 @@ class TestPickleNullEmbedding:
         wav_bytes = _make_wav_bytes()
         good = {
             "id": 1,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -255,7 +255,7 @@ class TestPickleNullEmbedding:
         }
         bad = {
             "id": 2,
-            "type": "audio",
+            "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
             "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
@@ -283,7 +283,7 @@ class TestPickleNullEmbedding:
             "medias": {
                 1: {
                     "id": 1,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     "md5": hashlib.md5(wav_bytes).hexdigest(),
@@ -294,7 +294,7 @@ class TestPickleNullEmbedding:
                 },
                 2: {
                     "id": 2,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
@@ -327,7 +327,7 @@ class TestPickleMD5Preservation:
             "medias": {
                 1: {
                     "id": 1,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     "md5": pre_md5,
@@ -353,7 +353,7 @@ class TestPickleMD5Preservation:
             "medias": {
                 1: {
                     "id": 1,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     # no "md5" key
@@ -380,7 +380,7 @@ class TestPickleMD5Preservation:
             "medias": {
                 1: {
                     "id": 1,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     "md5": pre_md5,
@@ -431,7 +431,7 @@ class TestThinImporters:
             "medias": {
                 1: {
                     "id": 1,
-                    "type": "audio",
+                    "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
                     "md5": hashlib.md5(wav_bytes).hexdigest(),

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -34,7 +34,7 @@ def _make_text_media(media_id: int, text: str, *, origin_path: str = "/data/text
     rng = np.random.default_rng(media_id)
     return {
         "id": media_id,
-        "type": "text",
+        "media_type": "text",
         "filename": f"doc_{media_id}.txt",
         "media_string": text,
         "duration": 0,

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -306,7 +306,7 @@ class TestEvalTextSort:
         for _ in range(10):
             emb = cat_dir + rng.normal(0, 0.05, 16)
             emb /= np.linalg.norm(emb)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat", "media_type": "image"}
             media_id += 1
         # "dog" medias cluster around [0, 1, 0, ...]
         dog_dir = np.zeros(16)
@@ -314,7 +314,7 @@ class TestEvalTextSort:
         for _ in range(10):
             emb = dog_dir + rng.normal(0, 0.05, 16)
             emb /= np.linalg.norm(emb)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "dog", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "dog", "media_type": "image"}
             media_id += 1
         return medias, cat_dir, dog_dir
 
@@ -395,11 +395,11 @@ class TestEvalLearnedSort:
         media_id = 1
         for _ in range(n_per_cat):
             emb = rng.normal(1.0, 0.3, dim).astype(np.float32)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat_a", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat_a", "media_type": "image"}
             media_id += 1
         for _ in range(n_per_cat):
             emb = rng.normal(-1.0, 0.3, dim).astype(np.float32)
-            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat_b", "type": "image"}
+            medias[media_id] = {"id": media_id, "embedding": emb, "category": "cat_b", "media_type": "image"}
             media_id += 1
         return medias
 
@@ -425,8 +425,8 @@ class TestEvalLearnedSort:
     def test_learned_sort_skips_tiny_categories(self):
         """Categories with < 2 medias should be skipped."""
         medias = {
-            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32), "category": "rare", "type": "image"},
-            2: {"id": 2, "embedding": -np.ones(8, dtype=np.float32), "category": "common", "type": "image"},
+            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32), "category": "rare", "media_type": "image"},
+            2: {"id": 2, "embedding": -np.ones(8, dtype=np.float32), "category": "common", "media_type": "image"},
         }
         queries = [EvalQuery("rare stuff", "rare")]
         results = eval_learned_sort(medias, queries, train_fraction=0.5)

--- a/tests_lib/detectors/test_score_sanitization.py
+++ b/tests_lib/detectors/test_score_sanitization.py
@@ -186,7 +186,7 @@ class TestLabelsetTrainAndScoreNaNSafety:
             cid: {
                 "embedding": rng.standard_normal(dim).astype(np.float32),
                 "embedder": "test",
-                "type": "audio",
+                "media_type": "audio",
                 "md5": f"m{cid:031d}",
             }
             for cid in (100, 101, 102)

--- a/tests_lib/detectors/test_video_clip_embedding.py
+++ b/tests_lib/detectors/test_video_clip_embedding.py
@@ -294,7 +294,7 @@ def _make_tiled_video_clips() -> list[dict]:
         tiles.append(
             {
                 "id": 100 + idx,
-                "type": "video",
+                "media_type": "video",
                 "media_bytes": parent_bytes,
                 "media_path": "/data/parent.mp4",
                 "md5": parent_md5,  # stale; the fixup should rewrite it

--- a/tests_lib/downloads/test_ucsf_documents_download.py
+++ b/tests_lib/downloads/test_ucsf_documents_download.py
@@ -309,7 +309,7 @@ class TestLoadDemoSourceUcsfDocuments:
 
         assert len(clips) == 1
         clip = clips[1]
-        assert clip["type"] == "image"
+        assert clip["media_type"] == "image"
         assert clip["category"] == "Drug"
         assert clip["media_bytes"] is not None
         assert clip["width"] == 100

--- a/tests_lib/fixtures/medias.py
+++ b/tests_lib/fixtures/medias.py
@@ -78,7 +78,7 @@ def init_medias():
         fname = f"test_media_{i}.wav"
         medias[i] = {
             "id": i,
-            "type": "audio",
+            "media_type": "audio",
             "embedder": "clap",
             "frequency": freq,
             "duration": duration,

--- a/tests_lib/gpu/test_gpu.py
+++ b/tests_lib/gpu/test_gpu.py
@@ -56,7 +56,7 @@ def _make_embeddings(n: int, dim: int = 512, seed: int = 42) -> np.ndarray:
 def _make_clips_dict(n: int = 20, dim: int = 512, seed: int = 42) -> dict:
     """Build a minimal medias dict similar to the real application."""
     embs = _make_embeddings(n, dim, seed)
-    return {i + 1: {"id": i + 1, "embedding": embs[i], "type": "audio"} for i in range(n)}
+    return {i + 1: {"id": i + 1, "embedding": embs[i], "media_type": "audio"} for i in range(n)}
 
 
 def _make_votes(good_ids: list[int], bad_ids: list[int]):
@@ -279,7 +279,7 @@ class TestTrainAndScoreGPU:
             clips_dict = {}
             for i in range(1, 21):
                 emb = rng.randn(dim).astype(np.float32) + (2.0 if i <= 5 else -2.0 if i > 15 else 0.0)
-                clips_dict[i] = {"id": i, "embedding": emb, "type": "audio"}
+                clips_dict[i] = {"id": i, "embedding": emb, "media_type": "audio"}
 
             good, bad = _make_votes([1, 2, 3, 4, 5], [16, 17, 18, 19, 20])
             results, _, _m = train_and_score(clips_dict, good, bad)

--- a/tests_lib/helpers.py
+++ b/tests_lib/helpers.py
@@ -110,7 +110,7 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id)
     return {
         "id": media_id,
-        "type": "image",
+        "media_type": "image",
         "embedder": "siglip",
         "width": 16,
         "height": 16,
@@ -135,7 +135,7 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id + 1000)
     return {
         "id": media_id,
-        "type": "text",
+        "media_type": "text",
         "embedder": "e5",
         "word_count": len(content.split()),
         "character_count": len(content),
@@ -160,7 +160,7 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
     rng = np.random.RandomState(media_id + 2000)
     return {
         "id": media_id,
-        "type": "video",
+        "media_type": "video",
         "embedder": "xclip",
         "duration": 1.0,
         "file_size": len(mp4),

--- a/tests_lib/io/test_clip_reembed_bulk.py
+++ b/tests_lib/io/test_clip_reembed_bulk.py
@@ -26,7 +26,7 @@ def _make_audio_media(media_id: int, duration: float = 5.1) -> dict:
     rng = np.random.default_rng(media_id)
     return {
         "id": media_id,
-        "type": "audio",
+        "media_type": "audio",
         "filename": f"clip_{media_id}.wav",
         "media_bytes": wav,
         "duration": duration,
@@ -47,7 +47,7 @@ def _make_image_media(media_id: int, width: int = 300, height: int = 100) -> dic
     rng = np.random.default_rng(media_id + 1000)
     return {
         "id": media_id,
-        "type": "image",
+        "media_type": "image",
         "filename": f"img_{media_id}.png",
         "media_bytes": img_bytes,
         "width": width,
@@ -64,7 +64,7 @@ def _make_text_media(media_id: int, text: str = "First sentence. Second sentence
     rng = np.random.default_rng(media_id + 2000)
     return {
         "id": media_id,
-        "type": "text",
+        "media_type": "text",
         "filename": f"text_{media_id}.txt",
         "media_string": text,
         "media_bytes": text_bytes,
@@ -244,7 +244,7 @@ class TestSingleOutputClipperMD5Recompute:
         # importer skipped embedding when a clipper was requested.
         clip = {
             "id": 1,
-            "type": "image",
+            "media_type": "image",
             "media_bytes": crop_bytes,
             "md5": parent_md5,
             "embedding": None,
@@ -271,7 +271,7 @@ class TestSingleOutputClipperMD5Recompute:
 
         clip = {
             "id": 1,
-            "type": "text",
+            "media_type": "text",
             "media_string": clip_text,
             "md5": parent_md5,
             "embedding": None,

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -698,7 +698,7 @@ class TestImporterBulkHooks:
         records = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
 
         def fetch_one(record, _fv, _thin):
-            return {"type": "audio", "filename": record["name"], "embedding": None}
+            return {"media_type": "audio", "filename": record["name"], "embedding": None}
 
         imp = self._make_importer(records=records, fetch_one=fetch_one)
         medias: dict = {}
@@ -714,7 +714,7 @@ class TestImporterBulkHooks:
 
         def fetch_one(record, _fv, _thin):
             # fetch_record may omit origin / origin_name — run() fills them in.
-            return {"type": "audio", "filename": record["name"], "embedding": None}
+            return {"media_type": "audio", "filename": record["name"], "embedding": None}
 
         imp = self._make_importer(records=records, fetch_one=fetch_one)
         medias: dict = {}
@@ -729,7 +729,7 @@ class TestImporterBulkHooks:
         def fetch_one(record, _fv, _thin):
             if record == "skip":
                 return None
-            return {"type": "audio", "filename": record, "embedding": None}
+            return {"media_type": "audio", "filename": record, "embedding": None}
 
         imp = self._make_importer(records=records, fetch_one=fetch_one)
         medias: dict = {}
@@ -745,7 +745,7 @@ class TestImporterBulkHooks:
 
         def fetch_one(record, _fv, _thin):
             seen.append(record)
-            return {"type": "audio", "filename": record, "embedding": None}
+            return {"media_type": "audio", "filename": record, "embedding": None}
 
         imp = self._make_importer(records=["x", "y"], fetch_one=fetch_one)
         out = imp.fetch_records_bulk(["x", "y"], {})
@@ -761,11 +761,11 @@ class TestImporterBulkHooks:
 
         def fetch_one(record, _fv, _thin):
             per_item_calls.append(record)
-            return {"type": "audio", "filename": record, "embedding": None}
+            return {"media_type": "audio", "filename": record, "embedding": None}
 
         def fetch_bulk(records, _fv, _thin):
             # Pretend we did one batched call.
-            return [{"type": "audio", "filename": f"bulk:{r}", "embedding": None} for r in records]
+            return [{"media_type": "audio", "filename": f"bulk:{r}", "embedding": None} for r in records]
 
         imp = self._make_importer(records=["a", "b"], fetch_one=fetch_one, fetch_bulk=fetch_bulk)
         medias: dict = {}
@@ -844,7 +844,7 @@ class TestReCallerMultiMedia:
             )
         )
         assert [m["filename"] for m in audio_yields] == ["C0", "C2"]
-        assert all(m["type"] == "audio" for m in audio_yields)
+        assert all(m["media_type"] == "audio" for m in audio_yields)
 
         image_yields = list(
             imp.fetch_source_media(
@@ -854,7 +854,7 @@ class TestReCallerMultiMedia:
             )
         )
         assert [m["filename"] for m in image_yields] == ["C1"]
-        assert image_yields[0]["type"] == "image"
+        assert image_yields[0]["media_type"] == "image"
 
     def test_fetch_source_media_requires_query_id(self, monkeypatch):
         from vtscore.datasets.importers.base import SourceSpec
@@ -904,7 +904,7 @@ class TestReCallerMultiMedia:
             observed_params.append(dict(params))
             return [
                 {
-                    "type": "image",
+                    "media_type": "image",
                     "filename": f"{media['filename']}_frame_{k}.png",
                     "media_bytes": None,
                     "media_path": None,
@@ -937,7 +937,7 @@ class TestReCallerMultiMedia:
 
         # Two image records (direct) + one video record × 2 frames = 4 medias.
         assert len(medias) == 4
-        types = sorted(m["type"] for m in medias.values())
+        types = sorted(m["media_type"] for m in medias.values())
         assert types == ["image", "image", "image", "image"]
         # The framework, not the importer, called video2image.convert with
         # the spec's params.

--- a/tests_lib/io/test_pdf_import.py
+++ b/tests_lib/io/test_pdf_import.py
@@ -237,7 +237,7 @@ class TestFolderImporterPdf:
 
         # Only the WAV should be loaded, not the PDF
         assert len(medias) == 1
-        assert medias[1]["type"] == "audio"
+        assert medias[1]["media_type"] == "audio"
 
     def test_pdf_thin_mode_no_media_bytes(self, tmp_path):
         """In thin mode, PDF-derived medias should have media_bytes=None."""
@@ -274,7 +274,7 @@ class TestFolderImporterPdf:
 
         pdf_medias = [m for m in medias.values() if m["filename"].startswith("doc.pdf-")]
         assert len(pdf_medias) >= 1
-        assert all(m["type"] == "image" for m in pdf_medias)
+        assert all(m["media_type"] == "image" for m in pdf_medias)
 
     def test_pdf_media_has_width_height(self, tmp_path):
         """PDF-derived medias should have non-None width and height."""

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -277,7 +277,7 @@ def _build_multi_results_dict(
 def _detect_media_type(medias: dict[int, dict[str, Any]]) -> str:
     """Return the media type from the first media, or ``"unknown"``."""
     for media in medias.values():
-        return media.get("type", "unknown")
+        return media.get("media_type", "unknown")
     return "unknown"
 
 

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -132,7 +132,7 @@ def _build_converted_media_dict(
 ) -> dict[str, Any]:
     media_data: dict[str, Any] = {
         "id": media_id,
-        "type": target_type,
+        "media_type": target_type,
         "embedder": target_emb.name if target_emb else "",
         "file_size": len(output.get("media_bytes", b"") or output.get("media_string", "").encode()),
         "md5": _compute_md5(output),

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -382,7 +382,7 @@ def _load_source_as_media(file_path: Path, source_media_type: str) -> dict[str, 
     at: ``media_bytes`` / ``media_string``, ``filename``, and ``type``.
     """
     media: dict[str, Any] = {
-        "type": source_media_type,
+        "media_type": source_media_type,
         "filename": file_path.name,
         "media_path": str(file_path),
     }

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -87,7 +87,7 @@ def _iter_unique_source_clips(
             continue
 
         first_clip = next(iter(source_clips.values()))
-        source_media_type = first_clip.get("type", "audio")
+        source_media_type = first_clip.get("media_type", "audio")
         if mtype_state[0] is None:
             mtype_state[0] = source_media_type
         elif source_media_type != mtype_state[0]:

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -146,7 +146,7 @@ def _build_media(
         },
     }
     return {
-        "type": media_type,
+        "media_type": media_type,
         "filename": content_id,
         "md5": record["md5"],
         "embedding": embedding_info["embedding"],

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -110,7 +110,7 @@ def _load_pdf_images(  # noqa: C901
 
             media_data: dict[str, Any] = {
                 "id": media_id,
-                "type": mt.type_id,
+                "media_type": mt.type_id,
                 "embedder": embedder_id,
                 "file_size": len(image_bytes),
                 "md5": hashlib.md5(image_bytes).hexdigest(),

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -97,7 +97,7 @@ def _embedder_name_for_type(medias: dict[int, dict[str, Any]], media_type_id: st
     string when no matching media is found (caller falls back to the default).
     """
     for m in medias.values():
-        if m.get("type") == media_type_id:
+        if m.get("media_type") == media_type_id:
             name = m.get("embedder", "")
             if name:
                 return name
@@ -125,7 +125,7 @@ def _build_media_data(
     """
     name = origin_name or file_path.name
     media_data: dict[str, Any] = {
-        "type": media_type_id,
+        "media_type": media_type_id,
         "file_size": len(file_bytes),
         "md5": md5,
         "embedding": embedding,

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -313,10 +313,10 @@ def _apply_clipper(  # noqa: C901
     _fixup_clip_md5_and_embeddings(clips_list, needs_recompute, final_type, on_progress=on_progress)
     _regenerate_clip_thumbnails(clips_list, needs_recompute, final_type)
 
-    # Update `type` on every clip so downstream code sees the final type
+    # Update `media_type` on every clip so downstream code sees the final type
     # (converter chains change the media_type of the carriers).
     for clip in clips_dict.values():
-        clip["type"] = final_type
+        clip["media_type"] = final_type
 
 
 def _regenerate_clip_thumbnails(  # noqa: C901
@@ -577,7 +577,7 @@ def _auto_register_dataset(
         return None
 
     first = next(iter(media_dict.values()))
-    media_type = first.get("type", "audio")
+    media_type = first.get("media_type", "audio")
     num_items = len(media_dict)
 
     if not embedder:
@@ -1240,7 +1240,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 return
 
             first = next(iter(temp_medias.values()))
-            media_type = first.get("type", "audio")
+            media_type = first.get("media_type", "audio")
             count = len(temp_medias)
             name = label or importer.resolve_display_name(field_values)
 

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -160,7 +160,7 @@ def export_dataset_to_file(
         "medias": {
             cid: {
                 "id": media["id"],
-                "type": media.get("type", "audio"),
+                "media_type": media.get("media_type", "audio"),
                 "duration": media["duration"],
                 "file_size": media["file_size"],
                 "md5": media["md5"],

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -567,7 +567,7 @@ def _build_folder_media_data(
         }
     return {
         "id": media_id,
-        "type": type_id,
+        "media_type": type_id,
         "embedder": embedder_id,
         "file_size": file_size,
         "md5": md5,

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -120,7 +120,7 @@ def _build_pickle_thin_media(
     fname = media_info.get("filename", f"media_{new_id}.{media_type}")
     media_data: dict[str, Any] = {
         "id": new_id,
-        "type": media_type,
+        "media_type": media_type,
         "embedder": media_info.get("embedder", ""),
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", 0),
@@ -155,7 +155,7 @@ def _build_pickle_full_media(
     fname = media_info.get("filename", f"media_{new_id}.{media_type}")
     media_data = {
         "id": new_id,
-        "type": media_type,
+        "media_type": media_type,
         "embedder": media_info.get("embedder", ""),
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", len(media_bytes)),
@@ -193,7 +193,7 @@ def _convert_one_pickle_media(
     its embedding or external-file reference could not be resolved
     (used to bump the "missing media" warning counter).
     """
-    media_type = media_info.get("type", "audio")
+    media_type = media_info.get("media_type", "audio")
     extra_fields = extra_fields_map.get(media_type, [])
 
     # Treat missing key and explicit ``None`` identically: both mean

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -51,7 +51,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
     # Determine the embedder and media type from the loaded dataset so we
     # can embed example files that aren't already in the dataset.
     first_media = next(iter(snap.values()))
-    dataset_media_type = first_media.get("type", "audio")
+    dataset_media_type = first_media.get("media_type", "audio")
     dataset_embedder_name = first_media.get("embedder", "")
     embedder = None  # lazily loaded only when needed
 
@@ -105,7 +105,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
                 new_id = next_media_id(medias)
                 medias[new_id] = {
                     "id": new_id,
-                    "type": dataset_media_type,
+                    "media_type": dataset_media_type,
                     "embedder": dataset_embedder_name,
                     "md5": file_md5,
                     "embedding": embedding,

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -168,7 +168,7 @@ def apply_and_retrain(  # noqa: C901
             det_ctx.training_medias = training
             first = next(iter(snap.values()), {})
             det_ctx.embedder = first.get("embedder", "")
-            det_ctx.media_type = first.get("type", "")
+            det_ctx.media_type = first.get("media_type", "")
             from vtscore.detectors.registry import record_detector_embedder
 
             record_detector_embedder(det_ctx.detector_id, det_ctx.embedder)

--- a/vtscore/docs/concepts.md
+++ b/vtscore/docs/concepts.md
@@ -24,7 +24,7 @@ detector reads and writes media dicts.
 ```python
 medias[42] = {
     "id": 42,                              # int, matches dict key
-    "type": "audio",                       # MediaType.type_id
+    "media_type": "audio",                       # MediaType.type_id
     "embedder": "audio_clap",              # MediaEmbedder.name
     "file_size": 318456,                   # bytes
     "md5": "5d41402abc4b2a76b9719d911017c592",  # content hash

--- a/vtscore/docs/extending/clippers.md
+++ b/vtscore/docs/extending/clippers.md
@@ -280,7 +280,7 @@ class TestSoundOverlapClipper:
     def test_clip_returns_overlapping_windows(self):
         cl = get_clipper("sound_overlap_2.0s")
         media = {
-            "id": 1, "type": "audio", "category": "",
+            "id": 1, "media_type": "audio", "category": "",
             "filename": "x.wav", "origin": None, "origin_name": "x.wav",
             "media_bytes": _make_wav(5.0),
         }
@@ -293,7 +293,7 @@ class TestSoundOverlapClipper:
     def test_short_clip_passes_through(self):
         cl = get_clipper("sound_overlap_2.0s")
         media = {
-            "id": 1, "type": "audio", "category": "",
+            "id": 1, "media_type": "audio", "category": "",
             "filename": "x.wav", "origin": None, "origin_name": "x.wav",
             "media_bytes": _make_wav(1.0),
         }

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -279,7 +279,7 @@ class TestMyImporterRun:
         imp.run({"path": str(tmp_path), "media_type": "audio"}, medias)
         assert medias
         for m in medias.values():
-            assert m["type"] == "audio"
+            assert m["media_type"] == "audio"
             assert m["origin"]["importer"] == "my_importer"
 ```
 
@@ -337,7 +337,7 @@ class CatalogueImporter(DatasetImporter):
     ) -> dict | None:
         embedding = np.asarray(record["embedding"], dtype=np.float32)
         return {
-            "type": "audio",
+            "media_type": "audio",
             "filename": record["id"] + ".wav",
             "md5": record["md5"],
             "embedding": embedding,

--- a/vtscore/docs/faq.md
+++ b/vtscore/docs/faq.md
@@ -95,7 +95,7 @@ functional refactor. `medias` is mutated in place; the function returns
 
 ```python
 medias[42] = {
-    "id": 42, "type": "audio", "embedder": "audio_clap",
+    "id": 42, "media_type": "audio", "embedder": "audio_clap",
     "file_size": 318456,
     "md5": "5d41402abc4b2a76b9719d911017c592",
     "embedding": np.ndarray,            # shape (D,), float32

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -304,7 +304,7 @@ The runner builds each output media dict via
 ```python
 {
     "id": <assigned by runner>,
-    "type": <converter.target_type>,
+    "media_type": <converter.target_type>,
     "embedder": <name of target media type's default embedder>,
     "file_size": <len of media_bytes or media_string.encode()>,
     "md5": <hashlib.md5 of bytes/string>,

--- a/vtscore/docs/packages/security.md
+++ b/vtscore/docs/packages/security.md
@@ -206,7 +206,7 @@ payload, appends `b""`), `APPEND` / `APPENDS` (drops the value(s) that
 would have been appended).
 
 The outer dict structure is materialised (so you can index into
-`data["medias"][0]["type"]`), but embedding lists are empty and inline
+`data["medias"][0]["media_type"]`), but embedding lists are empty and inline
 media-byte blobs are `b""`. For a multi-GB dataset upload this turns a
 30-second `pickle.load` into a sub-second peek.
 
@@ -216,7 +216,7 @@ from vtscore.security import peek_pickle_dataset_summary
 with open(uploaded_pkl, "rb") as f:
     summary = peek_pickle_dataset_summary(f)
 n_medias = len(summary["medias"])
-media_type = summary["medias"][0]["type"] if n_medias else None
+media_type = summary["medias"][0]["media_type"] if n_medias else None
 ```
 
 The peek result is **only** safe for inspecting structure. Code that

--- a/vtscore/docs/quickstart.md
+++ b/vtscore/docs/quickstart.md
@@ -93,7 +93,7 @@ What's now in each `medias[cid]`:
 medias[1]
 # {
 #   "id": 1,
-#   "type": "audio",
+#   "media_type": "audio",
 #   "embedder": "audio_clap",
 #   "md5": "5d41402abc4b2a76b9719d911017c592",
 #   "embedding": np.ndarray(shape=(512,), dtype=float32),

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -603,7 +603,7 @@ class AudioMediaType(MediaType):
             media_fields = self.load_media_data(audio_path)
             clips[clip_id] = {
                 "id": clip_id,
-                "type": self.type_id,
+                "media_type": self.type_id,
                 "embedder": embedder.name,
                 "duration": media_fields["duration"],
                 "file_size": len(wav_bytes),

--- a/vtscore/media/cropping.py
+++ b/vtscore/media/cropping.py
@@ -40,7 +40,7 @@ def crop_file_bytes(
         start = float(params.get("start", 0.0))
         end = float(params.get("end", 0.0))
         clipper = SoundClipClipper(start, end)
-        media = {"id": 0, "type": "audio", "media_bytes": media_bytes}
+        media = {"id": 0, "media_type": "audio", "media_bytes": media_bytes}
         clipped = clipper.clip(media)
         return clipped[0].get("media_bytes", media_bytes)
 
@@ -57,7 +57,7 @@ def crop_file_bytes(
             width, height = img.size
         media = {
             "id": 0,
-            "type": "image",
+            "media_type": "image",
             "media_bytes": media_bytes,
             "width": width,
             "height": height,

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -505,7 +505,7 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin) -> N
             width, height = None, None
         clips[clip_id] = {
             "id": clip_id,
-            "type": _MEDIA_TYPE_ID,
+            "media_type": _MEDIA_TYPE_ID,
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
@@ -545,7 +545,7 @@ def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin) 
         rel_name = f"{category}/{page_name}"
         clips[clip_id] = {
             "id": clip_id,
-            "type": _MEDIA_TYPE_ID,
+            "media_type": _MEDIA_TYPE_ID,
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
@@ -588,7 +588,7 @@ def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin) -> 
         fname = f"{category}/{category}_{clip_id}.png"
         clips[clip_id] = {
             "id": clip_id,
-            "type": _MEDIA_TYPE_ID,
+            "media_type": _MEDIA_TYPE_ID,
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -598,7 +598,7 @@ class TextMediaType(MediaType):
             fname = f"{category}/{category}_{clip_id}.txt"
             clips[clip_id] = {
                 "id": clip_id,
-                "type": self.type_id,
+                "media_type": self.type_id,
                 "embedder": embedder.name,
                 "duration": 0,
                 "file_size": len(text_bytes),

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -767,7 +767,7 @@ class VideoMediaType(MediaType):
             media_fields = self.load_media_data(video_path)
             clips[clip_id] = {
                 "id": clip_id,
-                "type": self.type_id,
+                "media_type": self.type_id,
                 "embedder": embedder.name,
                 "duration": media_fields["duration"],
                 "file_size": len(video_bytes),

--- a/vtscore/security/pickle.py
+++ b/vtscore/security/pickle.py
@@ -163,7 +163,7 @@ def peek_pickle_dataset_summary(f: io.BufferedIOBase) -> Any:
     Returns the same top-level structure ``pickle.load`` would, but with
     embedding lists left empty and inline media-byte blobs replaced by
     ``b""``. Sufficient for reading the media count and the first entry's
-    ``"type"`` field; not suitable for any operation that needs the
+    ``"media_type"`` field; not suitable for any operation that needs the
     underlying vectors or bytes.
 
     Rejects non-allowlisted classes the same way :func:`safe_pickle_load`

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -321,7 +321,7 @@ def get_embedder_for_medias(media_dict: dict):
         return None
     first = next(iter(media_dict.values()))
     embedder_name = first.get("embedder", "")
-    media_type = first.get("type", "audio")
+    media_type = first.get("media_type", "audio")
 
     from vtscore.media import embedders_for_type, get_embedder  # noqa: PLC0415
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -132,7 +132,7 @@ def stage_file():
         if isinstance(media_dict, dict) and media_dict:
             first = next(iter(media_dict.values()))
             if isinstance(first, dict):
-                media_type = first.get("type", "audio") or "unknown"
+                media_type = first.get("media_type", "audio") or "unknown"
         del peeked, media_dict
     except Exception as e:
         count = 0

--- a/vtsearch/routes/datasets/status.py
+++ b/vtsearch/routes/datasets/status.py
@@ -41,7 +41,7 @@ def dataset_status():
     snap = snapshot_medias()
     media_type = None
     if snap:
-        media_type = next(iter(snap.values())).get("type", "audio")
+        media_type = next(iter(snap.values())).get("media_type", "audio")
     return {
         "loaded": len(snap) > 0,
         "num_medias": len(snap),

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -463,7 +463,7 @@ def dashboard_dataset_info():
         abort(404, message="No dataset loaded")
 
     first = next(iter(snap.values()))
-    media_type = first.get("type", "audio")
+    media_type = first.get("media_type", "audio")
     num_medias = len(snap)
 
     # Determine origin from the first media that has one

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -452,7 +452,7 @@ def _score_dataset(
     if not temp_medias:
         return [], [], scored_units, 0, ""
 
-    detected_media_type = next(iter(temp_medias.values()), {}).get("type", "")
+    detected_media_type = next(iter(temp_medias.values()), {}).get("media_type", "")
 
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -246,7 +246,7 @@ def find_label(body: dict):  # noqa: C901
         update_find_progress("idle", "")
         abort(400, message="No medias loaded")
 
-    media_type = d.get("media_type", "") or next(iter(snap.values())).get("type", "image")
+    media_type = d.get("media_type", "") or next(iter(snap.values())).get("media_type", "image")
     det_path = _detector_path(d["name"])
     det_data = _read_detector(det_path)
 
@@ -493,7 +493,7 @@ def auto_detect(body: dict):
     if not snap:
         abort(400, message="No medias loaded")
 
-    media_type = next(iter(snap.values())).get("type", "audio")
+    media_type = next(iter(snap.values())).get("media_type", "audio")
 
     # Clear a leftover cancel flag from a previously-cancelled run.
     find_progress.reset_cancel()

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -99,7 +99,7 @@ def _build_entry_metadata(media: dict) -> dict:
     from vtscore.media import get as get_media_type  # noqa: PLC0415
 
     try:
-        meta = get_media_type(media.get("type", "audio")).display_metadata(media)
+        meta = get_media_type(media.get("media_type", "audio")).display_metadata(media)
     except KeyError:
         meta = {}
 
@@ -322,7 +322,7 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
 
     media_type = "unknown"
     for media in snap_medias.values():
-        media_type = media.get("type", "unknown")
+        media_type = media.get("media_type", "unknown")
         break
 
     results_dict = {

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -269,7 +269,7 @@ def list_media_ids():
     """
     result: list[dict[str, Any]] = []
     for c in snapshot_medias().values():
-        item: dict[str, Any] = {"id": c["id"], "type": c.get("type", "audio")}
+        item: dict[str, Any] = {"id": c["id"], "media_type": c.get("media_type", "audio")}
         embedder = c.get("embedder")
         if embedder:
             item["embedder"] = embedder
@@ -301,10 +301,10 @@ def batch_medias(body: dict):
         c = snap.get(cid)
         if c is None:
             continue
-        media_type_id = c.get("type", "audio")
+        media_type_id = c.get("media_type", "audio")
         media_data: dict[str, Any] = {
             "id": c["id"],
-            "type": media_type_id,
+            "media_type": media_type_id,
             "filename": c.get("filename", f"media_{c['id']}.wav"),
             "md5": c["md5"],
         }
@@ -364,7 +364,7 @@ def media_video(media_id: int):
     c = get_media(media_id)
     if not c:
         abort(404, message="not found")
-    if c.get("type") != "video":
+    if c.get("media_type") != "video":
         abort(400, message="not a video")
 
     filename = c.get("filename", "")
@@ -420,7 +420,7 @@ def media_image(media_id: int):  # noqa: C901
     if not c:
         abort(404, message="not found")
 
-    media_type = c.get("type")
+    media_type = c.get("media_type")
 
     # For non-image types, delegate to the media type's image_response if available
     if media_type and media_type != "image":
@@ -475,7 +475,7 @@ def media_paragraph(media_id: int):
     c = get_media(media_id)
     if not c:
         abort(404, message="not found")
-    if c.get("type") not in ("text", "paragraph"):
+    if c.get("media_type") not in ("text", "paragraph"):
         abort(400, message="not a text media")
 
     content = _resolve_string(c)
@@ -510,7 +510,7 @@ def media_generic(media_id: int):
     from vtscore.media import get as media_get
 
     try:
-        mt = media_get(c.get("type", ""))
+        mt = media_get(c.get("media_type", ""))
     except KeyError:
         abort(400, message=f"unsupported media type: {c.get('type')}")
 
@@ -657,7 +657,7 @@ def add_media_to_pile():  # noqa: C901
         abort(400, message="No dataset loaded. Load a dataset first.")
 
     first_media = next(iter(snap.values()))
-    dataset_media_type = first_media.get("type", "audio")
+    dataset_media_type = first_media.get("media_type", "audio")
     dataset_embedder_name = first_media.get("embedder", "")
 
     from vtscore.media import embedders_for_type, get_embedder
@@ -705,7 +705,7 @@ def add_media_to_pile():  # noqa: C901
         thumb = generate_video_thumbnail(file_bytes)
 
     new_media: dict[str, Any] = {
-        "type": dataset_media_type,
+        "media_type": dataset_media_type,
         "embedder": dataset_embedder_name,
         "md5": file_md5,
         "embedding": embedding,

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -361,7 +361,7 @@ def _media_extension(media: dict) -> str:
     suffix = Path(filename).suffix
     if suffix:
         return suffix
-    media_type = media.get("type", "")
+    media_type = media.get("media_type", "")
     if media_type == "audio":
         return ".wav"
     if media_type == "image":
@@ -481,7 +481,7 @@ def server_media_file_from_media_id(body: dict):
 
     crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
     if crop_params:
-        media_type = media.get("type", "")
+        media_type = media.get("media_type", "")
         try:
             from vtscore.media.cropping import crop_file_bytes
 

--- a/vtsearch/routes/processors/scoring.py
+++ b/vtsearch/routes/processors/scoring.py
@@ -137,7 +137,7 @@ def run_extract(body: dict):
     except Exception as e:
         abort(400, message=f"Invalid extractor config: {e}")
 
-    media_type = next(iter(snap.values())).get("type", "")
+    media_type = next(iter(snap.values())).get("media_type", "")
     if extractor.media_type != media_type:
         abort(
             400,
@@ -165,7 +165,7 @@ def auto_extract():
     if not snap:
         abort(400, message="No medias loaded")
 
-    media_type = next(iter(snap.values())).get("type", "")
+    media_type = next(iter(snap.values())).get("media_type", "")
     extractors = get_autorun_extractors_by_media(media_type)
 
     if not extractors:
@@ -206,7 +206,7 @@ def run_localize(body: dict):
     except Exception as e:
         abort(400, message=f"Invalid localizer config: {e}")
 
-    media_type = next(iter(snap.values())).get("type", "")
+    media_type = next(iter(snap.values())).get("media_type", "")
     if localizer.media_type != media_type:
         abort(
             400,
@@ -234,7 +234,7 @@ def auto_localize():
     if not snap:
         abort(400, message="No medias loaded")
 
-    media_type = next(iter(snap.values())).get("type", "")
+    media_type = next(iter(snap.values())).get("media_type", "")
     localizers = get_autorun_localizers_by_media(media_type)
 
     if not localizers:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -158,7 +158,7 @@ def sort_clips(body: dict):
         abort(400, message="No medias loaded")
 
     first = next(iter(snap.values()))
-    media_type = first.get("type", "audio")
+    media_type = first.get("media_type", "audio")
     embedder_name = first.get("embedder", "")
     total_steps = 3  # load embedder, embed query, compute similarities
 
@@ -319,7 +319,7 @@ def _update_det_ctx_with_trained_model(det_ctx, model, threshold, labelset, trai
     if snap:
         first = next(iter(snap.values()), {})
         det_ctx.embedder = first.get("embedder", "")
-        det_ctx.media_type = first.get("type", "")
+        det_ctx.media_type = first.get("media_type", "")
 
 
 def _build_learned_sort_signature(
@@ -760,7 +760,7 @@ def _apply_crop_or_keep(temp_path: Path, crop_params: dict | None) -> Path:
     if not snap:
         return temp_path
     first_media = next(iter(snap.values()))
-    media_type = first_media.get("type", "")
+    media_type = first_media.get("media_type", "")
 
     from vtscore.media.cropping import crop_file_bytes
 

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -57,7 +57,7 @@ class _MediaIdEntrySchema(Schema):
     """One entry in the lightweight ``GET /api/medias/ids`` listing."""
 
     id = fields.Integer(required=True)
-    type = fields.String(required=True)
+    media_type = fields.String(required=True)
     embedder = fields.String()
 
 
@@ -70,7 +70,7 @@ class MediaIdsListResponseSchema(Schema):
     """
 
     id = fields.Integer(required=True)
-    type = fields.String(required=True)
+    media_type = fields.String(required=True)
     embedder = fields.String()
 
     class Meta:
@@ -98,7 +98,7 @@ class _MediaBatchEntrySchema(Schema):
     """
 
     id = fields.Integer(required=True)
-    type = fields.String(required=True)
+    media_type = fields.String(required=True)
     filename = fields.String(required=True)
     md5 = fields.String(required=True)
     custom_metadata = fields.Dict(required=True)


### PR DESCRIPTION
## Summary

Unifies the field name everywhere a media-item dict is constructed or read. Previously the dict used `"type"` while the surrounding code (clippers, processors, registry, marshmallow schemas, etc.) used `"media_type"` for the same concept. Now every reference is `"media_type"`.

Three spellings collapsed to one:

| Context | Before | After |
|---|---|---|
| media dict | `"type"` | `"media_type"` |
| dataset registry, clippers, processors | `"media_type"` | `"media_type"` (unchanged) |
| embedders | `"media_type_id"` | `"media_type_id"` (unchanged — separate identifier) |

## Scope

- **Python writes** — every media-dict literal across `vtscore/media/{audio,text,video,image}`, `vtscore/datasets/{loader,loader_pickle,loader_folder,ingest,clipper_chain,load_pipeline}`, `vtscore/datasets/importers/{server_folder,recaller,combine_datasets}`, `vtscore/converters/runner.py`, `vtscore/detectors/media_seeding.py`, `vtscore/media/cropping.py`.
- **Python reads** — every `.get("type")` / `media["type"]` on a media dict in `vtscore/cli.py` and across `vtsearch/routes/{media,sorting,labels,datasets,processors,detectors,_shared}`.
- **API surface** — `MediaIdsListResponseSchema` and `_MediaBatchEntrySchema` field renamed; `frontend/openapi.json` snapshot updated to match.
- **Frontend** — every `media.type` / `medias[0].type` access in components and templates plus all `*.spec.ts` mock fixtures.
- **Tests** — `tests/` and `tests_lib/` media fixtures and assertions updated.
- **Docs** — `quickstart.md`, `faq.md`, `security.md`, `converters.md`, extending guides, API docs.

Detector example dicts (which carry their own `"type": "text" | "media"` discriminator) are intentionally untouched.

## Breaking change

Old dataset pickle files that contain `"type"` inside their media dicts will no longer load. Per project policy, no compatibility shim is added — re-import the dataset to refresh.

## Test plan

- [x] `./run-tests.sh` — all 4201 tests pass (1 skipped)
- [x] Two pre-existing contract tests that asserted `"type"` were updated to assert `"media_type"`


---
_Generated by [Claude Code](https://claude.ai/code/session_015Tfmj7bE5wRXAUoXbjFQ67)_