### PR TITLE
Fix KeyError: 'md5'/'file_size' on converter outputs from service importers

### DIFF
--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -1099,5 +1099,148 @@ class TestIngestSpecStreamMediaType:
 
 
 # ---------------------------------------------------------------------------
+# _ingest_spec_stream: required framework fields on converter outputs
+# ---------------------------------------------------------------------------
+#
+# Converters return only content fields (media_bytes, filename, duration, …).
+# _ingest_spec_stream is responsible for computing file_size / md5 and
+# defaulting embedding / embedder / category so the rest of the pipeline
+# never sees a KeyError.
+
+
+class TestIngestSpecStreamRequiredFields:
+    """Converter outputs get file_size, md5, embedding, embedder, category."""
+
+    @staticmethod
+    def _make_importer(records: list[dict]):
+        from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+
+        class _Imp(DatasetImporter):
+            name = "test_fields"
+            display_name = "Test"
+            description = "Test importer."
+            fields = [
+                ImporterField(
+                    "media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"
+                ),
+            ]
+
+            def fetch_source_media(self, spec: SourceSpec, field_values: dict, thin: bool = False):
+                yield from iter(records)
+
+        return _Imp()
+
+    def test_file_size_and_md5_computed_from_bytes(self, monkeypatch):
+        """file_size and md5 are derived from media_bytes when the converter omits them."""
+        import hashlib
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        png = b"PNGDATA"
+
+        def fake_convert(media, params):
+            return [{"filename": "frame_0.png", "media_bytes": png, "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert len(medias) == 1
+        m = medias[1]
+        assert m["file_size"] == len(png)
+        assert m["md5"] == hashlib.md5(png).hexdigest()
+
+    def test_embedding_embedder_category_defaulted(self, monkeypatch):
+        """embedding=None, embedder='', category='custom' are set on converter outputs."""
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            return [{"filename": "frame_0.png", "media_bytes": b"PNG", "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        m = medias[1]
+        assert m.get("embedding") is None
+        assert m.get("embedder") == ""
+        assert m.get("category") == "custom"
+
+    def test_preexisting_md5_not_overwritten(self, monkeypatch):
+        """If a converter explicitly sets md5 (future-proofing), it is preserved."""
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            return [{"filename": "frame_0.png", "media_bytes": b"PNG", "duration": 0, "md5": "precomputed"}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert medias[1]["md5"] == "precomputed"
+
+    def test_no_bytes_yields_empty_md5(self, monkeypatch):
+        """A converter that produces no bytes gets md5=md5(b'')."""
+        import hashlib
+        import json
+
+        from vtscore.converters import get_converter
+
+        v2i = get_converter("video2image")
+        assert v2i is not None
+
+        def fake_convert(media, params):
+            return [{"filename": "empty.png", "duration": 0}]
+
+        monkeypatch.setattr(v2i, "convert", fake_convert)
+
+        imp = self._make_importer([{"filename": "clip.mp4", "media_bytes": b"VID"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        assert medias[1]["md5"] == hashlib.md5(b"").hexdigest()
+        assert medias[1]["file_size"] == 0
+
+    def test_direct_spec_not_affected(self):
+        """Pass-through (no-converter) specs are not modified by _fill_converter_output_fields."""
+        import json
+
+        # A direct spec whose raw media explicitly lacks file_size/md5 should
+        # NOT have them added (that would mask a broken importer).
+        imp = self._make_importer([{"filename": "photo.png", "media_bytes": b"PNG", "media_type": "image"}])
+        medias: dict = {}
+        source_specs = json.dumps([{"source_type": "image", "converter": None, "params": {}}])
+        imp.run({"media_type": "image", "source_specs": source_specs}, medias)
+
+        # file_size / md5 are NOT added for direct (no-converter) specs
+        assert "file_size" not in medias[1]
+        assert "md5" not in medias[1]
+
+
+# ---------------------------------------------------------------------------
 # load_dataset_from_folder – content_vectors support
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/importers/base.py
+++ b/vtscore/datasets/importers/base.py
@@ -56,6 +56,7 @@ verifies that every imported package is declared there.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field as dc_field
 from pathlib import Path
@@ -183,6 +184,33 @@ def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) 
 
 
 PickerView = str  # one of: "form", "demo", "server_folder", "local"
+
+
+def _fill_converter_output_fields(media: dict[str, Any]) -> None:
+    """Fill framework-required fields that converters don't produce.
+
+    Converter implementations return only content fields (``media_bytes``,
+    ``media_string``, ``filename``, ``duration``, ``width``, ``height``).
+    The ingestion layer is responsible for stamping the bookkeeping fields
+    that the rest of the framework (``export_dataset_to_file``, the embed
+    stage, etc.) expects on every media dict.
+    """
+    if "file_size" not in media:
+        mb = media.get("media_bytes") or b""
+        ms = (media.get("media_string") or "").encode("utf-8")
+        media["file_size"] = len(mb) if mb else len(ms)
+    if "md5" not in media:
+        mb = media.get("media_bytes")
+        if mb:
+            media["md5"] = hashlib.md5(mb).hexdigest()
+        elif media.get("media_string"):
+            media["md5"] = hashlib.md5((media["media_string"] or "").encode("utf-8")).hexdigest()
+        else:
+            media["md5"] = hashlib.md5(b"").hexdigest()
+    media.setdefault("embedding", None)
+    media.setdefault("embedder", "")
+    media.setdefault("category", "custom")
+    media.setdefault("duration", 0)
 
 
 # Synthetic per-importer field that lets the user pick a name for the new
@@ -627,6 +655,8 @@ class DatasetImporter(PluginBase):
                 media["id"] = next_id
                 media.setdefault("origin", default_origin)
                 media.setdefault("origin_name", media.get("filename") or str(next_id))
+                if spec.converter is not None:
+                    _fill_converter_output_fields(media)
                 medias[next_id] = media
                 next_id += 1
         return next_id


### PR DESCRIPTION
## Summary

- **Root cause**: When a service importer (DataXplorer, ReCaller, etc.) uses `source_specs` with a converter (e.g. `video2image`), `_ingest_spec_stream` stored raw converter outputs directly into `medias` without adding the framework-required bookkeeping fields. Converters intentionally only return content fields (`media_bytes`, `filename`, `duration`, `width`, `height`); the ingestion layer is supposed to compute the rest.
- **Symptoms**: `KeyError: 'file_size'` and `KeyError: 'md5'` when `export_dataset_to_file` tried to serialise the dataset after import; additionally, converted frames (e.g. images extracted from video) appeared in the UI with no metadata (`custom_metadata` missing, no MD5 shown, name shown as "Media #N").
- **Fix**: Added `_fill_converter_output_fields()` called on each converter output inside `_ingest_spec_stream`. This computes `file_size` (from byte length), `md5` (from bytes/string), and defaults `embedding=None`, `embedder=""`, `category="custom"`, `duration=0` — matching the logic already present in `runner.py`'s `_build_converted_media_dict` for the folder-importer path.
- **Not affected**: The folder importer path (`run_converters_on_folder` → `_build_converted_media_dict`) was correct already. Only the spec-stream path used by service importers was broken.

## Test plan

- [ ] New `TestIngestSpecStreamRequiredFields` class with 5 regression tests covering: `file_size`/`md5` computed from bytes, `embedding`/`embedder`/`category` defaulted, pre-existing `md5` preserved, no-bytes edge case, and direct (no-converter) specs not affected
- [ ] Full test suite: 4342 passed, 0 failures

https://claude.ai/code/session_01CXK367qLgXv7DGqtUsigqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXK367qLgXv7DGqtUsigqT)_