### PR TITLE
Consolidate muted-subhead h4 styling into shared .subhead class

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -310,6 +310,7 @@ SHARED_CLASSES = [
     "modal-close",
     "modal-backdrop",
     "back-btn",
+    "subhead",
 ]
 
 

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -105,7 +105,7 @@
         </label>
         <button class="btn btn--secondary file-btn" (click)="openMediaPicker()" title="Browse server media sources to pick an example file">Browse media sources...</button>
         @if (serverMediaFiles.length > 0) {
-          <h4 title="Example media files available on the server">Server Example Media</h4>
+          <h4 class="subhead" title="Example media files available on the server">Server Example Media</h4>
           <div class="file-list">
             @for (file of serverMediaFiles; track file.name) {
               <button class="file-item" (click)="loadServerMedia(file.filename || file.name)" [title]="'Sort by example: ' + (file.filename || file.name)">{{ file.filename || file.name }}</button>

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -8,16 +8,10 @@
   // `<h3>` inherits its font-size from `_components.scss`.
   h3 { margin: 0 0 var(--space-lg); }
 
-  // `<h4>` here labels a sub-section ("Server Example Media") within
-  // the h3 panel and is styled as a muted subhead rather than a full
-  // heading — same pattern as settings-modal. If this is touched
-  // again, promote a shared `.subhead` class to `_components.scss`
-  // and convert these to `<h4 class="subhead">`.
-  h4 {
-    margin: var(--space-lg) 0 var(--space-md);
-    font-size: var(--font-md);
-    color: var(--text-secondary);
-  }
+  // `<h4 class="subhead">` ("Server Example Media") inherits its
+  // font-size/color from the global `.subhead`; we only scope its
+  // contextual margins here.
+  h4 { margin: var(--space-lg) 0 var(--space-md); }
 }
 
 .file-btn {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -73,7 +73,7 @@
           </label>
 
           @if (mediaTypes.length > 0) {
-            <h4 title="Configure how media items are displayed and selected in each panel, per media type">Scroll Style</h4>
+            <h4 class="subhead" title="Configure how media items are displayed and selected in each panel, per media type">Scroll Style</h4>
             <div class="view-tabs">
               @for (mt of mediaTypes; track mt.type_id) {
                 <button
@@ -86,7 +86,7 @@
             </div>
             <div class="view-tab-content">
               <div class="view-side-section">
-                <h4 title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
+                <h4 class="subhead" title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
                 <div class="form-group">
                   <label class="form-label" title="Display media as a vertical list or a thumbnail grid">View Mode:</label>
                   <div class="toggle-group">
@@ -121,7 +121,7 @@
                 </div>
               </div>
               <div class="view-side-section">
-                <h4 title="Display settings for the right panel (labeled goods and bads)">Right Side</h4>
+                <h4 class="subhead" title="Display settings for the right panel (labeled goods and bads)">Right Side</h4>
                 <div class="form-group">
                   <label class="form-label" title="Display labeled items as a vertical list or a thumbnail grid">View Mode:</label>
                   <div class="toggle-group">

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -67,14 +67,10 @@
     &:first-child { margin-top: 0; }
   }
 
-  // `<h4>` here labels a small subsection inside an h3 panel and is
-  // styled as a muted subhead. See the load-sort-modal comment about
-  // promoting a `.subhead` class once this pattern is touched again.
-  h4 {
-    margin: var(--space-md) 0 0;
-    font-size: var(--font-md);
-    color: var(--text-secondary);
-  }
+  // `<h4 class="subhead">` labels a small subsection inside an h3
+  // panel; identity comes from the global `.subhead`, only the
+  // contextual margin is scoped here.
+  h4 { margin: var(--space-md) 0 0; }
 }
 
 .checkbox-row {
@@ -136,12 +132,11 @@
   flex-direction: column;
   gap: var(--space-md);
 
-  // Sub-section divider — see settings-modal h4 comment above re. the
-  // pending `.subhead` consolidation.
+  // `<h4 class="subhead">` divider — global `.subhead` handles font
+  // identity; the border-bottom + padding-bottom are this site's
+  // contextual divider styling.
   h4 {
     margin: 0;
-    font-size: var(--font-md);
-    color: var(--text-secondary);
     border-bottom: 1px solid var(--border-color);
     padding-bottom: var(--space-xs);
   }

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -367,6 +367,16 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   padding: var(--space-xl) 0;
 }
 
+// `.subhead` styles a heading tag (typically `<h4>`) as a small muted
+// sub-section label inside a larger panel — e.g. "Server Example
+// Media" inside the load-sort-modal's `<h3>` panel. Vertical rhythm
+// (margins) stays scoped per-component since it depends on what's
+// above/below; identity (font-size, color) lives here.
+.subhead {
+  font-size: var(--font-md);
+  color: var(--text-secondary);
+}
+
 // --- Scrollbars ---
 
 * {


### PR DESCRIPTION
## Summary

Picks up the three deferred `.subhead` TODOs left behind by the previous `/style-check` curation pass (#1678). All three were the same pattern — an `<h4>` styled with `font-size: var(--font-md); color: var(--text-secondary);` to act as a muted sub-section heading inside a larger `<h3>` panel — and each carried an inline comment saying *"if this is touched again, promote a shared `.subhead` class to `_components.scss` and convert these to `<h4 class="subhead">`."*

- New `.subhead` utility in `frontend/src/scss/_components.scss`. Identity (font-size + color) lives there; vertical rhythm (margins) stays scoped per-component because it depends on what sits above/below the heading.
- Registered `subhead` in `SHARED_CLASSES` in `.claude/scripts/style-check.py` so any future local redeclaration gets flagged by §4.15.
- Converted 4 spots across 2 components:
  - `load-sort-modal`: "Server Example Media" `<h4>`
  - `settings-modal`: "Scroll Style", "Left Side", "Right Side" `<h4>`s
- Component SCSS now keeps only contextual styling — margins everywhere, plus the `view-side-section` h4's border-bottom + padding-bottom which is genuinely site-specific divider styling, not subhead identity.

The fourth `§4.7` hit (the label-list `<h3>` styled as a compact uppercase chip) is intentionally **not** consolidated — it's a visually different pattern (`font-sm`, `letter-spacing`, regular weight) and doesn't share enough with the muted-subhead style to live under the same class. Leaving it as a single documented exception is cleaner than introducing a `.subhead--chip` modifier for one consumer.

`/style-check` results: §4.7 drops from 4 → 1, total findings 26 → 23, no other rules regress.

## Test plan

- [x] `python .claude/scripts/style-check.py` — §4.7 = 1 hit (the deliberate label-list chip), §4.15 = 0
- [x] `cd frontend && npm run build:prod` — clean, no warnings, no budget overruns
- [ ] Manual visual check in the running app: open Settings modal → Display tab (Scroll Style / Left Side / Right Side headings still look like muted subheads); open Load Sort modal → confirm "Server Example Media" subhead still reads right


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hj59VEEafs2S2siwCrHq35)_