### PR TITLE
Bump Node.js install instructions from 18 to 22

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -202,7 +202,7 @@ build (~2 GB).
 
 ## Building the frontend
 
-The Angular frontend must be built after checking out the code; the compiled files are not committed to Git. You'll need **Node.js 18+** and **npm**.
+The Angular frontend must be built after checking out the code; the compiled files are not committed to Git. You'll need **Node.js 22+** and **npm**.
 
 Check if they're installed:
 
@@ -216,7 +216,7 @@ If not installed:
 <details><summary>Ubuntu / Debian</summary>
 
 ```bash
-curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs
 ```
 
@@ -225,7 +225,7 @@ sudo apt install -y nodejs
 <details><summary>RHEL / Fedora / Rocky / Alma</summary>
 
 ```bash
-curl -fsSL https://rpm.nodesource.com/setup_18.x | sudo -E bash -
+curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo -E bash -
 sudo dnf install -y nodejs
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ Angular SPA for the VTSearch media explorer. Built with Angular CLI 19.2 and Typ
 
 ## Prerequisites
 
-- **Node.js 18+** (LTS recommended)
+- **Node.js 22+** (LTS recommended)
 - **npm** (bundled with Node.js)
 
 ## Development server


### PR DESCRIPTION
## Summary
- Node.js 18 reached EOL in April 2025; following `docs/SETUP.md` now prints a deprecation banner.
- Point `docs/SETUP.md` and `frontend/README.md` at Node.js 22 (current active LTS), including the `nodesource setup_22.x` URLs for Debian/Ubuntu and RHEL/Fedora.
- Docker images already pin `node:20-slim`, which is still supported (maintenance LTS until April 2026); left untouched.

## Test plan
- [ ] Re-run the SETUP.md install commands on a clean Ubuntu/Fedora box and confirm the deprecation banner is gone.

https://claude.ai/code/session_01PSY3mxktscdnoFmtmXj9C3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSY3mxktscdnoFmtmXj9C3)_