### PR TITLE
Fix Add Dataset modal vertical rhythm and dropdown font-size

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -180,7 +180,7 @@ Rules:
 ```
 
 - `.form-input` and `.form-select` share padding, border, focus state. They sit on `--bg-subtle` so they read as "input wells."
-- `.form-label` is `--font-sm`, `--weight-medium`, `--text-primary` — visually heavier than helper text so it reads as a header above its input.
+- `.form-label` is `--font-md`, `--weight-medium`, `--text-primary` — sized to match `.form-input` so the header is never visually smaller than the value the user types/picks underneath it. Custom `<button>`-based dropdown triggers that play the role of `.form-select` (e.g. icon-bearing media-type pickers) must set `font-size: var(--font-md)` explicitly: `<button>` doesn't inherit page font by default, and component-scoped overrides (`font: inherit`, etc.) silently win over the global `.form-select` because Angular view encapsulation raises their specificity. If the trigger text ever renders larger than the label above it, that rule is the regression.
 - `.form-hint` (used for plugin-field `hint` strings) is muted monospace.
 - `.required` marks required fields with `--color-bad`.
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
@@ -33,8 +33,16 @@
   justify-content: space-between;
   gap: var(--space-sm);
   text-align: left;
-  font: inherit;
   // ``.form-select`` already supplies padding/border/radius/background.
+  // Set font-family/size explicitly: `<button>` doesn't inherit page
+  // font by default, and Angular view encapsulation gives this rule
+  // higher specificity than the global `.form-select`, so an `inherit`
+  // shorthand here would silently win over `.form-select`'s
+  // `font-size: var(--font-md)` and render the trigger at the page-root
+  // 1rem instead — making "Audio" visibly larger than the
+  // "Dataset MediaType" label above it (style-guide §2.3).
+  font-family: inherit;
+  font-size: var(--font-md);
 }
 
 .media-type-trigger-content {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
@@ -20,6 +20,13 @@
 .server-folder-browser { gap: var(--space-lg); }
 .sf-browse-section { gap: var(--space-sm); }
 
+// Stacked form sections inside the local-files / local-folder uploader
+// (lfInfo description, lfBefore media-type picker, drop zone, lfAfter
+// fields) need consistent inter-row spacing. Matches `.importer-form`'s
+// `gap: var(--space-lg)` (see _components.scss) so the two parallel
+// importer flows have identical vertical rhythm.
+.local-folder-uploader { gap: var(--space-lg); }
+
 // Indent the per-importer source widgets inward from the tabs above
 // (matches the parent modal's `.importer-form` indent so the hierarchy
 // reads top-down: category tabs → importer tabs → controls).

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -326,22 +326,31 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   padding: var(--space-xs) var(--space-md);
 }
 
+// Body-text utility classes used on `<p>`/`<span>` elements inside modals
+// and panels. We explicitly zero the UA `<p>` margin: surrounding layouts
+// rely on the parent's flex `gap` to space stacked elements, and default
+// browser `<p>` margins (~1em) inject inconsistent extra space that
+// breaks the vertical rhythm (see style-guide §3.0).
 .info-text {
+  margin: 0;
   font-size: var(--font-md);
   color: var(--text-secondary);
 }
 
 .error-text {
+  margin: 0;
   font-size: var(--font-md);
   color: var(--color-bad);
 }
 
 .success-text {
+  margin: 0;
   font-size: var(--font-md);
   color: var(--color-good);
 }
 
 .status-text {
+  margin: 0;
   font-size: var(--font-md);
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## Summary

Three style-guide violations were making the **Local > Files** view of the Add Dataset modal look uneven:

1. **`.local-folder-uploader` was a flex column with no `gap`** — the lfInfo description, media-type picker, drop zone, Dataset Name, and Advanced section all stacked flush against each other (no space between drop zone and "Dataset Name", no space between the "Include media" checkboxes and "Embedder", etc.). Added `gap: var(--space-lg)` to match the sibling `.importer-form` container.

2. **`.info-text` / `.error-text` / `.success-text` / `.status-text` never zeroed the UA `<p>` margin.** The lfInfo paragraph injected ~1em above and below itself, giving more space between the **Files** tab and the description than between the description and **Dataset MediaType** — making the description visually belong to the section below it instead of the tab above. Style-guide §3.0 says titles belong to the content *below* them; the UA margin broke that rhythm. Reset to `margin: 0` globally so parent flex `gap` owns spacing.

3. **The custom media-type dropdown trigger used `font: inherit`.** Angular view encapsulation gives that component-scoped rule higher specificity than the global `.form-select` (`font-size: var(--font-md)`), so the button silently fell back to the page-root 1rem — rendering "Audio" larger than the "Dataset MediaType" label above it. Replaced with explicit `font-family: inherit; font-size: var(--font-md);`.

Also synced `docs/style-guide.md` §2.3: `.form-label` is `--font-md` (matching `.form-input`), not `--font-sm`. The SCSS source-of-truth comment already explained this — the doc was stale. Added a paragraph warning future contributors about the custom-trigger specificity trap.

## Test plan

- [x] `npm run build:prod` — clean, no warnings
- [ ] Verify visually in the Add Dataset > Local > Files view:
  - [ ] Gap between **Files** tab and the description paragraph is smaller than the gap between the description and **Dataset MediaType**
  - [ ] Drop zone and **Dataset Name** are separated by `--space-lg` (12px)
  - [ ] **Include media** checkboxes and **Embedder** label are separated by `--space-lg`
  - [ ] **Dataset MediaType** label and "Audio" button text render at the same size (both `--font-md`)
- [ ] Spot-check the Add Dataset > Server view (uses `.server-folder-browser`, which already had `gap`) and the New Detector > Browse Media view (uses the same `<vt-source-picker>` with its `.local-folder-uploader` block) to confirm nothing regressed

---
_Generated by [Claude Code](https://claude.ai/code/session_017Jh96D2f5yx8hYH5AumG6Z)_