### PR TITLE
Field-hint (?) icon: show tooltip immediately on click

### DIFF
--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -1,15 +1,24 @@
-import { Component, Input } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { Component, ElementRef, HostListener, Input, signal } from '@angular/core';
+
+const HOVER_DELAY_MS = 500;
 
 @Component({
   selector: 'vt-field-hint-icon',
   standalone: true,
+  imports: [NgIf],
   template: `
     <span
       class="field-hint-icon"
-      [title]="hint"
       tabindex="0"
       role="img"
       [attr.aria-label]="ariaLabel || hint"
+      (mouseenter)="onMouseEnter()"
+      (mouseleave)="onMouseLeave()"
+      (focus)="onMouseEnter()"
+      (blur)="hide()"
+      (click)="onClick($event)"
+      (keydown.escape)="hide()"
     >
       <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true" focusable="false">
         <circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor" stroke-width="1.3" />
@@ -22,11 +31,13 @@ import { Component, Input } from '@angular/core';
           fill="currentColor"
         >?</text>
       </svg>
+      <span class="field-hint-tooltip" *ngIf="visible()" role="tooltip">{{ hint }}</span>
     </span>
   `,
   styles: [
     `
       .field-hint-icon {
+        position: relative;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -41,10 +52,78 @@ import { Component, Input } from '@angular/core';
         color: var(--text-primary);
         outline: none;
       }
+      .field-hint-tooltip {
+        position: absolute;
+        bottom: calc(100% + 4px);
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 1000;
+        width: max-content;
+        max-width: 260px;
+        padding: 6px 8px;
+        background: var(--bg-surface);
+        color: var(--text-primary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 1.4;
+        white-space: normal;
+        text-align: left;
+        cursor: default;
+        pointer-events: none;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
     `,
   ],
 })
 export class FieldHintIconComponent {
   @Input() hint = '';
   @Input() ariaLabel = '';
+
+  readonly visible = signal(false);
+  private hoverTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly elementRef: ElementRef<HTMLElement>) {}
+
+  onMouseEnter(): void {
+    if (this.visible()) return;
+    this.clearTimer();
+    this.hoverTimer = setTimeout(() => {
+      this.hoverTimer = null;
+      this.visible.set(true);
+    }, HOVER_DELAY_MS);
+  }
+
+  onMouseLeave(): void {
+    this.clearTimer();
+    this.visible.set(false);
+  }
+
+  onClick(event: MouseEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.clearTimer();
+    this.visible.set(true);
+  }
+
+  hide(): void {
+    this.clearTimer();
+    this.visible.set(false);
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.visible()) return;
+    if (!this.elementRef.nativeElement.contains(event.target as Node)) {
+      this.hide();
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.hoverTimer !== null) {
+      clearTimeout(this.hoverTimer);
+      this.hoverTimer = null;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

The (?) field-hint icon previously used the native HTML `title` attribute for its tooltip. That gives the OS-native hover delay, but it also means a **click** on the icon resets the browser's tooltip timer — so a user who mistakes the icon for a button gets punished with a longer wait, not a faster one.

Replaced the native title with a small custom tooltip managed by `FieldHintIconComponent`:

- Hover still waits ~500ms (a setTimeout that matches typical native delays) before showing.
- A click cancels the pending timer and shows the tooltip **immediately**.
- The tooltip hides on `mouseleave`, `blur`, `Escape`, or any click outside the icon.
- Uses existing CSS variables (`--bg-surface`, `--text-primary`, `--border-color`) so it themes correctly.
- Keeps `aria-label` and `role="tooltip"` so screen-reader behavior is preserved.

No other call sites change — every consumer of `<vt-field-hint-icon [hint]="…">` keeps the same API.

## Test plan

- [x] `npm run build:prod` — clean, no TS errors, no budget warnings
- [ ] Manually hover a (?) icon: tooltip appears after the usual short delay
- [ ] Manually click a (?) icon while the hover timer is pending: tooltip appears immediately
- [ ] Click outside / press Escape / move mouse away: tooltip hides


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBfkTz2Un9DR88RQZABLLf)_