### PR TITLE
Wrap view-controls button pairs when panel is too narrow

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -118,6 +118,7 @@
   margin: 0;
   color: var(--text-secondary);
   font-weight: var(--weight-regular);
+  flex-shrink: 0;
 }
 
 .view-controls-slot {

--- a/frontend/src/app/components/view-controls/view-controls.component.scss
+++ b/frontend/src/app/components/view-controls/view-controls.component.scss
@@ -1,11 +1,13 @@
 :host {
   display: inline-flex;
+  min-width: 0;
 }
 
 .view-controls {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: var(--space-md);
+  flex-wrap: wrap;
+  gap: var(--space-sm) var(--space-md);
 }
 
 .vc-group {


### PR DESCRIPTION
## Summary

- Add `flex-wrap: wrap` to `.view-controls` so the three button-pairs can reflow to a second line when the panel is squeezed
- Add `min-width: 0` to the `:host` element so the inline-flex container can be squeezed by its parent panel flex layout
- Add `flex-shrink: 0` to `.images-header-title` in the left panel so the media-count label never shrinks — all available squeeze is applied to the view-controls slot

Each `.vc-group` (one button pair) remains `display: inline-flex` with no internal wrapping, so pairs always stay together. The row/column gap uses `var(--space-sm)` vertically and `var(--space-md)` horizontally, matching the existing horizontal rhythm.

https://claude.ai/code/session_016EVyF5PNKaNzqRvG5EQrWw

---
_Generated by [Claude Code](https://claude.ai/code/session_016EVyF5PNKaNzqRvG5EQrWw)_