### PR TITLE
Pin modal header/footer; rename Demo importer label

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -53,7 +53,7 @@ describe('DatasetImporterModalComponent', () => {
     },
     {
       name: 'demo',
-      display_name: 'Downloaded Demo Media',
+      display_name: 'Downloaded Media',
       description: 'Pre-configured demo datasets',
       icon: '🗄',
       picker_view: 'demo',

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -204,8 +204,13 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   min-width: 320px;
   max-width: 90vw;
   max-height: 85vh;
-  overflow-y: auto;
   box-shadow: var(--shadow-lg);
+  // Flex column so the body is the only scrollable area; the header
+  // and footer stay pinned even when the body overflows, so primary
+  // actions (Cancel / Import / etc.) remain visible.
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .modal-header {
@@ -237,6 +242,9 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
 .modal-body {
   margin-bottom: var(--space-xl);
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .modal-footer {

--- a/vtscore/datasets/importers/demo/__init__.py
+++ b/vtscore/datasets/importers/demo/__init__.py
@@ -29,7 +29,7 @@ class DemoDatasetImporter(DatasetImporter):
     """
 
     name = "demo"
-    display_name = "Downloaded Demo Media"
+    display_name = "Downloaded Media"
     description = "Choose from a selection of pre-configured demo datasets"
     icon = "\U0001f5c4"  # 🗄 — frontend renders as a database icon
     ui_mode = "custom"

--- a/vtscore/docs/packages/datasets.md
+++ b/vtscore/docs/packages/datasets.md
@@ -267,7 +267,7 @@ entry-point group; built-ins win on name clashes. See
 | `local`            | Local                  | `multi_media=True`. Browser-upload placeholder; re-enters `server_folder`.        |
 | `pickle`           | Upload Saved Dataset   | `multi_media=True`, hidden. `.pkl` round-trip path.                               |
 | `http_archive`     | Import from URL        | `multi_media=True`, hidden. Downloads + extracts an archive.                      |
-| `demo`             | Downloaded Demo Media  | `multi_media=True`. Wraps `load_demo_dataset`.                                    |
+| `demo`             | Downloaded Media       | `multi_media=True`. Wraps `load_demo_dataset`.                                    |
 | `synthetic`        | Synthetic Media        | `multi_media=True`. Generates deterministic media via `vtscore.utils.synthetic`.  |
 | `combine_datasets` | Combined Datasets      | `multi_media=True`, hidden. Internal: merges two loaded datasets.                 |
 | `recaller`         | ReCaller Query         | `multi_media=True`, hidden. Scaffold for the ReCaller external API.               |


### PR DESCRIPTION
## Summary
- `.modal-content` is now a flex column with the body as the only scrollable area, so the header and footer (Cancel / Import) stay pinned when content overflows. In the Add Dataset > Demo > Downloaded view, the demo chart scrolls internally instead of pushing the action buttons off-screen.
- Renames the demo importer's display label from "Downloaded Demo Media" to "Downloaded Media" (the tab now reads "Downloaded Media"). Updates the spec fixture and `docs/packages/datasets.md` to match.

## Test plan
- [x] `./run-tests.sh core` — 605 passed
- [x] `./run-tests.sh datasets io` — 1269 passed
- [x] `cd frontend && npm run build:prod` — clean build, no warnings
- [ ] Manual: open Add Dataset > Demo > Downloaded at small viewport heights, confirm Cancel/Import remain visible and the demo table scrolls internally

https://claude.ai/code/session_01JBxt2T6yUSCCSed7fUZCzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBxt2T6yUSCCSed7fUZCzB)_