### PR TITLE
Fix stale detector context after delete-then-create-then-train

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -11,6 +11,7 @@ import { DetectorsRegistryApiService } from '../../services/detectors-registry-a
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
+import { ActiveContextService } from '../../services/active-context.service';
 import { ContextSwitchService } from '../../services/context-switch.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
@@ -150,6 +151,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private dialog: VtDialogService,
     private labelSession: LabelSessionService,
     public datasetState: DatasetStateService,
+    private activeContext: ActiveContextService,
     private contextSwitch: ContextSwitchService,
     private authService: AuthService,
     private topBarState: TopBarStateService,
@@ -612,6 +614,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.detectorsRegistryApi.deleteFromRegistry(model.id).subscribe({
         next: () => {
           this.selectedDetectorIds.delete(model.id);
+          if (this.activeContext.modelId === model.id || this.activeContext.intentModelId === model.id) {
+            this.activeContext.setActivePair(this.activeContext.datasetId, '');
+          }
           this.datasetState.refresh();
         },
         error: () => {
@@ -691,6 +696,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsRegistryApi.deleteRegistered(dataset.id).subscribe({
       next: () => {
         this.selectedDatasetIds.delete(dataset.id);
+        if (this.activeContext.datasetId === dataset.id || this.activeContext.intentDatasetId === dataset.id) {
+          this.activeContext.setActivePair('', '');
+        }
         this.datasetState.refresh();
       },
     });
@@ -742,6 +750,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.detectorsRegistryApi.deleteFromRegistry(model.id).subscribe({
       next: () => {
         this.selectedDetectorIds.delete(model.id);
+        if (this.activeContext.modelId === model.id || this.activeContext.intentModelId === model.id) {
+          this.activeContext.setActivePair(this.activeContext.datasetId, '');
+        }
         this.datasetState.refresh();
       },
       error: () => {

--- a/frontend/src/app/services/active-context-watcher.service.spec.ts
+++ b/frontend/src/app/services/active-context-watcher.service.spec.ts
@@ -58,8 +58,10 @@ describe('ActiveContextWatcherService', () => {
     activeContext.setActivePair('d1', 'm1');
     expect(toast.toasts.length).toBe(0);
 
-    // d1 deleted from another tab / session.
+    // d1 deleted from another tab / session; detectors still present so the
+    // detectors.length > 0 guard confirms the registry is loaded.
     setDatasets([]);
+    // Re-emit detectors to trigger combineLatest with detectors.length > 0.
     setDetectors([makeDetector('m1', 'Det')]);
 
     expect(activeContext.datasetId).toBe('');
@@ -70,14 +72,28 @@ describe('ActiveContextWatcherService', () => {
 
   it('toasts and clears the detector half when the active detector disappears', () => {
     setDatasets([makeDataset('d1', 'DS')]);
-    setDetectors([makeDetector('m1', 'CatDet')]);
+    setDetectors([makeDetector('m1', 'CatDet'), makeDetector('m2', 'Other')]);
     activeContext.setActivePair('d1', 'm1');
 
-    setDetectors([]);
+    // m1 deleted; m2 still present — registry confirmed loaded via datasets.length > 0.
+    setDetectors([makeDetector('m2', 'Other')]);
 
     expect(activeContext.modelId).toBe('');
     expect(toast.toasts.length).toBe(1);
     expect(toast.toasts[0].message).toContain('CatDet');
+  });
+
+  it('toasts when the only detector is deleted (datasets still present)', () => {
+    setDatasets([makeDataset('d1', 'DS')]);
+    setDetectors([makeDetector('m1', 'Solo')]);
+    activeContext.setActivePair('d1', 'm1');
+
+    // m1 is the only detector; datasets still present so datasets.length > 0 passes.
+    setDetectors([]);
+
+    expect(activeContext.modelId).toBe('');
+    expect(toast.toasts.length).toBe(1);
+    expect(toast.toasts[0].message).toContain('Solo');
   });
 
   it('does not toast when the user switches to a different active item', () => {
@@ -91,13 +107,52 @@ describe('ActiveContextWatcherService', () => {
     expect(activeContext.datasetId).toBe('d2');
   });
 
-  it('is idempotent — calling start() twice does not double-subscribe', () => {
-    watcher.start();
-    setDatasets([makeDataset('d1', 'X')]);
-    setDetectors([]);
-    activeContext.setActivePair('d1', '');
-    setDatasets([]);
+  it('does not toast when intent has already moved to a different detector', () => {
+    // Simulates the delete-then-create-and-train flow: user deletes m1, creates
+    // m2, navigates to the train view. The route guard sets intent=m2 but the
+    // active is still m1 when the registry refresh (with m1 gone, m2 present)
+    // arrives. The watcher must not fire "m1 removed" in this case.
+    setDatasets([makeDataset('d1', 'DS')]);
+    setDetectors([makeDetector('m1', 'OldDet'), makeDetector('m2', 'NewDet')]);
+    activeContext.setActivePair('d1', 'm1');
 
+    // Intent moves to m2 (route guard called setIntent); active still m1.
+    activeContext.setIntent('d1', 'm2');
+
+    // Registry arrives: m1 gone, m2 present.
+    setDetectors([makeDetector('m2', 'NewDet')]);
+
+    // Must NOT fire — user already moved on.
+    expect(toast.toasts.length).toBe(0);
+    expect(activeContext.modelId).toBe('m1'); // active unchanged; route guard promotes it
+  });
+
+  it('does not toast when intent has already moved to a different dataset', () => {
+    setDatasets([makeDataset('d1', 'OldDS'), makeDataset('d2', 'NewDS')]);
+    setDetectors([makeDetector('m1', 'Det')]);
+    activeContext.setActivePair('d1', 'm1');
+
+    // Intent moves to d2; active still d1.
+    activeContext.setIntent('d2', 'm1');
+
+    // d1 disappears, d2 remains.
+    setDatasets([makeDataset('d2', 'NewDS')]);
+    setDetectors([makeDetector('m1', 'Det')]);
+
+    expect(toast.toasts.length).toBe(0);
+    expect(activeContext.datasetId).toBe('d1'); // active unchanged
+  });
+
+  it('is idempotent — calling start() twice does not double-subscribe', () => {
+    watcher.start(); // second call — should be a no-op
+    setDatasets([makeDataset('d1', 'X')]);
+    setDetectors([makeDetector('m1', 'Det')]);
+    activeContext.setActivePair('d1', 'm1');
+
+    // m1 deleted; datasets still present so datasets.length > 0 guard passes.
+    setDetectors([]);
+
+    // If start() double-subscribed we'd see 2 toasts; idempotency gives exactly 1.
     expect(toast.toasts.length).toBe(1);
   });
 });

--- a/frontend/src/app/services/active-context-watcher.service.ts
+++ b/frontend/src/app/services/active-context-watcher.service.ts
@@ -65,7 +65,8 @@ export class ActiveContextWatcherService {
       } else if (
         pair.datasetId &&
         this.lastSeenDatasetName?.id === pair.datasetId &&
-        datasets.length > 0
+        detectors.length > 0 &&
+        this.activeContext.intentDatasetId === pair.datasetId
       ) {
         const removedName = this.lastSeenDatasetName.name;
         this.lastSeenDatasetName = null;
@@ -83,7 +84,8 @@ export class ActiveContextWatcherService {
       } else if (
         pair.modelId &&
         this.lastSeenDetectorName?.id === pair.modelId &&
-        detectors.length > 0
+        datasets.length > 0 &&
+        this.activeContext.intentModelId === pair.modelId
       ) {
         const removedName = this.lastSeenDetectorName.name;
         this.lastSeenDetectorName = null;


### PR DESCRIPTION
## Summary

Fixes the bug where deleting DetectorA, creating DetectorC, and navigating to the Train interface would show "DetectorA removed" inside the Train view, silently drop all votes, and bounce the user back to /dashboard.

**Three root causes fixed:**

- **Swapped length guards in the watcher.** The detector removal check used `detectors.length > 0` (same category). When the user deleted A (empty list → guard blocks), then created C (list now `[C]` → guard passes), the watcher incorrectly fired "A removed" based on a registry arrival rather than a genuine live removal. Fixed by cross-referencing: detector removal now checks `datasets.length > 0`, dataset removal checks `detectors.length > 0`.

- **No intent guard.** Between `setIntent(dataset, newDet)` (called by the route guard immediately) and `setActive` (called after loads finish), `pair.modelId` was still the old detector. Any registry emission showing the old detector missing would trigger the removal path even though the user had already moved on. Fixed by adding `intentModelId === pair.modelId` (and the dataset analog) as a condition — the watcher skips the removal if intent has diverged.

- **Dashboard did not clear active context on explicit delete.** After deletion, `pair.modelId` stayed as the deleted ID until the registry refresh arrived, keeping the stale ID live for the watcher to react to. Fixed: `deleteDetector` (both single and bulk-delete paths) and `deleteDataset` now immediately call `setActivePair` to clear the relevant half when the deleted item is the active or intent one.

## Test plan

- [ ] Delete a detector and create a new one with Train checked — no "X removed" toast, votes register correctly
- [ ] Delete a dataset — active context clears immediately, no stale header
- [ ] Existing external-deletion behavior (other tab/CLI deletes active detector) still shows toast and bounces to /dashboard
- [ ] TypeScript build: clean (`npm run build:prod`)
- [ ] Python tests: `./run-tests.sh core` — all pass

https://claude.ai/code/session_01KEEXc9WjQyAKhgFW3QVHrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEEXc9WjQyAKhgFW3QVHrH)_