### PR TITLE
Fix demo dataset registering as Audio when loaded from a stale pkl

### DIFF
--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -40,6 +40,31 @@ def _stamp_demo_origin(
         media["origin"] = {"importer": "demo", "params": dict(demo_origin_params)}
 
 
+def _stamp_media_type(
+    medias: dict[int, dict[str, Any]],
+    source_type_id: str,
+    converter_name: str = "",
+) -> None:
+    """Fill in missing ``media_type`` on cached medias.
+
+    Old pkl files may have been created before ``media_type`` was stored
+    per-media, causing ``load_dataset_from_pickle`` to fall back to the
+    ``"audio"`` default for every item.  This corrects any media whose
+    ``media_type`` is absent or empty so the dataset registers with the
+    right type.
+    """
+    expected = source_type_id
+    if converter_name:
+        from vtscore.converters import get_converter  # noqa: PLC0415
+
+        conv = get_converter(converter_name)
+        if conv is not None:
+            expected = conv.target_type
+    for media in medias.values():
+        if not media.get("media_type"):
+            media["media_type"] = expected
+
+
 def load_demo_dataset(  # noqa: C901
     dataset_name: str,
     medias: dict[int, dict[str, Any]],
@@ -130,6 +155,11 @@ def load_demo_dataset(  # noqa: C901
                 # Old pickles (created before origin stamping) may have empty
                 # params — this ensures they are corrected on load.
                 _stamp_demo_origin(medias, dataset_name, converter_name)
+                # Fill in missing media_type: old pkls may lack the field,
+                # causing every item to fall back to the "audio" default in
+                # load_dataset_from_pickle and the dataset to register with
+                # the wrong type.
+                _stamp_media_type(medias, media_type_id, converter_name)
                 on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)
                 return
 


### PR DESCRIPTION
## Summary

- Old pkl cache files created before `media_type` was stored per-media caused `load_dataset_from_pickle` to default every item to `"audio"`, so image (and other non-audio) demo datasets registered with the wrong type in the dashboard list.
- Adds `_stamp_media_type()` helper and calls it in the cache-hit path of `load_demo_dataset`, alongside the existing `_stamp_demo_origin()` call. Medias missing `media_type` are corrected to the expected type derived from `DEMO_DATASETS` (or the converter's `target_type` for converted datasets). Medias that already carry the correct type are left untouched.
- Deleting the data directory and rebuilding was the workaround — this fix makes stale pkls self-heal on next load.

## Test plan

- [ ] Load an image demo dataset (e.g. Caltech101) from an older pkl that lacks per-media `media_type` — it should now register as `image`, not `audio`
- [ ] Load an audio demo dataset — still registers as `audio`
- [ ] Load an audio demo dataset with a converter (e.g. audio→image) — registers as `image`
- [ ] `./run-tests.sh core datasets` passes (verified locally: 1262 passed)

https://claude.ai/code/session_01ThSfbzbEQnVnFDjXvtEJRw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThSfbzbEQnVnFDjXvtEJRw)_