### PR TITLE
Rename MediaConverter.converter_description → description

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -658,7 +658,7 @@ from typing import Any
 class Audio2TextMediaConverter(MediaConverter):
 
     display_name = "Audio → Text"
-    converter_description = "Transcribe audio to text using a speech model."
+    description = "Transcribe audio to text using a speech model."
 
     @property
     def source_type(self) -> str:
@@ -729,7 +729,7 @@ that expose a `CONVERTER` attribute. No manual registration in
 | Attribute               | Type  | Default | Description                              |
 |-------------------------|-------|---------|------------------------------------------|
 | `display_name`          | `str` | `""`    | Human-readable label (auto-derived if empty) |
-| `converter_description` | `str` | `""`    | Short description of the conversion      |
+| `description`           | `str` | `""`    | Short description of the conversion      |
 
 **Derived property (not overridable):**
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -745,7 +745,7 @@ from vtscore.plugins import PluginField
 
 class Image2TextMediaConverter(MediaConverter):
     display_name = "Image → Text (OCR)"
-    converter_description = "Run OCR on image files"
+    description = "Run OCR on image files"
     fields = [
         PluginField(
             key="lang",
@@ -790,7 +790,7 @@ CONVERTER = Image2TextMediaConverter()
 | `get_param(params, key)` | Helper: read a param value with field-default fallback |
 | `name` (property) | Auto-derived as `f"{source_type}2{target_type}"` |
 | `display_name` | Human-readable label shown in the picker |
-| `converter_description` | One-line description |
+| `description` | One-line description |
 
 Each returned dict must include a `filename` and the target type's data
 fields (`media_bytes` and `duration` for image/audio/video,

--- a/docs/plans/multi-media-import.md
+++ b/docs/plans/multi-media-import.md
@@ -77,7 +77,7 @@ attribute, just like every other plugin family. `convert()` gains a
 class Video2ImageMediaConverter(MediaConverter):
     name = "video2image"
     display_name = "Video → Images"
-    converter_description = "Extract frames from video files"
+    description = "Extract frames from video files"
     fields = [
         PluginField(
             key="n_clips",

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -111,11 +111,11 @@ class TestConverterBase:
         c = Video2ImageMediaConverter()
         assert c.display_name == "Video \u2192 Images"
 
-    def test_converter_description(self):
+    def test_description(self):
         from vtscore.converters import Document2ImageMediaConverter
 
         c = Document2ImageMediaConverter()
-        assert c.converter_description != ""
+        assert c.description != ""
 
     def test_to_dict(self):
         from vtscore.converters import Video2AudioMediaConverter

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -122,7 +122,7 @@ class Audio2ImageMediaConverter(MediaConverter):
     """
 
     display_name = "Audio → Image (spectrogram)"
-    converter_description = "Render audio as a mel-spectrogram or CQT image"
+    description = "Render audio as a mel-spectrogram or CQT image"
     fields = [
         PluginField(
             key="spectrogram_type",

--- a/vtscore/converters/audio2text.py
+++ b/vtscore/converters/audio2text.py
@@ -37,7 +37,7 @@ class Audio2TextMediaConverter(MediaConverter):
     """
 
     display_name = "Audio → Text (Whisper ASR)"
-    converter_description = "Transcribe speech in audio to text via Whisper"
+    description = "Transcribe speech in audio to text via Whisper"
     fields = [
         PluginField(
             key="model_size",

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -41,7 +41,7 @@ class MediaConverter(PluginBase, ABC):
     display_name: str = ""
 
     #: Short description of what this converter does.
-    converter_description: str = ""
+    description: str = ""
 
     #: User-configurable parameters.  Same :class:`PluginField` system
     #: every plugin family uses.  Empty by default — converters with no
@@ -139,6 +139,6 @@ class MediaConverter(PluginBase, ABC):
             "source_type": self.source_type,
             "target_type": self.target_type,
             "display_name": self.display_name or f"{self.source_type.title()} → {self.target_type.title()}",
-            "description": self.converter_description,
+            "description": self.description,
             "fields": [f.to_dict() for f in self.fields],
         }

--- a/vtscore/converters/document2image.py
+++ b/vtscore/converters/document2image.py
@@ -16,7 +16,7 @@ class Document2ImageMediaConverter(MediaConverter):
     .. attribute:: display_name
        :value: "Document \u2192 Images"
 
-    .. attribute:: converter_description
+    .. attribute:: description
        :value: "Render document pages as images"
 
     Supported formats:
@@ -31,7 +31,7 @@ class Document2ImageMediaConverter(MediaConverter):
     """
 
     display_name = "Document \u2192 Images"
-    converter_description = "Render document pages as images"
+    description = "Render document pages as images"
 
     @property
     def source_type(self) -> str:

--- a/vtscore/converters/document2text.py
+++ b/vtscore/converters/document2text.py
@@ -25,7 +25,7 @@ class Document2TextMediaConverter(MediaConverter):
     """
 
     display_name = "Document \u2192 Text"
-    converter_description = "Extract embedded text from documents"
+    description = "Extract embedded text from documents"
 
     @property
     def source_type(self) -> str:

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -93,7 +93,7 @@ class Image2TextMediaConverter(MediaConverter):
     """
 
     display_name = "Image → Text (OCR)"
-    converter_description = "Extract text from images via OCR"
+    description = "Extract text from images via OCR"
     fields = [
         PluginField(
             key="language",

--- a/vtscore/converters/video2audio.py
+++ b/vtscore/converters/video2audio.py
@@ -32,7 +32,7 @@ class Video2AudioMediaConverter(MediaConverter):
     """
 
     display_name = "Video \u2192 Audio"
-    converter_description = "Extract audio tracks from video files"
+    description = "Extract audio tracks from video files"
     fields = [
         PluginField(
             key="ffmpeg_timeout",

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -25,7 +25,7 @@ class Video2ImageMediaConverter(MediaConverter):
     """
 
     display_name = "Video → Images"
-    converter_description = "Extract frames from video files"
+    description = "Extract frames from video files"
     fields = [
         PluginField(
             key="n_clips",

--- a/vtscore/docs/extending/converters.md
+++ b/vtscore/docs/extending/converters.md
@@ -67,7 +67,7 @@ Optional overrides:
 | Member | Default | Purpose |
 |--------|---------|---------|
 | `display_name` | derived | Human-readable label for the chooser UI |
-| `converter_description` | `""` | One-line description |
+| `description` | `""` | One-line description |
 | `fields` | `[]` | User-configurable parameters |
 
 ### What `convert()` returns
@@ -173,7 +173,7 @@ class Audio2TextWhisperConverter(MediaConverter):
     """Transcribe audio to text using OpenAI Whisper."""
 
     display_name = "Audio → Text (Whisper)"
-    converter_description = "Run OpenAI Whisper ASR on audio files."
+    description = "Run OpenAI Whisper ASR on audio files."
     fields = [
         PluginField(
             key="model_size",

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -41,7 +41,7 @@ field-driven configuration system every other plugin family uses.
 ```python
 class MediaConverter(PluginBase, ABC):
     display_name: str = ""
-    converter_description: str = ""
+    description: str = ""
     fields: list[PluginField] = []           # user-configurable params
 
     @property
@@ -206,7 +206,7 @@ Every concrete converter module ends with a module-level
 # vtscore/converters/audio2image.py
 class Audio2ImageMediaConverter(MediaConverter):
     display_name = "Audio → Image (spectrogram)"
-    converter_description = "Render audio as a mel-spectrogram or CQT image"
+    description = "Render audio as a mel-spectrogram or CQT image"
     fields = [...]
     @property
     def source_type(self) -> str: return "audio"
@@ -339,7 +339,7 @@ Sketch — the walk-through is in
 1. Create `vtscore/converters/<source>2<target>.py`.
 2. Subclass `MediaConverter`. Implement `source_type`,
    `target_type`, and `convert(media, params)`.
-3. Declare `display_name`, `converter_description`, and any
+3. Declare `display_name`, `description`, and any
    `fields` you need.
 4. At the bottom of the module, expose `CONVERTER = MyConverter()`.
 5. Restart the process — discovery picks it up on next import.
@@ -354,7 +354,7 @@ from vtscore.plugins import PluginField
 
 class Text2EmojiMediaConverter(MediaConverter):
     display_name = "Text → Emoji"
-    converter_description = "Replace common words with their emoji equivalents."
+    description = "Replace common words with their emoji equivalents."
     fields = [
         PluginField(
             key="lang",


### PR DESCRIPTION
## Summary

`MediaConverter` was the only plugin family that named its description attribute `converter_description` — every other family (importers, exporters, label importers, settings sources, etc.) inherits `description` from `PluginBase`. Aligning the names removes the inconsistency.

- Rename the class attribute on `MediaConverter` and all 7 subclasses (`audio2image`, `audio2text`, `document2image`, `document2text`, `image2text`, `video2audio`, `video2image`).
- Update `MediaConverter.to_dict()` to read `self.description`.
- Update the test in `tests/converters/test_converter_selection.py`.
- Update the converter docs (`vtscore/docs/packages/converters.md`, `vtscore/docs/extending/converters.md`, `docs/EXTENDING-plugins.md`, `docs/EXTENDING-media.md`, `docs/plans/multi-media-import.md`).

Breaking change for any out-of-tree converters that set `converter_description`; per CLAUDE.md no shim is added.

## Test plan

- [x] `./run-tests.sh converters` — 190 passed
- [x] `./run-tests.sh` — 4192 passed, 1 skipped, 2 xpassed

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2QLHRPGqJBwSevHR5yNk3)_