### PR TITLE
Fix demo importer UX: show Name/Advanced before demo selection, add Clipper label

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -41,38 +41,36 @@
     </ng-container>
 
     <ng-container demoAfter>
-      @if (selectedDemo) {
-        <div class="form-group">
-          <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
-          <input
-            id="demo-dataset-name"
-            type="text"
-            class="form-input"
-            [ngModel]="demoDatasetName"
-            (ngModelChange)="onDemoDatasetNameInput($event)"
-            placeholder="Leave blank to use the demo's name"
-          />
-        </div>
+      <div class="form-group">
+        <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
+        <input
+          id="demo-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="demoDatasetName"
+          (ngModelChange)="onDemoDatasetNameInput($event)"
+          placeholder="Leave blank to use the demo's name"
+        />
+      </div>
 
-        @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
-          <div class="form-group form-group--section">
-            <vt-import-advanced
-              [availableConverters]="[]"
-              [nativeType]="''"
-              [typeLabels]="mediaTypeLabels"
-              [embedders]="demoEmbedders"
-              [clippers]="demoClippers"
-              [showSourceSpecs]="false"
-              [sourceSpecs]="[]"
-              [selectedEmbedder]="selectedDemoEmbedder"
-              (selectedEmbedderChange)="onDemoEmbedderChange($event)"
-              [lockedEmbedder]="lockedEmbedderFor(activeTab, demoEmbedders)"
-              [selectedClipper]="selectedDemoClipper"
-              [selectedClipperParams]="{}"
-              (clipperChooserRequested)="openClipperChooser('demo')"
-            ></vt-import-advanced>
-          </div>
-        }
+      @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
+        <div class="form-group form-group--section">
+          <vt-import-advanced
+            [availableConverters]="[]"
+            [nativeType]="''"
+            [typeLabels]="mediaTypeLabels"
+            [embedders]="demoEmbedders"
+            [clippers]="demoClippers"
+            [showSourceSpecs]="false"
+            [sourceSpecs]="[]"
+            [selectedEmbedder]="selectedDemoEmbedder"
+            (selectedEmbedderChange)="onDemoEmbedderChange($event)"
+            [lockedEmbedder]="lockedEmbedderFor(activeTab, demoEmbedders)"
+            [selectedClipper]="selectedDemoClipper"
+            [selectedClipperParams]="{}"
+            (clipperChooserRequested)="openClipperChooser('demo')"
+          ></vt-import-advanced>
+        </div>
       }
     </ng-container>
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -54,6 +54,7 @@
 }
 
 @if (showStandaloneClipperButton) {
+  <label class="form-label" title="Pre-processing clipper applied before embedding (e.g. clips audio into shorter segments)">Clipper</label>
   <button
     class="btn btn--secondary clipper-btn"
     (click)="onClipperClick()"


### PR DESCRIPTION
## Summary

- **Name field and Advanced section now always visible** in the demo picker — previously both were wrapped in `@if (selectedDemo)` so nothing below the grid appeared until the user clicked a row. Removed the guard so they render as soon as the demo tab is active, matching every other importer's layout (Name below, Advanced hide below Name, Cancel/Import in the footer).
- **Clipper section now has a header** in `import-advanced` — the standalone clipper button was rendering as an orphan `[Details: None]` with no context. A `Clipper` `form-label` now precedes it, consistent with the adjacent `Embedder` label + select.

## Test plan

- [ ] Open Add Dataset → Demo tab: Dataset Name field and Advanced toggle are visible immediately (before selecting any row)
- [ ] Select a demo row: Dataset Name auto-fills with the demo's label; Advanced still present
- [ ] Open Advanced on a media type with multiple clippers: section shows **Clipper** label above the Details button
- [ ] Verify Import button remains disabled until a row is selected
- [ ] Verify other importer flows (Server Folder, Local Folder, generic form) are unaffected

https://claude.ai/code/session_01LuYiKNB7sPF7uChK7hJoUe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuYiKNB7sPF7uChK7hJoUe)_