### PR TITLE
Framework owns embedding (not importers)

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -406,7 +406,15 @@ only when the UI needs to display or play the media.
 
 Most importers delegate to `load_dataset_from_folder()` after downloading
 files to a local directory.  However, importers whose data comes from
-API calls (not files on disk) can build media dicts directly in `run()`:
+API calls (not files on disk) can build media dicts directly in `run()`.
+
+**Importers do not embed.** Set `embedding=None` and `embedder=""`; the
+framework `embed_missing` stage embeds every item still at `None` after
+`run()` returns, using the user-selected embedder (or the default for
+the media type).  Only set `embedding` to a real vector when your data
+source ships pre-computed vectors that are dimension-compatible with the
+embedder the user picked — in that case also set `embedder` to the name
+of that embedder.
 
 ```python
 def run(self, field_values, medias, thin=False):
@@ -416,8 +424,8 @@ def run(self, field_values, medias, thin=False):
             "media_type": "audio",
             "filename": item["id"],
             "md5": item["md5"],                  # pre-computed by the service
-            "embedding": item["embedding"],      # pre-computed by the service
-            "embedder": item["embedder_name"],   # must match a VTSearch embedder
+            "embedding": None,                   # framework embed stage fills this in
+            "embedder": "",                      # framework embed stage stamps this
             "media_bytes": data if not thin else None,
             "media_path": None,
             "media_url": item["url"],            # URL-based lazy-fetch fallback
@@ -433,6 +441,11 @@ def run(self, field_values, medias, thin=False):
             "custom_metadata": {"contentID": item["id"], ...},
         }
 ```
+
+If the source ships pre-computed vectors, prefer
+`self.content_vectors[filename] = vec` or
+`self.custom_metadata_map[filename] = {"embedding": vec}` — the framework
+treats those as already-embedded and skips them.
 
 When building dicts directly, the importer should also override
 `build_origin()` to return an empty origin (since the default

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -168,8 +168,11 @@ def load_dataset_from_folder(
     progress: ProgressCallback | None = None,
     **opts,
 ) -> tuple[list[Media], list[Embedding]]:
-    """Walk `folder`, embed each file with the default embedder for `media_type`,
-    return (medias, embeddings). Honours filetype filters declared by the MediaType."""
+    """Walk `folder` and build a media dict per file.  Loaders do NOT embed —
+    items leave with `embedding=None` unless a pre-computed vector is supplied
+    via `content_vectors` / `custom_metadata_map`.  The framework
+    `embed_missing` stage (or the caller) fills the rest in afterwards.
+    Honours filetype filters declared by the MediaType."""
 
 def load_dataset_from_pickle(path: Path | str) -> tuple[list[Media], list[Embedding]]:
     """Restore a (media, embedding) snapshot previously written by export_dataset_to_file.

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -16,8 +16,6 @@ import hashlib
 import io
 from unittest.mock import MagicMock, patch
 
-import numpy as np
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -375,7 +373,6 @@ class TestRunConvertersOnFolder:
 
         medias: dict = {}
         with (
-            patch("vtscore.converters.runner._embed_converted_output", return_value=np.zeros(768)),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -388,19 +385,20 @@ class TestRunConvertersOnFolder:
         assert medias == {}
 
     def test_converter_produces_output_with_origin(self, tmp_path):
-        """Mock converter + embedder to verify the full pipeline."""
+        """Verify the runner emits one media per converter output with the
+        right origin.  The runner does not embed — outputs leave with
+        ``embedding=None`` for the framework embed stage to fill in.
+        """
         from vtscore.converters.runner import run_converters_on_folder
 
         # Create a fake "video" file.
         (tmp_path / "clip.mp4").write_bytes(b"fake-video-data")
 
-        fake_embedding = np.ones(768, dtype=np.float32)
         mock_converter = self._mock_video2image_converter()
 
         medias: dict = {}
         with (
             patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=fake_embedding),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -428,8 +426,11 @@ class TestRunConvertersOnFolder:
         # Check media type
         assert media["media_type"] == "image"
 
-        # Check embedding
-        assert np.array_equal(media["embedding"], fake_embedding)
+        # Embedding is deferred to the framework embed stage.
+        assert media["embedding"] is None
+        # media_bytes flows through from the converter output so the
+        # framework embed stage can embed without a tempfile.
+        assert media["media_bytes"] is not None
 
     def test_converter_with_multiple_outputs(self, tmp_path):
         """A converter that produces multiple outputs per source file."""
@@ -466,7 +467,6 @@ class TestRunConvertersOnFolder:
         medias: dict = {}
         with (
             patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=np.ones(768)),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -502,7 +502,6 @@ class TestRunConvertersOnFolder:
         medias: dict = {}
         with (
             patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=np.ones(768)),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -528,7 +527,6 @@ class TestRunConvertersOnFolder:
         medias: dict = {1: {"id": 1}, 5: {"id": 5}, 10: {"id": 10}}
         with (
             patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=np.ones(768)),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -541,30 +539,6 @@ class TestRunConvertersOnFolder:
 
         # New media should start from ID 11
         assert 11 in medias
-
-    def test_embed_failure_skips_output(self, tmp_path):
-        """If embedding returns None, that output is skipped."""
-        from vtscore.converters.runner import run_converters_on_folder
-
-        (tmp_path / "clip.mp4").write_bytes(b"video")
-
-        mock_converter = self._mock_video2image_converter()
-
-        medias: dict = {}
-        with (
-            patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=None),
-            patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
-        ):
-            run_converters_on_folder(
-                folder_path=tmp_path,
-                converter_names=["video2image"],
-                target_media_type="image",
-                medias=medias,
-                on_progress=lambda *a: None,
-            )
-
-        assert medias == {}
 
     def test_converter_follows_symlinked_directories(self, tmp_path):
         """Source files in a symlinked subdirectory must be discovered."""
@@ -579,13 +553,11 @@ class TestRunConvertersOnFolder:
 
         (root / "linked").symlink_to(external)
 
-        fake_embedding = np.ones(768, dtype=np.float32)
         mock_converter = self._mock_video2image_converter()
 
         medias: dict = {}
         with (
             patch("vtscore.converters.get_converter", return_value=mock_converter),
-            patch("vtscore.converters.runner._embed_converted_output", return_value=fake_embedding),
             patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
         ):
             run_converters_on_folder(
@@ -603,7 +575,7 @@ class TestRunConvertersOnFolder:
 
 
 # ===========================================================================
-# _embed_converted_output and _compute_md5
+# _compute_md5
 # ===========================================================================
 
 
@@ -626,43 +598,6 @@ class TestEmbedAndMd5Helpers:
         from vtscore.converters.runner import _compute_md5
 
         assert _compute_md5({}) == hashlib.md5(b"").hexdigest()
-
-    def test_embed_converted_output_binary(self, tmp_path):
-        """Binary output is written to temp file and embed_media is called."""
-        from vtscore.converters.runner import _embed_converted_output
-
-        png_bytes = _make_png_bytes()
-        fake_embedding = np.ones(768)
-        mock_mt = MagicMock()
-        mock_mt.embed_media.return_value = fake_embedding
-
-        result = _embed_converted_output(mock_mt, {"media_bytes": png_bytes, "filename": "test.png"})
-
-        assert result is not None
-        assert np.array_equal(result, fake_embedding)
-        mock_mt.embed_media.assert_called_once()
-
-    def test_embed_converted_output_text(self, tmp_path):
-        """Text output is written to temp .txt and embed_media is called."""
-        from vtscore.converters.runner import _embed_converted_output
-
-        fake_embedding = np.ones(768)
-        mock_mt = MagicMock()
-        mock_mt.embed_media.return_value = fake_embedding
-
-        result = _embed_converted_output(mock_mt, {"media_string": "hello world", "filename": "doc.txt"})
-
-        assert result is not None
-        assert np.array_equal(result, fake_embedding)
-        mock_mt.embed_media.assert_called_once()
-
-    def test_embed_converted_output_empty(self):
-        """Empty output returns None."""
-        from vtscore.converters.runner import _embed_converted_output
-
-        mock_mt = MagicMock()
-        result = _embed_converted_output(mock_mt, {})
-        assert result is None
 
 
 # ===========================================================================

--- a/tests/datasets/test_memory_errors.py
+++ b/tests/datasets/test_memory_errors.py
@@ -131,30 +131,18 @@ class TestFolderMemoryError:
         mock_mt.file_extensions = ["*.wav"]
         mock_mt.type_id = "audio"
 
-        mock_emb = mock.MagicMock()
-        mock_emb.name = "clap"
-        mock_emb.media_type_id = "audio"
-        mock_emb._model = True
-
         call_count = 0
 
-        def embed_then_oom(path):
+        def load_then_oom(path, media_bytes=None):
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
                 raise MemoryError("simulated OOM")
-            return np.zeros(10)
+            return {"media_bytes": b"\x00", "duration": 1}
 
-        mock_emb.embed_media.side_effect = embed_then_oom
-        # Route the bulk entrypoint through embed_media so the per-file OOM
-        # simulator still fires under the loader's bulk dispatch.
-        mock_emb.embed_media_bulk.side_effect = lambda medias: [mock_emb.embed_media(m) for m in medias]
-        mock_mt.load_media_data.return_value = {"media_bytes": b"\x00", "duration": 1}
+        mock_mt.load_media_data.side_effect = load_then_oom
 
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mock_mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[mock_emb]),
-        ):
+        with mock.patch("vtscore.media.get_by_folder_name", return_value=mock_mt):
             with pytest.raises(MemoryError, match="Out of memory after loading"):
                 load_dataset_from_folder(
                     tmp_path,

--- a/tests/io/test_dataset_importer_media.py
+++ b/tests/io/test_dataset_importer_media.py
@@ -140,15 +140,15 @@ class TestImporterProvidedVectors:
         np.testing.assert_array_equal(embs["b.wav"], vec_b)
         emb.embed_media.assert_not_called()
 
-    def test_mixed_importer_and_model_vectors(self, tmp_path):
+    def test_mixed_importer_vectors_and_no_vector(self, tmp_path):
+        """Importer-supplied vectors land on the matching files; the rest leave
+        with ``embedding=None`` for the framework embed stage to fill in."""
         rng = np.random.default_rng(7)
         pre_vec = rng.standard_normal(8).astype(np.float32)
-        model_vec = np.ones(8, dtype=np.float32) * 0.5
 
         _write_wav(tmp_path / "pre.wav")
         _write_wav(tmp_path / "model.wav")
         mt, emb = _make_mock_media_type()
-        emb.embed_media.return_value = model_vec
         imp = _VectorAndMD5Importer.create(
             tmp_path,
             vectors={"pre.wav": pre_vec},
@@ -162,7 +162,7 @@ class TestImporterProvidedVectors:
         assert len(medias) == 2
         embs = {m["filename"]: m["embedding"] for m in medias.values()}
         np.testing.assert_array_equal(embs["pre.wav"], pre_vec)
-        np.testing.assert_array_equal(embs["model.wav"], model_vec)
+        assert embs["model.wav"] is None
 
     def test_importer_vector_in_thin_mode(self, tmp_path):
         rng = np.random.default_rng(99)
@@ -547,18 +547,17 @@ class TestImporterCustomMetadataEmbedding:
         assert medias[1]["md5"] == cm_md5
         emb.embed_media.assert_not_called()
 
-    def test_custom_metadata_embedding_mixed_with_model(self, tmp_path):
-        """Files with custom_metadata embedding skip the model; others use the model."""
+    def test_custom_metadata_embedding_mixed_with_no_override(self, tmp_path):
+        """Files with custom_metadata embedding get that vector; files without
+        leave with ``embedding=None`` for the framework embed stage."""
         from vtscore.datasets.loader import load_dataset_from_folder
 
         rng = np.random.default_rng(33)
         cm_vec = rng.standard_normal(8).astype(np.float32)
-        model_vec = np.ones(8, dtype=np.float32) * 0.5
 
         _write_wav(tmp_path / "meta.wav")
         _write_wav(tmp_path / "model.wav")
         mt, emb = _make_mock_media_type()
-        emb.embed_media.return_value = model_vec
 
         medias: dict = {}
         with _patch_media_registry(mt, emb):
@@ -572,7 +571,7 @@ class TestImporterCustomMetadataEmbedding:
 
         embs = {m["filename"]: m["embedding"] for m in medias.values()}
         np.testing.assert_array_equal(embs["meta.wav"], cm_vec)
-        np.testing.assert_array_equal(embs["model.wav"], model_vec)
+        assert embs["model.wav"] is None
 
     def test_custom_metadata_embedding_chunked(self, tmp_path):
         """custom_metadata_map embedding should work with the chunked loader."""

--- a/tests_lib/datasets/test_chunked_loading.py
+++ b/tests_lib/datasets/test_chunked_loading.py
@@ -122,13 +122,14 @@ class TestFolderChunked:
         media = chunks[0][1]
         assert media["media_bytes"] is not None
 
-    def test_embeddings_present(self, tmp_path):
-        """Each media in a chunk has an embedding array."""
+    def test_embedding_is_none_until_framework_stage_runs(self, tmp_path):
+        """The folder loader does not embed — items leave with embedding=None
+        for the framework ``embed_missing`` stage to fill in.
+        """
         _make_wav_file(tmp_path, "test.wav")
         chunks = list(load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=10, thin=True))
         media = chunks[0][1]
-        assert isinstance(media["embedding"], np.ndarray)
-        assert len(media["embedding"]) > 0
+        assert media["embedding"] is None
 
     def test_all_files_covered(self, tmp_path):
         """The total number of medias across all chunks equals total files."""

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -58,13 +58,13 @@ class TestThinLoadFromFolder:
         assert media["media_bytes"] is None
         assert media["media_string"] is None
 
-    def test_thin_clips_have_embedding(self, tmp_path):
+    def test_thin_clips_leave_embedding_none(self, tmp_path):
+        """The loader doesn't embed; framework ``embed_missing`` fills these in."""
         _make_wav_file(tmp_path, "test.wav")
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
         media = medias[1]
-        assert isinstance(media["embedding"], np.ndarray)
-        assert len(media["embedding"]) > 0
+        assert media["embedding"] is None
 
     def test_thin_clips_have_correct_file_size(self, tmp_path):
         wav_path = _make_wav_file(tmp_path, "test.wav")

--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -496,38 +496,39 @@ class TestPatchForwardBulkOverrides:
 
 
 # ---------------------------------------------------------------------------
-# Loader integration: _bulk_patch_forward_files goes through patch_forward_bulk
+# embed_missing routes patch-region embedders through patch_forward_bulk
 # ---------------------------------------------------------------------------
 
 
-class TestLoaderRoutesToPatchForwardBulk:
-    def test_loader_calls_patch_forward_bulk_once(self, tmp_path):
-        from vtscore.datasets.loader_folder import _bulk_patch_forward_files
+class TestEmbedMissingRoutesToPatchForwardBulk:
+    def test_embed_missing_calls_patch_forward_bulk_once(self):
+        from vtscore.datasets.load_pipeline import embed_missing
 
-        # Build a mock embedder that mimics the new bulk surface.
         emb = mock.MagicMock()
+        emb.name = "fake_patch"
+        emb._model = True
         emb._on_progress = lambda *a, **kw: None
+        emb.supports_patch_regions = True
+        emb.embed_media_bulk.side_effect = lambda medias: [np.zeros(768, dtype=np.float32) for _ in medias]
 
-        def fake_bulk(medias):
-            return [{"i": i} for i, _ in enumerate(medias)]
+        patch_outputs = [mock.MagicMock(patch_grid=np.zeros((4, 4, 768), dtype=np.float32)) for _ in range(3)]
+        emb.patch_forward_bulk.return_value = patch_outputs
 
-        emb.patch_forward_bulk.side_effect = fake_bulk
+        medias = {
+            i: {"media_type": "image", "embedding": None, "media_path": f"/tmp/img_{i}.png"}
+            for i in range(1, 4)
+        }
 
-        paths = []
-        for i in range(3):
-            p = tmp_path / f"img_{i}.png"
-            _write_image(p)
-            paths.append(p)
-
-        out = _bulk_patch_forward_files(
-            emb,
-            paths,
-            folder_path=tmp_path,
-            on_progress=lambda *a, **kw: None,
-            media_type="image",
-        )
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+            mock.patch("vtscore.media.patch_embed.build_region_tree", return_value=np.zeros((23, 768), dtype=np.float32)),
+            mock.patch("vtscore.media.patch_embed.to_fp16", side_effect=lambda x: x.astype(np.float16)),
+        ):
+            embed_missing(medias)
 
         assert emb.patch_forward_bulk.call_count == 1
         sent = emb.patch_forward_bulk.call_args.args[0]
-        assert sorted(Path(m["media_path"]).name for m in sent) == sorted(p.name for p in paths)
-        assert set(out.keys()) == set(paths)
+        assert len(sent) == 3
+        for m in medias.values():
+            assert m.get("patch_regions") is not None
+            assert m.get("patch_grid") is not None

--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -514,14 +514,13 @@ class TestEmbedMissingRoutesToPatchForwardBulk:
         patch_outputs = [mock.MagicMock(patch_grid=np.zeros((4, 4, 768), dtype=np.float32)) for _ in range(3)]
         emb.patch_forward_bulk.return_value = patch_outputs
 
-        medias = {
-            i: {"media_type": "image", "embedding": None, "media_path": f"/tmp/img_{i}.png"}
-            for i in range(1, 4)
-        }
+        medias = {i: {"media_type": "image", "embedding": None, "media_path": f"/tmp/img_{i}.png"} for i in range(1, 4)}
 
         with (
             mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-            mock.patch("vtscore.media.patch_embed.build_region_tree", return_value=np.zeros((23, 768), dtype=np.float32)),
+            mock.patch(
+                "vtscore.media.patch_embed.build_region_tree", return_value=np.zeros((23, 768), dtype=np.float32)
+            ),
             mock.patch("vtscore.media.patch_embed.to_fp16", side_effect=lambda x: x.astype(np.float16)),
         ):
             embed_missing(medias)

--- a/tests_lib/io/test_bulk_embedding.py
+++ b/tests_lib/io/test_bulk_embedding.py
@@ -158,51 +158,73 @@ class TestEmbedderDefaults:
 
 
 # ---------------------------------------------------------------------------
-# load_dataset_from_folder always routes through embed_media_bulk
+# embed_missing: framework stage that bulk-embeds items with embedding=None
 # ---------------------------------------------------------------------------
 
 
-class TestLoaderRoutesToBulk:
-    """The loader hands pending files to embed_media_bulk in a single call."""
+class TestEmbedMissingRoutesToBulk:
+    """The framework ``embed_missing`` stage hands every media with
+    ``embedding=None`` to ``embed_media_bulk`` in a single call."""
 
-    def test_single_bulk_call_for_folder(self, tmp_path):
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        for name in ("a.wav", "b.wav", "c.wav"):
-            _write_wav(tmp_path / name)
+    def test_single_bulk_call_for_unembedded_medias(self):
+        from vtscore.datasets.load_pipeline import embed_missing
 
         mt = _make_media_type_for_audio()
         emb = _make_bulk_embedder()
 
-        medias: dict = {}
+        medias = {
+            i: {"media_type": "audio", "embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)
+        }
+
         with (
             mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
             mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
         ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+            embed_missing(medias)
 
-        assert len(medias) == 3
-        # Exactly one bulk call — all three files in one request.
         assert emb.embed_media_bulk.call_count == 1
-        sent_medias = emb.embed_media_bulk.call_args.args[0]
-        assert sorted(Path(m["media_path"]).name for m in sent_medias) == ["a.wav", "b.wav", "c.wav"]
+        sent = emb.embed_media_bulk.call_args.args[0]
+        assert len(sent) == 3
+        assert all(m["embedding"] is not None for m in medias.values())
 
-    def test_loader_routes_embedder_progress_to_caller(self, tmp_path):
-        """The loader sets emb._on_progress to its own on_progress for the
-        duration of the bulk call, so progress emitted by the embedder (or
-        its default per-item loop) reaches the UI."""
-        from vtscore.datasets.loader import load_dataset_from_folder
+    def test_already_embedded_medias_are_left_alone(self):
+        from vtscore.datasets.load_pipeline import embed_missing
 
-        for name in ("a.wav", "b.wav"):
-            _write_wav(tmp_path / name)
+        emb = _make_bulk_embedder()
 
-        mt = _make_media_type_for_audio()
+        pre_vec = np.array([99.0, 99.0, 99.0], dtype=np.float32)
+        medias = {
+            1: {"media_type": "audio", "embedding": pre_vec, "embedder": "external"},
+            2: {"media_type": "audio", "embedding": None, "media_path": "/tmp/2.wav"},
+        }
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
+
+        sent = emb.embed_media_bulk.call_args.args[0]
+        assert len(sent) == 1
+        np.testing.assert_array_equal(medias[1]["embedding"], pre_vec)
+        assert medias[1]["embedder"] == "external"
+        assert medias[2]["embedding"] is not None
+
+    def test_no_op_when_nothing_missing(self):
+        from vtscore.datasets.load_pipeline import embed_missing
+
+        emb = _make_bulk_embedder()
+        pre_vec = np.array([1.0], dtype=np.float32)
+        medias = {1: {"media_type": "audio", "embedding": pre_vec, "embedder": "external"}}
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
+
+        emb.embed_media_bulk.assert_not_called()
+
+    def test_routes_progress_to_caller(self):
+        from vtscore.datasets.load_pipeline import embed_missing
 
         captured_cb: list = []
 
         def _bulk_that_pings_progress(medias_in):
-            # Whatever _on_progress is set to *at the moment of the bulk call*
-            # is what the loader routed through.
             captured_cb.append(emb._on_progress)
             emb._on_progress("embedding", "halfway", 1, 2)
             return [np.array([1.0], dtype=np.float32) for _ in medias_in]
@@ -212,138 +234,37 @@ class TestLoaderRoutesToBulk:
 
         events: list[tuple] = []
 
-        def loader_progress(status, msg="", cur=0, tot=0):
+        def caller_progress(status, msg="", cur=0, tot=0):
             events.append((status, msg, cur, tot))
 
-        medias: dict = {}
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-        ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=loader_progress)
+        medias = {1: {"media_type": "audio", "embedding": None, "media_path": "/tmp/a.wav"}}
 
-        # The embedder's _on_progress during the call is the loader's callback.
-        assert captured_cb and captured_cb[0] is loader_progress
-        # The "halfway" event from inside the bulk call reached the loader's callback.
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias, on_progress=caller_progress)
+
+        assert captured_cb and captured_cb[0] is caller_progress
         assert ("embedding", "halfway", 1, 2) in events
 
-    def test_overrides_skip_bulk_call(self, tmp_path):
-        """Files with content_vectors or custom_metadata embedding aren't sent to bulk."""
-        from vtscore.datasets.loader import load_dataset_from_folder
+    def test_bulk_returning_none_leaves_embedding_none(self):
+        from vtscore.datasets.load_pipeline import embed_missing
 
-        for name in ("keep.wav", "pre1.wav", "pre2.wav"):
-            _write_wav(tmp_path / name)
-
-        mt = _make_media_type_for_audio()
         emb = _make_bulk_embedder()
-
-        pre_vec = np.array([99.0, 99.0, 99.0], dtype=np.float32)
-        cm_vec = np.array([42.0, 42.0, 42.0], dtype=np.float32)
-
-        medias: dict = {}
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-        ):
-            load_dataset_from_folder(
-                tmp_path,
-                "audio",
-                medias,
-                content_vectors={"pre1.wav": pre_vec},
-                custom_metadata_map={"pre2.wav": {"embedding": cm_vec}},
-                on_progress=lambda *a: None,
-            )
-
-        assert len(medias) == 3
-        assert emb.embed_media_bulk.call_count == 1
-        sent = emb.embed_media_bulk.call_args.args[0]
-        assert [Path(m["media_path"]).name for m in sent] == ["keep.wav"]
-
-        by_name = {m["filename"]: m["embedding"] for m in medias.values()}
-        np.testing.assert_array_equal(by_name["pre1.wav"], pre_vec)
-        np.testing.assert_array_equal(by_name["pre2.wav"], cm_vec)
-
-    def test_skip_embedding_does_not_trigger_bulk(self, tmp_path):
-        """skip_embedding=True must bypass the bulk API entirely."""
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        _write_wav(tmp_path / "a.wav")
-
-        mt = _make_media_type_for_audio()
-        emb = _make_bulk_embedder()
-
-        medias: dict = {}
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-        ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None, skip_embedding=True)
-
-        emb.embed_media_bulk.assert_not_called()
-        assert medias[1]["embedding"] is None
-
-    def test_bulk_returning_none_skips_file(self, tmp_path):
-        """A None entry in the bulk response should skip that file."""
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        _write_wav(tmp_path / "good.wav")
-        _write_wav(tmp_path / "bad.wav")
-
-        mt = _make_media_type_for_audio()
-        emb = mock.MagicMock()
-        emb.name = "fake_bulk"
-        emb.media_type_id = "audio"
-        emb._model = True
-        emb._on_progress = lambda *a, **kw: None
 
         def _bulk(medias_in):
-            return [None if Path(m["media_path"]).name == "bad.wav" else np.array([1.0, 2.0]) for m in medias_in]
+            return [None if m["media_path"].endswith("bad.wav") else np.array([1.0, 2.0]) for m in medias_in]
 
         emb.embed_media_bulk.side_effect = _bulk
 
-        medias: dict = {}
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-        ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+        medias = {
+            1: {"media_type": "audio", "embedding": None, "media_path": "/tmp/good.wav"},
+            2: {"media_type": "audio", "embedding": None, "media_path": "/tmp/bad.wav"},
+        }
 
-        assert len(medias) == 1
-        assert list(medias.values())[0]["filename"] == "good.wav"
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
 
-
-# ---------------------------------------------------------------------------
-# Chunked loader bulk-embeds per chunk
-# ---------------------------------------------------------------------------
-
-
-class TestChunkedLoaderBulkPerChunk:
-    """The chunked loader issues one bulk call per chunk — preserving the
-    memory story where only one chunk's worth of embeddings is in RAM at a time."""
-
-    def test_bulk_call_scoped_to_chunk(self, tmp_path):
-        from vtscore.datasets.loader import load_dataset_from_folder_chunked
-
-        for i in range(4):
-            _write_wav(tmp_path / f"f{i}.wav")
-
-        mt = _make_media_type_for_audio()
-        emb = _make_bulk_embedder()
-
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
-        ):
-            chunks = list(
-                load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=2, on_progress=lambda *a: None)
-            )
-
-        assert len(chunks) == 2
-        assert all(len(c) == 2 for c in chunks)
-        # One bulk call per chunk, each receiving exactly 2 files.
-        assert emb.embed_media_bulk.call_count == 2
-        for call in emb.embed_media_bulk.call_args_list:
-            assert len(call.args[0]) == 2
+        assert medias[1]["embedding"] is not None
+        assert medias[2]["embedding"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/io/test_bulk_embedding.py
+++ b/tests_lib/io/test_bulk_embedding.py
@@ -172,9 +172,7 @@ class TestEmbedMissingRoutesToBulk:
         mt = _make_media_type_for_audio()
         emb = _make_bulk_embedder()
 
-        medias = {
-            i: {"media_type": "audio", "embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)
-        }
+        medias = {i: {"media_type": "audio", "embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)}
 
         with (
             mock.patch("vtscore.media.get_by_folder_name", return_value=mt),

--- a/tests_lib/io/test_importer_loading.py
+++ b/tests_lib/io/test_importer_loading.py
@@ -1,8 +1,13 @@
 """Importer loading tests.
 
-Tests for load_dataset_from_folder: content_vectors, skip_embedding,
-content_md5s, relative paths, archive extraction directory isolation,
-and the resolve_file contract.
+Tests for load_dataset_from_folder: content_vectors, content_md5s,
+relative paths, archive extraction directory isolation, and the
+resolve_file contract.
+
+The loader does **not** call any embedder — items leave with
+``embedding=None`` unless a pre-computed vector is supplied via
+``content_vectors`` or ``custom_metadata_map``.  The framework
+``embed_missing`` stage fills the rest in.
 """
 
 from __future__ import annotations
@@ -82,32 +87,28 @@ class TestLoadDatasetContentVectors:
         np.testing.assert_array_equal(medias[1]["embedding"], pre_vector)
         mt._mock_embedder.embed_media.assert_not_called()
 
-    def test_embeds_normally_when_not_in_content_vectors(self, tmp_path):
-        """A file NOT in content_vectors falls back to embed_media()."""
-        import numpy as np
-
+    def test_leaves_embedding_none_when_not_in_content_vectors(self, tmp_path):
+        """The loader no longer embeds; non-override files leave with embedding=None."""
         from vtscore.datasets.loader import load_dataset_from_folder
 
         wav = tmp_path / "b.wav"
         self._write_wav(wav)
 
-        model_vector = np.array([1.0, 2.0, 3.0])
-        mt = self._make_fake_media_type(embed_return=model_vector)
+        mt = self._make_fake_media_type(embed_return=None)
 
         medias: dict = {}
 
-        def _noop(*a):
-            pass
-
         with self._patch_media_registry(mt):
-            load_dataset_from_folder(tmp_path, "audio", medias, content_vectors={}, on_progress=_noop)
+            load_dataset_from_folder(tmp_path, "audio", medias, content_vectors={}, on_progress=lambda *a: None)
 
         assert len(medias) == 1
-        np.testing.assert_array_equal(medias[1]["embedding"], model_vector)
-        mt._mock_embedder.embed_media.assert_called_once()
+        assert medias[1]["embedding"] is None
+        assert medias[1]["embedder"] == ""
+        mt._mock_embedder.embed_media.assert_not_called()
+        mt._mock_embedder.embed_media_bulk.assert_not_called()
 
     def test_mixed_content_vectors_and_embedding(self, tmp_path):
-        """Only files in content_vectors skip embed_media; others are embedded."""
+        """Only files in content_vectors get a pre-computed vector; others get None."""
         import numpy as np
 
         from vtscore.datasets.loader import load_dataset_from_folder
@@ -118,53 +119,46 @@ class TestLoadDatasetContentVectors:
         self._write_wav(wav_b)
 
         pre_vector = np.array([10.0, 20.0])
-        model_vector = np.array([1.0, 2.0])
-        mt = self._make_fake_media_type(embed_return=model_vector)
+        mt = self._make_fake_media_type(embed_return=None)
 
         medias: dict = {}
 
-        def _noop(*a):
-            pass
-
         with self._patch_media_registry(mt):
             load_dataset_from_folder(
-                tmp_path, "audio", medias, content_vectors={"a.wav": pre_vector}, on_progress=_noop
+                tmp_path, "audio", medias, content_vectors={"a.wav": pre_vector}, on_progress=lambda *a: None
             )
 
         assert len(medias) == 2
-        # One media should have the pre-computed vector, the other the model vector
         embeddings = {c["filename"]: c["embedding"] for c in medias.values()}
         np.testing.assert_array_equal(embeddings["a.wav"], pre_vector)
-        np.testing.assert_array_equal(embeddings["b.wav"], model_vector)
+        assert embeddings["b.wav"] is None
+        mt._mock_embedder.embed_media_bulk.assert_not_called()
 
-    def test_no_content_vectors_param_embeds_all(self, tmp_path):
-        """When content_vectors is None (default), all files are embedded."""
-        import numpy as np
-
+    def test_no_content_vectors_param_leaves_all_none(self, tmp_path):
+        """When content_vectors is None (default), all files get embedding=None."""
         from vtscore.datasets.loader import load_dataset_from_folder
 
         wav = tmp_path / "c.wav"
         self._write_wav(wav)
 
-        model_vector = np.array([5.0, 6.0])
-        mt = self._make_fake_media_type(embed_return=model_vector)
+        mt = self._make_fake_media_type(embed_return=None)
 
         medias: dict = {}
 
-        def _noop(*a):
-            pass
-
         with self._patch_media_registry(mt):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=_noop)
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
 
         assert len(medias) == 1
-        np.testing.assert_array_equal(medias[1]["embedding"], model_vector)
-        mt._mock_embedder.embed_media.assert_called_once()
+        assert medias[1]["embedding"] is None
+        assert medias[1]["embedder"] == ""
+        mt._mock_embedder.embed_media.assert_not_called()
+        mt._mock_embedder.embed_media_bulk.assert_not_called()
 
     def test_content_vector_file_has_empty_embedder_id(self, tmp_path):
         """Files whose vectors came from content_vectors should not be stamped
-        with the active embedder's name — the external vector may be a different
-        dimension, and downstream re-embedding for queries would dimension-mismatch.
+        with any embedder name — the external vector may be a different
+        dimension.  Files without an override also get ``embedder=""`` (the
+        framework embed stage stamps the live embedder later).
         """
         import numpy as np
 
@@ -175,11 +169,8 @@ class TestLoadDatasetContentVectors:
         self._write_wav(wav_pre)
         self._write_wav(wav_model)
 
-        # External vector with a different dimension than the model would produce
-        # — simulates an NPZ from a higher-dim embedder (e.g. SigLIP-so400m 1152d).
         external_vector = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
-        model_vector = np.array([1.0, 2.0, 3.0])
-        mt = self._make_fake_media_type(embed_return=model_vector)
+        mt = self._make_fake_media_type(embed_return=None)
 
         medias: dict = {}
 
@@ -194,10 +185,11 @@ class TestLoadDatasetContentVectors:
 
         by_name = {m["filename"]: m for m in medias.values()}
         assert by_name["pre.wav"]["embedder"] == ""
-        assert by_name["model.wav"]["embedder"] == "clap"
+        assert by_name["model.wav"]["embedder"] == ""
+        assert by_name["model.wav"]["embedding"] is None
 
-    def test_content_vector_file_skips_none_embed_check(self, tmp_path):
-        """A file with a content vector is included even if embed_media would return None."""
+    def test_content_vector_file_carries_vector_through(self, tmp_path):
+        """A file with a content vector is always included with its supplied vector."""
         import unittest.mock as mock
 
         import numpy as np
@@ -208,186 +200,21 @@ class TestLoadDatasetContentVectors:
         self._write_wav(wav)
 
         pre_vector = np.array([7.0, 8.0])
-        # embed_media returns None, which would normally skip the file
         mt = self._make_fake_media_type(embed_return=None)
 
         medias: dict = {}
 
-        def _noop(*a):
-            pass
-
         with mock.patch("vtscore.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(
-                tmp_path, "audio", medias, content_vectors={"d.wav": pre_vector}, on_progress=_noop
+                tmp_path,
+                "audio",
+                medias,
+                content_vectors={"d.wav": pre_vector},
+                on_progress=lambda *a: None,
             )
 
         assert len(medias) == 1
         np.testing.assert_array_equal(medias[1]["embedding"], pre_vector)
-
-
-# ---------------------------------------------------------------------------
-# load_dataset_from_folder – skip_embedding support
-# ---------------------------------------------------------------------------
-
-
-class TestLoadDatasetSkipEmbedding:
-    """Verify that load_dataset_from_folder respects skip_embedding=True."""
-
-    def _write_wav(self, path):
-        """Write a minimal WAV file to *path*."""
-        path.write_bytes(_make_wav_bytes())
-
-    def test_skip_embedding_with_content_vectors(self, tmp_path):
-        """Pre-computed vectors are used; no embedder is resolved."""
-        import unittest.mock as mock
-
-        import numpy as np
-
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        wav = tmp_path / "a.wav"
-        self._write_wav(wav)
-
-        pre_vector = np.array([1.0, 2.0, 3.0])
-        medias: dict = {}
-
-        mt = mock.MagicMock()
-        mt.type_id = "audio"
-        mt.file_extensions = ["*.wav"]
-        mt.load_media_data.return_value = {"duration": 1.0}
-
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type") as mock_emb_for_type,
-            mock.patch("vtscore.media.get_embedder") as mock_get_emb,
-        ):
-            load_dataset_from_folder(
-                tmp_path,
-                "audio",
-                medias,
-                content_vectors={"a.wav": pre_vector},
-                on_progress=lambda *a: None,
-                skip_embedding=True,
-            )
-
-        assert len(medias) == 1
-        np.testing.assert_array_equal(medias[1]["embedding"], pre_vector)
-        # Embedder registry should never be consulted.
-        mock_emb_for_type.assert_not_called()
-        mock_get_emb.assert_not_called()
-
-    def test_skip_embedding_without_vectors_sets_none(self, tmp_path):
-        """Files without pre-computed vectors get embedding=None."""
-        import unittest.mock as mock
-
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        wav = tmp_path / "a.wav"
-        self._write_wav(wav)
-
-        medias: dict = {}
-
-        mt = mock.MagicMock()
-        mt.type_id = "audio"
-        mt.file_extensions = ["*.wav"]
-        mt.load_media_data.return_value = {"duration": 1.0}
-
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type") as mock_emb_for_type,
-        ):
-            load_dataset_from_folder(
-                tmp_path,
-                "audio",
-                medias,
-                on_progress=lambda *a: None,
-                skip_embedding=True,
-            )
-
-        assert len(medias) == 1
-        assert medias[1]["embedding"] is None
-        assert medias[1]["embedder"] == ""
-        mock_emb_for_type.assert_not_called()
-
-    def test_skip_embedding_progress_says_loading(self, tmp_path):
-        """Progress messages should say 'Loading' not 'Embedding'."""
-        import unittest.mock as mock
-
-        from vtscore.datasets.loader import load_dataset_from_folder
-
-        wav = tmp_path / "a.wav"
-        self._write_wav(wav)
-
-        mt = mock.MagicMock()
-        mt.type_id = "audio"
-        mt.file_extensions = ["*.wav"]
-        mt.load_media_data.return_value = {"duration": 1.0}
-
-        progress_calls: list = []
-
-        def track_progress(*args):
-            progress_calls.append(args)
-
-        medias: dict = {}
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type"),
-        ):
-            load_dataset_from_folder(
-                tmp_path,
-                "audio",
-                medias,
-                on_progress=track_progress,
-                skip_embedding=True,
-            )
-
-        # The per-file progress calls should use "loading" phase, not "embedding".
-        per_file = [c for c in progress_calls if len(c) >= 4 and c[2] > 0]
-        assert len(per_file) >= 1
-        assert per_file[0][0] == "loading"
-        assert "Loading" in per_file[0][1]
-
-    def test_skip_embedding_chunked(self, tmp_path):
-        """skip_embedding works with the chunked variant too."""
-        import unittest.mock as mock
-
-        import numpy as np
-
-        from vtscore.datasets.loader import load_dataset_from_folder_chunked
-
-        for name in ("a.wav", "b.wav"):
-            self._write_wav(tmp_path / name)
-
-        vectors = {
-            "a.wav": np.array([1.0, 2.0]),
-            "b.wav": np.array([3.0, 4.0]),
-        }
-
-        mt = mock.MagicMock()
-        mt.type_id = "audio"
-        mt.file_extensions = ["*.wav"]
-        mt.load_media_data.return_value = {"duration": 1.0}
-
-        with (
-            mock.patch("vtscore.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtscore.media.embedders_for_type") as mock_emb_for_type,
-        ):
-            chunks = list(
-                load_dataset_from_folder_chunked(
-                    tmp_path,
-                    "audio",
-                    chunk_size=10,
-                    content_vectors=vectors,
-                    on_progress=lambda *a: None,
-                    skip_embedding=True,
-                )
-            )
-
-        all_medias = {}
-        for chunk in chunks:
-            all_medias.update(chunk)
-        assert len(all_medias) == 2
-        mock_emb_for_type.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/io/test_pdf_import.py
+++ b/tests_lib/io/test_pdf_import.py
@@ -394,7 +394,7 @@ class TestPdfSymlinkDiscovery:
             stack.enter_context(mock.patch("vtscore.media.get_by_folder_name", return_value=mt))
             stack.enter_context(mock.patch("vtscore.media.get_embedder", return_value=emb))
             stack.enter_context(mock.patch("vtscore.media.embedders_for_type", return_value=[emb]))
-            _load_pdf_images(root, medias, embedder_name="siglip")
+            _load_pdf_images(root, medias)
 
         assert len(medias) == 2
         filenames = {m["filename"] for m in medias.values()}

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
-
 from vtscore.datasets.importers import get_importer
 from vtscore.datasets.importers.server_files import (
     ServerFilesDatasetImporter,
@@ -191,11 +189,8 @@ class TestImporterMetadata:
 
 class TestRunEndToEnd:
     """Verify run() produces medias whose origin/origin_name point at the
-    real source paths.
-
-    The folder importer's audio loader runs the embedder, which on the
-    test container is the lightweight raw-WAV embedder; that's fine for
-    our purposes as long as we use real WAV bytes."""
+    real source paths.  The importer does not embed — items leave with
+    ``embedding=None`` for the framework ``embed_missing`` stage."""
 
     def test_run_imports_listed_files_and_rewrites_origin(self, tmp_path):
         from helpers import make_raw_wav_bytes
@@ -226,7 +221,8 @@ class TestRunEndToEnd:
             # is cleaned up.
             assert media["origin_name"] in {str(src_a), str(src_b)}
             assert Path(media["origin_name"]).is_file()
-            assert isinstance(media["embedding"], np.ndarray)
+            # The loader leaves embedding=None; framework embed_missing fills it.
+            assert media["embedding"] is None
 
 
 class TestRunWithSymlinkEntries:

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -2,15 +2,16 @@
 
 This module provides :func:`run_converters_on_folder`, a reusable utility
 that any dataset importer can call to scan a directory for source media
-files, convert them via one or more :class:`MediaConverter` instances, embed
-the results with the target media type's embedder, and append them to an
-existing medias dict.
+files, convert them via one or more :class:`MediaConverter` instances,
+and append them to an existing medias dict.  The converter outputs are
+left with ``embedding=None``; the framework
+:func:`vtscore.datasets.load_pipeline.embed_missing` stage fills them
+in after the importer returns.
 """
 
 from __future__ import annotations
 
 import hashlib
-import tempfile
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -79,17 +80,6 @@ def _default_progress() -> ProgressCallback:
 _OPTIONAL_OUTPUT_FIELDS = ("media_bytes", "media_string", "width", "height", "word_count", "character_count")
 
 
-def _resolve_target_embedder(target_type: str):
-    """Resolve and (if necessary) warm up the embedder for *target_type*."""
-    from vtscore.media import embedders_for_type  # noqa: PLC0415
-
-    avail = embedders_for_type(target_type)
-    target_emb = avail[0] if avail else None
-    if target_emb is not None and getattr(target_emb, "_model", None) is None:
-        target_emb.load_models()
-    return target_emb
-
-
 def _scan_source_files(folder_path: Path, source_mt, recursive: bool) -> list[Path]:
     source_files: list[Path] = []
     for ext in source_mt.file_extensions:
@@ -124,16 +114,22 @@ def _build_converted_media_dict(
     media_id: int,
     output: dict[str, Any],
     target_type: str,
-    target_emb,
     origin: dict[str, Any],
     origin_name: str,
     media_path: str,
     category: str,
 ) -> dict[str, Any]:
+    """Build the media dict for one converter output.
+
+    ``embedding`` is left at ``None`` — the framework
+    :func:`~vtscore.datasets.load_pipeline.embed_missing` stage embeds
+    converter outputs via ``media_bytes`` / ``media_string`` after the
+    importer returns.
+    """
     media_data: dict[str, Any] = {
         "id": media_id,
         "media_type": target_type,
-        "embedder": target_emb.name if target_emb else "",
+        "embedder": "",
         "file_size": len(output.get("media_bytes", b"") or output.get("media_string", "").encode()),
         "md5": _compute_md5(output),
         "embedding": None,
@@ -178,33 +174,30 @@ def _emit_converted_outputs(
     source_rel: str,
     source_path: Path,
     target_type: str,
-    target_emb,
     origin: dict[str, Any],
     medias: dict[int, dict[str, Any]],
     start_id: int,
     category: str,
 ) -> int:
-    """Embed each converter output, append to *medias*, return next media_id."""
+    """Append each converter output to *medias*; return next media_id.
+
+    Outputs leave with ``embedding=None``; the framework embed stage
+    embeds them from ``media_bytes`` / ``media_string``.
+    """
     media_id = start_id
     for output in outputs:
         output_filename = output.get("filename", f"converted_{media_id}")
         origin_name = f"{source_rel}\u2192{output_filename}"
 
-        embedding = _embed_converted_output(target_emb, output)
-        if embedding is None:
-            continue
-
         media_data = _build_converted_media_dict(
             media_id,
             output,
             target_type,
-            target_emb,
             origin,
             origin_name,
             str(source_path.resolve()),
             category,
         )
-        media_data["embedding"] = embedding
         medias[media_id] = media_data
         media_id += 1
     return media_id
@@ -275,7 +268,6 @@ def run_converters_on_folder(
     if not converters_with_params:
         return
 
-    target_emb = _resolve_target_embedder(target_mt.type_id)
     media_id = max(medias.keys(), default=0) + 1
 
     for converter, conv_params in converters_with_params:
@@ -314,53 +306,11 @@ def run_converters_on_folder(
                 source_rel=source_rel,
                 source_path=source_path,
                 target_type=target_mt.type_id,
-                target_emb=target_emb,
                 origin=origin,
                 medias=medias,
                 start_id=media_id,
                 category="custom",
             )
-
-
-def _embed_converted_output(target_emb, output: dict[str, Any]):
-    """Embed converter output using the target embedder.
-
-    Writes the output to a temporary file and calls ``embed_media()``,
-    which is the most general approach across all media types.
-    """
-
-    if target_emb is None:
-        return None
-
-    media_bytes = output.get("media_bytes")
-    media_string = output.get("media_string")
-
-    from vtscore.media.embedder import media_from_path  # noqa: PLC0415
-
-    if media_bytes:
-        # Binary media (image, audio, video) — write to temp file.
-        suffix = Path(output.get("filename", "output")).suffix or ".bin"
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-            tmp.write(media_bytes)
-            tmp_path = Path(tmp.name)
-        try:
-            embedding = target_emb.embed_media(media_from_path(tmp_path))
-        finally:
-            tmp_path.unlink(missing_ok=True)
-        return embedding
-
-    if media_string:
-        # Text media — write to temp .txt file.
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", encoding="utf-8", delete=False) as tmp:
-            tmp.write(media_string)
-            tmp_path = Path(tmp.name)
-        try:
-            embedding = target_emb.embed_media(media_from_path(tmp_path))
-        finally:
-            tmp_path.unlink(missing_ok=True)
-        return embedding
-
-    return None
 
 
 def _compute_md5(output: dict[str, Any]) -> str:
@@ -374,36 +324,20 @@ def _compute_md5(output: dict[str, Any]) -> str:
     return hashlib.md5(b"").hexdigest()
 
 
-def _resolve_demo_target_embedder(converter, embedder_name: str):
-    """Resolve the target embedder for *converter* (named override > default)."""
-    from vtscore.media import get_embedder  # noqa: PLC0415
-
-    target_emb = None
-    if embedder_name:
-        try:
-            target_emb = get_embedder(embedder_name)
-        except KeyError:
-            pass
-    if target_emb is None:
-        target_emb = _resolve_target_embedder(converter.target_type)
-        return target_emb
-    if getattr(target_emb, "_model", None) is None:
-        target_emb.load_models()
-    return target_emb
-
-
 def apply_converter_to_demo(
     converter_name: str,
     dataset_name: str,
     medias: dict[int, dict[str, Any]],
-    embedder_name: str = "",
+    embedder_name: str = "",  # noqa: ARG001 — kept for call-site compatibility; framework picks the embedder now
     on_progress: Optional[ProgressCallback] = None,
 ) -> None:
     """Convert all medias in-place using the named converter.
 
     After conversion, *medias* contains the converted outputs (target type)
     instead of the original source-type medias.  Each converted media's
-    origin records the demo dataset and the converter used.
+    origin records the demo dataset and the converter used.  Outputs
+    leave with ``embedding=None``; the framework embed stage fills them
+    in.
     """
     from vtscore.converters import get_converter  # noqa: PLC0415 — deferred to avoid circular import during eager registry discovery
 
@@ -413,8 +347,6 @@ def apply_converter_to_demo(
 
     if on_progress is None:
         on_progress = _default_progress()
-
-    target_emb = _resolve_demo_target_embedder(converter, embedder_name)
 
     source_items = list(medias.items())
     converted: dict[int, dict[str, Any]] = {}
@@ -453,7 +385,6 @@ def apply_converter_to_demo(
             source_name=source_name,
             source_media=src_media,
             target_type=converter.target_type,
-            target_emb=target_emb,
             origin=origin,
             converted=converted,
             start_id=new_id,
@@ -469,32 +400,28 @@ def _emit_converted_demo_outputs(
     source_name: str,
     source_media: dict[str, Any],
     target_type: str,
-    target_emb,
     origin: dict[str, Any],
     converted: dict[int, dict[str, Any]],
     start_id: int,
 ) -> int:
-    """Embed each converter output, append to *converted*, return next id."""
+    """Append each converter output to *converted*, return next id.
+
+    Outputs leave with ``embedding=None`` for the framework embed stage.
+    """
     new_id = start_id
     for output in outputs:
         output_filename = output.get("filename", f"converted_{new_id}")
         origin_name = f"{source_name}\u2192{output_filename}"
 
-        embedding = _embed_converted_output(target_emb, output)
-        if embedding is None:
-            continue
-
         media_data = _build_converted_media_dict(
             new_id,
             output,
             target_type,
-            target_emb,
             origin,
             origin_name,
             source_media.get("media_path", ""),
             source_media.get("category", "custom"),
         )
-        media_data["embedding"] = embedding
         converted[new_id] = media_data
         new_id += 1
     return new_id

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -233,6 +233,20 @@ class DatasetImporter(PluginBase):
     and expose a module-level ``IMPORTER = YourImporter()`` – the registry
     picks it up automatically.
 
+    Embedding contract
+    ------------------
+    Importers do **not** call any embedder.  Emit media dicts with
+    ``embedding=None`` (and ``embedder=""``); the framework
+    :func:`~vtscore.datasets.load_pipeline.embed_missing` stage runs
+    after the importer returns and bulk-embeds every item still at
+    ``None`` using the user's selected embedder (or the default for the
+    media type).  Items where the embedder returns ``None`` get dropped
+    by the next stage.
+
+    If your importer ships pre-computed vectors (e.g. an NPZ archive),
+    use :attr:`content_vectors` or :attr:`custom_metadata_map` (below)
+    so the framework treats them as already-embedded and skips them.
+
     Custom metadata
     ---------------
     Importers can attach arbitrary per-media display metadata by setting
@@ -248,10 +262,9 @@ class DatasetImporter(PluginBase):
     Some importers provide pre-computed content vectors (embeddings) alongside
     the media files.  To take advantage of this, populate
     :attr:`content_vectors` with a mapping of ``filename`` to
-    ``numpy.ndarray`` during :meth:`run`.  When the dataset is later embedded
-    (e.g. via :func:`~vtscore.datasets.loader.load_dataset_from_folder`),
-    files whose names appear in this mapping will reuse the supplied vector
-    instead of running the embedding model.
+    ``numpy.ndarray`` during :meth:`run`.  Files whose names appear in
+    this mapping land on the media dict with the supplied vector; the
+    framework embed stage then leaves them alone.
 
     Content MD5s
     ------------
@@ -268,9 +281,9 @@ class DatasetImporter(PluginBase):
     non-empty ``"md5"`` key, that value is used as the media's content hash
     (taking priority over both :attr:`content_md5s` and on-the-fly
     calculation).  When it contains an ``"embedding"`` key, that value is
-    used as the media's embedding vector (taking priority over both
-    :attr:`content_vectors` and the embedding model).  The metadata dict
-    is also attached to the media as ``custom_metadata``.
+    used as the media's embedding vector (taking priority over
+    :attr:`content_vectors` and the framework embed stage).  The metadata
+    dict is also attached to the media as ``custom_metadata``.
 
     CLI support
     -----------

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -245,8 +245,6 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         _extract_archive(archive_path, extract_dir, on_progress=progress)
         archive_path.unlink(missing_ok=True)
 
-        emb_name = field_values.get("embedder", "")
-        skip_emb = bool(field_values.get("skip_embedding"))
         try:
             load_dataset_from_folder(
                 extract_dir,
@@ -254,11 +252,9 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 medias,
                 on_progress=progress,
                 thin=thin,
-                embedder_name=emb_name,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
-                skip_embedding=skip_emb,
             )
             _run_converter_specs(extract_dir, media_type, field_values, specs, medias, thin=thin)
         finally:
@@ -315,19 +311,15 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         media_type = field_values.get("media_type", "audio")
         specs = self.effective_source_specs(field_values)
         converter_specs = [s for s in specs if s.converter is not None]
-        emb_name = field_values.get("embedder", "")
-        skip_emb = bool(field_values.get("skip_embedding"))
         try:
             yield from load_dataset_from_folder_chunked(
                 extract_dir,
                 media_type,
                 chunk_size,
                 thin=thin,
-                embedder_name=emb_name,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
-                skip_embedding=skip_emb,
             )
             if converter_specs:
                 converter_chunk: dict[int, dict[str, Any]] = {}

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -315,11 +315,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 mt.folder_import_name,
                 medias,
                 thin=thin,
-                embedder_name=field_values.get("embedder", ""),
                 content_vectors=merged_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
-                skip_embedding=bool(field_values.get("skip_embedding")),
             )
         except ValueError:
             return False
@@ -405,11 +403,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
                         mt.folder_import_name,
                         chunk_size,
                         thin=thin,
-                        embedder_name=field_values.get("embedder", ""),
                         content_vectors=merged_vectors or None,
                         content_md5s=self.content_md5s or None,
                         custom_metadata_map=self.custom_metadata_map or None,
-                        skip_embedding=bool(field_values.get("skip_embedding")),
                     ):
                         self._rewrite_origins(chunk, name_to_source, origin)
                         yield chunk

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import hashlib
 import io
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, Iterator
 
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
@@ -38,70 +38,41 @@ def _coerce_recursive(field_values: dict[str, Any]) -> bool:
     return str(val).lower() != "false"
 
 
-def _load_pdf_images(  # noqa: C901
+def _load_pdf_images(
     folder: Path,
     medias: dict[int, dict[str, Any]],
     thin: bool = False,
-    embedder_name: str = "",
     recursive: bool = True,
 ) -> None:
     """Expand all PDFs in *folder* into per-page image medias.
 
-    Each page is rendered at 150 DPI, embedded with the image embedder, and
-    appended to *medias* with sequential IDs continuing from the current
-    maximum.  The ``origin`` is set to ``{"importer": "pdf", "params":
-    {"path": ...}}`` so the provenance points back to the source document.
+    Each page is rendered at 150 DPI and appended to *medias* with
+    sequential IDs continuing from the current maximum.  Pages leave
+    here with ``embedding=None``; the framework embed stage fills the
+    vectors in.  The ``origin`` is set to ``{"importer": "pdf",
+    "params": {"path": ...}}`` so provenance points back to the source
+    document.
     """
     pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
     if not pdf_files:
         return
 
     from vtscore.datasets.pdf import render_pdf_pages  # noqa: PLC0415
-    from vtscore.media import embedders_for_type, get_by_folder_name, get_embedder  # noqa: PLC0415
+    from vtscore.media import get_by_folder_name  # noqa: PLC0415
 
     mt = get_by_folder_name("image")
-
-    # Resolve the embedder
-    emb = None
-    if embedder_name:
-        try:
-            emb = get_embedder(embedder_name)
-        except KeyError:
-            pass
-    if emb is None:
-        avail = embedders_for_type(mt.type_id)
-        if avail:
-            emb = avail[0]
-    if emb is None:
-        return
-
-    if getattr(emb, "_model", None) is None:
-        emb.load_models()
-
-    embedder_id = emb.name
     media_id = max(medias.keys(), default=0) + 1
 
     for pdf_path in pdf_files:
         origin = {"importer": "pdf", "params": {"path": str(pdf_path)}}
         pages = render_pdf_pages(pdf_path)
-        # Relative path prefix so that PDFs in different subdirectories
-        # produce distinct page names.
         pdf_rel = pdf_path.relative_to(folder).as_posix()
 
         for page_name, pil_image in pages:
-            # Image-type embedders all implement embed_pil_image, but
-            # it's not declared on the MediaEmbedder ABC.
-            embedding = cast(Any, emb).embed_pil_image(pil_image)
-            if embedding is None:
-                continue
-
             buf = io.BytesIO()
             pil_image.save(buf, format="PNG")
             image_bytes = buf.getvalue()
 
-            # page_name is e.g. "doc.pdf-1"; prefix with relative dir
-            # so that identically-named PDFs in different folders stay
-            # distinct (e.g. "subdir/doc.pdf-1").
             rel_dir = str(Path(pdf_rel).parent)
             if rel_dir and rel_dir != ".":
                 full_page_name = f"{rel_dir}/{page_name}"
@@ -111,10 +82,10 @@ def _load_pdf_images(  # noqa: C901
             media_data: dict[str, Any] = {
                 "id": media_id,
                 "media_type": mt.type_id,
-                "embedder": embedder_id,
+                "embedder": "",
                 "file_size": len(image_bytes),
                 "md5": hashlib.md5(image_bytes).hexdigest(),
-                "embedding": embedding,
+                "embedding": None,
                 "filename": full_page_name,
                 "category": "custom",
                 "origin": origin,
@@ -250,11 +221,9 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 mt.folder_import_name,
                 medias,
                 thin=thin,
-                embedder_name=field_values.get("embedder", ""),
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
-                skip_embedding=bool(field_values.get("skip_embedding")),
                 recursive=recursive,
             )
         except ValueError:
@@ -290,7 +259,6 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 folder,
                 medias,
                 thin=thin,
-                embedder_name=field_values.get("embedder", ""),
                 recursive=recursive,
             )
 
@@ -351,11 +319,9 @@ class ServerFolderDatasetImporter(DatasetImporter):
                     mt.folder_import_name,
                     chunk_size,
                     thin=thin,
-                    embedder_name=field_values.get("embedder", ""),
                     content_vectors=self.content_vectors or None,
                     content_md5s=self.content_md5s or None,
                     custom_metadata_map=self.custom_metadata_map or None,
-                    skip_embedding=bool(field_values.get("skip_embedding")),
                     recursive=recursive,
                 )
             except ValueError:

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -1199,8 +1199,8 @@ def _run_origin_load_in_background(
 
             apply_custom_metadata_md5(ctx.medias)
             _tag_origins(ctx.medias, origin)
-            _embed_missing_stage(ctx, tracker, embedder)
             _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
+            _embed_missing_stage(ctx, tracker, embedder)
             _drop_none_embeddings_stage(ctx, tracker)
             _collapse_duplicates_stage(ctx, tracker)
             _build_diversity_tree_stage(ctx, tracker)
@@ -1310,14 +1310,6 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # importer writes a .clipper sidecar for readiness tracking).
     field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
-
-    # When a multi-output clipper (or any non-empty chain) is selected,
-    # skip embedding during the import phase.  The chain re-embeds every
-    # final clip anyway, so computing parent embeddings up front is
-    # wasted work.  Default clippers (pass-through, single output) still
-    # need the parent embedding since it won't be recomputed.
-    if (clipper_name and not clipper_name.endswith("_default")) or chain_steps:
-        field_values["skip_embedding"] = True
 
     # Extract media_type from field_values so in-progress tasks can expose it
     # to the frontend (used for guessing the type in subsequent add dialogs).

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -776,7 +776,7 @@ def _apply_clipper_stage(
     invalidate_embedding_matrix(ctx)
 
 
-def embed_missing(
+def embed_missing(  # noqa: C901
     medias: dict[int, dict[str, Any]],
     embedder_name: str = "",
     on_progress: Callable[[str, str, int, int], None] | None = None,
@@ -824,8 +824,11 @@ def embed_missing(
         return
 
     if on_progress is None:
-        def on_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+
+        def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
             return None
+
+        on_progress = _noop_progress
 
     if getattr(emb, "_model", None) is None:
         on_progress("loading", "Loading embedding model…", 0, 0)
@@ -840,9 +843,7 @@ def embed_missing(
     try:
         vectors = emb.embed_media_bulk(inputs)
     except Exception:
-        logging.getLogger(__name__).exception(
-            "Bulk embed failed for media_type=%s (%d items)", media_type, total
-        )
+        logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
         return
     finally:
         emb._on_progress = original_cb

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import logging
 import time
 import traceback
 import threading
@@ -775,6 +776,140 @@ def _apply_clipper_stage(
     invalidate_embedding_matrix(ctx)
 
 
+def embed_missing(
+    medias: dict[int, dict[str, Any]],
+    embedder_name: str = "",
+    on_progress: Callable[[str, str, int, int], None] | None = None,
+) -> None:
+    """Embed media items in *medias* that don't already have an embedding.
+
+    Importers are not responsible for calling the embedder — they emit
+    media dicts and optionally pre-populate ``embedding`` from
+    ``content_vectors`` / ``custom_metadata_map``.  Items still at
+    ``None`` after the importer finishes go through this function, which
+    resolves a single embedder (the user's pick when given, otherwise the
+    default for the media type of the unembedded items) and bulk-embeds
+    them in one ``embed_media_bulk`` call.
+
+    Items whose bulk-embed call returns ``None`` stay at ``None``; the
+    load pipeline drops them via :func:`_drop_none_embeddings_stage`.
+    Patch-region tensors are also attached here for embedders that
+    report ``supports_patch_regions``.
+    """
+    missing = [(mid, m) for mid, m in medias.items() if m.get("embedding") is None]
+    if not missing:
+        return
+
+    media_type = ""
+    for _, m in missing:
+        mt = m.get("media_type")
+        if mt:
+            media_type = mt
+            break
+    if not media_type:
+        return
+
+    from vtscore.media import embedders_for_type, get_embedder  # noqa: PLC0415
+
+    emb = None
+    if embedder_name:
+        try:
+            emb = get_embedder(embedder_name)
+        except KeyError:
+            emb = None
+    if emb is None:
+        avail = embedders_for_type(media_type)
+        emb = avail[0] if avail else None
+    if emb is None:
+        return
+
+    if on_progress is None:
+        def on_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+            return None
+
+    if getattr(emb, "_model", None) is None:
+        on_progress("loading", "Loading embedding model…", 0, 0)
+        emb.load_models()
+
+    total = len(missing)
+    on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
+
+    inputs = [m for _, m in missing]
+    original_cb = emb._on_progress
+    emb._on_progress = on_progress
+    try:
+        vectors = emb.embed_media_bulk(inputs)
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "Bulk embed failed for media_type=%s (%d items)", media_type, total
+        )
+        return
+    finally:
+        emb._on_progress = original_cb
+
+    embedder_id = emb.name
+    for (mid, _), vec in zip(missing, vectors):
+        if vec is None:
+            continue
+        media = medias.get(mid)
+        if media is None:
+            continue
+        media["embedding"] = vec
+        if not media.get("embedder"):
+            media["embedder"] = embedder_id
+
+    # Patch-region pass for embedders that support it (DINOv2/v3/EUPE).
+    if getattr(emb, "supports_patch_regions", False) is not True:
+        return
+
+    patch_inputs = [m for _, m in missing if m.get("patch_regions") is None]
+    if not patch_inputs:
+        return
+
+    emb._on_progress = on_progress
+    try:
+        outputs = emb.patch_forward_bulk(patch_inputs)
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "Bulk patch-forward failed for media_type=%s (%d items)", media_type, len(patch_inputs)
+        )
+        outputs = [None] * len(patch_inputs)
+    finally:
+        emb._on_progress = original_cb
+
+    for media, patch_out in zip(patch_inputs, outputs):
+        if patch_out is None:
+            continue
+        _attach_patch_regions_to_media(media, patch_out)
+
+
+def _embed_missing_stage(
+    ctx: DatasetContext,
+    tracker,
+    embedder_name: str,
+) -> None:
+    """Pipeline wrapper around :func:`embed_missing` with tracker-routed progress."""
+
+    def _emb_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        tracker.check_cancelled()
+        step = _STATUS_TO_STEP.get(status, _STATUS_TO_STEP["embedding"])
+        tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+
+    embed_missing(ctx.medias, embedder_name, on_progress=_emb_progress)
+    invalidate_embedding_matrix(ctx)
+
+
+def _attach_patch_regions_to_media(media: dict, patch_out) -> None:
+    """Attach HAC patch-region tree to *media* (mirrors ``loader_folder._attach_patch_regions``)."""
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.media.patch_embed import build_region_tree, to_fp16  # noqa: PLC0415
+
+    regions = build_region_tree(patch_out, k=12, alpha=0.5)
+    media["patch_regions"] = to_fp16(regions)
+    media["patch_grid"] = patch_out.patch_grid.astype(np.float16, copy=False)
+
+
 def _drop_none_embeddings_stage(ctx: DatasetContext, tracker) -> None:
     """Drop any media that finished the clipper stage without an embedding.
 
@@ -1063,6 +1198,7 @@ def _run_origin_load_in_background(
 
             apply_custom_metadata_md5(ctx.medias)
             _tag_origins(ctx.medias, origin)
+            _embed_missing_stage(ctx, tracker, embedder)
             _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
             _drop_none_embeddings_stage(ctx, tracker)
             _collapse_duplicates_stage(ctx, tracker)
@@ -1234,6 +1370,8 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
             temp_medias: dict = {}
             importer.run(field_values, temp_medias)
             apply_custom_metadata_md5(temp_medias)
+            embed_missing(temp_medias, field_values.get("embedder", "") or "", on_progress=update_progress)
+            temp_medias = {mid: m for mid, m in temp_medias.items() if m.get("embedding") is not None}
 
             if not temp_medias:
                 update_progress("idle", "", 0, 0, error="Import produced no medias.")

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -1,7 +1,12 @@
 """Folder-based dataset loaders.
 
 Loads datasets from a directory tree of media files, with optional
-pre-computed embeddings/MD5s, custom metadata, and chunked iteration.
+pre-computed embeddings/MD5s and custom metadata.  Loaders build the
+media dicts but do **not** call the embedder — items without a
+pre-computed embedding leave ``embedding=None`` for the framework
+embed stage (:func:`vtscore.datasets.load_pipeline.embed_missing`) to
+fill in.
+
 Split out from :mod:`vtscore.datasets.loader` for navigability.
 """
 
@@ -34,229 +39,28 @@ def _scan_files(folder: Path, pattern: str, recursive: bool) -> list[Path]:
     return glob_top_level(folder, pattern)
 
 
-# ---------------------------------------------------------------------------
-# Bulk-embedding helpers used by the folder loaders below.
-# ---------------------------------------------------------------------------
-
-
-def _has_override(
-    rel_path: str,
-    file_name: str,
-    content_vectors: dict[str, Any] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-) -> bool:
-    """Return True if the file's embedding is already resolved by overrides.
-
-    An override is either a ``custom_metadata`` entry with an ``"embedding"``
-    key or a ``content_vectors`` entry.  Files with overrides do not need to
-    be sent to the embedding model.
-    """
-    if custom_metadata_map:
-        cm = custom_metadata_map.get(rel_path) or custom_metadata_map.get(file_name)
-        if cm and _get_embedding_value(cm) is not None:
-            return True
-    if content_vectors and (rel_path in content_vectors or file_name in content_vectors):
-        return True
-    return False
-
-
-def _make_embed_input(
-    file_path: Path,
+def _resolve_folder_load_inputs(
     folder_path: Path,
-    origin: dict[str, Any] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-) -> dict[str, Any]:
-    """Build a minimal media dict suitable for :meth:`MediaEmbedder.embed_media`.
-
-    File-based embedders pull ``media["media_path"]`` from this dict;
-    service-based embedders can use ``media["origin"]``, ``media["origin_name"]``,
-    and ``media.get("custom_metadata")`` to resolve the content without
-    touching local disk.  The full media dict (with bytes, md5, duration,
-    type-specific fields) is constructed after the embedding succeeds.
-    """
-    rel_path = file_path.relative_to(folder_path).as_posix()
-    file_cm: dict[str, Any] | None = None
-    if custom_metadata_map:
-        file_cm = custom_metadata_map.get(rel_path) or custom_metadata_map.get(file_path.name)
-    return {
-        "media_path": str(file_path.resolve()),
-        "origin": origin,
-        "origin_name": rel_path,
-        "filename": rel_path,
-        "custom_metadata": file_cm,
-    }
-
-
-def _bulk_embed_files(
-    emb: Any,
-    media_files: list[Path],
-    folder_path: Path,
-    content_vectors: dict[str, Any] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-    on_progress: ProgressCallback,
     media_type: str,
-    origin: dict[str, Any] | None = None,
-) -> dict[Path, Any]:
-    """Pre-compute embeddings for *media_files* via :meth:`embed_media_bulk`.
+    recursive: bool,
+    content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> tuple[Any, list[Path], int]:
+    """Shared front-matter for the folder loaders.
 
-    Files already resolved by ``custom_metadata`` or ``content_vectors``
-    are skipped; the rest are packaged into minimal media dicts (via
-    :func:`_make_embed_input`) and handed to the embedder in a single
-    call.  The embedder's ``_on_progress`` callback is routed through
-    *on_progress* for the duration of the call so progress updates
-    (whether from the default per-item loop or a subclass's custom
-    batching) reach the UI.
-
-    Returns a dict mapping ``Path`` → embedding vector.  Paths whose
-    bulk call returned ``None`` are omitted, matching the per-file
-    behaviour of skipping files that fail to embed.
+    Resolves the media type, scans the folder, and validates the
+    override maps against the scanned file list.  Returns
+    ``(mt, media_files, total_files)``.  Raises ``ValueError`` for
+    unknown media types, empty folders, or ambiguous basename keys in
+    any override map.
     """
-    pending_paths: list[Path] = []
-    pending_medias: list[dict[str, Any]] = []
-    for file_path in media_files:
-        rel_path = file_path.relative_to(folder_path).as_posix()
-        if _has_override(rel_path, file_path.name, content_vectors, custom_metadata_map):
-            continue
-        pending_paths.append(file_path)
-        pending_medias.append(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
-
-    if not pending_paths:
-        return {}
-
-    on_progress("embedding", f"Embedding {len(pending_paths)} {media_type} files...", 0, len(pending_paths))
-
-    original_cb = emb._on_progress
-    emb._on_progress = on_progress
-    try:
-        vectors = emb.embed_media_bulk(pending_medias)
-    finally:
-        emb._on_progress = original_cb
-
-    return {fp: vec for fp, vec in zip(pending_paths, vectors) if vec is not None}
-
-
-def _bulk_patch_forward_files(
-    emb: Any,
-    media_files: list[Path],
-    folder_path: Path,
-    on_progress: ProgressCallback,
-    media_type: str,
-    origin: dict[str, Any] | None = None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None = None,
-) -> dict[Path, Any]:
-    """Run :meth:`MediaEmbedder.patch_forward_bulk` on every file in *media_files*.
-
-    Only called when the active embedder reports
-    ``supports_patch_regions == True``.  Returns a ``Path → PatchEmbedOutput``
-    mapping; files whose patch forward returned ``None`` are omitted.
-
-    The embedder may batch the forward internally (DINOv2 / DINOv3 / EUPE
-    patch variants do) or fall back to per-item via the default loop
-    contract on :class:`MediaEmbedder`.
-    """
-    pending_paths: list[Path] = []
-    pending_medias: list[dict[str, Any]] = []
-    for file_path in media_files:
-        pending_paths.append(file_path)
-        pending_medias.append(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
-
-    if not pending_paths:
-        return {}
-
-    on_progress("embedding", f"Patch-embedding {len(pending_paths)} {media_type} files...", 0, len(pending_paths))
-
-    original_cb = emb._on_progress
-    emb._on_progress = on_progress
-    try:
-        outputs = emb.patch_forward_bulk(pending_medias)
-    finally:
-        emb._on_progress = original_cb
-
-    return {fp: out for fp, out in zip(pending_paths, outputs) if out is not None}
-
-
-def _resolve_folder_embedder(media_type: str, embedder_name: str, skip_embedding: bool) -> tuple[Any, Any]:
-    """Look up the media type and pick an embedder.
-
-    Returns ``(mt, emb)``.  ``emb`` is ``None`` when ``skip_embedding`` is
-    set or when no embedder is registered for the media type.
-    """
-    from vtscore.media import embedders_for_type, get_by_folder_name, get_embedder  # noqa: PLC0415
+    from vtscore.media import get_by_folder_name  # noqa: PLC0415
 
     try:
         mt = get_by_folder_name(media_type)
     except KeyError:
         raise ValueError(f"Invalid media type: {media_type}")
-
-    if skip_embedding:
-        return mt, None
-    if embedder_name:
-        try:
-            return mt, get_embedder(embedder_name)
-        except KeyError:
-            raise ValueError(f"Unknown embedder: {embedder_name}")
-    avail = embedders_for_type(mt.type_id)
-    return mt, (avail[0] if avail else None)
-
-
-def _eager_load_embedder_models(
-    emb: Any,
-    media_files: list[Path],
-    folder_path: Path,
-    content_vectors: dict[str, Any] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-    on_progress: ProgressCallback,
-) -> None:
-    """Eagerly load model weights when at least one file needs the embedder.
-
-    Skipped when every file already has an override (NPZ-only imports
-    shouldn't pay the weight-load cost).  Loading happens here so that
-    download / weight-loading time does not pollute the per-file
-    embedding progress bar that the caller starts immediately after.
-    """
-    if getattr(emb, "_model", None) is not None:
-        return
-    needs_model = any(
-        not _has_override(
-            fp.relative_to(folder_path).as_posix(),
-            fp.name,
-            content_vectors,
-            custom_metadata_map,
-        )
-        for fp in media_files
-    )
-    if not needs_model:
-        return
-
-    on_progress("loading", "Loading embedding model…", 0, 0)
-    original_cb = emb._on_progress
-    emb._on_progress = on_progress
-    try:
-        emb.load_models()
-    finally:
-        emb._on_progress = original_cb
-
-
-def _resolve_folder_load_inputs(
-    folder_path: Path,
-    media_type: str,
-    embedder_name: str,
-    skip_embedding: bool,
-    recursive: bool,
-    content_vectors: dict[str, Any] | None,
-    content_md5s: dict[str, str] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-    on_progress: ProgressCallback,
-) -> tuple[Any, Any, list[Path], int]:
-    """Shared front-matter for the folder loaders.
-
-    Resolves the media type + embedder, scans the folder, validates the
-    override maps against the scanned file list, and eagerly loads model
-    weights when needed.  Returns ``(mt, emb, media_files, total_files)``.
-    Raises ``ValueError`` for unknown media types, unknown embedder names,
-    empty folders, or ambiguous basename keys in any override map.
-    """
-    mt, emb = _resolve_folder_embedder(media_type, embedder_name, skip_embedding)
 
     media_files: list[Path] = []
     for ext in mt.file_extensions:
@@ -273,17 +77,7 @@ def _resolve_folder_load_inputs(
         custom_metadata_map,
     )
 
-    if not skip_embedding and emb is not None:
-        _eager_load_embedder_models(
-            emb,
-            media_files,
-            folder_path,
-            content_vectors,
-            custom_metadata_map,
-            on_progress,
-        )
-
-    return mt, emb, media_files, len(media_files)
+    return mt, media_files, len(media_files)
 
 
 def _embeddings_equal(a: Any, b: Any) -> bool:
@@ -480,20 +274,13 @@ def _resolve_file_embedding(
     file_name: str,
     file_cm: dict[str, Any] | None,
     content_vectors: dict[str, Any] | None,
-    skip_embedding: bool,
-    emb: Any,
-    bulk_embeddings: dict[Path, Any],
-    file_path: Path,
-) -> tuple[Any, str] | None:
-    """Pick the embedding + embedder_id for *file_path*.
+) -> tuple[Any, str]:
+    """Pick a pre-computed embedding for *file_path* if available.
 
-    Resolution order matches the original inline logic: custom_metadata
-    embedding → content_vectors[rel_path] → content_vectors[basename] →
-    ``None`` when ``skip_embedding`` → bulk-embedded vector.  Returns
-    ``None`` when the file should be skipped entirely (no embedder
-    available, or bulk embedding failed for this path).  External
-    vectors come back with ``embedder_id == ""`` so downstream code does
-    not re-embed against a mismatched model.
+    Resolution order: custom_metadata embedding → content_vectors[rel_path]
+    → content_vectors[basename] → ``(None, "")``.  External vectors come
+    back with ``embedder_id == ""``; the framework embed stage stamps
+    the live embedder name on items that come out at ``None`` here.
     """
     cm_embedding = _get_embedding_value(file_cm) if file_cm else None
     if cm_embedding is not None:
@@ -502,14 +289,7 @@ def _resolve_file_embedding(
         return content_vectors[rel_path], ""
     if content_vectors and file_name in content_vectors:
         return content_vectors[file_name], ""
-    if skip_embedding:
-        return None, ""
-    if emb is None:
-        return None
-    embedding = bulk_embeddings.get(file_path)
-    if embedding is None:
-        return None
-    return embedding, emb.name
+    return None, ""
 
 
 def _resolve_file_md5(
@@ -583,51 +363,8 @@ def _build_folder_media_data(
     }
 
 
-def _run_bulk_embedders(
-    emb: Any,
-    media_files: list[Path],
-    folder_path: Path,
-    content_vectors: dict[str, Any] | None,
-    custom_metadata_map: dict[str, dict[str, Any]] | None,
-    on_progress: ProgressCallback,
-    media_type: str,
-    origin: dict[str, Any] | None,
-    skip_embedding: bool,
-) -> tuple[dict[Path, Any], dict[Path, Any]]:
-    """Run :func:`_bulk_embed_files` and (when supported) the patch-forward pass.
-
-    Returns ``(bulk_embeddings, bulk_patch_outputs)``.  Both default to
-    empty dicts when ``emb`` is missing or ``skip_embedding`` is set.
-    """
-    if emb is None or skip_embedding:
-        return {}, {}
-    bulk_embeddings = _bulk_embed_files(
-        emb,
-        media_files,
-        folder_path,
-        content_vectors,
-        custom_metadata_map,
-        on_progress,
-        media_type,
-        origin=origin,
-    )
-    bulk_patch_outputs: dict[Path, Any] = {}
-    if getattr(emb, "supports_patch_regions", False) is True:
-        bulk_patch_outputs = _bulk_patch_forward_files(
-            emb,
-            media_files,
-            folder_path,
-            on_progress,
-            media_type,
-            origin=origin,
-            custom_metadata_map=custom_metadata_map,
-        )
-    return bulk_embeddings, bulk_patch_outputs
-
-
 def _emit_per_file_progress(
     on_progress: ProgressCallback,
-    skip_embedding: bool,
     media_type: str,
     rel_path: str,
     current: int,
@@ -635,10 +372,8 @@ def _emit_per_file_progress(
     chunk_label: str,
 ) -> None:
     """Emit a per-file progress update (folder loaders)."""
-    phase = "loading" if skip_embedding else "embedding"
-    verb = "Loading" if skip_embedding else "Embedding"
-    msg = f"{verb} {media_type} {rel_path}{chunk_label}..."
-    on_progress(phase, msg, current, total)
+    msg = f"Loading {media_type} {rel_path}{chunk_label}..."
+    on_progress("loading", msg, current, total)
 
 
 def _build_per_file_media(
@@ -647,38 +382,20 @@ def _build_per_file_media(
     file_path: Path,
     rel_path: str,
     mt: Any,
-    emb: Any,
-    bulk_embeddings: dict[Path, Any],
-    bulk_patch_outputs: dict[Path, Any],
     content_vectors: dict[str, Any] | None,
     content_md5s: dict[str, str] | None,
     custom_metadata_map: dict[str, dict[str, Any]] | None,
-    skip_embedding: bool,
     thin: bool,
     origin: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Resolve embedding + md5 and build the per-file media dict.
+) -> dict[str, Any]:
+    """Resolve any pre-computed embedding + md5 and build the per-file media dict.
 
-    Returns ``None`` when the file should be skipped (no embedder / bulk
-    embedding failed).  Handles both thin and full modes, attaches
-    custom_metadata and patch regions when available, and merges in
-    type-specific fields in full mode.
+    Files without a pre-computed embedding are returned with
+    ``embedding=None``; the framework embed stage fills those in.
     """
     file_cm = _lookup_file_custom_metadata(rel_path, file_path.name, custom_metadata_map)
 
-    resolved = _resolve_file_embedding(
-        rel_path,
-        file_path.name,
-        file_cm,
-        content_vectors,
-        skip_embedding,
-        emb,
-        bulk_embeddings,
-        file_path,
-    )
-    if resolved is None:
-        return None
-    embedding, embedder_id = resolved
+    embedding, embedder_id = _resolve_file_embedding(rel_path, file_path.name, file_cm, content_vectors)
 
     cm_md5 = _get_md5_value(file_cm) if file_cm else ""
 
@@ -716,34 +433,7 @@ def _build_per_file_media(
     if file_cm:
         media_data["custom_metadata"] = file_cm
 
-    patch_out = bulk_patch_outputs.get(file_path)
-    if patch_out is not None:
-        _attach_patch_regions(media_data, patch_out)
-
     return media_data
-
-
-def _attach_patch_regions(media_data: dict[str, Any], patch_out: Any) -> None:
-    """Build the HAC region tree from *patch_out* and attach it to *media_data*.
-
-    Converts the float32 region vectors and patch grid to **float16**
-    for pickling — vectors are rehydrated to float32 on read by callers
-    that score them.  Sets ``media_data["patch_regions"]`` (the
-    ``2K - 1 + 1`` region nodes including the CLS full-image node) and
-    ``media_data["patch_grid"]`` (the raw H × W × 768 patch tokens
-    needed by phase-2 region voting).
-
-    Both ``K`` and the HAC affinity ``alpha`` are pinned to the design
-    doc's defaults; the caltech101_s sweep is the prescribed way to
-    revisit them.
-    """
-    import numpy as np  # noqa: PLC0415
-
-    from vtscore.media.patch_embed import build_region_tree, to_fp16  # noqa: PLC0415
-
-    regions = build_region_tree(patch_out, k=12, alpha=0.5)
-    media_data["patch_regions"] = to_fp16(regions)
-    media_data["patch_grid"] = patch_out.patch_grid.astype(np.float16, copy=False)
 
 
 # ---------------------------------------------------------------------------
@@ -760,130 +450,83 @@ def load_dataset_from_folder(
     on_progress: Optional[ProgressCallback] = None,
     origin: dict[str, Any] | None = None,
     thin: bool = False,
-    embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
-    skip_embedding: bool = False,
     recursive: bool = True,
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
-    Scans ``folder_path`` for all files matching the extensions for ``media_type``,
-    embeds each file using the appropriate model, and populates ``medias`` with
-    the resulting media dicts. Progress is reported via :func:`update_progress`.
-
-    Files whose basename appears in ``content_vectors`` will use the supplied
-    embedding instead of running the embedding model.  This allows importers
-    that already provide content vectors to avoid redundant computation.
-
-    Similarly, files whose basename appears in ``content_md5s`` will use the
-    supplied hash instead of computing it from the file contents.
+    Scans ``folder_path`` for all files matching the extensions for
+    ``media_type`` and populates ``medias`` with one media dict per
+    file.  Loaders do **not** call the embedder — items leave with
+    ``embedding=None`` unless a pre-computed vector is supplied through
+    ``content_vectors`` or ``custom_metadata_map``.  The framework
+    embed stage (:func:`vtscore.datasets.load_pipeline.embed_missing`)
+    fills the rest in after the importer returns.
 
     The ``medias`` dict is cleared before loading begins.
 
     ``media_type`` is looked up in the media type registry by
-    :attr:`~vtscore.media.base.MediaType.folder_import_name`.  Adding a
-    new media type to the registry automatically makes it available here
-    without any changes to this function.
+    :attr:`~vtscore.media.base.MediaType.folder_import_name`.
 
     Args:
         folder_path: Path to the root directory containing media files.
-            Subdirectories are scanned recursively.
         media_type: Media type identifier (e.g. ``"audio"``).
-        medias: Dict to populate in-place. Existing entries are removed before
-            loading. Keys are sequential integer media IDs starting from 1.
+        medias: Dict to populate in-place. Existing entries are removed
+            before loading. Keys are sequential integer media IDs
+            starting from 1.
         content_vectors: Optional mapping of filename to a pre-computed
             embedding ``numpy.ndarray``.  Keys may be relative paths
-            (``"subdir/file.wav"``) or basenames (``"file.wav"``); relative
-            paths are checked first for an exact match, then basenames as a
-            fallback.  When a bare basename would match more than one file
-            in the folder (without a disambiguating relative-path entry for
-            every match) the load fails with ``ValueError``; when both a
-            relative-path entry and a basename entry exist for the same
-            file with different values, the loader logs a warning and
-            keeps the relative-path entry.
-        content_md5s: Optional mapping of filename to a pre-computed MD5 hex
-            digest string.  Keys follow the same lookup logic as
-            ``content_vectors`` (relative path first, then basename), and
-            the same ambiguity checks apply.
+            (``"subdir/file.wav"``) or basenames (``"file.wav"``);
+            relative paths are checked first.  When a bare basename
+            would match more than one file in the folder without a
+            disambiguating relative-path entry, the load fails.
+        content_md5s: Optional mapping of filename to a pre-computed
+            MD5 hex digest string.  Same lookup logic as
+            ``content_vectors``.
         origin: Optional serialised
-            :class:`~vtscore.datasets.origin.Origin` dict to attach to each
-            media (as ``media["origin"]``).  When ``None`` no origin is set
-            and the caller is expected to set it afterwards.
-        thin: When ``True``, store a ``media_path`` reference to the file on
-            disk instead of reading all bytes into ``media_bytes``.  This saves
-            memory for CLI workflows that only need embeddings for scoring.
-            MD5 is still computed via streaming (constant memory).
-        embedder_name: Optional name of a registered embedder to use.
-            When empty, the first registered embedder for the media type
-            is used.
-        custom_metadata_map: Optional mapping of filename to a metadata dict.
-            Keys follow the same lookup logic as ``content_vectors`` (relative
-            path first, then basename), and the same ambiguity checks apply.
-            When a metadata dict contains a non-empty ``"md5"`` key, that
-            value is used as the media's MD5 instead of computing it from
-            the file contents.  When it contains an ``"embedding"`` key,
-            that value is used as the media's embedding vector (highest
-            priority, above ``content_vectors`` and the embedding model).
-            The metadata dict is also attached to the media as
-            ``custom_metadata``.
-        skip_embedding: When ``True``, skip embedder resolution and model
-            loading entirely.  Files with pre-computed vectors in
-            ``content_vectors`` use those; files without are included with
-            ``embedding=None``.  Useful when vectors have already been
-            downloaded or computed externally.
+            :class:`~vtscore.datasets.origin.Origin` dict.
+        thin: When ``True``, store ``media_path`` instead of reading
+            all bytes into ``media_bytes``.  MD5 is computed via
+            streaming.
+        custom_metadata_map: Optional mapping of filename to a metadata
+            dict.  Same lookup logic as ``content_vectors``.  An
+            ``"md5"`` key overrides the computed hash; an
+            ``"embedding"`` key supplies a pre-computed vector
+            (highest priority).  The dict is attached as
+            ``media["custom_metadata"]``.
+        recursive: When ``True`` (default), scan subdirectories.
 
     Raises:
         ValueError: If ``media_type`` is not recognised, if no matching
-            files are found in ``folder_path``, or if an override map has
-            a bare-basename key that would silently fan out to multiple
-            files in the folder.
+            files are found in ``folder_path``, or if an override map
+            has a bare-basename key that would silently fan out to
+            multiple files in the folder.
     """
     if on_progress is None:
         on_progress = _default_progress()
 
     on_progress("loading", "Scanning media files...", 0, 0)
 
-    mt, emb, media_files, total_files = _resolve_folder_load_inputs(
+    mt, media_files, total_files = _resolve_folder_load_inputs(
         folder_path,
         media_type,
-        embedder_name,
-        skip_embedding,
         recursive,
         content_vectors,
         content_md5s,
         custom_metadata_map,
-        on_progress,
     )
 
     medias.clear()
     media_id = 1
     _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 1
 
-    # Flush everything that still needs embedding through the embedder's
-    # bulk entrypoint up front; the per-file loop below just looks up the
-    # pre-computed vector.  Subclasses that override ``_embed_media_bulk_impl``
-    # can batch internally; the default impl loops per item and emits
-    # per-item progress so the UI stays responsive.
     try:
-        bulk_embeddings, bulk_patch_outputs = _run_bulk_embedders(
-            emb,
-            media_files,
-            folder_path,
-            content_vectors,
-            custom_metadata_map,
-            on_progress,
-            media_type,
-            origin,
-            skip_embedding,
-        )
-
         for i, file_path in enumerate(media_files):
             rel_path = file_path.relative_to(folder_path).as_posix()
 
             if i % _progress_interval == 0 or i + 1 == total_files:
                 _emit_per_file_progress(
                     on_progress,
-                    skip_embedding,
                     media_type,
                     rel_path,
                     i + 1,
@@ -896,18 +539,12 @@ def load_dataset_from_folder(
                 file_path=file_path,
                 rel_path=rel_path,
                 mt=mt,
-                emb=emb,
-                bulk_embeddings=bulk_embeddings,
-                bulk_patch_outputs=bulk_patch_outputs,
                 content_vectors=content_vectors,
                 content_md5s=content_md5s,
                 custom_metadata_map=custom_metadata_map,
-                skip_embedding=skip_embedding,
                 thin=thin,
                 origin=origin,
             )
-            if built is None:
-                continue
             medias[media_id] = built
             media_id += 1
     except MemoryError:
@@ -956,61 +593,34 @@ def load_dataset_from_folder_chunked(
     on_progress: Optional[ProgressCallback] = None,
     origin: dict[str, Any] | None = None,
     thin: bool = False,
-    embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
-    skip_embedding: bool = False,
     recursive: bool = True,
 ) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias from a folder of media files.
 
     Works identically to :func:`load_dataset_from_folder` but yields the
-    medias in groups of at most *chunk_size*.  Each yielded dict is a
-    self-contained medias dict with IDs starting at 1.  After the caller
-    has processed a chunk, the dict can be discarded to free memory.
-
-    Args:
-        folder_path: Path to the root directory containing media files.
-            Subdirectories are scanned recursively.
-        media_type: Media type identifier (e.g. ``"audio"``).
-        chunk_size: Maximum number of medias per chunk.
-        content_vectors: Optional pre-computed embeddings keyed by filename
-            (relative path or basename; relative path is tried first).
-        content_md5s: Optional pre-computed MD5s keyed by filename (same
-            lookup logic as *content_vectors*).
-        origin: Optional origin dict to attach to each media.
-        thin: When ``True``, store ``media_path`` instead of ``media_bytes``.
-        embedder_name: Optional name of a registered embedder to use.
-            When empty, the first registered embedder for the media type
-            is used.
-        custom_metadata_map: Optional mapping of filename to a metadata dict.
-            Same semantics as in :func:`load_dataset_from_folder`.
-        skip_embedding: Same semantics as in :func:`load_dataset_from_folder`.
-
-    Yields:
-        A dict mapping int media IDs (starting at 1) to media data dicts.
-        Each yielded dict contains at most *chunk_size* medias.
+    medias in groups of at most *chunk_size*.  Each yielded dict is
+    self-contained with IDs starting at 1.  Embedding is left to the
+    framework embed stage; items without a pre-computed vector come out
+    with ``embedding=None``.
 
     Raises:
         ValueError: If ``media_type`` is not recognised, if no matching
-            files are found in ``folder_path``, or if an override map has
-            a bare-basename key that would silently fan out to multiple
-            files in the folder.
+            files are found in ``folder_path``, or if an override map
+            has a bare-basename key that would silently fan out.
     """
     if on_progress is None:
         on_progress = _default_progress()
 
     on_progress("loading", "Scanning media files...", 0, 0)
 
-    mt, emb, media_files, total_files = _resolve_folder_load_inputs(
+    mt, media_files, total_files = _resolve_folder_load_inputs(
         folder_path,
         media_type,
-        embedder_name,
-        skip_embedding,
         recursive,
         content_vectors,
         content_md5s,
         custom_metadata_map,
-        on_progress,
     )
 
     _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 1
@@ -1019,19 +629,6 @@ def load_dataset_from_folder_chunked(
         batch = media_files[start : start + chunk_size]
         chunk_medias: dict[int, dict[str, Any]] = {}
         media_id = 1
-
-        # Scope bulk embedding to one chunk so memory stays bounded.
-        chunk_bulk_embeddings, chunk_bulk_patch_outputs = _run_bulk_embedders(
-            emb,
-            batch,
-            folder_path,
-            content_vectors,
-            custom_metadata_map,
-            on_progress,
-            media_type,
-            origin,
-            skip_embedding,
-        )
 
         chunk_label = f" (chunk {start // chunk_size + 1})"
 
@@ -1042,7 +639,6 @@ def load_dataset_from_folder_chunked(
             if global_idx % _progress_interval == 0 or global_idx + 1 == total_files:
                 _emit_per_file_progress(
                     on_progress,
-                    skip_embedding,
                     media_type,
                     rel_path,
                     global_idx + 1,
@@ -1055,18 +651,12 @@ def load_dataset_from_folder_chunked(
                 file_path=file_path,
                 rel_path=rel_path,
                 mt=mt,
-                emb=emb,
-                bulk_embeddings=chunk_bulk_embeddings,
-                bulk_patch_outputs=chunk_bulk_patch_outputs,
                 content_vectors=content_vectors,
                 content_md5s=content_md5s,
                 custom_metadata_map=custom_metadata_map,
-                skip_embedding=skip_embedding,
                 thin=thin,
                 origin=origin,
             )
-            if built is None:
-                continue
             chunk_medias[media_id] = built
             media_id += 1
 

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -105,11 +105,9 @@ def _build_local_folder_field_values(form, upload_dir: Path, clipper_params: dic
 
 
 def _extract_clipper_config(field_values: dict) -> tuple[str, dict | None, list[dict] | None]:
-    """Pop clipper-related keys, set skip_embedding when applicable.
+    """Pop clipper-related keys; mutate *field_values* in place.
 
-    Returns ``(clipper_name, clipper_params, chain_steps)``; *field_values*
-    is mutated in place so ``clipper`` is normalised and ``skip_embedding``
-    is set when a non-default clipper or a chain is configured.
+    Returns ``(clipper_name, clipper_params, chain_steps)``.
     """
     from vtscore.datasets.load_pipeline import _parse_chain_field
 
@@ -117,8 +115,6 @@ def _extract_clipper_config(field_values: dict) -> tuple[str, dict | None, list[
     clipper_params = field_values.pop("clipper_params", None)
     chain_steps = _parse_chain_field(field_values.pop("clipper_chain", None))
     field_values["clipper"] = clipper_name
-    if (clipper_name and not clipper_name.endswith("_default")) or chain_steps:
-        field_values["skip_embedding"] = True
     return clipper_name, clipper_params, chain_steps
 
 


### PR DESCRIPTION
## Why

Importers used to be on the hook for calling the embedder on every media item they emitted. An extension importer that produced media without embedding them got the items silently dropped by `_drop_none_embeddings_stage` — the symptom that started this:

```
WARNING vtscore.datasets.load_pipeline: Dropped 10 media item(s) with embedding=None
(importer or re-embed step failed)
```

The contract leaked the embedder concern into every extension and into the in-tree folder/converter/PDF code paths, even though embedding is generic, batchable work the framework can do better in one place.

## What

The framework now owns embedding. Importers emit media dicts and the new `embed_missing` stage in `vtscore/datasets/load_pipeline.py` bulk-embeds everything still at `embedding=None` after the importer (and clipper) finish, using the user-selected embedder (or the default for the media type). The drop stage stays as a safety net for items the embedder genuinely couldn't handle.

### Pipeline change (`vtscore/datasets/load_pipeline.py`)
- New `embed_missing(medias, embedder_name, on_progress)` — resolves the embedder once, batches everything at `embedding=None` through `embed_media_bulk`, stamps `media["embedder"]`, attaches patch regions for embedders that support them.
- New `_embed_missing_stage` wrapper threads tracker progress in.
- Stage runs after `_apply_clipper_stage` (so clip-fixup work isn't wasted) and before `_drop_none_embeddings_stage`.
- Also runs in the staging path (`_stage_importer_in_background`) so combine-flow staging produces fully-embedded pickles.
- Drops the `skip_embedding` gating in `_run_importer_in_background` and `vtsearch/routes/datasets/load.py` (loaders no longer read it).

### Inline embedding removed
- `vtscore/datasets/loader_folder.py`: drops `embedder_name`, `skip_embedding`, `_resolve_folder_embedder`, `_eager_load_embedder_models`, `_bulk_embed_files`, `_bulk_patch_forward_files`, `_run_bulk_embedders`, `_attach_patch_regions`. `load_dataset_from_folder` and the chunked variant just build media dicts.
- `vtscore/converters/runner.py`: drops `_embed_converted_output`, `_resolve_target_embedder`, `_resolve_demo_target_embedder`, and the tempfile-roundtrip indirection. Converter outputs carry `media_bytes` / `media_string` through so the framework embed stage can embed without a tempfile.
- `vtscore/datasets/importers/server_folder/__init__.py`: PDF expansion (`_load_pdf_images`) stops calling `embed_pil_image`. Stops passing `embedder_name`/`skip_embedding` to loader calls.
- `server_files` and `http_archive` importers: same parameter cleanup.

### Pre-computed vectors still supported
`content_vectors`, `content_md5s`, and `custom_metadata_map["embedding"]` continue to work — they land on the media dict during loading, so the framework embed stage sees `embedding is not None` and skips them.

### Docs
- `vtscore/datasets/importers/base.py` — new "Embedding contract" section on `DatasetImporter`.
- `docs/EXTENDING-plugins.md` — direct-construction example now uses `embedding=None`.
- `docs/vtscore-api.md` — loader docstring updated.

### Tests
- `tests_lib/io/test_bulk_embedding.py` — `TestLoaderRoutesToBulk` and `TestChunkedLoaderBulkPerChunk` (testing loader→bulk routing) replaced with `TestEmbedMissingRoutesToBulk` (testing the new framework stage).
- `tests_lib/io/test_importer_loading.py` — `TestLoadDatasetContentVectors` updated to expect `embedding=None` for non-override files.
- `tests_lib/detectors/test_image_bulk_embedding.py` — patch-forward integration test now targets `embed_missing` instead of the deleted `_bulk_patch_forward_files`.
- `tests/converters/test_converter_selection.py` — drops `_embed_converted_output` patching; converter outputs are now asserted to leave with `embedding=None`.
- `tests_lib/datasets/test_chunked_loading.py`, `tests_lib/datasets/test_thin_loading.py`, `tests_lib/io/test_server_files_importer.py`, `tests/io/test_dataset_importer_media.py`, `tests/datasets/test_memory_errors.py` — assertions updated for the new contract.

## Test plan
- [x] `./run-tests.sh` — 4192 passing, 1 skipped
- [ ] Manual: load a small folder dataset via the UI, confirm embeddings appear and search works
- [ ] Manual: trigger the dev's keyframe-importer extension, confirm the 10 items survive instead of being dropped

## Breaking changes

- `load_dataset_from_folder` and `load_dataset_from_folder_chunked` no longer accept `embedder_name` or `skip_embedding`.
- `_embed_converted_output`, `_bulk_embed_files`, `_bulk_patch_forward_files`, `_resolve_folder_embedder`, `_attach_patch_regions` (and helpers) are removed.
- The `skip_embedding` key in importer `field_values` is now ignored.
- Any extension importer that relied on inline embedding inside the loader needs to either (a) emit `embedding=None` and let the framework embed, or (b) populate `content_vectors` / `custom_metadata_map` with pre-computed vectors.

https://claude.ai/code/session_011hWfQ4QHB28Jp6FAjjB1H8

---
_Generated by [Claude Code](https://claude.ai/code/session_0135yv7oNuHKeKq75dTo79s8)_