### PR TITLE
Close M30: document autopilot phase oscillation decision

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -912,8 +912,17 @@ Cross-section interaction agents:
   console or overwrite the next media's canvas.
 - **M29.** `AudioContext` not cleaned up on rapid navigation → resource
   exhaustion.
-- **M30.** Autopilot phase transitions can oscillate
-  (`hard → new → hard → new`) when smart/stable status flickers.
+- ~~**M30.** Autopilot phase transitions can oscillate
+  (`hard → new → hard → new`) when smart/stable status flickers.~~
+  **Won't fix.** Evaluated and closed. The current derivation in
+  `AutopilotStateService.checkPhaseTransition` is intentionally instantaneous
+  so the phase tracks real indicator state both forward and backward (per the
+  existing comment about vote-removal regressions). A one-way ratchet or
+  hysteresis would suppress the bounce but would also mask genuine
+  instability after entering `new`, leaving the user on a stale sort with no
+  automatic recovery. The observable oscillation is rate-limited by the
+  autopilot resort interval and settles on its own; adding stickiness costs
+  more than the noise it would remove.
 - ~~**M31.** `settings-importer-modal` auto-closes after 1.5s timeout
   regardless of operation duration.~~; resolved. The 1.5s timer fires only
   after the server returns success (not mid-operation), so the original


### PR DESCRIPTION
## Summary
Updated the logical bug audit to close M30 (autopilot phase transition oscillation) with a detailed rationale for why the current behavior is intentional and preferable to alternatives.

## Changes
- Marked M30 as "Won't fix" with comprehensive explanation
- Documented that the instantaneous phase derivation in `AutopilotStateService.checkPhaseTransition` is intentional to track real indicator state bidirectionally
- Explained the tradeoff: adding hysteresis/ratcheting would suppress oscillation but would mask genuine instability and prevent automatic recovery
- Noted that the observable oscillation is naturally rate-limited by the autopilot resort interval and self-settles

## Details
The decision reflects a careful evaluation of the cost-benefit: the current design prioritizes correctness (detecting real state changes and recovering from stale sorts) over suppressing transient noise. The noise is already bounded by the resort interval, making the cost of adding stickiness higher than the benefit of removing it.

https://claude.ai/code/session_019dThfrLdWQQ7bzGJuTC1h5