### PR TITLE
Remove per-user solo-embedder setting from Settings > Appearance

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -67,32 +67,6 @@
               <p class="form-hint">{{ soloMediaTypeNote }}</p>
             }
           </div>
-
-          @if (mediaTypes.length > 0) {
-            <div class="form-group" title="Lock the embedder for a media type so the dataset-importer modal hides its embedder picker for that type. Other media types keep the normal embedder dropdown.">
-              <label class="form-label">Solo media embedder</label>
-              <div class="solo-embedder-grid">
-                @for (mt of mediaTypes; track mt.type_id) {
-                  <div class="solo-embedder-row">
-                    <span class="solo-embedder-label">{{ mt.name }}</span>
-                    <select
-                      class="form-select"
-                      [ngModel]="soloEmbedderSelectValue(mt.type_id)"
-                      (ngModelChange)="onSoloEmbedderChange(mt.type_id, $event)"
-                      [attr.aria-label]="'Solo embedder for ' + mt.name">
-                      <option value="">Ask each time</option>
-                      @for (emb of embeddersForType(mt.type_id); track emb.name) {
-                        <option [value]="emb.name">{{ emb.display_name || emb.name }}</option>
-                      }
-                    </select>
-                    @if (soloEmbedderNote(mt.type_id); as note) {
-                      <p class="form-hint">{{ note }}</p>
-                    }
-                  </div>
-                }
-              </div>
-            </div>
-          }
           <label class="checkbox-row" title="Animate media transitions when voting (swipe left/right effect)">
             <input type="checkbox" [ngModel]="settings.swipe_animation" (ngModelChange)="onToggle('swipe_animation', $event)" />
             Swipe animation

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -81,29 +81,6 @@
   cursor: pointer;
 }
 
-.solo-embedder-grid {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-.solo-embedder-row {
-  display: grid;
-  grid-template-columns: 110px 1fr;
-  align-items: center;
-  gap: var(--space-md);
-
-  .form-hint {
-    grid-column: 2;
-    margin: 0;
-  }
-}
-
-.solo-embedder-label {
-  font-size: var(--font-md);
-  color: var(--text-secondary);
-}
-
 // Scroll Style's two-side layout sits inside the shared `.view-tab-content`
 // panel (base styling in `_components.scss`). Encapsulation scopes this
 // grid override to ScrollStyle's tab content only — other consumers

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -13,7 +13,7 @@ import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { DatasetsListingsApiService } from '../../../services/datasets-listings-api.service';
 import type { AppSettings } from '../../../generated/api-client/models/app-settings';
-import { EmbedderInfo, MediaTypeInfo } from '../../../models/api.models';
+import { MediaTypeInfo } from '../../../models/api.models';
 import { Theme, ThemeService } from '../../../services/theme.service';
 import { formatVersion } from '../../../utils/format-date';
 import { VtDialogService } from '../../../services/dialog.service';
@@ -31,9 +31,6 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
 
   settings: AppSettings = { volume: 50 };
   mediaTypes: MediaTypeInfo[] = [];
-  /** All registered embedders, keyed by media-type id, used to populate
-   *  the per-mediaType "Solo embedder" dropdowns under Appearance. */
-  embeddersByType: Record<string, EmbedderInfo[]> = {};
   activeSettingsTab = 'appearance';
   activeViewTab = '';
   loading = true;
@@ -64,7 +61,6 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     forkJoin({
       settings: this.settingsApi.getSettings(),
       mediaTypes: this.datasetsListingsApi.getMediaTypes(),
-      embedders: this.datasetsListingsApi.getEmbedders(),
       version: this.settingsApi.getVersion(),
     })
       .pipe(takeUntil(this.destroy$))
@@ -73,19 +69,6 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
         this.settings = res.settings;
         this.version = formatVersion(res.version.version);
         this.mediaTypes = res.mediaTypes.media_types || [];
-        const allEmbedders = res.embedders || [];
-        // Group embedders by media_type_id with defaults first, matching
-        // the order ``embedders_for_type`` returns from the API.
-        const byType: Record<string, EmbedderInfo[]> = {};
-        for (const emb of allEmbedders) {
-          const tid = emb.media_type_id || '';
-          if (!tid) continue;
-          (byType[tid] ||= []).push(emb);
-        }
-        for (const list of Object.values(byType)) {
-          list.sort((a, b) => Number(!!b.is_default) - Number(!!a.is_default));
-        }
-        this.embeddersByType = byType;
         if (this.mediaTypes.length > 0) {
           const preselected = this.preselectedViewTab;
           if (preselected && this.mediaTypes.some((mt) => mt.type_id === preselected)) {
@@ -146,69 +129,6 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     (this.settings as Record<string, unknown>)['solo_media_type'] = next;
     (this.settings as Record<string, unknown>)['solo_media_type_explicit'] = true;
     (this.settings as Record<string, unknown>)['effective_solo_media_type'] = next;
-    this.save();
-  }
-
-  /** Embedder options for a given media type, used by the per-type
-   *  "Solo embedder" dropdowns. Returns an empty list when the registry
-   *  hasn't loaded yet or the type has no embedders. */
-  embeddersForType(typeId: string): EmbedderInfo[] {
-    return this.embeddersByType[typeId] || [];
-  }
-
-  /** Currently selected solo embedder name for *typeId*. Reads from the
-   *  effective map (user explicit overlaid on the CLI fallback) so the
-   *  picker shows what the user will actually get when they open the
-   *  importer — including a CLI-only lock that has not been overridden. */
-  soloEmbedderSelectValue(typeId: string): string {
-    const map = this.settings.effective_solo_embedder_per_media_type || {};
-    const value = map[typeId];
-    if (!value) return '';
-    // If the stored embedder no longer exists for this type, surface
-    // "Ask each time" rather than a broken-looking option.
-    const valid = this.embeddersByType[typeId] || [];
-    return valid.find((e) => e.name === value) ? value : '';
-  }
-
-  /** Hint text under a solo-embedder dropdown — explains a CLI override
-   *  ("from --solo-embedder") or a stale embedder reference so the user
-   *  understands why the dropdown shows what it does. Returns ``''`` for
-   *  the normal case (no lock, or a user-explicit pick). */
-  soloEmbedderNote(typeId: string): string {
-    const userMap = this.settings.solo_embedder_per_media_type || {};
-    const effectiveMap = this.settings.effective_solo_embedder_per_media_type || {};
-    const userVal = userMap[typeId];
-    const effective = effectiveMap[typeId];
-    if (!effective && !userVal) return '';
-    const valid = this.embeddersByType[typeId] || [];
-    if (effective && !valid.find((e) => e.name === effective)) {
-      return `Locked embedder "${effective}" is no longer registered for this type. ` +
-        'Pick a different embedder to update the lock.';
-    }
-    if (effective && !userVal) {
-      return `Currently set to ${effective} by --solo-embedder. Pick any value here to override it.`;
-    }
-    return '';
-  }
-
-  onSoloEmbedderChange(typeId: string, value: string): void {
-    const userMap = { ...(this.settings.solo_embedder_per_media_type || {}) };
-    // Empty value = "Ask each time". Persist it as the opt-out sentinel
-    // (an empty-string entry) so it overrides any ``--solo-embedder``
-    // CLI fallback for this type — same pattern as solo_media_type's
-    // explicit-null override of --solo-media-type.
-    userMap[typeId] = value || '';
-    (this.settings as Record<string, unknown>)['solo_embedder_per_media_type'] = userMap;
-    // Optimistically update the effective map so the dropdown reflects
-    // the new choice immediately; the PUT response will replace it with
-    // the authoritative server view including any CLI fallback.
-    const effective = { ...(this.settings.effective_solo_embedder_per_media_type || {}) };
-    if (value) {
-      effective[typeId] = value;
-    } else {
-      delete effective[typeId];
-    }
-    (this.settings as Record<string, unknown>)['effective_solo_embedder_per_media_type'] = effective;
     this.save();
   }
 


### PR DESCRIPTION
## Summary

- Removes the "Solo media embedder" section from Settings > Appearance — the per-user ability to lock themselves to a specific embedder per media type belongs at the admin level, not in user preferences
- Drops the four handler methods (`embeddersForType`, `soloEmbedderSelectValue`, `soloEmbedderNote`, `onSoloEmbedderChange`), the `embeddersByType` field, and the now-unnecessary `/api/embedders` fetch that ran on settings-modal open
- Cleans up the three SCSS rules (`.solo-embedder-grid`, `.solo-embedder-row`, `.solo-embedder-label`)

The admin-level `--solo-embedder` CLI flag is unchanged. The dataset importer still respects `effective_solo_embedder_per_media_type` from the server when present.

https://claude.ai/code/session_01P7tUnyVgTtRWJrEvKGGhwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7tUnyVgTtRWJrEvKGGhwQ)_