### PR TITLE
Close M23 (setup_logging duplicate handlers) as not-a-bug

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -828,8 +828,21 @@ Cross-section interaction agents:
 - **M22.** `set_thread_user()` cleanup relies on every caller's `finally`; a
   future `ThreadPoolExecutor` reuse would leak user identity across
   requests.
-- **M23.** `setup_logging` re-running can leave duplicate handlers on
-  non-root loggers.
+- ~~**M23.** `setup_logging` re-running can leave duplicate handlers on
+  non-root loggers.~~ — closed as not-a-bug.
+  `vtsearch/logging_config.py:setup_logging` only attaches a
+  `StreamHandler` to the root logger, and clears `root.handlers`
+  before re-attaching, so root cannot accumulate duplicates. For the
+  named libraries (`werkzeug`, `huggingface_hub`,
+  `huggingface_hub.utils._http`) it only calls `.setLevel(...)`; it
+  never calls `.addHandler(...)` on them, so repeated calls cannot
+  leave duplicates on non-root loggers either. Records from those
+  libraries propagate to root and are emitted by the single root
+  handler. `tests/core/test_structured_logging.py::TestSetupLogging::test_idempotent_no_duplicate_handlers`
+  covers the root case. A speculative "defensive" fix that wiped
+  handlers from a hard-coded list of non-root loggers would stomp any
+  handler a test or future feature legitimately attached there, and
+  encode a closed list that would drift from reality silently.
 - **M24.** `CoreConfig.from_settings()` raises if a blueprint's module-level
   code runs before `vtsearch/shim/__init__.py` registers the
   builder.


### PR DESCRIPTION
## Summary

Marks `logical-bug-audit.md` finding **M23** as not-a-bug with an inline explanation.

The audit claim was: *"`setup_logging` re-running can leave duplicate handlers on non-root loggers."* Reading `vtsearch/logging_config.py:setup_logging`:

- The function attaches a single `StreamHandler` to the **root** logger, after iterating `root.handlers` and removing each existing one — so root cannot accumulate duplicates.
- For the named libraries (`werkzeug`, `huggingface_hub`, `huggingface_hub.utils._http`) it only calls `.setLevel(...)`. It never calls `.addHandler(...)` on them, so no handler is ever attached to those non-root loggers in the first place — repeated calls cannot leave duplicates there.
- Library records propagate up to root and are emitted by the single root handler. The existing `TestSetupLogging::test_idempotent_no_duplicate_handlers` test pins the root behavior.

A speculative "defensive" fix that wiped handlers from a hard-coded list of non-root loggers would stomp anything a test or future feature legitimately attached there, and the closed list would drift silently.

## Test plan
- [ ] Doc-only change; no code modified, no tests to run.


---
_Generated by [Claude Code](https://claude.ai/code/session_015MToUBmiX6xXLrBeuUF8L5)_