### PR TITLE
Fix media_bytes support in AudioWhisperEncoderEmbedder

### DIFF
--- a/tests_lib/io/test_bulk_embedding.py
+++ b/tests_lib/io/test_bulk_embedding.py
@@ -217,6 +217,26 @@ class TestEmbedMissingRoutesToBulk:
 
         emb.embed_media_bulk.assert_not_called()
 
+    def test_no_op_when_media_type_absent(self):
+        """embed_missing silently skips all items when media_type is missing.
+
+        This is the regression contract for the converter-ingestion bug:
+        if _ingest_spec_stream forgets to stamp media_type, embed_missing
+        returns early and leaves all embeddings as None.
+        """
+        from vtscore.datasets.load_pipeline import embed_missing
+
+        emb = _make_bulk_embedder()
+        # Mimic what a converter output looked like before the fix:
+        # media_type absent, embedding still None.
+        medias = {i: {"embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)}
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
+
+        emb.embed_media_bulk.assert_not_called()
+        assert all(m["embedding"] is None for m in medias.values())
+
     def test_routes_progress_to_caller(self):
         from vtscore.datasets.load_pipeline import embed_missing
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -948,5 +948,156 @@ class TestReCallerMultiMedia:
 
 
 # ---------------------------------------------------------------------------
+# _ingest_spec_stream: media_type stamping
+# ---------------------------------------------------------------------------
+#
+# These tests guard the regression where _ingest_spec_stream never stamped
+# media_type on converter outputs, causing embed_missing to silently skip
+# every converter-derived item because it reads m.get("media_type") to pick
+# the right embedder.
+#
+# The fake converter in TestReCaller above returned media_type explicitly —
+# masking the bug.  The tests below use a converter that omits media_type,
+# matching the real converter contract.
+
+
+class TestIngestSpecStreamMediaType:
+    """_ingest_spec_stream stamps media_type on all outputs."""
+
+    # ------------------------------------------------------------------
+    # Minimal DatasetImporter that yields (spec, raw) pairs via
+    # fetch_source_media so the base class _ingest_spec_stream drives it.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_importer(records: list[dict]):
+        """Return a DatasetImporter subclass that yields *records* for any spec."""
+        from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+
+        class _Imp(DatasetImporter):
+            name = "test_stamp"
+            display_name = "Test"
+            description = "Test importer."
+            fields = [
+                ImporterField(
+                    "media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"
+                ),
+            ]
+
+            def fetch_source_media(self, spec: SourceSpec, field_values: dict, thin: bool = False):
+                yield from iter(records)
+
+        return _Imp()
+
+    def test_converter_output_gets_media_type_stamped(self, monkeypatch):
+        """Converter outputs that omit media_type get it stamped by _ingest_spec_stream."""
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            # Real converters return bytes without media_type — mirror that here.
+            return [{"filename": "frame_0.png", "media_bytes": b"PNG", "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert len(medias) == 1
+        assert medias[1]["media_type"] == "image"
+
+    def test_direct_spec_gets_media_type_stamped(self):
+        """Pass-through (no-converter) specs get source_type stamped as media_type."""
+        import json
+
+        imp = self._make_importer([{"filename": "photo.png", "media_bytes": b"PNG"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "image", "converter": None, "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert len(medias) == 1
+        assert medias[1]["media_type"] == "image"
+
+    def test_existing_media_type_not_overwritten(self, monkeypatch):
+        """setdefault: if an importer already stamps media_type, it is preserved."""
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            return [{"filename": "frame.png", "media_bytes": b"PNG", "media_type": "image", "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert medias[1]["media_type"] == "image"
+
+    def test_embed_missing_uses_stamped_media_type(self, monkeypatch):
+        """End-to-end: converter → _ingest_spec_stream → embed_missing populates embeddings.
+
+        This is the regression test for the full bug.  Before the fix,
+        embed_missing returned early (no media_type → no embedder found)
+        and every converter-derived item stayed at embedding=None.
+        """
+        import json
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtscore.converters import get_converter
+        from vtscore.datasets.load_pipeline import embed_missing
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            return [{"filename": "frame_0.png", "media_bytes": b"PNG", "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer(
+            [
+                {"filename": "clip1.mp4", "media_bytes": b"VID1"},
+                {"filename": "clip2.mp4", "media_bytes": b"VID2"},
+            ]
+        )
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert len(medias) == 2
+        assert all(m["media_type"] == "image" for m in medias.values())
+        assert all(m.get("embedding") is None for m in medias.values())
+
+        fake_emb = mock.MagicMock()
+        fake_emb.name = "fake_image_emb"
+        fake_emb._model = True
+        fake_emb._on_progress = lambda *a, **kw: None
+        fake_emb.embed_media_bulk.return_value = [
+            np.array([1.0, 2.0], dtype=np.float32),
+            np.array([3.0, 4.0], dtype=np.float32),
+        ]
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[fake_emb]):
+            embed_missing(medias)
+
+        fake_emb.embed_media_bulk.assert_called_once()
+        assert all(m["embedding"] is not None for m in medias.values())
+
+
+# ---------------------------------------------------------------------------
 # load_dataset_from_folder – content_vectors support
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -609,6 +609,7 @@ class DatasetImporter(PluginBase):
                 continue
             if spec.converter is None:
                 outs = [raw]
+                target_type = spec.source_type
             else:
                 converter = converter_cache.get(spec.converter)
                 if converter is None:
@@ -618,9 +619,11 @@ class DatasetImporter(PluginBase):
                     converter = resolved
                     converter_cache[spec.converter] = converter
                 outs = converter.convert_normalized(raw, spec.params)
+                target_type = converter.target_type
             for media in outs:
                 if media is None:
                     continue
+                media.setdefault("media_type", target_type)
                 media["id"] = next_id
                 media.setdefault("origin", default_origin)
                 media.setdefault("origin_name", media.get("filename") or str(next_id))

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -133,7 +133,11 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            if audio_bytes is not None:
+                source: io.BytesIO | Path = io.BytesIO(bytes(audio_bytes))
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
             audio_data, _sr = librosa.load(source, sr=WHISPER_SAMPLE_RATE, mono=True)
             inputs = self._processor(audio_data, sampling_rate=WHISPER_SAMPLE_RATE, return_tensors="pt")
             device = next(self._model.parameters()).device

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -14,6 +14,7 @@ transcript with a text embedder instead.
 
 from __future__ import annotations
 
+import io
 import logging
 from pathlib import Path
 from typing import Any, Optional
@@ -119,12 +120,21 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
             self.load_models()
         if self._model is None or self._processor is None:
             return None
-        file_path = Path(media["media_path"])
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
         try:
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=WHISPER_SAMPLE_RATE, mono=True)
+            source = io.BytesIO(bytes(audio_bytes)) if audio_bytes is not None else file_path
+            audio_data, _sr = librosa.load(source, sr=WHISPER_SAMPLE_RATE, mono=True)
             inputs = self._processor(audio_data, sampling_rate=WHISPER_SAMPLE_RATE, return_tensors="pt")
             device = next(self._model.parameters()).device
             input_features = inputs.input_features.to(device)
@@ -137,7 +147,7 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
                 pooled = hidden.mean(dim=1).detach().cpu().numpy()
             return pooled[0]
         except Exception:
-            logging.getLogger(__name__).exception("Error embedding %s", file_path)
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
 


### PR DESCRIPTION
## Summary

- `AudioWhisperEncoderEmbedder._embed_media_impl` was reading `media["media_path"]` directly, identical to the bug fixed in clap_general/clap_music/ast in #1712. Converter outputs (e.g. `video2audio → whisper`) carry audio in `media_bytes` without a usable file path, so the embedder would crash or produce no embedding.
- Fix applies the same bytes-first / path-fallback pattern: check `media_bytes` first, fall back to `media_path`, return `None` gracefully if neither is present.
- Uses the `if/else + assert` form (not the ternary) to satisfy pyright's type narrowing, matching the pattern from `embedder_ast.py` (650647f1).

## What this completes

The previous session (`3c6766aa`) fixed:
- `clipper_chain.py` — wrong key `"type"` → `"media_type"` so `embed_missing` can find the media type
- `embedder_clap_general`, `embedder_clap_music`, `embedder_ast` — `media_bytes` support
- All image embedders (clip, siglip, siglip2, dinov2, dinov3, eupe) — `media_bytes` support via `_pil_source_for`

This PR finishes the audit: `embedder_whisper` was the last audio embedder still reading `media_path` unconditionally. Video embedders (xclip, languagebind, videomae) all go through `sample_video_frames()` which already handles `media_bytes`. Text embedders already preferred `media_string`. `embedder_face` was already bytes-first.

## Test plan

- `./run-tests.sh converters` — 174 passed
- `./run-tests.sh core` — 679 passed (includes pyright)

https://claude.ai/code/session_018kPHKyUT3CxS83cBiHfDVs

---
_Generated by [Claude Code](https://claude.ai/code/session_018kPHKyUT3CxS83cBiHfDVs)_