### PR TITLE
Inline summary preview + permanent-on native row in importer source-specs

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -67,6 +67,7 @@
               [selectedEmbedder]="selectedDemoEmbedder"
               (selectedEmbedderChange)="onDemoEmbedderChange($event)"
               [selectedClipper]="selectedDemoClipper"
+              [selectedClipperParams]="{}"
               (clipperChooserRequested)="openClipperChooser('demo')"
             ></vt-import-advanced>
           </div>
@@ -126,6 +127,7 @@
           [selectedEmbedder]="sfSelectedEmbedder"
           (selectedEmbedderChange)="sfSelectedEmbedder = $event"
           [selectedClipper]="sfSelectedClipper"
+          [selectedClipperParams]="sfClipperParamValues"
           (clipperChooserRequested)="openClipperChooser('sf')"
         ></vt-import-advanced>
       </div>
@@ -201,6 +203,7 @@
           [selectedEmbedder]="lfSelectedEmbedder"
           (selectedEmbedderChange)="lfSelectedEmbedder = $event"
           [selectedClipper]="lfSelectedClipper"
+          [selectedClipperParams]="lfClipperParamValues"
           (clipperChooserRequested)="openClipperChooser('lf')"
         ></vt-import-advanced>
       </div>
@@ -358,6 +361,7 @@
             [selectedEmbedder]="selectedEmbedder"
             (selectedEmbedderChange)="selectedEmbedder = $event"
             [selectedClipper]="selectedClipper"
+            [selectedClipperParams]="clipperParamValues"
             (clipperChooserRequested)="openClipperChooser('form')"
           ></vt-import-advanced>
         </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -18,6 +18,8 @@
     [typeLabels]="typeLabels"
     [specs]="sourceSpecs"
     [clippers]="clippers"
+    [selectedClipperName]="selectedClipper"
+    [selectedClipperParams]="selectedClipperParams"
     (specsChange)="onSourceSpecsChange($event)"
     (clipperChooserRequested)="onClipperClick()"
   ></vt-source-specs-picker>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -67,6 +67,12 @@ export class ImportAdvancedComponent {
    *  after the chooser settles. */
   @Input() selectedClipper = '';
 
+  /** Current parameter values for the selected clipper, keyed by the
+   *  clipper's parameter ``key``.  Forwarded to the source-specs
+   *  picker so the native row can render a live preview of the active
+   *  settings. */
+  @Input() selectedClipperParams: Record<string, string | number> = {};
+
   /** Fired when the user clicks either the native row's Details
    *  button (inside the source-specs column) or the standalone
    *  Details fallback below the Advanced block — parent opens its

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
@@ -2,19 +2,22 @@
   <div class="ssp-row ssp-row--native">
     <label
       class="ssp-row-main"
-      title="Include files of the dataset's native media type directly, without any conversion."
+      title="Native files of the dataset's media type are always included."
     >
       <input
         type="checkbox"
         class="ssp-checkbox"
-        [checked]="isNativeChecked()"
-        (change)="toggleNative($any($event.target).checked)"
+        [checked]="true"
+        [disabled]="true"
       />
       <span class="ssp-row-label">
         <strong>{{ labelFor(nativeType) }}</strong>
-        <span class="ssp-native-tag">native</span>
       </span>
     </label>
+
+    @if (nativeSummary(); as summary) {
+      <span class="ssp-row-summary">{{ summary }}</span>
+    }
 
     @if (hasNativeDetails()) {
       <button
@@ -42,6 +45,10 @@
         />
         <span class="ssp-row-label">{{ labelFor(st) }}</span>
       </label>
+
+      @if (nonNativeSummary(st); as summary) {
+        <span class="ssp-row-summary">{{ summary }}</span>
+      }
 
       @if (hasDetails(st)) {
         <button

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.scss
@@ -3,7 +3,7 @@
 
 .ssp {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   row-gap: var(--space-xs);
   column-gap: var(--space-lg);
@@ -33,21 +33,22 @@
   gap: var(--space-sm);
 }
 
-.ssp-native-tag {
-  font-size: var(--font-2xs);
-  text-transform: uppercase;
-  letter-spacing: .04em;
+// Inline preview of the active clipper/converter settings, rendered
+// between the row label and the "Details" button.
+.ssp-row-summary {
+  grid-column: 2;
   color: var(--text-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 0 var(--space-xs);
+  font-size: var(--font-sm);
   line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ssp-details-toggle {
   justify-self: end;
   white-space: nowrap;
-  grid-column: 2;
+  grid-column: 3;
 }
 
 .ssp-details-panel {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -41,6 +41,14 @@ export class SourceSpecsPickerComponent implements OnChanges {
    *  Clipper section).  An empty list means "no clipper choice", and
    *  the Details button is suppressed. */
   @Input() clippers: ClipperInfo[] = [];
+  /** Name of the clipper currently selected by the parent for the
+   *  native row.  Used to look up the matching :class:`ClipperInfo`
+   *  for the inline summary preview. */
+  @Input() selectedClipperName = '';
+  /** Current parameter values for the selected native clipper, keyed by
+   *  the clipper's parameter ``key``.  Substituted into the clipper's
+   *  ``summary_template`` to render the inline preview. */
+  @Input() selectedClipperParams: Record<string, string | number> = {};
   @Output() specsChange = new EventEmitter<SourceSpec[]>();
   /** Fired when the user clicks the native row's "Details" button.
    *  The parent opens the shared clipper-chooser modal in response. */
@@ -72,10 +80,6 @@ export class SourceSpecsPickerComponent implements OnChanges {
 
   labelFor(sourceType: string): string {
     return this.typeLabels[sourceType] || sourceType;
-  }
-
-  isNativeChecked(): boolean {
-    return this.specs.some((s) => s.source_type === this.nativeType && s.converter === null);
   }
 
   isNonNativeChecked(sourceType: string): boolean {
@@ -117,6 +121,44 @@ export class SourceSpecsPickerComponent implements OnChanges {
     this.clipperChooserRequested.emit();
   }
 
+  /** Currently-selected clipper for the native row, looked up in the
+   *  ``clippers`` input by ``selectedClipperName``.  Falls back to the
+   *  first available clipper so the summary still renders when the
+   *  parent hasn't picked one yet. */
+  private currentClipper(): ClipperInfo | null {
+    if (!this.clippers.length) return null;
+    const byName = this.clippers.find((c) => c.name === this.selectedClipperName);
+    return byName || this.clippers[0];
+  }
+
+  /** Live one-line summary of the native row's clipper, with current
+   *  parameter values substituted into its ``summary_template``.  Falls
+   *  back to ``description`` when no template is set, and to an empty
+   *  string when neither is available.  Missing values fall back to the
+   *  clipper's declared parameter defaults so the preview reads cleanly
+   *  before the user opens the chooser. */
+  nativeSummary(): string {
+    const c = this.currentClipper();
+    if (!c) return '';
+    const params: Record<string, string | number | null | undefined> = {};
+    for (const p of c.parameters || []) {
+      params[p.key] = p.default;
+    }
+    for (const k of Object.keys(this.selectedClipperParams)) {
+      const v = this.selectedClipperParams[k];
+      if (v !== undefined && v !== null && v !== '') params[k] = v;
+    }
+    return formatSummary(c.summary_template || c.description || '', params);
+  }
+
+  /** Live one-line summary of a non-native row's converter, with the
+   *  current draft params substituted into its ``summary_template``. */
+  nonNativeSummary(sourceType: string): string {
+    const c = this.currentConverter(sourceType);
+    if (!c) return '';
+    return formatSummary(c.summary_template || c.description || '', this.getDraft(sourceType).params);
+  }
+
   currentConverterName(sourceType: string): string {
     return this.getDraft(sourceType).converter || '';
   }
@@ -129,15 +171,6 @@ export class SourceSpecsPickerComponent implements OnChanges {
   paramValue(sourceType: string, key: string): string | number | null {
     const v = this.getDraft(sourceType).params[key];
     return v === undefined ? null : v;
-  }
-
-  toggleNative(checked: boolean): void {
-    const others = this.specs.filter((s) => !(s.source_type === this.nativeType && s.converter === null));
-    if (checked) {
-      this.specsChange.emit([{ source_type: this.nativeType, converter: null, params: {} }, ...others]);
-    } else {
-      this.specsChange.emit(others);
-    }
   }
 
   toggleNonNative(sourceType: string, checked: boolean): void {
@@ -197,4 +230,19 @@ export class SourceSpecsPickerComponent implements OnChanges {
     }
     return out;
   }
+}
+
+/** Substitute ``{key}`` placeholders in *template* with values from
+ *  *params*.  Unknown keys and ``null`` / ``undefined`` values are
+ *  rendered as ``"?"`` so the surrounding sentence remains readable. */
+function formatSummary(
+  template: string,
+  params: Record<string, string | number | null | undefined>,
+): string {
+  if (!template) return '';
+  return template.replace(/\{([^{}]+)\}/g, (_match, key: string) => {
+    const v = params[key];
+    if (v === undefined || v === null || v === '') return '?';
+    return String(v);
+  });
 }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -130,6 +130,11 @@ export interface ConverterInfo {
   target_type: string;
   display_name?: string;
   description?: string;
+  /** One-line preview with ``{key}`` placeholders for each field.  The
+   *  importer modal renders it next to the source-spec row, substituting
+   *  the current field values, so the user sees a live summary of what
+   *  the converter will do.  Falls back to ``description`` when empty. */
+  summary_template?: string;
   fields?: ImporterField[];
 }
 
@@ -262,6 +267,11 @@ export interface ClipperInfo {
   name: string;
   display_name?: string;
   description?: string;
+  /** One-line preview with ``{key}`` placeholders for each parameter.  The
+   *  native row of the importer source-specs picker substitutes the current
+   *  parameter values, so the user sees a live summary of what the clipper
+   *  will do.  Falls back to ``description`` when empty. */
+  summary_template?: string;
   media_type: string;
   parameters?: ClipperParameter[];
   creation_questions?: ClipperParameter[];

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -127,6 +127,27 @@ class TestConverterBase:
         assert d["target_type"] == "audio"
         assert "display_name" in d
         assert "description" in d
+        # summary_template surfaces the configurable ffmpeg_timeout so the
+        # frontend can preview the active setting next to the import row.
+        assert d["summary_template"] == "Pull the audio track from each video. Timeout {ffmpeg_timeout}s."
+
+    def test_to_dict_omits_summary_template_when_unset(self):
+        from vtscore.converters.base import MediaConverter
+
+        class Dummy(MediaConverter):
+            @property
+            def source_type(self):
+                return "foo"
+
+            @property
+            def target_type(self):
+                return "bar"
+
+            def convert(self, media, params=None):
+                return []
+
+        d = Dummy().to_dict()
+        assert "summary_template" not in d
 
     def test_to_dict_fallback_display_name(self):
         """If display_name is empty, to_dict derives one from type IDs."""

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -2120,6 +2120,24 @@ class TestClipperParameters:
         d = c.to_dict()
         assert "parameters" not in d
 
+    def test_to_dict_includes_summary_template_when_overridden(self):
+        from vtscore.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
+
+        # SoundTilingClipper provides a templated summary distinct from its
+        # description — that template should show up in to_dict().
+        d = SoundTilingClipper(2.0).to_dict()
+        assert d["summary_template"] == "Cut each audio file into {duration}s tiles (min overlap {min_overlap}s)."
+        # SoundAutoClipper too.
+        d = SoundAutoClipper().to_dict()
+        assert d["summary_template"] == "Cut into {tile_duration}s tiles when audio is over {threshold}s."
+
+    def test_to_dict_omits_summary_template_when_equal_to_description(self):
+        from vtscore.media.audio.clipper import SoundDefaultClipper
+
+        # No template override → summary_template equals description → not serialised.
+        d = SoundDefaultClipper().to_dict()
+        assert "summary_template" not in d
+
 
 class TestClipperParametersApi:
     """Test that the /api/clippers endpoint returns parameter info."""

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -123,6 +123,10 @@ class Audio2ImageMediaConverter(MediaConverter):
 
     display_name = "Audio → Image (spectrogram)"
     description = "Render audio as a mel-spectrogram or CQT image"
+    summary_template = (
+        "Render each audio file as a {spectrogram_type} spectrogram "
+        "(first {time_window_s}s, {colormap})."
+    )
     fields = [
         PluginField(
             key="spectrogram_type",

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -124,8 +124,7 @@ class Audio2ImageMediaConverter(MediaConverter):
     display_name = "Audio → Image (spectrogram)"
     description = "Render audio as a mel-spectrogram or CQT image"
     summary_template = (
-        "Render each audio file as a {spectrogram_type} spectrogram "
-        "(first {time_window_s}s, {colormap})."
+        "Render each audio file as a {spectrogram_type} spectrogram (first {time_window_s}s, {colormap})."
     )
     fields = [
         PluginField(

--- a/vtscore/converters/audio2text.py
+++ b/vtscore/converters/audio2text.py
@@ -38,6 +38,7 @@ class Audio2TextMediaConverter(MediaConverter):
 
     display_name = "Audio → Text (Whisper ASR)"
     description = "Transcribe speech in audio to text via Whisper"
+    summary_template = "Transcribe speech with Whisper ({model_size}, language: {language})."
     fields = [
         PluginField(
             key="model_size",

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -43,6 +43,15 @@ class MediaConverter(PluginBase, ABC):
     #: Short description of what this converter does.
     description: str = ""
 
+    #: One-line preview with ``{key}`` placeholders for the converter's
+    #: parameter values.  The frontend substitutes each ``{key}`` with the
+    #: current value of the field named ``key`` (see :attr:`fields`) when
+    #: rendering the import row preview.  Subclasses with configurable
+    #: parameters should override to surface the active values — e.g.
+    #: ``"Pull the audio track from video. Timeout {ffmpeg_timeout}sec."``.
+    #: Defaults to empty (falls back to :attr:`description`).
+    summary_template: str = ""
+
     #: User-configurable parameters.  Same :class:`PluginField` system
     #: every plugin family uses.  Empty by default — converters with no
     #: tunables don't have to declare anything.
@@ -134,7 +143,7 @@ class MediaConverter(PluginBase, ABC):
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise converter metadata for API endpoints."""
-        return {
+        d: dict[str, Any] = {
             "name": self.name,
             "source_type": self.source_type,
             "target_type": self.target_type,
@@ -142,3 +151,6 @@ class MediaConverter(PluginBase, ABC):
             "description": self.description,
             "fields": [f.to_dict() for f in self.fields],
         }
+        if self.summary_template:
+            d["summary_template"] = self.summary_template
+        return d

--- a/vtscore/converters/document2image.py
+++ b/vtscore/converters/document2image.py
@@ -32,6 +32,7 @@ class Document2ImageMediaConverter(MediaConverter):
 
     display_name = "Document \u2192 Images"
     description = "Render document pages as images"
+    summary_template = "Render each page of each document as a PNG image."
 
     @property
     def source_type(self) -> str:

--- a/vtscore/converters/document2text.py
+++ b/vtscore/converters/document2text.py
@@ -26,6 +26,7 @@ class Document2TextMediaConverter(MediaConverter):
 
     display_name = "Document \u2192 Text"
     description = "Extract embedded text from documents"
+    summary_template = "Extract the embedded text of each document into a single text entry."
 
     @property
     def source_type(self) -> str:

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -94,6 +94,7 @@ class Image2TextMediaConverter(MediaConverter):
 
     display_name = "Image → Text (OCR)"
     description = "Extract text from images via OCR"
+    summary_template = "Run PaddleOCR ({language}) on each image; drop regions below confidence {threshold}."
     fields = [
         PluginField(
             key="language",

--- a/vtscore/converters/video2audio.py
+++ b/vtscore/converters/video2audio.py
@@ -33,6 +33,7 @@ class Video2AudioMediaConverter(MediaConverter):
 
     display_name = "Video \u2192 Audio"
     description = "Extract audio tracks from video files"
+    summary_template = "Pull the audio track from each video. Timeout {ffmpeg_timeout}s."
     fields = [
         PluginField(
             key="ffmpeg_timeout",

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -26,6 +26,7 @@ class Video2ImageMediaConverter(MediaConverter):
 
     display_name = "Video → Images"
     description = "Extract frames from video files"
+    summary_template = "Cut each video into {n_clips} evenly-spaced frames."
     fields = [
         PluginField(
             key="n_clips",

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -352,8 +352,7 @@ class SoundSilenceClipper(MediaClipper):
     @property
     def summary_template(self) -> str:
         return (
-            "Split each audio file at silences quieter than {top_db}dB; "
-            "drop clips shorter than {min_clip_duration}s."
+            "Split each audio file at silences quieter than {top_db}dB; drop clips shorter than {min_clip_duration}s."
         )
 
     @property
@@ -657,8 +656,7 @@ class SoundSpeechActivityClipper(MediaClipper):
     @property
     def summary_template(self) -> str:
         return (
-            "Split each audio file at detected speech turns (VAD threshold {threshold}, "
-            "min clip {min_clip_duration}s)."
+            "Split each audio file at detected speech turns (VAD threshold {threshold}, min clip {min_clip_duration}s)."
         )
 
     @property

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -101,6 +101,10 @@ class SoundTilingClipper(MediaClipper):
         return "Split each audio file into fixed-length overlapping segments."
 
     @property
+    def summary_template(self) -> str:
+        return "Cut each audio file into {duration}s tiles (min overlap {min_overlap}s)."
+
+    @property
     def duration(self) -> float:
         return self._duration
 
@@ -219,6 +223,10 @@ class SoundAutoClipper(MediaClipper):
             f"Pass short audio through unchanged; tile audio longer than "
             f"{self._threshold:g}s into {self._tile_duration:g}s segments."
         )
+
+    @property
+    def summary_template(self) -> str:
+        return "Cut into {tile_duration}s tiles when audio is over {threshold}s."
 
     @property
     def threshold(self) -> float:
@@ -340,6 +348,13 @@ class SoundSilenceClipper(MediaClipper):
     @property
     def description(self) -> str:
         return "Split each audio file into non-silent segments. Drops intro/outro silence."
+
+    @property
+    def summary_template(self) -> str:
+        return (
+            "Split each audio file at silences quieter than {top_db}dB; "
+            "drop clips shorter than {min_clip_duration}s."
+        )
 
     @property
     def top_db(self) -> float:
@@ -509,6 +524,10 @@ class SoundClipClipper(MediaClipper):
         return "Extract a single user-specified [start, end) range from the audio."
 
     @property
+    def summary_template(self) -> str:
+        return "Extract audio from {start}s to {end}s."
+
+    @property
     def start(self) -> float:
         return self._start
 
@@ -634,6 +653,13 @@ class SoundSpeechActivityClipper(MediaClipper):
     @property
     def description(self) -> str:
         return "Split each audio file into one clip per speech turn using Silero VAD. Good for podcasts."
+
+    @property
+    def summary_template(self) -> str:
+        return (
+            "Split each audio file at detected speech turns (VAD threshold {threshold}, "
+            "min clip {min_clip_duration}s)."
+        )
 
     @property
     def threshold(self) -> float:

--- a/vtscore/media/clipper.py
+++ b/vtscore/media/clipper.py
@@ -69,6 +69,19 @@ class MediaClipper(ABC):
         """
         return ""
 
+    @property
+    def summary_template(self) -> str:
+        """One-line preview of this clipper with ``{key}`` placeholders.
+
+        The frontend substitutes each ``{key}`` with the current value of
+        the parameter named ``key`` (see :attr:`parameters`) when rendering
+        the import row preview.  Subclasses with configurable parameters
+        should override to surface the active values — e.g.
+        ``"Cut each audio file into {duration}s tiles."``.  Defaults to
+        :attr:`description` so static clippers don't have to override.
+        """
+        return self.description
+
     # ------------------------------------------------------------------
     # Parameters
     # ------------------------------------------------------------------
@@ -183,6 +196,9 @@ class MediaClipper(ABC):
         desc = self.description
         if desc:
             d["description"] = desc
+        template = self.summary_template
+        if template and template != desc:
+            d["summary_template"] = template
         params = self.parameters
         if params:
             d["parameters"] = params

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -495,8 +495,7 @@ class ImageFaceClipper(MediaClipper):
     @property
     def summary_template(self) -> str:
         return (
-            "Detect faces with MediaPipe (confidence ≥ {threshold}, min size {min_size}px) "
-            "and crop one clip per face."
+            "Detect faces with MediaPipe (confidence ≥ {threshold}, min size {min_size}px) and crop one clip per face."
         )
 
     @property

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -248,6 +248,13 @@ class ImageObjectClipper(MediaClipper):
         return "Detect objects with YOLO/RT-DETR and crop one clip per detection."
 
     @property
+    def summary_template(self) -> str:
+        return (
+            "Detect objects with {model_id} (confidence ≥ {threshold}, max "
+            "{max_detections} per image) and crop one clip per detection."
+        )
+
+    @property
     def threshold(self) -> float:
         return self._threshold
 
@@ -483,6 +490,13 @@ class ImageFaceClipper(MediaClipper):
         return (
             "Detect faces with MediaPipe and emit one crop per detected face; "
             "images with no detected faces are skipped."
+        )
+
+    @property
+    def summary_template(self) -> str:
+        return (
+            "Detect faces with MediaPipe (confidence ≥ {threshold}, min size {min_size}px) "
+            "and crop one clip per face."
         )
 
     @property

--- a/vtscore/media/video/clipper.py
+++ b/vtscore/media/video/clipper.py
@@ -71,6 +71,10 @@ class VideoTilingClipper(MediaClipper):
         return "Split each video into fixed-length overlapping segments."
 
     @property
+    def summary_template(self) -> str:
+        return "Cut each video into {duration}s clips (min overlap {min_overlap}s)."
+
+    @property
     def duration(self) -> float:
         return self._duration
 
@@ -180,6 +184,10 @@ class VideoAutoClipper(MediaClipper):
             f"Pass short videos through unchanged; tile videos longer than "
             f"{self._threshold:g}s into {self._tile_duration:g}s segments."
         )
+
+    @property
+    def summary_template(self) -> str:
+        return "Cut into {tile_duration}s tiles when video is over {threshold}s."
 
     @property
     def threshold(self) -> float:
@@ -358,6 +366,13 @@ class VideoSceneClipper(MediaClipper):
     @property
     def description(self) -> str:
         return "Automatically split each video at detected scene changes."
+
+    @property
+    def summary_template(self) -> str:
+        return (
+            "Split each video at scene changes (histogram threshold {threshold}, "
+            "min scene {min_scene_duration}s)."
+        )
 
     @property
     def threshold(self) -> float:

--- a/vtscore/media/video/clipper.py
+++ b/vtscore/media/video/clipper.py
@@ -369,10 +369,7 @@ class VideoSceneClipper(MediaClipper):
 
     @property
     def summary_template(self) -> str:
-        return (
-            "Split each video at scene changes (histogram threshold {threshold}, "
-            "min scene {min_scene_duration}s)."
-        )
+        return "Split each video at scene changes (histogram threshold {threshold}, min scene {min_scene_duration}s)."
 
     @property
     def threshold(self) -> float:


### PR DESCRIPTION
## Summary
- Add `summary_template` (a `{key}`-placeholder template) to both `MediaClipper` and `MediaConverter`. Override it on every parameterised clipper/converter so each can describe itself with its *current* settings — e.g. `"Cut into 10s tiles when audio is over 30s."` or `"Pull the audio track from each video. Timeout 600s."`.
- Source-specs picker renders the live summary inline between the row label and the `Details ▸` button. Native row uses the selected clipper; non-native rows use each row's draft converter. Missing values fall back to declared defaults.
- Native checkbox is now permanent-on (checked + disabled); the separate "native" tag chip is removed since the always-on checkbox already communicates "required".
- Grid layout updated to `auto 1fr auto` so the summary can fill the middle column without disturbing the Details button alignment.

## Test plan
- [x] `./run-tests.sh` (4211 passed)
- [ ] Open Add Dataset → server folder → Advanced and verify the summary text appears next to each row and updates when the user picks a different clipper / tweaks converter params.
- [ ] Confirm the native row's checkbox cannot be unchecked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01473GDtY1ZoVmZsJt3MAisd)_