### PR TITLE
New Detector: move Name to bottom + audit required stars

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -14,20 +14,6 @@
     </div>
 
     <form class="new-detector-form" (ngSubmit)="submit()">
-      <div class="form-group">
-        <label class="col-label" for="detector-name" title="A short name to identify this detector">Detector Name <span class="required">*</span></label>
-        <input
-          id="detector-name"
-          class="form-input"
-          [ngModel]="name"
-          (ngModelChange)="onNameInput($event)"
-          name="name"
-          placeholder="e.g. Dog Barks"
-          title="A short name to identify this detector"
-          autofocus
-        />
-      </div>
-
       @if (tab === 'blank' && !effectiveSoloMediaType) {
         <div class="form-group">
           <label class="col-label" title="The type of media this detector will process">Media Type</label>
@@ -260,6 +246,19 @@
           </div>
         }
       }
+
+      <div class="form-group">
+        <label class="col-label" for="detector-name" title="A short name to identify this detector">Detector Name</label>
+        <input
+          id="detector-name"
+          class="form-input"
+          [ngModel]="name"
+          (ngModelChange)="onNameInput($event)"
+          name="name"
+          placeholder="e.g. Dog Barks"
+          title="A short name to identify this detector"
+        />
+      </div>
 
       @if (error) {
         <p class="error-text">{{ error }}</p>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -255,6 +255,7 @@ export class NewDetectorModalComponent implements OnInit {
           this.exampleMediaType = this.mediaType;
           this.exampleThumbFailed = false;
           this.pendingText = '';
+          this.autoFillNameFromExample();
           this.submitting = false;
         },
         error: (err) => {
@@ -272,6 +273,26 @@ export class NewDetectorModalComponent implements OnInit {
    *  becomes a single-line name. */
   private sanitizeName(text: string): string {
     return text.trim().replace(/\s+/g, ' ');
+  }
+
+  /** Strip a trailing extension and the leading path so a filename like
+   *  ``/foo/bar/My Sound.wav`` becomes ``My Sound``. */
+  private nameFromFilename(text: string): string {
+    const base = text.split(/[\\/]/).pop() || text;
+    const dot = base.lastIndexOf('.');
+    return dot > 0 ? base.slice(0, dot) : base;
+  }
+
+  /** Auto-derive the detector name from the picked example while the user
+   *  hasn't typed into the name field. Lets the user fill the form
+   *  top-down and leave Name blank. */
+  private autoFillNameFromExample(): void {
+    if (this.nameTouched) return;
+    if (this.exampleType === 'media' && this.exampleDisplay) {
+      this.name = this.sanitizeName(this.nameFromFilename(this.exampleDisplay));
+    } else if (this.pendingText) {
+      this.name = this.sanitizeName(this.pendingText);
+    }
   }
 
   onPendingTextInput(value: string): void {
@@ -555,6 +576,7 @@ export class NewDetectorModalComponent implements OnInit {
         this.exampleMediaType = this.activeDemoTab || this.mediaType;
         this.exampleThumbFailed = false;
         this.pendingText = '';
+        this.autoFillNameFromExample();
         this.demoFileLoading = false;
         this.view = 'main';
       },
@@ -601,6 +623,7 @@ export class NewDetectorModalComponent implements OnInit {
         this.exampleMediaType = this.mediaType || this.mediaTypeFromFilename(raw);
         this.exampleThumbFailed = false;
         this.pendingText = '';
+        this.autoFillNameFromExample();
         this.sfFileSelecting = false;
         this.view = 'main';
       },
@@ -646,6 +669,7 @@ export class NewDetectorModalComponent implements OnInit {
           this.exampleMediaType = mediaType || this.mediaType;
           this.exampleThumbFailed = false;
           this.pendingText = '';
+          this.autoFillNameFromExample();
           // Close the picker if it was open so the user lands back on the form.
           if (this.view === 'media-picker') this.view = 'main';
         },

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -149,6 +149,7 @@ class CombineDatasetsImporter(DatasetImporter):
             # Display-only — not part of the dataset's identity, so leave it
             # out of the persisted origin to keep reloads deterministic.
             include_in_origin=False,
+            required=False,
         ),
     ]
 

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -207,6 +207,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             field_type="select",
             description="Type of media files contained in the archive.",
             default="audio",
+            required=False,
         ),
     ]
 

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -194,6 +194,7 @@ class ReCallerDatasetImporter(DatasetImporter):
             options=all_folder_names(),
             default="audio",
             description="The media type this dataset will hold.  Source-type rows below specify which ReCaller record types to pull in and how to convert them to this output type.",
+            required=False,
         ),
         ImporterField(
             key="query_id",

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -208,6 +208,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 "row with a matching converter pulls them in too."
             ),
             default="audio",
+            required=False,
         ),
         ImporterField(
             key="paths_file",

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -169,6 +169,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
             field_type="select",
             description="Type of media files the dataset ends up holding.",
             default="audio",
+            required=False,
         ),
         ImporterField(
             key="path",

--- a/vtscore/datasets/importers/synthetic/__init__.py
+++ b/vtscore/datasets/importers/synthetic/__init__.py
@@ -55,6 +55,7 @@ class SyntheticDatasetImporter(DatasetImporter):
             description="What kind of media to generate.",
             options=_SUPPORTED_MEDIA_TYPES,
             default="image",
+            required=False,
         ),
         ImporterField(
             key="size",
@@ -65,6 +66,7 @@ class SyntheticDatasetImporter(DatasetImporter):
             placeholder="100",
             min="1",
             step="1",
+            required=False,
         ),
     ]
 


### PR DESCRIPTION
## Summary

- **New Detector modal:** moved **Detector Name** from the top of the form to the bottom and dropped its required-star. Users fill the form top-down (text seed or media example), and the name auto-derives from whichever they picked — so the field is normally already filled by the time it scrolls into view. The text-seed → name mirror was already there; this PR adds the same auto-fill for media examples (strips the path + extension from the picked filename). Submit is still gated on a non-empty name, so manually clearing the auto-filled value still disables Create.
- **Required-star audit:** walked every PluginField across importers, exporters, label importers, settings I/O, and converters. Pulldowns and number inputs that always have a usable default now declare `required=False`, so the rendered form drops their stars. Truly blocking fields (paths, URLs, emails, demo dataset picker, etc.) keep `required=True`. Specifically:
  - `media_type` in `http_archive`, `server_folder`, `server_files`, `recaller`, `synthetic` (all default to a media type)
  - `size` in `synthetic` (defaults to 100)
  - `name` in `combine_datasets` (falls back to importer display name when blank)
- Modal-driven hardcoded stars (e.g. `combine-detectors-modal` "New Name", source-picker file/folder pickers, "Import Labels From") were checked and left as-is — they are truly required to proceed.

## Test plan

- [x] `./run-tests.sh` — 4255 passed, 1 skipped
- [ ] Smoke test in browser: open **New Detector**, pick a media example, confirm name auto-fills from the filename; type a text seed, confirm name still mirrors; type into the name field, confirm it stops mirroring.
- [ ] Open **Add Dataset** with each in-tree importer, confirm the audited fields no longer show a star while the truly-required ones still do.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP2bbjJHppX1AVmG3VRpZV)_