### PR TITLE
Force progress bars to 100% before the next task starts

### DIFF
--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -121,8 +121,16 @@ def _make_console_progress(original_callback):
     _last_base: list[str | None] = [None]
     _on_progress_line: list[bool] = [False]
 
+    _FULL_BAR = "#" * 30
+
+    def _complete_bar() -> None:
+        """Overwrite the current progress line with a 100% bar."""
+        if _last_base[0]:
+            sys.stdout.write(f"\r    {_last_base[0]} [{_FULL_BAR}] 100%\033[K")
+
     def _flush() -> None:
         if _on_progress_line[0]:
+            _complete_bar()
             sys.stdout.write("\n")
             sys.stdout.flush()
             _on_progress_line[0] = False
@@ -134,8 +142,10 @@ def _make_console_progress(original_callback):
 
         if total > 0:
             base = _strip_time_suffix(message)
-            # If we're already on a progress line for a different task, terminate it.
+            # If we're already on a progress line for a different task, complete it
+            # at 100% before starting the new bar.
             if _on_progress_line[0] and _last_base[0] is not None and _last_base[0] != base:
+                _complete_bar()
                 sys.stdout.write("\n")
             pct = min(100, current * 100 // total)
             filled = pct * 30 // 100
@@ -149,8 +159,9 @@ def _make_console_progress(original_callback):
             _last_base[0] = base
             _last_msg[0] = message
         elif message and message != _last_msg[0]:
-            # New phase message - print on its own line
+            # New phase message - print on its own line; complete any active bar first.
             if _on_progress_line[0]:
+                _complete_bar()
                 sys.stdout.write("\n")
                 _on_progress_line[0] = False
                 _last_base[0] = None


### PR DESCRIPTION
## Summary

- Progress bars left at a mid-percentage (e.g. `Importing torch… 50%`, `Loading weights 93%`) when the next task began or when preloading finished.
- `_make_console_progress` now calls a new `_complete_bar()` helper in three places — transitioning to a different bar, transitioning to a phase message, and in `flush()` — which overwrites the current line with a full `[##############################] 100%` render before emitting the newline that terminates the line.
- No changes to any progress callback signatures or external APIs; all 158 CLI tests pass.

## What the terminal now shows

Before:
```
    Importing torch… (16s, 809 modules) [###############...............]  50%
    Importing transformers… (22s, 2231 modules) [##############################] 100%
    Loading weights [###########################...]  93%
    Loading SigLIP processor…
```

After:
```
    Importing torch… [##############################] 100%
    Importing transformers… [##############################] 100%
    Loading weights [##############################] 100%
    Loading SigLIP processor…
```

## Test plan

- [x] `./run-tests.sh cli` — 158 tests passed

https://claude.ai/code/session_013pC37gavc25qyov5LT4HHD

---
_Generated by [Claude Code](https://claude.ai/code/session_013pC37gavc25qyov5LT4HHD)_