### PR TITLE
Fix Dockerfile import paths and add Docker build validation

### DIFF
--- a/docker/Dockerfile.image-embedders
+++ b/docker/Dockerfile.image-embedders
@@ -91,6 +91,7 @@ COPY vtsearch/__init__.py vtsearch/__init__.py
 
 # Copy package source so `pip install -e .` finds it.
 COPY vtsearch/ vtsearch/
+COPY vtscore/ vtscore/
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir \
@@ -140,7 +141,7 @@ COPY model_cache/ "$VTSEARCH_MODELS_DIR/"
 
 # SigLIP (default, ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import SIGLIP_MODEL_ID; \
+from vtscore.config import SIGLIP_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {SIGLIP_MODEL_ID} to {cache}', flush=True); \
 from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
@@ -151,7 +152,7 @@ print('SigLIP weights cached.', flush=True)"
 
 # SigLIP 2 (ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import SIGLIP2_MODEL_ID; \
+from vtscore.config import SIGLIP2_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {SIGLIP2_MODEL_ID} to {cache}', flush=True); \
 from transformers import AutoModel, AutoProcessor; \
@@ -161,7 +162,7 @@ print('SigLIP 2 weights cached.', flush=True)"
 
 # OpenAI CLIP (ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import CLIP_MODEL_ID; \
+from vtscore.config import CLIP_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {CLIP_MODEL_ID} to {cache}', flush=True); \
 from transformers import CLIPModel, CLIPProcessor; \
@@ -171,7 +172,7 @@ print('CLIP weights cached.', flush=True)"
 
 # DINOv2 (ungated; anyone can download these).
 RUN python -u -c "import os; \
-from vtsearch.config import DINOV2_MODEL_ID; \
+from vtscore.config import DINOV2_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {DINOV2_MODEL_ID} to {cache}', flush=True); \
 from transformers import AutoModel, AutoImageProcessor; \
@@ -189,7 +190,7 @@ print('DINOv2 weights cached.', flush=True)"
 # is a single ``python -c`` line and try/except is a compound statement
 # that can't be flattened with semicolons.
 RUN python -u -c "import os; \
-from vtsearch.config import DINOV3_MODEL_ID; \
+from vtscore.config import DINOV3_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 from transformers import AutoModel, AutoImageProcessor; \
 AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
@@ -206,7 +207,7 @@ print('DINOv3 weights loaded from local cache.', flush=True)" \
 # to skipping EUPE if the build host has no network access.
 ENV TORCH_HOME=${VTSEARCH_MODELS_DIR}
 RUN python -u -c "import os; \
-from vtsearch.config import EUPE_MODEL_ID; \
+from vtscore.config import EUPE_MODEL_ID; \
 import torch; \
 torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', \
                pretrained=True, weights=EUPE_MODEL_ID, trust_repo=True); \

--- a/docker/Dockerfile.image-embedders.gpu
+++ b/docker/Dockerfile.image-embedders.gpu
@@ -86,6 +86,7 @@ COPY vtsearch/__init__.py vtsearch/__init__.py
 
 # Copy package source so `pip install -e .` finds it.
 COPY vtsearch/ vtsearch/
+COPY vtscore/ vtscore/
 
 # Pre-install numpy/scipy as binary-only wheels so the PyTorch extra-index
 # cannot pull in source tarballs that require g++.
@@ -119,7 +120,7 @@ COPY model_cache/ "$VTSEARCH_MODELS_DIR/"
 
 # SigLIP (default, ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import SIGLIP_MODEL_ID; \
+from vtscore.config import SIGLIP_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {SIGLIP_MODEL_ID} to {cache}', flush=True); \
 from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
@@ -130,7 +131,7 @@ print('SigLIP weights cached.', flush=True)"
 
 # SigLIP 2 (ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import SIGLIP2_MODEL_ID; \
+from vtscore.config import SIGLIP2_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {SIGLIP2_MODEL_ID} to {cache}', flush=True); \
 from transformers import AutoModel, AutoProcessor; \
@@ -140,7 +141,7 @@ print('SigLIP 2 weights cached.', flush=True)"
 
 # OpenAI CLIP (ungated).
 RUN python -u -c "import os; \
-from vtsearch.config import CLIP_MODEL_ID; \
+from vtscore.config import CLIP_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {CLIP_MODEL_ID} to {cache}', flush=True); \
 from transformers import CLIPModel, CLIPProcessor; \
@@ -150,7 +151,7 @@ print('CLIP weights cached.', flush=True)"
 
 # DINOv2 (ungated; anyone can download these).
 RUN python -u -c "import os; \
-from vtsearch.config import DINOV2_MODEL_ID; \
+from vtscore.config import DINOV2_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 print(f'Pre-downloading {DINOV2_MODEL_ID} to {cache}', flush=True); \
 from transformers import AutoModel, AutoImageProcessor; \
@@ -165,7 +166,7 @@ print('DINOv2 weights cached.', flush=True)"
 # DINOv3 will be unavailable. We swallow the failure so the build still
 # produces a usable image with the other five embedders.
 RUN python -u -c "import os; \
-from vtsearch.config import DINOV3_MODEL_ID; \
+from vtscore.config import DINOV3_MODEL_ID; \
 from transformers import AutoModel, AutoImageProcessor; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
 AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
@@ -182,7 +183,7 @@ print('DINOv3 weights loaded from local cache.', flush=True)" \
 # to skipping EUPE if the build host has no network access.
 ENV TORCH_HOME=${VTSEARCH_MODELS_DIR}
 RUN python -u -c "import os; \
-from vtsearch.config import EUPE_MODEL_ID; \
+from vtscore.config import EUPE_MODEL_ID; \
 import torch; \
 torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', \
                pretrained=True, weights=EUPE_MODEL_ID, trust_repo=True); \

--- a/docker/Dockerfile.labbench
+++ b/docker/Dockerfile.labbench
@@ -51,6 +51,7 @@ COPY vtsearch/__init__.py vtsearch/__init__.py
 
 # Copy package source so `pip install -e .` finds it.
 COPY vtsearch/ vtsearch/
+COPY vtscore/ vtscore/
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -150,6 +150,15 @@ if ! diff -u frontend/openapi.json "$_openapi_regen" > /dev/null; then
 fi
 rm -f "$_openapi_regen" "$_openapi_dump_log"
 
+echo "Checking Dockerfiles..."
+if ! python scripts/check-dockerfiles.py ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: Dockerfile check failed"
+    echo "============================================================"
+    exit 1
+fi
+
 # Split arguments into groups and extra pytest args
 TEST_GROUPS=()
 EXTRA_ARGS=()

--- a/scripts/check-dockerfiles.py
+++ b/scripts/check-dockerfiles.py
@@ -1,0 +1,88 @@
+"""Check Dockerfiles for ordering bugs.
+
+Currently checks: RUN steps that execute Python before vtsearch/ and vtscore/
+are both available in the image layer (via COPY vtsearch/, COPY vtscore/, or
+a full COPY . .).
+
+Run from the repo root:
+    python scripts/check-dockerfiles.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _check(path: Path) -> list[str]:
+    errors: list[str] = []
+    copied_full = False
+    copied_vtsearch = False
+    copied_vtscore = False
+    in_continuation = False  # previous physical line ended with \
+
+    lines = path.read_text().splitlines()
+    for lineno, raw in enumerate(lines, 1):
+        line = raw.strip()
+        is_continuation = in_continuation
+        # Update continuation state for next iteration: this line continues
+        # if it ends with \ (but not \\, which is a literal backslash).
+        in_continuation = raw.rstrip().endswith("\\") and not raw.rstrip().endswith("\\\\")
+
+        if not line or line.startswith("#"):
+            continue
+
+        # Skip lines that are continuations of a previous instruction
+        # (e.g. second+ physical lines of a multi-line RUN "...").
+        if is_continuation:
+            continue
+
+        upper = line.upper()
+
+        # Each FROM starts a new stage; reset layer tracking.
+        if upper.startswith("FROM "):
+            copied_full = copied_vtsearch = copied_vtscore = False
+            continue
+
+        if upper.startswith("COPY "):
+            # Skip multi-stage --from= copies (they pull from a prior stage,
+            # not the build context, so they don't affect package availability).
+            if "--from=" in line.lower():
+                continue
+            if re.search(r"COPY\s+\.\s+\.", line, re.IGNORECASE):
+                copied_full = True
+            elif re.search(r"COPY\s+vtsearch/", line, re.IGNORECASE):
+                copied_vtsearch = True
+            elif re.search(r"COPY\s+vtscore/", line, re.IGNORECASE):
+                copied_vtscore = True
+            continue
+
+        if upper.startswith("RUN ") and re.search(r"\bpython\b", line, re.IGNORECASE):
+            if not copied_full and not (copied_vtsearch and copied_vtscore):
+                errors.append(
+                    f"{path}:{lineno}: RUN executes Python before vtsearch/ and vtscore/ are both COPY'd\n  {line}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    docker_dir = Path(__file__).parent.parent / "docker"
+    dockerfiles = sorted(f for f in docker_dir.iterdir() if f.name.startswith("Dockerfile"))
+
+    all_errors: list[str] = []
+    for df in dockerfiles:
+        all_errors.extend(_check(df))
+
+    if all_errors:
+        for err in all_errors:
+            print(err)
+        return 1
+
+    print(f"Checked {len(dockerfiles)} Dockerfile(s): OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Fixes import paths in Dockerfiles to use `vtscore.config` instead of `vtsearch.config`, and adds a new validation script to catch similar ordering bugs in the future.

## Changes

- **Added `scripts/check-dockerfiles.py`**: New linter that validates Dockerfile instruction ordering, specifically checking that Python RUN steps don't execute before both `vtsearch/` and `vtscore/` directories are copied into the image layer. Handles multi-line instructions, multi-stage builds, and continuation lines correctly.

- **Updated Dockerfile imports**: Changed all model pre-download RUN steps in both `Dockerfile.image-embedders` and `Dockerfile.image-embedders.gpu` to import from `vtscore.config` instead of `vtsearch.config` (affects SIGLIP_MODEL_ID, SIGLIP2_MODEL_ID, CLIP_MODEL_ID, DINOV2_MODEL_ID, DINOV3_MODEL_ID, and EUPE_MODEL_ID).

- **Added missing COPY directives**: Added `COPY vtscore/ vtscore/` to three Dockerfiles (`Dockerfile.image-embedders`, `Dockerfile.image-embedders.gpu`, and `Dockerfile.labbench`) to ensure the vtscore package is available before Python code tries to import from it.

- **Integrated validation into test suite**: Added Dockerfile check to `run-tests.sh` so the validation runs as part of the standard test pipeline and blocks the build if any Dockerfile ordering issues are detected.

## Implementation Details

The `check-dockerfiles.py` script:
- Tracks which directories have been copied at each layer
- Resets tracking at each `FROM` instruction (multi-stage builds)
- Skips multi-stage `--from=` copies since they don't affect package availability
- Properly handles line continuations (backslash-terminated lines)
- Reports specific line numbers and the problematic instruction for easy debugging

https://claude.ai/code/session_018HX77TqREbt6ZicpHfP9yQ