### PR TITLE
Fix M28: log waveform errors and cancel stale fetches

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -855,8 +855,12 @@ Cross-section interaction agents:
   `destroy$`; rapid switches leak polls.
 - **M27.** `progress-events.service` doesn't reconcile stale `task_id`s after
   backend restart.
-- **M28.** Audio waveform fetch's `catch {}` silently shows "Unable to load
-  waveform" with no UI state propagation.
+- ~~**M28.** Audio waveform fetch's `catch {}` silently shows "Unable to load
+  waveform" with no UI state propagation.~~ **Shipped.** `drawWaveform` now
+  uses an `AbortController` (cancelled on next load / `ngOnDestroy`), checks
+  `response.ok`, and logs the underlying error via `console.warn` instead of
+  swallowing it. `AbortError` is suppressed so rapid swiping doesn't spam the
+  console or overwrite the next media's canvas.
 - **M29.** `AudioContext` not cleaned up on rapid navigation → resource
   exhaustion.
 - **M30.** Autopilot phase transitions can oscillate

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -32,6 +32,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   audioSrc = '';
 
   private audioCtx: AudioContext | null = null;
+  private waveformAbort: AbortController | null = null;
   private viewReady = false;
   // See ImageViewerComponent.lastMediaId: the `media` input reference changes
   // whenever the metadata cache hydrates; without this guard, every cache
@@ -63,6 +64,8 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   ngOnDestroy(): void {
+    this.waveformAbort?.abort();
+    this.waveformAbort = null;
     const audio = this.audioRef?.nativeElement;
     if (audio) {
       audio.pause();
@@ -144,8 +147,17 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--bg-surface').trim() || '#1a1d27';
     ctx.fillRect(0, 0, width, height);
 
+    this.waveformAbort?.abort();
+    const abort = new AbortController();
+    this.waveformAbort = abort;
+
     try {
-      const response = await fetch(this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`));
+      const response = await fetch(this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`), {
+        signal: abort.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching audio for media ${mediaId}`);
+      }
       const arrayBuffer = await response.arrayBuffer();
 
       if (!this.audioCtx || this.audioCtx.state === 'closed') {
@@ -184,11 +196,19 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
       ctx.moveTo(0, height / 2);
       ctx.lineTo(width, height / 2);
       ctx.stroke();
-    } catch {
+    } catch (err) {
+      if (abort.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) {
+        return;
+      }
+      console.warn('waveform render failed', err);
       ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--color-bad').trim() || '#f44336';
       ctx.font = '12px sans-serif';
       ctx.textAlign = 'center';
       ctx.fillText('Unable to load waveform', width / 2, height / 2);
+    } finally {
+      if (this.waveformAbort === abort) {
+        this.waveformAbort = null;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes M28 from `docs/plans/logical-bug-audit.md`. The audio player's `drawWaveform` previously had a bare `catch {}` that swallowed every error (HTTP failure, decode failure, AudioContext failure) and never cancelled in-flight fetches across rapid media switches, so a late response could overwrite the next media's canvas.

- Added an `AbortController` per render; cancelled on the next `loadAudio()` call and in `ngOnDestroy`.
- Added a `response.ok` check before parsing.
- Replaced `catch {}` with `catch (err) { console.warn('waveform render failed', err); ... }`. `AbortError` is suppressed so rapid swiping doesn't paint the failure overlay over the freshly-cleared canvas or spam the console.

Plan entry struck through with a "Shipped" note.

## Test plan

- [x] `npm run build:prod` — clean, no warnings
- [x] `./run-tests.sh core` — 652 passed
- [ ] Manual: load an audio media, swipe rapidly through several items, confirm waveforms render correctly and no error overlay flashes; force a 500 from `/api/medias/:id/audio` and confirm the red "Unable to load waveform" message appears with a `console.warn` containing the HTTP status.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NGLx5KSCiEdsRxbnPpQpgJ)_