### PR TITLE
Ship Phase C: converter param normalization, library-tier UploadedFile, yield_precomputed

### DIFF
--- a/docs/plans/plugin-interface-streamlines.md
+++ b/docs/plans/plugin-interface-streamlines.md
@@ -654,6 +654,95 @@ hypothesis before Phase B raises the stakes.
   declarative-`server_path`-validation slice forward into Phase A. Park
   this until Phase A is in flight.
 
+### Phase C — Candidates #2 + #9 + #13: shape unification (P1)
+
+**Status:** **shipped.** Three independent surfaces landed in one PR:
+
+- **#9 — converter param normalization.**
+  :meth:`MediaConverter.convert_normalized` is the new framework entry
+  point.  It pre-strips empty-string values whose field declares a
+  default, runs the per-converter marshmallow schema (validating
+  declared :attr:`~PluginField.min` / :attr:`max` / :attr:`options`
+  constraints), fills missing or empty-string keys with the field's
+  declared default, then dispatches to the subclass's
+  :meth:`~MediaConverter.convert`.  Every in-tree call site
+  (:meth:`DatasetImporter._ingest_spec_stream`,
+  :func:`vtscore.converters.runner._run_converter_on_source`,
+  :func:`vtscore.converters.runner.run_converters_on_folder`,
+  :func:`vtscore.datasets.clipper_chain._run_converter_step`, the
+  clipper-chain replay loop) routes through it.  Validation failures
+  raise :class:`ValueError` (matching the rest of the plugin-arg error
+  contract) rather than :class:`marshmallow.ValidationError`.
+  :meth:`~MediaConverter.get_param` stays as a back-compat shim for
+  third-party converters whose call sites bypass the framework
+  wrapper.
+- **#13 — drop Werkzeug from library tier.**  New module
+  :mod:`vtscore.plugins.uploads` defines :class:`UploadedFile` (a
+  ``runtime_checkable`` :class:`typing.Protocol` with ``filename`` /
+  ``read`` / ``save``), :class:`CliUploadedFile` (adapter wrapping a
+  filesystem path string), and :class:`BytesIOUploadedFile` (adapter
+  holding upload bytes in memory for background-thread reads).
+  Werkzeug's :class:`~werkzeug.datastructures.FileStorage` satisfies
+  the protocol natively and is passed through unchanged on the Flask
+  request path.  The default :meth:`DatasetImporter.run_cli` and
+  :meth:`LabelImporter.run_cli` now wrap any ``field_type="file"``
+  path-string argument in :class:`CliUploadedFile` before delegating
+  to :meth:`run`, so plugin bodies see one shape regardless of
+  ingress.  :func:`vtscore.datasets.load_pipeline._run_importer_in_background`
+  and :func:`_stage_importer_in_background` apply the same wrapping,
+  so the reload-from-origin path (which supplies a server-path string)
+  reaches :meth:`run` as an :class:`UploadedFile` too.  The bytesio
+  branch of :func:`vtsearch.routes._shared.validate_plugin_args` now
+  produces a :class:`BytesIOUploadedFile` instead of a bare
+  :class:`io.BytesIO` with ``.name`` taped on (``.name`` still exposed
+  as a back-compat shim).  Settled on ``.filename`` as the canonical
+  attr per the open follow-up.  The pickle importer's ``run_cli``
+  override was deleted (its custom logic collapsed into the now-shared
+  base path via :meth:`UploadedFile.save`).  Library-tier base-class
+  docstrings (:mod:`vtscore.datasets.importers.base`,
+  :mod:`vtscore.labels.importers.base`, :class:`PluginField`'s
+  ``"file"`` description) stopped referencing
+  :class:`~werkzeug.datastructures.FileStorage` and point at
+  :class:`UploadedFile`.
+- **#2 — yield_precomputed helper.**  New method
+  :meth:`DatasetImporter.yield_precomputed(filename, *, embedding,
+  md5, metadata)` routes to the three legacy precomputed dicts
+  (:attr:`content_vectors`, :attr:`content_md5s`,
+  :attr:`custom_metadata_map`).  Plugin authors that previously wrote
+  to all three dicts in parallel can now collapse to a single helper
+  call so a misspelled key can't land in only one or two of the
+  parallel maps.  The three dicts stay public and continue to work for
+  third-party importers that write to them directly.  The full
+  generator-based :class:`RawMedia` shape proposed in the original
+  candidate is deferred — it isn't separable from #12 (implicit
+  between-yield cancellation), which has no scheduled work yet.
+
+Coverage in :file:`tests_lib/datasets/test_phase_c.py` (22 tests).
+4277 in-suite tests pass.
+
+#### Migration impact — external plugins
+
+| Family | Cost |
+|---|---|
+| `DatasetImporter` (e.g. `recaller`) | None required.  CLI invocations of plugins with ``file`` fields now receive an :class:`UploadedFile` instead of a raw path string — plugin bodies that read ``.filename`` / ``.read()`` / ``.save(dst)`` continue to work, and the pre-existing ``isinstance(value, str)`` fallback in :meth:`PickleDatasetImporter.default_display_name` is no longer needed.  Multi-source-type importers can call :meth:`yield_precomputed` per file instead of writing to the three dicts. |
+| `MediaSource` (e.g. `pullwrest`) | None.  Sources do not participate in this candidate. |
+| `LabelImporter` (e.g. `holder`) | None required.  Same UploadedFile change as DatasetImporter: ``run`` now receives a wrapped path on the CLI path. |
+| `LabelsetExporter` (e.g. `holder`) | None.  Exporters do not participate. |
+| Third-party converters | None required.  Plugins called via the framework path now receive validated + default-filled ``params``; subclasses that route reads through :meth:`get_param` keep working; subclasses that index ``params[key]`` directly start working for the cases that previously crashed on missing keys.  Third-party call sites that invoke ``convert()`` directly (rather than ``convert_normalized()``) keep getting raw, un-validated params — the shim is intentional. |
+
+#### Open follow-ups
+
+- The full generator-based :class:`RawMedia` flow (candidate #2's
+  ambitious form) plus implicit cancellation (#12) remain unscheduled.
+  Worth revisiting only when a concrete importer wants both — the
+  cancellation win doesn't materialise without it.
+- :meth:`PickleDatasetImporter.run_chunked_cli` still expects a bare
+  path string (its own override, untouched by Phase C); consolidating
+  it with the wrapping default is a minor cleanup worth folding into
+  any future chunked-load refactor.
+- The :meth:`MediaConverter.get_param` shim can be removed once a
+  soak period confirms no third-party converters rely on it.
+
 ### Phase B — Candidates #3 + #4 + #7: declarative validation & templates
 
 **Status:** **shipped.** One central
@@ -760,6 +849,23 @@ which is idempotent.
 
 ## What shipped
 
+- **Phase C — Candidates #2 + #9 + #13 (shape unification).**
+  :meth:`MediaConverter.convert_normalized` is the new framework
+  entry-point: validation + default-fill runs once before
+  :meth:`convert` is reached, so subclass bodies (and clipper-chain /
+  importer call sites) can trust ``params`` is non-``None`` and
+  fully-populated.  :mod:`vtscore.plugins.uploads` ships the
+  :class:`UploadedFile` protocol plus :class:`CliUploadedFile` /
+  :class:`BytesIOUploadedFile` adapters; the default ``run_cli`` on
+  every file-accepting plugin family wraps path strings before
+  dispatching so library-tier plugin bases stop mentioning Werkzeug.
+  :meth:`DatasetImporter.yield_precomputed` collapses
+  ``content_vectors`` / ``content_md5s`` / ``custom_metadata_map``
+  writes into one call.  External plugins keep working unchanged
+  (Werkzeug `FileStorage` satisfies the new protocol; ``get_param``
+  remains as a shim; the three precomputed dicts still accept direct
+  writes).  Generator-based `RawMedia` (#2's ambitious form) and
+  implicit cancellation (#12) are explicitly deferred.
 - **Phase A — Candidate #1 (declarative origin construction).** Six
   in-tree `build_origin` overrides deleted; framework default driven by
   `PluginField.include_in_origin` / `origin_serializer` and
@@ -787,10 +893,15 @@ which is idempotent.
 
 ## Open follow-ups
 
-- Phase C (P1 shape — #1 already done; remaining: #2 RawMedia, #9
-  converter param normalization, #13 drop Werkzeug from library tier).
-  No work scheduled yet.
-- #13 has a subtle attr-name choice (`.filename` vs `.name`) the
-  current Shim note doesn't flag — the in-tree `_shared.py` adapter
-  uses `.name`, but Werkzeug exposes `.filename`. Settle on one before
-  scheduling.
+- The full generator-based `RawMedia` shape (candidate #2's ambitious
+  form, paired with #12 implicit between-yield cancellation) remains
+  unscheduled. The minimal `yield_precomputed` helper shipped in
+  Phase C handles the parallel-dict footgun without restructuring
+  `run()`; revisit the generator form when a concrete importer wants
+  the cancellation win as well.
+- `MediaConverter.get_param` is retained as a back-compat shim. After
+  a soak period confirms no third-party converter call sites rely on
+  it, delete the helper.
+- `PickleDatasetImporter.run_chunked_cli` still takes a bare path
+  string (its own override, untouched by Phase C). Consolidate with
+  the wrapping default in any future chunked-load refactor.

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -343,18 +343,21 @@ class TestRunConvertersOnFolder:
         c.source_type = "video"
         c.target_type = "image"
         c.display_name = "Video \u2192 Images"
-        c.convert.return_value = overrides.pop(
-            "convert_return",
-            [
-                {
-                    "filename": "clip_clip_1.png",
-                    "media_bytes": _make_png_bytes(),
-                    "duration": 0,
-                    "width": 4,
-                    "height": 4,
-                },
-            ],
-        )
+        default_return = [
+            {
+                "filename": "clip_clip_1.png",
+                "media_bytes": _make_png_bytes(),
+                "duration": 0,
+                "width": 4,
+                "height": 4,
+            },
+        ]
+        convert_return = overrides.pop("convert_return", default_return)
+        c.convert.return_value = convert_return
+        # Framework call sites route through ``convert_normalized``
+        # (Phase C #9); mirror the return value so tests that mock the
+        # raw ``convert`` still pass.
+        c.convert_normalized.return_value = convert_return
         for k, v in overrides.items():
             setattr(c, k, v)
         return c
@@ -519,6 +522,7 @@ class TestRunConvertersOnFolder:
 
         mock_converter = self._mock_video2image_converter()
         mock_converter.convert.side_effect = _side_effect
+        mock_converter.convert_normalized.side_effect = _side_effect
 
         medias: dict = {}
         with (

--- a/tests_lib/datasets/test_phase_c.py
+++ b/tests_lib/datasets/test_phase_c.py
@@ -1,0 +1,271 @@
+"""Phase C plugin-interface streamlines — coverage for the three landed surfaces.
+
+Three independent candidates:
+
+#9 — :meth:`MediaConverter.convert_normalized` validates and default-fills
+``params`` before dispatch, so :meth:`convert` receives a fully-populated
+non-``None`` dict.
+
+#13 — :mod:`vtscore.plugins.uploads` defines :class:`UploadedFile` plus the
+:class:`CliUploadedFile` / :class:`BytesIOUploadedFile` adapters; the
+``DatasetImporter`` / ``LabelImporter`` base classes' default ``run_cli``
+wraps path strings so plugin bodies see one shape regardless of ingress.
+
+#2 — :meth:`DatasetImporter.yield_precomputed` collapses the three
+precomputed-dict writes into one helper call so a single miskeyed entry
+cannot land in only one or two of the parallel dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vtscore.converters.base import MediaConverter
+from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.plugins import PluginField
+from vtscore.plugins.uploads import (
+    BytesIOUploadedFile,
+    CliUploadedFile,
+    UploadedFile,
+    wrap_cli_file_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# #9 — convert_normalized
+# ---------------------------------------------------------------------------
+
+
+class _NClipsConverter(MediaConverter):
+    """Throwaway converter declaring one bounded integer field."""
+
+    # ``MediaConverter.name`` is normally derived from source_type /
+    # target_type, but we override it here so tests get a stable name
+    # the marshmallow schema cache can key on.
+    display_name = "Fake Video → Image"
+    description = ""
+    fields = [
+        PluginField(
+            key="n_clips",
+            label="Frames",
+            field_type="number",
+            default="10",
+            required=False,
+            min="1",
+            max="100",
+            step="1",
+        ),
+    ]
+
+    last_params: dict[str, Any] | None = None
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return "fakevideo2image"
+
+    @property
+    def source_type(self) -> str:
+        return "video"
+
+    @property
+    def target_type(self) -> str:
+        return "image"
+
+    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        self.last_params = dict(params) if params is not None else None
+        return [{"filename": "out.png", "media_bytes": b""}]
+
+
+class TestConvertNormalized:
+    def test_none_params_get_default_filled(self):
+        c = _NClipsConverter()
+        c.convert_normalized({"filename": "v.mp4"}, None)
+        assert c.last_params == {"n_clips": 10}
+
+    def test_string_value_coerced_to_int(self):
+        c = _NClipsConverter()
+        c.convert_normalized({"filename": "v.mp4"}, {"n_clips": "5"})
+        assert c.last_params == {"n_clips": 5}
+
+    def test_empty_string_falls_back_to_default(self):
+        c = _NClipsConverter()
+        c.convert_normalized({"filename": "v.mp4"}, {"n_clips": ""})
+        assert c.last_params == {"n_clips": 10}
+
+    def test_out_of_range_value_raises_value_error(self):
+        c = _NClipsConverter()
+        with pytest.raises(ValueError, match="n_clips"):
+            c.convert_normalized({"filename": "v.mp4"}, {"n_clips": 9999})
+
+    def test_unknown_keys_are_dropped(self):
+        c = _NClipsConverter()
+        c.convert_normalized({"filename": "v.mp4"}, {"n_clips": 3, "ignored": "garbage"})
+        assert c.last_params == {"n_clips": 3}
+
+    def test_convert_directly_still_receives_raw_params(self):
+        """Backwards-compat: third-party callers that invoke convert() directly
+        bypass normalization, so the raw params reach the body."""
+        c = _NClipsConverter()
+        c.convert({"filename": "v.mp4"}, {"n_clips": "raw-string"})
+        assert c.last_params == {"n_clips": "raw-string"}
+
+
+# ---------------------------------------------------------------------------
+# #13 — UploadedFile + CLI wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestUploadedFileAdapters:
+    def test_cli_uploaded_file_exposes_filename(self, tmp_path):
+        p = tmp_path / "data.bin"
+        p.write_bytes(b"hello")
+        u = CliUploadedFile(p)
+        assert u.filename == "data.bin"
+        assert u.read() == b"hello"
+
+    def test_cli_uploaded_file_save_copies(self, tmp_path):
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"payload")
+        dst = tmp_path / "dst.bin"
+        CliUploadedFile(src).save(dst)
+        assert dst.read_bytes() == b"payload"
+
+    def test_bytesio_uploaded_file_exposes_filename_and_name(self):
+        u = BytesIOUploadedFile(b"abc", filename="upload.pkl")
+        assert u.filename == "upload.pkl"
+        # Legacy ``.name`` shim — pre-Phase-C readers expected it.
+        assert u.name == "upload.pkl"
+        assert u.read() == b"abc"
+
+    def test_bytesio_uploaded_file_save_writes_bytes(self, tmp_path):
+        dst = tmp_path / "out.bin"
+        BytesIOUploadedFile(b"abc", filename="x").save(dst)
+        assert dst.read_bytes() == b"abc"
+
+    def test_cli_and_bytesio_satisfy_uploaded_file_protocol(self):
+        assert isinstance(CliUploadedFile("/tmp/x"), UploadedFile)
+        assert isinstance(BytesIOUploadedFile(b"", "x"), UploadedFile)
+
+
+class TestWrapCliFileFields:
+    def test_wraps_string_paths(self, tmp_path):
+        p = tmp_path / "data.bin"
+        p.write_bytes(b"x")
+        fields = [PluginField(key="file", label="F", field_type="file")]
+        wrapped = wrap_cli_file_fields(fields, {"file": str(p)})
+        assert isinstance(wrapped["file"], CliUploadedFile)
+        assert wrapped["file"].filename == "data.bin"
+
+    def test_passes_uploaded_file_through(self):
+        existing = BytesIOUploadedFile(b"", "x")
+        fields = [PluginField(key="file", label="F", field_type="file")]
+        wrapped = wrap_cli_file_fields(fields, {"file": existing})
+        assert wrapped["file"] is existing
+
+    def test_leaves_non_file_fields_alone(self):
+        fields = [
+            PluginField(key="file", label="F", field_type="file"),
+            PluginField(key="name", label="N", field_type="text"),
+        ]
+        wrapped = wrap_cli_file_fields(fields, {"file": None, "name": "/some/path"})
+        assert wrapped["file"] is None
+        assert wrapped["name"] == "/some/path"
+
+    def test_returns_a_copy(self):
+        fields: list[PluginField] = []
+        original = {"k": "v"}
+        wrapped = wrap_cli_file_fields(fields, original)
+        wrapped["k"] = "mutated"
+        assert original["k"] == "v"
+
+
+class _FileImporter(DatasetImporter):
+    """In-memory importer with a single ``file`` field.
+
+    ``run`` records the type / surface of the value it receives so tests
+    can assert that ``run_cli`` wraps path strings in
+    :class:`CliUploadedFile` before dispatching.
+    """
+
+    name = "_file_importer"
+    display_name = "_file_importer"
+    description = ""
+    fields = [ImporterField(key="file", label="F", field_type="file")]
+
+    last_value: Any = None
+
+    def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
+        self.last_value = field_values["file"]
+
+
+class TestRunCliWrapsFileFields:
+    def test_string_path_arrives_as_uploaded_file(self, tmp_path):
+        p = tmp_path / "x.bin"
+        p.write_bytes(b"data")
+        imp = _FileImporter()
+        imp.run_cli({"file": str(p)}, {})
+        assert isinstance(imp.last_value, UploadedFile)
+        assert imp.last_value.filename == "x.bin"
+        assert imp.last_value.read() == b"data"
+
+    def test_already_uploaded_file_passes_through(self):
+        u = BytesIOUploadedFile(b"x", "x")
+        imp = _FileImporter()
+        imp.run_cli({"file": u}, {})
+        assert imp.last_value is u
+
+
+# ---------------------------------------------------------------------------
+# #2 — yield_precomputed
+# ---------------------------------------------------------------------------
+
+
+class _PrecomputedImporter(DatasetImporter):
+    name = "_pre"
+    display_name = "_pre"
+    description = ""
+    fields = []
+
+
+class TestYieldPrecomputed:
+    def test_routes_to_three_underlying_dicts(self):
+        imp = _PrecomputedImporter()
+        imp.yield_precomputed(
+            "tone.wav",
+            embedding=[0.1, 0.2],
+            md5="deadbeef",
+            metadata={"source": "test"},
+        )
+        assert imp.content_vectors == {"tone.wav": [0.1, 0.2]}
+        assert imp.content_md5s == {"tone.wav": "deadbeef"}
+        assert imp.custom_metadata_map == {"tone.wav": {"source": "test"}}
+
+    def test_omitted_args_dont_touch_their_dicts(self):
+        imp = _PrecomputedImporter()
+        imp.yield_precomputed("a.wav", embedding=[1.0])
+        assert imp.content_vectors == {"a.wav": [1.0]}
+        assert imp.content_md5s == {}
+        assert imp.custom_metadata_map == {}
+
+    def test_all_three_optional(self):
+        imp = _PrecomputedImporter()
+        imp.yield_precomputed("noop.wav")
+        assert imp.content_vectors == {}
+        assert imp.content_md5s == {}
+        assert imp.custom_metadata_map == {}
+
+    def test_subsequent_calls_accumulate(self):
+        imp = _PrecomputedImporter()
+        imp.yield_precomputed("a.wav", embedding=[1.0])
+        imp.yield_precomputed("b.wav", embedding=[2.0])
+        assert imp.content_vectors == {"a.wav": [1.0], "b.wav": [2.0]}
+
+    def test_legacy_direct_dict_writes_still_work(self):
+        """Back-compat: external importers writing to the dicts directly
+        keep working unchanged."""
+        imp = _PrecomputedImporter()
+        imp.content_vectors["legacy.wav"] = [0.0]
+        imp.yield_precomputed("new.wav", embedding=[1.0])
+        assert imp.content_vectors == {"legacy.wav": [0.0], "new.wav": [1.0]}

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -940,8 +940,11 @@ class TestReCallerMultiMedia:
         types = sorted(m["media_type"] for m in medias.values())
         assert types == ["image", "image", "image", "image"]
         # The framework, not the importer, called video2image.convert with
-        # the spec's params.
-        assert observed_params == [{"n_clips": "2"}]
+        # the spec's params.  The framework's ``convert_normalized`` pass
+        # (Phase C #9) validates params through the converter's declared
+        # schema, so ``n_clips`` arrives at ``convert`` as the coerced
+        # ``int`` rather than the raw string the spec carried.
+        assert observed_params == [{"n_clips": 2}]
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -24,8 +24,18 @@ class MediaConverter(PluginBase, ABC):
     :attr:`fields` class attribute (a list of
     :class:`~vtscore.plugins.PluginField`) — the same mechanism
     every other plugin family uses.  Values flow in through the ``params``
-    dict on :meth:`convert`.  When no params are supplied (or an unknown
-    key is passed), the field's declared :attr:`default` applies.
+    dict on :meth:`convert`.
+
+    Framework-side call sites use :meth:`convert_normalized` instead of
+    :meth:`convert` directly.  That wrapper validates ``params`` against
+    the declared :attr:`fields` schema (rejecting out-of-range numbers,
+    unknown ``select`` values, etc.) and fills missing or empty-string
+    keys with the field's declared :attr:`~vtscore.plugins.PluginField.default`,
+    so :meth:`convert` receives a fully-populated, non-``None`` dict
+    where every declared field key is present.  Subclasses can therefore
+    read ``params[key]`` directly without juggling ``None`` / missing /
+    empty-string cases — :meth:`get_param` remains as a thin shim for
+    third-party converters not yet migrated.
 
     The returned media dicts contain the fields produced by the target
     media type's :meth:`~vtscore.media.base.MediaType.load_media_data`
@@ -76,15 +86,24 @@ class MediaConverter(PluginBase, ABC):
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         """Convert *media* and return a list of new media dicts.
 
+        Framework call sites invoke :meth:`convert_normalized` (not
+        :meth:`convert` directly), so when ``self`` is reached through
+        the framework, *params* is guaranteed to be a non-``None`` dict
+        with every declared field key populated.  Subclasses can therefore
+        index ``params[key]`` directly.  Third-party call sites that
+        invoke :meth:`convert` themselves should call
+        :meth:`convert_normalized` instead, or route their reads through
+        :meth:`get_param` to keep working with ``None`` / missing keys.
+
         Args:
             media: The source media dict (target of conversion).  Must
                 contain at minimum ``media_bytes`` or ``media_path`` for
                 binary types, or ``media_string`` for text.  ``filename``
                 is used to derive output names.
             params: Mapping of :attr:`PluginField.key` → user-supplied
-                value, or ``None`` for "use declared defaults".  Implementers
-                should always read params through :meth:`get_param` so
-                missing keys fall back to the field defaults.
+                value.  When reached via :meth:`convert_normalized`
+                (the framework path), this is a fully-populated dict;
+                otherwise it may be ``None`` or partially populated.
 
         Each returned dict must contain at minimum:
 
@@ -97,9 +116,67 @@ class MediaConverter(PluginBase, ABC):
         output (e.g. an empty document).
         """
 
+    def convert_normalized(
+        self,
+        media: dict[str, Any],
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Validate and default-fill *params*, then dispatch to :meth:`convert`.
+
+        This is the framework's entry point — every in-tree call site
+        (importer multi-media ingestion, converter-folder runner,
+        clipper-chain runner) routes through here so :meth:`convert`
+        receives a fully-populated dict every time.
+
+        On a validation failure (out-of-range number, unknown ``select``
+        value, etc.) this raises :class:`ValueError` rather than
+        :class:`marshmallow.ValidationError`, matching the rest of the
+        framework's plugin-arg error contract.
+        """
+        normalized = self.normalize_params(params)
+        return self.convert(media, normalized)
+
     # ------------------------------------------------------------------
     # Param helpers
     # ------------------------------------------------------------------
+
+    def normalize_params(self, params: dict[str, Any] | None) -> dict[str, Any]:
+        """Validate *params* and fill missing / empty-string keys with declared defaults.
+
+        Pre-strips empty-string values for any declared field that has a
+        non-empty :attr:`PluginField.default`, then runs
+        :meth:`validate_params` (which loads through the per-plugin
+        marshmallow schema, enforcing declared :attr:`PluginField.min` /
+        :attr:`max` ranges and :attr:`options` whitelists).  This
+        preserves the legacy :meth:`get_param` semantics where ``""``
+        was treated as "unset" — marshmallow's ``Number`` fields would
+        otherwise reject an empty string as "Not a valid integer".
+
+        Subclasses rarely call this directly; :meth:`convert_normalized`
+        wraps it.  Raises :class:`ValueError` on a validation failure.
+        """
+        from marshmallow import ValidationError  # noqa: PLC0415
+
+        if params:
+            scrubbed: dict[str, Any] = {}
+            default_for: dict[str, str] = {f.key: f.default for f in self.fields if f.default}
+            for key, value in params.items():
+                if isinstance(value, str) and not value and key in default_for:
+                    continue
+                scrubbed[key] = value
+            params = scrubbed
+
+        try:
+            validated = self.validate_params(params)
+        except ValidationError as exc:
+            raise ValueError(f"Invalid params for converter {self.name!r}: {exc.messages}") from exc
+
+        for f in self.fields:
+            existing = validated.get(f.key)
+            if existing is None or (isinstance(existing, str) and existing == ""):
+                if f.default:
+                    validated[f.key] = f.default
+        return validated
 
     def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any]:
         """Validate *params* against this converter's :attr:`fields` schema.
@@ -107,12 +184,10 @@ class MediaConverter(PluginBase, ABC):
         Converters are usually invoked from ``source_specs`` /
         ``clipper_chain`` dicts that flow through the API as pass-through
         payloads — they don't go through :func:`validate_plugin_args`
-        like importer/exporter form bodies do.  Call this from any entry
-        point that accepts user-supplied params to enforce declared
-        :class:`PluginField` constraints (in particular numeric
-        :attr:`min` / :attr:`max` ranges) before the params reach the
-        expensive :meth:`convert` body.  Raises
-        :class:`marshmallow.ValidationError` on a bad value.
+        like importer/exporter form bodies do.  Framework call sites
+        invoke :meth:`convert_normalized`, which wraps this method;
+        most plugin code never calls ``validate_params`` directly.
+        Raises :class:`marshmallow.ValidationError` on a bad value.
         """
         from vtscore.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
 
@@ -131,6 +206,12 @@ class MediaConverter(PluginBase, ABC):
         Empty strings are treated as "unset" so a UI that submits empty
         inputs still gets the default.  Returns ``""`` if no field with
         *key* is declared.
+
+        Framework-routed :meth:`convert` calls receive params already
+        default-filled by :meth:`convert_normalized`, so this helper is
+        mostly redundant for in-tree converters; it remains for
+        third-party converters whose call sites bypass the framework
+        wrapper.
         """
         if params is not None:
             value = params.get(key, None)

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -162,7 +162,7 @@ def _run_converter_on_source(
         except Exception:
             return None
     try:
-        return converter.convert(source_media, conv_params)
+        return converter.convert_normalized(source_media, conv_params)
     except Exception as exc:
         print(f"Converter {converter.name} failed on {source_rel}: {exc}")
         return None
@@ -364,7 +364,7 @@ def apply_converter_to_demo(
         )
 
         try:
-            outputs = converter.convert(src_media, {})
+            outputs = converter.convert_normalized(src_media, {})
         except Exception:
             continue
         if not outputs:

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -191,7 +191,7 @@ def _run_converter_step(media: dict[str, Any], step: ChainStep) -> tuple[list[di
     conv = get_converter(step["name"])
     if conv is None:
         raise ValueError(f"unknown converter {step['name']!r}")
-    outputs = conv.convert(media, step.get("params") or {})
+    outputs = conv.convert_normalized(media, step.get("params") or {})
     target = conv.target_type
     n_out = len(outputs)
     trail_entries: list[ChainStep] = []
@@ -563,7 +563,7 @@ def replay_chain_on_file(  # noqa: C901
             conv = get_converter(entry["name"])
             if conv is None:
                 return None
-            outputs = conv.convert(media, entry.get("params") or {})
+            outputs = conv.convert_normalized(media, entry.get("params") or {})
             current_type = conv.target_type
         picked = _select_chain_output(outputs, entry)
         if picked is None:

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -8,10 +8,15 @@ discover it automatically.
 Each importer also supports CLI usage via :meth:`~DatasetImporter.add_cli_arguments`
 and :meth:`~DatasetImporter.run_cli`.  The base class provides default
 implementations that derive CLI arguments from the :attr:`fields` list, so most
-importers work on the command line without any extra code.  Importers whose
-:meth:`run` expects non-string values (e.g. Werkzeug ``FileStorage`` objects)
-should override :meth:`run_cli` to handle the CLI-appropriate types (file paths
-as strings).
+importers work on the command line without any extra code.  ``field_type="file"``
+values arrive at :meth:`run` as a
+:class:`~vtscore.plugins.uploads.UploadedFile` regardless of whether the
+import came in via the Flask request path (a Werkzeug ``FileStorage``,
+which already satisfies the protocol) or the CLI path (a
+:class:`~vtscore.plugins.uploads.CliUploadedFile` wrapping the
+``--<field>`` path argument).  Plugin bodies should rely only on
+``.filename`` / ``.read()`` / ``.save(dst)`` / ``.stream`` and never
+mention Werkzeug.
 
 Example – a minimal SFTP importer skeleton::
 
@@ -323,10 +328,15 @@ class DatasetImporter(PluginBase):
     Every importer is automatically usable from the command line via
     ``python app.py --autodetect --importer <name> [importer args] --settings <file>``.
 
-    The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
-    :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override
-    either method when the defaults are not sufficient (e.g. when :meth:`run`
-    expects a Werkzeug ``FileStorage`` rather than a plain file path).
+    The default :meth:`add_cli_arguments` derives ``argparse`` arguments
+    from :attr:`fields` and :meth:`run_cli` wraps any
+    ``field_type="file"`` CLI argument in
+    :class:`~vtscore.plugins.uploads.CliUploadedFile` before delegating
+    to :meth:`run`, so plugin bodies written against the
+    :class:`~vtscore.plugins.uploads.UploadedFile` surface work
+    identically in both code paths.  Subclasses only need to override
+    :meth:`run_cli` when their CLI-specific behaviour genuinely diverges
+    from the request-time flow (e.g. the chunked-pickle fast path).
     """
 
     #: Emoji or icon string shown next to the display name in the UI.
@@ -439,14 +449,16 @@ class DatasetImporter(PluginBase):
     def __init__(self) -> None:
         #: Mapping of filename to pre-computed embedding vector.  Importers
         #: that supply content vectors alongside media should populate this
-        #: dict during :meth:`run` (keyed by the basename of each file).
+        #: dict during :meth:`run` (keyed by the basename of each file) —
+        #: or, preferably, call :meth:`yield_precomputed` once per file
+        #: which writes to all three precomputed dicts atomically.
         #: :func:`~vtscore.datasets.loader.load_dataset_from_folder` will
         #: skip the embedding model for any file whose name appears here.
         self.content_vectors: dict[str, Any] = {}
 
         #: Mapping of filename to pre-computed MD5 hex digest string.
         #: Importers that already know the hash of each file should populate
-        #: this dict during :meth:`run`.
+        #: this dict during :meth:`run` (or call :meth:`yield_precomputed`).
         #: :func:`~vtscore.datasets.loader.load_dataset_from_folder` will
         #: skip its own MD5 calculation for any file whose name appears here.
         self.content_md5s: dict[str, str] = {}
@@ -461,6 +473,50 @@ class DatasetImporter(PluginBase):
         #: order as :attr:`content_vectors` (relative path first, then
         #: basename).
         self.custom_metadata_map: dict[str, dict[str, Any]] = {}
+
+    def yield_precomputed(
+        self,
+        filename: str,
+        *,
+        embedding: Any = None,
+        md5: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Register pre-computed embedding / MD5 / metadata for *filename*.
+
+        Single entry point for the three legacy precomputed dicts
+        (:attr:`content_vectors`, :attr:`content_md5s`,
+        :attr:`custom_metadata_map`).  Importers that already know any of
+        these values up-front — e.g. when reading an NPZ sidecar or a
+        manifest that ships hashes — should call this once per file
+        instead of writing to the three dicts directly, so a single
+        misspelled key (or one entry landing in only two of the three)
+        cannot silently produce a mismatched-per-file precomputed state.
+
+        Any combination of arguments may be omitted; only the supplied
+        ones land in the matching dict.  The three legacy dicts remain
+        public for back-compat — third-party importers that write to
+        them directly continue to work — but new code should prefer this
+        helper.
+
+        Args:
+            filename: The basename (or dataset-relative path) the
+                framework uses to key precomputed lookups against the
+                file the loader discovers on disk.  Must match the key
+                that ``load_dataset_from_folder`` will see.
+            embedding: Pre-computed embedding vector.  Goes into
+                :attr:`content_vectors`.
+            md5: Pre-computed MD5 hex digest string.  Goes into
+                :attr:`content_md5s`.
+            metadata: Per-file custom metadata dict.  Goes into
+                :attr:`custom_metadata_map`.
+        """
+        if embedding is not None:
+            self.content_vectors[filename] = embedding
+        if md5 is not None:
+            self.content_md5s[filename] = md5
+        if metadata is not None:
+            self.custom_metadata_map[filename] = metadata
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Perform the import, populating *medias* in-place.
@@ -527,9 +583,12 @@ class DatasetImporter(PluginBase):
 
         Args:
             field_values: Mapping of :attr:`ImporterField.key` → value.
-                Fields with ``field_type="file"`` receive a Werkzeug
-                :class:`~werkzeug.datastructures.FileStorage` object; all
-                other fields receive plain strings.
+                Fields with ``field_type="file"`` receive an
+                :class:`~vtscore.plugins.uploads.UploadedFile` (Flask
+                requests pass a Werkzeug ``FileStorage`` straight
+                through; CLI invocations wrap the path argument in
+                :class:`~vtscore.plugins.uploads.CliUploadedFile`).
+                All other fields receive plain strings.
             medias: The global medias dict to populate.  Modify it in-place;
                 do not replace the reference.
             thin: When ``True``, store a ``media_path`` file reference
@@ -605,7 +664,7 @@ class DatasetImporter(PluginBase):
                         raise ValueError(f"Unknown converter: {spec.converter!r}")
                     converter = resolved
                     converter_cache[spec.converter] = converter
-                outs = converter.convert(raw, spec.params)
+                outs = converter.convert_normalized(raw, spec.params)
             for media in outs:
                 if media is None:
                     continue
@@ -931,10 +990,13 @@ class DatasetImporter(PluginBase):
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Load a dataset from CLI-provided *field_values* into *medias*.
 
-        The default implementation simply delegates to :meth:`run`, which
-        works for importers whose ``run()`` only expects plain string values.
-        Importers that expect non-string objects (e.g. ``FileStorage``) must
-        override this method to handle file-path strings appropriately.
+        The default implementation wraps any ``field_type="file"`` CLI
+        path argument in :class:`~vtscore.plugins.uploads.CliUploadedFile`
+        so :meth:`run` sees the same
+        :class:`~vtscore.plugins.uploads.UploadedFile` shape it does for
+        a Flask request, then delegates.  Subclasses only need to
+        override this method when the CLI path needs genuinely different
+        behaviour from the request-time flow (e.g. a chunked fast path).
 
         Args:
             field_values: Mapping of importer field keys to their CLI values.
@@ -942,7 +1004,9 @@ class DatasetImporter(PluginBase):
             thin: When ``True``, store file path references instead of
                 loading media bytes.  Passed through to :meth:`run`.
         """
-        self.run(field_values, medias, thin=thin)
+        from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
+
+        self.run(wrap_cli_file_fields(self.fields, field_values), medias, thin=thin)
 
     def build_cli_args(self, field_values: dict[str, Any]) -> str:
         """Build a CLI argument string that would recreate this import.

--- a/vtscore/datasets/importers/pickle/__init__.py
+++ b/vtscore/datasets/importers/pickle/__init__.py
@@ -52,7 +52,7 @@ class PickleDatasetImporter(DatasetImporter):
     ]
 
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
-        file_obj = field_values["file"]  # werkzeug FileStorage
+        file_obj = field_values["file"]  # UploadedFile (FileStorage / CliUploadedFile / BytesIOUploadedFile)
         progress = _get_progress()
         progress("loading", "Loading dataset from file...", 0, 0)
         DATA_DIR.mkdir(exist_ok=True)
@@ -62,21 +62,13 @@ class PickleDatasetImporter(DatasetImporter):
             import os
 
             os.close(fd)
-            if hasattr(file_obj, "save"):
-                file_obj.save(temp_path)
-            else:
-                temp_path.write_bytes(file_obj.read())
+            # UploadedFile.save() persists to disk; FileStorage, CliUploadedFile,
+            # and BytesIOUploadedFile all implement it.
+            file_obj.save(temp_path)
             load_dataset_from_pickle(temp_path, medias, thin=thin)
         finally:
             temp_path.unlink(missing_ok=True)
         progress("idle", f"Loaded {len(medias)} medias from file")
-
-    def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
-        """Load from a pickle file path (string) instead of FileStorage."""
-        file_path = Path(field_values["file"])
-        if not file_path.exists():
-            raise FileNotFoundError(f"Dataset file not found: {file_path}")
-        load_dataset_from_pickle(file_path, medias, thin=thin)
 
     @property
     def supports_chunked(self) -> bool:

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -246,7 +246,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
         - ``content_vectors`` maps each staged symlink basename to a
           pre-computed embedding vector.  Populated when the paths file
           is itself a ``.npz`` archive that holds vectors alongside the
-          paths.
+          paths.  Returned as a local dict (not threaded through
+          :meth:`~DatasetImporter.yield_precomputed`) so the singleton
+          importer instance does not accumulate per-import state.
         """
         paths_file = Path(field_values["paths_file"])
         paths, path_to_vector = _read_paths_and_vectors(paths_file)

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -1301,6 +1301,14 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
 
     Returns the task_id for progress tracking.
     """
+    from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
+
+    # Normalize ``field_type="file"`` values to UploadedFile.  The
+    # request path supplies a FileStorage / BytesIOUploadedFile already;
+    # the reload-from-origin path supplies a server path string that
+    # needs CliUploadedFile wrapping so ``run()`` doesn't have to
+    # branch on the input shape.
+    field_values = wrap_cli_file_fields(importer.fields, field_values)
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
     clipper_name = field_values.pop("clipper", "") or ""
@@ -1352,7 +1360,9 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     :data:`STAGING_DIR` and sets the ``staging_result`` field on the progress
     tracker when finished.
     """
+    from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
 
+    field_values = wrap_cli_file_fields(importer.fields, field_values)
     _request_user = get_current_user()
 
     def stage_task():

--- a/vtscore/labels/importers/base.py
+++ b/vtscore/labels/importers/base.py
@@ -8,10 +8,13 @@ will discover it automatically.
 Each importer also supports CLI usage via :meth:`~LabelImporter.add_cli_arguments`
 and :meth:`~LabelImporter.run_cli`.  The base class provides default
 implementations that derive CLI arguments from the :attr:`fields` list, so most
-importers work on the command line without any extra code.  Importers whose
-:meth:`run` expects non-string values (e.g. Werkzeug ``FileStorage`` objects)
-should override :meth:`run_cli` to handle the CLI-appropriate types (file paths
-as strings).
+importers work on the command line without any extra code.  ``field_type="file"``
+values arrive at :meth:`run` as a
+:class:`~vtscore.plugins.uploads.UploadedFile` regardless of the
+ingress path (Flask requests pass a Werkzeug ``FileStorage`` straight
+through; CLI invocations wrap the path argument in
+:class:`~vtscore.plugins.uploads.CliUploadedFile`), so plugin bodies
+never mention Werkzeug.
 
 The label format used throughout is a list of dicts::
 
@@ -86,10 +89,13 @@ class LabelImporter(PluginBase):
     From the CLI, labels can be applied indirectly by using the ``label_file``
     processor importer in a settings file for the autodetect workflow.
 
-    The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
-    :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override
-    either when the defaults are insufficient (e.g. when :meth:`run` expects a
-    Werkzeug ``FileStorage`` rather than a plain file path).
+    The default :meth:`add_cli_arguments` derives ``argparse`` arguments
+    from :attr:`fields` and :meth:`run_cli` wraps any
+    ``field_type="file"`` CLI argument in
+    :class:`~vtscore.plugins.uploads.CliUploadedFile` before delegating
+    to :meth:`run`, so plugin bodies written against the
+    :class:`~vtscore.plugins.uploads.UploadedFile` surface work
+    identically in both code paths.
     """
 
     #: Emoji or icon string shown next to the display name in the UI.
@@ -102,9 +108,12 @@ class LabelImporter(PluginBase):
 
         Args:
             field_values: Mapping of :attr:`LabelImporterField.key` → value.
-                Fields with ``field_type="file"`` receive a Werkzeug
-                :class:`~werkzeug.datastructures.FileStorage` object; all
-                other fields receive plain strings.
+                Fields with ``field_type="file"`` receive an
+                :class:`~vtscore.plugins.uploads.UploadedFile` (Flask
+                requests pass a Werkzeug ``FileStorage`` straight
+                through; CLI invocations wrap the path argument in
+                :class:`~vtscore.plugins.uploads.CliUploadedFile`).
+                All other fields receive plain strings.
 
         Returns:
             A list of dicts, each with ``"md5"`` and ``"label"`` keys.
@@ -125,9 +134,12 @@ class LabelImporter(PluginBase):
     def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
         """Import labels from CLI-provided *field_values*.
 
-        The default implementation simply delegates to :meth:`run`, which
-        works for importers whose ``run()`` only expects plain string values.
-        Importers that expect non-string objects (e.g. ``FileStorage``) must
-        override this method to handle file-path strings appropriately.
+        The default implementation wraps any ``field_type="file"`` CLI
+        path argument in :class:`~vtscore.plugins.uploads.CliUploadedFile`
+        so :meth:`run` sees the same
+        :class:`~vtscore.plugins.uploads.UploadedFile` shape it does for
+        a Flask request, then delegates.
         """
-        return self.run(field_values)
+        from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
+
+        return self.run(wrap_cli_file_fields(self.fields, field_values))

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -74,8 +74,11 @@ class PluginField:
 
     The ``field_type`` value drives how the frontend renders it:
 
-    - ``"file"``     – OS file-picker; value arrives as a Werkzeug
-      :class:`~werkzeug.datastructures.FileStorage` object.
+    - ``"file"``     – OS file-picker; value arrives as an
+      :class:`~vtscore.plugins.uploads.UploadedFile` (Werkzeug
+      ``FileStorage`` from a Flask request, a ``CliUploadedFile``
+      wrapping a path argument from the CLI, or a ``BytesIOUploadedFile``
+      for background-thread reads).
     - ``"folder"``   – Path text-input or OS folder-picker.
     - ``"url"``      – Text input pre-validated as a URL.
     - ``"text"``     – Generic single-line text input.

--- a/vtscore/plugins/uploads.py
+++ b/vtscore/plugins/uploads.py
@@ -1,0 +1,166 @@
+"""Normalized upload type shared by library-tier plugin bases.
+
+Library-tier plugin bases (:class:`vtscore.datasets.importers.base.DatasetImporter`,
+:class:`vtscore.labels.importers.base.LabelImporter`) declare
+``field_type="file"`` form inputs that historically arrived as a
+Werkzeug :class:`~werkzeug.datastructures.FileStorage` — a Flask-side
+type that the library tier is not supposed to know about.
+
+This module provides :class:`UploadedFile`, a structural protocol that
+both Flask's ``FileStorage`` and the CLI-side :class:`CliUploadedFile`
+adapter satisfy.  Plugin bodies can accept either source without
+importing any Flask / Werkzeug symbols:
+
+- The Flask request path passes the ``FileStorage`` straight through —
+  it already exposes ``.filename``, ``.read()`` / ``.stream``, and
+  ``.save(dst)``.
+- The CLI path (:meth:`DatasetImporter.run_cli`) wraps the user's
+  ``--file <path>`` argument in :class:`CliUploadedFile`, which exposes
+  the same surface backed by a local filesystem path.
+- The background-thread upload path
+  (``file_mode="bytesio"`` in :func:`vtsearch.routes._shared.validate_plugin_args`)
+  uses :class:`BytesIOUploadedFile`, which holds the upload bytes in
+  memory so the thread can read them after the Flask request context
+  has been torn down.
+
+All three carry a ``.filename`` attr (matching Werkzeug's name); the
+historical ``.name`` attr on the bytesio adapter remains as a back-compat
+shim for plugin code that still reads it.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, BinaryIO, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from vtscore.plugins import PluginField
+
+
+@runtime_checkable
+class UploadedFile(Protocol):
+    """Structural type for an uploaded file in a plugin field.
+
+    Satisfied by Werkzeug's :class:`~werkzeug.datastructures.FileStorage`
+    (Flask request uploads), :class:`CliUploadedFile` (CLI path
+    arguments), and :class:`BytesIOUploadedFile` (in-memory bytes for
+    background-thread consumption).  Plugin bodies that accept a
+    ``field_type="file"`` value should rely only on the attributes
+    declared here.
+    """
+
+    #: Original (user-visible) filename, never a server-side path.
+    filename: str
+
+    def read(self, size: int = -1) -> bytes:
+        """Return up to *size* bytes (all bytes when *size* is ``-1``)."""
+        ...
+
+    def save(self, dst: str | Path) -> None:
+        """Persist the upload to *dst* on the local filesystem."""
+        ...
+
+
+class CliUploadedFile:
+    """Adapter that exposes a local filesystem path as an :class:`UploadedFile`.
+
+    Used by :meth:`DatasetImporter.run_cli` (and the equivalent label /
+    settings importer methods) so a plugin body written against the
+    :class:`UploadedFile` surface can be reached from the CLI without
+    the plugin author handling string-vs-FileStorage branching.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self.filename = self._path.name
+        self._fh: BinaryIO | None = None
+
+    def _open(self) -> BinaryIO:
+        if self._fh is None:
+            self._fh = self._path.open("rb")
+        return self._fh
+
+    def read(self, size: int = -1) -> bytes:
+        fh = self._open()
+        return fh.read() if size == -1 else fh.read(size)
+
+    def save(self, dst: str | Path) -> None:
+        shutil.copyfile(self._path, dst)
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+
+    @property
+    def stream(self) -> BinaryIO:
+        return self._open()
+
+
+class BytesIOUploadedFile:
+    """In-memory :class:`UploadedFile` backed by a :class:`io.BytesIO` buffer.
+
+    Used by the dataset-importer request path
+    (``file_mode="bytesio"`` in :func:`validate_plugin_args`) so an
+    upload's bytes survive past the Flask request lifetime — the import
+    body runs in a background thread that may outlive the request, by
+    which time the underlying ``FileStorage`` is no longer readable.
+
+    The buffer exposes both ``.filename`` (UploadedFile-canonical) and
+    ``.name`` (back-compat: pre-existing plugin code reads either).
+    """
+
+    def __init__(self, data: bytes, filename: str) -> None:
+        self.filename = filename
+        self._buf = io.BytesIO(data)
+        # ``.name`` retained for plugins that read it (matches the
+        # pre-Phase-C in-tree convention).  ``BytesIO`` doesn't claim
+        # ``.name`` as part of its public surface, so setting it
+        # post-construction is safe.
+        self._buf.name = filename  # type: ignore[attr-defined]
+
+    @property
+    def name(self) -> str:
+        return self.filename
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buf.read() if size == -1 else self._buf.read(size)
+
+    def save(self, dst: str | Path) -> None:
+        Path(dst).write_bytes(self._buf.getvalue())
+
+    @property
+    def stream(self) -> BinaryIO:
+        return self._buf
+
+
+def wrap_cli_file_fields(fields: list[PluginField], field_values: dict[str, Any]) -> dict[str, Any]:
+    """Return *field_values* with each ``file`` field's path string
+    wrapped as a :class:`CliUploadedFile`.
+
+    Used by the default ``run_cli`` implementations on every plugin
+    family that accepts ``field_type="file"`` (dataset importers, label
+    importers).  Values that are already an :class:`UploadedFile`, or
+    ``None``, pass through untouched so CLI test harnesses constructing
+    field_values by hand can still inject fakes.
+    """
+    wrapped = dict(field_values)
+    for f in fields:
+        if f.field_type != "file":
+            continue
+        value = wrapped.get(f.key)
+        if value is None or isinstance(value, UploadedFile):
+            continue
+        if isinstance(value, (str, Path)):
+            wrapped[f.key] = CliUploadedFile(value)
+    return wrapped
+
+
+__all__ = [
+    "BytesIOUploadedFile",
+    "CliUploadedFile",
+    "UploadedFile",
+    "wrap_cli_file_fields",
+]

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -192,15 +192,17 @@ def validate_plugin_args(
     plugin:
         Any plugin instance with a :attr:`fields` declaration.
     file_mode:
-        How to surface file uploads.  ``"filestorage"`` (default) keeps
-        :class:`werkzeug.datastructures.FileStorage` objects — used by
+        How to surface file uploads.  Both modes satisfy the
+        :class:`~vtscore.plugins.uploads.UploadedFile` protocol.
+        ``"filestorage"`` (default) keeps the Werkzeug
+        :class:`~werkzeug.datastructures.FileStorage` object — used by
         label-importer routes where the file is consumed synchronously.
-        ``"bytesio"`` reads each upload into an in-memory
-        :class:`io.BytesIO` carrying the original filename on its
-        ``.name`` attribute — used by dataset-importer routes that hand
-        the file off to a background thread (the request context, and
-        the underlying ``FileStorage``, are torn down before the thread
-        reads).
+        ``"bytesio"`` wraps the upload bytes in a
+        :class:`~vtscore.plugins.uploads.BytesIOUploadedFile` carrying
+        the original filename — used by dataset-importer routes that
+        hand the file off to a background thread (the request context,
+        and the underlying ``FileStorage``, are torn down before the
+        thread reads).
     extra_keys:
         Pass-through keys whose values should ride along on the
         returned dict if present in the request body.  Each is copied
@@ -260,7 +262,7 @@ def _populate_file_fields(
     envelope (matching schema-level rejects); optional missing fields
     land in *validated* as ``None``.
     """
-    import io  # noqa: PLC0415 — defer to avoid import cost when unused
+    from vtscore.plugins.uploads import BytesIOUploadedFile  # noqa: PLC0415
 
     missing_files: list[str] = []
     for f in plugin.fields:
@@ -274,9 +276,7 @@ def _populate_file_fields(
                 validated[f.key] = None
             continue
         if file_mode == "bytesio":
-            buf = io.BytesIO(storage.read())
-            buf.name = storage.filename  # type: ignore[attr-defined]
-            validated[f.key] = buf
+            validated[f.key] = BytesIOUploadedFile(storage.read(), storage.filename or "")
         else:
             validated[f.key] = storage
 


### PR DESCRIPTION
## Summary

Phase C of `docs/plans/plugin-interface-streamlines.md` — bundles three independent shape-unification candidates under a single set of additive shims so external plugins keep working unchanged.

- **#9 — Converter param normalization.** New `MediaConverter.convert_normalized` runs `validate_params` + default-fills empty / missing keys before dispatching to `convert`, so `params` is non-`None` and fully-populated on every framework call path (importer multi-media ingestion, the converter folder runner, clipper-chain runner). `get_param` stays as a back-compat shim.
- **#13 — Drop Werkzeug from library tier.** New `vtscore.plugins.uploads` defines `UploadedFile` (`runtime_checkable` `Protocol`) plus `CliUploadedFile` and `BytesIOUploadedFile` adapters. The default `run_cli` on every file-accepting plugin family (and `_run_importer_in_background` / `_stage_importer_in_background`) wraps path strings before dispatch, so plugin bodies see one shape regardless of ingress. The pickle importer's `run_cli` override is deleted; library-tier base-class docstrings stop mentioning Werkzeug. Settled on `.filename` as the canonical attr per the open follow-up (`.name` retained as a back-compat shim on the bytesio adapter).
- **#2 — `yield_precomputed` helper.** `DatasetImporter.yield_precomputed(filename, *, embedding, md5, metadata)` collapses writes to the three legacy precomputed dicts into one helper call so a single miskeyed entry cannot land in only one or two of the parallel maps. The dicts stay public for back-compat.

The generator-based `RawMedia` shape proposed in the original #2 — paired with #12 implicit between-yield cancellation — is explicitly deferred. It isn't separable from #12, which has no scheduled work yet.

## Migration impact — external plugins

| Family | Cost |
|---|---|
| `DatasetImporter` (e.g. `recaller`) | None required. `file` fields on the CLI path now arrive as `UploadedFile` instead of raw strings; bodies that read `.filename` / `.read()` / `.save(dst)` keep working. |
| `LabelImporter` (e.g. `holder`) | None required. Same `UploadedFile` wrapping on the CLI path. |
| `MediaSource` (e.g. `pullwrest`) | None — sources don't participate in this candidate. |
| `LabelsetExporter` (e.g. `holder`) | None — exporters don't participate. |
| Third-party converters | None required. Framework-routed `convert()` calls now see validated + default-filled `params`; subclasses that route reads through `get_param` keep working; direct-`convert()` callers keep getting raw params (intentional shim). |

## Test plan

- [x] `./run-tests.sh` — 4277 pass, 1 skipped (was 4255 pre-Phase-C; +22 new tests in `tests_lib/datasets/test_phase_c.py` covering `convert_normalized` validation / default-fill / out-of-range rejection, the three `UploadedFile` adapters, `wrap_cli_file_fields` semantics, and `yield_precomputed` dict routing)
- [x] Updated `tests/converters/test_converter_selection.py` mock helper to mirror `convert_normalized.return_value` alongside `convert.return_value` so existing MagicMock-based runner tests still pass
- [x] Updated `tests_lib/io/test_importers.py::test_default_run_drives_converter_per_spec` to expect the coerced `int` (`{"n_clips": 2}`) instead of the raw string — framework now validates params through the schema

https://claude.ai/code/session_01892bf71sJMPRLRe5B7x6ci

---
_Generated by [Claude Code](https://claude.ai/code/session_01892bf71sJMPRLRe5B7x6ci)_