### PR TITLE
Fix media_type not set on converter outputs; fix embedders to support media_bytes

### DIFF
--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -196,7 +196,7 @@ def _run_converter_step(media: dict[str, Any], step: ChainStep) -> tuple[list[di
     n_out = len(outputs)
     trail_entries: list[ChainStep] = []
     for idx, clip in enumerate(outputs):
-        clip.setdefault("type", target)
+        clip["media_type"] = target
         entry: ChainStep = {
             "kind": "converter",
             "name": conv.name,
@@ -361,7 +361,7 @@ def apply_chain_to_clips(  # noqa: C901
         # in a different vector space).
         is_sub_item = chain_changes_type or outputs_per_parent[parent_idx] > 1
         media["id"] = new_id
-        media.setdefault("type", final_type)
+        media.setdefault("media_type", final_type)
         _stamp_origin(media, parent_origin, parent_name, trail, is_sub_item=is_sub_item)
         clips_dict[new_id] = media
         needs_recompute.append(is_sub_item)

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -110,12 +110,22 @@ class AudioASTEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
         try:
+            import io  # noqa: PLC0415
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=AST_SAMPLE_RATE, mono=True)
+            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            audio_data, _sr = librosa.load(source, sr=AST_SAMPLE_RATE, mono=True)
             inputs = self._processor(audio_data, sampling_rate=AST_SAMPLE_RATE, return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}
@@ -126,7 +136,7 @@ class AudioASTEmbedder(MediaEmbedder):
                 embedding = outputs.pooler_output.detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
 

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -124,7 +124,11 @@ class AudioASTEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            if audio_bytes is not None:
+                source: io.BytesIO | Path = io.BytesIO(bytes(audio_bytes))
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
             audio_data, _sr = librosa.load(source, sr=AST_SAMPLE_RATE, mono=True)
             inputs = self._processor(audio_data, sampling_rate=AST_SAMPLE_RATE, return_tensors="pt")
             device = next(self._model.parameters()).device

--- a/vtscore/media/audio/embedder_clap_general.py
+++ b/vtscore/media/audio/embedder_clap_general.py
@@ -136,7 +136,11 @@ class AudioClapGeneralEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            if audio_bytes is not None:
+                source: io.BytesIO | Path = io.BytesIO(bytes(audio_bytes))
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
             audio_data, _sr = librosa.load(source, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,

--- a/vtscore/media/audio/embedder_clap_general.py
+++ b/vtscore/media/audio/embedder_clap_general.py
@@ -122,12 +122,22 @@ class AudioClapGeneralEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
         try:
+            import io  # noqa: PLC0415
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=CLAP_SAMPLE_RATE, mono=True)
+            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            audio_data, _sr = librosa.load(source, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,
                 sampling_rate=CLAP_SAMPLE_RATE,
@@ -143,7 +153,7 @@ class AudioClapGeneralEmbedder(MediaEmbedder):
                 embedding = self._model.audio_projection(outputs.pooler_output).detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:

--- a/vtscore/media/audio/embedder_clap_music.py
+++ b/vtscore/media/audio/embedder_clap_music.py
@@ -132,7 +132,11 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            if audio_bytes is not None:
+                source: io.BytesIO | Path = io.BytesIO(bytes(audio_bytes))
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
             audio_data, _sr = librosa.load(source, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,

--- a/vtscore/media/audio/embedder_clap_music.py
+++ b/vtscore/media/audio/embedder_clap_music.py
@@ -118,12 +118,22 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
         try:
+            import io  # noqa: PLC0415
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=CLAP_SAMPLE_RATE, mono=True)
+            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            audio_data, _sr = librosa.load(source, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,
                 sampling_rate=CLAP_SAMPLE_RATE,
@@ -139,7 +149,7 @@ class AudioClapMusicEmbedder(MediaEmbedder):
                 embedding = self._model.audio_projection(outputs.pooler_output).detach().cpu().numpy()
             return embedding[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -17,7 +17,6 @@ files are imported as plugins) — the variant modules import from here.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -90,16 +89,15 @@ class _Dinov2Base(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
-        try:
-            from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
-            return self.embed_pil_image(image)
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+        source = _pil_source_for(media)
+        if source is None:
             return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
 
     def embed_pil_image(self, image: "Image.Image") -> Optional[np.ndarray]:
         if self._model is None:
@@ -173,13 +171,17 @@ class _Dinov2Base(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
+
+        source = _pil_source_for(media)
+        if source is None:
+            return None
+        image = _load_pil(source)
+        if image is None:
+            return None
         try:
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}
@@ -187,5 +189,5 @@ class _Dinov2Base(MediaEmbedder):
                 outputs = self._model(**inputs, output_attentions=True)
             return hf_vit_to_patch_output(outputs, num_register_tokens=0)
         except Exception:
-            logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv2)", file_path)
+            logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv2)", source)
             return None

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -18,7 +18,6 @@ accepted the DINOv3 licence at
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -101,16 +100,15 @@ class _Dinov3Base(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
-        try:
-            from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
-            return self.embed_pil_image(image)
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+        source = _pil_source_for(media)
+        if source is None:
             return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
 
     def embed_pil_image(self, image: "Image.Image") -> Optional[np.ndarray]:
         if self._model is None:
@@ -193,13 +191,17 @@ class _Dinov3Base(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
+
+        source = _pil_source_for(media)
+        if source is None:
+            return None
+        image = _load_pil(source)
+        if image is None:
+            return None
         try:
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}
@@ -207,5 +209,5 @@ class _Dinov3Base(MediaEmbedder):
                 outputs = self._model(**inputs, output_attentions=True)
             return hf_vit_to_patch_output(outputs, num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS)
         except Exception:
-            logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv3)", file_path)
+            logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv3)", source)
             return None

--- a/vtscore/media/image/_eupe_shared.py
+++ b/vtscore/media/image/_eupe_shared.py
@@ -217,13 +217,17 @@ class _EupeBase(MediaEmbedder):
             self.load_models()
         if self._model is None or self._preprocess is None:
             return None
-        file_path = Path(media["media_path"])
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
+
+        source = _pil_source_for(media)
+        if source is None:
+            return None
+        image = _load_pil(source)
+        if image is None:
+            return None
         try:
             import torch  # noqa: PLC0415
-            from PIL import Image  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
             tensor = self._preprocess(image).unsqueeze(0)
             device = next(self._model.parameters()).device
             tensor = tensor.to(device)
@@ -231,5 +235,5 @@ class _EupeBase(MediaEmbedder):
                 features = self._model.forward_features(tensor)
             return features
         except Exception:
-            logging.getLogger(__name__).exception("Error running EUPE on %s", file_path)
+            logging.getLogger(__name__).exception("Error running EUPE on %s", source)
             return None

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -90,16 +89,15 @@ class ImageClipEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
-        try:
-            from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
-            return self.embed_pil_image(image)
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+        source = _pil_source_for(media)
+        if source is None:
             return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
 
     def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -114,16 +113,15 @@ class ImageSiglipEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
-        try:
-            from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
-            return self.embed_pil_image(image)
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+        source = _pil_source_for(media)
+        if source is None:
             return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
 
     def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
         """Embed a PIL Image that is already in memory (e.g. from CIFAR-10)."""

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -8,7 +8,6 @@ the embedder loads on any ``transformers`` version that ships SigLIP 2 support
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -96,16 +95,15 @@ class ImageSiglip2Embedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
-        try:
-            from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
 
-            with Image.open(file_path) as _img:
-                image = _img.convert("RGB")
-            return self.embed_pil_image(image)
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+        source = _pil_source_for(media)
+        if source is None:
             return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
 
     def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
         if self._model is None:


### PR DESCRIPTION
## Summary

- **Primary bug** (`clipper_chain.py`): `_run_converter_step` was stamping `"type"` (wrong key) on converter output clips instead of `"media_type"`. `embed_missing` reads `m.get("media_type")` to locate the right embedder, so it returned early without embedding any converter-produced media (video2image outputs, etc.). `apply_chain_to_clips` had the same wrong key on the final clip assignment.

- **Audio embedders** (`embedder_clap_general`, `embedder_clap_music`, `embedder_ast`): `_embed_media_impl` was reading `media["media_path"]` directly without checking `media_bytes` first. Converter outputs (e.g. video→audio) carry bytes in `media_bytes` with no usable audio file at `media_path`. Fixed to match the pattern in the CLAP base class.

- **Image embedders** (`clip`, `siglip`, `siglip2`, `dinov2`, `dinov3`, `eupe`): `_embed_media_impl` and patch-forward methods had the same direct `media["media_path"]` access. Fixed to use `_pil_source_for`/`_load_pil` from `_image_bulk`, which correctly prefers `media_bytes`. The bulk embed path (`_embed_media_bulk_impl`) already used `_pil_source_for` correctly; this aligns the single-item path to match.

## Test plan

- [ ] `./run-tests.sh` — all 4294 tests pass

https://claude.ai/code/session_01Dhyrq4fZutgsGBPJ4C77mF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhyrq4fZutgsGBPJ4C77mF)_