### PR TITLE
Explain why Dashboard button is disabled in its tooltip

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -29,7 +29,7 @@
         role="menuitem"
         tabindex="-1"
         (click)="onDashboard()"
-        title="Return to the Dashboard to manage datasets and detectors"
+        [title]="isOnLabelView ? 'Return to the Dashboard to manage datasets and detectors' : 'Return to the Dashboard to manage datasets and detectors — already at Dashboard'"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <rect x="1" y="1" width="14" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
           <rect x="3.5" y="3" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
@@ -102,7 +102,7 @@
     [class.disabled]="!isOnLabelView"
     [disabled]="!isOnLabelView"
     (click)="onDashboard()"
-    title="Return to the Dashboard to manage datasets and detectors"
+    [title]="isOnLabelView ? 'Return to the Dashboard to manage datasets and detectors' : 'Return to the Dashboard to manage datasets and detectors — already at Dashboard'"
   >Dashboard</button>
   <vt-context-pulldown kind="dataset" />
   <vt-context-pulldown kind="detector" />


### PR DESCRIPTION
## Summary
- When the Dashboard button is disabled (the user is already on the Dashboard), append "— already at Dashboard" to its tooltip so hovering explains the disabled state.
- Applied to both the top-bar button and the burger-menu item, which share the `!isOnLabelView` disabled condition.

## Test plan
- [x] `npm run build:prod` succeeds with no warnings.
- [ ] On the Dashboard, hover the Dashboard button → tooltip ends with "— already at Dashboard".
- [ ] On a label/find view, hover the Dashboard button → tooltip is the original text.

https://claude.ai/code/session_01TLBHkP59ph2CvBs1SVSaNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLBHkP59ph2CvBs1SVSaNK)_