### PR TITLE
Narrow Add Dataset modal: drop #Cat column, shorten demo descriptions

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -6,15 +6,15 @@
 // `<vt-source-picker>` (see source-picker.component.scss).  Only
 // styles unique to this top-level modal remain below.
 
-// Pin the Add Dataset modal to a single large width so flipping between
-// tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
-// the dialog.  680px (matching the Settings modal) was too narrow for the
-// demo table; 900px gives the table room without overflowing typical
-// laptop displays.  min-height keeps the dialog from collapsing to a thin
-// strip in the no-selection state and then jumping to fit the demo table.
+// Pin the Add Dataset modal to a single width so flipping between tabs
+// (Services / Server / Local / Demo) and inner widgets doesn't reflow the
+// dialog.  Sized to fit the demo table comfortably after dropping the
+// #Cat column and tightening descriptions.  min-height keeps the dialog
+// from collapsing to a thin strip in the no-selection state and then
+// jumping to fit the demo table.
 :host {
   ::ng-deep .modal-content {
-    width: 900px;
+    width: 720px;
     min-height: 480px;
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -81,11 +81,10 @@ export class DatasetImporterModalComponent implements OnInit {
   static readonly DEMO_COL_META: Record<string, ColMeta> = {
     label: { label: 'Name', title: 'Demo dataset name (click to sort)', sortable: true },
     num_files: { label: '# Media', title: 'Number of media files in the demo dataset (click to sort)', sortable: true },
-    num_categories: { label: '# Cat.', title: 'Number of distinct categories or classes in the dataset (click to sort)', sortable: true },
     description: { label: 'Description', title: 'Short description of the demo dataset contents (click to sort)', sortable: true },
     status: { label: 'Readiness', title: 'Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)', sortable: true },
   };
-  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'num_categories', 'description', 'status'];
+  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'description', 'status'];
   private static readonly DEMO_COL_ORDER_KEY = 'vtsearch.dashboard.demoColumnOrder';
 
   demoCols = new ManagedColumns(

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -73,7 +73,7 @@
                     [class.sortable]="demoCols.meta(col).sortable"
                     [class.col-drop-target]="demoCols.isDropTarget(col)"
                     [class.col-dragging]="demoCols.isDragging(col)"
-                    [class.col-num]="col === 'num_files' || col === 'num_categories'"
+                    [class.col-num]="col === 'num_files'"
                     [attr.data-col]="col"
                     [title]="demoCols.meta(col).title"
                     [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
@@ -110,9 +110,6 @@
                       }
                       @case ('num_files') {
                         <td class="col-num">{{ demo.num_files | number }}</td>
-                      }
-                      @case ('num_categories') {
-                        <td class="col-num">{{ demo.num_categories | number }}</td>
                       }
                       @case ('description') {
                         <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -124,11 +124,10 @@ export class NewDetectorModalComponent implements OnInit {
   static readonly DEMO_COL_META: Record<string, ColMeta> = {
     label: { label: 'Name', title: 'Demo dataset name (click to sort)', sortable: true },
     num_files: { label: '# Media', title: 'Number of media files in the demo dataset (click to sort)', sortable: true },
-    num_categories: { label: '# Cat.', title: 'Number of distinct categories or classes in the dataset (click to sort)', sortable: true },
     description: { label: 'Description', title: 'Short description of the demo dataset contents (click to sort)', sortable: true },
     status: { label: 'Readiness', title: 'Whether the dataset is pre-downloaded and ready to browse, or still needs to be fetched (click to sort)', sortable: true },
   };
-  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'num_categories', 'description', 'status'];
+  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'description', 'status'];
   private static readonly DEMO_COL_ORDER_KEY = 'vtsearch.dashboard.demoColumnOrder';
 
   demoCols = new ManagedColumns(

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -293,9 +293,9 @@ class AudioMediaType(MediaType):
 
         cats = self._DEMO_CATEGORIES
         folder = DATA_DIR / "ESC-50-master" / "audio"
-        esc_desc = "Environmental recordings of animals, nature, cities, and homes."
-        sc_desc = "One-second keyword utterances from crowd-sourced speakers."
-        us_desc = "Real urban field recordings, pre-segmented into labeled sounds."
+        esc_desc = "Animals, nature, cities, & homes"
+        sc_desc = "Spoken keyword utterances"
+        us_desc = "Urban recordings"
         return [
             DemoDataset(
                 id="esc50_s",
@@ -348,7 +348,7 @@ class AudioMediaType(MediaType):
             DemoDataset(
                 id="gtzan_a",
                 label="GTZAN Music Genre (A)",
-                description="30-second music excerpts, one per genre.",
+                description="30sec music excerpts",
                 categories=self._GTZAN_CATEGORIES,
                 source="gtzan",
                 slice_frac_start=0.0,

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -47,15 +47,15 @@ def build_demo_datasets() -> list[DemoDataset]:
 
     cats101 = DEMO_CATEGORIES_CALTECH101
     cats256 = DEMO_CATEGORIES_CALTECH256
-    ct101_desc = "Centered object photos — a classic vision benchmark."
+    ct101_desc = "Centered object photos"
     ct101_folder = DATA_DIR / "caltech-101" / "101_ObjectCategories"
-    food_desc = "Crowd-sourced food photos — a deliberately noisy benchmark."
+    food_desc = "Crowd-sourced food photos"
     food_folder = DATA_DIR / "food-101" / "images"
-    euro_desc = "Sentinel-2 satellite imagery classified by land use type."
+    euro_desc = "Satellite imagery by land use"
     euro_folder = DATA_DIR / "EuroSAT_RGB"
-    dogs_desc = "Fine-grained dog breeds with many visually similar classes."
+    dogs_desc = "Dog breeds"
     dogs_folder = DATA_DIR / "stanford_dogs" / "Images"
-    places_desc = "Scene photos across indoor, natural, and man-made settings."
+    places_desc = "Indoor & outdoor scenes"
     places_folder = DATA_DIR / "places365" / "val_256"
     return [
         DemoDataset(
@@ -109,7 +109,7 @@ def build_demo_datasets() -> list[DemoDataset]:
         DemoDataset(
             id="caltech256_a",
             label="Caltech-256 (A)",
-            description="Harder object photos with cluttered backgrounds than Caltech-101.",
+            description="Cluttered object photos",
             categories=cats256,
             source="caltech256",
             required_folder=DATA_DIR / "caltech-256" / "256_ObjectCategories",
@@ -121,7 +121,7 @@ def build_demo_datasets() -> list[DemoDataset]:
         DemoDataset(
             id="oxford_flowers_102_a",
             label="Oxford Flowers 102 (A)",
-            description="Close-up flower photography with fine-grained species variation.",
+            description="Close-up flower photos",
             categories=OXFORD_FLOWERS_CATEGORIES,
             source="oxford_flowers_102",
             required_folder=DATA_DIR / "oxford_flowers",
@@ -325,7 +325,7 @@ def build_demo_datasets() -> list[DemoDataset]:
         DemoDataset(
             id="ucsf_documents_a",
             label="UCSF Documents (A)",
-            description="Scanned pages from the UCSF Industry Documents Library.",
+            description="Scanned document pages",
             categories=UCSF_DOCUMENTS_CATEGORIES,
             source="ucsf_documents",
             required_folder=DATA_DIR / "ucsf_documents",

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -167,12 +167,12 @@ class TextMediaType(MediaType):
     @property
     def demo_datasets(self) -> list:
         cats = self._DEMO_CATEGORIES
-        ng_desc = "Early-1990s Usenet posts across technical and political topics."
-        ag_desc = "Short news summaries across world, sports, business, tech."
-        imdb_desc = "Long-form movie reviews with positive/negative sentiment labels."
-        wiki_desc = "Wikipedia abstracts across 14 DBpedia ontology topics."
-        arxiv_desc = "arXiv titles + abstracts across CS, math, and the sciences."
-        reuters_desc = "Reuters-21578 financial newswire — a classic text benchmark."
+        ng_desc = "Early-90s Usenet posts"
+        ag_desc = "Short news summaries"
+        imdb_desc = "Long-form movie reviews"
+        wiki_desc = "Wikipedia abstracts"
+        arxiv_desc = "arXiv titles & abstracts"
+        reuters_desc = "Financial newswire"
         return [
             DemoDataset(
                 id="20newsgroups_s",
@@ -265,7 +265,7 @@ class TextMediaType(MediaType):
             DemoDataset(
                 id="bbc_news_a",
                 label="BBC News (A)",
-                description="BBC news articles — professionally written and cleanly labeled.",
+                description="BBC news articles",
                 categories=self._BBC_NEWS_CATEGORIES,
                 source="bbc_news",
                 slice_frac_start=0.0,

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -470,10 +470,10 @@ class VideoMediaType(MediaType):
         kth_cats = self._KTH_CATEGORIES
         kth_folder = VIDEO_DIR / "kth"
 
-        desc = "YouTube action videos covering sports and everyday activities."
-        hmdb_desc = "Human motion clips spanning 51 diverse action categories."
-        ucf_full_desc = "Full UCF-101 with 101 action classes across activities."
-        kth_desc = "Simple human actions — a classic recognition benchmark."
+        desc = "YouTube action videos"
+        hmdb_desc = "Human motion clips"
+        ucf_full_desc = "Action videos, 101 classes"
+        kth_desc = "Simple human actions"
         return [
             # UCF-101 subset (10 classes, 171 MB download)
             DemoDataset(


### PR DESCRIPTION
## Summary
- Drop the `# Cat.` column from both demo tables (Add Dataset modal and New Detector modal).
- Tighten every demo dataset description to a short noun phrase focused on content, not categories or collection method (e.g. "Environmental recordings of animals, nature, cities, and homes." → "Animals, nature, cities, & homes").
- Narrow the Add Dataset modal from 900px to 720px now that the demo table no longer needs to fit the categories column or long descriptions.

## Test plan
- [ ] Open Add Dataset → Demo tab; confirm modal is noticeably narrower and the table has only Name / # Media / Description / Readiness columns.
- [ ] Switch through media-type tabs (audio / image / text / video); descriptions read as short content-only phrases.
- [ ] Open New Model → Demo flow; same shorter columns appear there too.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VAwmCS88x7ZxFPV1irzCcV)_