### PR TITLE
Polish Settings &gt; Data Imports to match ScrollStyle tab look

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
@@ -1,8 +1,8 @@
 @if (visibleTypes.length === 0) {
   <p class="empty-state">No media types registered.</p>
 } @else {
-  <p class="form-hint" title="These defaults auto-fill the Add Dataset modal whenever you start an import whose output is the matching media type.">
-    Pick the embedder, clipper, and converters you want pre-selected each time you import a dataset.
+  <p class="info-text import-defaults-intro" title="These defaults auto-fill the Add Dataset modal whenever you start an import whose output is the matching media type.">
+    Default import settings per media type.
   </p>
 
   <div class="view-tabs">
@@ -43,9 +43,8 @@
         <select
           [id]="'import-default-embedder-' + activeType"
           class="form-select"
-          [ngModel]="currentEmbedder"
+          [ngModel]="displayedEmbedder"
           (ngModelChange)="onEmbedderChange($event)">
-          <option value="">Use importer default</option>
           @if (recommendedEmbedders.length > 0) {
             <optgroup label="Recommended">
               @for (embedder of recommendedEmbedders; track embedder.name) {
@@ -78,17 +77,18 @@
         </button>
       }
 
-      @if (hasOverridesForActiveType) {
-        <div class="import-defaults-footer">
-          <button
-            type="button"
-            class="btn btn--ghost btn--sm"
-            (click)="resetActiveType()"
-            title="Clear your saved {{ activeTypeLabel }} import defaults and fall back to the importer's own defaults">
-            Reset {{ activeTypeLabel }} defaults
-          </button>
-        </div>
-      }
+      <div class="import-defaults-footer">
+        <button
+          type="button"
+          class="btn btn--ghost btn--sm"
+          [disabled]="!hasOverridesForActiveType"
+          (click)="resetActiveType()"
+          [title]="hasOverridesForActiveType
+            ? 'Clear your saved ' + activeTypeLabel + ' import defaults and restore the built-in defaults'
+            : activeTypeLabel + ' defaults are already at the built-in values — nothing to reset'">
+          Reset {{ activeTypeLabel }} defaults
+        </button>
+      </div>
     }
   </div>
 }

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
@@ -1,8 +1,13 @@
+.import-defaults-intro {
+  margin-bottom: var(--space-sm);
+}
+
+// Adds the inner column-flex layout on top of the shared `.view-tab-content`
+// base (border, padding, background) defined in global `_components.scss`.
 .import-defaults-body {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
-  padding-top: var(--space-sm);
 }
 
 .license-warning {

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
@@ -218,6 +218,23 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
     return this.activeEmbedders.filter((e) => !e.is_default);
   }
 
+  /** Built-in default embedder for the active mediaType — the first
+   *  ``is_default`` option, falling back to the first available embedder.
+   *  Used to seed the dropdown when the user has no saved override. */
+  get defaultEmbedderName(): string {
+    const recommended = this.recommendedEmbedders[0];
+    if (recommended) return recommended.name;
+    const first = this.activeEmbedders[0];
+    return first ? first.name : '';
+  }
+
+  /** What the dropdown actually shows as selected: the user's override if
+   *  set, otherwise the built-in default.  Picking this value back from
+   *  the dropdown clears the override (see ``onEmbedderChange``). */
+  get displayedEmbedder(): string {
+    return this.currentEmbedder || this.defaultEmbedderName;
+  }
+
   embedderLabel(embedder: EmbedderInfo): string {
     return embedder.display_name || embedder.name;
   }
@@ -280,7 +297,11 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   }
 
   onEmbedderChange(name: string): void {
-    this.updateActive({ embedder: name });
+    // Re-picking the built-in default clears the override so the saved
+    // settings stay compact and the Reset button doesn't activate for a
+    // no-op change.
+    const next = name === this.defaultEmbedderName ? '' : name;
+    this.updateActive({ embedder: next });
   }
 
   onSourceSpecsChange(specs: SourceSpec[]): void {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -81,50 +81,14 @@
   cursor: pointer;
 }
 
-.view-tabs {
-  display: flex;
-  gap: 0;
-  margin-bottom: 0;
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  border: 1px solid var(--border-color);
-  border-bottom: none;
-  padding: var(--space-xs) var(--space-xs) 0;
-}
-
-.view-tab {
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--font-sm);
-  font-weight: var(--weight-medium);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
-  }
-
-  &--active {
-    color: var(--text-primary);
-    background: var(--bg-primary);
-    border-bottom-color: var(--accent-color);
-  }
-}
-
+// Scroll Style's two-side layout sits inside the shared `.view-tab-content`
+// panel (base styling in `_components.scss`). Encapsulation scopes this
+// grid override to ScrollStyle's tab content only — other consumers
+// (e.g. Data Imports) keep their own inner layout.
 .view-tab-content {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--space-xl);
-  padding: var(--space-lg);
-  border: 1px solid var(--border-color);
-  border-top: 1px solid var(--border-color);
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-  background: var(--bg-primary);
 }
 
 .view-side-section {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -385,6 +385,57 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   color: var(--text-secondary);
 }
 
+// `.view-tabs` / `.view-tab` / `.view-tab-content` — a paneled tab strip
+// where the active tab visually flows into the inset content region
+// below. The active tab's background matches `.view-tab-content` so the
+// border between them disappears, leaving only the accent underline.
+// Lives here (not in a component SCSS) so child components can reuse the
+// pattern without copying the rules — Angular's emulated encapsulation
+// otherwise blocks parent classes from styling child template content.
+// `.view-tab-content` intentionally omits `display`; consumers pick
+// `flex` or `grid` to suit their inner layout.
+.view-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  padding: var(--space-xs) var(--space-xs) 0;
+}
+
+.view-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  &--active {
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border-bottom-color: var(--accent-color);
+  }
+}
+
+.view-tab-content {
+  padding: var(--space-lg);
+  border: 1px solid var(--border-color);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  background: var(--bg-primary);
+}
+
 // --- Scrollbars ---
 
 * {


### PR DESCRIPTION
## Summary

Settings > Data Imports now looks like Settings > Appearance > ScrollStyle: real tabs with an inset content panel where the active tab flows into the content region.

### What changed

- **Tab styling now works.** The `.view-tabs` / `.view-tab` / `.view-tab-content` rules lived in `settings-modal.component.scss`, so Angular's emulated encapsulation prevented them from reaching the `vt-import-defaults-settings` child component — that's why the tabs there rendered as unstyled buttons. Hoisted the shared base styles into the global `_components.scss`; both ScrollStyle and Data Imports now share the look. ScrollStyle's two-column grid override stays encapsulated in the parent SCSS.
- **Section description.** Replaced the long monospace `.form-hint` blurb ("Pick the embedder, clipper, and converters you want pre-selected each time you import a dataset.") with a concise `.info-text` line: "Default import settings per media type."
- **Embedder dropdown.** Dropped the misleading `"Use importer default"` option — the importer doesn't pick the embedder, this setting does. The dropdown now seeds with the built-in default embedder (first `is_default`) when there's no saved override. Re-picking the default clears the override so the persisted dict stays compact and the Reset button doesn't activate for a no-op.
- **Reset button.** Always rendered at the bottom of each tab so the affordance is discoverable, and disabled (with an explanatory tooltip) when there's nothing to reset.

## Test plan

- [ ] Open Settings > Data Imports — tabs should look like ScrollStyle's, active tab visually flows into the inset content region
- [ ] Switch between mediaType tabs; the active tab is unmistakable
- [ ] Embedder dropdown pre-selects the built-in default; no "Use importer default" entry
- [ ] Change the embedder to something non-default → Reset button enables
- [ ] Click Reset → settings clear, dropdown falls back to the default
- [ ] Re-pick the default embedder explicitly → Reset stays disabled (no override stored)


---
_Generated by [Claude Code](https://claude.ai/code/session_018on4yqZV9sq3uZaSX8aUsb)_