### PR TITLE
Add dynamic field options support to label importers

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -10467,6 +10467,69 @@
         ]
       }
     },
+    "/api/label-importers/field-options/{importer_name}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "importer_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "label_importer_field_options",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterFieldOptionsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterFieldOptionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Unknown or non-dynamic field key."
+          },
+          "404": {
+            "description": "Unknown importer name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "500": {
+            "description": "get_field_options did not return a list."
+          },
+          "501": {
+            "description": "Importer does not implement get_field_options."
+          },
+          "502": {
+            "description": "Remote service backing dynamic options raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return dropdown options for a dynamic-options field on a label importer.",
+        "tags": [
+          "label_importers"
+        ]
+      }
+    },
     "/api/label-importers/import/holder": {
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -124,11 +124,21 @@
                 [id]="'lif-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+                [disabled]="!!dynamicFieldLoading[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
               >
-                @for (opt of field.options || []; track opt) {
+                @if (field.dynamic_options && dynamicFieldLoading[field.key]) {
+                  <option value="">Loading…</option>
+                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError[field.key]) {
+                  <option value="">No options available</option>
+                }
+                @for (opt of optionsFor(field); track opt) {
                   <option [value]="opt">{{ opt }}</option>
                 }
               </select>
+              @if (field.dynamic_options && dynamicFieldError[field.key]) {
+                <p class="error-text">{{ dynamicFieldError[field.key] }}</p>
+              }
             } @else if (field.field_type === 'number') {
               <input
                 [id]="'lif-' + field.key"

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -49,6 +49,9 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
   submitting = false;
   error = '';
   successMessage = '';
+  dynamicFieldOptions: Record<string, string[]> = {};
+  dynamicFieldLoading: Record<string, boolean> = {};
+  dynamicFieldError: Record<string, string> = {};
   addingGood = false;
   addingBad = false;
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -93,6 +96,9 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
     this.selectedFileFieldKey = null;
     this.error = '';
     this.successMessage = '';
+    this.dynamicFieldOptions = {};
+    this.dynamicFieldLoading = {};
+    this.dynamicFieldError = {};
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -105,7 +111,58 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
         this.formValues[field.key] = field.options![0];
       }
     }
+    for (const field of fields) {
+      if (field.dynamic_options) {
+        this.refreshDynamicFieldOptions(field);
+      }
+    }
     this.view = 'form';
+  }
+
+  onFormFieldChanged(changedKey: string): void {
+    const importer = this.selectedImporter;
+    if (!importer?.fields) return;
+    for (const field of (importer.fields as ImporterField[])) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      this.formValues[field.key] = '';
+      this.refreshDynamicFieldOptions(field);
+    }
+  }
+
+  optionsFor(field: ImporterField): string[] {
+    if (field.dynamic_options) {
+      return this.dynamicFieldOptions[field.key] || [];
+    }
+    return field.options || [];
+  }
+
+  private refreshDynamicFieldOptions(field: ImporterField): void {
+    const importer = this.selectedImporter;
+    if (!importer) return;
+    const key = field.key;
+    this.dynamicFieldLoading[key] = true;
+    this.dynamicFieldError[key] = '';
+    this.labelImportersApi
+      .getFieldOptions(importer.name, key, { ...this.formValues })
+      .subscribe({
+        next: (res) => {
+          this.dynamicFieldOptions[key] = res.options || [];
+          this.dynamicFieldLoading[key] = false;
+          const current = this.formValues[key];
+          if (current && !this.dynamicFieldOptions[key].includes(String(current))) {
+            this.formValues[key] = '';
+          }
+          if (!this.formValues[key] && field.required && this.dynamicFieldOptions[key].length > 0) {
+            this.formValues[key] = this.dynamicFieldOptions[key][0];
+          }
+        },
+        error: (err) => {
+          this.dynamicFieldLoading[key] = false;
+          this.dynamicFieldError[key] = err?.error?.error || 'Could not load options';
+          this.dynamicFieldOptions[key] = [];
+        },
+      });
   }
 
   back(): void {

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -59,6 +59,13 @@ export class LabelImportersApiService {
     return this.http.post(url, params);
   }
 
+  getFieldOptions(importerName: string, fieldKey: string, values: Record<string, string>): Observable<{ options: string[] }> {
+    return this.http.post<{ options: string[] }>(
+      `/api/label-importers/field-options/${encodeURIComponent(importerName)}`,
+      { field_key: fieldKey, values },
+    );
+  }
+
   ingestMissing(entries: Record<string, unknown>[]): Observable<IngestMissingResponse> {
     return ingestMissing(this.http, this.config.rootUrl, {
       body: { entries },

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -9,6 +9,10 @@ GET  /api/label-importers
     List all registered label importers with their metadata and field
     definitions.
 
+POST /api/label-importers/field-options/<importer_name>
+    Return dropdown options for a dynamic-options field.  Delegates to
+    ``get_field_options(field_key, current_values)`` on the importer.
+
 POST /api/label-importers/import/<importer_name>
     Run the named label importer. Accepts ``multipart/form-data`` (when
     the importer has a ``"file"`` field) or JSON (for text-only
@@ -50,6 +54,8 @@ from flask_smorest import Blueprint
 
 logger = logging.getLogger(__name__)
 
+from flask_smorest import abort
+
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
     get_plugin_or_404,
@@ -58,6 +64,10 @@ from vtsearch.routes._shared import (
     require_detector_header,
     run_plugin_or_error,
     validate_plugin_args,
+)
+from vtsearch.schemas.datasets import (
+    ImporterFieldOptionsRequestSchema,
+    ImporterFieldOptionsResponseSchema,
 )
 from vtsearch.schemas.labels import (
     IngestMissingRequestSchema,
@@ -133,6 +143,47 @@ def get_label_importers():
     from vtsearch.settings import filter_visible_plugins
 
     return [imp.to_dict() for imp in filter_visible_plugins("label_importers", list_label_importers())]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/label-importers/field-options/<importer_name>
+# ---------------------------------------------------------------------------
+
+
+@label_importers_bp.route("/api/label-importers/field-options/<importer_name>", methods=["POST"])
+@label_importers_bp.arguments(ImporterFieldOptionsRequestSchema)
+@label_importers_bp.response(200, ImporterFieldOptionsResponseSchema)
+@label_importers_bp.alt_response(400, description="Unknown or non-dynamic field key.")
+@label_importers_bp.alt_response(404, description="Unknown importer name.")
+@label_importers_bp.alt_response(500, description="get_field_options did not return a list.")
+@label_importers_bp.alt_response(501, description="Importer does not implement get_field_options.")
+@label_importers_bp.alt_response(502, description="Remote service backing dynamic options raised an error.")
+def label_importer_field_options(body: dict, importer_name: str):
+    """Return dropdown options for a dynamic-options field on a label importer."""
+    importer, err = get_plugin_or_404(get_label_importer, list_label_importers, importer_name, "label importer")
+    if err:
+        return err
+    assert importer is not None
+
+    field_key = body["field_key"].strip()
+    values = body.get("values") or {}
+
+    field = next((f for f in importer.fields if f.key == field_key), None)
+    if field is None:
+        abort(400, message=f"Unknown field: {field_key!r}")
+    if not getattr(field, "dynamic_options", False):
+        abort(400, message=f"Field {field_key!r} is not dynamic")
+
+    try:
+        options = importer.get_field_options(field_key, values)
+    except NotImplementedError as exc:
+        abort(501, message=str(exc) or "Importer does not implement get_field_options")
+    except Exception as exc:  # noqa: BLE001
+        abort(502, message=str(exc) or type(exc).__name__)
+
+    if not isinstance(options, list):
+        abort(500, message="get_field_options must return a list")
+    return {"options": [str(o) for o in options]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds support for dynamic dropdown options in label importer fields. Fields can now declare themselves as `dynamic_options` and depend on other fields, allowing their available options to be fetched from the importer based on the current form state.

## Changes

**Backend (`vtsearch/routes/labels/importers.py`)**
- New POST endpoint `/api/label-importers/field-options/<importer_name>` that delegates to the importer's `get_field_options(field_key, current_values)` method
- Validates that the field exists and is marked as dynamic
- Handles errors from the importer (NotImplementedError → 501, other exceptions → 502, invalid return type → 500)

**Frontend Component (`label-importer-modal.component.ts`)**
- Added state tracking for dynamic field options, loading states, and errors
- `onFormFieldChanged()` method detects when a field changes and refreshes options for any dependent dynamic fields
- `refreshDynamicFieldOptions()` calls the backend API and updates form values if the current selection is no longer valid
- `optionsFor()` helper returns either static or dynamic options depending on field type
- Initializes dynamic field options when an importer is selected

**Frontend Template (`label-importer-modal.component.html`)**
- Select dropdowns now use `optionsFor()` instead of directly accessing `field.options`
- Added loading state display ("Loading…") while options are being fetched
- Added "No options available" placeholder when dynamic field has no options
- Added error message display below dynamic fields
- Disabled select while loading or when no options are available
- Wired `(ngModelChange)` to trigger `onFormFieldChanged()`

**API Service (`label-importers-api.service.ts`)**
- New `getFieldOptions()` method that POSTs to the field-options endpoint with field key and current form values

**OpenAPI Schema (`frontend/openapi.json`)**
- Added endpoint definition with request/response schemas and comprehensive error responses

## Implementation Details
- Dynamic fields are refreshed both on initial importer selection and whenever a field they depend on changes
- If a selected option becomes invalid after a dependency changes, the form value is cleared
- If a required field becomes empty after refresh and options are available, the first option is auto-selected
- All error handling is graceful: loading/error states are tracked per field and displayed to the user

https://claude.ai/code/session_01DpRueHN1NcKsGjcjWxmV4J