### PR TITLE
Curated style-check sweep: 80 hits → 26 (real exceptions only)

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Static SCSS audit for the VTSearch frontend.
+
+Scans `frontend/src/**/*.scss` for violations of the rules in
+`docs/style-guide.md`.  Designed to be invoked by the `/style-check`
+skill: prints findings grouped by rule, with file:line and a one-line
+explanation per hit.  Exits 0 even when violations are found — this is
+a report tool, not a CI gate.
+
+Run from the repo root or via the skill.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCSS_DIR = REPO_ROOT / "frontend" / "src"
+
+# Files where raw values are legitimate (token source-of-truth).
+EXCLUDE_FILES = {
+    SCSS_DIR / "scss" / "_variables.scss",
+}
+
+# Files where shared utility classes are the source-of-truth (allowed
+# to define `.info-text`, `.form-label`, etc.).
+SHARED_UTILITY_FILES = {
+    SCSS_DIR / "scss" / "_components.scss",
+    SCSS_DIR / "scss" / "_picker-shared.scss",
+    SCSS_DIR / "scss" / "_data-table.scss",
+    SCSS_DIR / "scss" / "_layout.scss",
+}
+
+
+@dataclass
+class Finding:
+    rule: str
+    description: str
+    hits: list[tuple[Path, int, str]] = field(default_factory=list)
+
+
+def scss_files() -> list[Path]:
+    files = sorted(SCSS_DIR.rglob("*.scss"))
+    return [f for f in files if f not in EXCLUDE_FILES]
+
+
+def rel(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+
+# ---------------------------------------------------------------------------
+# §4.1-2 Hardcoded px/rem in spacing or font-size properties
+# ---------------------------------------------------------------------------
+SPACING_PROP = re.compile(
+    r"\b(padding|padding-(?:top|right|bottom|left)|margin|margin-(?:top|right|bottom|left)|"
+    r"gap|row-gap|column-gap|font-size)\s*:\s*([^;}\n]+)"
+)
+RAW_LENGTH = re.compile(r"(?<![\w\.\-])(\d+(?:\.\d+)?)(px|rem)\b")
+# Values that are conventionally OK even though they're raw:
+#   0 of any unit, 1px borders, hairline offsets in skeletons.
+RAW_OK_VALUES = {"0px", "0rem", "1px"}
+
+
+def check_raw_lengths(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.1-2 Hardcoded px/rem in spacing/font-size",
+        description=(
+            "Use --space-* / --font-* tokens. Raw values in padding | margin | "
+            "gap | font-size bypass the token system."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            for m in SPACING_PROP.finditer(line):
+                value = m.group(2)
+                # Skip if the value is fully a token: `var(--space-md)` etc.
+                if "var(--" in value and not RAW_LENGTH.search(
+                    re.sub(r"var\([^)]+\)", "", value)
+                ):
+                    continue
+                for length_match in RAW_LENGTH.finditer(value):
+                    raw = length_match.group(0)
+                    if raw in RAW_OK_VALUES:
+                        continue
+                    # Allow 1px borders inside `border:` declarations — we
+                    # already filter by SPACING_PROP, so they wouldn't reach
+                    # here, but skip any leftover.
+                    f.hits.append((path, lineno, line.rstrip()))
+                    break
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.3 Hex colors in component SCSS
+# ---------------------------------------------------------------------------
+HEX_COLOR = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+
+
+def check_hex_colors(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.3 Hex colors in component SCSS",
+        description=(
+            "Theme variables only. Component-local hex literals don't respond "
+            "to theme changes — add a token to _variables.scss instead."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            # Skip URL-like sequences.
+            sanitized = re.sub(r"url\([^)]+\)", "", line)
+            for m in HEX_COLOR.finditer(sanitized):
+                f.hits.append((path, lineno, line.rstrip()))
+                break
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.6 font-weight: 700 / bold
+# ---------------------------------------------------------------------------
+BOLD_RE = re.compile(r"font-weight\s*:\s*(700|bold)\b")
+
+
+def check_bold_weight(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.6 font-weight: 700 / bold",
+        description="Use --weight-semibold (600). <strong> is fine; raw 700 is not.",
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if BOLD_RE.search(line) and not line.strip().startswith("//"):
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.7 Heading tags restyled in component SCSS
+# ---------------------------------------------------------------------------
+HEADING_RULE_RE = re.compile(r"^\s*h[1-6]\s*\{")
+
+
+def check_heading_restyling(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.7 Heading tags restyled in component SCSS",
+        description=(
+            "Use the right tag; let the global rule style it. Per-component "
+            "h1/h2/h3 restyling defeats the typography baseline."
+        ),
+    )
+    for path in files:
+        if path in SHARED_UTILITY_FILES:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if HEADING_RULE_RE.match(line):
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.10 transition: all <custom-duration>
+# ---------------------------------------------------------------------------
+TRANSITION_ALL_RE = re.compile(r"transition\s*:\s*all\s+0?\.\d+s")
+
+
+def check_transition_all(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.10 transition: all <custom-duration>",
+        description=(
+            "Use var(--transition-base) (or a specific property). `transition: "
+            "all 0.2s` couples every animatable property to a one-off duration."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if TRANSITION_ALL_RE.search(line) and "var(--transition" not in line:
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.13 `font: inherit` on form-input/form-select aliases
+# ---------------------------------------------------------------------------
+def check_font_inherit_trap(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.13 `font: inherit` may silently override .form-select",
+        description=(
+            "Angular view encapsulation gives component-scoped rules higher "
+            "specificity than the global .form-input/.form-select. `font: "
+            "inherit` in a component class then wins, dropping --font-md and "
+            "rendering the page-root 1rem. Use explicit `font-family: inherit; "
+            "font-size: var(--font-md);` or set the size that actually applies."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if re.search(r"\bfont\s*:\s*inherit\b", line) and not line.strip().startswith("//"):
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# §4.14 flex-direction: column rule blocks without an explicit `gap`
+# ---------------------------------------------------------------------------
+def check_flex_column_no_gap(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.14 `flex-direction: column` block missing explicit `gap`",
+        description=(
+            "Stacked-column containers must own their inter-row spacing. "
+            "Either set `gap: var(--space-*)` on the parent or rely on a "
+            "child class (form-group, etc.) that has its own margins."
+        ),
+    )
+    for path in files:
+        text = path.read_text()
+        # Walk through SCSS, tracking brace depth and per-block flags.
+        # When a block closes, if it set flex-direction: column without a
+        # `gap` declaration anywhere in its OWN body, flag the line where
+        # the column directive appeared.
+        depth = 0
+        stack: list[dict] = [{"has_col": False, "col_line": 0, "has_gap": False}]
+        line_no = 0
+        for line in text.splitlines():
+            line_no += 1
+            stripped = re.sub(r"//.*$", "", line)
+            for ch in stripped:
+                if ch == "{":
+                    depth += 1
+                    stack.append({"has_col": False, "col_line": 0, "has_gap": False})
+                elif ch == "}":
+                    if stack:
+                        frame = stack.pop()
+                        if frame["has_col"] and not frame["has_gap"]:
+                            # Only flag rules that look like display:flex containers.
+                            f.hits.append(
+                                (path, frame["col_line"], _read_line(text, frame["col_line"]))
+                            )
+                    depth = max(0, depth - 1)
+            if "flex-direction" in stripped and "column" in stripped and stack:
+                stack[-1]["has_col"] = True
+                stack[-1]["col_line"] = line_no
+            if re.search(r"\bgap\s*:", stripped) and stack:
+                stack[-1]["has_gap"] = True
+    return f
+
+
+def _read_line(text: str, line_no: int) -> str:
+    lines = text.splitlines()
+    if 1 <= line_no <= len(lines):
+        return lines[line_no - 1].rstrip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# §4.15 Shared utility classes redeclared locally
+# ---------------------------------------------------------------------------
+SHARED_CLASSES = [
+    "info-text",
+    "error-text",
+    "success-text",
+    "status-text",
+    "form-label",
+    "form-input",
+    "form-select",
+    "form-hint",
+    "form-group",
+    "btn",
+    "modal-content",
+    "modal-header",
+    "modal-body",
+    "modal-footer",
+    "modal-close",
+    "modal-backdrop",
+    "back-btn",
+]
+
+
+def check_redeclared_utility(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§4.15 Shared utility classes redeclared in component SCSS",
+        description=(
+            "The classes in _components.scss are the source of truth. "
+            "Redeclaring `.info-text { ... }` etc. locally drifts styling "
+            "across modals and defeats the shared baseline. Extend with a "
+            "child selector (`.my-panel .info-text { ... }`) if a scoped "
+            "tweak is genuinely needed."
+        ),
+    )
+    pattern = re.compile(
+        r"^\s*\.(" + "|".join(re.escape(c) for c in SHARED_CLASSES) + r")\s*\{"
+    )
+    for path in files:
+        if path in SHARED_UTILITY_FILES:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            m = pattern.match(line)
+            if m:
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+def print_report(findings: list[Finding]) -> int:
+    total = 0
+    bold = "\033[1m"
+    reset = "\033[0m"
+    dim = "\033[2m"
+    yellow = "\033[33m"
+    for finding in findings:
+        count = len(finding.hits)
+        total += count
+        header = f"{bold}── {finding.rule} ──{reset}  {yellow}{count} hit{'s' if count != 1 else ''}{reset}"
+        print()
+        print(header)
+        print(f"{dim}{finding.description}{reset}")
+        if not finding.hits:
+            print("  (clean)")
+            continue
+        for path, lineno, snippet in finding.hits:
+            print(f"  {rel(path)}:{lineno}: {snippet.strip()}")
+    print()
+    print(f"{bold}Total findings: {total}{reset}")
+    print(
+        "Findings are informational — review and curate before fixing; "
+        "some hits (e.g. a column-header button intentionally inheriting "
+        "its parent's small uppercase font) are legitimate."
+    )
+    return 0
+
+
+def main() -> int:
+    files = scss_files()
+    findings = [
+        check_raw_lengths(files),
+        check_hex_colors(files),
+        check_bold_weight(files),
+        check_heading_restyling(files),
+        check_transition_all(files),
+        check_font_inherit_trap(files),
+        check_flex_column_no_gap(files),
+        check_redeclared_utility(files),
+    ]
+    return print_report(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -152,18 +152,46 @@ HEADING_RULE_RE = re.compile(r"^\s*h[1-6]\s*\{")
 
 def check_heading_restyling(files: list[Path]) -> Finding:
     f = Finding(
-        rule="§4.7 Heading tags restyled in component SCSS",
+        rule="§4.7 Heading tags visually restyled in component SCSS",
         description=(
-            "Use the right tag; let the global rule style it. Per-component "
-            "h1/h2/h3 restyling defeats the typography baseline."
+            "Use the right tag; let the global rule style it. Margin-only "
+            "scoping (`h3 { margin: 0 0 var(--space-md); }`) is fine — it "
+            "positions the heading without changing its identity. This flags "
+            "blocks that override `font-size` or `font-weight`, which is the "
+            "actual 'make a smaller tag look like a bigger one' anti-pattern."
         ),
     )
     for path in files:
         if path in SHARED_UTILITY_FILES:
             continue
-        for lineno, line in enumerate(path.read_text().splitlines(), 1):
-            if HEADING_RULE_RE.match(line):
-                f.hits.append((path, lineno, line.rstrip()))
+        text = path.read_text()
+        lines = text.splitlines()
+        i = 0
+        while i < len(lines):
+            if HEADING_RULE_RE.match(lines[i]):
+                # Walk the block until the opening `{` is matched, then
+                # inspect the body for visual restyling.
+                rule_line = i + 1
+                start = i
+                stripped = re.sub(r"//.*$", "", lines[i])
+                opens = stripped.count("{")
+                closes = stripped.count("}")
+                depth = opens - closes
+                j = i + 1
+                while j < len(lines) and depth > 0:
+                    stripped = re.sub(r"//.*$", "", lines[j])
+                    depth += stripped.count("{") - stripped.count("}")
+                    j += 1
+                # `body` includes the opening line so single-line rules
+                # (`h1 { margin: 0; }`) are inspected correctly.
+                body = "\n".join(lines[start:j])
+                if re.search(r"\bfont-size\b", body) or re.search(
+                    r"\bfont-weight\b", body
+                ):
+                    f.hits.append((path, rule_line, lines[i].rstrip()))
+                i = j
+            else:
+                i += 1
     return f
 
 
@@ -296,16 +324,26 @@ def check_redeclared_utility(files: list[Path]) -> Finding:
             "tweak is genuinely needed."
         ),
     )
+    # End of the class name must be a non-class-character — not `-` or
+    # `\w` — so `.btn-good` and `.form-group--section` (which are new
+    # classes, not redeclarations of `.btn` or `.form-group`) don't match.
     pattern = re.compile(
-        r"^\s*\.(" + "|".join(re.escape(c) for c in SHARED_CLASSES) + r")\s*\{"
+        r"^\.(" + "|".join(re.escape(c) for c in SHARED_CLASSES) + r")(?![-\w])[^{]*\{"
     )
     for path in files:
         if path in SHARED_UTILITY_FILES:
             continue
-        for lineno, line in enumerate(path.read_text().splitlines(), 1):
-            m = pattern.match(line)
-            if m:
+        text = path.read_text()
+        depth = 0
+        for lineno, line in enumerate(text.splitlines(), 1):
+            stripped = re.sub(r"//.*$", "", line)
+            # Only flag declarations at top level (depth 0). Nested
+            # `.parent { .form-input { ... } }` is a scoped override,
+            # not a redeclaration.
+            if depth == 0 and pattern.match(line):
                 f.hits.append((path, lineno, line.rstrip()))
+            depth += stripped.count("{") - stripped.count("}")
+            depth = max(depth, 0)
     return f
 
 

--- a/.claude/skills/style-check/SKILL.md
+++ b/.claude/skills/style-check/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: style-check
+description: Run a systematic frontend style audit. Use when the user asks for a "style check", "style sweep", or wants to find SCSS violations of the rules in docs/style-guide.md across the codebase. Static-only — does not render the app.
+---
+
+# Frontend style check
+
+Static audit of `frontend/src/**/*.scss` against the rules in
+`docs/style-guide.md`. Catches the categories of mistakes that produce
+the kind of "spacing looks off / fonts inconsistent" bugs that motivated
+this skill in the first place.
+
+## How to run it
+
+```
+python3 .claude/scripts/style-check.py
+```
+
+The script prints findings grouped by style-guide section, with
+`file:line: snippet` for each hit, plus a one-line "why" per rule.
+It exits 0 even when findings exist — this is a **report tool, not a
+CI gate**. Many hits are legitimate (see "Curating findings" below);
+your job is to review them and decide which to fix.
+
+## What it checks
+
+| Rule | What | How |
+|---|---|---|
+| §4.1-2 | Hardcoded `px`/`rem` in `padding`/`margin`/`gap`/`font-size` | Regex on the property list |
+| §4.3   | Hex color literals in component SCSS | `#xxxxxx` outside `_variables.scss` |
+| §4.6   | `font-weight: 700` / `bold` | Regex |
+| §4.7   | Heading tags (`h1`–`h6`) restyled in component SCSS | Top-level `hN {` rule blocks |
+| §4.10  | `transition: all <custom-duration>` | Regex, ignores tokenised durations |
+| §4.13  | `font: inherit` inside component SCSS (specificity trap) | Regex |
+| §4.14  | `flex-direction: column` blocks without an explicit `gap` | Brace-depth aware SCSS parser |
+| §4.15  | Shared utility classes redeclared locally | Top-level `.{class} {` outside shared files |
+
+## Curating findings
+
+The scanner is intentionally inclusive — it will flag legitimate
+patterns alongside real bugs. Apply judgement before fixing:
+
+- **§4.13 `font: inherit`** is sometimes intentional — e.g. a button
+  that is itself nested inside an explicitly-styled small-font header
+  (`folder-browser.component.scss:93` inherits its parent's
+  `--font-2xs` uppercase header style on purpose). Check the parent
+  chain before flagging.
+- **§4.14 `flex-direction: column` without `gap`** is fine when each
+  child element carries its own `margin` or `padding` — the rule
+  allows either pattern. Top-level layout panels (`.left-panel`,
+  `.center-panel`, `.app-shell`, etc.) usually fall in this bucket.
+  Flag a hit only when stacked siblings look like form rows / labelled
+  sections (`.form-group`, `<label>`, `.section-title`, `<p>`).
+- **§4.15 redeclared utility class** is almost always real drift —
+  the redeclared `.info-text`/`.error-text` blocks across modals are
+  near-identical copies. Worth consolidating, but a bulk rewrite
+  touches many components; consider doing it as its own PR.
+- **§4.1-2 raw `px`/`rem`** is sometimes a deliberate off-scale value
+  with an inline comment justifying it (e.g.
+  `padding: var(--space-xs) 0.625rem; // 10px — off-scale horizontal
+  kept exact`). Comments documenting the exception are acceptable;
+  unexplained raw values are not.
+
+When in doubt, read the file context (a few lines above and below the
+hit) before deciding it's a violation.
+
+## How to report
+
+When invoked by the user, run the script, then:
+
+1. **Summarise total findings** (e.g. "83 hits across 8 rules").
+2. **Highlight the clear bugs first** — anything in §4.13 or §4.15 is
+   usually genuine; §4.6 (`font-weight: 700`) and §4.10 (`transition:
+   all`) are almost always real.
+3. **Group §4.14 hits by likely category** (real form/section
+   containers vs. top-level layout panels) before listing.
+4. **Offer to fix categories one at a time** rather than dumping a
+   single mega-diff. The user can pick which categories matter for
+   this sweep.
+
+Keep the response scannable — file paths, line numbers, a one-line
+"why". Don't paste the script's raw output verbatim if it's hundreds
+of lines; curate first.
+
+## Extending it
+
+When a new style-guide rule lands (or a new specificity trap is
+discovered the way `font: inherit` was), add a check function in
+`.claude/scripts/style-check.py` and a row to the table above. Keep
+each check small and focused — a check that flags multiple
+unrelated patterns becomes hard to curate.
+
+The scanner is static-only. A visual sweep (render key modals,
+screenshot, look for layout drift) is a useful follow-up but lives
+outside this skill.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -352,6 +352,14 @@ Avoid them. The right answer is almost always "use a theme variable." If a compo
 10. **`transition: all <duration>` with a custom duration.** Use `var(--transition-base)`.
 11. **Cancel as a Back button (or vice versa).** See §2.4.
 12. **Designing for mobile.** Desktop only.
+13. **`font: inherit` on a class that combines with `.form-input` / `.form-select`** (or any shared element class whose font-size is set globally). Angular's view-encapsulated component selectors get an attribute-selector specificity bump that beats the global `.form-input` rule, so a component-scoped `font: inherit` silently drops `var(--font-md)` and renders the page-root `1rem` instead — which is why a custom dropdown trigger can render its content larger than the `.form-label` above it. If you need the button to inherit something from the parent, be explicit: `font-family: inherit; font-size: var(--font-md);`. The same trap applies to any shorthand that sets `font-size` (raw `font: 14px ...`, `font: bold 1rem`, etc.) under a component-scoped selector.
+14. **`flex-direction: column` without an explicit `gap`** (and no per-child margins). A stacked-column container has to own its inter-row spacing — either set `gap: var(--space-*)` on the parent, or commit to a child class (`.form-group`, `.section-title`) that carries its own margins. Mixing the two ad-hoc produces uneven rhythms like "no space between drop zone and the input below it, but huge space between the section header and its description." Pick one mechanism per container.
+15. **Redeclaring shared utility classes locally.** `.info-text`, `.error-text`, `.success-text`, `.status-text`, `.form-label`, `.form-input`, `.form-select`, `.form-group`, `.btn`, `.modal-*`, `.back-btn` live in `_components.scss` as the single source of truth. Copying their bodies into a component SCSS file — even with the same property values — causes drift the moment someone tunes the global rule. Need a scoped tweak? Extend with a descendant selector (`.my-panel .info-text { ... }`) instead of redeclaring. As a corollary, **shared `<p>`-based utility classes (`.info-text` etc.) must reset `margin: 0`** so the surrounding layout's flex `gap` owns inter-row spacing — UA `<p>` margins inject ~1em above and below and break the §3.0 rhythm.
+
+> A static scan for items 1-3, 6-7, 10, 13-15 lives at
+> `.claude/scripts/style-check.py` (invoked via the `/style-check`
+> skill). Run it before a styling-heavy PR, or whenever a layout
+> regression shows up that you can't explain by reading one file.
 
 ---
 
@@ -374,3 +382,4 @@ When you add a new token:
 - `frontend/src/scss/_data-table.scss` — dashboard table.
 - `frontend/src/scss/_layout.scss` — 3-panel grid.
 - `CLAUDE.md` — Back vs Cancel rules, desktop-only scope.
+- `.claude/scripts/style-check.py` — static SCSS audit (invoked via the `/style-check` skill).

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -9,7 +9,7 @@ header {
   display: flex;
   align-items: center;
   gap: var(--space-lg);
-  padding: 3px var(--space-md);
+  padding: var(--space-xs) var(--space-md);
   background: var(--header-bg);
   border-bottom: 1px solid var(--header-border);
 
@@ -37,7 +37,7 @@ header {
   justify-content: center;
   gap: var(--space-xs);
   padding: 0;
-  transition: all 0.2s;
+  transition: background var(--transition-base), border-color var(--transition-base);
 
   &:hover {
     background: var(--header-btn-hover-bg);
@@ -49,7 +49,7 @@ header {
     width: 18px;
     height: 2px;
     background: var(--header-text-dim);
-    transition: all 0.2s;
+    transition: background var(--transition-base);
   }
 
   &:hover span {
@@ -86,10 +86,10 @@ header {
   cursor: pointer;
   font-size: var(--font-md);
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition: background var(--transition-base), color var(--transition-base);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-sm);
 
   &:hover {
     background: var(--bg-hover);
@@ -144,7 +144,7 @@ header {
 
   .recent-sep {
     color: var(--text-dim);
-    padding: 0 2px;
+    padding: 0 var(--space-2xs);
   }
 
   .recent-time {
@@ -161,7 +161,7 @@ header {
   font-size: var(--font-sm);
   padding: var(--space-xs) 0.625rem;  // 4px 10px — off-scale horizontal kept exact
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   white-space: nowrap;
 
   &:hover:not(:disabled) {
@@ -190,7 +190,7 @@ header {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   flex-shrink: 0;
 
   svg {
@@ -218,7 +218,7 @@ header {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: background var(--transition-base), border-color var(--transition-base);
   flex-shrink: 0;
 
   svg {

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
@@ -21,20 +21,14 @@
 }
 
 // Color themes — currentColor is consumed by both the ring SVG and the inner icon.
-.tier-bronze {
-  color: #cd7f32; // achievement-tier intrinsic color, not theme-aware
-}
-
-.tier-silver {
-  color: #d9d9d9; // achievement-tier intrinsic color, not theme-aware
-}
-
-.tier-gold {
-  color: #f0c419; // achievement-tier intrinsic color, not theme-aware
-}
-
+// Tier colors are intrinsic (bronze/silver/gold/platinum); the tokens
+// live at `:root` in `_variables.scss` and are intentionally NOT
+// overridden per theme.
+.tier-bronze   { color: var(--tier-bronze); }
+.tier-silver   { color: var(--tier-silver); }
+.tier-gold     { color: var(--tier-gold); }
 .tier-platinum {
-  color: #f5f6fa; // achievement-tier intrinsic color, not theme-aware
+  color: var(--tier-platinum);
   filter: drop-shadow(0 0 4px rgba(245, 246, 250, 0.45));
 }
 

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -76,10 +76,11 @@
   background: var(--bg-hover);
   color: var(--text-muted);
 
-  &[data-tier-idx="0"] { color: #cd7f32; } // achievement-tier intrinsic color, not theme-aware
-  &[data-tier-idx="1"] { color: #d9d9d9; } // achievement-tier intrinsic color, not theme-aware
-  &[data-tier-idx="2"] { color: #f0c419; } // achievement-tier intrinsic color, not theme-aware
-  &[data-tier-idx="3"] { color: #f5f6fa; } // achievement-tier intrinsic color, not theme-aware
+  // Tier colors are intentionally theme-agnostic — see `--tier-*` in `_variables.scss`.
+  &[data-tier-idx="0"] { color: var(--tier-bronze); }
+  &[data-tier-idx="1"] { color: var(--tier-silver); }
+  &[data-tier-idx="2"] { color: var(--tier-gold); }
+  &[data-tier-idx="3"] { color: var(--tier-platinum); }
   &[data-tier-idx="-1"] { cursor: help; }
 }
 

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -128,21 +128,11 @@
   font-style: italic;
 }
 
-.info-text {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: var(--font-md);
-}
-
+// `.info-text` / `.error-text` come from `_components.scss`; only
+// `.warn-text` is local (no shared `--text-warning` utility class yet).
 .warn-text {
   margin: 0;
   color: var(--text-warning);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  margin: 0;
-  color: var(--color-bad);
   font-size: var(--font-md);
 }
 

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
@@ -6,12 +6,7 @@
   max-width: 100%;
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
+// `.form-group`, `.info-text`, `.error-text` come from `_components.scss`.
 .col-label {
   font-weight: var(--weight-semibold);
   font-size: var(--font-md);
@@ -20,18 +15,6 @@
 
 .required {
   color: var(--color-bad);
-}
-
-.info-text {
-  margin: var(--space-xs) 0 0;
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  margin: var(--space-xs) 0 0;
-  color: var(--color-bad);
-  font-size: var(--font-md);
 }
 
 .source-list {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -65,23 +65,8 @@
   max-width: 100%;
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
+// `.form-group`, `.info-text`, `.error-text` come from `_components.scss`.
 .required { color: var(--color-bad); }
-
-.info-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
-}
 
 // Two-column layout for text vs media example input
 .example-columns {
@@ -178,7 +163,7 @@
   gap: var(--space-lg);
 }
 
-.back-btn { align-self: flex-start; }
+// `.back-btn` from `_components.scss` already sets `align-self: flex-start`.
 
 // Picker chrome (.importer-picker, .demo-picker, .sf-browse-section,
 // .local-folder-uploader) lives inside <vt-source-picker>.  The

--- a/frontend/src/app/components/dialog-host/dialog-host.component.scss
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.scss
@@ -5,7 +5,9 @@
   gap: var(--space-md);
 }
 
-.form-input {
-  width: 100%;
-  margin-top: var(--space-md);
+// `.form-input` is global; `width: 100%` is already set there.
+// The dialog needs a top margin so the input sits clear of the
+// message above — scoped via `:host`.
+:host {
+  .form-input { margin-top: var(--space-md); }
 }

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -1,7 +1,7 @@
 <div class="login-backdrop">
   <div class="login-card">
     <img src="logo.png" alt="VTSearch logo" class="login-logo">
-    <h2>VTSearch</h2>
+    <h1>VTSearch</h1>
     <p class="login-subtitle">Enter your name to get started</p>
     <form (ngSubmit)="submit()" class="login-form">
       <label for="login-username" class="sr-only">Username</label>

--- a/frontend/src/app/components/login/login.component.scss
+++ b/frontend/src/app/components/login/login.component.scss
@@ -24,11 +24,9 @@
   margin-bottom: var(--space-lg);
 }
 
-h2 {
-  color: var(--text-primary);
-  margin: 0 0 var(--space-xs);
-  font-size: var(--font-3xl);
-}
+// `<h1>` (the app name) inherits its font-size from `_components.scss`
+// (`--font-3xl`); only the bottom margin needs scoping.
+h1 { margin: 0 0 var(--space-xs); }
 
 .login-subtitle {
   color: var(--text-secondary);

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -3,9 +3,10 @@
   font-style: italic;
 }
 
-.error-text {
-  color: var(--error-text);
-}
+// `.error-text` comes from `_components.scss` (uses `--color-bad`).
+// The previous local copy used `var(--error-text)` (an alias for
+// `--color-bad`); both render the same red, so removing the local is
+// a no-op visually.
 
 .stats-table {
   width: 100%;

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.scss
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.scss
@@ -5,10 +5,9 @@
 }
 
 .examples-section {
-  h3 {
-    margin: 0 0 var(--space-lg);
-    font-size: var(--font-xl);
-  }
+  // `<h3>` inherits its `font-size` from `_components.scss`; only the
+  // section's specific bottom-margin needs scoping.
+  h3 { margin: 0 0 var(--space-lg); }
 }
 
 .examples-grid {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -5,10 +5,8 @@
 .export-section {
   margin-bottom: var(--space-2xl);
 
-  h3 {
-    margin: 0 0 var(--space-md);
-    font-size: var(--font-xl);
-  }
+  // `<h3>` inherits its font-size from `_components.scss`.
+  h3 { margin: 0 0 var(--space-md); }
 }
 
 .preview-count {
@@ -202,31 +200,19 @@
 }
 
 // --- Form elements ---
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
+//
+// `.form-group`, `.info-text`, `.error-text`, `.status-text` come from
+// `_components.scss`. The two trailing rows below need a small top
+// margin to sit clear of the form section above — scoped via `:host`
+// so it's a contextual override, not a redeclaration of the base.
+:host {
+  .status-text, .error-text {
+    margin-top: var(--space-md);
+  }
 }
 
 .required {
   color: var(--color-bad);
-}
-
-.info-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
-}
-
-.status-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-  margin-top: var(--space-md);
 }
 
 .form-actions {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -48,29 +48,13 @@
   max-width: 100%;
 }
 
-.back-btn {
-  align-self: flex-start;
-  margin-bottom: var(--space-xs);
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
+// `.back-btn`, `.form-group`, `.info-text`, `.error-text` come from
+// `_components.scss`. The back button used to carry a small bottom
+// margin to space it from the form below; the parent `.importer-form`
+// already provides `gap: var(--space-lg)` (12px) which is plenty.
 
 .required {
   color: var(--color-bad);
-}
-
-.info-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
 }
 
 .form-actions {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -5,11 +5,14 @@
 }
 
 .sort-section {
-  h3 {
-    margin: 0 0 var(--space-lg);
-    font-size: var(--font-xl);
-  }
+  // `<h3>` inherits its font-size from `_components.scss`.
+  h3 { margin: 0 0 var(--space-lg); }
 
+  // `<h4>` here labels a sub-section ("Server Example Media") within
+  // the h3 panel and is styled as a muted subhead rather than a full
+  // heading — same pattern as settings-modal. If this is touched
+  // again, promote a shared `.subhead` class to `_components.scss`
+  // and convert these to `<h4 class="subhead">`.
   h4 {
     margin: var(--space-lg) 0 var(--space-md);
     font-size: var(--font-md);
@@ -72,8 +75,11 @@
   min-height: 200px;
 }
 
-.back-btn {
-  margin-bottom: var(--space-lg);
+// `.back-btn` from `_components.scss`. The bottom margin here is the
+// gap between the back button and the source list below it — the
+// parent isn't a flex column with a `gap`, so we set it explicitly.
+:host {
+  .back-btn { margin-bottom: var(--space-lg); }
 }
 
 .picker-instructions {

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
@@ -49,18 +49,17 @@
   display: none;
 }
 
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
-}
+// `.error-text` and `.back-btn` come from `_components.scss`.
+// The back-btn needs a bottom margin to space it from the picker
+// instructions below — scoped via `:host` so it's a contextual override.
 
 // Media picker view (reuses styles from new-model-modal)
 .media-picker {
   min-height: 200px;
 }
 
-.back-btn {
-  margin-bottom: var(--space-lg);
+:host {
+  .back-btn { margin-bottom: var(--space-lg); }
 }
 
 .picker-instructions {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
@@ -44,29 +44,12 @@
   gap: var(--space-lg);
 }
 
-.back-btn {
-  align-self: flex-start;
-  margin-bottom: var(--space-xs);
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
+// `.back-btn`, `.form-group`, `.info-text`, `.error-text` come from
+// `_components.scss`. The parent `.exporter-form` provides `gap:
+// var(--space-lg)`, which spaces the back button from the form below.
 
 .required {
   color: var(--color-bad);
-}
-
-.info-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
 }
 
 .form-actions {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
@@ -44,29 +44,12 @@
   gap: var(--space-lg);
 }
 
-.back-btn {
-  align-self: flex-start;
-  margin-bottom: var(--space-xs);
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
+// `.back-btn`, `.form-group`, `.info-text`, `.error-text` come from
+// `_components.scss`. The parent `.importer-form` provides `gap:
+// var(--space-lg)`, which spaces the back button from the form below.
 
 .required {
   color: var(--color-bad);
-}
-
-.info-text {
-  color: var(--text-muted);
-  font-size: var(--font-md);
-}
-
-.error-text {
-  color: var(--color-bad);
-  font-size: var(--font-md);
 }
 
 .form-actions {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -59,14 +59,17 @@
   // gap from the h3 to its own content, so the title visually belongs to
   // what's below it. Asymmetric margins handle this; flex-gap still
   // provides the rest of the in-section rhythm.
+  // `<h3>` inherits its font-size and color from `_components.scss`;
+  // we only need to scope the asymmetric section-title margins.
   h3 {
     margin: var(--space-xl) 0 0;
-    font-size: var(--font-xl);
-    color: var(--text-primary);
 
     &:first-child { margin-top: 0; }
   }
 
+  // `<h4>` here labels a small subsection inside an h3 panel and is
+  // styled as a muted subhead. See the load-sort-modal comment about
+  // promoting a `.subhead` class once this pattern is touched again.
   h4 {
     margin: var(--space-md) 0 0;
     font-size: var(--font-md);
@@ -133,6 +136,8 @@
   flex-direction: column;
   gap: var(--space-md);
 
+  // Sub-section divider — see settings-modal h4 comment above re. the
+  // pending `.subhead` consolidation.
   h4 {
     margin: 0;
     font-size: var(--font-md);

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -14,6 +14,10 @@
   flex-direction: column;
 }
 
+// The "Good votes" / "Bad votes" panel headers use `<h3>` semantically
+// but are styled as compact uppercase chips, not as full section
+// headings. See the load-sort-modal comment about promoting a shared
+// `.subhead` class — same pattern, same eventual fix.
 h3 {
   font-size: var(--font-sm);
   letter-spacing: 0.05em;
@@ -23,13 +27,8 @@ h3 {
   align-items: center;
   font-weight: var(--weight-regular);
 
-  &.good {
-    color: var(--color-good);
-  }
-
-  &.bad {
-    color: var(--color-bad);
-  }
+  &.good { color: var(--color-good); }
+  &.bad  { color: var(--color-bad); }
 }
 
 .vote-list {

--- a/frontend/src/app/components/view-controls/view-controls.component.scss
+++ b/frontend/src/app/components/view-controls/view-controls.component.scss
@@ -19,7 +19,7 @@
   justify-content: center;
   min-width: 26px;
   height: 22px;
-  padding: 0 5px;
+  padding: 0 var(--space-sm);
   background: var(--bg-primary);
   border: 1px solid var(--border);
   color: var(--text-muted);

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -308,7 +308,7 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 // the placeholder).  Stays visible after the user starts typing — used for
 // accepted extensions, expected column schemas, JSON/CSV sample snippets.
 .form-hint {
-  margin: 2px 0 0;
+  margin: var(--space-2xs) 0 0;
   font-size: var(--font-sm);
   line-height: 1.4;
   color: var(--text-muted);
@@ -331,10 +331,15 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 // rely on the parent's flex `gap` to space stacked elements, and default
 // browser `<p>` margins (~1em) inject inconsistent extra space that
 // breaks the vertical rhythm (see style-guide §3.0).
+// `.info-text` is body helper text — the kind of muted explanatory
+// copy ("Pick a folder on this computer…") that sits below or
+// alongside form controls. Uses `--text-muted` per §1.5 ("hints"),
+// which matches the de-facto pattern that ~5 modals had been
+// reimplementing locally before this consolidation.
 .info-text {
   margin: 0;
   font-size: var(--font-md);
-  color: var(--text-secondary);
+  color: var(--text-muted);
 }
 
 .error-text {

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -112,6 +112,14 @@
   --btn-icon-hover-bg: rgba(255, 255, 255, 0.08);
   --text-warning: #e6a700;
 
+  // Achievement tiers — deliberately theme-agnostic (bronze should
+  // look bronze in every theme). Defined once at `:root` and NOT
+  // overridden in `[data-theme="light"]`/`[data-theme="highviz"]`.
+  --tier-bronze: #cd7f32;
+  --tier-silver: #d9d9d9;
+  --tier-gold: #f0c419;
+  --tier-platinum: #f5f6fa;
+
   // Aliases used by component SCSS files
   --border-color: var(--border);
   --bg-secondary: var(--bg-subtle);


### PR DESCRIPTION
## Summary

Brings in the `/style-check` skill and applies its findings. Reduces the audit from **80 hits across 8 rules → 26 hits**, all remaining hits are either justified exceptions (3) or documented TODOs (4). The two never-merged commits from PR #1676's branch land here:

1. The `/style-check` skill + scanner script + style-guide §4.13-15 anti-patterns (commit 1) — these were on `claude/blissful-hamilton-xF5Dq` but only the spacing-fix commit got merged.
2. The curated cleanup itself (commit 2).

## By rule

| Rule | Before | After | Status |
|---|---|---|---|
| §4.1-2 raw px/rem in spacing | 8 | 3 | Remaining have `// off-scale ... kept exact` comments per §1.1 |
| §4.3 hex literals | 8 | **0** | Achievement tiers promoted to `--tier-bronze/silver/gold/platinum` |
| §4.6 `font-weight: 700` | 0 | 0 | Already clean |
| §4.7 heading restyled | 9 | 4 | Removed redundant `font-size`, converted login h2→h1; 4 muted-subhead patterns marked with TODO |
| §4.10 `transition: all 0.2s` | 6 | **0** | Replaced with specific-property `--transition-base` |
| §4.13 `font: inherit` trap | 1 | 1 | The folder-browser column-header button — intentional |
| §4.14 flex-column no `gap` | 18 | 18 | All hits are layout panels where children own margins — the rule allows this |
| §4.15 utility class redeclared | 30 | **0** | Massive consolidation across 8 modals |

## What changed visually

The biggest semantic shift: **`.info-text` global color moved from `--text-secondary` (#aaa) to `--text-muted` (#888)**. This matches §1.5's semantic mapping ("hints") and the de-facto pattern that ~5 modals had been re-implementing locally. The visual effect is helper text rendering very slightly darker; the consolidation is the win.

Everything else is mechanical:
- 8 modal SCSS files lose ~10 lines each of duplicate `.info-text`/`.error-text`/`.form-group`/`.back-btn` blocks that were already identical to the global (or differed only in the contextual margin, which is now scoped via `:host { ... }` per §4.15).
- App shell loses every `transition: all` in favor of specific transitions on `--transition-base`.
- Achievement tier colors (bronze/silver/gold/platinum) are now tokens at `:root` and don't get re-declared in theme blocks (they're intrinsic, not theme-aware).
- Login's `<h2>VTSearch</h2>` → `<h1>VTSearch</h1>` (it's the app-level page header).

## Scanner improvements (in the same commit as the skill cherry-pick)

The `§4.15` regex was too greedy on first run — it matched `.btn-good` as a redeclaration of `.btn`. Tightened to require a non-class-character after the name. The `§4.7` check now only flags blocks that actually override `font-size`/`font-weight` (margin-only overrides for vertical rhythm aren't "restyling to look like a different heading"). And both `§4.7` and `§4.15` are now brace-depth aware so nested `.parent { .form-input { ... } }` scoped overrides don't trip them.

## Remaining findings — why they stayed

- **§4.1-2 (3 hits)**: All header-button or alignment paddings with explicit `// 6px 10px — off-scale horizontal kept exact` justification comments. §1.1 allows tiny shifts (1-3px) with a comment.
- **§4.7 (4 hits)**: `<h4>` and `<h3>` blocks visually restyled to "muted subhead" labels (load-sort, settings-modal, label-list). Inline TODO comments mark the pending consolidation: promote a shared `.subhead` class to `_components.scss` next time this pattern is touched.
- **§4.13 (1 hit)**: `folder-browser` column-header `<button>` with `font: inherit` — it's nested inside an explicitly-styled `--font-2xs` uppercase header and intentionally inherits that small font.
- **§4.14 (18 hits)**: All top-level layout panels (`.left-panel`, `.center-panel`, `.dashboard-section`, `.media-list`, etc.) where children carry their own padding/margin. The rule explicitly allows this — flagged so the next author can verify intent rather than because they're wrong.

## Test plan

- [x] `npm run build:prod` — clean, no warnings
- [x] `python3 .claude/scripts/style-check.py` — 26 remaining hits, all curated
- [ ] Visual spot-check: open Add Dataset modal (any view), Settings modal, Load Sort modal, Achievements panel. Verify:
  - [ ] Helper text under form fields renders slightly darker than before (it now uses `--text-muted` via the global rule)
  - [ ] Status / error rows still sit clear of the form above them
  - [ ] Achievement tier badges look bronze/silver/gold/platinum exactly as before
  - [ ] Back buttons in nested-modal flows still have breathing room below them

---
_Generated by [Claude Code](https://claude.ai/code/session_017Jh96D2f5yx8hYH5AumG6Z)_