### PR TITLE
fix: add missing core framework deps to slim requirements files

### DIFF
--- a/requirements/image-embedders-gpu.txt
+++ b/requirements/image-embedders-gpu.txt
@@ -7,6 +7,10 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+flask-smorest
+marshmallow
+pydantic>=2
+werkzeug
 gunicorn
 numpy
 requests

--- a/requirements/image-embedders.txt
+++ b/requirements/image-embedders.txt
@@ -13,6 +13,10 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+flask-smorest
+marshmallow
+pydantic>=2
+werkzeug
 gunicorn
 numpy
 requests

--- a/requirements/labbench.txt
+++ b/requirements/labbench.txt
@@ -8,6 +8,10 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+flask-smorest
+marshmallow
+pydantic>=2
+werkzeug
 gunicorn
 numpy
 requests

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -49,9 +49,7 @@ def _is_forwarding(path: Path) -> bool:
 
 
 _SLIM_FILES = [
-    p
-    for p in sorted((_REPO_ROOT / "requirements").iterdir())
-    if p.suffix == ".txt" and not _is_forwarding(p)
+    p for p in sorted((_REPO_ROOT / "requirements").iterdir()) if p.suffix == ".txt" and not _is_forwarding(p)
 ]
 
 

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -38,7 +38,7 @@ def _parse_packages(path: Path) -> set[str]:
         line = line.strip()
         if not line or line.startswith("#") or line.startswith("-"):
             continue
-        name = re.split(r"[>=<!;\[", line)[0].strip()
+        name = re.split(r"[>=<!;\[\]]", line)[0].strip()
         if name:
             pkgs.add(_normalise(name))
     return pkgs

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -1,0 +1,65 @@
+"""Validate that slim requirements files include the core framework deps.
+
+The slim files (image-embedders.txt, labbench.txt, etc.) are hand-edited flat
+lists used by specialised Docker images.  They do not forward to pyproject.toml
+via `-e .`, so missing entries silently produce broken images.  This test
+catches that class of bug at CI time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Packages that every VTSearch deployment requires regardless of variant.
+# These are imported at app startup before any plugin-specific code runs.
+_ALWAYS_REQUIRED: frozenset[str] = frozenset(
+    {
+        "flask",
+        "flask-smorest",
+        "marshmallow",
+        "pydantic",
+        "werkzeug",
+    }
+)
+
+
+def _normalise(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _parse_packages(path: Path) -> set[str]:
+    pkgs: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        name = re.split(r"[>=<!;\[", line)[0].strip()
+        if name:
+            pkgs.add(_normalise(name))
+    return pkgs
+
+
+def _is_forwarding(path: Path) -> bool:
+    return any(line.strip().startswith("-e") for line in path.read_text().splitlines())
+
+
+_SLIM_FILES = [
+    p
+    for p in sorted((_REPO_ROOT / "requirements").iterdir())
+    if p.suffix == ".txt" and not _is_forwarding(p)
+]
+
+
+@pytest.mark.parametrize("req_file", _SLIM_FILES, ids=[p.name for p in _SLIM_FILES])
+def test_slim_requirements_include_core_deps(req_file: Path) -> None:
+    declared = _parse_packages(req_file)
+    missing = {_normalise(p) for p in _ALWAYS_REQUIRED} - declared
+    assert not missing, (
+        f"{req_file.name} is missing core framework deps: {sorted(missing)}\n"
+        "Add them to the '── Core framework ──' section of that file."
+    )


### PR DESCRIPTION
## Summary

- `pydantic`, `flask-smorest`, `marshmallow`, and `werkzeug` were absent from the three slim requirements files (`image-embedders.txt`, `image-embedders-gpu.txt`, `labbench.txt`) used by specialised Docker images. These packages are imported at app startup (settings.py uses pydantic, routes use flask-smorest/marshmallow/werkzeug) before any plugin code runs, so the omission caused import errors in every Docker variant that does not delegate to pyproject.toml via `-e .`.
- Adds `tests/core/test_requirements.py`: a parametrised test over all slim requirements files that asserts each one declares the always-required core framework deps, so this class of bug is caught by `./run-tests.sh` going forward.

## Test plan

- [x] `./run-tests.sh core` — all 682 tests pass, including the 3 new parametrised cases for `image-embedders.txt`, `image-embedders-gpu.txt`, and `labbench.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkwKfwVqp13x3Vwbx1XNTS)_