### PR TITLE
M25: takeUntil pattern on LeftPanelComponent init subscriptions

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1,9 +1,9 @@
 # Logical-Bug Audit: 2026-05
 
 **Status:** Mostly resolved; C1–C12 (critical) and H1–H34 (high) are
-shipped; ~14 medium/low items remain open (M21–M25, M27–M34, L1–L9;
-M26 was a false positive). Resolved findings are marked as
-struck-through headings.
+shipped; ~13 medium/low items remain open (M21–M24, M27–M34, L1–L9;
+M25 shipped, M26 was a false positive). Resolved findings are marked
+as struck-through headings.
 
 **Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
 interaction passes) of the entire VTSearch codebase, focused on
@@ -868,8 +868,16 @@ Cross-section interaction agents:
 
 ### Frontend
 
-- **M25.** `LeftPanelComponent` lacks `OnDestroy` / `takeUntil` on init
-  subscriptions; subscriptions leak across dataset switches.
+- ~~**M25.** `LeftPanelComponent` lacks `OnDestroy` / `takeUntil` on init
+  subscriptions; subscriptions leak across dataset switches.~~ Code-style
+  alignment, not a real leak. The two `ngOnInit` subscriptions go through
+  Angular `HttpClient`, which emits once and completes, so memory was never
+  retained; and `LeftPanelComponent` is mounted once by `label-view` /
+  `find-view` and reused across dataset switches via `@Input`, so `ngOnInit`
+  doesn't re-fire per switch either. Still added the standard
+  `destroy$` + `takeUntil(this.destroy$)` pattern plus `OnDestroy` so an
+  in-flight HTTP response can't fire `.next` on a destroyed component during
+  a route teardown, matching the convention used elsewhere in the frontend.
 - ~~**M26.** `labelset-state.service` `startPolling()` is not tied to
   `destroy$`; rapid switches leak polls.~~ **False positive.** The
   service is `providedIn: 'root'` (singleton; `destroy$` effectively

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,5 +1,17 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { SortBarComponent } from './sort-bar/sort-bar.component';
 import { SelectModeComponent } from './select-mode/select-mode.component';
 import { InclusionSliderComponent } from './inclusion-slider/inclusion-slider.component';
@@ -32,7 +44,7 @@ export type { SortMode, SelectMode, SortedItem };
   templateUrl: './left-panel.component.html',
   styleUrl: './left-panel.component.scss',
 })
-export class LeftPanelComponent implements OnInit, OnChanges {
+export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
@@ -99,22 +111,29 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   private mediaTypeInfos: MediaTypeInfo[] = [];
   private currentTypeId = '';
   private embedderInfos: EmbedderInfo[] = [];
+  private readonly destroy$ = new Subject<void>();
 
   constructor(private datasetsListingsApi: DatasetsListingsApiService) {}
 
   ngOnInit(): void {
-    this.datasetsListingsApi.getMediaTypes().subscribe({
-      next: (resp) => {
-        this.mediaTypeInfos = resp.media_types;
-        this.updateMediaTypeName();
-      },
-    });
-    this.datasetsListingsApi.getEmbedders().subscribe({
-      next: (embedders) => {
-        this.embedderInfos = embedders;
-        this.updateTextSortAvailable();
-      },
-    });
+    this.datasetsListingsApi
+      .getMediaTypes()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (resp) => {
+          this.mediaTypeInfos = resp.media_types;
+          this.updateMediaTypeName();
+        },
+      });
+    this.datasetsListingsApi
+      .getEmbedders()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (embedders) => {
+          this.embedderInfos = embedders;
+          this.updateTextSortAvailable();
+        },
+      });
     if (this.panelMode === 'find') {
       // Find mode doesn't use tabs; keep manual as a no-op default
       this.activeTab = 'manual';
@@ -131,6 +150,11 @@ export class LeftPanelComponent implements OnInit, OnChanges {
       this.updateMediaTypeName();
       this.updateTextSortAvailable();
     }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private updateMediaTypeName(): void {


### PR DESCRIPTION
## Summary

Closes M25 from `docs/plans/logical-bug-audit.md`.

- Add `destroy$` `Subject` + `takeUntil(this.destroy$)` to the two `ngOnInit` HTTP subscriptions in `LeftPanelComponent` (`getMediaTypes`, `getEmbedders`).
- Implement `OnDestroy` to complete the subject.
- Mark M25 as shipped in the audit doc with a note that the original "leaks across dataset switches" framing was wrong (HttpClient auto-completes; the component is mounted once and reused via `@Input`). The fix is a code-style alignment with the `takeUntil` pattern used elsewhere in the frontend, and it ensures an in-flight response can't fire `.next` on a destroyed component during route teardown.

No behavior change for the normal mount/use/destroy path; the only observable difference is that an unfinished GET is cancelled when the component is destroyed.

## Test plan

- [x] `cd frontend && npm run build:prod` succeeds with no warnings.
- [ ] (No new test added — pure refactor; existing `left-panel.component.spec.ts` continues to instantiate the component, exercising `ngOnInit` / `ngOnDestroy`.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C499g7YZZKRziBq4ikeCQp)_