### PR TITLE
Add progress bar and cancel to Find-mode scoring overlay

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -37,7 +37,18 @@
   <div class="panel-center">
     @if (sortState.sortBusy) {
       <div class="find-wait-overlay">
-        <p class="find-wait-message">Please wait — scoring dataset with detector…</p>
+        <div class="find-wait-content">
+          <p class="find-wait-message">Please wait — scoring dataset with detector…</p>
+          <vt-progress-bar
+            [indeterminate]="sortState.sortProgressTotal <= 0"
+            [value]="sortState.sortProgress"
+            [max]="sortState.sortProgressTotal"
+          />
+          @if (sortState.sortProgressTotal > 0) {
+            <span class="find-wait-count">{{ sortState.sortProgress | number }} / {{ sortState.sortProgressTotal | number }}</span>
+          }
+          <button class="btn btn--secondary btn--sm" (click)="onSortCancel()">Cancel</button>
+        </div>
       </div>
     }
     <vt-center-panel

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -88,13 +88,26 @@
   justify-content: center;
   z-index: var(--z-elevated);
   background: var(--bg-panel);
-  opacity: 0.85;
+  opacity: 0.9;
   pointer-events: all;
+}
+
+.find-wait-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  width: min(380px, 80%);
 }
 
 .find-wait-message {
   font-size: var(--font-xl);
   color: var(--text-secondary);
   text-align: center;
-  padding: 0 var(--space-2xl);
+}
+
+.find-wait-count {
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -5,6 +5,7 @@ import { finalize, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
+import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
@@ -22,7 +23,7 @@ import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/gr
 @Component({
   selector: 'vt-find-view',
   standalone: true,
-  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent],
+  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent, ProgressBarComponent],
   templateUrl: './find-view.component.html',
   styleUrl: './find-view.component.scss',
 })


### PR DESCRIPTION
## Summary

- The center-panel overlay during Find-mode scoring showed only a static "Please wait" message — no visual feedback that anything was happening, making it feel like the app had frozen.
- The overlay now has a real progress bar (indeterminate animation while the item count is unknown, then a determinate fill as scoring proceeds), a live `current / total` item counter, and a Cancel button so the user doesn't have to hunt for it in the left-panel header.

## What changed

- `find-view.component.html` — upgraded `.find-wait-overlay` to include `<vt-progress-bar>`, a count span, and a Cancel button wrapped in `.find-wait-content`
- `find-view.component.ts` — imported `ProgressBarComponent`
- `find-view.component.scss` — added `.find-wait-content` column layout, `.find-wait-count` styling; nudged overlay opacity to 0.90

https://claude.ai/code/session_012VrXqbhfcv3k9G6nPHnhke

---
_Generated by [Claude Code](https://claude.ai/code/session_012VrXqbhfcv3k9G6nPHnhke)_