### PR TITLE
Lazy-load icon SVGs (#4) + API services audit (#5)

### DIFF
--- a/docs/plans/frontend-bundle-organization.md
+++ b/docs/plans/frontend-bundle-organization.md
@@ -1,7 +1,8 @@
 # Frontend bundle organization
 
-Status: **#1 shipped (all five checkpoints). #2 shipped. #3 shipped.**
-Items #4–#6 are scoped but not started.
+Status: **#1 shipped (all five checkpoints). #2 shipped. #3 shipped.
+#4 shipped. #5 investigation shipped (per-domain split deferred as a
+follow-up).** Item #6 is scoped but not started.
 
 ## What shipped
 
@@ -215,6 +216,45 @@ Items #4–#6 are scoped but not started.
   smaller delegations.  Structural goal — three focused files
   (directive, service, pure factory) instead of one 1200-line
   coordinator — is what shipped.
+- **#4 Lazy-load icon SVGs**: split `IconComponent`'s 42 inline SVGs
+  out of the eager bundle.  Shell now ships only the 5 icons the
+  `DialogHostComponent` needs (`warning`, `x-circle`, `check`,
+  `info`, plus the `file` fallback) plus the dynamic letter glyph;
+  the other 37 SVGs live in `icon-svgs-extended.ts` which the
+  component lazy-loads via dynamic `import()` the first time a
+  non-shell icon is requested.  Each loaded SVG is sanitised and
+  cached on a static `Map` shared across every `IconComponent`
+  instance — sanitisation per icon happens once per process.
+  Rendering switched from a giant `@switch` template with one
+  `<svg>` branch per icon name to `[innerHTML]="svgHtml"` on a
+  wrapper span sized via CSS variables; the inner SVG (with `viewBox
+  0 0 24 24`) scales to the wrapper's `width` / `height`, replacing
+  the previous per-SVG `[attr.width]` / `[attr.height]` bindings.
+  No call-site changes — `<vt-icon [icon]>` / `[type]` / `[size]`
+  inputs are byte-identical.
+  **Bundle effect.** Initial bundle dropped from 537.45 kB → 525.73
+  kB raw (139.53 → 137.54 kB gzip); a new `icon-svgs-extended` lazy
+  chunk weighs 12.09 kB raw / 1.81 kB gzip and is referenced by
+  every lazy chunk that uses non-shell icons (dashboard,
+  label-view, all of the deferred modals).  First render of an
+  extended icon waits one microtask for the dynamic import to
+  resolve — visually invisible in practice because the lazy chunk
+  the icon ships inside already gates on its own download.
+- **#5 API services audit** (investigation only): documented that
+  the four big hand-written API services (`detectors-api`,
+  `datasets-api`, `sorting-api`, `medias-api`) already delegate
+  almost every call to the `ng-openapi-gen` generated `fn/`
+  modules — the "fold-into-generated-client" half of the original
+  plan is effectively done. The remaining direct `this.http.*`
+  calls are all justified (FormData uploads for plugin endpoints
+  whose body shape isn't in the OpenAPI spec, plus one blob
+  download). The real eager-bundle cost identified by the audit is
+  that `activeContextGuard` → `ContextSwitchService` statically
+  imports the full `DetectorsApiService` and `DatasetsApiService`
+  even though `ContextSwitchService` only calls 4 endpoints across
+  the two. A per-domain split of both services is the next move,
+  but is left as a follow-up (see Open follow-ups) — the
+  investigation is what shipped here, not the refactor.
 - **#1 Checkpoint 4**: extracted `<vt-source-picker>` — the importer
   category-tab + sub-tab chrome plus the source-side widgets (demo
   media-type tabs + sortable demo table, server-folder typed-path
@@ -444,48 +484,107 @@ After: `LabelViewComponent` is route-level wiring (data loading +
 inclusion + autopilot coordination), with layout / interaction
 concerns owned by directives and services.
 
-### #4 — Lazy-load icon SVGs
-
-`IconComponent` (663 lines / 20 KB) ships every one of its 42 inline
-SVGs into `main.js` because `DialogHostComponent` imports it. Most
-icons are only used inside deferred modals.
-
-Concrete moves:
-
-- Split the SVG table out into a separate data module
-  `icon-svgs.ts` that exports `{ name: string }`.
-- Partition into "shell icons" (the 5-10 the shell actually needs)
-  vs "modal icons" (the rest). The shell tier imports its set
-  statically; modal icons are looked up via a dynamic import on
-  first use, or partitioned into a separate `IconComponent` variant
-  that the modals import.
-
-After: ~15 KB of SVG markup moves out of the initial bundle into
-the deferred chunks that actually use it.
+### #4 — Lazy-load icon SVGs (shipped — see "What shipped")
 
 ### #5 — Audit API services vs auto-generated client
 
 `detectors-api.service.ts` (435 lines / 21 KB),
-`datasets-api.service.ts` (338 lines / 17 KB),
+`datasets-api.service.ts` (344 lines / 17 KB),
 `vote-state.service.ts` (401 lines / 15 KB),
 `sorting-api.service.ts` (278 lines / 14 KB) are each flat method
 bags directly mirroring REST endpoints. `ng-openapi-gen` runs on
 `prebuild` and ships its own copy of the request/response models and
 operation wrappers under `src/app/generated/api-client/`.
 
-Investigation:
+#### Investigation findings
 
-- Survey overlap: how many endpoints in the four hand-written
-  services already exist in the generated client?
-- For the overlapping ones, can the hand-written wrappers delegate to
-  the generated functions, removing the duplicate model imports?
-- If `detectors-api` is irreducibly big, split per-concern
-  (`detectors-crud`, `detectors-train`, `detectors-find`,
-  `detectors-labels`) so consumers only drag in the slice they need.
+**Overlap with the generated client: already high.** Each hand-written
+API service is already delegating almost every call to the generated
+`fn/` modules:
 
-Outcome: investigation report inline below before any refactor; then
-follow-up either as a fold-into-generated-client task or a per-domain
-split task.
+| Service                         | Generated imports | Direct `this.http.*` calls |
+|---------------------------------|-------------------|----------------------------|
+| `detectors-api.service.ts`      | 87                | 2 (plugin upload only)     |
+| `datasets-api.service.ts`       | 61                | 8 (FormData / blob only)   |
+| `sorting-api.service.ts`        | 49                | 6 (FormData uploads)       |
+| `medias-api.service.ts`         | 11                | 1 (FormData upload)        |
+| `label-importers-api.service.ts`| 5                 | 4 (FormData uploads)       |
+
+The remaining direct `http.*` calls are all justified — they hit
+plugin endpoints whose body shape is plugin-defined (not in the
+OpenAPI spec) or stream a blob download. So the "fold-into-generated-
+client" half of the original plan is **already done**; there is no
+meaningful overlap left to remove. The wrapper services still add
+value: cleaner names (`list()` vs `listDetectors()`), `r.body`
+unwrapping so callers don't see `StrictHttpResponse`, and type
+narrowing where the generated types are loose (e.g. the
+`ImporterInfo` cast on the importer-listing return).
+
+**`vote-state.service.ts` is not in scope.** Despite its size it is
+not an API service — it owns vote state with optimistic updates and
+undo/redo bookkeeping, using `MediasApiService` and
+`SortingApiService` for HTTP. Folding it into the generated client
+isn't applicable.
+
+**The real eager-bundle cost: per-domain splitting is justified.**
+The eager bundle pulls in the full `DetectorsApiService` (435 lines)
+and `DatasetsApiService` (344 lines) via this static chain:
+
+```
+app.routes.ts  →  activeContextGuard  →  ContextSwitchService
+                                          →  DatasetsApiService
+                                          →  DetectorsApiService
+```
+
+But `ContextSwitchService` only calls **4 endpoints** across both
+services:
+
+- `datasetsApi.loadRegistered(id)`
+- `datasetsApi.cancelTask(id)`
+- `detectorsApi.loadDetector(id)`
+- `detectorsApi.cancelDetectorLoadingTask(id)`
+
+The other ~80 methods (find, scoring, CRUD, registry, extractors,
+localizers, pregen processors, labels, …) are only called from lazy
+chunks (dashboard, label-view, find-view, the deferred modals), but
+they all ship in the eager bundle today because Angular cannot
+tree-shake methods off an injectable class.
+
+#### Follow-up: per-domain split (not started, scope-only)
+
+Split `DetectorsApiService` and `DatasetsApiService` along the
+section boundaries already documented in the source:
+
+- `DetectorsApiService` → `DetectorsCrudApiService` (list/create/
+  get/delete/rename/labels/combine/examples) +
+  `DetectorsRegistryApiService` (registry list/load/unload/rename/
+  cancel/autorun/labelset-move/from-labelset) +
+  `DetectorScoringApiService` (auto-detect, extract/auto-extract,
+  localize/auto-localize) + `DetectorFindApiService` (find,
+  find-label, find-check-labels, cancelFind) +
+  `ProcessorsApiService` (autorun-extractors, autorun-localizers,
+  pregen-processors).
+- `DatasetsApiService` → `DatasetsCrudApiService` (importers
+  listings, import, stage, clear, export, detect-media-type) +
+  `DatasetsRegistryApiService` (registry list/load/unload/rename/
+  stats/readers + cancel) + `DatasetsListingsApiService` (clippers,
+  embedders, converters, media-types, demo categories/list) +
+  `DatasetsUiApiService` (dashboard disk/RAM usage, browse-media-
+  files, select-browsed-file).
+
+`ContextSwitchService` then imports only the two registry slices,
+keeping CRUD/scoring/find/listings/UI out of the eager bundle.
+
+The split is mostly mechanical (no logic change, no API change to
+the generated client) but touches **all consumers** of the two
+services — ~10 components and a handful of other services for
+detectors-api, similar fan-out for datasets-api. Defer until after
+#6 lands so the gzip-budget reading isn't disturbed by an unrelated
+refactor.
+
+Outcome: investigation report shipped (this section). No refactor
+required for the "fold-into-generated-client" angle. The per-domain
+split is a scoped follow-up.
 
 ### #6 — Switch budget metric to compressed size
 
@@ -517,12 +616,19 @@ functionality is added.
 
 ## Open follow-ups
 
-- **Roll the warning budget back to 525 kB** (or lower) once a few
-  more checkpoints land. Current initial total is 526.40 kB against a
-  540 kB warning threshold; the previous 525 kB threshold was bumped
-  on `4bd4cc40` and the headroom restored by Checkpoint 1 means the
-  bump is no longer needed. Hold off on the budget edit until #1's
-  remaining checkpoints and #4 are in so we don't ping-pong the
-  threshold across PRs. Requires user approval (CLAUDE.md says budget
-  bumps — including reductions that could break future PRs — are
-  user-decisions).
+- **#5 follow-up: per-domain split of `DetectorsApiService` /
+  `DatasetsApiService`** to keep CRUD / scoring / find / listings /
+  UI out of the eager bundle. Mechanical refactor — no logic change —
+  but touches every consumer (~10 components per service). Defer
+  until #6 lands so a gzip-budget reading isn't disturbed by an
+  unrelated refactor. Scope and rationale documented inline under
+  "#5 — Audit API services vs auto-generated client".
+
+- **Roll the warning budget back to 525 kB** (or lower) now that
+  #1–#4 are in. Current initial total is 525.73 kB raw / 137.54 kB
+  gzip against the 540 kB warning threshold; the previous 525 kB
+  threshold was bumped on `4bd4cc40` and the gains from #1
+  (Checkpoints 1-5) plus #4 mean the bump is no longer needed.
+  Requires user approval (CLAUDE.md says budget bumps — including
+  reductions that could break future PRs — are user-decisions).
+  Combine with #6 (flip to gzip metric) if that lands first.

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -1,0 +1,85 @@
+/**
+ * Extended icon SVGs — split out of the initial bundle.
+ *
+ * Loaded lazily by `IconComponent` via `loadExtendedIconSvgs()` the
+ * first time a non-shell icon is rendered. All callers live behind
+ * lazy routes or `@defer`-loaded modals (dashboard, label-view, the
+ * importer / new-detector / settings modals, …) so the extra
+ * round-trip happens after the shell is already interactive.
+ */
+export const EXTENDED_ICON_SVGS: Record<string, string> = {
+  audio:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>',
+  image:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>',
+  'file-text':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>',
+  video:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>',
+  document:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>',
+  server:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>',
+  globe:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>',
+  email:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,4 12,13 2,4"/></svg>',
+  satellite:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12 7 2"/><path d="M7 2l5 10"/><path d="M12 12l5-10"/><path d="M17 2l5 10"/><circle cx="12" cy="18" r="4"/><line x1="12" y1="14" x2="12" y2="12"/></svg>',
+  folder:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>',
+  'folder-open':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="9" y1="14" x2="15" y2="14"/></svg>',
+  upload:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>',
+  database:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4.03 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/></svg>',
+  graduation:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>',
+  'arrow-up':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>',
+  shuffle:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg>',
+  elephant:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 8c0-3.3-2.7-6-6-6H8C5.8 2 4 3.8 4 6v4c0 1.1.9 2 2 2h1v6c0 1.1.9 2 2 2h1v-4h4v4h1c1.1 0 2-.9 2-2v-6h1c1.1 0 2-.9 2-2V8z"/><circle cx="9" cy="8" r="1"/></svg>',
+  cloud:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>',
+  robot:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><line x1="12" y1="4.5" x2="12" y2="7"/><rect x="4" y="7" width="16" height="12" rx="2.5"/><path d="M4 11a2 2 0 0 0 0 4"/><path d="M20 11a2 2 0 0 1 0 4"/><circle cx="9.5" cy="12.5" r="1.2"/><circle cx="14.5" cy="12.5" r="1.2"/><line x1="10" y1="16" x2="14" y2="16"/></svg>',
+  list:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>',
+  grid:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
+  'cursor-click':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/><line x1="13" y1="13" x2="20" y2="20"/><line x1="16" y1="21" x2="21" y2="16"/><line x1="17.5" y1="17.5" x2="19.5" y2="19.5"/></svg>',
+  'cursor-hover':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/></svg>',
+  palette:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c1.1 0 2-.9 2-2 0-.5-.2-1-.5-1.3-.3-.4-.5-.8-.5-1.3 0-1.1.9-2 2-2h2.4c3 0 5.6-2.5 5.6-5.6C23 6.4 18 2 12 2z"/><circle cx="7.5" cy="11.5" r="1"/><circle cx="10" cy="7.5" r="1"/><circle cx="14.5" cy="7.5" r="1"/><circle cx="17.5" cy="11.5" r="1"/></svg>',
+  'sort-descending':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="4" x2="15" y2="4"/><line x1="3" y1="9" x2="13" y2="9"/><line x1="3" y1="14" x2="11" y2="14"/><line x1="3" y1="19" x2="9" y2="19"/><polyline points="19 10 19 20"/><polyline points="16 17 19 20 22 17"/></svg>',
+  'steering-wheel':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="2"/><line x1="12" y1="4" x2="12" y2="1"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4" y1="12" x2="1" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="6.34" y1="6.34" x2="4.22" y2="4.22"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/><line x1="6.34" y1="17.66" x2="4.22" y2="19.78"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/></svg>',
+  'cloud-upload':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>',
+  'thumbs-up':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>',
+  'thumbs-down':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>',
+  factory:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8l-7 5V8l-7 5V4a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/><path d="M17 18h1"/><path d="M12 18h1"/><path d="M7 18h1"/></svg>',
+  house:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>',
+  lightning:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  flask:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>',
+  cubes:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h18v18H2z"/><path d="M2 4l2-2h18v18l-2 2"/><path d="M20 4l2-2"/><path d="M11 4v18M2 13h18"/><path d="M11 4l2-2"/><path d="M20 13l2-2"/></svg>',
+  'checkbox-checked':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3" ry="3"/><polyline points="8 12 11 15 16 9"/></svg>',
+  search:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>',
+  trophy:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4h12v4a6 6 0 0 1-12 0z"/><path d="M6 6H3a2 2 0 0 0 0 4h3"/><path d="M18 6h3a2 2 0 0 1 0 4h-3"/><line x1="10" y1="14" x2="10" y2="18"/><line x1="14" y1="14" x2="14" y2="18"/><rect x="7" y="18" width="10" height="3" rx="1"/></svg>',
+};

--- a/frontend/src/app/components/icon/icon-svgs.ts
+++ b/frontend/src/app/components/icon/icon-svgs.ts
@@ -1,0 +1,65 @@
+/**
+ * Shell icon SVGs — kept in the initial bundle.
+ *
+ * Only the icons that components in the eager app shell (today: the
+ * `DialogHostComponent`, which renders ``info`` / ``warning`` /
+ * ``x-circle`` / ``check`` for confirm/prompt dialogs) plus the
+ * ``file`` fallback live here. Every other icon is lazy-loaded by
+ * `IconComponent` from `icon-svgs-extended.ts` on first request.
+ *
+ * SVGs are stored as plain strings without ``width`` / ``height``
+ * attributes — `IconComponent` sets the size on its wrapper span so
+ * the SVG (which has a 24x24 ``viewBox``) scales via CSS.
+ */
+export const SHELL_ICON_SVGS: Record<string, string> = {
+  check:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>',
+  warning:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  'x-circle':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
+  info:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
+  file:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>',
+};
+
+let extendedCache: Record<string, string> | null = null;
+let extendedPromise: Promise<Record<string, string>> | null = null;
+
+/**
+ * Lazy-load the extended icon table.  Returns a cached map on
+ * subsequent calls so the dynamic import fires at most once per
+ * process.
+ */
+export function loadExtendedIconSvgs(): Promise<Record<string, string>> {
+  if (extendedCache) return Promise.resolve(extendedCache);
+  if (!extendedPromise) {
+    extendedPromise = import('./icon-svgs-extended').then((m) => {
+      extendedCache = m.EXTENDED_ICON_SVGS;
+      return extendedCache;
+    });
+  }
+  return extendedPromise;
+}
+
+/** Returns the extended map only if it has already been loaded. */
+export function peekExtendedIconSvgs(): Record<string, string> | null {
+  return extendedCache;
+}
+
+/**
+ * Build the SVG for a single capital letter glyph (A–Z), used by
+ * `IconComponent` when the icon resolves to a single uppercase letter.
+ */
+export function letterGlyphSvg(letter: string): string {
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<rect x="2" y="2" width="20" height="20" rx="5" ry="5"/>' +
+    '<text x="12" y="17" text-anchor="middle" font-size="14" font-weight="600" ' +
+    'font-family="system-ui, sans-serif" fill="currentColor" stroke="none">' +
+    letter +
+    '</text></svg>'
+  );
+}

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -1,5 +1,13 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+import {
+  SHELL_ICON_SVGS,
+  letterGlyphSvg,
+  loadExtendedIconSvgs,
+  peekExtendedIconSvgs,
+} from './icon-svgs';
 
 /**
  * Maps emoji strings (from backend or hardcoded) to an SVG icon type.
@@ -23,31 +31,31 @@ function emojiToType(icon: string): string {
   // Pass through known SVG type names directly
   if (KNOWN_TYPES.has(icon)) return icon;
   // Normalise: strip variation selectors (U+FE0E, U+FE0F)
-  const norm = icon.replace(/[\uFE0E\uFE0F]/g, '');
+  const norm = icon.replace(/[︎️]/g, '');
   const map: Record<string, string> = {
     // Infrastructure
-    '\uD83D\uDDA5': 'server',      // 🖥
-    '\uD83C\uDF10': 'globe',       // 🌐
-    '\uD83D\uDCE7': 'email',       // 📧
-    '\uD83D\uDCE1': 'satellite',   // 📡
+    '🖥': 'server',      // 🖥
+    '🌐': 'globe',       // 🌐
+    '📧': 'email',       // 📧
+    '📡': 'satellite',   // 📡
     // Files & folders
-    '\uD83D\uDCC2': 'folder-open', // 📂
-    '\uD83D\uDCC1': 'folder',      // 📁
-    '\uD83D\uDCE4': 'upload',      // 📤
+    '📂': 'folder-open', // 📂
+    '📁': 'folder',      // 📁
+    '📤': 'upload',      // 📤
     // Actions & misc
-    '\uD83C\uDF93': 'graduation',  // 🎓
-    '\uD83C\uDFED': 'factory',     // 🏭
-    '\uD83E\uDDEA': 'factory',     // 🧪 — alias for synthetic-data factory
-    '\uD83D\uDDC4': 'database',     // 🗄
-    '\u2B06': 'arrow-up',          // ⬆
-    '\uD83D\uDD00': 'shuffle',     // 🔀
-    '\uD83D\uDC18': 'elephant',    // 🐘
-    '\u2601': 'cloud',             // ☁
-    '\u2705': 'check',             // ✅
+    '🎓': 'graduation',  // 🎓
+    '🏭': 'factory',     // 🏭
+    '🧪': 'factory',     // 🧪 — alias for synthetic-data factory
+    '🗄': 'database',     // 🗄
+    '⬆': 'arrow-up',          // ⬆
+    '🔀': 'shuffle',     // 🔀
+    '🐘': 'elephant',    // 🐘
+    '☁': 'cloud',             // ☁
+    '✅': 'check',             // ✅
     // Dialog types
-    '\u26A0': 'warning',            // ⚠
-    '\u274C': 'x-circle',           // ❌
-    '\u2139': 'info',               // ℹ
+    '⚠': 'warning',            // ⚠
+    '❌': 'x-circle',           // ❌
+    'ℹ': 'info',               // ℹ
   };
   if (map[norm]) return map[norm];
   // Single capital letter → pass through as letter icon
@@ -55,141 +63,23 @@ function emojiToType(icon: string): string {
   return 'file';
 }
 
+/**
+ * Cache of sanitised SVG markup keyed by icon name (or
+ * ``__letter:<X>`` for letter glyphs).  Shared across every
+ * `IconComponent` instance — sanitisation per icon happens once per
+ * process and the result is trusted SVG that Angular can blit via
+ * ``[innerHTML]``.
+ */
+const sanitizedCache = new Map<string, SafeHtml>();
+
 @Component({
   selector: 'vt-icon',
   standalone: true,
   imports: [CommonModule],
   template: `
-    @if (letterChar) {
-      <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><text [attr.x]="12" [attr.y]="17" text-anchor="middle" font-size="14" font-weight="600" font-family="system-ui, sans-serif" fill="currentColor" stroke="none">{{ letterChar }}</text></svg>
-    } @else { @switch (iconType) {
-      @case ('audio') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>
-      }
-      @case ('image') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-      }
-      @case ('file-text') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-      }
-      @case ('video') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-      }
-      @case ('document') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-      }
-      @case ('server') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
-      }
-      @case ('globe') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-      }
-      @case ('email') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,4 12,13 2,4"/></svg>
-      }
-      @case ('satellite') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12 7 2"/><path d="M7 2l5 10"/><path d="M12 12l5-10"/><path d="M17 2l5 10"/><circle cx="12" cy="18" r="4"/><line x1="12" y1="14" x2="12" y2="12"/></svg>
-      }
-      @case ('folder') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-      }
-      @case ('folder-open') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="9" y1="14" x2="15" y2="14"/></svg>
-      }
-      @case ('upload') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-      }
-      @case ('database') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4.03 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/></svg>
-      }
-      @case ('graduation') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
-      }
-      @case ('arrow-up') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-      }
-      @case ('shuffle') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg>
-      }
-      @case ('elephant') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 8c0-3.3-2.7-6-6-6H8C5.8 2 4 3.8 4 6v4c0 1.1.9 2 2 2h1v6c0 1.1.9 2 2 2h1v-4h4v4h1c1.1 0 2-.9 2-2v-6h1c1.1 0 2-.9 2-2V8z"/><circle cx="9" cy="8" r="1"/></svg>
-      }
-      @case ('cloud') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
-      }
-      @case ('check') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-      }
-      @case ('warning') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-      }
-      @case ('x-circle') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-      }
-      @case ('info') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-      }
-      @case ('robot') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><line x1="12" y1="4.5" x2="12" y2="7"/><rect x="4" y="7" width="16" height="12" rx="2.5"/><path d="M4 11a2 2 0 0 0 0 4"/><path d="M20 11a2 2 0 0 1 0 4"/><circle cx="9.5" cy="12.5" r="1.2"/><circle cx="14.5" cy="12.5" r="1.2"/><line x1="10" y1="16" x2="14" y2="16"/></svg>
-      }
-      @case ('file') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-      }
-      @case ('list') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
-      }
-      @case ('grid') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-      }
-      @case ('cursor-click') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/><line x1="13" y1="13" x2="20" y2="20"/><line x1="16" y1="21" x2="21" y2="16"/><line x1="17.5" y1="17.5" x2="19.5" y2="19.5"/></svg>
-      }
-      @case ('cursor-hover') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/></svg>
-      }
-      @case ('palette') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c1.1 0 2-.9 2-2 0-.5-.2-1-.5-1.3-.3-.4-.5-.8-.5-1.3 0-1.1.9-2 2-2h2.4c3 0 5.6-2.5 5.6-5.6C23 6.4 18 2 12 2z"/><circle cx="7.5" cy="11.5" r="1"/><circle cx="10" cy="7.5" r="1"/><circle cx="14.5" cy="7.5" r="1"/><circle cx="17.5" cy="11.5" r="1"/></svg>
-      }
-      @case ('sort-descending') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="4" x2="15" y2="4"/><line x1="3" y1="9" x2="13" y2="9"/><line x1="3" y1="14" x2="11" y2="14"/><line x1="3" y1="19" x2="9" y2="19"/><polyline points="19 10 19 20"/><polyline points="16 17 19 20 22 17"/></svg>
-      }
-      @case ('steering-wheel') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="2"/><line x1="12" y1="4" x2="12" y2="1"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4" y1="12" x2="1" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="6.34" y1="6.34" x2="4.22" y2="4.22"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/><line x1="6.34" y1="17.66" x2="4.22" y2="19.78"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/></svg>
-      }
-      @case ('cloud-upload') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
-      }
-      @case ('thumbs-up') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
-      }
-      @case ('thumbs-down') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
-      }
-      @case ('factory') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8l-7 5V8l-7 5V4a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/><path d="M17 18h1"/><path d="M12 18h1"/><path d="M7 18h1"/></svg>
-      }
-      @case ('house') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-      }
-      @case ('lightning') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-      }
-      @case ('flask') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>
-      }
-      @case ('cubes') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h18v18H2z"/><path d="M2 4l2-2h18v18l-2 2"/><path d="M20 4l2-2"/><path d="M11 4v18M2 13h18"/><path d="M11 4l2-2"/><path d="M20 13l2-2"/></svg>
-      }
-      @case ('checkbox-checked') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3" ry="3"/><polyline points="8 12 11 15 16 9"/></svg>
-      }
-      @case ('search') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>
-      }
-      @case ('trophy') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4h12v4a6 6 0 0 1-12 0z"/><path d="M6 6H3a2 2 0 0 0 0 4h3"/><path d="M18 6h3a2 2 0 0 1 0 4h-3"/><line x1="10" y1="14" x2="10" y2="18"/><line x1="14" y1="14" x2="14" y2="18"/><rect x="7" y="18" width="10" height="3" rx="1"/></svg>
-      }
-    } }
+    @if (svgHtml) {
+      <span class="vt-icon__svg" [style.width.px]="size" [style.height.px]="size" [innerHTML]="svgHtml"></span>
+    }
   `,
   styles: [`
     :host {
@@ -197,16 +87,33 @@ function emojiToType(icon: string): string {
       align-items: center;
       vertical-align: middle;
     }
-    svg {
+    .vt-icon__svg {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 0;
+    }
+    .vt-icon__svg ::ng-deep svg {
+      width: 100%;
+      height: 100%;
+      display: block;
       vertical-align: middle;
     }
   `],
 })
-export class IconComponent {
+export class IconComponent implements OnChanges {
   @Input() icon = '';
   @Input() size = 16;
   /** Directly set the icon type, bypassing emoji mapping. */
   @Input() type = '';
+
+  protected svgHtml: SafeHtml | null = null;
+
+  constructor(private sanitizer: DomSanitizer, private cdr: ChangeDetectorRef) {}
+
+  ngOnChanges(): void {
+    this.renderIcon();
+  }
 
   get iconType(): string {
     if (this.type) return this.type;
@@ -217,5 +124,43 @@ export class IconComponent {
   get letterChar(): string {
     const t = this.iconType;
     return /^[A-Z]$/.test(t) ? t : '';
+  }
+
+  private renderIcon(): void {
+    const letter = this.letterChar;
+    if (letter) {
+      this.svgHtml = this.cached(`__letter:${letter}`, () => letterGlyphSvg(letter));
+      return;
+    }
+    const t = this.iconType;
+    if (!t) {
+      this.svgHtml = null;
+      return;
+    }
+    if (SHELL_ICON_SVGS[t]) {
+      this.svgHtml = this.cached(t, () => SHELL_ICON_SVGS[t]);
+      return;
+    }
+    const peeked = peekExtendedIconSvgs();
+    if (peeked) {
+      this.svgHtml = this.cached(t, () => peeked[t] ?? SHELL_ICON_SVGS['file']);
+      return;
+    }
+    // Extended set hasn't been loaded yet — defer the render until the
+    // dynamic import resolves.  Until then we render nothing rather
+    // than flashing the fallback (avoids a visible glyph swap).
+    this.svgHtml = null;
+    loadExtendedIconSvgs().then((map) => {
+      this.svgHtml = this.cached(t, () => map[t] ?? SHELL_ICON_SVGS['file']);
+      this.cdr.markForCheck();
+    });
+  }
+
+  private cached(key: string, build: () => string): SafeHtml {
+    const hit = sanitizedCache.get(key);
+    if (hit !== undefined) return hit;
+    const safe = this.sanitizer.bypassSecurityTrustHtml(build());
+    sanitizedCache.set(key, safe);
+    return safe;
   }
 }


### PR DESCRIPTION
## Summary

Continues `docs/plans/frontend-bundle-organization.md` by shipping
**#4** (lazy-load icon SVGs) and **#5** (API services audit —
investigation only).

### #4 Lazy-load icon SVGs

`IconComponent` previously inlined all 42 SVGs as `@switch` template
branches, dragging them into the eager bundle via
`DialogHostComponent`. The split now keeps only the 5 icons the
shell actually needs (`warning`, `x-circle`, `check`, `info`, plus
the `file` fallback) plus the dynamic letter glyph in
`icon-svgs.ts`. The other 37 SVGs live in
`icon-svgs-extended.ts`, which the component lazy-loads via dynamic
`import()` the first time a non-shell icon is requested. Sanitised
SVG markup is cached on a static `Map` shared across every
`IconComponent` instance.

Rendering switched from per-icon `@switch` branches to
`[innerHTML]="svgHtml"` on a wrapper span sized via inline `width` /
`height`; the inner SVG (with `viewBox 0 0 24 24`) scales via CSS.
No call-site changes — `<vt-icon [icon] [type] [size]>` inputs are
byte-identical.

**Bundle effect.** Initial bundle dropped from 537.45 → 525.73 kB
raw (139.53 → 137.54 kB gzip). New `icon-svgs-extended` lazy chunk
weighs 12.09 kB raw / 1.81 kB gzip.

### #5 API services audit (investigation)

Documented inline in the plan. Headline: the four hand-written API
services (`detectors-api`, `datasets-api`, `sorting-api`,
`medias-api`) already delegate ~all calls to the `ng-openapi-gen`
generated `fn/` modules, so the "fold-into-generated-client" angle is
effectively done. Remaining direct `http.*` calls are justified
(plugin-endpoint FormData uploads, one blob download).

The real eager-bundle cost the audit surfaced: `activeContextGuard`
→ `ContextSwitchService` statically pulls in the full
`DetectorsApiService` (435 lines) and `DatasetsApiService` (344
lines), even though it only calls 4 endpoints across the two. A
per-domain split that would fix that is scoped under Open follow-ups
and deferred until #6 lands so the gzip-budget reading isn't
disturbed by an unrelated refactor.

## Test plan

- [x] `./run-tests.sh core` (632 passed; includes the frontend
  `build:prod` check)
- [x] Verified styles compile correctly through `::ng-deep` for the
  `[innerHTML]`-injected SVG (`.vt-icon__svg[_ngcontent-*] svg`
  selector present in the built CSS)
- [ ] Manual smoke: confirm dialogs (which use shell icons) and
  dashboard / label-view / modals (which use extended icons) all
  render correctly in a browser

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrCDdG7EvWr6fRXptQyBDb)_