### PR TITLE
Fix region-box armed-pulse to use opacity instead of box-shadow animation

### DIFF
--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -58,8 +58,14 @@
   // The bad-vote-with-box discard is armed — pulse a red glow so it's
   // unmistakable that the next ArrowLeft will throw the box away. The state
   // has no timeout; the user backs out via Esc or by touching the box.
+  // box-shadow is static (painted once); the pulse runs via opacity so it stays
+  // on the compositor thread and doesn't trigger per-frame repaints.
   &.armed {
     border-color: rgba(255, 110, 110, 0.95);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.35),
+      0 0 14px 4px rgba(255, 110, 110, 0.7);
     animation: region-box-armed-pulse 1.4s ease-in-out infinite;
   }
 }
@@ -74,18 +80,8 @@
 }
 
 @keyframes region-box-armed-pulse {
-  0%, 100% {
-    box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.45) inset,
-      0 0 0 1px rgba(0, 0, 0, 0.35),
-      0 0 8px 2px rgba(255, 110, 110, 0.35);
-  }
-  50% {
-    box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.45) inset,
-      0 0 0 1px rgba(0, 0, 0, 0.35),
-      0 0 14px 4px rgba(255, 110, 110, 0.7);
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 .region-handle {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The `region-box-armed-pulse` animation previously animated `box-shadow` between two sizes, triggering a software repaint on every frame. On thin clients with no GPU compositing this creates continuous CPU paint pressure for as long as the armed state is active.
- Fixed by keeping the max-glow `box-shadow` as a static property on `.armed` (painted once) and running the pulse via `opacity` animation only. `opacity` is compositor-thread-only and never triggers a repaint.
- Visual result is nearly identical: the red glow is always visible, and the box pulses by fading between full-opacity and half-opacity instead of between glow sizes.

## Context

Full audit of the frontend animation system for thin-client safety:

| Area | Status |
|------|--------|
| Global `@media (prefers-reduced-motion: reduce)` block in `styles.scss` | ✅ already present — kills all animations/transitions to 0.01ms when the OS preference is set |
| JS `prefersReducedMotion()` utility + swipe-animation/scroll usage | ✅ already present — swipe animations and smooth scroll respect the OS preference |
| All spinners/loaders (`vt-pulldown-spin`, `indeterminate`, `icon-waggle`) | ✅ use `transform` only — compositor-friendly, drop frames without blocking |
| Swipe animations (`swipe-right`/`swipe-left`) | ✅ `transform` + `opacity` — compositor-friendly; `setTimeout(180)` fires on wall-clock time, not animation completion, so slow machines don't get stuck |
| Canvas waveform drawing | ✅ one-shot `requestAnimationFrame` calls (not a continuous loop) |
| `region-box-armed-pulse` | ❌ → ✅ fixed in this PR |

## Test plan

- [ ] Open an image with a region box, arm the discard (ArrowLeft while box exists), confirm the box pulses red
- [ ] Confirm the pulse still looks like a warning (red glow visible statically, opacity animates between ~50% and 100%)
- [ ] Enable OS "reduce motion" — confirm the pulse stops immediately
- [ ] Vote/swipe still works normally on a non-animated machine

https://claude.ai/code/session_01VgucuHE8YSV3E1w7p7JX62
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgucuHE8YSV3E1w7p7JX62)_