### PR TITLE
CLI: stream-results for media sources larger than RAM

### DIFF
--- a/app.py
+++ b/app.py
@@ -684,6 +684,29 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--stream-results",
+        action="store_true",
+        dest="stream_results",
+        help=(
+            "Stream each chunk's hits straight to the exporter instead of "
+            "accumulating them all in memory. Requires --chunk-size and a "
+            "streaming-capable exporter (server_json_file → NDJSON, "
+            "server_csv_file, gui). Output is ordered by chunk, not globally "
+            "sorted by score. Lets --autodetect run against a media source "
+            "with more items (and more hits) than fit in RAM."
+        ),
+    )
+    parser.add_argument(
+        "--keep-negatives",
+        action="store_true",
+        dest="keep_negatives",
+        help=(
+            "With --stream-results, also stream below-threshold (negative) "
+            "hits, tagged label=bad. Off by default: a find over a massive "
+            "source only emits the predicted-good items."
+        ),
+    )
+    parser.add_argument(
         "--import-labels-into",
         type=str,
         default=None,
@@ -963,6 +986,13 @@ if __name__ == "__main__":
 
         dry_run = bool(getattr(args, "dry_run", False))
 
+        stream_results = bool(getattr(args, "stream_results", False))
+        keep_negatives = bool(getattr(args, "keep_negatives", False))
+        if stream_results and not chunk_size:
+            parser.error("--stream-results requires --chunk-size N (it streams chunk by chunk)")
+        if keep_negatives and not stream_results:
+            parser.error("--keep-negatives only applies with --stream-results")
+
         # Optional one-shot label import into a detector before scoring.
         # The merged labelset is picked up by the autodetect pipeline below.
         if args.import_labels_into:
@@ -1025,6 +1055,8 @@ if __name__ == "__main__":
                     args.exporter,
                     exporter_field_values,
                     dry_run=dry_run,
+                    stream_results=stream_results,
+                    keep_negatives=keep_negatives,
                 )
             else:
                 from vtscore.cli import autodetect_importer_main
@@ -1050,6 +1082,8 @@ if __name__ == "__main__":
                     args.exporter,
                     exporter_field_values,
                     dry_run=dry_run,
+                    stream_results=stream_results,
+                    keep_negatives=keep_negatives,
                 )
             else:
                 from vtscore.cli import autodetect_main

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -35,6 +35,28 @@ python app.py --autodetect --dataset data.pkl --settings settings.json --chunk-s
 python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --settings settings.json --chunk-size 500
 ```
 
+`--chunk-size` bounds the *loading and embedding* working set, but the default
+flow still accumulates every hit in memory and buffers the whole result set
+before the exporter writes it. For a media source with more items (and more
+hits) than fit in RAM — e.g. a folder tree of billions of images — add
+`--stream-results` (requires `--chunk-size` and a streaming-capable exporter:
+`server_json_file`, `server_csv_file`, or `gui`):
+
+```bash
+python app.py --autodetect --importer server_folder --path /data/images \
+  --media-type image --settings settings.json --chunk-size 500 \
+  --stream-results --exporter server_json_file --filepath hits.ndjson
+```
+
+With `--stream-results` the folder is enumerated lazily (the full file list is
+never held in memory), each chunk's hits are written straight to the exporter,
+and nothing accumulates across chunks. `server_json_file` switches to
+newline-delimited JSON (NDJSON): a metadata header line followed by one hit per
+line. The tradeoff: streamed hits are ordered by chunk, **not** globally sorted
+by score (sort the NDJSON afterwards if you need a global ranking). Only
+above-threshold (predicted-good) hits are written; add `--keep-negatives` to
+also stream the below-threshold items (tagged `label=bad`).
+
 **Exporting results**: by default results are printed to the console. Add `--exporter <name>` to send them elsewhere:
 
 ```bash
@@ -152,6 +174,15 @@ detectors:
 
 # Optional. Process medias in batches of N. Same as --chunk-size.
 chunk_size: 1000
+
+# Optional. Stream each chunk's hits straight to the exporter instead of
+# accumulating them (same as --stream-results). Requires chunk_size and a
+# streaming-capable exporter. Output is chunk-ordered, not globally sorted.
+stream_results: false
+
+# Optional. With stream_results, also emit below-threshold hits (label=bad).
+# Same as --keep-negatives. Off by default.
+keep_negatives: false
 
 # Optional. One-shot merge of an external label file into a detector
 # before scoring (same as --import-labels-into / --label-importer /

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -131,6 +131,10 @@ Exporter: server_json_file
   filepath: out.json
 ```
 
+When `--stream-results` is set, the plan adds a `Streaming: yes (...)` line
+under the source (noting whether negatives are dropped or included), so a
+streaming run can be sanity-checked before it starts.
+
 `--dry-run` validates importer and exporter names, checks that the
 dataset pickle (if given) exists, verifies required CLI fields are
 populated, and reports any detector JSON files that are missing; so

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -883,6 +883,46 @@ EXPORTER = SftpLabelsetExporter()
 | Member | Signature | Description |
 |--------|-----------|-------------|
 | `export_cli()` | `(results: dict, field_values: dict) -> dict` | CLI variant; default delegates to `export()` |
+| `supports_streaming` | `property -> bool` | Whether this exporter can write results incrementally. Default `False`. |
+| `export_cli_streaming()` | `(header: dict, records: Iterator[tuple[str, dict]], field_values: dict) -> dict` | Write hits incrementally as scored chunks stream in. Required when `supports_streaming` is `True`. |
+
+#### Streaming exports (`--stream-results`)
+
+`export()` / `export_cli()` receive the **fully-materialised** results dict, so
+they buffer every hit in memory. For a media source larger than RAM (e.g. a
+folder tree of billions of images scanned via
+`--autodetect --chunk-size N --stream-results`), an exporter can instead write
+each hit as it is scored, by opting in:
+
+```python
+@property
+def supports_streaming(self) -> bool:
+    return True
+
+def export_cli_streaming(self, header, records, field_values):
+    # header = {"media_type": str,
+    #           "detectors": [{"detector_name": str, "threshold": float}, ...],
+    #           "keep_negatives": bool}
+    # records yields (detector_name, hit) tuples in CHUNK order (not globally
+    # sorted by score). Each hit is the build_media_hit() dict plus a "label"
+    # key ("good" above threshold, "bad" otherwise — "bad" only appears when
+    # keep_negatives is set).
+    path = Path(field_values["filepath"])
+    with open(path, "w") as f:
+        for detector_name, hit in records:
+            f.write(json.dumps({"detector": detector_name, **hit}) + "\n")
+    return {"message": f"Streamed to {path}"}
+```
+
+The `--stream-results` CLI path routes to `export_cli_streaming` instead of
+`export_cli`. Built-ins that implement it: `server_json_file` (NDJSON, one hit
+per line), `server_csv_file` (one CSV row per hit), and `gui` (prints each hit).
+Exporters that inherently need the whole payload at once — `email_smtp` (one
+email), `webhook` (one POST) — leave `supports_streaming` at `False`, and
+requesting `--stream-results` with them is rejected with a clear error. Write to
+a sibling `.tmp` path and `os.replace` on success so a crash mid-stream can't
+leave a half-written file at the destination. See
+`docs/plans/cli-stream-massive-images.md` for the full design.
 
 **Default class attributes:**
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -36,6 +36,13 @@ POST /api/exporters/export
 Available built-in exporters: `server_json_file`, `server_csv_file`, `webhook`,
 `email_smtp`, `gui`.
 
+**Streaming support** (CLI `--autodetect --stream-results` for sources larger
+than RAM): `server_json_file` (NDJSON), `server_csv_file`, and `gui` write hits
+incrementally; `webhook` and `email_smtp` do not (they need the whole payload).
+This applies to the CLI streaming path only — the `POST /api/exporters/export`
+route above always receives a fully-materialised results dict. See
+[CLI.md](../CLI.md) and `docs/plans/cli-stream-massive-images.md`.
+
 ---
 
 ## Label Importers

--- a/docs/plans/cli-stream-massive-images.md
+++ b/docs/plans/cli-stream-massive-images.md
@@ -72,6 +72,8 @@ re-includes them. Exporters opt in via `supports_streaming` +
 
 `email_smtp` / `webhook` inherently need the whole payload, so they do not
 support streaming; requesting `--stream-results` with them is a clear error.
+`--dry-run` reports a `Streaming: yes (...)` line (with whether negatives are
+dropped) so a streaming run can be sanity-checked before it starts.
 
 **Tradeoff (accepted):** streamed output is ordered by chunk, **not** globally
 sorted by score. Callers who need a global ranking sort the NDJSON afterwards.

--- a/docs/plans/cli-stream-massive-images.md
+++ b/docs/plans/cli-stream-massive-images.md
@@ -1,0 +1,89 @@
+# CLI streaming for massive media sources
+
+**Status:** Phase 1 shipped (lazy enumeration + streaming export + per-chunk
+embed). See "What shipped" / "Open follow-ups" below.
+
+**Parent:** [`scalability.md`](scalability.md) — the brainstorm that defines the
+`S#` IDs. This plan implements the CLI-specific pieces (S15 enumeration, S20
+scoring, S13 export) needed to run `--autodetect` against a folder-of-folders
+holding far more images than fit in RAM.
+
+## Problem
+
+The use case: a saved detector (e.g. a "bomb" detector trained on 50 positive +
+50 negative example images, stored as a `LabelSet`) is applied to a folder tree
+holding billions of images via:
+
+```
+python app.py --autodetect --importer server_folder --path /data/images \
+  --media-type image --chunk-size 500 --stream-results \
+  --exporter server_json_file --filepath hits.ndjson --settings settings.json
+```
+
+The chunked CLI already streamed *loading* and *embedding* one chunk at a time,
+but three pieces still grew `O(N)` with the total image count and broke before a
+billion:
+
+1. **File enumeration** — `load_dataset_from_folder_chunked` materialised the
+   entire file list (`media_files: list[Path]`) before yielding any chunk
+   (`loader_folder.py`). Billions of `Path` objects = tens of GB, and nothing
+   processed until the whole `os.walk` finished.
+2. **Hit accumulation** — `_merge_detector_results` extended and **re-sorted**
+   the full accumulated hit list after every chunk (`cli.py`), `O(N)` RAM plus
+   repeated `O(N log N)` sorts.
+3. **Export** — exporters buffered the entire result dict in RAM before writing.
+
+A latent fourth issue: the CLI scoring path never called `embed_missing`, so
+folder chunks (which arrive with `embedding=None`) would raise `ValueError` at
+scoring time. Only pre-embedded sources (pickles) worked.
+
+## What shipped (Phase 1)
+
+### 1. Lazy file enumeration (wall #1)
+
+`vtscore/security/path_validation.py` gains generator twins
+`iter_rglob_follow_symlinks` / `iter_glob_top_level`; the existing list
+functions now wrap them. `load_dataset_from_folder_chunked` streams files via
+`_iter_media_files` (no full list) whenever no precomputed-override maps are
+supplied (the common CLI case). With override maps present it keeps the
+materialise-and-validate path (those maps are themselves bounded). The media
+type is still validated eagerly, and an empty folder still raises
+`ValueError("No <type> files found in folder")`.
+
+### 2. Per-chunk embed (latent bug)
+
+`_score_medias_with_detectors` now calls `embed_missing` (idempotent — a no-op
+for already-embedded pickle chunks) and drops any item whose embedding is still
+`None` before scoring. Folder → autodetect now actually embeds and scores.
+
+### 3. Streaming export (walls #2 + #3)
+
+A new opt-in `--stream-results` path (`_run_streaming_pipeline` in `cli.py`)
+trains detectors on the first chunk, then streams each chunk's above-threshold
+hits straight to the exporter with **no global accumulation and no global
+sort**. Negative (below-threshold) hits are dropped by default; `--keep-negatives`
+re-includes them. Exporters opt in via `supports_streaming` +
+`export_cli_streaming(header, records, field_values)`:
+
+- `server_json_file` → newline-delimited JSON (NDJSON): one metadata header line
+  then one hit per line, written to a temp file and atomically renamed.
+- `server_csv_file` → appends rows as they stream (fixed column superset).
+- `gui` → prints each hit as it arrives plus a final count.
+
+`email_smtp` / `webhook` inherently need the whole payload, so they do not
+support streaming; requesting `--stream-results` with them is a clear error.
+
+**Tradeoff (accepted):** streamed output is ordered by chunk, **not** globally
+sorted by score. Callers who need a global ranking sort the NDJSON afterwards.
+
+## Open follow-ups
+
+- **Global ordering for streamed results.** External merge-sort of the NDJSON,
+  or a bounded top-K heap mode (`--max-results N`) that keeps the best N hits
+  globally sorted at `O(K)` RAM.
+- **Non-streaming merge path still re-sorts per chunk** (`_merge_detector_results`).
+  Left as-is because that path already holds all hits in RAM by design; switch
+  it to sort-once if it ever matters.
+- **Streaming for `email_smtp` / `webhook`** via chunked/batched delivery.
+- **Resume / checkpoint** for multi-hour billion-image runs (record the last
+  completed chunk so an interrupted run can restart mid-tree).

--- a/docs/plans/scalability-plan.md
+++ b/docs/plans/scalability-plan.md
@@ -1,6 +1,10 @@
 # Scalability Implementation Plan
 
-**Status:** Open; no fixes shipped yet.
+**Status:** Open; none of the phases below shipped yet.  Separately, the
+CLI-specific streaming work (lazy folder enumeration, per-chunk embed, and
+streaming export — partial fixes for S20/S15/S13 on the `--autodetect` target
+side) **has** shipped; see
+[`cli-stream-massive-images.md`](cli-stream-massive-images.md).
 
 **Parent:** [`scalability.md`](scalability.md); the brainstorm that defines
 all S# IDs referenced here.

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -319,6 +319,12 @@ before JSON encoding.
 `stream_with_context` + a generator that encodes one element at a time, so
 the full payload is never in memory at once.
 
+**Partially shipped:** CLI *autodetect results* now stream via
+`--stream-results` (NDJSON / streamed CSV; see
+[`cli-stream-massive-images.md`](cli-stream-massive-images.md)).  The
+`/api/labels/export` route (this item) still buffers the full JSON; apply the
+same streaming pattern there.
+
 ---
 
 ### S14: `snapshot_medias()` full-dict copies
@@ -349,6 +355,12 @@ loading it in one shot is not feasible on typical hardware.
 **Fix direction:** Pickle datasets > some threshold (e.g. 100 k items) should
 be loaded in streaming chunks.  Embeddings should be written to a companion
 mmap'd `.npy` (see S1) instead of stored inline in the pickle.
+
+**Note:** the *folder* importer's chunked CLI path now enumerates files lazily
+(no full file list in RAM); see
+[`cli-stream-massive-images.md`](cli-stream-massive-images.md).  This item is
+specifically about the *pickle* loader, which still reads the whole file at
+once.
 
 ---
 
@@ -441,6 +453,13 @@ has unresolved labels, resolves+embeds them before scoring all N items.
 Label resolution is serial within each detector.  With 10 detectors each
 having 1 000 unresolved labels at 50 ms/label: **500 s just for resolution**,
 before any inference.
+
+**Partially shipped** (see [`cli-stream-massive-images.md`](cli-stream-massive-images.md)):
+`--autodetect --chunk-size N --stream-results` now scores chunk by chunk and
+streams hits straight to the exporter, so the *target* side no longer holds all
+N items, all hits, or the full export in RAM; folder enumeration is lazy; and
+each chunk is embedded one at a time.  **Still open:** the per-detector
+*label* resolution below is unchanged.
 
 **Fix direction:** Resolve all detectors' labels in parallel (thread pool).
 Bundle duplicate-file resolves across detectors.  Use batch embedding for

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -1146,7 +1146,13 @@ sentinel module attribute is `EXPORTER`.
 ```python
 class LabelsetExporter(PluginBase):
     """Abstract base. Subclasses declare `fields` and implement
-    `export(labelset: LabelSet, field_values: dict) -> None`."""
+    `export(labelset: LabelSet, field_values: dict) -> None`.
+
+    For the CLI `--stream-results` path (sources larger than RAM), an
+    exporter can write hits incrementally by setting
+    `supports_streaming = True` and implementing
+    `export_cli_streaming(header, records, field_values)`. See
+    EXTENDING-plugins.md and docs/plans/cli-stream-massive-images.md."""
 
 ExporterField = PluginField  # backwards-compat alias
 
@@ -1156,6 +1162,9 @@ def list_exporters() -> list[LabelsetExporter]: ...
 # Built-ins (each registered via an `EXPORTER` sentinel in its module):
 #   server_json_file, server_csv_file, webhook, email_smtp, gui (display-only,
 #   hidden_from_picker), holder (scaffold, hidden_from_picker until API client lands).
+# Streaming-capable (export_cli_streaming): server_json_file (NDJSON),
+#   server_csv_file, gui. webhook / email_smtp need the whole payload at once,
+#   so they are not streamable.
 ```
 
 ---

--- a/tests/cli/test_cli_dry_run.py
+++ b/tests/cli/test_cli_dry_run.py
@@ -126,6 +126,44 @@ class TestDryRunPickle:
         out = capsys.readouterr().out
         assert "Chunk size: 250" in out
 
+    def test_dry_run_reports_streaming(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtscore.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            str(dataset_path),
+            chunk_size=250,
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(tmp_path / "out.ndjson")},
+            dry_run=True,
+            stream_results=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Streaming: yes" in out
+        assert "negatives dropped" in out
+
+    def test_dry_run_streaming_without_stream_results_has_no_streaming_line(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtscore.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            str(dataset_path),
+            chunk_size=250,
+            settings_path=str(settings_path),
+            dry_run=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Streaming:" not in out
+
     def test_dry_run_missing_dataset_file_errors(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])

--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -1,0 +1,191 @@
+"""End-to-end tests for the ``--stream-results`` CLI autodetect path.
+
+Streaming scores each chunk and writes its hits straight to the exporter
+with no global accumulation, so a media source larger than RAM can be
+scanned.  These tests pin: (1) NDJSON streaming export shape, (2) negatives
+dropped by default but kept with ``keep_negatives``, and (3) a clear error
+when the chosen exporter can't stream.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+import shutil
+from pathlib import Path
+
+import pytest
+
+from vtsearch.settings import get_detectors_dir
+
+
+def _unique_bytes(media_id: int) -> bytes:
+    return media_id.to_bytes(4, "little") + b"\x00" * 96
+
+
+def _make_audio_media(media_id: int) -> dict:
+    raw = _unique_bytes(media_id)
+    return {
+        "id": media_id,
+        "media_type": "audio",
+        "duration": 1.0,
+        "file_size": len(raw),
+        "md5": hashlib.md5(raw).hexdigest(),
+        # 2-dim embedding: [id, id + 0.5].  The stubbed MLP reads dim 0.
+        "embedding": [float(media_id), float(media_id) + 0.5],
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": None,
+        "filename": f"clip_{media_id:03d}.wav",
+        "category": "test",
+        "origin": {"importer": "stub_ds", "params": {}},
+        "origin_name": f"clip_{media_id:03d}.wav",
+    }
+
+
+def _write_pickle_dataset(path: Path, medias: dict) -> None:
+    with open(path, "wb") as f:
+        pickle.dump({"medias": medias}, f)
+
+
+def _settings_file_with_detector(tmp_path: Path, detector_name: str) -> Path:
+    settings = {"autorun_detectors": [detector_name], "detectors_dir": str(get_detectors_dir())}
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps(settings))
+    return p
+
+
+def _write_pretrained_detector(name: str) -> None:
+    from vtscore.detectors.store import _detector_path, _write_detector
+
+    _write_detector(
+        _detector_path(name),
+        {
+            "name": name,
+            "media_type": "audio",
+            "labelset": {
+                "labels": [
+                    {"md5": "a" * 32, "label": "good", "origin": {"importer": "s", "params": {}}, "origin_name": "a"},
+                    {"md5": "b" * 32, "label": "bad", "origin": {"importer": "s", "params": {}}, "origin_name": "b"},
+                ]
+            },
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_detectors_dir():
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+    yield
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+
+
+@pytest.fixture
+def _stub_split_training(monkeypatch):
+    """Train a deterministic MLP whose logit is ``3 - embedding[0]``.
+
+    With embeddings ``[id, id + 0.5]`` and threshold 0.5 (sigmoid), media
+    ids 1/2/3 score above threshold (good) and 4/5 below (bad), giving a
+    fixed positive/negative split to assert against.
+    """
+    import torch
+    from torch import nn
+
+    import vtscore.cli as cli_mod
+
+    def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
+        linear = nn.Linear(2, 1)
+        with torch.no_grad():
+            linear.weight.data = torch.tensor([[-1.0, 0.0]])
+            linear.bias.data = torch.tensor([3.0])
+        mlp = nn.Sequential(linear)
+        mlp.eval()
+        return {name: {"mlp": mlp, "threshold": 0.5} for name in detector_names}
+
+    monkeypatch.setattr(cli_mod, "_load_and_train_detectors", _fake_load_and_train)
+
+
+def _read_ndjson(path: Path) -> tuple[dict, list[dict]]:
+    """Return ``(meta, hit_records)`` from an NDJSON export file."""
+    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    objs = [json.loads(ln) for ln in lines]
+    meta = objs[0]["_meta"]
+    return meta, objs[1:]
+
+
+class TestStreamingNdjsonExport:
+    def test_default_streams_only_positive_hits(self, client, tmp_path, _stub_split_training):
+        _write_pretrained_detector("stream-tm")
+        settings_path = _settings_file_with_detector(tmp_path, "stream-tm")
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, {i: _make_audio_media(i) for i in range(1, 6)})
+        out = tmp_path / "hits.ndjson"
+
+        from vtscore.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            dataset_path=str(ds_path),
+            chunk_size=2,
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out)},
+            stream_results=True,
+        )
+
+        meta, hits = _read_ndjson(out)
+        assert meta["format"] == "vtsearch-hits-ndjson/v1"
+        assert meta["keep_negatives"] is False
+        assert {d["detector_name"] for d in meta["detectors"]} == {"stream-tm"}
+        # ids 1,2,3 are above threshold; negatives dropped by default.
+        assert all(h["label"] == "good" for h in hits)
+        assert sorted(h["id"] for h in hits) == [1, 2, 3]
+        assert all(h["detector"] == "stream-tm" for h in hits)
+        # The atomic temp file must not be left behind.
+        assert not out.with_name(out.name + ".tmp").exists()
+
+    def test_keep_negatives_streams_both(self, client, tmp_path, _stub_split_training):
+        _write_pretrained_detector("stream-tm2")
+        settings_path = _settings_file_with_detector(tmp_path, "stream-tm2")
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, {i: _make_audio_media(i) for i in range(1, 6)})
+        out = tmp_path / "hits.ndjson"
+
+        from vtscore.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            dataset_path=str(ds_path),
+            chunk_size=2,
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out)},
+            stream_results=True,
+            keep_negatives=True,
+        )
+
+        meta, hits = _read_ndjson(out)
+        assert meta["keep_negatives"] is True
+        good = sorted(h["id"] for h in hits if h["label"] == "good")
+        bad = sorted(h["id"] for h in hits if h["label"] == "bad")
+        assert good == [1, 2, 3]
+        assert bad == [4, 5]
+
+
+class TestStreamingExporterGuard:
+    def test_non_streaming_exporter_raises(self):
+        from vtscore.cli import _run_streaming_pipeline
+
+        with pytest.raises(ValueError, match="does not support --stream-results"):
+            _run_streaming_pipeline(
+                iter([{1: _make_audio_media(1)}]),
+                exporter_name="webhook",
+                exporter_field_values={},
+                override_detectors=None,
+                autorun_detectors=[],
+                keep_negatives=False,
+                empty_error="none",
+            )

--- a/tests/cli/test_pipeline_file.py
+++ b/tests/cli/test_pipeline_file.py
@@ -192,6 +192,43 @@ class TestLoadPipelineFile:
         with pytest.raises(ValueError, match="list of detector names"):
             load_pipeline_file(p)
 
+    def test_stream_results_requires_chunk_size(self, tmp_path):
+        from vtscore.cli_pipeline import load_pipeline_file
+
+        p = tmp_path / "p.yaml"
+        p.write_text(yaml.safe_dump({"dataset": "foo.pkl", "stream_results": True}))
+        with pytest.raises(ValueError, match="requires 'chunk_size:'"):
+            load_pipeline_file(p)
+
+    def test_keep_negatives_requires_stream_results(self, tmp_path):
+        from vtscore.cli_pipeline import load_pipeline_file
+
+        p = tmp_path / "p.yaml"
+        p.write_text(yaml.safe_dump({"dataset": "foo.pkl", "chunk_size": 10, "keep_negatives": True}))
+        with pytest.raises(ValueError, match="only applies with 'stream_results:'"):
+            load_pipeline_file(p)
+
+    def test_stream_results_must_be_bool(self, tmp_path):
+        from vtscore.cli_pipeline import load_pipeline_file
+
+        p = tmp_path / "p.yaml"
+        p.write_text(yaml.safe_dump({"dataset": "foo.pkl", "chunk_size": 10, "stream_results": "yes"}))
+        with pytest.raises(ValueError, match="must be a boolean"):
+            load_pipeline_file(p)
+
+    def test_stream_results_and_keep_negatives_round_trip(self, tmp_path):
+        from vtscore.cli_pipeline import load_pipeline_file
+
+        p = tmp_path / "p.yaml"
+        p.write_text(
+            yaml.safe_dump(
+                {"dataset": "foo.pkl", "chunk_size": 10, "stream_results": True, "keep_negatives": True}
+            )
+        )
+        cfg = load_pipeline_file(p)
+        assert cfg["stream_results"] is True
+        assert cfg["keep_negatives"] is True
+
     def test_import_labels_requires_detector_and_file(self, tmp_path):
         from vtscore.cli_pipeline import load_pipeline_file
 

--- a/tests/cli/test_pipeline_file.py
+++ b/tests/cli/test_pipeline_file.py
@@ -221,9 +221,7 @@ class TestLoadPipelineFile:
 
         p = tmp_path / "p.yaml"
         p.write_text(
-            yaml.safe_dump(
-                {"dataset": "foo.pkl", "chunk_size": 10, "stream_results": True, "keep_negatives": True}
-            )
+            yaml.safe_dump({"dataset": "foo.pkl", "chunk_size": 10, "stream_results": True, "keep_negatives": True})
         )
         cfg = load_pipeline_file(p)
         assert cfg["stream_results"] is True

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -691,3 +691,84 @@ class TestExportEndpoint:
 
         assert any("Permission denied" in r.message for r in caplog.records)
         assert any(r.exc_info for r in caplog.records if "Permission denied" in r.message)
+
+
+# ---------------------------------------------------------------------------
+# Streaming CLI export (--stream-results)
+# ---------------------------------------------------------------------------
+
+_STREAM_HEADER = {
+    "media_type": "audio",
+    "detectors": [{"detector_name": "dog_bark", "threshold": 0.5}],
+    "keep_negatives": False,
+}
+
+
+def _stream_records():
+    """Two good hits and one bad hit, in chunk order (not score-sorted)."""
+    yield "dog_bark", {"id": 2, "filename": "b2.wav", "category": "c", "score": 0.7, "label": "good"}
+    yield "dog_bark", {"id": 9, "filename": "b9.wav", "category": "c", "score": 0.9, "label": "good"}
+    yield "dog_bark", {"id": 4, "filename": "b4.wav", "category": "c", "score": 0.2, "label": "bad"}
+
+
+class TestStreamingExportSupport:
+    def test_streaming_exporters_advertise_support(self):
+        from vtscore.exporters import get_exporter
+
+        for name in ("gui", "server_json_file", "server_csv_file"):
+            assert get_exporter(name).supports_streaming is True
+
+    def test_non_streaming_exporters_do_not(self):
+        from vtscore.exporters import get_exporter
+
+        for name in ("email_smtp", "webhook"):
+            assert get_exporter(name).supports_streaming is False
+
+
+class TestServerJsonStreaming:
+    def test_writes_ndjson_with_meta_header(self):
+        from vtscore.exporters import get_exporter
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "hits.ndjson"
+            res = get_exporter("server_json_file").export_cli_streaming(
+                _STREAM_HEADER, _stream_records(), {"filepath": str(out)}
+            )
+            lines = [json.loads(ln) for ln in out.read_text().splitlines() if ln.strip()]
+            assert lines[0]["_meta"]["format"] == "vtsearch-hits-ndjson/v1"
+            hits = lines[1:]
+            assert [h["id"] for h in hits] == [2, 9, 4]  # chunk order preserved
+            assert hits[0]["detector"] == "dog_bark"
+            assert "3 hit(s)" in res["message"]
+            assert not out.with_name(out.name + ".tmp").exists()
+
+
+class TestServerCsvStreaming:
+    def test_writes_csv_rows(self):
+        import csv
+
+        from vtscore.exporters import get_exporter
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "hits.csv"
+            get_exporter("server_csv_file").export_cli_streaming(
+                _STREAM_HEADER, _stream_records(), {"filepath": str(out)}
+            )
+            rows = list(csv.reader(out.read_text().splitlines()))
+            assert rows[0][0] == "detector"
+            assert "label" in rows[0]
+            assert len(rows) == 4  # header + 3 hits
+            assert rows[1][0] == "dog_bark"
+
+
+class TestGuiStreaming:
+    def test_prints_only_good_hits(self, capsys):
+        from vtscore.exporters import get_exporter
+
+        res = get_exporter("gui").export_cli_streaming(_STREAM_HEADER, _stream_records(), {})
+        captured = capsys.readouterr()
+        # Only the two good hits print; the bad one is filtered.
+        assert "b2.wav" in captured.out
+        assert "b9.wav" in captured.out
+        assert "b4.wav" not in captured.out
+        assert "2 hit(s)" in res["message"]

--- a/tests_lib/io/test_lazy_file_enumeration.py
+++ b/tests_lib/io/test_lazy_file_enumeration.py
@@ -13,9 +13,9 @@ from pathlib import Path
 from helpers import make_wav_bytes as _make_wav_bytes
 
 
-def _make_wav_files(folder: Path, n: int) -> None:
+def _make_wav_files(folder: Path, n: int, prefix: str = "clip") -> None:
     for i in range(n):
-        (folder / f"clip_{i:03d}.wav").write_bytes(_make_wav_bytes(frequency=440.0 + i))
+        (folder / f"{prefix}_{i:03d}.wav").write_bytes(_make_wav_bytes(frequency=440.0 + i))
 
 
 class TestGeneratorGlobs:
@@ -23,11 +23,11 @@ class TestGeneratorGlobs:
         from vtscore.security.path_validation import iter_rglob_follow_symlinks, rglob_follow_symlinks
 
         (tmp_path / "sub").mkdir()
-        _make_wav_files(tmp_path, 2)
-        _make_wav_files(tmp_path / "sub", 2)
+        _make_wav_files(tmp_path, 2, prefix="top")
+        _make_wav_files(tmp_path / "sub", 2, prefix="nested")
 
-        streamed = {p.name for p in iter_rglob_follow_symlinks(tmp_path, "*.wav")}
-        materialised = {p.name for p in rglob_follow_symlinks(tmp_path, "*.wav")}
+        streamed = {p.resolve() for p in iter_rglob_follow_symlinks(tmp_path, "*.wav")}
+        materialised = {p.resolve() for p in rglob_follow_symlinks(tmp_path, "*.wav")}
         assert streamed == materialised
         assert len(streamed) == 4
 

--- a/tests_lib/io/test_lazy_file_enumeration.py
+++ b/tests_lib/io/test_lazy_file_enumeration.py
@@ -1,0 +1,86 @@
+"""Lazy file enumeration for the chunked folder loader.
+
+The chunked folder loader must stream files (and start building chunks)
+without first materialising the whole file list, so a directory tree with
+more files than fit in RAM can be scanned.  See
+``docs/plans/cli-stream-massive-images.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from helpers import make_wav_bytes as _make_wav_bytes
+
+
+def _make_wav_files(folder: Path, n: int) -> None:
+    for i in range(n):
+        (folder / f"clip_{i:03d}.wav").write_bytes(_make_wav_bytes(frequency=440.0 + i))
+
+
+class TestGeneratorGlobs:
+    def test_iter_rglob_matches_list_version(self, tmp_path):
+        from vtscore.security.path_validation import iter_rglob_follow_symlinks, rglob_follow_symlinks
+
+        (tmp_path / "sub").mkdir()
+        _make_wav_files(tmp_path, 2)
+        _make_wav_files(tmp_path / "sub", 2)
+
+        streamed = {p.name for p in iter_rglob_follow_symlinks(tmp_path, "*.wav")}
+        materialised = {p.name for p in rglob_follow_symlinks(tmp_path, "*.wav")}
+        assert streamed == materialised
+        assert len(streamed) == 4
+
+    def test_iter_glob_top_level_matches_list_version(self, tmp_path):
+        from vtscore.security.path_validation import glob_top_level, iter_glob_top_level
+
+        (tmp_path / "sub").mkdir()
+        _make_wav_files(tmp_path, 3)
+        _make_wav_files(tmp_path / "sub", 2)  # must NOT be matched (no recursion)
+
+        streamed = {p.name for p in iter_glob_top_level(tmp_path, "*.wav")}
+        assert streamed == {p.name for p in glob_top_level(tmp_path, "*.wav")}
+        assert len(streamed) == 3
+
+    def test_iter_glob_top_level_missing_dir_is_empty(self, tmp_path):
+        from vtscore.security.path_validation import iter_glob_top_level
+
+        assert list(iter_glob_top_level(tmp_path / "nope", "*.wav")) == []
+
+
+class TestChunkedLoaderIsLazy:
+    def test_first_chunk_builds_only_chunk_size_medias(self, tmp_path, monkeypatch):
+        """Pulling one chunk must build only ``chunk_size`` medias, not all.
+
+        Proves the loader does not materialise/build the whole dataset up
+        front when no precomputed-override maps are supplied.
+        """
+        import vtscore.datasets.loader_folder as lf
+        from vtscore.datasets.loader import load_dataset_from_folder_chunked
+
+        _make_wav_files(tmp_path, 20)
+
+        calls = {"n": 0}
+        real_build = lf._build_per_file_media
+
+        def _counting_build(**kwargs):
+            calls["n"] += 1
+            return real_build(**kwargs)
+
+        monkeypatch.setattr(lf, "_build_per_file_media", _counting_build)
+
+        gen = load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=5, thin=True)
+        first = next(gen)
+        assert len(first) == 5
+        # Only the first chunk's worth of files were read/built — the rest of
+        # the 20-file tree has not been touched yet.
+        assert calls["n"] == 5
+
+    def test_empty_folder_still_raises(self, tmp_path):
+        from vtscore.datasets.loader import load_dataset_from_folder_chunked
+
+        try:
+            list(load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=5, thin=True))
+            raise AssertionError("expected ValueError")
+        except ValueError as e:
+            assert "No audio files found" in str(e)

--- a/vtscore/README.md
+++ b/vtscore/README.md
@@ -83,7 +83,7 @@ The 17 subpackages and what they do:
 | `vtscore.detectors` | Detector lifecycle: train, store, score, labelset sync |
 | `vtscore.eval` | Offline evaluation (text-sort, learned-sort, voting iterations) |
 | `vtscore.converters` | Cross-format converters (audio→spectrogram, ASR, OCR, …) |
-| `vtscore.exporters` | Results exporters (JSON, CSV, webhook, email) |
+| `vtscore.exporters` | Results exporters (JSON, CSV, webhook, email); JSON/CSV/gui support CLI streaming for sources larger than RAM |
 | `vtscore.labels` | Label importers + labelset sync sources |
 | `vtscore.plugins` | `PluginRegistry`, sentinel discovery, `importlib.metadata` hooks |
 | `vtscore.concurrency` | Async jobs, memory budget, long-running progress trackers |

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -216,23 +216,18 @@ def _score_medias_with_detectors(
 ) -> dict[str, dict[str, Any]]:
     """Score *medias* against pre-trained detector MLPs.
 
-    Embeds any items still missing a vector (idempotent — a no-op for
-    pre-embedded pickle chunks, the actual embed pass for folder chunks that
-    arrive with ``embedding=None``) and drops anything the embedder couldn't
-    embed before scoring.
+    Every media must already carry an embedding; an unexpected ``None`` here
+    raises (the M11 guard) rather than silently scoring NaN.  Sources that
+    legitimately arrive unembedded (folder chunks) are embedded one chunk at a
+    time by :func:`_embed_and_filter_chunk` in the pipeline layer before they
+    reach this scorer.
     """
     if not medias or not detector_mlps:
         return {}
 
     import torch  # noqa: PLC0415
 
-    from vtscore.datasets.load_pipeline import embed_missing  # noqa: PLC0415
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
-
-    embed_missing(medias, "")
-    medias = {cid: m for cid, m in medias.items() if m.get("embedding") is not None}
-    if not medias:
-        return {}
 
     all_ids, all_embs = get_embedding_matrix_for_snap(medias)
     X_all = torch.from_numpy(all_embs)
@@ -553,6 +548,24 @@ def _train_detectors_for_first_chunk(
     return detector_mlps
 
 
+def _embed_and_filter_chunk(chunk: dict[int, dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    """Embed any chunk medias still missing a vector, then drop un-embeddable ones.
+
+    Importers emit media with ``embedding=None`` (folder chunks especially);
+    the framework embed stage is what fills them in.  The CLI scores chunk by
+    chunk without going through the full load pipeline, so it runs the embed
+    stage here, one chunk at a time, keeping peak memory bounded by the chunk
+    size.  :func:`embed_missing` is idempotent — a no-op for pre-embedded
+    pickle chunks — so this is safe on every source.  Items the embedder
+    couldn't embed (returned ``None``) are dropped, mirroring the load
+    pipeline's drop-none stage, so the strict scorer never sees a ``None``.
+    """
+    from vtscore.datasets.load_pipeline import embed_missing  # noqa: PLC0415
+
+    embed_missing(chunk, "")
+    return {cid: m for cid, m in chunk.items() if m.get("embedding") is not None}
+
+
 def _score_chunk(
     chunk_medias: dict[int, dict[str, Any]],
     chunk_num: int,
@@ -568,7 +581,7 @@ def _score_chunk(
             chunk_num=chunk_num,
             chunk_size=len(chunk_medias),
         )
-    chunk_results = _score_medias_with_detectors(chunk_medias, detector_mlps)
+    chunk_results = _score_medias_with_detectors(_embed_and_filter_chunk(chunk_medias), detector_mlps)
     _merge_detector_results(merged_results, chunk_results)
 
 
@@ -656,7 +669,7 @@ def _stream_hit_records(
                 chunk_num=chunk_num,
                 chunk_size=len(chunk),
             )
-        chunk_results = _score_medias_with_detectors(chunk, detector_mlps)
+        chunk_results = _score_medias_with_detectors(_embed_and_filter_chunk(chunk), detector_mlps)
         for det_name, det_result in chunk_results.items():
             for hit in det_result.get("hits", []):
                 yield det_name, {**hit, "label": "good"}

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -57,18 +57,8 @@ def _summarize_autorun_detectors(detector_names: list[str]) -> list[dict[str, An
     return summaries
 
 
-def _print_dry_run_plan(
-    *,
-    source_description: dict[str, Any],
-    settings_path: str | None,
-    autorun_detectors: list[str],
-    exporter_name: str | None,
-    exporter_field_values: dict[str, Any] | None,
-) -> None:
-    """Print the autodetect plan that ``--dry-run`` would otherwise execute."""
-    print("DRY RUN - no media will be loaded, embedded, scored, or exported.", flush=True)
-    print("", flush=True)
-
+def _print_dry_run_source(source_description: dict[str, Any]) -> None:
+    """Print the ``Source:`` block of the dry-run plan (kind, params, chunking)."""
     print("Source:", flush=True)
     kind = source_description.get("kind", "")
     if kind == "pickle":
@@ -84,6 +74,24 @@ def _print_dry_run_plan(
             print("  Params: (none)", flush=True)
     chunk_size = source_description.get("chunk_size")
     print(f"  Chunk size: {chunk_size if chunk_size else 'whole dataset'}", flush=True)
+    if source_description.get("stream_results"):
+        neg = "included" if source_description.get("keep_negatives") else "dropped"
+        print(f"  Streaming: yes (hits written to the exporter per chunk; negatives {neg})", flush=True)
+
+
+def _print_dry_run_plan(
+    *,
+    source_description: dict[str, Any],
+    settings_path: str | None,
+    autorun_detectors: list[str],
+    exporter_name: str | None,
+    exporter_field_values: dict[str, Any] | None,
+) -> None:
+    """Print the autodetect plan that ``--dry-run`` would otherwise execute."""
+    print("DRY RUN - no media will be loaded, embedded, scored, or exported.", flush=True)
+    print("", flush=True)
+
+    _print_dry_run_source(source_description)
     print("", flush=True)
 
     print(f"Settings: {settings_path or '(default: data/settings.json)'}", flush=True)
@@ -881,7 +889,13 @@ def autodetect_main_chunked(
             dry_run=dry_run,
             stream_results=stream_results,
             keep_negatives=keep_negatives,
-            source_description={"kind": "pickle", "dataset": dataset_path, "chunk_size": chunk_size},
+            source_description={
+                "kind": "pickle",
+                "dataset": dataset_path,
+                "chunk_size": chunk_size,
+                "stream_results": stream_results,
+                "keep_negatives": keep_negatives,
+            },
         )
     except Exception as e:
         cli_progress.emit_error(str(e))
@@ -916,6 +930,8 @@ def autodetect_importer_main_chunked(
                 "importer": importer_name,
                 "params": field_values,
                 "chunk_size": chunk_size,
+                "stream_results": stream_results,
+                "keep_negatives": keep_negatives,
             },
         )
     except Exception as e:

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -214,13 +214,25 @@ def _score_medias_with_detectors(
     medias: dict[int, dict[str, Any]],
     detector_mlps: dict[str, dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
-    """Score *medias* against pre-trained detector MLPs."""
+    """Score *medias* against pre-trained detector MLPs.
+
+    Embeds any items still missing a vector (idempotent — a no-op for
+    pre-embedded pickle chunks, the actual embed pass for folder chunks that
+    arrive with ``embedding=None``) and drops anything the embedder couldn't
+    embed before scoring.
+    """
     if not medias or not detector_mlps:
         return {}
 
     import torch  # noqa: PLC0415
 
+    from vtscore.datasets.load_pipeline import embed_missing  # noqa: PLC0415
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
+
+    embed_missing(medias, "")
+    medias = {cid: m for cid, m in medias.items() if m.get("embedding") is not None}
+    if not medias:
+        return {}
 
     all_ids, all_embs = get_embedding_matrix_for_snap(medias)
     X_all = torch.from_numpy(all_embs)
@@ -607,6 +619,111 @@ def _run_live_pipeline(
     _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
 
 
+def _list_streaming_exporter_names() -> list[str]:
+    """Return the names of exporters that support ``--stream-results``."""
+    from vtscore.exporters import list_exporters
+
+    return [exp.name for exp in list_exporters() if getattr(exp, "supports_streaming", False)]
+
+
+def _stream_hit_records(
+    first_chunk: dict[int, dict[str, Any]],
+    rest: Iterator[dict[int, dict[str, Any]]],
+    detector_mlps: dict[str, dict[str, Any]],
+    keep_negatives: bool,
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Score each chunk and yield ``(detector_name, hit)`` pairs in chunk order.
+
+    No global accumulation and no global sort: each chunk is scored, its hits
+    are yielded, and the chunk is dropped before the next one is pulled, so
+    peak memory stays bounded by the chunk size regardless of how many hits
+    the whole run produces.  Above-threshold hits carry ``label="good"``;
+    below-threshold hits are emitted (with ``label="bad"``) only when
+    *keep_negatives* is set.
+    """
+    import itertools  # noqa: PLC0415
+
+    for chunk_num, chunk in enumerate(itertools.chain([first_chunk], rest), 1):
+        if not chunk:
+            continue
+        if chunk is not first_chunk:
+            # The first chunk was already normalised by the caller (it had to
+            # be, to train the detectors and build the header).
+            apply_custom_metadata_md5(chunk)
+            cli_progress.emit(
+                "chunk_start",
+                text=f"Processing chunk {chunk_num} ({len(chunk)} medias)...",
+                chunk_num=chunk_num,
+                chunk_size=len(chunk),
+            )
+        chunk_results = _score_medias_with_detectors(chunk, detector_mlps)
+        for det_name, det_result in chunk_results.items():
+            for hit in det_result.get("hits", []):
+                yield det_name, {**hit, "label": "good"}
+            if keep_negatives:
+                for hit in det_result.get("negative_hits", []):
+                    yield det_name, {**hit, "label": "bad"}
+
+
+def _run_streaming_pipeline(
+    media_source: Iterator[dict[int, dict[str, Any]]],
+    *,
+    exporter_name: str | None,
+    exporter_field_values: dict[str, Any] | None,
+    override_detectors: list[str] | None,
+    autorun_detectors: list[str],
+    keep_negatives: bool,
+    empty_error: str,
+) -> None:
+    """Stream scored hits straight to a streaming-capable exporter.
+
+    Trains detectors on the first chunk (so the exporter gets its header
+    before any hit), then hands the exporter a lazy record iterator.  Nothing
+    accumulates across chunks, so this is the path that scales to a media
+    source with more items (and more hits) than fit in RAM.
+    """
+    from vtscore.exporters import get_exporter
+
+    exporter = get_exporter(exporter_name or "gui")
+    if exporter is None:
+        available = _list_exporter_names()
+        raise ValueError(f"Unknown exporter: {exporter_name}. Available: {', '.join(available)}")
+    if not getattr(exporter, "supports_streaming", False):
+        streaming = ", ".join(_list_streaming_exporter_names())
+        raise ValueError(
+            f"Exporter '{exporter.name}' does not support --stream-results. Streaming-capable exporters: {streaming}."
+        )
+    exporter.validate_cli_field_values(exporter_field_values or {})
+
+    # Pull the first non-empty chunk so we can detect the media type and train
+    # the detectors before any hit streams out.
+    iterator = iter(media_source)
+    first_chunk: dict[int, dict[str, Any]] | None = None
+    for chunk in iterator:
+        if chunk:
+            first_chunk = chunk
+            break
+    if first_chunk is None:
+        raise ValueError(empty_error)
+
+    apply_custom_metadata_md5(first_chunk)
+    media_type = _detect_media_type(first_chunk)
+    detector_mlps = _train_detectors_for_first_chunk(first_chunk, media_type, override_detectors, autorun_detectors)
+
+    header = {
+        "media_type": media_type,
+        "detectors": [
+            {"detector_name": name, "threshold": round(info["threshold"], 4)} for name, info in detector_mlps.items()
+        ],
+        "keep_negatives": bool(keep_negatives),
+    }
+
+    records = _stream_hit_records(first_chunk, iterator, detector_mlps, keep_negatives)
+    result = exporter.export_cli_streaming(header, records, exporter_field_values or {})
+    message = result.get("message", "Export complete.")
+    cli_progress.emit("export_complete", text=message, message=message)
+
+
 def _run_pipeline(
     media_source: Iterator[dict[int, dict[str, Any]]],
     *,
@@ -616,6 +733,8 @@ def _run_pipeline(
     override_detectors: list[str] | None = None,
     empty_error: str = "No medias loaded",
     dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
     source_description: dict[str, Any] | None = None,
 ) -> None:
     """Shared pipeline: read settings, iterate media chunks, score, export.
@@ -648,6 +767,18 @@ def _run_pipeline(
             autorun_detectors,
             exporter_name,
             exporter_field_values,
+        )
+        return
+
+    if stream_results:
+        _run_streaming_pipeline(
+            media_source,
+            exporter_name=exporter_name,
+            exporter_field_values=exporter_field_values,
+            override_detectors=override_detectors,
+            autorun_detectors=autorun_detectors,
+            keep_negatives=keep_negatives,
+            empty_error=empty_error,
         )
         return
 
@@ -723,6 +854,8 @@ def autodetect_main_chunked(
     exporter_field_values: dict[str, Any] | None = None,
     *,
     dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect on a pickle dataset."""
     try:
@@ -733,6 +866,8 @@ def autodetect_main_chunked(
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded from dataset: {dataset_path}",
             dry_run=dry_run,
+            stream_results=stream_results,
+            keep_negatives=keep_negatives,
             source_description={"kind": "pickle", "dataset": dataset_path, "chunk_size": chunk_size},
         )
     except Exception as e:
@@ -749,6 +884,8 @@ def autodetect_importer_main_chunked(
     exporter_field_values: dict[str, Any] | None = None,
     *,
     dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect with a named importer."""
     try:
@@ -759,6 +896,8 @@ def autodetect_importer_main_chunked(
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded by importer '{importer_name}'",
             dry_run=dry_run,
+            stream_results=stream_results,
+            keep_negatives=keep_negatives,
             source_description={
                 "kind": "importer",
                 "importer": importer_name,

--- a/vtscore/cli_pipeline.py
+++ b/vtscore/cli_pipeline.py
@@ -21,6 +21,8 @@ _TOP_LEVEL_KEYS = {
     "settings",
     "detectors",
     "chunk_size",
+    "stream_results",
+    "keep_negatives",
     "import_labels",
     "exporter",
 }
@@ -86,6 +88,17 @@ def load_pipeline_file(path: str | Path) -> dict[str, Any]:  # noqa: C901
         if not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size <= 0:
             raise ValueError("'chunk_size:' must be a positive integer.")
 
+    stream_results = raw.get("stream_results", False)
+    if not isinstance(stream_results, bool):
+        raise ValueError("'stream_results:' must be a boolean.")
+    keep_negatives = raw.get("keep_negatives", False)
+    if not isinstance(keep_negatives, bool):
+        raise ValueError("'keep_negatives:' must be a boolean.")
+    if stream_results and not chunk_size:
+        raise ValueError("'stream_results:' requires 'chunk_size:' (it streams chunk by chunk).")
+    if keep_negatives and not stream_results:
+        raise ValueError("'keep_negatives:' only applies with 'stream_results:'.")
+
     import_labels = raw.get("import_labels")
     parsed_import_labels: dict[str, str] | None = None
     if import_labels is not None:
@@ -106,6 +119,8 @@ def load_pipeline_file(path: str | Path) -> dict[str, Any]:  # noqa: C901
         "settings": settings,
         "detectors": list(detectors) if detectors else None,
         "chunk_size": chunk_size,
+        "stream_results": stream_results,
+        "keep_negatives": keep_negatives,
         "import_labels": parsed_import_labels,
         "exporter": exporter_name,
         "exporter_fields": exporter_fields,
@@ -273,5 +288,7 @@ def _dispatch(config: dict[str, Any]) -> None:
         exporter_name=config["exporter"],
         exporter_field_values=config["exporter_fields"],
         override_detectors=config["detectors"],
+        stream_results=config.get("stream_results", False),
+        keep_negatives=config.get("keep_negatives", False),
         empty_error=empty_error,
     )

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -27,7 +27,12 @@ from vtscore.datasets.loader import (
     _pop_md5_key,
     _streaming_md5,
 )
-from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+from vtscore.security.path_validation import (
+    glob_top_level,
+    iter_glob_top_level,
+    iter_rglob_follow_symlinks,
+    rglob_follow_symlinks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +42,28 @@ def _scan_files(folder: Path, pattern: str, recursive: bool) -> list[Path]:
     if recursive:
         return rglob_follow_symlinks(folder, pattern)
     return glob_top_level(folder, pattern)
+
+
+def _iter_scan_files(folder: Path, pattern: str, recursive: bool) -> Iterator[Path]:
+    """Stream files in *folder* matching *pattern* (generator twin of :func:`_scan_files`)."""
+    if recursive:
+        yield from iter_rglob_follow_symlinks(folder, pattern)
+    else:
+        yield from iter_glob_top_level(folder, pattern)
+
+
+def _iter_media_files(folder_path: Path, mt: Any, recursive: bool) -> Iterator[Path]:
+    """Stream every media file of type *mt* under *folder_path*, lazily.
+
+    Chains the per-extension scans in the same order the materialised loader
+    used (all of extension 1, then extension 2, …) but never holds the full
+    file list — the caller can begin building/embedding chunks before the
+    directory walk finishes.  Used by the chunked loader for the no-override
+    (massive-folder) case so peak memory stays bounded by the chunk size
+    rather than the total file count.
+    """
+    for ext in mt.file_extensions:
+        yield from _iter_scan_files(folder_path, ext, recursive)
 
 
 def _resolve_folder_load_inputs(
@@ -627,54 +654,83 @@ def load_dataset_from_folder_chunked(
 
     on_progress("loading", "Scanning media files...", 0, 0)
 
-    mt, media_files, total_files = _resolve_folder_load_inputs(
-        folder_path,
-        media_type,
-        recursive,
-        content_vectors,
-        content_md5s,
-        custom_metadata_map,
-    )
+    has_overrides = bool(content_vectors or content_md5s or custom_metadata_map)
+    if has_overrides:
+        # Precomputed maps (vectors / md5s / metadata) require a full-list
+        # cross-check for ambiguous basenames, and are themselves bounded in
+        # memory, so materialise the file list and validate as the monolithic
+        # loader does.
+        mt, media_files, total_files = _resolve_folder_load_inputs(
+            folder_path,
+            media_type,
+            recursive,
+            content_vectors,
+            content_md5s,
+            custom_metadata_map,
+        )
+        file_iter: Iterator[Path] = iter(media_files)
+    else:
+        # Massive-folder case: stream files lazily so peak memory stays bounded
+        # by the chunk size rather than the total file count.  The media type is
+        # still validated eagerly; emptiness is reported after the (lazy) walk.
+        from vtscore.media import get_by_folder_name  # noqa: PLC0415
 
-    _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 1
+        try:
+            mt = get_by_folder_name(media_type)
+        except KeyError:
+            raise ValueError(f"Invalid media type: {media_type}")
+        total_files = 0  # unknown up front when streaming
+        file_iter = _iter_media_files(folder_path, mt, recursive)
 
-    for start in range(0, total_files, chunk_size):
-        batch = media_files[start : start + chunk_size]
-        chunk_medias: dict[int, dict[str, Any]] = {}
-        media_id = 1
+    # When the total is known, report progress at ~50 evenly spaced ticks;
+    # when streaming (total unknown) fall back to a fixed file interval.
+    _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 200
 
-        chunk_label = f" (chunk {start // chunk_size + 1})"
+    chunk_medias: dict[int, dict[str, Any]] = {}
+    media_id = 1
+    chunk_index = 0
+    media_seen = 0
 
-        for i, file_path in enumerate(batch):
-            global_idx = start + i
-            rel_path = file_path.relative_to(folder_path).as_posix()
+    for global_idx, file_path in enumerate(file_iter):
+        rel_path = file_path.relative_to(folder_path).as_posix()
 
-            if global_idx % _progress_interval == 0 or global_idx + 1 == total_files:
-                _emit_per_file_progress(
-                    on_progress,
-                    media_type,
-                    rel_path,
-                    global_idx + 1,
-                    total_files,
-                    chunk_label=chunk_label,
-                )
-
-            built = _build_per_file_media(
-                media_id=media_id,
-                file_path=file_path,
-                rel_path=rel_path,
-                mt=mt,
-                content_vectors=content_vectors,
-                content_md5s=content_md5s,
-                custom_metadata_map=custom_metadata_map,
-                thin=thin,
-                origin=origin,
-                content_embedder_name=content_embedder_name,
+        if global_idx % _progress_interval == 0 or (total_files and global_idx + 1 == total_files):
+            _emit_per_file_progress(
+                on_progress,
+                media_type,
+                rel_path,
+                global_idx + 1,
+                total_files,
+                chunk_label=f" (chunk {chunk_index + 1})",
             )
-            chunk_medias[media_id] = built
-            media_id += 1
 
-        if chunk_medias:
+        chunk_medias[media_id] = _build_per_file_media(
+            media_id=media_id,
+            file_path=file_path,
+            rel_path=rel_path,
+            mt=mt,
+            content_vectors=content_vectors,
+            content_md5s=content_md5s,
+            custom_metadata_map=custom_metadata_map,
+            thin=thin,
+            origin=origin,
+            content_embedder_name=content_embedder_name,
+        )
+        media_id += 1
+        media_seen += 1
+
+        if len(chunk_medias) >= chunk_size:
             yield chunk_medias
+            chunk_medias = {}
+            media_id = 1
+            chunk_index += 1
 
-    on_progress("idle", f"Finished chunked loading of {total_files} {media_type} files", 0, 0)
+    if chunk_medias:
+        yield chunk_medias
+
+    if media_seen == 0:
+        # Matches the monolithic loader's empty-folder contract.  Raised after
+        # the (no-op) walk so streaming callers still see the familiar error.
+        raise ValueError(f"No {media_type} files found in folder")
+
+    on_progress("idle", f"Finished chunked loading of {media_seen} {media_type} files", 0, 0)

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -46,7 +46,7 @@ verifies that every imported package is declared there.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
 from vtscore.plugins import PluginBase, PluginField
 
@@ -123,3 +123,57 @@ class LabelsetExporter(PluginBase):
         GUI exporter, which has no browser) should override this method.
         """
         return self.export(results, field_values)
+
+    # ------------------------------------------------------------------
+    # Streaming CLI support (massive sources)
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_streaming(self) -> bool:
+        """Whether this exporter can write results incrementally.
+
+        Exporters that override :meth:`export_cli_streaming` return ``True``
+        so the ``--stream-results`` CLI path can route to them.  Exporters
+        that inherently need the whole payload at once (e.g. sending a single
+        email or webhook POST) leave this ``False``; requesting
+        ``--stream-results`` with them is rejected with a clear error.
+
+        See ``docs/plans/cli-stream-massive-images.md``.
+        """
+        return False
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Write results incrementally as scored chunks stream in.
+
+        Unlike :meth:`export_cli`, which receives the fully-materialised
+        results dict, this method receives a lazy *records* iterator and is
+        expected to write each record to the destination as it arrives,
+        never buffering the whole set.  This is what lets ``--autodetect``
+        run against a media source with more items (and more hits) than fit
+        in RAM.
+
+        Args:
+            header: Metadata known before any hit streams, with keys
+                ``"media_type"`` (str), ``"detectors"`` (a list of
+                ``{"detector_name": str, "threshold": float}`` dicts), and
+                ``"keep_negatives"`` (bool — whether below-threshold hits are
+                included in *records*).
+            records: Yields ``(detector_name, hit)`` tuples in chunk order
+                (NOT globally sorted by score).  Each *hit* is the dict from
+                :func:`vtscore.utils.hits.build_media_hit` plus a ``"label"``
+                key (``"good"`` for above-threshold, ``"bad"`` otherwise).
+            field_values: Mapping of :attr:`ExporterField.key` → value.
+
+        Returns:
+            A status dict with a ``"message"`` key (and optionally
+            ``"filepath"``), like :meth:`export`.
+
+        Raises:
+            NotImplementedError: If the exporter does not support streaming.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support streaming export")

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -12,6 +12,12 @@ exporters work on the command line without any extra code.  Exporters whose
 :meth:`export` expects non-string values should override :meth:`export_cli` to
 handle the CLI-appropriate types.
 
+For the CLI ``--stream-results`` path (scoring a media source larger than RAM),
+an exporter can write hits incrementally instead of buffering the whole result
+set: set :attr:`~LabelsetExporter.supports_streaming` to ``True`` and implement
+:meth:`~LabelsetExporter.export_cli_streaming`.  See that method's docstring and
+``docs/plans/cli-stream-massive-images.md`` for details.
+
 Example – a minimal SFTP exporter skeleton::
 
     # vtsearch/exporters/sftp/__init__.py
@@ -67,6 +73,11 @@ class LabelsetExporter(PluginBase):
     ``/api/auto-detect`` and a flat mapping of field values supplied by the
     user via the UI.  It should return a dict with at minimum a ``"message"``
     key describing what happened (shown to the user as confirmation).
+
+    Exporters that can write results incrementally (for the CLI
+    ``--stream-results`` path on a media source larger than RAM) override
+    :attr:`supports_streaming` to return ``True`` and implement
+    :meth:`export_cli_streaming`.
     """
 
     #: Emoji or icon string shown next to the display name in the UI.

--- a/vtscore/exporters/gui/__init__.py
+++ b/vtscore/exporters/gui/__init__.py
@@ -6,7 +6,7 @@ entirely by the frontend JavaScript, and in CLI mode it prints to stdout.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
 from vtscore.exporters.base import LabelsetExporter
 
@@ -92,6 +92,42 @@ class DisplayLabelsetExporter(LabelsetExporter):
             print("\n".join(lines))
         return {
             "message": (f"Printed {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s) to stdout."),
+        }
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Print each hit's origin/name to stdout as it streams in.
+
+        Bounded memory: only the current hit is held, so this works on a
+        media source far larger than RAM.  Only above-threshold hits stream
+        unless ``--keep-negatives`` was set, so (matching :meth:`export_cli`)
+        the printed list is the predicted-Good set.
+        """
+        detector_count = len(header.get("detectors", []))
+        total_hits = 0
+        printed_header = False
+        for detector_name, hit in records:
+            if hit.get("label") == "bad":
+                continue
+            if not printed_header:
+                print("Predicted Good:\n")
+                printed_header = True
+            origin_str = _format_origin(hit)
+            name = hit.get("origin_name") or hit.get("filename", "")
+            print(f"  {origin_str}  {name}" if origin_str else f"  {name}")
+            total_hits += 1
+        if total_hits == 0:
+            print("No items predicted as Good.")
+        return {
+            "message": (f"Printed {total_hits} hit(s) across {detector_count} detector(s) to stdout."),
         }
 
 

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import csv
 import io
 import json
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
 from vtscore.exporters.base import ExporterField, LabelsetExporter
@@ -90,6 +91,87 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
 
         # Autodetect results format (from CLI / fill-from-sort)
         return self._export_autodetect(results, filepath)
+
+    #: Fixed column order for streamed autodetect exports.  Streaming cannot
+    #: pre-scan all hits to detect which optional clip columns are present, so
+    #: the full superset is always written (empty cells where a hit lacks the
+    #: field).
+    _STREAM_COLUMNS = [
+        "detector",
+        "threshold",
+        "filename",
+        "category",
+        "score",
+        "label",
+        "clip_start",
+        "clip_end",
+        "clip_box",
+        "origin",
+        "origin_name",
+    ]
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Write hits as CSV rows, one per hit, flushed as they stream.
+
+        Uses a fixed column superset (see :attr:`_STREAM_COLUMNS`) because a
+        streaming writer cannot look ahead to decide which optional clip
+        columns are present.  The file is built at a sibling ``.tmp`` path and
+        atomically renamed on success.
+        """
+        from vtscore.datasets.origin import Origin  # noqa: PLC0415
+
+        filepath = Path(field_values["filepath"])
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = filepath.with_name(filepath.name + ".tmp")
+
+        thresholds = {d.get("detector_name", ""): d.get("threshold", "") for d in header.get("detectors", [])}
+
+        total_hits = 0
+        try:
+            with open(tmp_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(self._STREAM_COLUMNS)
+                for detector_name, hit in records:
+                    origin = hit.get("origin")
+                    origin_str = Origin.from_dict(origin).display() if origin else ""
+                    clip_box = hit.get("clip_box")
+                    writer.writerow(
+                        [
+                            _sanitize_csv_cell(str(detector_name)),
+                            thresholds.get(detector_name, ""),
+                            _sanitize_csv_cell(hit.get("filename", "")),
+                            _sanitize_csv_cell(hit.get("category", "")),
+                            hit.get("score", ""),
+                            _sanitize_csv_cell(hit.get("label", "")),
+                            hit.get("clip_start", ""),
+                            hit.get("clip_end", ""),
+                            ",".join(str(v) for v in clip_box) if clip_box else "",
+                            _sanitize_csv_cell(origin_str),
+                            _sanitize_csv_cell(hit.get("origin_name", "")),
+                        ]
+                    )
+                    total_hits += 1
+            os.replace(tmp_path, filepath)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+        return {
+            "message": (
+                f"Streamed {total_hits} hit(s) across "
+                f"{len(header.get('detectors', []))} detector(s) to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
 
     def _export_labels(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
         """Export labels with user-selected columns.

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -10,8 +10,10 @@ No additional pip packages are required; uses only Python's ``json`` and
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
 from vtscore.exporters.base import ExporterField, LabelsetExporter
@@ -71,6 +73,58 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
                 f"Saved {total_hits} hit(s) across "
                 f"{results.get('detectors_run', 0)} detector(s) "
                 f"to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Write hits as newline-delimited JSON (NDJSON), one hit per line.
+
+        The first line is a metadata object describing the run; every
+        subsequent line is a single hit with its ``detector`` name merged in.
+        Lines are flushed as they stream, so the full result set is never
+        held in memory.  The file is built at a sibling ``.tmp`` path and
+        atomically renamed on success, so a crash mid-run cannot leave a
+        half-written file at the destination.
+        """
+        filepath = Path(field_values["filepath"])
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = filepath.with_name(filepath.name + ".tmp")
+
+        meta = {
+            "format": "vtsearch-hits-ndjson/v1",
+            "media_type": header.get("media_type", "unknown"),
+            "detectors": header.get("detectors", []),
+            "keep_negatives": bool(header.get("keep_negatives", False)),
+        }
+
+        total_hits = 0
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"_meta": meta}) + "\n")
+                for detector_name, hit in records:
+                    f.write(json.dumps({"detector": detector_name, **hit}) + "\n")
+                    total_hits += 1
+            os.replace(tmp_path, filepath)
+        finally:
+            # Clean up the temp file if the rename never happened (e.g. an
+            # exception propagated out of the records iterator).
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+        return {
+            "message": (
+                f"Streamed {total_hits} hit(s) across "
+                f"{len(meta['detectors'])} detector(s) to {filepath.resolve()} (NDJSON)."
             ),
             "filepath": str(filepath.resolve()),
         }

--- a/vtscore/security/path_validation.py
+++ b/vtscore/security/path_validation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import fnmatch
 import os
 from pathlib import Path
+from typing import Iterator
 
 
 def get_file_access_base_dir() -> Path | None:
@@ -97,6 +98,20 @@ def sanitize_template_value(value: str) -> str:
     return sanitized
 
 
+def iter_rglob_follow_symlinks(root: Path, pattern: str) -> Iterator[Path]:
+    """Stream files under *root* matching *pattern*, following symlinks.
+
+    Generator twin of :func:`rglob_follow_symlinks`.  Yields each match as
+    :func:`os.walk` discovers it, so the caller never holds the full file
+    list in memory — essential when scanning a directory tree with more
+    files than fit in RAM (see ``docs/plans/cli-stream-massive-images.md``).
+    """
+    for dirpath, _dirnames, filenames in os.walk(root, followlinks=True):
+        for filename in filenames:
+            if fnmatch.fnmatch(filename, pattern):
+                yield Path(dirpath) / filename
+
+
 def rglob_follow_symlinks(root: Path, pattern: str) -> list[Path]:
     """Like ``Path.rglob(pattern)`` but follows symlinks into directories.
 
@@ -104,13 +119,23 @@ def rglob_follow_symlinks(root: Path, pattern: str) -> list[Path]:
     media files inside symlinked sub-folders are silently skipped during
     dataset import.  This helper uses :func:`os.walk` with
     ``followlinks=True`` to ensure symlinked directory trees are traversed.
+
+    Materialises the full list; callers that can stream should prefer
+    :func:`iter_rglob_follow_symlinks`.
     """
-    results: list[Path] = []
-    for dirpath, _dirnames, filenames in os.walk(root, followlinks=True):
-        for filename in filenames:
-            if fnmatch.fnmatch(filename, pattern):
-                results.append(Path(dirpath) / filename)
-    return results
+    return list(iter_rglob_follow_symlinks(root, pattern))
+
+
+def iter_glob_top_level(root: Path, pattern: str) -> Iterator[Path]:
+    """Stream files directly in *root* matching *pattern* (no recursion).
+
+    Generator twin of :func:`glob_top_level`.
+    """
+    if not root.is_dir():
+        return
+    for entry in os.scandir(root):
+        if entry.is_file(follow_symlinks=True) and fnmatch.fnmatch(entry.name, pattern):
+            yield Path(entry.path)
 
 
 def glob_top_level(root: Path, pattern: str) -> list[Path]:
@@ -118,11 +143,8 @@ def glob_top_level(root: Path, pattern: str) -> list[Path]:
 
     Mirrors :func:`rglob_follow_symlinks` but limited to the immediate
     children of *root*.  Subdirectories are not descended into.
+
+    Materialises the full list; callers that can stream should prefer
+    :func:`iter_glob_top_level`.
     """
-    results: list[Path] = []
-    if not root.is_dir():
-        return results
-    for entry in os.scandir(root):
-        if entry.is_file(follow_symlinks=True) and fnmatch.fnmatch(entry.name, pattern):
-            results.append(Path(entry.path))
-    return results
+    return list(iter_glob_top_level(root, pattern))


### PR DESCRIPTION
## Problem

Applying a saved detector to a huge media source via `--autodetect` (e.g. a
"bomb" detector trained on 100 example images, run against a folder tree of
billions of images) broke before a billion. `--chunk-size` bounded *loading and
embedding*, but three pieces still grew `O(N)` with the total item count:

1. **File enumeration** — `load_dataset_from_folder_chunked` materialised the
   entire file list before yielding any chunk.
2. **Hit accumulation** — `_merge_detector_results` extended and re-sorted the
   full accumulated hit list after every chunk.
3. **Export** — exporters buffered the whole result dict before writing.

Plus a latent bug: the CLI scoring path never embedded folder chunks (which
arrive `embedding=None`), so folder → autodetect would have raised at scoring.

## What this does

New opt-in `--stream-results` path (requires `--chunk-size` + a streaming-capable
exporter). Full design + open follow-ups in
`docs/plans/cli-stream-massive-images.md`.

- **Lazy enumeration:** generator twins `iter_rglob_follow_symlinks` /
  `iter_glob_top_level`; the chunked folder loader streams files (no full list)
  when no precomputed-override maps are supplied. Media type still validated
  eagerly; empty folder still raises the familiar error.
- **Per-chunk embed:** `_embed_and_filter_chunk` runs the embed stage one chunk
  at a time (idempotent — a no-op for pre-embedded pickle chunks) and drops
  un-embeddable items. The low-level scorer keeps its strict M11 "no None
  embedding" guard.
- **Streaming export:** trains detectors on the first chunk, then streams each
  chunk's hits straight to the exporter with no global accumulation or sort.
  `supports_streaming` + `export_cli_streaming(header, records, field_values)`;
  `server_json_file` (NDJSON), `server_csv_file`, and `gui` implement it.
  `email_smtp` / `webhook` can't stream, so `--stream-results` with them errors.
- **Negatives** dropped by default; `--keep-negatives` re-includes them.
- Flags wired through `app.py` and the YAML pipeline (`stream_results:` /
  `keep_negatives:`), with validation. Docs in `docs/CLI.md`.

**Tradeoff:** streamed hits are ordered by chunk, **not** globally sorted by
score (sort the NDJSON afterwards if a global ranking is needed). Global
ordering / bounded top-K is recorded as an open follow-up.

## Backwards compatibility

No change to existing flows: `--stream-results` is opt-in, and without it the
default accumulate-then-export path is unchanged.

## Testing

`./run-tests.sh` → all 4395 passed; `vtscore-clean` → 1123 passed; ruff /
format / codespell / deptry green. New coverage: lazy enumeration (generator
equivalence, laziness, empty-folder), NDJSON/CSV/gui streaming exporters, the
positive/negative split, and flag/YAML validation.

https://claude.ai/code/session_01Jg3uccSYPoNjzbecJYCaEB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg3uccSYPoNjzbecJYCaEB)_