### PR TITLE
Fix NPZ import gaps: store embedder name + add ServerFilesSource

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,7 +121,9 @@ VTSearch/
 │   │   ├── load_pipeline.py        Background-task orchestration, ConcurrencyGate, clip fix-up
 │   │   ├── registry.py             Persistent dataset registry (data/dataset_registry.json)
 │   │   ├── downloader/             Demo dataset downloaders (audio, image, video, text, docs)
-│   │   ├── sources/                MediaSource abstraction (local_folder, http_archive, pullwrest)
+│   │   ├── sources/                MediaSource abstraction (local_folder, http_archive, pullwrest);
+│   │   │                           all fetch/resolve ops return FetchedItem (path + optional
+│   │   │                           embedding, embedder_name, extra metadata)
 │   │   └── importers/              Plugin importers (server_folder, server_files, local_folder,
 │   │                               local_files, pickle, http_archive, combine_datasets,
 │   │                               demo, synthetic, recaller)

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -764,15 +764,24 @@ Unlike other plugin families, media sources use a **factory pattern**.
 The `SOURCE` sentinel is a factory object with a `create_from_origin()`
 method that returns a `MediaSource` instance.
 
+All fetch and resolve methods return `FetchedItem` instead of a bare
+`Path | None`. `FetchedItem` carries the local path alongside optional
+pre-computed data that the source's API may have returned alongside the
+file — embeddings, embedder name, file size, duration, and so on. The
+ingest path uses whatever is in `FetchedItem` to avoid redundant local
+work (re-embedding from disk, re-reading for file size, etc.).
+
 ```python
 # vtscore/datasets/sources/s3/__init__.py
 
 from __future__ import annotations
 
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Iterator
 
-from vtscore.datasets.sources.base import MediaItem, MediaSource
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
 
 
 class S3MediaSource(MediaSource):
@@ -797,24 +806,52 @@ class S3MediaSource(MediaSource):
                     continue
                 yield MediaItem(key=key, filename=filename, source_name=self.name)
 
-    def fetch_item(self, key: str) -> Path | None:
-        """Download an item to a temp directory and return the local path."""
-        import boto3, tempfile
+    def fetch_item(self, key: str) -> FetchedItem:
+        """Download an item to a temp directory and return a FetchedItem."""
+        import boto3
         local = Path(tempfile.gettempdir()) / "vtsearch_s3" / key
         local.parent.mkdir(parents=True, exist_ok=True)
         if not local.exists():
             boto3.client("s3").download_file(self._bucket, key, str(local))
-        return local
+        return FetchedItem(path=local)
 
-    def resolve_path(self, origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
         """Resolve a media file by origin_name or filename."""
         for candidate in (origin_name, filename):
             if candidate:
                 key = f"{self._prefix}{candidate}" if self._prefix else candidate
-                path = self.fetch_item(key)
-                if path and path.exists():
-                    return path
-        return None
+                item = self.fetch_item(key)
+                if item.path and item.path.exists():
+                    return item
+        return FetchedItem(path=None)
+
+    def fetch_items(self, keys: list[str]) -> dict[str, FetchedItem]:
+        """Download multiple items concurrently instead of one at a time.
+
+        Override the default loop to use a thread pool. If your backing
+        service returns embeddings or metadata alongside the file bytes,
+        populate ``FetchedItem.embedding`` / ``FetchedItem.extra`` here
+        so the ingest path can skip local re-embedding and stat calls.
+        """
+        def _fetch(key: str) -> tuple[str, FetchedItem]:
+            return key, self.fetch_item(key)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            return dict(pool.map(_fetch, keys))
+
+    def resolve_paths(
+        self, entries: list[tuple[str, str]]
+    ) -> list[FetchedItem]:
+        """Resolve multiple entries concurrently.
+
+        The ingest fast-path calls ``resolve_paths`` (not ``fetch_items``),
+        so override this to parallelise the path used by re-ingestion.
+        """
+        def _resolve(pair: tuple[str, str]) -> FetchedItem:
+            return self.resolve_path(*pair)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            return list(pool.map(_resolve, entries))
 
 
 class _S3SourceFactory:
@@ -833,33 +870,61 @@ class _S3SourceFactory:
 SOURCE = _S3SourceFactory()
 ```
 
+### FetchedItem fields
+
+Every fetch and resolve method returns `FetchedItem`. The `path` field is
+always required; the rest are optional bonuses that let sources surface
+data they already have without forcing VTSearch to re-derive it.
+
+| Field | Type | When to set |
+|-------|------|-------------|
+| `path` | `Path \| None` | Always — local file path, or `None` if not found/downloadable |
+| `embedding` | `np.ndarray \| None` | When your API returns a pre-computed vector. The ingest path skips re-embedding when this is present (provided the origin has no clip params) |
+| `embedder_name` | `str` | Required alongside `embedding` — names the embedding space so vectors can be matched against the dataset |
+| `extra` | `dict[str, Any]` | Source-authoritative field overrides written into the media record (e.g. `{"file_size": 12345, "duration": 3.5, "created_at": "2024-01-01T00:00:00Z"}`) |
+
+For a simple source that just downloads files, returning
+`FetchedItem(path=local_path)` is sufficient. The other fields are only
+worth populating when your backing API already provides them in the same
+round-trip.
+
 ### MediaSource abstract interface reference
 
-**Required abstract methods:**
+**Required abstract methods** — must return `FetchedItem`, not `Path | None`:
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `list_items()` | `(extensions: list[str] \| None) -> Iterator[MediaItem]` | Yield all media items, optionally filtered |
-| `fetch_item()` | `(key: str) -> Path \| None` | Return local path for item (may download on demand) |
-| `resolve_path()` | `(origin_name: str, filename: str) -> Path \| None` | Find a file by origin_name or filename |
+| `fetch_item()` | `(key: str) -> FetchedItem` | Fetch by key; `item.path` is `None` if not found |
+| `resolve_path()` | `(origin_name: str, filename: str) -> FetchedItem` | Find by origin_name or filename; `item.path` is `None` if not found |
 
-**Optional methods:**
+**Optional methods** — default implementations loop over the single-item
+counterparts; override for parallelism or to surface pre-computed data:
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
+| `fetch_items()` | `(keys: list[str]) -> dict[str, FetchedItem]` | Bulk form of `fetch_item`. Override to parallelise downloads or return pre-computed embeddings/metadata |
+| `resolve_paths()` | `(entries: list[tuple[str, str]]) -> list[FetchedItem]` | Bulk form of `resolve_path`, result aligned with input. The ingest fast-path calls this; override to parallelise re-ingestion |
 | `cleanup()` | `() -> None` | Release temporary resources (default: no-op) |
 
 **Data types:**
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `MediaItem` | `key`, `filename`, `source_name` | A discoverable file within a source |
+| `MediaItem` | `key`, `filename`, `source_name` | A discoverable file within a source (yielded by `list_items`) |
+| `FetchedItem` | `path`, `embedding`, `embedder_name`, `extra` | Result of any fetch or resolve call; `path` may be `None` |
 
 ### How it gets invoked
 
 `get_source_for_origin(origin_dict)` looks up the factory by matching
 `origin["importer"]` to the factory's `name`, then calls
 `factory.create_from_origin(origin)`.
+
+The ingest fast-path (`vtscore.datasets.ingest._ingest_via_source`) calls
+`resolve_paths()` once for all missing entries before the sequential
+embed loop, so any parallelism in your `resolve_paths()` override
+completes before per-item work begins. If your source's `resolve_path()`
+populates `FetchedItem.embedding`, the embed step is skipped automatically.
 
 ---
 

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -562,3 +562,192 @@ class TestExampleSortOriginEndpoint:
         )
         # Will get 500 if embedder can't handle fake audio, but not 400/404
         assert resp.status_code in (200, 500)
+
+
+# ── ServerFilesSource ─────────────────────────────────────────────────
+
+
+class TestServerFilesSource:
+    def _make_npz(self, tmp_path, paths_and_vecs, embedder_name=""):
+        """Create a .npz archive with given paths and vectors."""
+        import numpy as np
+
+        names = np.array([str(p) for p in paths_and_vecs])
+        vecs = np.stack([v for _, v in paths_and_vecs.items()])
+        kwargs = {"filenames": names, "vectors": vecs}
+        if embedder_name:
+            kwargs["embedder_name"] = np.array(embedder_name)
+        npz = tmp_path / "list.npz"
+        np.savez(npz, **kwargs)
+        return npz
+
+    def test_fetch_item_returns_path_and_embedding(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        media = tmp_path / "clip.wav"
+        media.write_bytes(b"audio")
+        vec = np.ones(4, dtype=np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(media)]),
+            vectors=vec[np.newaxis],
+            embedder_name=np.array("test-embedder"),
+        )
+
+        source = ServerFilesSource(npz, embedder_name="test-embedder")
+        item = source.fetch_item(str(media))
+        assert item.path == media
+        np.testing.assert_array_equal(item.embedding, vec)
+        assert item.embedder_name == "test-embedder"
+
+    def test_fetch_item_missing_file_returns_none_path(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        vec = np.zeros(4, dtype=np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(tmp_path / "nonexistent.wav")]),
+            vectors=vec[np.newaxis],
+        )
+        source = ServerFilesSource(npz)
+        item = source.fetch_item(str(tmp_path / "nonexistent.wav"))
+        assert item.path is None
+
+    def test_resolve_path_by_origin_name(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        media = tmp_path / "clip.wav"
+        media.write_bytes(b"audio")
+        vec = np.full(4, 2.0, dtype=np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(media)]),
+            vectors=vec[np.newaxis],
+            embedder_name=np.array("my-embedder"),
+        )
+        source = ServerFilesSource(npz, embedder_name="my-embedder")
+        item = source.resolve_path(origin_name=str(media))
+        assert item.path == media
+        np.testing.assert_array_equal(item.embedding, vec)
+        assert item.embedder_name == "my-embedder"
+
+    def test_resolve_path_neither_found_returns_none(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(tmp_path / "missing.wav")]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+        )
+        source = ServerFilesSource(npz)
+        assert source.resolve_path().path is None
+        assert source.resolve_path(origin_name=str(tmp_path / "missing.wav")).path is None
+
+    def test_list_items_yields_existing_paths(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        existing = tmp_path / "a.wav"
+        existing.write_bytes(b"audio")
+        missing = tmp_path / "b.wav"
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(existing), str(missing)]),
+            vectors=np.zeros((2, 4), dtype=np.float32),
+        )
+        source = ServerFilesSource(npz)
+        items = list(source.list_items())
+        assert len(items) == 1
+        assert items[0].key == str(existing)
+        assert items[0].filename == "a.wav"
+        assert items[0].source_name == "server_files"
+
+    def test_list_items_extension_filter(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        wav = tmp_path / "a.wav"
+        mp3 = tmp_path / "b.mp3"
+        wav.write_bytes(b"audio_wav")
+        mp3.write_bytes(b"audio_mp3")
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(wav), str(mp3)]),
+            vectors=np.zeros((2, 4), dtype=np.float32),
+        )
+        source = ServerFilesSource(npz)
+        wav_items = list(source.list_items(extensions=[".wav"]))
+        assert len(wav_items) == 1
+        assert wav_items[0].filename == "a.wav"
+
+    def test_factory_creates_source_for_npz_origin(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import SOURCE, ServerFilesSource
+
+        media = tmp_path / "clip.wav"
+        media.write_bytes(b"audio")
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(media)]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+            embedder_name=np.array("test-embed"),
+        )
+
+        origin = {
+            "importer": "server_files",
+            "params": {"paths_file": str(npz), "embedder_name": "test-embed"},
+        }
+        source = SOURCE.create_from_origin(origin)
+        assert isinstance(source, ServerFilesSource)
+        assert source._embedder_name == "test-embed"
+
+    def test_factory_returns_none_for_txt_origin(self, tmp_path):
+        from vtscore.datasets.sources.server_files import SOURCE
+
+        txt = tmp_path / "list.txt"
+        txt.write_text("/a.wav\n")
+        origin = {
+            "importer": "server_files",
+            "params": {"paths_file": str(txt)},
+        }
+        assert SOURCE.create_from_origin(origin) is None
+
+    def test_factory_returns_none_for_missing_npz(self, tmp_path):
+        from vtscore.datasets.sources.server_files import SOURCE
+
+        origin = {
+            "importer": "server_files",
+            "params": {"paths_file": str(tmp_path / "nonexistent.npz")},
+        }
+        assert SOURCE.create_from_origin(origin) is None
+
+    def test_get_source_for_npz_origin(self, tmp_path):
+        import numpy as np
+        from vtscore.datasets.sources.server_files import ServerFilesSource
+
+        media = tmp_path / "clip.wav"
+        media.write_bytes(b"audio")
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(media)]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+        )
+
+        origin = {
+            "importer": "server_files",
+            "params": {"paths_file": str(npz)},
+        }
+        source = get_source_for_origin(origin)
+        assert isinstance(source, ServerFilesSource)

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -437,7 +437,6 @@ class TestIngestViaSource:
         ingest path skips local re-embedding and uses the source's vector and
         any extra metadata (e.g. duration) directly."""
         import numpy as np
-        from unittest.mock import MagicMock
 
         from vtscore.datasets.ingest import _ingest_via_source
         from vtscore.datasets.sources.base import FetchedItem
@@ -473,7 +472,9 @@ class TestIngestViaSource:
         medias: dict = {}
         with patch("vtscore.datasets.sources.get_source_for_origin", return_value=real_source):
             # embed_file must NOT be called when pre-computed embedding is provided.
-            with patch("vtscore.detectors.resolver.embed_file", side_effect=AssertionError("embed_file called unexpectedly")) as mock_embed:
+            with patch(
+                "vtscore.detectors.resolver.embed_file", side_effect=AssertionError("embed_file called unexpectedly")
+            ):
                 result = _ingest_via_source(origin, entries, medias, lambda *a: None)
 
         assert result == 1

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -132,6 +132,38 @@ class TestLocalFolderSource:
         source = LocalFolderSource(root)
         assert source.resolve_path() is None
 
+    def test_fetch_items_returns_existing_and_missing(self, tmp_path):
+        root = self._make_tree(tmp_path)
+        source = LocalFolderSource(root)
+        result = source.fetch_items(["a.wav", "sub/c.wav", "missing.wav"])
+        assert result["a.wav"] is not None
+        assert result["a.wav"].name == "a.wav"
+        assert result["sub/c.wav"] is not None
+        assert result["sub/c.wav"].name == "c.wav"
+        assert result["missing.wav"] is None
+
+    def test_fetch_items_empty_list(self, tmp_path):
+        source = LocalFolderSource(tmp_path)
+        assert source.fetch_items([]) == {}
+
+    def test_resolve_paths_aligned_with_input(self, tmp_path):
+        root = self._make_tree(tmp_path)
+        source = LocalFolderSource(root)
+        entries = [
+            ("a.wav", ""),
+            ("nope.wav", "sub/c.wav"),
+            ("", ""),
+        ]
+        result = source.resolve_paths(entries)
+        assert len(result) == 3
+        assert result[0] is not None and result[0].name == "a.wav"
+        assert result[1] is not None and result[1].name == "c.wav"
+        assert result[2] is None
+
+    def test_resolve_paths_empty_list(self, tmp_path):
+        source = LocalFolderSource(tmp_path)
+        assert source.resolve_paths([]) == []
+
     def test_folder_path_property(self, tmp_path):
         source = LocalFolderSource(tmp_path)
         assert source.folder_path == tmp_path
@@ -332,8 +364,8 @@ class TestResolverUsesSource:
 
 
 class TestIngestViaSource:
-    def test_ingest_fetches_individually(self, tmp_path):
-        """When a source is available and embedding works, ingest fetches individually."""
+    def test_ingest_bulk_fetch(self, tmp_path):
+        """When a source is available and embedding works, ingest resolves paths in bulk."""
         import numpy as np
 
         folder = tmp_path / "audio"

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -96,41 +96,41 @@ class TestLocalFolderSource:
     def test_fetch_item(self, tmp_path):
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
-        result = source.fetch_item("sub/c.wav")
-        assert result is not None
-        assert result.name == "c.wav"
-        assert result.read_bytes() == b"audio_c"
+        item = source.fetch_item("sub/c.wav")
+        assert item.path is not None
+        assert item.path.name == "c.wav"
+        assert item.path.read_bytes() == b"audio_c"
 
     def test_fetch_item_missing(self, tmp_path):
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
-        assert source.fetch_item("nonexistent.wav") is None
+        assert source.fetch_item("nonexistent.wav").path is None
 
     def test_fetch_item_path_traversal(self, tmp_path):
         root = self._make_tree(tmp_path)
         # Create a file outside the root
         (tmp_path.parent / "secret.txt").write_bytes(b"secret")
         source = LocalFolderSource(root)
-        assert source.fetch_item("../secret.txt") is None
+        assert source.fetch_item("../secret.txt").path is None
 
     def test_resolve_path_by_origin_name(self, tmp_path):
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
-        result = source.resolve_path(origin_name="a.wav")
-        assert result is not None
-        assert result.name == "a.wav"
+        item = source.resolve_path(origin_name="a.wav")
+        assert item.path is not None
+        assert item.path.name == "a.wav"
 
     def test_resolve_path_by_filename_fallback(self, tmp_path):
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
-        result = source.resolve_path(filename="sub/c.wav")
-        assert result is not None
-        assert result.name == "c.wav"
+        item = source.resolve_path(filename="sub/c.wav")
+        assert item.path is not None
+        assert item.path.name == "c.wav"
 
     def test_resolve_path_both_empty(self, tmp_path):
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
-        assert source.resolve_path() is None
+        assert source.resolve_path().path is None
 
     def test_fetch_items_returns_existing_and_missing(self, tmp_path):
         root = self._make_tree(tmp_path)
@@ -206,9 +206,9 @@ class TestHttpArchiveSource:
 
         try:
             source = HttpArchiveSource("https://example.com/test.zip")
-            result = source.resolve_path(origin_name="clip.wav")
-            assert result is not None
-            assert result.name == "clip.wav"
+            item = source.resolve_path(origin_name="clip.wav")
+            assert item.path is not None
+            assert item.path.name == "clip.wav"
         finally:
             import shutil
 
@@ -237,9 +237,9 @@ class TestHttpArchiveSource:
         source._extract_dir = extract_dir
         source._inner = LocalFolderSource(extract_dir)
 
-        result = source.fetch_item("audio/clip.wav")
-        assert result is not None
-        assert result.name == "clip.wav"
+        item = source.fetch_item("audio/clip.wav")
+        assert item.path is not None
+        assert item.path.name == "clip.wav"
 
         items = list(source.list_items(extensions=[".wav"]))
         assert any(i.key == "audio/clip.wav" for i in items)

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -136,11 +136,20 @@ class TestLocalFolderSource:
         root = self._make_tree(tmp_path)
         source = LocalFolderSource(root)
         result = source.fetch_items(["a.wav", "sub/c.wav", "missing.wav"])
-        assert result["a.wav"] is not None
-        assert result["a.wav"].name == "a.wav"
-        assert result["sub/c.wav"] is not None
-        assert result["sub/c.wav"].name == "c.wav"
-        assert result["missing.wav"] is None
+        assert result["a.wav"].path is not None
+        assert result["a.wav"].path.name == "a.wav"
+        assert result["sub/c.wav"].path is not None
+        assert result["sub/c.wav"].path.name == "c.wav"
+        assert result["missing.wav"].path is None
+
+    def test_fetch_items_empty_fields_on_plain_source(self, tmp_path):
+        """Default fetch_items leaves embedding/extra empty (no pre-computation)."""
+        root = self._make_tree(tmp_path)
+        source = LocalFolderSource(root)
+        item = source.fetch_items(["a.wav"])["a.wav"]
+        assert item.embedding is None
+        assert item.embedder_name == ""
+        assert item.extra == {}
 
     def test_fetch_items_empty_list(self, tmp_path):
         source = LocalFolderSource(tmp_path)
@@ -156,9 +165,9 @@ class TestLocalFolderSource:
         ]
         result = source.resolve_paths(entries)
         assert len(result) == 3
-        assert result[0] is not None and result[0].name == "a.wav"
-        assert result[1] is not None and result[1].name == "c.wav"
-        assert result[2] is None
+        assert result[0].path is not None and result[0].path.name == "a.wav"
+        assert result[1].path is not None and result[1].path.name == "c.wav"
+        assert result[2].path is None
 
     def test_resolve_paths_empty_list(self, tmp_path):
         source = LocalFolderSource(tmp_path)
@@ -422,6 +431,57 @@ class TestIngestViaSource:
 
         assert result == -1
         assert len(medias) == 0  # Nothing ingested, caller should use legacy
+
+    def test_ingest_uses_precomputed_embedding_from_source(self, tmp_path):
+        """When resolve_paths returns a FetchedItem with an embedding, the
+        ingest path skips local re-embedding and uses the source's vector and
+        any extra metadata (e.g. duration) directly."""
+        import numpy as np
+        from unittest.mock import MagicMock
+
+        from vtscore.datasets.ingest import _ingest_via_source
+        from vtscore.datasets.sources.base import FetchedItem
+        from vtscore.datasets.sources import get_source_for_origin
+
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"audio_data")
+
+        origin = {
+            "importer": "server_folder",
+            "params": {"path": str(folder), "media_type": "audio"},
+        }
+        entries = [
+            {"origin": origin, "origin_name": "clip.wav", "md5": "", "label": "good", "filename": "clip.wav"},
+        ]
+
+        precomputed_emb = np.ones(512, dtype=np.float32)
+
+        # Patch the source so resolve_paths returns a FetchedItem with a
+        # pre-computed embedding and extra metadata.
+        real_source = get_source_for_origin(origin)
+        assert real_source is not None
+        real_source.resolve_paths = lambda pairs: [  # type: ignore[method-assign]
+            FetchedItem(
+                path=folder / "clip.wav",
+                embedding=precomputed_emb,
+                embedder_name="test-embedder",
+                extra={"duration": 3.5},
+            )
+        ]
+
+        medias: dict = {}
+        with patch("vtscore.datasets.sources.get_source_for_origin", return_value=real_source):
+            # embed_file must NOT be called when pre-computed embedding is provided.
+            with patch("vtscore.detectors.resolver.embed_file", side_effect=AssertionError("embed_file called unexpectedly")) as mock_embed:
+                result = _ingest_via_source(origin, entries, medias, lambda *a: None)
+
+        assert result == 1
+        assert len(medias) == 1
+        media = next(iter(medias.values()))
+        assert np.array_equal(media["embedding"], precomputed_emb)
+        assert media["embedder"] == "test-embedder"
+        assert media["duration"] == 3.5
 
     def test_ingest_returns_negative_one_for_pickle(self):
         """Non-file-based origins return -1 (fallback to full importer)."""

--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -110,11 +110,11 @@ class TestCsvExporterCLI:
         # silently overwrite one another.
         assert args.filepath == f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
 
-    def test_validate_passes(self):
+    def test_validate_passes(self, tmp_path):
         from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
 
         exp = ServerCsvLabelsetExporter()
-        exp.validate_cli_field_values({"filepath": "/tmp/out.csv"})
+        exp.validate_cli_field_values({"filepath": str(tmp_path / "out.csv")})
 
     def test_validate_missing_filepath(self):
         from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vtscore.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
+from vtscore.datasets.importers._npz_vectors import read_npz_embedder_name, read_npz_filenames_and_vectors
 from vtscore.datasets.importers.server_files import (
     ServerFilesDatasetImporter,
     _read_npz_paths_file,
@@ -95,6 +95,51 @@ class TestReadNpzFilenamesAndVectors:
 
 
 # ---------------------------------------------------------------------------
+# read_npz_embedder_name
+# ---------------------------------------------------------------------------
+
+
+class TestReadNpzEmbedderName:
+    def test_reads_embedder_name_key(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.wav"]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+            embedder_name=np.array("laion-clap"),
+        )
+        assert read_npz_embedder_name(npz) == "laion-clap"
+
+    def test_reads_embedder_key_as_fallback(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.wav"]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+            embedder=np.array("siglip"),
+        )
+        assert read_npz_embedder_name(npz) == "siglip"
+
+    def test_returns_empty_string_when_absent(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        np.savez(npz, filenames=np.array(["a.wav"]), vectors=np.zeros((1, 4), dtype=np.float32))
+        assert read_npz_embedder_name(npz) == ""
+
+    def test_returns_empty_string_for_missing_file(self, tmp_path):
+        assert read_npz_embedder_name(tmp_path / "missing.npz") == ""
+
+    def test_strips_whitespace(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.wav"]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+            embedder_name=np.array("  clap  "),
+        )
+        assert read_npz_embedder_name(npz) == "clap"
+
+
+# ---------------------------------------------------------------------------
 # server_files paths-file plumbing
 # ---------------------------------------------------------------------------
 
@@ -145,10 +190,11 @@ class TestServerFilesNpzPathsFile:
         vectors = np.arange(8, dtype=np.float32).reshape(2, 4)
         np.savez(npz, filenames=np.array([str(media_a), str(media_b)]), vectors=vectors)
 
-        paths, path_to_vector = _read_npz_paths_file(npz)
+        paths, path_to_vector, embedder_name = _read_npz_paths_file(npz)
         assert paths == [Path(str(media_a)), Path(str(media_b))]
         assert set(path_to_vector) == {str(media_a), str(media_b)}
         np.testing.assert_array_equal(path_to_vector[str(media_a)], vectors[0])
+        assert embedder_name == ""
 
     def test_relative_npz_paths_resolved_against_npz_dir(self, tmp_path):
         media = tmp_path / "data" / "x.wav"
@@ -161,18 +207,34 @@ class TestServerFilesNpzPathsFile:
             vectors=np.zeros((1, 4), dtype=np.float32),
         )
 
-        paths, vecs = _read_npz_paths_file(npz)
+        paths, vecs, embedder_name = _read_npz_paths_file(npz)
         assert paths == [media.resolve()]
         # Vector is keyed by the resolved absolute path so the staging
         # rekey step can look it up.
         assert str(media.resolve()) in vecs
+        assert embedder_name == ""
 
     def test_read_paths_and_vectors_txt_returns_empty_vectors(self, tmp_path):
         txt = tmp_path / "list.txt"
         txt.write_text("/a.wav\n")
-        paths, vecs = _read_paths_and_vectors(txt)
+        paths, vecs, embedder_name = _read_paths_and_vectors(txt)
         assert paths == [Path("/a.wav")]
         assert vecs == {}
+        assert embedder_name == ""
+
+    def test_read_npz_paths_file_returns_embedder_name(self, tmp_path):
+        media = tmp_path / "clip.wav"
+        media.write_bytes(b"data")
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(media)]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+            embedder_name=np.array("laion-clap"),
+        )
+        paths, vecs, embedder_name = _read_npz_paths_file(npz)
+        assert paths == [media]
+        assert embedder_name == "laion-clap"
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +280,32 @@ class TestServerFilesNpzRunsEndToEnd:
         for media in medias.values():
             assert media["origin"]["importer"] == "server_files"
             assert media["origin"]["params"]["paths_file"] == str(npz)
+
+    def test_npz_embedder_name_stored_in_media_and_origin(self, tmp_path):
+        """Embedder name from the NPZ is recorded on media['embedder'] and origin params."""
+        from helpers import make_raw_wav_bytes
+
+        src = tmp_path / "clip.wav"
+        src.write_bytes(make_raw_wav_bytes())
+
+        rng = np.random.default_rng(0)
+        vec = rng.standard_normal(512).astype(np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src)]),
+            vectors=vec[np.newaxis],
+            embedder_name=np.array("laion-clap"),
+        )
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+
+        assert len(medias) == 1
+        media = next(iter(medias.values()))
+        assert media["embedder"] == "laion-clap"
+        assert media["origin"]["params"]["embedder_name"] == "laion-clap"
 
     def test_npz_per_key_layout_is_accepted(self, tmp_path):
         from helpers import make_raw_wav_bytes

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -34,6 +34,30 @@ import numpy as np
 
 _FILENAMES_KEYS = ("filenames", "names", "paths", "filename")
 _VECTORS_KEYS = ("vectors", "embeddings", "vecs", "embedding")
+_EMBEDDER_NAME_KEYS = ("embedder_name", "embedder")
+
+
+def read_npz_embedder_name(npz_path: Path) -> str:
+    """Return the embedder name stored in *npz_path*, or ``""`` if absent.
+
+    Checks for a scalar or 1-element string array under the keys
+    ``"embedder_name"`` or ``"embedder"``.  Returns ``""`` for any archive
+    that does not contain such a key or where the stored value is blank.
+    Does not raise; returns ``""`` on any read error.
+    """
+    p = Path(npz_path)
+    if not p.is_file():
+        return ""
+    try:
+        with np.load(p, allow_pickle=False) as data:
+            for key in _EMBEDDER_NAME_KEYS:
+                if key in data.files:
+                    val = data[key]
+                    raw = str(val) if val.ndim == 0 else str(val.flat[0])
+                    return raw.strip()
+    except Exception:
+        pass
+    return ""
 
 
 def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -379,7 +379,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         # Note: we intentionally do NOT call source.cleanup() here because
         # the extracted archive should remain cached for future resolve_file
         # calls (matching the previous behaviour of keeping resolve dirs).
-        return source.resolve_path(origin_name, filename)
+        return source.resolve_path(origin_name, filename).path
 
 
 IMPORTER = HttpArchiveDatasetImporter()

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -33,7 +33,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-from vtscore.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
+from vtscore.datasets.importers._npz_vectors import read_npz_embedder_name, read_npz_filenames_and_vectors
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 
@@ -69,14 +69,17 @@ def _read_text_paths_file(paths_file: Path) -> list[Path]:
     return paths
 
 
-def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any]]:
-    """Read media paths + pre-computed vectors from a ``.npz`` archive.
+def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any], str]:
+    """Read media paths + pre-computed vectors + embedder name from a ``.npz``.
 
-    Returns ``(paths, path_to_vector)`` where keys of *path_to_vector*
-    are the absolute path strings of the resolved entries (the same
-    strings that appear in *paths*).
+    Returns ``(paths, path_to_vector, embedder_name)`` where keys of
+    *path_to_vector* are the absolute path strings of the resolved entries
+    (the same strings that appear in *paths*), and *embedder_name* is the
+    value stored under ``"embedder_name"`` or ``"embedder"`` in the archive
+    (``""`` when absent).
     """
     name_to_vector = read_npz_filenames_and_vectors(paths_file)
+    embedder_name = read_npz_embedder_name(paths_file)
     base_dir = paths_file.resolve().parent
     paths: list[Path] = []
     path_to_vector: dict[str, Any] = {}
@@ -89,7 +92,7 @@ def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any]]:
             candidate = (base_dir / candidate).resolve()
         paths.append(candidate)
         path_to_vector[str(candidate)] = vec
-    return paths, path_to_vector
+    return paths, path_to_vector, embedder_name
 
 
 def _read_paths_file(paths_file: Path) -> list[Path]:
@@ -103,23 +106,25 @@ def _read_paths_file(paths_file: Path) -> list[Path]:
     if not paths_file.is_file():
         raise FileNotFoundError(f"Paths file not found: {paths_file}")
     if paths_file.suffix.lower() == ".npz":
-        paths, _ = _read_npz_paths_file(paths_file)
+        paths, _, _embedder = _read_npz_paths_file(paths_file)
         return paths
     return _read_text_paths_file(paths_file)
 
 
-def _read_paths_and_vectors(paths_file: Path) -> tuple[list[Path], dict[str, Any]]:
-    """Like :func:`_read_paths_file` but also returns pre-computed vectors.
+def _read_paths_and_vectors(paths_file: Path) -> tuple[list[Path], dict[str, Any], str]:
+    """Like :func:`_read_paths_file` but also returns pre-computed vectors and embedder name.
 
-    For ``.txt`` / ``.list`` inputs the second tuple element is an empty
-    dict.  For ``.npz`` inputs it maps each resolved path string to its
-    pre-computed embedding vector.
+    For ``.txt`` / ``.list`` inputs the second and third tuple elements
+    are an empty dict and ``""`` respectively.  For ``.npz`` inputs the
+    second element maps each resolved path string to its pre-computed
+    embedding vector, and the third element is the embedder name (``""``
+    if the archive doesn't record one).
     """
     if not paths_file.is_file():
         raise FileNotFoundError(f"Paths file not found: {paths_file}")
     if paths_file.suffix.lower() == ".npz":
         return _read_npz_paths_file(paths_file)
-    return _read_text_paths_file(paths_file), {}
+    return _read_text_paths_file(paths_file), {}, ""
 
 
 def _expand_paths(paths: list[Path]) -> list[Path]:
@@ -234,10 +239,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
-    def _stage_paths(self, field_values: dict[str, Any]) -> tuple[Path, dict[str, Path], dict[str, Any]]:
+    def _stage_paths(self, field_values: dict[str, Any]) -> tuple[Path, dict[str, Path], dict[str, Any], str]:
         """Read the paths file and symlink each entry into a fresh temp dir.
 
-        Returns ``(staging_dir, name_to_source, content_vectors)`` where:
+        Returns ``(staging_dir, name_to_source, content_vectors, embedder_name)`` where:
 
         - ``staging_dir`` is the freshly created temp directory holding
           one symlink per imported file (caller must ``rmtree`` it).
@@ -249,9 +254,12 @@ class ServerFilesDatasetImporter(DatasetImporter):
           paths.  Returned as a local dict (not threaded through
           :meth:`~DatasetImporter.yield_precomputed`) so the singleton
           importer instance does not accumulate per-import state.
+        - ``embedder_name`` is the name of the embedder that produced the
+          pre-computed vectors (``""`` for plain text paths files or NPZ
+          archives that don't record an embedder name).
         """
         paths_file = Path(field_values["paths_file"])
-        paths, path_to_vector = _read_paths_and_vectors(paths_file)
+        paths, path_to_vector, embedder_name = _read_paths_and_vectors(paths_file)
         if not paths:
             raise ValueError(f"No paths found in {paths_file}")
 
@@ -270,26 +278,33 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 vec = path_to_vector.get(str(source))
                 if vec is not None:
                     content_vectors[name] = vec
-        return staging, name_to_source, content_vectors
+        return staging, name_to_source, content_vectors, embedder_name
 
     def _rewrite_origins(
         self,
         medias: dict[int, dict[str, Any]],
         name_to_source: dict[str, Path],
         origin: dict[str, Any],
+        embedder_name: str = "",
     ) -> None:
         """Point each media at its real source path instead of the symlink.
 
         Each media gets a fresh copy of *origin* so a later mutation of one
-        media's ``origin.params`` cannot leak across siblings.
+        media's ``origin.params`` cannot leak across siblings.  When
+        *embedder_name* is non-empty it is stored in the origin params so
+        the ``server_files`` :class:`~vtscore.datasets.sources.MediaSource`
+        can surface the embedder on re-ingestion.
         """
         for media in medias.values():
             src = name_to_source.get(media.get("origin_name", "")) or name_to_source.get(media.get("filename", ""))
             if src is None:
                 continue
+            params = dict(origin.get("params", {}))
+            if embedder_name:
+                params["embedder_name"] = embedder_name
             media["origin"] = {
                 "importer": origin.get("importer", ""),
-                "params": dict(origin.get("params", {})),
+                "params": params,
             }
             media["origin_name"] = str(src)
             media["media_path"] = str(src)
@@ -302,6 +317,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         medias: dict,
         thin: bool,
         merged_vectors: dict[str, Any],
+        content_embedder_name: str = "",
     ) -> bool:
         """Load files of ``spec.source_type`` from the staging dir.
 
@@ -318,6 +334,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 medias,
                 thin=thin,
                 content_vectors=merged_vectors or None,
+                content_embedder_name=content_embedder_name,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
             )
@@ -331,7 +348,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
 
-        staging, name_to_source, npz_vectors = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values)
         # Merge npz-supplied vectors with any vectors set externally on
         # ``self.content_vectors``.  NPZ vectors take priority for keys
         # that overlap.
@@ -341,7 +358,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
             had_direct = False
             for spec in specs:
                 if spec.converter is None:
-                    if self._load_direct_into(staging, spec, field_values, medias, thin, merged_vectors):
+                    if self._load_direct_into(
+                        staging, spec, field_values, medias, thin, merged_vectors, embedder_name
+                    ):
                         had_direct = True
 
             converter_rows = [s for s in specs if s.converter is not None]
@@ -360,7 +379,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                     },
                 )
 
-            self._rewrite_origins(medias, name_to_source, self.build_origin(field_values))
+            self._rewrite_origins(medias, name_to_source, self.build_origin(field_values), embedder_name)
 
             if not had_direct and not medias:
                 raise ValueError(f"No {output_type} files found in listed paths")
@@ -390,7 +409,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
 
-        staging, name_to_source, npz_vectors = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values)
         origin = self.build_origin(field_values)
         merged_vectors: dict[str, Any] = dict(self.content_vectors or {})
         merged_vectors.update(npz_vectors)
@@ -406,10 +425,11 @@ class ServerFilesDatasetImporter(DatasetImporter):
                         chunk_size,
                         thin=thin,
                         content_vectors=merged_vectors or None,
+                        content_embedder_name=embedder_name,
                         content_md5s=self.content_md5s or None,
                         custom_metadata_map=self.custom_metadata_map or None,
                     ):
-                        self._rewrite_origins(chunk, name_to_source, origin)
+                        self._rewrite_origins(chunk, name_to_source, origin, embedder_name)
                         yield chunk
                 except ValueError:
                     # Empty for this source type - keep going; converter

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -358,9 +358,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
             had_direct = False
             for spec in specs:
                 if spec.converter is None:
-                    if self._load_direct_into(
-                        staging, spec, field_values, medias, thin, merged_vectors, embedder_name
-                    ):
+                    if self._load_direct_into(staging, spec, field_values, medias, thin, merged_vectors, embedder_name):
                         had_direct = True
 
             converter_rows = [s for s in specs if s.converter is not None]

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -402,7 +402,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
         from vtscore.datasets.sources.local_folder import LocalFolderSource
 
         source = LocalFolderSource(folder)
-        return source.resolve_path(origin_name, filename)
+        return source.resolve_path(origin_name, filename).path
 
 
 IMPORTER = ServerFolderDatasetImporter()

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -280,9 +280,7 @@ def _ingest_via_source(
                 # fall back to the legacy full-import path so we don't produce
                 # medias with mismatched embedding/MD5/bytes triples.
                 effective_embedder = embedder_name
-                resolved = _resolve_clip_content_and_embedding(
-                    item.path, media_type_id, origin_dict, embedder_name
-                )
+                resolved = _resolve_clip_content_and_embedding(item.path, media_type_id, origin_dict, embedder_name)
                 if resolved is None:
                     source.cleanup()
                     return -1  # Signal caller to use legacy full-import path

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -225,7 +225,11 @@ def _ingest_via_source(
     medias: dict[int, dict[str, Any]],
     on_progress: ProgressCallback,
 ) -> int:
-    """Try to ingest missing entries using a MediaSource (item-by-item).
+    """Try to ingest missing entries using a MediaSource.
+
+    Resolves all entry paths in a single bulk call so sources that
+    override :meth:`~vtscore.datasets.sources.base.MediaSource.resolve_paths`
+    can parallelise network I/O before the sequential embed step.
 
     Returns the number of successfully ingested medias, or -1 if no
     MediaSource is available for this origin (caller should fall back to
@@ -243,11 +247,13 @@ def _ingest_via_source(
     ingested = 0
 
     try:
-        for entry in entries:
+        pairs = [(e.get("origin_name", ""), e.get("filename", "")) for e in entries]
+        paths = source.resolve_paths(pairs)
+
+        for entry, file_path in zip(entries, paths):
             origin_name = entry.get("origin_name", "")
             filename = entry.get("filename", "")
 
-            file_path = source.resolve_path(origin_name, filename)
             if file_path is None:
                 continue
 

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -229,7 +229,13 @@ def _ingest_via_source(
 
     Resolves all entry paths in a single bulk call so sources that
     override :meth:`~vtscore.datasets.sources.base.MediaSource.resolve_paths`
-    can parallelise network I/O before the sequential embed step.
+    can parallelise network I/O and return pre-computed embeddings / metadata
+    before the sequential per-item processing step.
+
+    When a :class:`~vtscore.datasets.sources.base.FetchedItem` carries a
+    pre-computed ``embedding`` (and the origin has no clip params), the embed
+    step is skipped and the source's ``embedder_name`` and any ``extra``
+    fields are merged into the media record.
 
     Returns the number of successfully ingested medias, or -1 if no
     MediaSource is available for this origin (caller should fall back to
@@ -248,38 +254,57 @@ def _ingest_via_source(
 
     try:
         pairs = [(e.get("origin_name", ""), e.get("filename", "")) for e in entries]
-        paths = source.resolve_paths(pairs)
+        fetched = source.resolve_paths(pairs)
 
-        for entry, file_path in zip(entries, paths):
+        for entry, item in zip(entries, fetched):
             origin_name = entry.get("origin_name", "")
             filename = entry.get("filename", "")
 
-            if file_path is None:
+            if item.path is None:
                 continue
 
-            # Resolve embedding + clip-aware bytes/md5 - if any step fails,
-            # fall back to the legacy full-import path so we don't produce
-            # medias with mismatched embedding/MD5/bytes triples.
             if not media_type_id:
                 source.cleanup()
                 return -1
-            resolved = _resolve_clip_content_and_embedding(file_path, media_type_id, origin_dict, embedder_name)
-            if resolved is None:
-                source.cleanup()
-                return -1  # Signal caller to use legacy full-import path
-            embedding, file_bytes, md5 = resolved
+
+            # When the source returns a pre-computed embedding (and there are
+            # no clip params that would require re-embedding a sub-segment),
+            # skip the local embed step entirely.
+            if item.embedding is not None and not _has_clip_params(origin_dict):
+                file_bytes = item.path.read_bytes()
+                embedding = item.embedding
+                effective_embedder = item.embedder_name or embedder_name
+                md5 = hashlib.md5(file_bytes).hexdigest()
+            else:
+                # Resolve embedding + clip-aware bytes/md5 - if any step fails,
+                # fall back to the legacy full-import path so we don't produce
+                # medias with mismatched embedding/MD5/bytes triples.
+                effective_embedder = embedder_name
+                resolved = _resolve_clip_content_and_embedding(
+                    item.path, media_type_id, origin_dict, embedder_name
+                )
+                if resolved is None:
+                    source.cleanup()
+                    return -1  # Signal caller to use legacy full-import path
+                embedding, file_bytes, md5 = resolved
 
             media_data = _build_media_data(
                 origin_dict=origin_dict,
                 entry=entry,
                 media_type_id=media_type_id,
                 origin_name=origin_name,
-                file_path=file_path,
+                file_path=item.path,
                 file_bytes=file_bytes,
                 md5=md5,
                 embedding=embedding,
-                embedder_name=embedder_name,
+                embedder_name=effective_embedder,
             )
+
+            # Merge source-provided metadata (file_size, duration, created_at,
+            # etc.) into the record so remote sources can supply authoritative
+            # values without a redundant file read.
+            if item.extra:
+                media_data.update(item.extra)
 
             # Allocate the ID and insert atomically, so two concurrent
             # ingests cannot collide on the same next_media_id.

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -274,21 +274,25 @@ def _resolve_file_embedding(
     file_name: str,
     file_cm: dict[str, Any] | None,
     content_vectors: dict[str, Any] | None,
+    content_embedder_name: str = "",
 ) -> tuple[Any, str]:
     """Pick a pre-computed embedding for *file_path* if available.
 
     Resolution order: custom_metadata embedding → content_vectors[rel_path]
-    → content_vectors[basename] → ``(None, "")``.  External vectors come
-    back with ``embedder_id == ""``; the framework embed stage stamps
-    the live embedder name on items that come out at ``None`` here.
+    → content_vectors[basename] → ``(None, "")``.  Custom-metadata vectors
+    come back with ``embedder_id == ""``.  Content-vectors hits use
+    *content_embedder_name* so the embedder that produced the NPZ archive
+    is recorded on the media; ``""`` is returned when the caller doesn't
+    know the embedder (the framework embed stage will stamp its own name
+    when embedding is ``None``).
     """
     cm_embedding = _get_embedding_value(file_cm) if file_cm else None
     if cm_embedding is not None:
         return cm_embedding, ""
     if content_vectors and rel_path in content_vectors:
-        return content_vectors[rel_path], ""
+        return content_vectors[rel_path], content_embedder_name
     if content_vectors and file_name in content_vectors:
-        return content_vectors[file_name], ""
+        return content_vectors[file_name], content_embedder_name
     return None, ""
 
 
@@ -387,6 +391,7 @@ def _build_per_file_media(
     custom_metadata_map: dict[str, dict[str, Any]] | None,
     thin: bool,
     origin: dict[str, Any] | None,
+    content_embedder_name: str = "",
 ) -> dict[str, Any]:
     """Resolve any pre-computed embedding + md5 and build the per-file media dict.
 
@@ -395,7 +400,9 @@ def _build_per_file_media(
     """
     file_cm = _lookup_file_custom_metadata(rel_path, file_path.name, custom_metadata_map)
 
-    embedding, embedder_id = _resolve_file_embedding(rel_path, file_path.name, file_cm, content_vectors)
+    embedding, embedder_id = _resolve_file_embedding(
+        rel_path, file_path.name, file_cm, content_vectors, content_embedder_name
+    )
 
     cm_md5 = _get_md5_value(file_cm) if file_cm else ""
 
@@ -452,6 +459,7 @@ def load_dataset_from_folder(
     thin: bool = False,
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
     recursive: bool = True,
+    content_embedder_name: str = "",
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
@@ -495,6 +503,9 @@ def load_dataset_from_folder(
             (highest priority).  The dict is attached as
             ``media["custom_metadata"]``.
         recursive: When ``True`` (default), scan subdirectories.
+        content_embedder_name: Name of the embedder that produced the
+            vectors in *content_vectors*.  Stored as ``media["embedder"]``
+            for every file whose vector comes from *content_vectors*.
 
     Raises:
         ValueError: If ``media_type`` is not recognised, if no matching
@@ -544,6 +555,7 @@ def load_dataset_from_folder(
                 custom_metadata_map=custom_metadata_map,
                 thin=thin,
                 origin=origin,
+                content_embedder_name=content_embedder_name,
             )
             medias[media_id] = built
             media_id += 1
@@ -595,6 +607,7 @@ def load_dataset_from_folder_chunked(
     thin: bool = False,
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
     recursive: bool = True,
+    content_embedder_name: str = "",
 ) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias from a folder of media files.
 
@@ -656,6 +669,7 @@ def load_dataset_from_folder_chunked(
                 custom_metadata_map=custom_metadata_map,
                 thin=thin,
                 origin=origin,
+                content_embedder_name=content_embedder_name,
             )
             chunk_medias[media_id] = built
             media_id += 1

--- a/vtscore/datasets/sources/base.py
+++ b/vtscore/datasets/sources/base.py
@@ -6,18 +6,17 @@ operations:
 
 - **list_items** - enumerate available media files, optionally filtered by
   file extension.
-- **fetch_item** - retrieve a single file by its key (relative path within
-  the source), returning a local ``Path``.
-- **fetch_items** - retrieve multiple files by key in one call; returns a
-  :class:`FetchedItem` per key so sources can bundle pre-computed embeddings
-  and arbitrary metadata alongside the path.  The default loops over
-  :meth:`fetch_item`; override to parallelise (e.g. concurrent network
-  downloads with a batch API that also returns vectors + file metadata).
+- **fetch_item** - retrieve a single file by its key; returns a
+  :class:`FetchedItem` so sources can bundle pre-computed embeddings and
+  metadata alongside the path.
+- **fetch_items** - bulk form of :meth:`fetch_item`; the default loops, but
+  sources can override to parallelise (e.g. one batch API call that returns
+  files + vectors + metadata for all keys at once).
 - **resolve_path** - find a file by ``origin_name`` or ``filename``, used by
-  the resolver module for cross-dataset label resolution.
-- **resolve_paths** - bulk form of :meth:`resolve_path`; returns a
-  :class:`FetchedItem` per entry, aligned with the input list.  Override to
-  parallelise.
+  the resolver module for cross-dataset label resolution; returns a
+  :class:`FetchedItem`.
+- **resolve_paths** - bulk form of :meth:`resolve_path`; returns a list of
+  :class:`FetchedItem` aligned with the input.  Override to parallelise.
 
 Sources are instantiated per-use (not singletons) because they may carry
 state such as downloaded archives or temporary extraction directories.
@@ -56,12 +55,12 @@ class MediaItem:
 
 @dataclass
 class FetchedItem:
-    """Rich result from a bulk-fetch operation.
+    """Result of any fetch or resolve operation on a :class:`MediaSource`.
 
-    Every bulk fetch returns one ``FetchedItem`` per input key/entry.  The
-    ``path`` is the only required field; the remaining fields are optional
-    bonuses that remote sources (e.g. PullWrest) can populate when their API
-    returns the data alongside the file, avoiding redundant local work.
+    All four fetch/resolve methods return ``FetchedItem``, so sources that
+    have pre-computed data available (e.g. a remote API that returns the file
+    bytes, an embedding, and file metadata in one round-trip) can surface it
+    through both the single-item and bulk paths without loss.
 
     Attributes:
         path: Local file path, or ``None`` when the item could not be
@@ -88,11 +87,13 @@ class MediaSource(ABC):
     """Abstract base class for media sources.
 
     Subclass this and implement the three abstract methods (``list_items``,
-    ``fetch_item``, ``resolve_path``) to add a new source type.  The two
-    bulk methods (``fetch_items``, ``resolve_paths``) have default
+    ``fetch_item``, ``resolve_path``) to add a new source type.  All four
+    fetch/resolve methods return :class:`FetchedItem` so pre-computed
+    embeddings and metadata flow through single-item and bulk paths alike.
+
+    The two bulk methods (``fetch_items``, ``resolve_paths``) have default
     implementations that loop over their single-item counterparts; override
-    them to parallelise I/O and surface pre-computed embeddings / metadata
-    from a remote batch API.
+    them to parallelise I/O and/or surface pre-computed data from a batch API.
 
     See :class:`~vtscore.datasets.sources.local_folder.LocalFolderSource`
     for a minimal concrete example and
@@ -117,21 +118,24 @@ class MediaSource(ABC):
         """
 
     @abstractmethod
-    def fetch_item(self, key: str) -> Path | None:
-        """Return a local file path for the item identified by *key*.
+    def fetch_item(self, key: str) -> FetchedItem:
+        """Return a :class:`FetchedItem` for the item identified by *key*.
 
-        May trigger a download or extraction on demand.
+        May trigger a download or extraction on demand.  Sources that have
+        pre-computed embeddings or metadata available (e.g. from a remote
+        API response) should populate the corresponding :class:`FetchedItem`
+        fields rather than returning a bare path.
 
         Args:
             key: The :attr:`MediaItem.key` (typically a relative path).
 
         Returns:
-            A :class:`Path` to the file on disk, or ``None`` if the key
+            A :class:`FetchedItem`; ``item.path`` is ``None`` if the key
             does not exist in this source.
         """
 
     @abstractmethod
-    def resolve_path(self, origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
         """Resolve a media file by origin_name or filename.
 
         Tries *origin_name* first, then *filename*.  Used by the resolver
@@ -142,15 +146,16 @@ class MediaSource(ABC):
             filename: The ``filename`` stored on the media dict.
 
         Returns:
-            A :class:`Path` to the resolved file, or ``None``.
+            A :class:`FetchedItem`; ``item.path`` is ``None`` when neither
+            name resolves to an existing file.
         """
 
     def fetch_items(self, keys: list[str]) -> dict[str, FetchedItem]:
         """Fetch multiple items, returning a :class:`FetchedItem` per key.
 
-        The default wraps each :meth:`fetch_item` result in a plain
-        ``FetchedItem(path=...)``.  Override to parallelise downloads and/or
-        to return pre-computed embeddings and metadata from a batch API.
+        The default calls :meth:`fetch_item` once per key.  Override to
+        parallelise downloads and/or return pre-computed embeddings and
+        metadata from a batch API.
 
         Args:
             keys: The :attr:`MediaItem.key` values to fetch.
@@ -159,15 +164,15 @@ class MediaSource(ABC):
             Mapping from each input key to its :class:`FetchedItem`.
             ``item.path`` is ``None`` for keys not found in this source.
         """
-        return {key: FetchedItem(path=self.fetch_item(key)) for key in keys}
+        return {key: self.fetch_item(key) for key in keys}
 
     def resolve_paths(self, entries: list[tuple[str, str]]) -> list[FetchedItem]:
         """Resolve multiple ``(origin_name, filename)`` pairs.
 
         Returns a list aligned with *entries*: index *i* corresponds to
-        ``entries[i]``.  The default wraps each :meth:`resolve_path` result
-        in a plain ``FetchedItem(path=...)``.  Override to parallelise and/or
-        return pre-computed embeddings and metadata.
+        ``entries[i]``.  The default calls :meth:`resolve_path` once per
+        entry.  Override to parallelise and/or return pre-computed embeddings
+        and metadata.
 
         Args:
             entries: Sequence of ``(origin_name, filename)`` pairs.
@@ -176,7 +181,7 @@ class MediaSource(ABC):
             A :class:`FetchedItem` per entry; ``item.path`` is ``None`` when
             the entry could not be resolved.
         """
-        return [FetchedItem(path=self.resolve_path(origin_name, filename)) for origin_name, filename in entries]
+        return [self.resolve_path(origin_name, filename) for origin_name, filename in entries]
 
     def cleanup(self) -> None:
         """Release any temporary resources (extraction directories, etc.).

--- a/vtscore/datasets/sources/base.py
+++ b/vtscore/datasets/sources/base.py
@@ -176,10 +176,7 @@ class MediaSource(ABC):
             A :class:`FetchedItem` per entry; ``item.path`` is ``None`` when
             the entry could not be resolved.
         """
-        return [
-            FetchedItem(path=self.resolve_path(origin_name, filename))
-            for origin_name, filename in entries
-        ]
+        return [FetchedItem(path=self.resolve_path(origin_name, filename)) for origin_name, filename in entries]
 
     def cleanup(self) -> None:
         """Release any temporary resources (extraction directories, etc.).

--- a/vtscore/datasets/sources/base.py
+++ b/vtscore/datasets/sources/base.py
@@ -1,15 +1,20 @@
 """Base classes for the media source abstraction.
 
 A :class:`MediaSource` describes how to access media files from a location
-(local folder, HTTP archive, S3 bucket, etc.).  It provides three core
+(local folder, HTTP archive, S3 bucket, etc.).  It provides five core
 operations:
 
 - **list_items** - enumerate available media files, optionally filtered by
   file extension.
 - **fetch_item** - retrieve a single file by its key (relative path within
   the source), returning a local ``Path``.
+- **fetch_items** - retrieve multiple files by key in one call; the default
+  loops over :meth:`fetch_item`, but sources can override to parallelise
+  (e.g. concurrent network downloads).
 - **resolve_path** - find a file by ``origin_name`` or ``filename``, used by
   the resolver module for cross-dataset label resolution.
+- **resolve_paths** - bulk form of :meth:`resolve_path`; returns a list
+  aligned with the input sequence.  Override to parallelise.
 
 Sources are instantiated per-use (not singletons) because they may carry
 state such as downloaded archives or temporary extraction directories.
@@ -46,8 +51,13 @@ class MediaItem:
 class MediaSource(ABC):
     """Abstract base class for media sources.
 
-    Subclass this and implement the three abstract methods to add a new
-    source type.  See :class:`~vtscore.datasets.sources.local_folder.LocalFolderSource`
+    Subclass this and implement the three abstract methods (``list_items``,
+    ``fetch_item``, ``resolve_path``) to add a new source type.  The two
+    bulk methods (``fetch_items``, ``resolve_paths``) have default
+    implementations that loop over their single-item counterparts; override
+    them to parallelise I/O (e.g. concurrent network downloads).
+
+    See :class:`~vtscore.datasets.sources.local_folder.LocalFolderSource`
     for a minimal concrete example.
     """
 
@@ -95,6 +105,38 @@ class MediaSource(ABC):
         Returns:
             A :class:`Path` to the resolved file, or ``None``.
         """
+
+    def fetch_items(self, keys: list[str]) -> dict[str, Path | None]:
+        """Return local file paths for multiple *keys*.
+
+        The default loops over :meth:`fetch_item`.  Override to parallelise
+        (e.g. concurrent network downloads).
+
+        Args:
+            keys: The :attr:`MediaItem.key` values to fetch.
+
+        Returns:
+            Mapping from each input key to its resolved :class:`Path`, or
+            ``None`` when the key does not exist in this source.  Keys not
+            present in the source map to ``None``.
+        """
+        return {key: self.fetch_item(key) for key in keys}
+
+    def resolve_paths(self, entries: list[tuple[str, str]]) -> list[Path | None]:
+        """Resolve multiple ``(origin_name, filename)`` pairs.
+
+        Returns a list aligned with *entries*: index *i* in the result
+        corresponds to ``entries[i]``.  The default loops over
+        :meth:`resolve_path`.  Override to parallelise.
+
+        Args:
+            entries: Sequence of ``(origin_name, filename)`` pairs.
+
+        Returns:
+            A list of resolved :class:`Path` objects (or ``None`` for
+            entries that could not be found).
+        """
+        return [self.resolve_path(origin_name, filename) for origin_name, filename in entries]
 
     def cleanup(self) -> None:
         """Release any temporary resources (extraction directories, etc.).

--- a/vtscore/datasets/sources/base.py
+++ b/vtscore/datasets/sources/base.py
@@ -8,13 +8,16 @@ operations:
   file extension.
 - **fetch_item** - retrieve a single file by its key (relative path within
   the source), returning a local ``Path``.
-- **fetch_items** - retrieve multiple files by key in one call; the default
-  loops over :meth:`fetch_item`, but sources can override to parallelise
-  (e.g. concurrent network downloads).
+- **fetch_items** - retrieve multiple files by key in one call; returns a
+  :class:`FetchedItem` per key so sources can bundle pre-computed embeddings
+  and arbitrary metadata alongside the path.  The default loops over
+  :meth:`fetch_item`; override to parallelise (e.g. concurrent network
+  downloads with a batch API that also returns vectors + file metadata).
 - **resolve_path** - find a file by ``origin_name`` or ``filename``, used by
   the resolver module for cross-dataset label resolution.
-- **resolve_paths** - bulk form of :meth:`resolve_path`; returns a list
-  aligned with the input sequence.  Override to parallelise.
+- **resolve_paths** - bulk form of :meth:`resolve_path`; returns a
+  :class:`FetchedItem` per entry, aligned with the input list.  Override to
+  parallelise.
 
 Sources are instantiated per-use (not singletons) because they may carry
 state such as downloaded archives or temporary extraction directories.
@@ -24,11 +27,14 @@ Callers should call :meth:`MediaSource.cleanup` when they're done.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
-__all__ = ["MediaItem", "MediaSource"]
+if TYPE_CHECKING:
+    import numpy as np
+
+__all__ = ["FetchedItem", "MediaItem", "MediaSource"]
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,36 @@ class MediaItem:
     source_name: str
 
 
+@dataclass
+class FetchedItem:
+    """Rich result from a bulk-fetch operation.
+
+    Every bulk fetch returns one ``FetchedItem`` per input key/entry.  The
+    ``path`` is the only required field; the remaining fields are optional
+    bonuses that remote sources (e.g. PullWrest) can populate when their API
+    returns the data alongside the file, avoiding redundant local work.
+
+    Attributes:
+        path: Local file path, or ``None`` when the item could not be
+            resolved/downloaded.
+        embedding: Pre-computed embedding vector.  When set the ingest path
+            skips re-embedding the file, provided the origin carries no clip
+            params (clip embeddings must be derived from the clipped segment).
+        embedder_name: Name of the embedder that produced *embedding*.  Must
+            be set whenever *embedding* is provided so the vector can be
+            matched against the dataset's embedding space.
+        extra: Arbitrary source-provided metadata keyed by media-record field
+            name (e.g. ``"file_size"``, ``"duration"``, ``"created_at"``).
+            The ingest path merges these into the media record, letting remote
+            sources supply authoritative values without a second file read.
+    """
+
+    path: Path | None
+    embedding: np.ndarray | None = None
+    embedder_name: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
 class MediaSource(ABC):
     """Abstract base class for media sources.
 
@@ -55,10 +91,13 @@ class MediaSource(ABC):
     ``fetch_item``, ``resolve_path``) to add a new source type.  The two
     bulk methods (``fetch_items``, ``resolve_paths``) have default
     implementations that loop over their single-item counterparts; override
-    them to parallelise I/O (e.g. concurrent network downloads).
+    them to parallelise I/O and surface pre-computed embeddings / metadata
+    from a remote batch API.
 
     See :class:`~vtscore.datasets.sources.local_folder.LocalFolderSource`
-    for a minimal concrete example.
+    for a minimal concrete example and
+    :class:`~vtscore.datasets.sources.pullwrest.PullWrestSource`
+    for an example of a bulk override that returns rich metadata.
     """
 
     #: Short identifier for this source type (e.g. ``"local_folder"``).
@@ -106,37 +145,41 @@ class MediaSource(ABC):
             A :class:`Path` to the resolved file, or ``None``.
         """
 
-    def fetch_items(self, keys: list[str]) -> dict[str, Path | None]:
-        """Return local file paths for multiple *keys*.
+    def fetch_items(self, keys: list[str]) -> dict[str, FetchedItem]:
+        """Fetch multiple items, returning a :class:`FetchedItem` per key.
 
-        The default loops over :meth:`fetch_item`.  Override to parallelise
-        (e.g. concurrent network downloads).
+        The default wraps each :meth:`fetch_item` result in a plain
+        ``FetchedItem(path=...)``.  Override to parallelise downloads and/or
+        to return pre-computed embeddings and metadata from a batch API.
 
         Args:
             keys: The :attr:`MediaItem.key` values to fetch.
 
         Returns:
-            Mapping from each input key to its resolved :class:`Path`, or
-            ``None`` when the key does not exist in this source.  Keys not
-            present in the source map to ``None``.
+            Mapping from each input key to its :class:`FetchedItem`.
+            ``item.path`` is ``None`` for keys not found in this source.
         """
-        return {key: self.fetch_item(key) for key in keys}
+        return {key: FetchedItem(path=self.fetch_item(key)) for key in keys}
 
-    def resolve_paths(self, entries: list[tuple[str, str]]) -> list[Path | None]:
+    def resolve_paths(self, entries: list[tuple[str, str]]) -> list[FetchedItem]:
         """Resolve multiple ``(origin_name, filename)`` pairs.
 
-        Returns a list aligned with *entries*: index *i* in the result
-        corresponds to ``entries[i]``.  The default loops over
-        :meth:`resolve_path`.  Override to parallelise.
+        Returns a list aligned with *entries*: index *i* corresponds to
+        ``entries[i]``.  The default wraps each :meth:`resolve_path` result
+        in a plain ``FetchedItem(path=...)``.  Override to parallelise and/or
+        return pre-computed embeddings and metadata.
 
         Args:
             entries: Sequence of ``(origin_name, filename)`` pairs.
 
         Returns:
-            A list of resolved :class:`Path` objects (or ``None`` for
-            entries that could not be found).
+            A :class:`FetchedItem` per entry; ``item.path`` is ``None`` when
+            the entry could not be resolved.
         """
-        return [self.resolve_path(origin_name, filename) for origin_name, filename in entries]
+        return [
+            FetchedItem(path=self.resolve_path(origin_name, filename))
+            for origin_name, filename in entries
+        ]
 
     def cleanup(self) -> None:
         """Release any temporary resources (extraction directories, etc.).

--- a/vtscore/datasets/sources/http_archive.py
+++ b/vtscore/datasets/sources/http_archive.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Iterator
 from uuid import uuid4
 
 from vtscore.config import DATA_DIR
-from vtscore.datasets.sources.base import MediaItem, MediaSource
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
 
 if TYPE_CHECKING:
     from vtscore.datasets.sources.local_folder import LocalFolderSource
@@ -124,11 +124,11 @@ class HttpArchiveSource(MediaSource):
                 source_name=self.name,
             )
 
-    def fetch_item(self, key: str) -> Path | None:
+    def fetch_item(self, key: str) -> FetchedItem:
         inner = self._ensure_extracted()
         return inner.fetch_item(key)
 
-    def resolve_path(self, origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
         inner = self._ensure_extracted()
         return inner.resolve_path(origin_name, filename)
 

--- a/vtscore/datasets/sources/local_folder.py
+++ b/vtscore/datasets/sources/local_folder.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Iterator
 
-from vtscore.datasets.sources.base import MediaItem, MediaSource
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
 
 __all__ = ["LocalFolderSource"]
 
@@ -54,29 +54,27 @@ class LocalFolderSource(MediaSource):
                     source_name=self.name,
                 )
 
-    def fetch_item(self, key: str) -> Path | None:
-        """Return the file path for *key* (a relative path within the folder).
+    def fetch_item(self, key: str) -> FetchedItem:
+        """Return a :class:`FetchedItem` for *key* (a relative path within the folder).
 
-        Returns ``None`` if the file doesn't exist or escapes the folder root.
+        ``item.path`` is ``None`` if the file doesn't exist or escapes the root.
         """
         candidate = (self._folder / key).resolve()
         # Prevent path traversal
         try:
             candidate.relative_to(self._folder.resolve())
         except ValueError:
-            return None
-        if candidate.is_file():
-            return candidate
-        return None
+            return FetchedItem(path=None)
+        return FetchedItem(path=candidate if candidate.is_file() else None)
 
-    def resolve_path(self, origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
         """Resolve by trying *origin_name* then *filename* as relative paths."""
         for name in [origin_name, filename]:
             if name:
-                result = self.fetch_item(name)
-                if result is not None:
-                    return result
-        return None
+                item = self.fetch_item(name)
+                if item.path is not None:
+                    return item
+        return FetchedItem(path=None)
 
 
 class _LocalFolderSourceFactory:

--- a/vtscore/datasets/sources/pullwrest.py
+++ b/vtscore/datasets/sources/pullwrest.py
@@ -145,17 +145,17 @@ class PullWrestSource(MediaSource):
                 source_name=self.name,
             )
 
-    def fetch_item(self, key: str) -> Path | None:
-        """Download and return a local path for the media."""
+    def fetch_item(self, key: str) -> FetchedItem:
+        """Download and return a :class:`FetchedItem` for the media."""
         if key != self._content_id:
-            return None
-        return self._download_to_cache()
+            return FetchedItem(path=None)
+        return FetchedItem(path=self._download_to_cache())
 
-    def resolve_path(self, origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
         """Resolve by downloading if origin_name or filename matches."""
         if origin_name == self._content_id or filename == self._content_id:
-            return self._download_to_cache()
-        return None
+            return FetchedItem(path=self._download_to_cache())
+        return FetchedItem(path=None)
 
     # ------------------------------------------------------------------
     # Bulk fetch - override to use the PullWrest batch endpoint
@@ -214,7 +214,7 @@ class PullWrestSource(MediaSource):
         # Single-item fallback for anything not resolved by the batch call.
         for key in keys:
             if key not in result:
-                result[key] = FetchedItem(path=self.fetch_item(key))
+                result[key] = self.fetch_item(key)
 
         return result
 

--- a/vtscore/datasets/sources/pullwrest.py
+++ b/vtscore/datasets/sources/pullwrest.py
@@ -182,9 +182,7 @@ class PullWrestSource(MediaSource):
 
         if owned:
             tmpdir = self._ensure_tmpdir()
-            batch_requests = [
-                {"media_url": self._media_url, "content_id": self._content_id}
-            ]
+            batch_requests = [{"media_url": self._media_url, "content_id": self._content_id}]
             try:
                 responses = _pw_fetch_media_batch(batch_requests)
                 for req, resp in zip(batch_requests, responses):

--- a/vtscore/datasets/sources/pullwrest.py
+++ b/vtscore/datasets/sources/pullwrest.py
@@ -16,6 +16,17 @@ Caching
 Downloaded files are cached in a temporary directory keyed by
 ``contentID``.  Call :meth:`PullWrestSource.cleanup` to remove the
 temporary directory when done.
+
+Bulk fetch
+----------
+:meth:`PullWrestSource.fetch_items` overrides the default loop-per-item
+implementation to issue a single batch request to the PullWrest service.
+The batch response carries not just the file bytes but also pre-computed
+embeddings and file-level metadata (size, duration, created_at, etc.) so
+VTSearch can skip local re-embedding and avoid redundant stat calls.
+
+The single-item :meth:`fetch_item` path remains as a fallback and for
+callers that only need one file.
 """
 
 from __future__ import annotations
@@ -25,7 +36,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
-from vtscore.datasets.sources.base import MediaItem, MediaSource
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +44,7 @@ __all__ = ["PullWrestSource"]
 
 
 # ---------------------------------------------------------------------------
-# TODO(dev): Implement the PullWrest client function below.
+# TODO(dev): Implement the PullWrest client functions below.
 # ---------------------------------------------------------------------------
 
 
@@ -44,6 +55,36 @@ def _pw_fetch_media(media_url: str) -> bytes:
     extracting a shared ``pullwrest_client`` module that both use.
     """
     raise NotImplementedError("TODO: implement PullWrest API client")
+
+
+def _pw_fetch_media_batch(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Call PullWrest to fetch a batch of media items in one request.
+
+    Args:
+        items: List of dicts, each with at least ``"media_url"`` and
+            ``"content_id"`` keys identifying the items to fetch.
+
+    Returns:
+        List of result dicts aligned with *items*.  Each result has:
+
+        - ``"data"`` (``bytes``): raw media bytes.
+        - ``"embedding"`` (``list[float] | None``): pre-computed embedding
+          vector from PullWrest, or ``None`` if the service did not return
+          one.
+        - ``"embedder_name"`` (``str``): name of the embedder used to
+          produce ``"embedding"`` (e.g. ``"laion-clap"``).
+        - ``"file_size"`` (``int``): byte count of the media file.
+        - ``"duration"`` (``float | None``): duration in seconds (audio /
+          video), or ``None`` for non-temporal media.
+        - ``"created_at"`` (``str | None``): ISO 8601 creation timestamp
+          from the PullWrest catalogue, or ``None``.
+
+    Raise:
+        NotImplementedError: Until the PullWrest batch endpoint is wired up.
+    """
+    raise NotImplementedError("TODO: implement PullWrest batch API client")
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +156,69 @@ class PullWrestSource(MediaSource):
         if origin_name == self._content_id or filename == self._content_id:
             return self._download_to_cache()
         return None
+
+    # ------------------------------------------------------------------
+    # Bulk fetch - override to use the PullWrest batch endpoint
+    # ------------------------------------------------------------------
+
+    def fetch_items(self, keys: list[str]) -> dict[str, FetchedItem]:
+        """Fetch multiple items via the PullWrest batch API.
+
+        Issues a single batch request that returns file bytes, pre-computed
+        embeddings, and file-level metadata for all requested keys.  The
+        returned :class:`~vtscore.datasets.sources.base.FetchedItem` objects
+        carry the embedding and ``extra`` metadata (file_size, duration,
+        created_at) so the ingest path can skip local re-embedding and
+        redundant stat calls.
+
+        Falls back to the single-item path for keys that are not
+        ``self._content_id``.
+        """
+        import numpy as np
+
+        # Collect items this source actually owns.
+        owned = [k for k in keys if k == self._content_id]
+        result: dict[str, FetchedItem] = {}
+
+        if owned:
+            tmpdir = self._ensure_tmpdir()
+            batch_requests = [
+                {"media_url": self._media_url, "content_id": self._content_id}
+            ]
+            try:
+                responses = _pw_fetch_media_batch(batch_requests)
+                for req, resp in zip(batch_requests, responses):
+                    cid = req["content_id"]
+                    cached = tmpdir / cid
+                    cached.write_bytes(resp["data"])
+
+                    raw_emb = resp.get("embedding")
+                    embedding = np.array(raw_emb, dtype=np.float32) if raw_emb else None
+
+                    extra: dict[str, Any] = {}
+                    for field in ("file_size", "duration", "created_at"):
+                        if resp.get(field) is not None:
+                            extra[field] = resp[field]
+
+                    result[cid] = FetchedItem(
+                        path=cached,
+                        embedding=embedding,
+                        embedder_name=resp.get("embedder_name", ""),
+                        extra=extra,
+                    )
+            except Exception:
+                logger.warning(
+                    "PullWrest batch fetch failed; falling back to single-item path",
+                    exc_info=True,
+                )
+                # Fall through to single-item path below.
+
+        # Single-item fallback for anything not resolved by the batch call.
+        for key in keys:
+            if key not in result:
+                result[key] = FetchedItem(path=self.fetch_item(key))
+
+        return result
 
     def cleanup(self) -> None:
         """Remove the temporary download directory."""

--- a/vtscore/datasets/sources/server_files.py
+++ b/vtscore/datasets/sources/server_files.py
@@ -14,7 +14,7 @@ proceeds as usual.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Iterator
 
 import numpy as np
 

--- a/vtscore/datasets/sources/server_files.py
+++ b/vtscore/datasets/sources/server_files.py
@@ -77,7 +77,9 @@ class ServerFilesSource(MediaSource):
         p = Path(resolved)
         if not p.is_file():
             return FetchedItem(path=None)
-        vec = path_to_vec.get(resolved) or path_to_vec.get(key)
+        vec = path_to_vec.get(resolved)
+        if vec is None:
+            vec = path_to_vec.get(key)
         if vec is not None:
             return FetchedItem(path=p, embedding=vec, embedder_name=self._embedder_name)
         return FetchedItem(path=p)

--- a/vtscore/datasets/sources/server_files.py
+++ b/vtscore/datasets/sources/server_files.py
@@ -1,0 +1,118 @@
+"""Server-files media source – re-ingests from a ``.npz`` paths archive.
+
+When the ``server_files`` importer is given a ``.npz`` paths file the
+origin params record both the path to that archive and the embedder name
+stored inside it.  On re-ingestion this source reads the archive and
+supplies the pre-computed embedding for each file so the embed stage is
+skipped, provided the origin carries no clip params.
+
+Plain ``.txt`` / ``.list`` paths files produce no pre-computed vectors
+so the factory returns ``None`` for those origins; normal embedding
+proceeds as usual.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import numpy as np
+
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
+
+__all__ = ["ServerFilesSource"]
+
+
+class ServerFilesSource(MediaSource):
+    """A media source backed by a ``.npz`` paths-and-vectors archive.
+
+    On re-ingestion the source supplies pre-computed embedding vectors
+    read directly from the archive, so files skip re-embedding as long
+    as the origin carries no clip params.
+
+    Args:
+        npz_path: Path to the ``.npz`` archive.
+        embedder_name: Name of the embedder that produced the vectors
+            stored in the archive.  Passed through to every returned
+            :class:`FetchedItem`.
+    """
+
+    name = "server_files"
+
+    def __init__(self, npz_path: str | Path, embedder_name: str = "") -> None:
+        self._npz_path = Path(npz_path)
+        self._embedder_name = embedder_name
+        self._path_to_vector: dict[str, np.ndarray] | None = None
+
+    def _ensure_loaded(self) -> dict[str, np.ndarray]:
+        if self._path_to_vector is None:
+            from vtscore.datasets.importers._npz_vectors import read_npz_filenames_and_vectors  # noqa: PLC0415
+
+            base_dir = self._npz_path.resolve().parent
+            name_to_vec = read_npz_filenames_and_vectors(self._npz_path)
+            mapping: dict[str, np.ndarray] = {}
+            for raw_name, vec in name_to_vec.items():
+                candidate = Path(raw_name.strip())
+                if not candidate.is_absolute():
+                    candidate = (base_dir / candidate).resolve()
+                mapping[str(candidate)] = vec
+            self._path_to_vector = mapping
+        return self._path_to_vector
+
+    def list_items(self, extensions: list[str] | None = None) -> Iterator[MediaItem]:
+        """Yield items for every path recorded in the NPZ archive."""
+        ext_set = {e.lower() for e in extensions} if extensions else None
+        for abs_path_str in self._ensure_loaded():
+            p = Path(abs_path_str)
+            if ext_set is not None and p.suffix.lower() not in ext_set:
+                continue
+            if not p.is_file():
+                continue
+            yield MediaItem(key=abs_path_str, filename=p.name, source_name=self.name)
+
+    def fetch_item(self, key: str) -> FetchedItem:
+        """Fetch item by absolute path string; supplies pre-computed embedding when available."""
+        path_to_vec = self._ensure_loaded()
+        resolved = str(Path(key).resolve())
+        p = Path(resolved)
+        if not p.is_file():
+            return FetchedItem(path=None)
+        vec = path_to_vec.get(resolved) or path_to_vec.get(key)
+        if vec is not None:
+            return FetchedItem(path=p, embedding=vec, embedder_name=self._embedder_name)
+        return FetchedItem(path=p)
+
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
+        """Resolve by trying *origin_name* then *filename* as absolute paths."""
+        for candidate_str in (origin_name, filename):
+            if not candidate_str:
+                continue
+            item = self.fetch_item(candidate_str)
+            if item.path is not None:
+                return item
+        return FetchedItem(path=None)
+
+
+class _ServerFilesSourceFactory:
+    """Factory for auto-discovery by :class:`~vtscore.plugins.PluginRegistry`.
+
+    Resolves origins emitted by the :mod:`server_files` dataset importer
+    when the paths file is a ``.npz`` archive.  Origins from plain ``.txt``
+    or ``.list`` paths files return ``None`` (no pre-computed vectors).
+    """
+
+    name = "server_files"
+
+    def create_from_origin(self, origin: dict) -> ServerFilesSource | None:
+        params = origin.get("params", {})
+        paths_file = params.get("paths_file", "")
+        if not paths_file:
+            return None
+        p = Path(paths_file)
+        if p.suffix.lower() != ".npz" or not p.is_file():
+            return None
+        embedder_name = params.get("embedder_name", "")
+        return ServerFilesSource(p, embedder_name)
+
+
+SOURCE = _ServerFilesSourceFactory()

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -146,7 +146,7 @@ def _auto_wire_resolvers() -> None:
                 # Keep the source alive (and its temp dir, if any) until
                 # the caller's resolve_file_context exits.
                 stack.callback(source.cleanup)
-                return source.resolve_path(origin_name, filename)
+                return source.resolve_path(origin_name, filename).path
 
             register_source_resolver(_default_source_resolver)
         except ImportError:

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -318,7 +318,7 @@ def example_sort_origin(body: dict):
     crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
 
     try:
-        file_path = source.fetch_item(key)
+        file_path = source.fetch_item(key).path
         if file_path is None:
             abort(404, message=f"File not found: {key}")
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Embedder name now stored from NPZ archives.** Previously, media imported from a `.npz` paths-and-vectors file always got `embedder = ""` because the embedder name was never read or threaded through the pipeline. Now `read_npz_embedder_name()` reads the `"embedder_name"` or `"embedder"` key from the archive; it flows through `_read_npz_paths_file` → `_stage_paths` → `_load_direct_into` → `load_dataset_from_folder` (new `content_embedder_name` param) → `_resolve_file_embedding` → `media["embedder"]` and `origin["params"]["embedder_name"]`.

- **`ServerFilesSource` added for re-ingestion.** When a dataset was re-ingested from a `server_files` NPZ origin, there was no `MediaSource` so the fast path (`_ingest_via_source`) was skipped and pre-computed vectors were never surfaced. The new `ServerFilesSource` reads the NPZ on demand and returns `FetchedItem(path=..., embedding=..., embedder_name=...)` from `fetch_item` / `resolve_path`, so re-ingestion skips the embed step for files whose vectors are in the archive.

## What landed

**`vtscore/datasets/importers/_npz_vectors.py`**
- `read_npz_embedder_name(npz_path) -> str` — reads `"embedder_name"` or `"embedder"` key; returns `""` if absent or on any read error.

**`vtscore/datasets/importers/server_files/__init__.py`**
- `_read_npz_paths_file` / `_read_paths_and_vectors` now return 3-tuples `(paths, vectors, embedder_name)`.
- `_stage_paths` returns 4-tuple; `_rewrite_origins` stores `embedder_name` in `origin["params"]`; `_load_direct_into` / `run` / `run_chunked` pass it through.

**`vtscore/datasets/loader_folder.py`**
- `content_embedder_name: str = ""` added to `load_dataset_from_folder`, `load_dataset_from_folder_chunked`, `_build_per_file_media`, `_resolve_file_embedding`. Content-vectors hits now record the caller-supplied embedder name instead of hardcoding `""`.

**`vtscore/datasets/sources/server_files.py`** (new)
- `ServerFilesSource` — lazy NPZ loading, `fetch_item` / `resolve_path` / `list_items`, returns `FetchedItem` with pre-computed embedding.
- `_ServerFilesSourceFactory` — auto-discovered via `SOURCE` sentinel; returns `None` for `.txt`/`.list` origins (no vectors to surface).

## Breaking changes

- `_read_npz_paths_file` and `_read_paths_and_vectors` now return 3-tuples. Any code unpacking them as 2-tuples will break (tests updated).

## Test plan

- [ ] `./run-tests.sh io datasets` — all 1345 tests pass
- [ ] `./run-tests.sh` — all 4378 tests pass
- [ ] New `TestReadNpzEmbedderName` class covers the embedder name reader
- [ ] `TestServerFilesNpzRunsEndToEnd::test_npz_embedder_name_stored_in_media_and_origin` verifies end-to-end embedder name propagation
- [ ] `TestServerFilesSource` covers `fetch_item`, `resolve_path`, `list_items`, factory, and `get_source_for_origin`

https://claude.ai/code/session_01Q59wvyGDA9ZhbRP5TQSESY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q59wvyGDA9ZhbRP5TQSESY)_