### PR TITLE
Propagate source custom_metadata to converter outputs

### DIFF
--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -134,7 +134,12 @@ class MediaConverter(PluginBase, ABC):
         framework's plugin-arg error contract.
         """
         normalized = self.normalize_params(params)
-        return self.convert(media, normalized)
+        outputs = self.convert(media, normalized)
+        source_metadata = media.get("custom_metadata")
+        if source_metadata:
+            for output in outputs:
+                output.setdefault("custom_metadata", source_metadata)
+        return outputs
 
     # ------------------------------------------------------------------
     # Param helpers


### PR DESCRIPTION
## Summary

- When any converter is invoked via `convert_normalized()`, `custom_metadata` from the source media dict is now copied into each output dict using `setdefault` — so a converter that explicitly sets its own metadata wins, but metadata from the source (e.g. a video) propagates to all generated frames by default.
- The fix lives in `MediaConverter.convert_normalized()` in `vtscore/converters/base.py`, so it applies to all converters (video2image, video2audio, document2image, audio2image, etc.) without any per-converter changes.

## Test plan

- [ ] Run `./run-tests.sh converters` — all 174 tests pass
- [ ] Import a video with custom metadata via the video2image converter and confirm each extracted frame carries the same `custom_metadata` as the source video

---
_Generated by [Claude Code](https://claude.ai/code/session_013coPnPeAGQ1XNW72XWaYg2)_