### PR TITLE
Plugin streamline Phase A: declarative origin construction

### DIFF
--- a/docs/plans/plugin-interface-streamlines.md
+++ b/docs/plans/plugin-interface-streamlines.md
@@ -479,9 +479,13 @@ that's already ready to use.**
 
 ### Phase A — Candidate #1: declarative origin construction
 
-**Status:** scheduled, no code yet.
+**Status:** **shipped.** All six in-tree `build_origin` overrides
+deleted; new declarative knobs (`include_in_origin`, `origin_serializer`,
+`extra_origin_keys`, `origin_suppressed`) live on `PluginField` /
+`DatasetImporter`. Coverage in `tests_lib/datasets/test_build_origin.py`;
+all 4232 tests pass.
 **Sequence:** first PR in the streamline series. Phase B (P0 field-schema
-collapse: #3 + finish #4 + #7) follows once this lands.
+collapse: #3 + finish #4 + #7) follows next.
 **Why first:** smallest blast radius (one base class + 6 in-tree
 importers, ~30-50 LOC deleted), zero required edits for external
 plugins, no CLI / HTTP-schema surface touched. It validates the
@@ -650,13 +654,24 @@ hypothesis before Phase B raises the stakes.
   declarative-`server_path`-validation slice forward into Phase A. Park
   this until Phase A is in flight.
 
+## What shipped
+
+- **Phase A — Candidate #1 (declarative origin construction).** Six
+  in-tree `build_origin` overrides deleted; framework default driven by
+  `PluginField.include_in_origin` / `origin_serializer` and
+  `DatasetImporter.extra_origin_keys` / `origin_suppressed`. Password
+  and file fields now default-excluded from origin (closes the latent
+  leak). External `DatasetImporter` plugins keep working unchanged
+  (override-wins shim); other plugin families (`MediaSource`,
+  `LabelImporter`, `LabelsetExporter`) untouched.
+
 ## Open follow-ups
 
-- Phase B (P0 collapse: #3 + finish #4 + #7) to be scheduled after
-  Phase A lands. Open question carried forward: extend the marshmallow
-  schema to be the single ingress for both HTTP and CLI calls, so
-  `validate_filepath_field`'s hardcoded `"filepath"` key can die and
-  `run_cli` plugins stop hand-checking required strings.
+- Phase B (P0 collapse: #3 + finish #4 + #7) is next up. Open question
+  carried forward: extend the marshmallow schema to be the single
+  ingress for both HTTP and CLI calls, so `validate_filepath_field`'s
+  hardcoded `"filepath"` key can die and `run_cli` plugins stop
+  hand-checking required strings.
 - #13 has a subtle attr-name choice (`.filename` vs `.name`) the
   current Shim note doesn't flag — the in-tree `_shared.py` adapter
   uses `.name`, but Werkzeug exposes `.filename`. Settle on one before

--- a/docs/plans/plugin-interface-streamlines.md
+++ b/docs/plans/plugin-interface-streamlines.md
@@ -475,8 +475,189 @@ that's already ready to use.**
   (`run` vs `export` vs `convert`). The unification proposed here is
   *behind* the bases, in the framework that calls them.
 
+## Next: scheduled work
+
+### Phase A — Candidate #1: declarative origin construction
+
+**Status:** scheduled, no code yet.
+**Sequence:** first PR in the streamline series. Phase B (P0 field-schema
+collapse: #3 + finish #4 + #7) follows once this lands.
+**Why first:** smallest blast radius (one base class + 6 in-tree
+importers, ~30-50 LOC deleted), zero required edits for external
+plugins, no CLI / HTTP-schema surface touched. It validates the
+"declarative replaces imperative override" pattern end-to-end before
+the more invasive validation work.
+
+#### What the existing overrides actually do
+
+A grep + read of every override exposes four distinct patterns, not
+just one. The Shim note in §1 above understated this — `_RENAMES` alone
+doesn't cover any of them. The patterns are:
+
+| Importer | Override pattern | Phase A handles via |
+|---|---|---|
+| `server_folder` | Add the non-`PluginField` key `source_specs` to params, JSON-encoding it if it arrived as a list | New `extra_origin_keys` class attr + framework-side list→JSON coercion |
+| `http_archive` | Same as `server_folder` | Same |
+| `server_files` | Include only `paths_file` and `media_type`; nothing else from `fields` | `include_in_origin=False` on the unwanted fields |
+| `demo` | Include only `name` and `converter`; emit `name` even when empty (the default skips empties) | `include_in_origin=False` on the unwanted fields; accept losing the empty-`name` edge case |
+| `combine_datasets` | Custom serializer for the `datasets` field (list-or-string → comma-joined string) | `origin_serializer` callable on `PluginField` |
+| `recaller` | Return empty params — dataset-level origin is meaningless; per-media origins are built in `_build_media` | `origin_suppressed = True` class attr |
+
+A latent footgun the override-by-override approach is hiding: **the
+current default `build_origin` does not exclude `field_type="password"`
+fields.** An importer like the SFTP skeleton in the base-class docstring
+(which declares a `password` field) would silently land that password
+in the persisted origin dict. Phase A fixes this by defaulting
+`include_in_origin=False` for `password` and `file` field types.
+
+#### Design
+
+Two additions to `PluginField` (in `vtscore/plugins/__init__.py`) and
+two to `DatasetImporter` (in `vtscore/datasets/importers/base.py`):
+
+```python
+# PluginField
+include_in_origin: bool | None = None    # None → field_type-driven default
+origin_serializer: Callable[[Any], str] | None = None
+
+# DatasetImporter
+extra_origin_keys: tuple[str, ...] = ()  # non-PluginField keys to copy
+origin_suppressed: bool = False          # short-circuit to {importer, params={}}
+```
+
+Default for `include_in_origin` resolves at runtime:
+- `field_type in ("file", "password")` → `False`
+- everything else → `True`
+
+The framework's new `build_origin` body becomes:
+
+1. If `origin_suppressed`, return `{"importer": self.name, "params": {}}`.
+2. For each `PluginField` where `include_in_origin` resolves true: pull
+   the value, run `origin_serializer` if set, fall back to the existing
+   checkbox / `str(val) if val else skip` rules.
+3. For each key in `extra_origin_keys`: copy from `field_values`,
+   JSON-encoding lists/dicts on the way out.
+4. Return `{"importer": self.name, "params": params}`.
+
+The list→JSON coercion for `source_specs` moves from the importer to
+the framework because every multi-media importer needs it. New
+multi-media importers (third-party `recaller`-style) get this for free
+by declaring `extra_origin_keys = ("source_specs",)` — or, even better,
+the framework auto-adds `"source_specs"` to `extra_origin_keys` when
+`multi_media = True` on the class.
+
+#### Migration impact — in-tree
+
+All six overrides get deleted. Concrete diffs:
+
+- `server_folder`: delete override (auto-added via `multi_media=True`).
+- `http_archive`: delete override (auto-added via `multi_media=True`).
+- `server_files`: delete override; add `include_in_origin=False` to any
+  field other than `paths_file` / `media_type` (today the field list is
+  already just those two plus `source_specs` for multi-media, so the
+  override is largely vestigial — deleting it is a near-no-op).
+- `demo`: delete override; add `include_in_origin=False` to whatever
+  fields aren't `name`/`converter`. Loses the "emit empty `name`" edge
+  case; verify no test asserts on the empty-name behavior.
+- `combine_datasets`: delete override; declare
+  `origin_serializer=lambda v: ",".join(v) if isinstance(v, list) else v`
+  on the `datasets` field.
+- `recaller`: delete override; set `origin_suppressed = True` on the
+  class.
+
+LOC delta: roughly -50 (six overrides averaging ~8 lines) +12 (new
+class attrs and PluginField args).
+
+#### Migration impact — external plugins (the four families you named)
+
+**`DatasetImporter` (external; the in-repo `recaller` scaffold is the
+template).** Migration cost: **zero required edits.** External
+importers that override `build_origin` keep working unchanged — the
+new framework default only fires when the subclass doesn't override.
+Optional cleanup: delete the override after declaring the equivalent
+class attrs. Concretely for a recaller-style importer, the migration
+is a one-line diff:
+
+```python
+# Before
+def build_origin(self, field_values):
+    return {"importer": self.name, "params": {}}
+
+# After
+origin_suppressed = True
+```
+
+**`MediaSource` (external; `pullwrest`).** Migration cost: **none.**
+`MediaSource` doesn't participate in field-schema-driven origin
+construction at all — sources are factoried from an existing origin
+dict via `create_from_origin(origin)`, they don't build origins.
+Phase A doesn't touch sources.
+
+**`LabelImporter` (external; `holder`).** Migration cost: **none.**
+Label importers don't have a `build_origin` concept — they return label
+dicts keyed by md5 / origin. Phase A doesn't touch label importers.
+
+**`LabelsetExporter` (external; `holder`).** Migration cost: **none.**
+Exporters consume labelsets, they don't produce origins. Phase A
+doesn't touch exporters.
+
+In summary: Phase A only affects DatasetImporters, and even there the
+override-still-wins shim means zero required edits for external code.
+This is the gentlest possible first move and is a clean test of the
+"declarative knobs on PluginField replace plugin-side overrides"
+hypothesis before Phase B raises the stakes.
+
+#### Implementation steps
+
+1. Add `include_in_origin` and `origin_serializer` to `PluginField` in
+   `vtscore/plugins/__init__.py`; thread them through `to_dict()` /
+   `from_dict()` so the registry's JSON snapshot stays round-trip safe.
+2. Add `extra_origin_keys` and `origin_suppressed` to `DatasetImporter`.
+3. Rewrite `DatasetImporter.build_origin` per the design above; add a
+   `_resolve_include_in_origin(field)` helper that applies the
+   field-type defaults.
+4. Auto-add `"source_specs"` to `extra_origin_keys` when
+   `multi_media = True`.
+5. Delete the six in-tree overrides; add the equivalent declarative
+   attrs.
+6. Tests: extend `tests_lib/datasets/` with cases for each pattern
+   (suppressed origin, omitted password field, list-typed field via
+   `origin_serializer`, `extra_origin_keys` JSON-encoded). Verify the
+   "override still wins" shim with a fake third-party-style importer
+   that overrides `build_origin` and asserts the override's return
+   value reaches `media["origin"]`.
+7. Run `./run-tests.sh datasets io detectors` first (origin info is
+   read by labelset resolution and label export, so the blast radius
+   touches those groups), then the full `./run-tests.sh`.
+
+#### Open questions
+
+- **`origin_suppressed` vs an empty `params` dict by default for
+  recaller.** Suppression is more explicit and is the only pattern that
+  emits the literal `{"importer": name, "params": {}}` short-circuit.
+  Alternative: declare all fields `include_in_origin=False` and let the
+  loop produce empty params. Cleaner per-field, but loses the "I have
+  no useful dataset-level origin" intent. Recommend keeping the
+  explicit class attr.
+- **Should `origin_serializer` get the full `field_values` dict** in
+  addition to the field's value, so a serializer can reach across to
+  another field? Only `combine_datasets` would care, and it doesn't
+  need cross-field access. Keep the API single-value to start; widen
+  later if a real use case appears.
+- **Phase A or Phase B owns the `validate_filepath_field` deletion.**
+  Phase A doesn't strictly need it — it's a separate route-layer
+  concern — but if Phase B drags, it might be worth pulling the
+  declarative-`server_path`-validation slice forward into Phase A. Park
+  this until Phase A is in flight.
+
 ## Open follow-ups
 
-- None yet. This is a discovery doc; pick which candidates to schedule
-  and crack them open in separate plan files (or fold them inline into
-  EXTENDING.md once they ship).
+- Phase B (P0 collapse: #3 + finish #4 + #7) to be scheduled after
+  Phase A lands. Open question carried forward: extend the marshmallow
+  schema to be the single ingress for both HTTP and CLI calls, so
+  `validate_filepath_field`'s hardcoded `"filepath"` key can die and
+  `run_cli` plugins stop hand-checking required strings.
+- #13 has a subtle attr-name choice (`.filename` vs `.name`) the
+  current Shim note doesn't flag — the in-tree `_shared.py` adapter
+  uses `.name`, but Werkzeug exposes `.filename`. Settle on one before
+  scheduling.

--- a/tests_lib/datasets/test_build_origin.py
+++ b/tests_lib/datasets/test_build_origin.py
@@ -1,0 +1,285 @@
+"""Tests for the declarative ``DatasetImporter.build_origin`` framework.
+
+These cover the four patterns the refactor consolidates:
+
+- ``origin_suppressed`` short-circuits to empty params.
+- ``PluginField.include_in_origin`` opts a field in/out.
+- ``PluginField.origin_serializer`` customises the string form.
+- ``extra_origin_keys`` copies non-PluginField keys into params,
+  including the automatic ``source_specs`` injection for multi-media
+  importers.
+
+Plus the safety defaults: ``file`` and ``password`` field types are
+excluded from origin by default, and explicit subclass overrides still
+win (the backwards-compat shim).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+
+
+def _make_importer(
+    *,
+    name: str = "fake",
+    fields: list[ImporterField] | None = None,
+    multi_media: bool = False,
+    extra_origin_keys: tuple[str, ...] = (),
+    origin_suppressed: bool = False,
+) -> DatasetImporter:
+    """Construct a throwaway DatasetImporter for build_origin testing."""
+
+    class _FakeImporter(DatasetImporter):
+        pass
+
+    _FakeImporter.name = name
+    _FakeImporter.display_name = name
+    _FakeImporter.description = ""
+    _FakeImporter.fields = fields or []
+    _FakeImporter.multi_media = multi_media
+    _FakeImporter.extra_origin_keys = extra_origin_keys
+    _FakeImporter.origin_suppressed = origin_suppressed
+    return _FakeImporter()
+
+
+class TestOriginSuppressed:
+    def test_returns_empty_params_when_suppressed(self):
+        imp = _make_importer(
+            fields=[ImporterField("k", "K", "text")],
+            origin_suppressed=True,
+        )
+        assert imp.build_origin({"k": "v"}) == {"importer": "fake", "params": {}}
+
+    def test_default_is_not_suppressed(self):
+        imp = _make_importer(fields=[ImporterField("k", "K", "text")])
+        assert imp.build_origin({"k": "v"})["params"] == {"k": "v"}
+
+
+class TestFieldTypeDefaults:
+    def test_password_field_is_excluded_by_default(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("user", "User", "text"),
+                ImporterField("password", "Password", "password"),
+            ],
+        )
+        params = imp.build_origin({"user": "alice", "password": "hunter2"})["params"]
+        assert params == {"user": "alice"}
+
+    def test_file_field_is_excluded_by_default(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("name", "Name", "text"),
+                ImporterField("upload", "Upload", "file"),
+            ],
+        )
+        params = imp.build_origin({"name": "x", "upload": "/should/not/leak"})["params"]
+        assert params == {"name": "x"}
+
+    def test_include_in_origin_overrides_default(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("debug_token", "Debug", "password", include_in_origin=True),
+            ],
+        )
+        params = imp.build_origin({"debug_token": "ok-to-persist"})["params"]
+        assert params == {"debug_token": "ok-to-persist"}
+
+    def test_include_in_origin_can_omit_a_text_field(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("keep", "Keep", "text"),
+                ImporterField("drop", "Drop", "text", include_in_origin=False),
+            ],
+        )
+        params = imp.build_origin({"keep": "a", "drop": "b"})["params"]
+        assert params == {"keep": "a"}
+
+
+class TestOriginSerializer:
+    def test_list_field_is_comma_joined_via_serializer(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField(
+                    "datasets",
+                    "Datasets",
+                    "text",
+                    origin_serializer=lambda v: ",".join(v) if isinstance(v, list) else str(v),
+                ),
+            ],
+        )
+        params = imp.build_origin({"datasets": ["a.pkl", "b.pkl"]})["params"]
+        assert params == {"datasets": "a.pkl,b.pkl"}
+
+    def test_serializer_ignored_when_value_empty(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("k", "K", "text", origin_serializer=lambda v: f"!{v}!"),
+            ],
+        )
+        # Empty value is skipped before the serializer runs.
+        assert imp.build_origin({"k": ""})["params"] == {}
+
+    def test_default_lists_are_json_encoded(self):
+        # Without an origin_serializer, list/dict values are JSON-encoded so
+        # they round-trip through the string-only origin contract.
+        imp = _make_importer(
+            fields=[ImporterField("payload", "Payload", "text")],
+        )
+        params = imp.build_origin({"payload": [{"a": 1}]})["params"]
+        assert params == {"payload": '[{"a": 1}]'}
+
+
+class TestExtraOriginKeys:
+    def test_extra_origin_keys_copy_from_field_values(self):
+        imp = _make_importer(
+            fields=[ImporterField("a", "A", "text")],
+            extra_origin_keys=("transient",),
+        )
+        params = imp.build_origin({"a": "1", "transient": "abc"})["params"]
+        assert params == {"a": "1", "transient": "abc"}
+
+    def test_extra_origin_keys_json_encode_lists(self):
+        imp = _make_importer(extra_origin_keys=("specs",))
+        params = imp.build_origin({"specs": [{"x": 1}]})["params"]
+        assert params == {"specs": '[{"x": 1}]'}
+
+    def test_multi_media_auto_adds_source_specs(self):
+        imp = _make_importer(multi_media=True)
+        params = imp.build_origin({"source_specs": [{"source_type": "audio"}]})["params"]
+        assert params == {"source_specs": '[{"source_type": "audio"}]'}
+
+    def test_multi_media_keeps_existing_extra_keys(self):
+        imp = _make_importer(
+            multi_media=True,
+            extra_origin_keys=("custom",),
+        )
+        params = imp.build_origin({"custom": "c", "source_specs": [{"source_type": "image"}]})["params"]
+        assert params == {"custom": "c", "source_specs": '[{"source_type": "image"}]'}
+
+    def test_multi_media_no_op_when_source_specs_empty(self):
+        imp = _make_importer(multi_media=True)
+        assert imp.build_origin({})["params"] == {}
+
+
+class TestCheckboxStillSerialised:
+    def test_checkbox_emits_true_false_strings(self):
+        imp = _make_importer(
+            fields=[
+                ImporterField("on", "On", "checkbox", default="false"),
+                ImporterField("off", "Off", "checkbox", default="false"),
+            ],
+        )
+        params = imp.build_origin({"on": True, "off": False})["params"]
+        assert params == {"on": "true", "off": "false"}
+
+    def test_checkbox_default_when_missing(self):
+        imp = _make_importer(
+            fields=[ImporterField("on", "On", "checkbox", default="true")],
+        )
+        # Field absent from field_values — falls back to declared default.
+        assert imp.build_origin({})["params"] == {"on": "true"}
+
+
+class TestSubclassOverrideWins:
+    """The backwards-compat shim: a third-party importer that still overrides
+    ``build_origin`` keeps working unchanged."""
+
+    def test_override_replaces_default_behavior(self):
+        class _OverridingImporter(DatasetImporter):
+            name = "overriding"
+            display_name = "Overriding"
+            description = ""
+            fields = [
+                ImporterField("password", "Password", "password"),
+                ImporterField("user", "User", "text"),
+            ]
+
+            def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
+                # Deliberately include the password — the override wins even
+                # over the new "exclude password by default" rule.
+                return {
+                    "importer": self.name,
+                    "params": {
+                        "user": str(field_values.get("user", "")),
+                        "password": str(field_values.get("password", "")),
+                    },
+                }
+
+        imp = _OverridingImporter()
+        params = imp.build_origin({"user": "alice", "password": "p"})["params"]
+        assert params == {"user": "alice", "password": "p"}
+
+
+class TestInTreeImportersAfterMigration:
+    """Smoke tests confirming each in-tree importer's origin matches the
+    pre-refactor expectations after deleting its override."""
+
+    def test_server_folder_includes_source_specs_in_origin(self):
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        origin = IMPORTER.build_origin(
+            {
+                "media_type": "audio",
+                "path": "/data/x",
+                "recursive": True,
+                "source_specs": [{"source_type": "audio"}],
+            }
+        )
+        assert origin["importer"] == "server_folder"
+        assert origin["params"]["path"] == "/data/x"
+        assert origin["params"]["media_type"] == "audio"
+        assert origin["params"]["recursive"] == "true"
+        assert origin["params"]["source_specs"] == '[{"source_type": "audio"}]'
+
+    def test_http_archive_includes_source_specs_in_origin(self):
+        from vtscore.datasets.importers.http_archive import IMPORTER
+
+        origin = IMPORTER.build_origin(
+            {
+                "url": "https://example.com/a.zip",
+                "media_type": "image",
+                "source_specs": [{"source_type": "image"}],
+            }
+        )
+        assert origin["importer"] == "http_archive"
+        assert origin["params"]["url"] == "https://example.com/a.zip"
+        assert origin["params"]["media_type"] == "image"
+        assert origin["params"]["source_specs"] == '[{"source_type": "image"}]'
+
+    def test_demo_omits_embedder_from_origin(self):
+        from vtscore.datasets.importers.demo import IMPORTER
+
+        origin = IMPORTER.build_origin({"name": "GTZAN", "embedder": "clap", "converter": "audio2image"})
+        assert origin["importer"] == "demo"
+        assert origin["params"] == {"name": "GTZAN", "converter": "audio2image"}
+
+    def test_combine_datasets_comma_joins_list(self):
+        from vtscore.datasets.importers.combine_datasets import IMPORTER
+
+        origin = IMPORTER.build_origin({"datasets": ["/a.pkl", "/b.pkl"], "name": "Combined"})
+        assert origin["importer"] == "combine_datasets"
+        # ``name`` is display-only — excluded from origin.
+        assert origin["params"] == {"datasets": "/a.pkl,/b.pkl"}
+
+    def test_combine_datasets_passes_through_string(self):
+        from vtscore.datasets.importers.combine_datasets import IMPORTER
+
+        origin = IMPORTER.build_origin({"datasets": "/a.pkl,/b.pkl"})
+        assert origin["params"]["datasets"] == "/a.pkl,/b.pkl"
+
+    def test_recaller_origin_is_empty(self):
+        from vtscore.datasets.importers.recaller import IMPORTER
+
+        origin = IMPORTER.build_origin({"query_id": "Q1", "media_type": "audio"})
+        assert origin == {"importer": "recaller", "params": {}}
+
+    def test_server_files_origin_includes_paths_file_and_media_type(self):
+        from vtscore.datasets.importers.server_files import IMPORTER
+
+        origin = IMPORTER.build_origin({"paths_file": "/tmp/list.txt", "media_type": "audio"})
+        assert origin["importer"] == "server_files"
+        assert origin["params"]["paths_file"] == "/tmp/list.txt"
+        assert origin["params"]["media_type"] == "audio"

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -215,6 +215,39 @@ PickerView = str  # one of: "form", "demo", "server_folder", "local"
 DATASET_NAME_FIELD_KEY = "dataset_name"
 
 
+_ORIGIN_EXCLUDED_FIELD_TYPES = frozenset({"file", "password"})
+
+
+def _field_in_origin(field: PluginField) -> bool:
+    """Resolve whether *field*'s value should land in the persisted origin.
+
+    Honors an explicit :attr:`PluginField.include_in_origin`; otherwise
+    falls back to the field-type default (file and password fields are
+    excluded).
+    """
+    if field.include_in_origin is not None:
+        return field.include_in_origin
+    return field.field_type not in _ORIGIN_EXCLUDED_FIELD_TYPES
+
+
+def _serialise_origin_value(value: Any, serializer: Any) -> str:
+    """Serialise *value* for inclusion in an origin ``params`` dict.
+
+    Returns the empty string when *value* is falsy (mirroring the
+    pre-refactor ``if val: params[key] = str(val)`` shape).  When
+    *serializer* is set it runs first; otherwise list/dict values are
+    JSON-encoded so an importer's structured ``field_values`` round-trip
+    through the string-only origin contract.
+    """
+    if not value:
+        return ""
+    if serializer is not None:
+        return str(serializer(value))
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return str(value)
+
+
 def _dataset_name_field() -> PluginField:
     return PluginField(
         key=DATASET_NAME_FIELD_KEY,
@@ -337,6 +370,25 @@ class DatasetImporter(PluginBase):
     #: See :doc:`/docs/plans/multi-media-import` for the migration
     #: checklist.
     multi_media: bool = False
+
+    #: Extra keys to copy from ``field_values`` into the origin ``params``
+    #: dict, in addition to the importer's declared :attr:`fields`.  Use
+    #: this for transient request-time values that aren't first-class
+    #: :class:`PluginField`\s (e.g. ``"source_specs"`` for multi-media
+    #: importers).  List/dict values are JSON-encoded; everything else is
+    #: stringified via ``str(...)``.  Empty values are skipped.  When
+    #: :attr:`multi_media` is ``True``, the framework automatically adds
+    #: ``"source_specs"`` to this tuple, so multi-media importers usually
+    #: leave this empty.
+    extra_origin_keys: tuple[str, ...] = ()
+
+    #: When ``True``, :meth:`build_origin` returns
+    #: ``{"importer": self.name, "params": {}}`` regardless of
+    #: ``field_values``.  Use this for importers whose dataset-level origin
+    #: is intentionally empty (e.g. the recaller importer, which builds a
+    #: useful per-media origin on each yielded record and has no useful
+    #: dataset-wide identifier).
+    origin_suppressed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
@@ -982,6 +1034,24 @@ class DatasetImporter(PluginBase):
         identify the data source (importer name + string-serialisable
         field values).
 
+        Behaviour is driven declaratively by:
+
+        - :attr:`origin_suppressed` — short-circuits to empty params.
+        - :attr:`PluginField.include_in_origin` — per-field opt-out.  The
+          default is ``False`` for ``"file"`` and ``"password"`` fields
+          (don't persist uploads or secrets) and ``True`` for every
+          other type.
+        - :attr:`PluginField.origin_serializer` — per-field custom
+          string conversion (e.g. comma-joining a list).
+        - :attr:`extra_origin_keys` — non-``PluginField`` keys to copy
+          from ``field_values``.  ``multi_media`` importers
+          automatically include ``"source_specs"``.
+
+        Subclasses may still override this method, in which case the
+        override wins — every declarative knob above is ignored.  Prefer
+        the declarative form unless you need something the framework
+        can't express.
+
         Args:
             field_values: The field values used for the import.
 
@@ -989,19 +1059,37 @@ class DatasetImporter(PluginBase):
             A dict with ``"importer"`` (str) and ``"params"`` (dict of str)
             keys.
         """
+        if self.origin_suppressed:
+            return {"importer": self.name, "params": {}}
+
         params: dict[str, str] = {}
         for f in self.fields:
-            if f.field_type == "file":
+            if not _field_in_origin(f):
                 continue
             if f.field_type == "checkbox":
                 val = field_values.get(f.key, str(f.default).lower() == "true")
                 truthy = val if isinstance(val, bool) else str(val).lower() == "true"
                 params[f.key] = "true" if truthy else "false"
                 continue
-            val = field_values.get(f.key, "")
-            if val:
-                params[f.key] = str(val)
+            raw = field_values.get(f.key, "")
+            serialised = _serialise_origin_value(raw, f.origin_serializer)
+            if serialised:
+                params[f.key] = serialised
+
+        for key in self._effective_extra_origin_keys():
+            raw = field_values.get(key, "")
+            serialised = _serialise_origin_value(raw, None)
+            if serialised:
+                params[key] = serialised
+
         return {"importer": self.name, "params": params}
+
+    def _effective_extra_origin_keys(self) -> tuple[str, ...]:
+        """Return :attr:`extra_origin_keys`, auto-adding ``"source_specs"``
+        for multi-media importers."""
+        if self.multi_media and "source_specs" not in self.extra_origin_keys:
+            return self.extra_origin_keys + ("source_specs",)
+        return self.extra_origin_keys
 
     # ------------------------------------------------------------------
     # Origin display and reload

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -136,12 +136,19 @@ class CombineDatasetsImporter(DatasetImporter):
             field_type="text",
             description="The existing datasets to merge into one new dataset.",
             hint="Comma-separated paths to .pkl files exported from VTSearch.",
+            # The ``datasets`` field is list-or-string at request time but the
+            # origin contract is string-only, so collapse lists to the same
+            # comma-joined form ``_parse_dataset_paths`` already accepts.
+            origin_serializer=lambda v: ",".join(v) if isinstance(v, list) else str(v),
         ),
         ImporterField(
             key="name",
             label="Name",
             field_type="text",
             description="Display name for the new combined dataset.",
+            # Display-only — not part of the dataset's identity, so leave it
+            # out of the persisted origin to keep reloads deterministic.
+            include_in_origin=False,
         ),
     ]
 
@@ -237,15 +244,5 @@ class CombineDatasetsImporter(DatasetImporter):
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
-
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        """Build an origin dict listing the source dataset paths."""
-        raw = field_values.get("datasets", "")
-        if isinstance(raw, list):
-            datasets_str = ",".join(raw)
-        else:
-            datasets_str = raw
-        return {"importer": self.name, "params": {"datasets": datasets_str}}
-
 
 IMPORTER = CombineDatasetsImporter()

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -245,4 +245,5 @@ class CombineDatasetsImporter(DatasetImporter):
     ) -> Iterator[dict[int, dict[str, Any]]]:
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
+
 IMPORTER = CombineDatasetsImporter()

--- a/vtscore/datasets/importers/demo/__init__.py
+++ b/vtscore/datasets/importers/demo/__init__.py
@@ -54,6 +54,7 @@ class DemoDatasetImporter(DatasetImporter):
             field_type="text",
             description="Override the default embedder (optional).",
             required=False,
+            include_in_origin=False,
         ),
         ImporterField(
             key="converter",
@@ -102,13 +103,6 @@ class DemoDatasetImporter(DatasetImporter):
             converter_name=converter_name,
             clipper_name=clipper_name,
         )
-
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        params: dict[str, str] = {"name": field_values.get("name", "")}
-        converter = field_values.get("converter", "")
-        if converter:
-            params["converter"] = converter
-        return {"importer": self.name, "params": params}
 
     def origin_display(self, origin: dict[str, Any]) -> str:
         params = origin.get("params", {})

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -369,15 +369,6 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 return tail
         return self.display_name
 
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        origin = super().build_origin(field_values)
-        specs = field_values.get("source_specs")
-        if specs:
-            if not isinstance(specs, str):
-                specs = json.dumps(specs)
-            origin["params"]["source_specs"] = specs
-        return origin
-
     def resolve_file(
         self,
         origin: dict[str, Any],

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -183,6 +183,9 @@ class ReCallerDatasetImporter(DatasetImporter):
     hidden_from_picker = True  # flip to False once API clients are implemented
     category = "services"
     multi_media = True
+    # Useful per-media origins are built in ``_build_media`` (keyed by
+    # contentID); the dataset-level origin carries no actionable identity.
+    origin_suppressed = True
     fields = [
         ImporterField(
             key="media_type",
@@ -208,11 +211,6 @@ class ReCallerDatasetImporter(DatasetImporter):
             output_type = current_values.get("media_type") or "audio"
             return list(_rc_list_queries(output_type))
         return super().get_field_options(field_key, current_values)
-
-    # The dataset-level origin (queryID) is NOT useful for provenance —
-    # each media gets its own origin keyed by contentID via _build_media.
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        return {"importer": self.name, "params": {}}
 
     # ------------------------------------------------------------------
     # Multi-media source hook

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -460,16 +460,6 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 return stem
         return self.display_name
 
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        params: dict[str, str] = {}
-        paths_file = field_values.get("paths_file", "")
-        if paths_file:
-            params["paths_file"] = str(paths_file)
-        media_type = field_values.get("media_type", "")
-        if media_type:
-            params["media_type"] = media_type
-        return {"importer": self.name, "params": params}
-
     def origin_display(self, origin: dict[str, Any]) -> str:
         params = origin.get("params", {})
         return f"server_files:{params.get('paths_file', '')}"

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -381,17 +381,6 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 return leaf
         return self.display_name
 
-    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
-        origin = super().build_origin(field_values)
-        specs = field_values.get("source_specs")
-        if specs:
-            import json as _json  # noqa: PLC0415
-
-            if not isinstance(specs, str):
-                specs = _json.dumps(specs)
-            origin["params"]["source_specs"] = specs
-        return origin
-
     def origin_display(self, origin: dict[str, Any]) -> str:
         params = origin.get("params", {})
         return f"server_folder:{params.get('path', '')}"

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -146,6 +146,24 @@ class PluginField:
     #: CLI parser to use :class:`float`; an integer step uses :class:`int`.
     step: str = ""
 
+    #: Whether this field's value should be copied into the importer's
+    #: persisted origin dict (see :meth:`DatasetImporter.build_origin`).
+    #: ``None`` means "use the field-type default": ``False`` for
+    #: ``"file"`` and ``"password"`` fields (don't persist file uploads or
+    #: secrets), ``True`` for every other type.  Set explicitly to
+    #: override the default — e.g. ``include_in_origin=False`` on a noisy
+    #: text field that doesn't belong in the persisted origin.
+    include_in_origin: bool | None = None
+
+    #: Optional callable that converts the field's value to the string
+    #: form persisted in the origin dict.  Receives the raw value (as
+    #: provided by the request or CLI) and must return a ``str``.  Use
+    #: this for list/dict-typed values whose default ``str(...)``
+    #: representation isn't round-trip safe (e.g. a list field that should
+    #: be serialised as a comma-joined string).  Ignored when
+    #: :attr:`include_in_origin` resolves to ``False``.
+    origin_serializer: Callable[[Any], str] | None = None
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "key": self.key,


### PR DESCRIPTION
## Summary

First PR in the plugin-interface-streamlines series (see
`docs/plans/plugin-interface-streamlines.md`).  Replaces per-importer
`build_origin` overrides with declarative knobs on the field schema and
importer base class:

- `PluginField.include_in_origin` — per-field opt-in/out (`None` → use
  field-type default).
- `PluginField.origin_serializer` — custom string serialisation
  (e.g. comma-joining a list).
- `DatasetImporter.extra_origin_keys` — copy non-`PluginField` keys
  from `field_values` into the origin (auto-adds `"source_specs"`
  when `multi_media=True`).
- `DatasetImporter.origin_suppressed` — short-circuit to empty params
  for importers whose dataset-level origin carries no useful identity.

The new `build_origin` default-excludes `field_type="file"` and
`field_type="password"` fields, which closes a latent leak: today an
importer with a password field (e.g. the SFTP skeleton in the base
docstring) would silently persist the password into the origin dict.

All six in-tree `build_origin` overrides are deleted:

- `server_folder`, `http_archive` — `source_specs` now auto-added via
  `multi_media=True`.
- `server_files` — override was vestigial; default behaviour matches.
- `demo` — `embedder` field flagged `include_in_origin=False`.
- `combine_datasets` — `datasets` field gets a comma-joining
  `origin_serializer`; `name` field flagged `include_in_origin=False`.
- `recaller` — `origin_suppressed = True`.

External `DatasetImporter` plugins that still override `build_origin`
keep working unchanged (override wins).  `MediaSource`,
`LabelImporter`, and `LabelsetExporter` families are not touched.

## Test plan

- [x] `tests_lib/datasets/test_build_origin.py` covers the four
  patterns, the type-driven defaults, the override-wins shim, and a
  smoke test per migrated in-tree importer.
- [x] `./run-tests.sh` — 4232 passed, 1 skipped.
- [ ] Manual: load a dataset via each migrated importer in the UI and
  confirm origin info still surfaces correctly in the labelset view
  (deferred — covered indirectly by the existing origin-isolation /
  origin-labelset tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCooN5s7MiNwEki8ZEHw9H)_