### PR TITLE
Wire CoreConfig builder before route imports (M24)

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,32 @@ from werkzeug.exceptions import MethodNotAllowed, NotFound
 from vtscore.state.core import DatasetNotLoadedError, DetectorNotLoadedError  # noqa: E402
 from vtsearch.auth import get_login_provider  # noqa: E402
 from vtscore.embedding import initialize_models, preload_predicted_embedders  # noqa: E402
+
+# Install Flask-aware request-context resolvers on the (library-candidate)
+# ``vtsearch.state`` core so its ``get_active_*_context()`` helpers can read
+# the per-request dataset/detector context from ``flask.g`` without
+# ``vtscore.state.core`` itself having to import Flask.  Also wire the
+# library's "persist this" hooks (currently just last-embedder-per-media-
+# type) to ``vtsearch.settings`` and install the app-side builder for
+# ``CoreConfig.from_settings()``.  See ``vtscore/docs/architecture.md`` for
+# the seam.
+#
+# This block runs BEFORE blueprint modules are imported so that any
+# module-level code in a route that calls ``CoreConfig.from_settings()``
+# (or any other shim-backed hook) finds the builder already installed.
+# See logical-bug-audit M24.
+from vtsearch.shim import (  # noqa: E402
+    register_app_config_builder,
+    register_app_persistence_hooks,
+    register_app_plugin_families,
+    register_flask_context_resolvers,
+)
+
+register_flask_context_resolvers()
+register_app_persistence_hooks()
+register_app_config_builder()
+register_app_plugin_families()
+
 from vtsearch.routes import (  # noqa: E402
     achievements_bp,
     auth_bp,
@@ -87,25 +113,6 @@ app = Flask(__name__)
 # if set; otherwise fall back to a dev-only default.  Production
 # deployments should always set the env var.
 app.secret_key = os.environ.get("VTSEARCH_SECRET_KEY", "vtsearch-dev-key-change-in-production")
-
-# Install Flask-aware request-context resolvers on the (library-candidate)
-# ``vtsearch.state`` core so its ``get_active_*_context()`` helpers can read
-# the per-request dataset/detector context from ``flask.g`` without
-# ``vtscore.state.core`` itself having to import Flask.  Also wire the
-# library's "persist this" hooks (currently just last-embedder-per-media-
-# type) to ``vtsearch.settings``.  See ``vtscore/docs/architecture.md`` for
-# the seam.
-from vtsearch.shim import (  # noqa: E402
-    register_app_config_builder,
-    register_app_persistence_hooks,
-    register_app_plugin_families,
-    register_flask_context_resolvers,
-)
-
-register_flask_context_resolvers()
-register_app_persistence_hooks()
-register_app_config_builder()
-register_app_plugin_families()
 
 # Optional cap on request body size (uploads).  ``MAX_UPLOAD_MB == 0`` leaves
 # Flask's default of no limit in place; a positive value rejects oversized

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -861,9 +861,13 @@ Cross-section interaction agents:
   handlers from a hard-coded list of non-root loggers would stomp any
   handler a test or future feature legitimately attached there, and
   encode a closed list that would drift from reality silently.
-- **M24.** `CoreConfig.from_settings()` raises if a blueprint's module-level
+- ~~**M24.** `CoreConfig.from_settings()` raises if a blueprint's module-level
   code runs before `vtsearch/shim/__init__.py` registers the
-  builder.
+  builder.~~ Fixed: `app.py` now installs the shim hooks
+  (`register_flask_context_resolvers` / `register_app_persistence_hooks` /
+  `register_app_config_builder` / `register_app_plugin_families`) before
+  any `vtsearch.routes` blueprint module is imported, so the builder is
+  registered for any module-level code in a route that needs it.
 
 ### Frontend
 


### PR DESCRIPTION
## Summary
- Move the `vtsearch.shim` hook registrations (Flask context resolvers, persistence hooks, `CoreConfig` builder, plugin families) above the `from vtsearch.routes import ...` block in `app.py`.
- Any module-level code in a blueprint that calls `CoreConfig.from_settings()` (or another shim-backed hook) now finds the builder already installed, so a future route adding e.g. `_DIR = CoreConfig.from_settings().detectors_dir` at module scope won't raise `RuntimeError` at app import.
- No current blueprint trips this; the reorder removes a latent footgun called out as M24 in `docs/plans/logical-bug-audit.md` and marks the entry as fixed.

## Test plan
- [x] `./run-tests.sh core` — 679 passed
- [x] `./run-tests.sh` — 4336 passed, 1 skipped, 2 xpassed
- [x] `ruff check app.py docs/plans/logical-bug-audit.md` — clean

https://claude.ai/code/session_01LmQqyekBz3c9XmGXe7GZto

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmQqyekBz3c9XmGXe7GZto)_