### PR TITLE
docs(audit): mark M26 as a false positive

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1,8 +1,9 @@
 # Logical-Bug Audit: 2026-05
 
 **Status:** Mostly resolved; C1–C12 (critical) and H1–H34 (high) are
-shipped; ~15 medium/low items remain open (M21–M34, L1–L9). Resolved
-findings are marked as struck-through headings.
+shipped; ~14 medium/low items remain open (M21–M25, M27–M34, L1–L9;
+M26 was a false positive). Resolved findings are marked as
+struck-through headings.
 
 **Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
 interaction passes) of the entire VTSearch codebase, focused on
@@ -869,8 +870,14 @@ Cross-section interaction agents:
 
 - **M25.** `LeftPanelComponent` lacks `OnDestroy` / `takeUntil` on init
   subscriptions; subscriptions leak across dataset switches.
-- **M26.** `labelset-state.service` `startPolling()` is not tied to
-  `destroy$`; rapid switches leak polls.
+- ~~**M26.** `labelset-state.service` `startPolling()` is not tied to
+  `destroy$`; rapid switches leak polls.~~ **False positive.** The
+  service is `providedIn: 'root'` (singleton; `destroy$` effectively
+  never fires), `startPolling()` is guarded by an idempotent `if
+  (this.polling) return` check, and `stopPolling()` emits on
+  `stopPolling$` which the timer's `takeUntil` honors. The only real
+  observation is that `destroy$` itself is dead code; cosmetic, not a
+  leak.
 - **M27.** `progress-events.service` doesn't reconcile stale `task_id`s after
   backend restart.
 - ~~**M28.** Audio waveform fetch's `catch {}` silently shows "Unable to load


### PR DESCRIPTION
## Summary

Re-evaluated M26 ("`labelset-state.service` `startPolling()` is not tied to `destroy$`; rapid switches leak polls") and marked it as a false positive in `docs/plans/logical-bug-audit.md`.

## Why it's not a real bug

- `LabelsetStateService` is `providedIn: 'root'` — singleton, so `destroy$` effectively never fires during the app lifetime.
- `startPolling()` is idempotent: `if (this.polling) return` short-circuits repeated calls, so rapid switches can't stack timers.
- `stopPolling()` emits on `stopPolling$`, which the timer's `takeUntil` honors, so the prior poll is properly torn down before any restart.

The only real observation is that `destroy$` itself is dead code in this service — cosmetic, not a leak.

## Changes

- Struck through the M26 entry with an inline "False positive" note explaining why.
- Updated the status header's open-item count and explicitly called out that M26 was a false positive.

## Test plan

- [x] Docs-only change; no code or tests affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JExJefvQxAMzD5b4mSAu95)_