### PR TITLE
Fix AudioContext leak in audio-player on rapid navigation

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -159,11 +159,13 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
         throw new Error(`HTTP ${response.status} fetching audio for media ${mediaId}`);
       }
       const arrayBuffer = await response.arrayBuffer();
+      if (abort.signal.aborted) return;
 
       if (!this.audioCtx || this.audioCtx.state === 'closed') {
         this.audioCtx = new AudioContext();
       }
       const audioBuffer = await this.audioCtx.decodeAudioData(arrayBuffer);
+      if (abort.signal.aborted) return;
 
       const channelData = audioBuffer.getChannelData(0);
       const step = Math.ceil(channelData.length / width);


### PR DESCRIPTION
## Summary

Fixes M29 from `docs/plans/logical-bug-audit.md`: `AudioContext` was not cleaned up on rapid navigation, eventually exhausting Chrome's ~6-context limit and surfacing "Unable to load waveform".

The leak path was a destroy-vs-async race in `drawWaveform()`:

1. User views audio media → component issues `await fetch(...)` for the waveform.
2. User swipes before fetch resolves → `ngOnDestroy` aborts the fetch and closes `this.audioCtx`.
3. If the coroutine was past `await response.arrayBuffer()` (signal-aborted fetches don't help here) and reached the `if (!this.audioCtx || this.audioCtx.state === 'closed')` branch, it saw `state === 'closed'` and constructed a **new** `AudioContext`. Nothing ever closed it because `ngOnDestroy` had already run.

The fix lifts the existing `AbortController` signal into the body of `drawWaveform` with two `if (abort.signal.aborted) return;` guards — after `arrayBuffer()` and after `decodeAudioData()` — so a destroyed (or superseded) call returns before recreating a context or decoding.

## Test plan

- [x] `cd frontend && npm run build:prod` — clean, no TS errors, no `▲ WARNING` budget lines.
- [ ] Manual: load a long audio sort, swipe rapidly through many items, confirm waveform keeps rendering past the 6th item (previously failed silently).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SWzQYp95VtrXDqveyTELcH)_