### PR TITLE
Make demo table fill modal height instead of capping at 50vh

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
@@ -4,6 +4,20 @@
 // modal that consumes <vt-source-picker>.  Layout-only styles unique to
 // this widget remain below.
 
+// Default host: flex column so child regions can opt into `flex: 1`.
+// Stays at natural height by default; only grows when the demo view is
+// active (see `:host:has(.demo-picker)` below) so the demo table can
+// claim the modal body's remaining height instead of capping itself.
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+:host:has(.demo-picker) {
+  flex: 1 1 auto;
+}
+
 .importer-picker,
 .demo-picker,
 .server-folder-browser,
@@ -15,7 +29,15 @@
 
 .importer-picker { gap: 0; margin-bottom: var(--space-lg); }
 
-.demo-picker { gap: var(--space-lg); }
+.demo-picker {
+  gap: var(--space-lg);
+  // Fill the host so the demo table inside can be the only scrollable
+  // region; min-height: 0 lets the flex algorithm actually shrink it
+  // (otherwise the implicit `min-height: auto` would force it to the
+  // table's full content height and re-introduce the body scrollbar).
+  flex: 1 1 auto;
+  min-height: 0;
+}
 
 .server-folder-browser { gap: var(--space-lg); }
 .sf-browse-section { gap: var(--space-sm); }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -154,13 +154,17 @@
   font-size: var(--font-lg);
 }
 
-// Media picker view container
+// Media picker view container.  Participates in the modal-body flex
+// chain (`flex: 1 1 auto; min-height: 0`) so the inner demo table can
+// claim remaining height instead of capping itself with a fixed
+// max-height that produces a nested scrollbar.
 .media-picker {
-  min-height: 320px;
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 // `.back-btn` from `_components.scss` already sets `align-self: flex-start`.

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -245,6 +245,13 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  // Flex column so a designated inner region (e.g. the demo table in the
+  // Add Dataset modal) can claim remaining space via `flex: 1` instead of
+  // capping itself with a hard-coded max-height that produces a second
+  // scrollbar nested inside the body's scrollbar. Normal block stacking
+  // is preserved for modals whose children all use natural height.
+  display: flex;
+  flex-direction: column;
 }
 
 .modal-footer {

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -87,8 +87,12 @@
 // --- Demo table ---
 
 .demo-content-area {
+  // Fill remaining height inside the demo picker so the table is the
+  // only scrollable region. Without this, a hard-coded max-height would
+  // produce a nested scrollbar inside the modal body's scrollbar
+  // whenever the modal grew taller than its fixed cap.
+  flex: 1 1 0;
   min-height: 200px;
-  max-height: 50vh;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary

The Add Dataset modal previously rendered two nested vertical scrollbars whenever the modal's content exceeded its 85vh cap: one on the demo table itself (`.demo-content-area { max-height: 50vh; overflow-y: auto }`) and another on `.modal-body` once the demo table plus the surrounding form fields pushed past available space. A vertical scrollbar inside a vertical scrollbar is almost impossible to use.

Fix: wire a flex chain through `modal-body` → `vt-source-picker` host → `.demo-picker` → `.demo-content-area` so the demo table claims whatever remains after the importer tabs, media-type picker, and dataset-name input have taken their natural height. The source-picker host opts into `flex: 1` only when a `.demo-picker` is rendered (via `:has()`), so the server-folder / local-folder / importer-form views keep their existing natural stacking. The same flex behaviour is applied to the New Detector modal's `.media-picker`, which embeds the same `<vt-source-picker>`.

`.modal-body` keeps `overflow-y: auto` as a fallback for genuinely compressed viewports — the user explicitly asked for the modal itself not to scroll "unless it's REALLY compressed."

## Test plan
- [ ] Open Add Dataset → Demo tab → confirm only the demo table scrolls (no double scrollbar)
- [ ] Resize the browser shorter and confirm the demo table shrinks to fit and remains the only scrollable region until the viewport gets too small for the form fields to fit
- [ ] Switch between Services / Server / Local / Demo tabs and confirm non-demo views still look correct (no empty whitespace, natural stacking)
- [ ] Open New Detector → Browse Media → confirm the embedded demo table also fills available height without a nested scrollbar

https://claude.ai/code/session_01RKZ5HDUzMZVDQxf2PuHKFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKZ5HDUzMZVDQxf2PuHKFC)_