### PR TITLE
Sweep Low contrast style-audit findings + add --opacity-disabled token

### DIFF
--- a/docs/reviews/2026-05-27-style-audit.md
+++ b/docs/reviews/2026-05-27-style-audit.md
@@ -1,5 +1,12 @@
 # Rendered Style Audit - 2026-05-27
 
+**Status:** V7 / V10 / V11 / V13 shipped, plus the underlying systemic
+fix (`--opacity-disabled` token, see §1.9 of `docs/style-guide.md`).
+V1 / V2 / V3 (tab-bar duplication) and the remaining Low findings (V4 /
+V5 / V6 / V8 / V9 / V12 / V14 / V15) are still open.
+
+
+
 **Scope.** Task 1 of `docs/plans/browser-vision-testing.md`: a rendered
 style audit of every major view in light and dark themes, comparing
 against `docs/style-guide.md` and the CLAUDE.md "Nested-modal back
@@ -75,6 +82,38 @@ No findings were promoted to High. The audit did not surface a
 broken-layout / unreadable-text bug in either theme; all issues are
 style-guide compliance or minor-contrast.
 
+### Systemic finding (added during fix-up)
+
+The four contrast Lows above (V7, V10, V11, V13) all traced back to one
+underlying habit: components reach for `opacity` to "tone something
+down" without picking a shared value, and without checking whether
+opacity is the right tool against the surface they're sitting on. A
+grep across `frontend/src` turned up **seven different opacity values**
+used to express the `:disabled` / `.disabled` state across button-like
+elements: `0.35`, `0.4`, `0.45`, `0.5`, `0.55`, `0.6`, `0.75`. The
+dashboard icon buttons sat at `0.35` (V10), the header "you are here"
+button at `0.4` against the accent-blue header (V11), the importer
+sub-tabs at `0.45`, and the global `.btn` baseline at `0.5`.
+
+Resolved by introducing a single `--opacity-disabled: 0.5` token (see
+`_variables.scss`; documented at §1.9 of `docs/style-guide.md`) and
+collapsing the standard `:disabled { opacity: ... }` sites onto it
+(`_components.scss`, `_picker-shared.scss`, `dashboard.component.scss`,
+`dataset-card.component.scss`, `app.component.scss`,
+`view-controls.component.scss`, `right-panel.component.scss`,
+`export-modal`, `media-crop-modal`, `audio-crop-overlay`,
+`label-importer-modal`). The few non-standard sites that mean
+"something different" (`folder-browser` at `0.55` is the wait-cursor
+state, `login` at `0.6`, achievement-tier opacities) are deliberately
+left alone - they convey distinct semantics and shouldn't be conflated
+with disabled.
+
+The V11 fix also makes the broader point: **opacity is the wrong tool
+for "disabled" when the surface is saturated**. White-on-accent-blue
+dimmed via opacity cannot hold contrast, so the header's Dashboard
+button now uses a `color: var(--header-text-dim)` shift instead. The
+style guide now calls this out explicitly.
+
 ---
 
 ## Dashboard
@@ -119,6 +158,12 @@ Suspected source: shared `.btn:disabled { opacity: 0.5 }` rule in
 chrome in `frontend/src/app/components/dashboard/dashboard.component.scss`
 (panel header right-aligned action group). Severity: Low.
 
+**Fixed.** `.side-action-btn:disabled` and `.select-checkbox:disabled`
+in `dashboard.component.scss` were sitting at `opacity: 0.35`; both now
+use `var(--opacity-disabled)` (0.5). Combined with the systemic token
+roll-out, every standard "this button is disabled" affordance now sits
+at the same opacity.
+
 ### V11 - "Dashboard" disabled button vs. accent header bg
 
 The persistent header bar uses the accent-purple background in both
@@ -132,6 +177,13 @@ Suspected source: header layout in
 `frontend/src/app/components/header/` (or wherever the top app bar
 lives) combined with `.btn:disabled { opacity: 0.5 }` in
 `frontend/src/scss/_components.scss`.
+
+**Fixed.** Actual source was `.top-bar-btn:disabled` in
+`app.component.scss` reaching for `opacity: 0.4`. Replaced with a
+color shift: `color: var(--header-text-dim)`,
+`background: transparent`, no opacity change. This is now the canonical
+example in §1.9 of the style guide: opacity cannot hold contrast on a
+saturated background; reach for a theme-aware dim color token instead.
 
 ---
 
@@ -184,6 +236,13 @@ Suspected source: `frontend/src/scss/_picker-shared.scss`
 `.badge-download` block + the `--bg-subtle`/`--text-muted` resolution
 on `[data-theme="dark"]` in `frontend/src/scss/_variables.scss`.
 Severity: Low.
+
+**Fixed.** `.badge-download` had been pairing `background: var(--border)`
+with `color: var(--text-muted)` - two near-equal shades of grey that
+flattened against the dark table row. Now uses
+`background: var(--bg-secondary-btn)` + `color: var(--text-secondary)`
+in `_picker-shared.scss`. Light mode also benefits (a hair more contrast
+on white).
 
 ### V15 - Picker-tab `<i>` icons mostly grey in light mode
 
@@ -372,6 +431,14 @@ likely overrides `overflow` without re-applying the project's
 `scrollbar-color` / webkit thumb rule that lives in
 `frontend/src/scss/_globals.scss` (or wherever the default scrollbar
 treatment is declared - grep for `::-webkit-scrollbar`).
+
+**Fixed.** The global `* { scrollbar-color: ... }` rule in
+`_components.scss` should reach `.guide`, but the screenshot proves it
+doesn't (likely a Chromium-on-Linux scrollbar-color quirk - the rule
+holds zero specificity and competes with whatever the engine falls
+back to per-overflow-context). Reasserted the theme scrollbar
+explicitly on `.guide` (both `scrollbar-color` and the
+`::-webkit-scrollbar*` variants), scoped to the Help modal body only.
 
 ---
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -116,6 +116,16 @@ All three resolve through `--shadow-dropdown` so they auto-tint per theme.
 
 Never use a raw z-index. If you need a new layer, add a token.
 
+### 1.9 Disabled state - `--opacity-disabled`
+
+| Token                | Value | When to use |
+|----------------------|-------|-------------|
+| `--opacity-disabled` | 0.5   | The `opacity` value on every `:disabled` / `.disabled` button or interactive element styled via opacity. |
+
+There is only one disabled opacity. Don't write `opacity: 0.35` or `opacity: 0.4` because it "looks right" - the rendered audit at `docs/reviews/2026-05-27-style-audit.md` found seven different ad-hoc values in the wild and several dropped text below readable contrast.
+
+**Don't use opacity to disable text on a saturated background.** Opacity dims the rendered pixels toward the background, so 50% white on the accent-blue header collapses to a mid-blue that fails contrast. For buttons sitting on `--header-bg` (or any saturated surface), shift `color` to a theme-aware dimmed token (e.g. `--header-text-dim`) and keep the cursor change - skip `opacity` entirely.
+
 ---
 
 ## 2. Shared component classes

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -97,7 +97,7 @@ header {
   }
 
   &.disabled {
-    opacity: 0.4;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
 
     &:hover {
@@ -171,7 +171,12 @@ header {
 
   &:disabled,
   &.disabled {
-    opacity: 0.4;
+    // Avoid `opacity` here: white text dimmed via opacity on the saturated
+    // accent-blue header collapses to unreadable contrast. A color shift to
+    // --header-text-dim keeps the "you are here / not actionable" feel while
+    // staying readable in all three themes.
+    color: var(--header-text-dim);
+    background: transparent;
     cursor: not-allowed;
   }
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -51,7 +51,7 @@
   }
 
   &:disabled {
-    opacity: 0.35;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 
@@ -79,7 +79,7 @@
   }
 
   &:disabled {
-    opacity: 0.35;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -161,7 +161,7 @@ td.actions-col {
   }
 
   &.disabled {
-    opacity: 0.35;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -57,7 +57,7 @@
   }
 
   &.disabled {
-    opacity: 0.5;
+    opacity: var(--opacity-disabled);
     cursor: default;
 
     input[type='radio'] {

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -116,6 +116,20 @@
 .guide {
   max-height: 70vh;
   overflow-y: auto;
+  // The global `* { scrollbar-color: ... }` rule in _components.scss does
+  // not reliably reach this element in dark theme (audit 2026-05-27
+  // observed the default browser thumb on a light track). Reassert it
+  // here so the help modal body stays on-theme.
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--bg-panel);
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: var(--bg-panel); }
+  &::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: var(--radius-sm);
+  }
+  &::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 }
 
 .guide-loading,

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -111,7 +111,7 @@
   }
 
   &:disabled {
-    opacity: 0.5;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }
@@ -145,7 +145,7 @@
   }
 
   &:disabled {
-    opacity: 0.5;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
@@ -65,7 +65,7 @@ canvas {
     background: white;
 
     &:disabled {
-      opacity: 0.5;
+      opacity: var(--opacity-disabled);
       cursor: not-allowed;
     }
 

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
@@ -50,7 +50,7 @@
     background: white;
 
     &:disabled {
-      opacity: 0.5;
+      opacity: var(--opacity-disabled);
       cursor: not-allowed;
     }
 

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -75,7 +75,7 @@
   }
 
   &:disabled {
-    opacity: 0.4;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }

--- a/frontend/src/app/components/view-controls/view-controls.component.scss
+++ b/frontend/src/app/components/view-controls/view-controls.component.scss
@@ -47,7 +47,7 @@
   }
 
   &:disabled {
-    opacity: 0.4;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -78,7 +78,7 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   }
 
   &:disabled {
-    opacity: 0.5;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -50,7 +50,7 @@
   @extend .importer-tab;
 
   &.disabled, &:disabled {
-    opacity: 0.45;
+    opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
 }
@@ -219,7 +219,11 @@
 
 .badge-ready { background: var(--color-good); }
 .badge-embedding { background: var(--badge-embedding, var(--accent)); }
-.badge-download { background: var(--border); color: var(--text-muted); }
+// Neutral "needs action" pill. Uses --bg-secondary-btn (a step lighter than
+// --border) + --text-secondary so the text holds readable contrast in dark
+// mode; the previous --border + --text-muted pairing layered two near-equal
+// shades of grey and was effectively invisible against the table row.
+.badge-download { background: var(--bg-secondary-btn); color: var(--text-secondary); }
 
 // (The server folder browser chrome - breadcrumbs, list, items, path footer -
 // now lives in `vt-folder-browser`. See

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -52,6 +52,17 @@
   --shadow-md: 0 4px 12px var(--shadow-dropdown);
   --shadow-lg: 0 8px 32px var(--shadow-dropdown);
 
+  // Disabled-state opacity. One value, used everywhere a button or
+  // interactive element renders its `:disabled` / `.disabled` state via
+  // opacity. Do not pick a different opacity per component - the audit at
+  // docs/reviews/2026-05-27-style-audit.md found seven different values in
+  // the wild (0.35/0.4/0.45/0.5/0.55/0.6/0.75) and several of them dropped
+  // text below readable contrast. For disabled buttons that sit on a
+  // saturated background (e.g. the accent-blue app header), prefer a
+  // `color: var(--header-text-dim)` shift over opacity - opacity can't hold
+  // contrast on a saturated surface.
+  --opacity-disabled: 0.5;
+
   // Z-index scale (centralised stacking order)
   --z-base: 1;
   --z-elevated: 10;


### PR DESCRIPTION
## Summary

Resolves the four contrast-related Low findings from the 2026-05-27 rendered style audit (V7, V10, V11, V13) and fixes the underlying systemic problem they all traced back to.

**The systemic issue.** A grep across `frontend/src` turned up **seven different opacity values** used to express the `:disabled` / `.disabled` state on button-like elements: `0.35`, `0.4`, `0.45`, `0.5`, `0.55`, `0.6`, `0.75`. Several of those values dropped text below readable contrast (dashboard icon buttons at `0.35`, the header "you are here" Dashboard button at `0.4` against the accent-blue header). They were picked component-by-component, not by design.

**Resolution.**
- New `--opacity-disabled: 0.5` token in `_variables.scss`. Documented in §1.9 of `docs/style-guide.md`.
- Standard `:disabled { opacity: ... }` sites collapsed onto it (`_components.scss`, `_picker-shared.scss`, dashboard / dataset-card / app.component, view-controls, right-panel, export-modal, media-crop-modal, audio-crop-overlay, label-importer-modal). Sites that mean something distinct (`folder-browser` 0.55 wait-cursor, `login` 0.6, achievement-tier opacities) are deliberately left alone.

**Per-finding fixes.**
- **V7** — `.badge-download` was layering `var(--border)` + `var(--text-muted)` (two near-equal greys, invisible in dark). Now uses `var(--bg-secondary-btn)` + `var(--text-secondary)`.
- **V10** — `.side-action-btn:disabled` was at `opacity: 0.35`; now uses the token.
- **V11** — `.top-bar-btn:disabled` was at `opacity: 0.4` against the saturated accent-blue header. Opacity can't hold contrast there. Replaced with `color: var(--header-text-dim)` + `background: transparent`. Style guide now calls this out as a general rule: don't use opacity to disable text on a saturated background.
- **V13** — Reasserted the theme scrollbar explicitly on the Help modal's `.guide` body; the global `* { scrollbar-color: ... }` in `_components.scss` is correct but isn't reliably reaching the element under Chromium.

The V1/V2/V3 Medium tab-bar cluster and the remaining Lows (V4/V5/V6/V8/V9/V12/V14/V15) are still open — recorded inline in `docs/reviews/2026-05-27-style-audit.md`.

## Test plan
- [x] `./run-tests.sh core` → 679/679 pass (frontend build, ruff, codespell, deptry, pyright, OpenAPI snapshot, npm audit all clean)
- [x] `npm run build:prod` → no `▲ [WARNING]` lines
- [ ] Manual verification in dark mode: Demo import table "Needs Download" badge readable; Help modal scrollbar matches theme
- [ ] Manual verification in light mode: dashboard panel-header trash/combine icons visible when disabled; header "Dashboard" button readable while disabled

https://claude.ai/code/session_01TBUgt1Au7jk9ZyTJYjWTwL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBUgt1Au7jk9ZyTJYjWTwL)_