### PR TITLE
Rename Default MediaClipper display name to None

### DIFF
--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -26,7 +26,7 @@ class TestMediaClipperABC:
         d = c.to_dict()
         assert d == {
             "name": "sound_default",
-            "display_name": "Default",
+            "display_name": "None",
             "description": "Import each audio file as-is, without splitting.",
             "media_type": "audio",
         }
@@ -35,7 +35,7 @@ class TestMediaClipperABC:
         from vtscore.media.audio.clipper import SoundDefaultClipper
 
         c = SoundDefaultClipper()
-        assert c.display_name == "Default"
+        assert c.display_name == "None"
 
     def test_display_name_tiling(self):
         from vtscore.media.audio.clipper import SoundTilingClipper

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -52,6 +52,10 @@ class SoundDefaultClipper(MediaClipper):
         return "sound_default"
 
     @property
+    def display_name(self) -> str:
+        return "None"
+
+    @property
     def media_type(self) -> str:
         return "audio"
 

--- a/vtscore/media/document/clipper.py
+++ b/vtscore/media/document/clipper.py
@@ -15,6 +15,10 @@ class DocumentDefaultClipper(MediaClipper):
         return "document_default"
 
     @property
+    def display_name(self) -> str:
+        return "None"
+
+    @property
     def media_type(self) -> str:
         return "document"
 

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -17,6 +17,10 @@ class ImageDefaultClipper(MediaClipper):
         return "image_default"
 
     @property
+    def display_name(self) -> str:
+        return "None"
+
+    @property
     def media_type(self) -> str:
         return "image"
 

--- a/vtscore/media/text/clipper.py
+++ b/vtscore/media/text/clipper.py
@@ -16,6 +16,10 @@ class TextDefaultClipper(MediaClipper):
         return "text_default"
 
     @property
+    def display_name(self) -> str:
+        return "None"
+
+    @property
     def media_type(self) -> str:
         return "text"
 

--- a/vtscore/media/video/clipper.py
+++ b/vtscore/media/video/clipper.py
@@ -16,6 +16,10 @@ class VideoDefaultClipper(MediaClipper):
         return "video_default"
 
     @property
+    def display_name(self) -> str:
+        return "None"
+
+    @property
     def media_type(self) -> str:
         return "video"
 


### PR DESCRIPTION
## Summary
- Each `*DefaultClipper` (audio / image / video / text / document) now overrides `display_name` to return `"None"` instead of the auto-derived `"Default"`.
- The clipper that doesn't split files is no longer presented as the "default" choice in the UI, since for many media types it isn't the recommended option.
- Updated `tests/detectors/test_clippers.py` assertions to expect `"None"`.

## Test plan
- [x] `python -m pytest tests/detectors/test_clippers.py` — 225 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_014EM24HRztxDPejrHrP3WHi)_