### PR TITLE
Add RAM usage bar to dashboard (bottom-left)

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -71,8 +71,7 @@ def check_raw_lengths(files: list[Path]) -> Finding:
     f = Finding(
         rule="§4.1-2 Hardcoded px/rem in spacing/font-size",
         description=(
-            "Use --space-* / --font-* tokens. Raw values in padding | margin | "
-            "gap | font-size bypass the token system."
+            "Use --space-* / --font-* tokens. Raw values in padding | margin | gap | font-size bypass the token system."
         ),
     )
     for path in files:
@@ -83,9 +82,7 @@ def check_raw_lengths(files: list[Path]) -> Finding:
             for m in SPACING_PROP.finditer(line):
                 value = m.group(2)
                 # Skip if the value is fully a token: `var(--space-md)` etc.
-                if "var(--" in value and not RAW_LENGTH.search(
-                    re.sub(r"var\([^)]+\)", "", value)
-                ):
+                if "var(--" in value and not RAW_LENGTH.search(re.sub(r"var\([^)]+\)", "", value)):
                     continue
                 for length_match in RAW_LENGTH.finditer(value):
                     raw = length_match.group(0)
@@ -185,9 +182,7 @@ def check_heading_restyling(files: list[Path]) -> Finding:
                 # `body` includes the opening line so single-line rules
                 # (`h1 { margin: 0; }`) are inspected correctly.
                 body = "\n".join(lines[start:j])
-                if re.search(r"\bfont-size\b", body) or re.search(
-                    r"\bfont-weight\b", body
-                ):
+                if re.search(r"\bfont-size\b", body) or re.search(r"\bfont-weight\b", body):
                     f.hits.append((path, rule_line, lines[i].rstrip()))
                 i = j
             else:
@@ -270,9 +265,7 @@ def check_flex_column_no_gap(files: list[Path]) -> Finding:
                         frame = stack.pop()
                         if frame["has_col"] and not frame["has_gap"]:
                             # Only flag rules that look like display:flex containers.
-                            f.hits.append(
-                                (path, frame["col_line"], _read_line(text, frame["col_line"]))
-                            )
+                            f.hits.append((path, frame["col_line"], _read_line(text, frame["col_line"])))
                     depth = max(0, depth - 1)
             if "flex-direction" in stripped and "column" in stripped and stack:
                 stack[-1]["has_col"] = True
@@ -327,9 +320,7 @@ def check_redeclared_utility(files: list[Path]) -> Finding:
     # End of the class name must be a non-class-character — not `-` or
     # `\w` — so `.btn-good` and `.form-group--section` (which are new
     # classes, not redeclarations of `.btn` or `.form-group`) don't match.
-    pattern = re.compile(
-        r"^\.(" + "|".join(re.escape(c) for c in SHARED_CLASSES) + r")(?![-\w])[^{]*\{"
-    )
+    pattern = re.compile(r"^\.(" + "|".join(re.escape(c) for c in SHARED_CLASSES) + r")(?![-\w])[^{]*\{")
     for path in files:
         if path in SHARED_UTILITY_FILES:
             continue

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,4 +1,3 @@
-⏳ Initializing VTSearch... (PID 11602)
 {
   "components": {
     "responses": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,3 +1,4 @@
+⏳ Initializing VTSearch... (PID 11602)
 {
   "components": {
     "responses": {
@@ -859,6 +860,26 @@
         "required": [
           "free",
           "path",
+          "total",
+          "used"
+        ],
+        "type": "object"
+      },
+      "DashboardRamUsageResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "free": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "used": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "free",
           "total",
           "used"
         ],
@@ -5710,6 +5731,31 @@
           }
         },
         "summary": "Return free / used / total bytes for the partition holding ``DATA_DIR``.",
+        "tags": [
+          "datasets_ui"
+        ]
+      }
+    },
+    "/api/dashboard/ram-usage": {
+      "get": {
+        "description": "Reads ``MemTotal`` and ``MemAvailable`` from ``/proc/meminfo`` (Linux).\n``free`` is reported as ``MemAvailable`` (memory reclaimable without\nswapping, which is what an application can actually use), and ``used``\nis derived as ``total - free`` to match.",
+        "operationId": "dashboard_ram_usage",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRamUsageResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return free / used / total bytes of system RAM.",
         "tags": [
           "datasets_ui"
         ]

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -330,7 +330,8 @@
       </button>
       <span class="btn-disabled-reason" [style.visibility]="(!findEnabled && findHint) ? 'visible' : 'hidden'">{{ findHint || '&nbsp;' }}</span>
     </div>
-    <vt-disk-usage [usage]="diskUsage" />
+    <vt-usage-bar [usage]="ramUsage" label="RAM" side="left" titlePrefix="System RAM" />
+    <vt-usage-bar [usage]="diskUsage" label="Disk" side="right" titlePrefix="Server disk" />
 
   </div>
 </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -38,7 +38,7 @@ import { LabelExporterModalComponent } from '../modals/label-exporter-modal/labe
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { DatasetStatsModalComponent } from '../modals/dataset-stats-modal/dataset-stats-modal.component';
 import { IconComponent } from '../icon/icon.component';
-import { DiskUsageComponent, DiskUsageBytes } from './disk-usage/disk-usage.component';
+import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
 
 @Component({
   selector: 'vt-dashboard',
@@ -55,7 +55,7 @@ import { DiskUsageComponent, DiskUsageBytes } from './disk-usage/disk-usage.comp
     LabelImporterModalComponent,
     DatasetStatsModalComponent,
     IconComponent,
-    DiskUsageComponent,
+    UsageBarComponent,
     SkeletonComponent,
   ],
   templateUrl: './dashboard.component.html',
@@ -134,7 +134,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   currentUser = '';
   isDefaultLogin = true;
 
-  diskUsage: DiskUsageBytes | null = null;
+  diskUsage: UsageBytes | null = null;
+  ramUsage: UsageBytes | null = null;
 
   constructor(
     private router: Router,
@@ -211,6 +212,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       });
     this.refresh();
     this.startDiskUsagePolling();
+    this.startRamUsagePolling();
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
         this.visibleImporters = (res.importers || []).filter((imp) => !imp['hidden_from_picker']);
@@ -301,6 +303,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
       )
       .subscribe((usage) => {
         this.diskUsage = { total: usage.total, used: usage.used, free: usage.free };
+      });
+  }
+
+  private startRamUsagePolling(): void {
+    timer(0, 10000)
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(() => this.datasetsApi.getRamUsage().pipe(catchError(() => EMPTY))),
+      )
+      .subscribe((usage) => {
+        this.ramUsage = { total: usage.total, used: usage.used, free: usage.free };
       });
   }
 

--- a/frontend/src/app/components/dashboard/disk-usage/disk-usage.component.html
+++ b/frontend/src/app/components/dashboard/disk-usage/disk-usage.component.html
@@ -1,8 +1,0 @@
-@if (usage) {
-  <div class="disk-usage" [title]="'Server disk: ' + freeText">
-    <div class="disk-usage-label">Disk: {{ freeText }}</div>
-    <div class="disk-usage-bar" [class.warn]="usedPct >= 80" [class.critical]="usedPct >= 95">
-      <div class="disk-usage-fill" [style.width.%]="usedPct"></div>
-    </div>
-  </div>
-}

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.html
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.html
@@ -1,0 +1,8 @@
+@if (usage) {
+  <div class="usage-bar" [title]="title">
+    <div class="usage-bar-label">{{ label }}: {{ freeText }}</div>
+    <div class="usage-bar-track" [class.warn]="usedPct >= 80" [class.critical]="usedPct >= 95">
+      <div class="usage-bar-fill" [style.width.%]="usedPct"></div>
+    </div>
+  </div>
+}

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.scss
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.scss
@@ -1,21 +1,29 @@
 // Host is layout-transparent: the parent's centred flex row must not shift
-// when the disk-usage indicator appears or disappears.
+// when the usage indicator appears or disappears.
 :host {
   display: contents;
 }
 
-.disk-usage {
+.usage-bar {
   position: absolute;
-  right: 0;
   top: 50%;
   transform: translateY(-50%);
-  width: 220px;
+  // ~3/4 of the original 220px disk-bar width.
+  width: 165px;
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.disk-usage-label {
+:host(.side-right) .usage-bar {
+  right: 0;
+}
+
+:host(.side-left) .usage-bar {
+  left: 0;
+}
+
+.usage-bar-label {
   font-size: var(--font-xs);
   color: var(--text-muted);
   white-space: nowrap;
@@ -23,7 +31,7 @@
   text-overflow: ellipsis;
 }
 
-.disk-usage-bar {
+.usage-bar-track {
   height: 8px;
   background: var(--bg-elevated, rgba(127, 127, 127, 0.2));
   border: 1px solid var(--border);
@@ -31,16 +39,16 @@
   overflow: hidden;
 }
 
-.disk-usage-fill {
+.usage-bar-fill {
   height: 100%;
   background: var(--accent);
   transition: width var(--transition-slow) ease, background-color var(--transition-slow) ease;
 }
 
-.disk-usage-bar.warn .disk-usage-fill {
+.usage-bar-track.warn .usage-bar-fill {
   background: var(--text-warning);
 }
 
-.disk-usage-bar.critical .disk-usage-fill {
+.usage-bar-track.critical .usage-bar-fill {
   background: var(--color-bad);
 }

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
@@ -1,20 +1,27 @@
 import { Component, Input } from '@angular/core';
 
-export interface DiskUsageBytes {
+export interface UsageBytes {
   total: number;
   used: number;
   free: number;
 }
 
 @Component({
-  selector: 'vt-disk-usage',
+  selector: 'vt-usage-bar',
   standalone: true,
   imports: [],
-  templateUrl: './disk-usage.component.html',
-  styleUrl: './disk-usage.component.scss',
+  templateUrl: './usage-bar.component.html',
+  styleUrl: './usage-bar.component.scss',
+  host: {
+    '[class.side-left]': "side === 'left'",
+    '[class.side-right]': "side === 'right'",
+  },
 })
-export class DiskUsageComponent {
-  @Input() usage: DiskUsageBytes | null = null;
+export class UsageBarComponent {
+  @Input() usage: UsageBytes | null = null;
+  @Input() label = '';
+  @Input() side: 'left' | 'right' = 'right';
+  @Input() titlePrefix = '';
 
   get usedPct(): number {
     if (!this.usage || this.usage.total <= 0) return 0;
@@ -24,6 +31,11 @@ export class DiskUsageComponent {
   get freeText(): string {
     if (!this.usage) return '';
     return `${this.formatBytes(this.usage.free)} free of ${this.formatBytes(this.usage.total)}`;
+  }
+
+  get title(): string {
+    const prefix = this.titlePrefix || this.label;
+    return prefix ? `${prefix}: ${this.freeText}` : this.freeText;
   }
 
   private formatBytes(n: number): string {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -9,6 +9,7 @@ import type { BrowseMediaFilesSelectResponse } from '../generated/api-client/mod
 import type { CancelDatasetLoadResponse } from '../generated/api-client/models/cancel-dataset-load-response';
 import type { ClearStagingResponse } from '../generated/api-client/models/clear-staging-response';
 import type { DashboardDiskUsageResponse } from '../generated/api-client/models/dashboard-disk-usage-response';
+import type { DashboardRamUsageResponse } from '../generated/api-client/models/dashboard-ram-usage-response';
 import type { DatasetAllImportersListResponse } from '../generated/api-client/models/dataset-all-importers-list-response';
 import type { DatasetAvailableFilesResponse } from '../generated/api-client/models/dataset-available-files-response';
 import type { DatasetClearResponse } from '../generated/api-client/models/dataset-clear-response';
@@ -43,6 +44,7 @@ import { selectBrowsedFile } from '../generated/api-client/fn/datasets-ui/select
 import { clippersList } from '../generated/api-client/fn/datasets-listings/clippers-list';
 import { convertersList } from '../generated/api-client/fn/datasets-listings/converters-list';
 import { dashboardDiskUsage } from '../generated/api-client/fn/datasets-ui/dashboard-disk-usage';
+import { dashboardRamUsage } from '../generated/api-client/fn/datasets-ui/dashboard-ram-usage';
 import { datasetAllImporters } from '../generated/api-client/fn/datasets-listings/dataset-all-importers';
 import { availableDatasetFiles } from '../generated/api-client/fn/datasets-staging/available-dataset-files';
 import { cancelDatasetLoad } from '../generated/api-client/fn/datasets-status/cancel-dataset-load';
@@ -334,5 +336,9 @@ export class DatasetsApiService {
 
   getDiskUsage(): Observable<DashboardDiskUsageResponse> {
     return dashboardDiskUsage(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  getRamUsage(): Observable<DashboardRamUsageResponse> {
+    return dashboardRamUsage(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -28,6 +28,7 @@ from vtsearch.schemas.datasets import (
     DashboardDatasetRenameRequestSchema,
     DashboardDatasetRenameResponseSchema,
     DashboardDiskUsageResponseSchema,
+    DashboardRamUsageResponseSchema,
     DemoCategoriesResponseSchema,
     DemoDatasetListQuerySchema,
     DemoDatasetListResponseSchema,
@@ -526,3 +527,30 @@ def dashboard_disk_usage():
         "free": usage.free,
         "path": str(probe),
     }
+
+
+@datasets_ui_bp.route("/api/dashboard/ram-usage")
+@datasets_ui_bp.response(200, DashboardRamUsageResponseSchema)
+def dashboard_ram_usage():
+    """Return free / used / total bytes of system RAM.
+
+    Reads ``MemTotal`` and ``MemAvailable`` from ``/proc/meminfo`` (Linux).
+    ``free`` is reported as ``MemAvailable`` (memory reclaimable without
+    swapping, which is what an application can actually use), and ``used``
+    is derived as ``total - free`` to match.
+    """
+    total = 0
+    available = 0
+    try:
+        with open("/proc/meminfo", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("MemTotal:"):
+                    total = int(line.split()[1]) * 1024
+                elif line.startswith("MemAvailable:"):
+                    available = int(line.split()[1]) * 1024
+                if total and available:
+                    break
+    except OSError:
+        pass
+    used = max(0, total - available)
+    return {"total": total, "used": used, "free": available}

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -319,6 +319,14 @@ class DashboardDiskUsageResponseSchema(Schema):
     path = fields.String(required=True)
 
 
+class DashboardRamUsageResponseSchema(Schema):
+    """Response for ``GET /api/dashboard/ram-usage``."""
+
+    total = fields.Integer(required=True)
+    used = fields.Integer(required=True)
+    free = fields.Integer(required=True)
+
+
 # ---------------------------------------------------------------------------
 # /api/dataset/load-* and /api/dataset/clear (vtsearch/routes/datasets/load.py)
 # ---------------------------------------------------------------------------
@@ -583,6 +591,7 @@ __all__ = [
     "DashboardDatasetRenameRequestSchema",
     "DashboardDatasetRenameResponseSchema",
     "DashboardDiskUsageResponseSchema",
+    "DashboardRamUsageResponseSchema",
     "DatasetAllImportersListResponseSchema",
     "DatasetAvailableFilesResponseSchema",
     "DatasetClearResponseSchema",


### PR DESCRIPTION
## Summary

- Adds a `RAM: <free> of <total>` bar to the bottom-left of the dashboard, mirroring the existing Disk bar at the bottom-right.
- Both bars are now ~3/4 the previous Disk-bar width (220px → 165px).
- New backend endpoint `GET /api/dashboard/ram-usage` returns total/used/free system RAM (read from `/proc/meminfo`'s `MemTotal` + `MemAvailable`).
- Refactored the `vt-disk-usage` component into a generic `vt-usage-bar` component with `label` / `side` (`left`|`right`) / `titlePrefix` inputs. Used twice in the dashboard.

## Files of note

- `vtsearch/routes/datasets/ui.py` — new `dashboard_ram_usage()` route
- `vtsearch/schemas/datasets.py` — new `DashboardRamUsageResponseSchema`
- `frontend/src/app/components/dashboard/usage-bar/*` — generic component (replaces old `disk-usage/*`)
- `frontend/src/app/components/dashboard/dashboard.component.{ts,html}` — second poller + second instance
- `frontend/openapi.json` + regenerated `frontend/src/app/generated/api-client/**` — RAM endpoint surface

## Test plan

- [x] `./run-tests.sh core` — 605 passed
- [x] `./run-tests.sh` (full default suite) — 4235 passed, 1 skipped, 2 xpassed
- [ ] Visual: load dashboard, confirm RAM bar appears on the left, Disk on the right, both ~3/4 of old width


---
_Generated by [Claude Code](https://claude.ai/code/session_01APJoKt6hTuwNYpcQXqooNB)_