### PR TITLE
Move multi-select actions to section headers; fix system bar alignment

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -5,6 +5,23 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</span>
       <div class="dashboard-section-actions">
+        <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isLoading || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
+            <path d="M3 17 C 10 17, 10 12, 17 12"/>
+            <polyline points="18 9 21 12 18 15"/>
+          </svg>
+        </button>
+        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
+          <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm && wasDeletingSelectedDatasetsConfirm" (animationend)="onDeleteSelectedDatasetsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+            <path d="M10 11v6"></path>
+            <path d="M14 11v6"></path>
+            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+          </svg>
+        </button>
+        <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
           [disabled]="isLoading"
           (click)="openImporterModal()" title="Import a new dataset"><span class="plus-icon"
@@ -144,25 +161,6 @@
       </div>
     }
   </div>
-  <div class="dashboard-side-actions">
-    <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isLoading || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
-      <!-- Two horizontal arrows on the left, merging smoothly into a single arrow on the right. -->
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
-        <path d="M3 17 C 10 17, 10 12, 17 12"/>
-        <polyline points="18 9 21 12 18 15"/>
-      </svg>
-    </button>
-    <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
-      <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm && wasDeletingSelectedDatasetsConfirm" (animationend)="onDeleteSelectedDatasetsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="3 6 5 6 21 6"></polyline>
-        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-        <path d="M10 11v6"></path>
-        <path d="M14 11v6"></path>
-        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-      </svg>
-    </button>
-  </div>
   </div>
 
   <!-- Detector Section -->
@@ -171,6 +169,23 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Trained detectors for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Detectors</span>
       <div class="dashboard-section-actions">
+        <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isLoading || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
+            <path d="M3 17 C 10 17, 10 12, 17 12"/>
+            <polyline points="18 9 21 12 18 15"/>
+          </svg>
+        </button>
+        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDetectors()" [disabled]="isLoading || selectedDetectorIds.size === 0" [title]="selectedDetectorIds.size === 0 ? 'No detectors selected' : 'Delete selected detectors'" aria-label="Delete selected">
+          <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDetectorsConfirm" [class.side-action-delete-inactive]="!deletingSelectedDetectorsConfirm && wasDeletingSelectedDetectorsConfirm" (animationend)="onDeleteSelectedDetectorsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+            <path d="M10 11v6"></path>
+            <path d="M14 11v6"></path>
+            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+          </svg>
+        </button>
+        <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
           [disabled]="isLoading"
           (click)="openNewDetectorModal()" title="Create a new detector"><span class="plus-icon"
@@ -269,25 +284,6 @@
         </table>
       </div>
     }
-  </div>
-  <div class="dashboard-side-actions">
-    <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isLoading || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
-      <!-- Two horizontal arrows on the left, merging smoothly into a single arrow on the right. -->
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
-        <path d="M3 17 C 10 17, 10 12, 17 12"/>
-        <polyline points="18 9 21 12 18 15"/>
-      </svg>
-    </button>
-    <button class="side-action-btn side-action-delete" (click)="deleteSelectedDetectors()" [disabled]="isLoading || selectedDetectorIds.size === 0" [title]="selectedDetectorIds.size === 0 ? 'No detectors selected' : 'Delete selected detectors'" aria-label="Delete selected">
-      <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDetectorsConfirm" [class.side-action-delete-inactive]="!deletingSelectedDetectorsConfirm && wasDeletingSelectedDetectorsConfirm" (animationend)="onDeleteSelectedDetectorsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="3 6 5 6 21 6"></polyline>
-        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-        <path d="M10 11v6"></path>
-        <path d="M14 11v6"></path>
-        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-      </svg>
-    </button>
   </div>
   </div>
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -32,15 +32,6 @@
   padding: var(--space-xl);
 }
 
-.dashboard-side-actions {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-xs) 0;
-}
-
 .side-action-btn {
   background: none;
   border: none;
@@ -192,6 +183,18 @@
 
 .dashboard-section-actions {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.section-actions-sep {
+  width: 1px;
+  height: 1.1em;
+  background: var(--border);
+  flex-shrink: 0;
+  margin: 0 var(--space-2xs);
+  align-self: center;
 }
 
 .dashboard-grid {


### PR DESCRIPTION
## Summary

- Moves the Combine and Delete multi-select buttons from the right-side column into the section header, next to the `+` button, separated by a thin vertical rule
- Removes the `.dashboard-side-actions` side column from both the Datasets and Detectors section wraps
- The two system bars (RAM / Disk) now align symmetrically with the outer edges of their respective grids — the right-side column was the cause of the asymmetry

## What changed

**Before:** Each section had a side column (`dashboard-side-actions`) to the right of the grid, holding the combine and delete icon buttons. This pushed the Disk bar's right edge out past the grid's right edge, breaking symmetry with the RAM bar.

**After:** Both icon buttons live in the section header alongside the `+` button (`[combine] [delete] | [+]`). No side column — the section wraps are flush with the grid edges on both sides, so the absolutely-positioned system bars land symmetrically.

https://claude.ai/code/session_01TgZ95tzFG5x4QZLyCC8fDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgZ95tzFG5x4QZLyCC8fDb)_