### PR TITLE
Clear modal auto-close setTimeout on close/destroy (M31)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -883,8 +883,17 @@ Cross-section interaction agents:
   exhaustion.
 - **M30.** Autopilot phase transitions can oscillate
   (`hard → new → hard → new`) when smart/stable status flickers.
-- **M31.** `settings-importer-modal` auto-closes after 1.5s timeout regardless
-  of operation duration.
+- ~~**M31.** `settings-importer-modal` auto-closes after 1.5s timeout
+  regardless of operation duration.~~; resolved. The 1.5s timer fires only
+  after the server returns success (not mid-operation), so the original
+  framing was inaccurate; behavior was a minor UX choice, not a correctness
+  bug. The latent hygiene issue — `setTimeout` not cleared when the user
+  dismisses the modal manually, letting a zombie `close()` fire on a
+  destroyed component — was fixed by tracking the handle and clearing it in
+  `close()` / `ngOnDestroy` across all four auto-closing modals
+  (`settings-importer-modal`, `settings-exporter-modal`,
+  `label-importer-modal`, `examples-editor-modal`). The 1.5s / 600ms /
+  3000ms delays themselves are unchanged.
 
 ### Security
 

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
@@ -17,7 +17,7 @@ interface Example {
   templateUrl: './examples-editor-modal.component.html',
   styleUrl: './examples-editor-modal.component.scss',
 })
-export class ExamplesEditorModalComponent implements OnInit {
+export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
   @Input() modelName = '';
   @Output() closed = new EventEmitter<void>();
   @Output() saved = new EventEmitter<void>();
@@ -27,6 +27,7 @@ export class ExamplesEditorModalComponent implements OnInit {
   saving = false;
   error = '';
   status = '';
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private detectorsCrudApi: DetectorsCrudApiService) {}
 
@@ -79,7 +80,7 @@ export class ExamplesEditorModalComponent implements OnInit {
         this.saving = false;
         this.status = 'Saved.';
         this.saved.emit();
-        setTimeout(() => this.close(), 600);
+        this.closeTimer = setTimeout(() => this.close(), 600);
       },
       error: (err) => {
         this.saving = false;
@@ -89,6 +90,17 @@ export class ExamplesEditorModalComponent implements OnInit {
   }
 
   close(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
     this.closed.emit();
+  }
+
+  ngOnDestroy(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
   }
 }

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -1,4 +1,13 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -19,7 +28,7 @@ type ModalView = 'picker' | 'form';
   templateUrl: './label-importer-modal.component.html',
   styleUrl: './label-importer-modal.component.scss',
 })
-export class LabelImporterModalComponent implements OnInit {
+export class LabelImporterModalComponent implements OnInit, OnDestroy {
   /** When set, labels are imported directly into this trainable model
    *  instead of into the active dataset's vote state. */
   @Input() targetModelName: string | null = null;
@@ -42,6 +51,7 @@ export class LabelImporterModalComponent implements OnInit {
   successMessage = '';
   addingGood = false;
   addingBad = false;
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private labelImportersApi: LabelImportersApiService,
@@ -152,7 +162,7 @@ export class LabelImporterModalComponent implements OnInit {
           this.error = `${res.failed_count} element(s) failed to apply. The remaining labels were applied successfully.`;
         }
         const hasIssue = res.missing_count > 0 || res.failed_count > 0;
-        setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
+        this.closeTimer = setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
       },
       error: (err) => {
         this.submitting = false;
@@ -208,6 +218,17 @@ export class LabelImporterModalComponent implements OnInit {
   }
 
   close(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
     this.closed.emit();
+  }
+
+  ngOnDestroy(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
   }
 }

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -18,7 +18,7 @@ type ModalView = 'picker' | 'form';
   templateUrl: './settings-exporter-modal.component.html',
   styleUrl: './settings-exporter-modal.component.scss',
 })
-export class SettingsExporterModalComponent implements OnInit {
+export class SettingsExporterModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() exported = new EventEmitter<void>();
 
@@ -30,6 +30,7 @@ export class SettingsExporterModalComponent implements OnInit {
   submitting = false;
   error = '';
   successMessage = '';
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private settingsIoApi: SettingsIoApiService) {}
 
@@ -116,7 +117,7 @@ export class SettingsExporterModalComponent implements OnInit {
 
         this.successMessage = res.message || 'Settings exported successfully';
         this.exported.emit();
-        setTimeout(() => this.close(), 1500);
+        this.closeTimer = setTimeout(() => this.close(), 1500);
       },
       error: (err) => {
         this.submitting = false;
@@ -126,6 +127,17 @@ export class SettingsExporterModalComponent implements OnInit {
   }
 
   close(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
     this.closed.emit();
+  }
+
+  ngOnDestroy(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
   }
 }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,7 +17,7 @@ type ModalView = 'picker' | 'form';
   templateUrl: './settings-importer-modal.component.html',
   styleUrl: './settings-importer-modal.component.scss',
 })
-export class SettingsImporterModalComponent implements OnInit {
+export class SettingsImporterModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() imported = new EventEmitter<void>();
 
@@ -31,6 +31,7 @@ export class SettingsImporterModalComponent implements OnInit {
   submitting = false;
   error = '';
   successMessage = '';
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private settingsIoApi: SettingsIoApiService) {}
 
@@ -117,7 +118,7 @@ export class SettingsImporterModalComponent implements OnInit {
           this.submitting = false;
           this.successMessage = res.message || 'Settings imported successfully';
           this.imported.emit();
-          setTimeout(() => this.close(), 1500);
+          this.closeTimer = setTimeout(() => this.close(), 1500);
         },
         error: (err) => {
           this.submitting = false;
@@ -127,6 +128,17 @@ export class SettingsImporterModalComponent implements OnInit {
   }
 
   close(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
     this.closed.emit();
+  }
+
+  ngOnDestroy(): void {
+    if (this.closeTimer !== null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Addresses **M31** from `docs/plans/logical-bug-audit.md`.

The audit framed M31 as "`settings-importer-modal` auto-closes after 1.5s timeout regardless of operation duration." That framing was inaccurate: the `setTimeout(this.close, 1500)` only fires *after* the import HTTP request resolves successfully, so the modal never closes mid-operation. The 1.5s is just a "show success message, then dismiss" delay; behavior is fine.

The real latent issue was hygiene: if the user dismissed the modal manually (or it was destroyed for any other reason) before the timer fired, the callback still ran on a torn-down component and emitted a stale `closed` event. Four modals share the pattern, so the fix is applied to all four:

- `settings-importer-modal` (1500ms)
- `settings-exporter-modal` (1500ms)
- `label-importer-modal` (1500ms / 3000ms)
- `examples-editor-modal` (600ms)

Each now stores the timer handle and clears it in both `close()` and `ngOnDestroy`. Delay durations are unchanged.

The M31 entry in `docs/plans/logical-bug-audit.md` is updated with the resolution and a note about why the original framing was misleading.

## Test plan

- [x] `npm run build:prod` — clean (no TS errors, no Angular warnings)
- [ ] Manual: open settings importer, submit successfully, observe modal closes after 1.5s as before
- [ ] Manual: open settings importer, submit successfully, click the X within 1.5s, confirm no zombie `close()` fires (no double-emit)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxFSaG8YUYFfZZxrML7icL)_