### PR TITLE
docs: add backwards-compat shim notes to plugin-interface-streamlines

### DIFF
--- a/docs/plans/plugin-interface-streamlines.md
+++ b/docs/plans/plugin-interface-streamlines.md
@@ -69,6 +69,13 @@ expressed as plugin code. Low risk — the default already does the right
 thing for new fields; the overrides exist only because the data model
 didn't have an "omit me" knob.
 
+**Shim.** Trivial — `build_origin()` stays a hook on the base class. If a
+subclass overrides it, the override wins (called as today). If a subclass
+doesn't override it, the new default consults `omit_from_origin` /
+`_RENAMES` and produces the same dict the old hand-written overrides
+produced. Third-party importers that still ship a `build_origin` override
+keep working unchanged.
+
 ### 2. Content optimization dicts (`content_vectors` / `content_md5s` / `custom_metadata_map`)
 
 **Leak.** Importers populate three parallel `dict[str, Any]` instance
@@ -89,6 +96,16 @@ unpacks it.
 parallel-keyed-by-filename state that's easy to get wrong (one entry in
 `content_md5s` but not in `content_vectors`, off-by-one filename casing,
 etc.). Folding into a single record makes the contract obvious.
+
+**Shim.** Keep the three instance dicts (`content_vectors`,
+`content_md5s`, `custom_metadata_map`) initialized on the base class and
+keep accepting them in the loader entry points. The framework's
+post-`run()` step inspects whichever surface the importer used: if `run()`
+returned/yielded `RawMedia` records, those win; otherwise it falls back to
+the three dicts (which is exactly today's behavior). Third-party
+importers that write to the dicts keep working; new code can yield
+`RawMedia` instead. Document the dicts as deprecated-but-supported in
+EXTENDING.md.
 
 ### 3. Declarative path / URL / template validation
 
@@ -119,6 +136,16 @@ pattern definition. Also: it would let `routes/_shared.py` stop
 special-casing the literal key `"filepath"` — every field carries its
 own validation rule.
 
+**Shim.** Purely additive — the existing `validate_url`,
+`validate_server_filepath`, and `sanitize_template_value` helpers stay
+exported from `vtscore.security` with the same signatures. A third-party
+plugin that calls them by hand inside `run()` keeps working: by the time
+its code runs, the framework has already validated the value, so the
+plugin's re-validation is an idempotent no-op (sanitize is idempotent on
+already-sanitized strings; validate is read-only). The "promotion" is in
+*what the framework does before calling `run()`*, not in removing the
+plugin-side API.
+
 ### 4. Required / empty-string handling
 
 **Leak.** Every file/path plugin has this snippet:
@@ -142,6 +169,14 @@ is a non-empty string.
 consistent 422-vs-500 error responses (today a missing required field
 becomes a 500 in some plugins, a 400 in others).
 
+**Shim.** Purely additive at the plugin-source level: a third-party
+plugin's manual `if not foo: raise ValueError(...)` check still compiles
+and runs — it just never fires, because the framework rejected the empty
+value before `run()` was called. The plugin's bespoke error message is
+preempted by the framework's 422, which is a *behavior* change in error
+text but not a *code* change the author has to make. No source edits
+required to keep an old plugin working.
+
 ### 5. File-read boilerplate for JSON-on-disk plugins
 
 **Leak.** Settings importer, label importer, settings exporter, and
@@ -161,6 +196,14 @@ slightly different error messages each time.
 "framework-prepares-the-input" pattern. (b) is a smaller refactor.
 Probably (b) first, (a) later if it pulls weight.
 
+**Shim.** Option (b) is intrinsically backwards-compatible — it's a new
+helper that old plugins can ignore. Option (a) needs more care: a new
+`field_type="server_json"` is a *new* field type, so existing plugins
+that declare `field_type="server_path"` keep receiving a path string
+exactly as before. Only plugins that opt into the new type receive a
+parsed dict. Old `server_path`-based JSON readers continue to work
+unchanged; we encourage migration but don't force it.
+
 ### 6. Atomic write helper
 
 **Leak.** `_atomic_write_text` is implemented in
@@ -177,6 +220,14 @@ fsync + rename + parent-mkdir.
 
 **Eval.** Small/medium win, but it's a real bug risk every time someone
 writes a new file-writing plugin and forgets.
+
+**Shim.** Purely additive — `vtscore.io.atomic_write_text` /
+`atomic_write_json` are new public helpers. Existing in-tree call sites
+(the two `server_json_file` exporters) get migrated when the helper
+lands; third-party plugins that ship their own atomic-write logic keep
+working unchanged. Re-export the helpers from the original locations
+(`vtscore/exporters/server_json_file/`) as well so any third-party that
+imported them directly from there doesn't break.
 
 ### 7. Template variable resolution
 
@@ -196,6 +247,15 @@ resolved.
 **Eval.** Medium win. Removes a class of bug where one plugin
 substitutes `{detector_name}` but forgets `{username}` (or vice versa).
 Same shape as #3 — declarative replaces imperative.
+
+**Shim.** Default `template_vars=None` on `PluginField` means "framework
+does no substitution" — i.e. existing fields keep receiving the raw
+template string and the plugin keeps doing its own substitution as
+today. Only fields that explicitly declare `template_vars=[...]` opt
+into framework substitution. Migration is per-field and per-plugin, on
+the plugin's own schedule. If a third-party plugin later opts in and
+*also* leaves a `sanitize_template_value` call in its body, that's a
+no-op on an already-resolved string (sanitize is idempotent).
 
 ### 8. Background-thread context propagation
 
@@ -219,6 +279,13 @@ user or crashes on a missing context. The "logical-bug-audit.md" plan
 already calls out context-propagation gaps as a recurring root-cause
 pattern; this would close most of them.
 
+**Shim.** Purely additive — `vtsearch.threading.spawn(...)` is a new
+helper. `set_thread_user()` / `set_thread_dataset_context()` /
+`set_thread_detector_context()` stay exported with the same signatures.
+A third-party plugin that builds its own `threading.Thread` and calls
+the setters by hand keeps working exactly as today; new code is just
+recommended to use `spawn()` instead.
+
 ### 9. Converter param normalization
 
 **Leak.** `MediaConverter.convert(media, params)` accepts
@@ -238,6 +305,17 @@ converter API to internal helpers the framework owns.
 **Eval.** Solid win. Same as #4 — converts an opt-in helper plugin
 authors might forget into a framework-guaranteed input shape.
 
+**Shim.** Keep `get_param()` as a method on `MediaConverter` — once the
+framework has pre-populated `params`, `get_param(params, key)` collapses
+to a plain `params[key]` lookup, so old converters that route through it
+keep working. Converters that did `params["key"]` directly *start*
+working (they previously crashed on `None`), which is a strict
+improvement. Keep `validate_params()` as a hook the framework calls
+before normalizing — if a third-party converter overrode it for custom
+checks, the override still runs. The `params: dict | None` type
+annotation stays `dict | None` for source compatibility even though
+the framework now always passes a non-None dict.
+
 ### 10. Converter metadata inconsistency
 
 **Leak.** `MediaConverter` declares `display_name` and
@@ -254,6 +332,13 @@ the collision (it appears `PluginBase` doesn't actually claim
 small mental tax every time someone writes a new converter and has to
 look up which name applies.
 
+**Shim.** The framework's description getter checks `description` first
+and falls back to `converter_description` if the former is unset. Old
+converters that only declare `converter_description` keep working; new
+converters declare `description` like every other plugin family does.
+After a long-enough soak period we can warn (or remove) the fallback,
+but the initial change is non-breaking.
+
 ### 11. Plugin metadata defaults
 
 **Leak.** Every plugin class declares `name`, `display_name`,
@@ -268,6 +353,13 @@ Override remains explicit and wins.
 **Eval.** Modest win. Saves boilerplate but doesn't remove a *concern*
 — just typing. Lowest priority of the candidates.
 
+**Shim.** Purely additive — the defaults only fire when the class attr
+is missing. Existing plugins that explicitly declare `name` /
+`display_name` / `description` keep using their explicit values
+verbatim. Use a sentinel (or `getattr(cls, "name", None)`) rather than
+overwriting attrs on the class so subclassed plugins still see their own
+declarations.
+
 ### 12. Cooperative cancellation in importers
 
 **Leak.** Some importers sprinkle `check_dataset_cancelled()` /
@@ -280,6 +372,15 @@ check cancellation between yields. The importer body never imports the
 cancellation API at all.
 
 **Eval.** Solid win if #2 lands; not really separable from it.
+
+**Shim.** Tracks #2 — if the importer uses the old non-generator `run()`
+shape, the framework can't insert cancellation points between yields, so
+those importers keep relying on their hand-placed
+`check_dataset_cancelled()` calls (which stay exported and functional).
+Only importers that opt into the generator/`RawMedia` shape get free
+between-yield cancellation. Third-party importers that mix both
+(generator yields + explicit `check_dataset_cancelled()`) are fine —
+the explicit call is a no-op redundant check.
 
 ### 13. `field_type="file"` returns Werkzeug `FileStorage`
 
@@ -298,6 +399,19 @@ trusts that representation and never mentions Werkzeug. `run_cli` /
 **Eval.** Medium-high win. Closes the cleanest tier-leak in the
 codebase and removes an entire CLI-vs-API method pair from every
 file-accepting plugin.
+
+**Shim.** Pick the normalized type to be *structurally compatible* with
+the FileStorage attrs old plugins already use — `.filename` (str) and
+`.read()` / `.stream` (binary IO). Werkzeug's `FileStorage` already
+satisfies this shape, so on the Flask side we can pass `FileStorage`
+through unchanged (or wrap it in a thin adapter that preserves those
+attrs); on the CLI side we wrap the path string in an adapter that
+opens the file lazily and exposes the same surface. Old plugin bodies
+that read `.filename` and call `.read()` keep working in both code
+paths. Keep `run_cli` callable on the base class: if a subclass
+overrides it, the framework still routes CLI invocations through the
+override; if not, CLI invocations go through `run()` with the adapter.
+That lets third-party plugins migrate at their own pace.
 
 ## Cross-cutting observation
 
@@ -347,10 +461,15 @@ that's already ready to use.**
 - Not changing the *capability* of any plugin family. Every existing
   plugin continues to express the same behavior, just with the
   framework-uniform parts hoisted out.
-- Not breaking external (third-party) plugin subclasses without an
-  obvious deprecation. The CLAUDE.md backwards-compat policy says
-  breaking is fine if needed, but we should at least mention it in the
-  PR description when a candidate ships.
+- Not breaking external (third-party) plugin subclasses. Even though
+  the CLAUDE.md backwards-compat policy says breaking is fine in
+  general, *written plugin extensions* are an exception: the goal is
+  that every candidate here can ship without forcing third-party plugin
+  authors to edit their code. Each candidate above has a **Shim** note
+  describing the specific backwards-compatibility hook (override
+  fallback, additive-only API, structural type compatibility, etc.).
+  Serialized objects (old detector JSON, cached pickles, etc.) are
+  *not* under this protection — those can change shape as needed.
 - Not unifying base classes across families into a single
   super-base — they have legitimately different return shapes
   (`run` vs `export` vs `convert`). The unification proposed here is


### PR DESCRIPTION
## Summary
- Add a **Shim** paragraph to each of the 13 candidate simplifications in `docs/plans/plugin-interface-streamlines.md`, describing how the change can land without forcing third-party plugin authors to edit their code.
- Clarify the Non-goals section so it's explicit that written plugin extensions are protected from breakage (even though serialized objects are not).

The shim notes cover the concrete backwards-compat strategy per candidate: override-fallback hooks (#1, #10, #13), additive-only APIs (#3, #4, #5, #6, #8, #11), opt-in field flags (#5a, #7), structural type compatibility (#13), and acceptance of both old and new contracts side by side (#2, #9, #12).

## Test plan
- [x] Docs-only change; no code or tests touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_014n8AprFaxhkNdRyhw6NvQq)_