### PR TITLE
Move list-file format detail into (?) hint icon

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -140,9 +140,7 @@
         <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
       } @else {
         <p class="info-text">
-          Upload a single file from <strong>this computer</strong> that lists the media to import
-          (a UTF-8 text file with one server-side path per line, or a <code>.npz</code> archive of
-          paths + pre-computed embedding vectors).
+          Upload a single file from <strong>this computer</strong> that lists the media to import.<vt-field-hint-icon hint="A UTF-8 text file with one server-side path per line, or a .npz archive of paths + pre-computed embedding vectors."></vt-field-hint-icon>
         </p>
       }
     </ng-container>


### PR DESCRIPTION
## Summary
- In the dataset importer's lf ("upload a single file") view, the parenthetical describing the two supported list-file formats (UTF-8 paths-per-line vs `.npz` paths + pre-computed embeddings) was visible body text.
- Tucked the detail into a `<vt-field-hint-icon>` (?) bubble next to the sentence so `info-text` stays a short one-liner.

## Test plan
- [ ] Open the dataset importer, switch to the lf "files" picker variant, and confirm the info paragraph reads as a single short sentence followed by a (?) icon.
- [ ] Hover the (?) icon and confirm the tooltip lists both formats.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cf1HNzSTzNbXDGuye9EStD)_