### PR TITLE
Normalize embeddings at ingest (VictoryTones prerequisite)

### DIFF
--- a/docs/design/victorytones-audio-browser.md
+++ b/docs/design/victorytones-audio-browser.md
@@ -430,7 +430,8 @@ anyone.
   dependency). Draw one filled hexagon per non-empty visible hex,
   **viewport-culled**. Canvas 2D comfortably handles low tens-of-thousands
   of on-screen hexes; because the screen-visible hex count is roughly
-  constant by construction (LOD), this stays well within budget. WebGL is
+  constant by construction (level-of-detail), this stays well within
+  budget. WebGL is
   the escape hatch if a future requirement blows past it.
 - **Density color.** Map `count` → a perceptually-uniform ramp (viridis /
   magma) on a **log or sqrt scale**, because density is heavy-tailed. Wire

--- a/docs/design/victorytones-audio-browser.md
+++ b/docs/design/victorytones-audio-browser.md
@@ -1,8 +1,11 @@
 # Design: VictoryTones — a UMAP hexbin Audio Browser on `vtscore`
 
-> **Status:** Proposed (design only; no code yet). This doc scopes
-> VictoryTones as a **second app tier** in the VTSearch repo, built on
-> the existing `vtscore` library alongside `vtsearch`.
+> **Status:** Prerequisite shipped (app-wide L2 normalization at ingest);
+> VictoryTones itself (projection backend, app tier, frontend) not yet
+> built. This doc scopes VictoryTones as a **second app tier** in the
+> VTSearch repo, built on the existing `vtscore` library alongside
+> `vtsearch`. See *§What shipped* and *§Open follow-ups* at the bottom for
+> where things stand.
 >
 > **Direction change (this revision):** the original sketch was a
 > *hover-to-hear grid* that reused VTSearch's left-panel media-list. The
@@ -236,6 +239,16 @@ full `./run-tests.sh`, with attention to diversity ordering, MLP
 convergence, and threshold calibration. Breaks backwards compatibility of
 stored-embedding magnitude (acceptable per repo policy) — call it out in the
 PR.
+
+> **Shipped — see *§What shipped*.** Implemented as a single helper,
+> `vtscore/embedding/normalize.py:l2_normalize`, applied at the
+> `MediaEmbedder` base wrappers (`embed_media`, `embed_media_bulk`, and a new
+> `embed_text` → `_embed_text_impl` indirection so every subclass is covered
+> at one layer) **and** at the pickle/re-ingest write paths
+> (`loader_pickle._build_pickle_{full,thin}_media`, `ingest._build_media_data`).
+> `region_similarity` now scores by plain dot product. The chosen chokepoint
+> was "normalize wherever a vector enters `medias` (plus query vectors at the
+> embedder)", not the matrix boundary.
 
 **Chokepoint placement (resolve at implementation).** Normalizing *only*
 inside `embed`/`embed_text` covers fresh embeds but **not pickle-loaded
@@ -543,10 +556,36 @@ should be written **Flask-free** (it belongs in `vtscore`, e.g.
 `vtscore/projection/`), so it can live under `./run-tests.sh
 vtscore-clean` from day one.
 
-## Open follow-ups
+## What shipped
 
-- Nothing shipped yet — this is a proposal. When the first slice lands,
-  add a *What shipped* section and update the status header.
+- **Prerequisite: app-wide L2 normalization at ingest.** Every embedding is
+  now unit-norm at the point it enters `medias`, and every text-query vector
+  is unit-norm at the embedder, so all similarity is a plain dot product.
+  - New leaf helper `vtscore/embedding/normalize.py:l2_normalize` (numpy-only;
+    zero / non-finite norms pass through untouched; idempotent).
+  - Applied at the `MediaEmbedder` base: `embed_media` and `embed_media_bulk`
+    normalize fresh outputs; `embed_text` became a thin wrapper over a new
+    `_embed_text_impl` hook (every embedder subclass renamed `embed_text →
+    _embed_text_impl`) so the normalization lives in one place.
+  - Applied at the stored-vector write paths so pickle/legacy loads and
+    re-ingest-from-origin also hold the invariant:
+    `loader_pickle._build_pickle_full_media` / `_build_pickle_thin_media` and
+    `ingest._build_media_data`.
+  - `vtscore/training/region_similarity.py` dropped per-comparison
+    normalization (both the per-media `score_against_query` path and the
+    vectorized `cosine_sort_with_boxes` fast path); the zero-query guard
+    stays. Contract change: callers must pass a unit-norm `query_vec` (all
+    in-tree sources already do).
+  - `svm.py` standardize-caveat docstring refreshed.
+  - **Behavior changes (per design):** the diversity tree's k-means now
+    clusters on unit vectors (angular, not magnitude+direction), so diversity
+    ordering shifts; the MLP trains on unit-scale inputs, which can shift
+    threshold calibration. **Breaks backwards compatibility** of
+    stored-embedding magnitude — legacy pickles re-normalize on load.
+  - Tests: `tests_lib/detectors/test_embedding_normalization.py`,
+    `tests_lib/datasets/test_pickle_normalization.py`.
+
+## Open follow-ups
 - **VTSearch detector handoff:** v1 is browse-only. The deferred feature is
   letting a user select/vote clips on the canvas to seed VTSearch's existing
   train-a-detector flow (and, once a detector exists, optionally recolor hexes

--- a/tests/api/test_embed.py
+++ b/tests/api/test_embed.py
@@ -80,9 +80,11 @@ class TestEmbedMediaUpload:
         assert body["embedder"] == "fake_image"
         assert body["media_type"] == "image"
         assert body["dim"] == 4
-        assert body["embedding"] == [1.0, 2.0, 3.0, 4.0]
-        # norm = sqrt(1+4+9+16) = sqrt(30)
-        assert body["norm"] == pytest.approx(np.sqrt(30.0), rel=1e-5)
+        # embed_media L2-normalizes at the base wrapper, so the response
+        # carries the unit vector (and its norm is 1.0).
+        expected = (np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0)).tolist()
+        assert body["embedding"] == pytest.approx(expected, rel=1e-5)
+        assert body["norm"] == pytest.approx(1.0, rel=1e-5)
         # Embedder saw a real file on disk that was cleaned up afterwards.
         assert fake_image_embedder.last_media_path is not None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,10 @@ def _fake_embed_audio(arg):
     except Exception:
         seed = hash(str(path)) % 2**31
     rng = np.random.RandomState(seed)
-    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    vec = rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    # Real embedders now L2-normalize at ingest, so the fakes must too:
+    # region_similarity scores by dot product on the unit-norm assumption.
+    return vec / np.linalg.norm(vec)
 
 
 def _fake_embed_text(text):
@@ -73,7 +76,8 @@ def _fake_embed_text(text):
 
     seed = int(_hl.md5(text.encode()).hexdigest(), 16) % 2**31
     rng = np.random.RandomState(seed)
-    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    vec = rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    return vec / np.linalg.norm(vec)
 
 
 # Patch embed_audio_file so init_medias() never triggers CLAP model loading.

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -480,7 +480,9 @@ class TestIngestViaSource:
         assert result == 1
         assert len(medias) == 1
         media = next(iter(medias.values()))
-        assert np.array_equal(media["embedding"], precomputed_emb)
+        # Ingest L2-normalizes the source's vector at the write chokepoint,
+        # so the stored embedding is the unit-norm form of precomputed_emb.
+        assert np.allclose(media["embedding"], precomputed_emb / np.linalg.norm(precomputed_emb))
         assert media["embedder"] == "test-embedder"
         assert media["duration"] == 3.5
 

--- a/tests/datasets/test_memory_errors.py
+++ b/tests/datasets/test_memory_errors.py
@@ -68,18 +68,21 @@ class TestPickleMemoryError:
 
         target: dict = {}
 
-        # Make np.array raise MemoryError on the 3rd call
+        # Make the per-media embedding step raise MemoryError on the 3rd
+        # call (l2_normalize is called once per media when building the
+        # pickle media dict, so it stands in for the old np.array hook).
+        from vtscore.embedding.normalize import l2_normalize as _real_l2
+
         call_count = 0
-        original_np_array = np.array
 
         def oom_on_third_call(*args, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count >= 3:
                 raise MemoryError("simulated OOM")
-            return original_np_array(*args, **kwargs)
+            return _real_l2(*args, **kwargs)
 
-        with mock.patch("vtscore.datasets.loader_pickle.np.array", side_effect=oom_on_third_call):
+        with mock.patch("vtscore.datasets.loader_pickle.l2_normalize", side_effect=oom_on_third_call):
             with pytest.raises(MemoryError, match="Out of memory after loading"):
                 load_dataset_from_pickle(pkl, target)
 

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -220,7 +220,9 @@ class TestIngestMissingClips:
         assert 1 in existing
         assert existing[1]["origin_name"] == "cat/test_001.jpg"
         assert existing[1]["origin"] == origin
-        assert existing[1]["embedding"] is fake_embedding
+        # Ingest L2-normalizes at the write chokepoint, so the stored vector
+        # is the unit-norm form of the resolver's embedding (not the same object).
+        assert np.allclose(existing[1]["embedding"], fake_embedding / np.linalg.norm(fake_embedding))
 
     def test_ingest_via_resolver_returns_neg1_for_unknown_media_type(self):
         """_ingest_via_resolver returns -1 when media type can't be determined."""

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -88,7 +88,10 @@ def _fake_embed_audio(arg):
     except Exception:
         seed = hash(str(path)) % 2**31
     rng = np.random.RandomState(seed)
-    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    vec = rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    # Real embedders now L2-normalize at ingest, so the fakes must too:
+    # region_similarity scores by dot product on the unit-norm assumption.
+    return vec / np.linalg.norm(vec)
 
 
 def _fake_embed_text(text):
@@ -96,7 +99,8 @@ def _fake_embed_text(text):
 
     seed = int(_hl.md5(text.encode()).hexdigest(), 16) % 2**31
     rng = np.random.RandomState(seed)
-    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    vec = rng.randn(_EMBEDDING_DIM).astype(np.float32)
+    return vec / np.linalg.norm(vec)
 
 
 _patch_embed_audio = patch("tests_lib.fixtures.medias.embed_audio_file", side_effect=_fake_embed_audio)

--- a/tests_lib/datasets/test_pickle_normalization.py
+++ b/tests_lib/datasets/test_pickle_normalization.py
@@ -1,0 +1,56 @@
+"""Pickle loads normalize stored embeddings (L2-at-ingest invariant).
+
+A ``vtsearch`` pickle stores whatever vectors it was written with - which,
+for datasets produced before the app-wide L2-normalization change, may be
+raw (non-unit) embeddings.  The pickle loader is one of the ingest
+chokepoints that re-establishes the "every stored embedding is unit-norm"
+invariant, so a legacy pickle opens with unit vectors without re-embedding.
+
+See ``docs/design/victorytones-audio-browser.md`` §Prerequisite
+(Chokepoint placement: the pickle/import write path must be covered).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.datasets.loader_pickle import (
+    _build_pickle_full_media,
+    _build_pickle_thin_media,
+)
+
+
+def _raw_info() -> dict:
+    # A deliberately non-unit stored embedding (norm 5).
+    return {
+        "filename": "clip.wav",
+        "embedding": [3.0, 4.0],
+        "media_type": "audio",
+        "embedder": "clap",
+    }
+
+
+def test_full_media_embedding_is_unit_norm():
+    media = _build_pickle_full_media(
+        new_id=1,
+        media_info=_raw_info(),
+        media_type="audio",
+        media_bytes=b"abc",
+        media_string=None,
+        media_path=None,
+        extra_fields=[],
+    )
+    np.testing.assert_allclose(np.linalg.norm(media["embedding"]), 1.0, atol=1e-6)
+    assert media["embedding"].dtype == np.float32
+
+
+def test_thin_media_embedding_is_unit_norm():
+    media = _build_pickle_thin_media(
+        new_id=1,
+        media_info=_raw_info(),
+        media_type="audio",
+        media_path=None,
+        extra_fields=[],
+    )
+    np.testing.assert_allclose(np.linalg.norm(media["embedding"]), 1.0, atol=1e-6)
+    assert media["embedding"].dtype == np.float32

--- a/tests_lib/detectors/test_embedding_normalization.py
+++ b/tests_lib/detectors/test_embedding_normalization.py
@@ -90,6 +90,7 @@ class _FakeEmbedder(MediaEmbedder):
 class TestEmbedderNormalizesOutput:
     def test_embed_media_is_unit_norm(self):
         vec = _FakeEmbedder().embed_media({})
+        assert vec is not None
         np.testing.assert_allclose(np.linalg.norm(vec), 1.0, atol=1e-6)
 
     def test_embed_media_none_passes_through(self):
@@ -99,10 +100,12 @@ class TestEmbedderNormalizesOutput:
         out = _FakeEmbedder().embed_media_bulk([{}, {"fail": True}, {}])
         assert out[1] is None
         for v in (out[0], out[2]):
+            assert v is not None
             np.testing.assert_allclose(np.linalg.norm(v), 1.0, atol=1e-6)
 
     def test_embed_text_is_unit_norm(self):
         vec = _FakeEmbedder().embed_text("hello")
+        assert vec is not None
         np.testing.assert_allclose(np.linalg.norm(vec), 1.0, atol=1e-6)
 
     def test_embed_text_none_passes_through(self):

--- a/tests_lib/detectors/test_embedding_normalization.py
+++ b/tests_lib/detectors/test_embedding_normalization.py
@@ -1,0 +1,159 @@
+"""App-wide L2-normalization-at-ingest invariant (VictoryTones prerequisite).
+
+Every embedding that enters the system is L2-normalized exactly once, so
+downstream similarity is a plain dot product.  These tests pin the four
+guarantees that make that safe, all model-free:
+
+* :func:`vtscore.embedding.normalize.l2_normalize` produces unit vectors,
+  passes zero / non-finite norms through untouched, and is idempotent.
+* :class:`vtscore.media.embedder.MediaEmbedder`'s public ``embed_media`` /
+  ``embed_media_bulk`` / ``embed_text`` wrappers normalize whatever the
+  subclass ``_*_impl`` returns, so no subclass has to normalize itself.
+* :mod:`vtscore.training.region_similarity` scores with a dot product (no
+  per-comparison normalization) and still guards the zero-query case.
+
+See ``docs/design/victorytones-audio-browser.md`` §Prerequisite.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from vtscore.embedding.normalize import l2_normalize
+from vtscore.media.embedder import MediaEmbedder
+
+
+# ---------------------------------------------------------------------------
+# l2_normalize
+# ---------------------------------------------------------------------------
+
+
+class TestL2Normalize:
+    def test_returns_unit_vector(self):
+        out = l2_normalize([3.0, 4.0])
+        np.testing.assert_allclose(np.linalg.norm(out), 1.0, atol=1e-6)
+        np.testing.assert_allclose(out, [0.6, 0.8], atol=1e-6)
+
+    def test_output_is_float32(self):
+        assert l2_normalize([3.0, 4.0]).dtype == np.float32
+        assert l2_normalize(np.array([1, 2, 2], dtype=np.float64)).dtype == np.float32
+
+    def test_zero_vector_passes_through_unchanged(self):
+        out = l2_normalize([0.0, 0.0, 0.0])
+        # No divide-by-zero -> no NaN/inf; the zero vector is preserved.
+        assert np.all(out == 0.0)
+        assert np.all(np.isfinite(out))
+
+    def test_non_finite_norm_passes_through(self):
+        out = l2_normalize([np.inf, 1.0])
+        # norm is inf -> we must not divide (inf/inf == nan); pass through.
+        assert out[1] == 1.0
+
+    def test_idempotent_on_unit_input(self):
+        once = l2_normalize([5.0, -2.0, 1.0])
+        twice = l2_normalize(once)
+        np.testing.assert_allclose(once, twice, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# MediaEmbedder wrappers normalize subclass output
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbedder(MediaEmbedder):
+    """Minimal embedder returning deliberately non-unit vectors."""
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    def _load_models_impl(self) -> None:  # pragma: no cover - never loaded
+        pass
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if media.get("fail"):
+            return None
+        return np.array([3.0, 4.0], dtype=np.float32)  # norm 5
+
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
+        if text == "":
+            return None
+        return np.array([0.0, 6.0, 8.0], dtype=np.float32)  # norm 10
+
+
+class TestEmbedderNormalizesOutput:
+    def test_embed_media_is_unit_norm(self):
+        vec = _FakeEmbedder().embed_media({})
+        np.testing.assert_allclose(np.linalg.norm(vec), 1.0, atol=1e-6)
+
+    def test_embed_media_none_passes_through(self):
+        assert _FakeEmbedder().embed_media({"fail": True}) is None
+
+    def test_embed_media_bulk_each_unit_norm(self):
+        out = _FakeEmbedder().embed_media_bulk([{}, {"fail": True}, {}])
+        assert out[1] is None
+        for v in (out[0], out[2]):
+            np.testing.assert_allclose(np.linalg.norm(v), 1.0, atol=1e-6)
+
+    def test_embed_text_is_unit_norm(self):
+        vec = _FakeEmbedder().embed_text("hello")
+        np.testing.assert_allclose(np.linalg.norm(vec), 1.0, atol=1e-6)
+
+    def test_embed_text_none_passes_through(self):
+        assert _FakeEmbedder().embed_text("") is None
+
+    def test_base_embed_text_default_is_none(self):
+        # A subclass that doesn't override _embed_text_impl gets None.
+        class _NoText(_FakeEmbedder):
+            _embed_text_impl = MediaEmbedder._embed_text_impl
+
+        assert _NoText().embed_text("hi") is None
+
+
+# ---------------------------------------------------------------------------
+# region_similarity scores via dot product (no per-comparison normalization)
+# ---------------------------------------------------------------------------
+
+
+class TestRegionSimilarityDotProduct:
+    def test_single_vector_cosine_equals_dot_for_unit_inputs(self):
+        from vtscore.training.region_similarity import score_against_query
+
+        media = {"embedding": np.array([0.6, 0.8], dtype=np.float32)}
+        q = np.array([0.6, 0.8], dtype=np.float32)
+        score, box = score_against_query(media, q)
+        np.testing.assert_allclose(score, 1.0, atol=1e-6)
+        assert box == (0.0, 0.0, 1.0, 1.0)
+
+    def test_orthogonal_unit_vectors_score_zero(self):
+        from vtscore.training.region_similarity import score_against_query
+
+        media = {"embedding": np.array([1.0, 0.0], dtype=np.float32)}
+        q = np.array([0.0, 1.0], dtype=np.float32)
+        score, _ = score_against_query(media, q)
+        np.testing.assert_allclose(score, 0.0, atol=1e-6)
+
+    def test_zero_query_returns_zero(self):
+        from vtscore.training.region_similarity import score_against_query
+
+        media = {"embedding": np.array([1.0, 0.0], dtype=np.float32)}
+        score, box = score_against_query(media, np.zeros(2, dtype=np.float32))
+        assert score == 0.0
+        assert box is None
+
+    def test_no_per_comparison_normalization(self):
+        # Contract change: the scorer assumes unit-norm inputs and does NOT
+        # renormalize.  A deliberately non-unit query therefore yields the
+        # raw dot product, not a cosine - proving the divide was removed.
+        from vtscore.training.region_similarity import score_against_query
+
+        media = {"embedding": np.array([1.0, 0.0], dtype=np.float32)}
+        q = np.array([5.0, 0.0], dtype=np.float32)  # not unit-norm
+        score, _ = score_against_query(media, q)
+        np.testing.assert_allclose(score, 5.0, atol=1e-6)

--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -264,7 +264,7 @@ class TestSiglipBulkOverride:
         assert len(out) == 3
         assert all(v is not None for v in out)
         # One-hot per slot confirms slot alignment (argmax survives L2-norm).
-        assert [int(np.argmax(v)) for v in out] == [0, 1, 2]
+        assert [int(np.argmax(v)) for v in out if v is not None] == [0, 1, 2]
 
     def test_routes_through_bulk_helper(self, tmp_path):
         from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder

--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -222,7 +222,7 @@ class TestBulkEmbedImageFilesHelper:
 # ---------------------------------------------------------------------------
 
 
-def _stub_image_embedder(emb, dim: int = 3):
+def _stub_image_embedder(emb, dim: int = 8):
     """Install minimal mocks so the bulk override can run end-to-end."""
 
     fake_processor = mock.MagicMock()
@@ -237,8 +237,13 @@ def _stub_image_embedder(emb, dim: int = 3):
 
     # Replace the per-class _forward_pil_batch so we never touch torch.
     def fake_forward(images):
-        # Position-based vectors so we can assert slot alignment.
-        return np.stack([np.full(dim, float(i), dtype=np.float32) for i in range(len(images))])
+        # One-hot per slot so the slot index is recoverable via argmax even
+        # after the base wrapper L2-normalizes the result (a constant-
+        # magnitude vector would collapse to one shared direction).
+        out = np.zeros((len(images), dim), dtype=np.float32)
+        for i in range(len(images)):
+            out[i, i] = 1.0
+        return out
 
     emb._forward_pil_batch = fake_forward
 
@@ -258,10 +263,8 @@ class TestSiglipBulkOverride:
 
         assert len(out) == 3
         assert all(v is not None for v in out)
-        # Position-based vectors confirm slot alignment.
-        assert out[0][0] == 0.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[1][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[2][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
+        # One-hot per slot confirms slot alignment (argmax survives L2-norm).
+        assert [int(np.argmax(v)) for v in out] == [0, 1, 2]
 
     def test_routes_through_bulk_helper(self, tmp_path):
         from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder
@@ -330,7 +333,7 @@ class TestDinov2BulkOverride:
 
         out = emb.embed_media_bulk([_media(p) for p in paths])
         assert all(v is not None for v in out)
-        assert [v[0] for v in out if v is not None] == [0.0, 1.0]
+        assert [int(np.argmax(v)) for v in out if v is not None] == [0, 1]
 
 
 class TestDinov3BulkOverride:
@@ -360,7 +363,11 @@ class TestEupeBulkOverride:
         # EUPE's bulk goes through _forward_pil_batch as well; same shortcut.
 
         def fake_forward(images):
-            return np.stack([np.full(3, float(i), dtype=np.float32) for i in range(len(images))])
+            # One-hot per slot so argmax recovers the slot after L2-norm.
+            out = np.zeros((len(images), 3), dtype=np.float32)
+            for i in range(len(images)):
+                out[i, i] = 1.0
+            return out
 
         emb._forward_pil_batch = fake_forward
 
@@ -370,7 +377,7 @@ class TestEupeBulkOverride:
 
         out = emb.embed_media_bulk([_media(p) for p in paths])
         assert all(v is not None for v in out)
-        assert [v[0] for v in out if v is not None] == [0.0, 1.0, 2.0]
+        assert [int(np.argmax(v)) for v in out if v is not None] == [0, 1, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -1202,8 +1202,8 @@ class TestEmbedMediaLock:
         finally:
             MediaEmbedder._embed_lock = original_lock
 
-    def test_embed_media_delegates_to_impl(self):
-        """embed_media() should call _embed_media_impl() and return its result."""
+    def test_embed_media_delegates_to_impl_and_normalizes(self):
+        """embed_media() calls _embed_media_impl() and L2-normalizes its result."""
         from vtscore.media.embedder import MediaEmbedder
 
         class SimpleEmbedder(MediaEmbedder):
@@ -1219,12 +1219,14 @@ class TestEmbedMediaLock:
                 pass
 
             def _embed_media_impl(self, media):
-                return np.ones(4, dtype=np.float32)
+                return np.ones(4, dtype=np.float32)  # raw norm 2
 
-            def embed_text(self, text):
+            def _embed_text_impl(self, text):
                 return None
 
         emb = SimpleEmbedder()
         result = emb.embed_media({"media_path": "/fake"})
         assert result is not None
-        np.testing.assert_array_equal(result, np.ones(4, dtype=np.float32))
+        # The base wrapper normalizes the raw (norm-2) vector to unit length.
+        np.testing.assert_allclose(result, np.full(4, 0.5, dtype=np.float32), atol=1e-6)
+        np.testing.assert_allclose(np.linalg.norm(result), 1.0, atol=1e-6)

--- a/tests_lib/io/test_bulk_embedding.py
+++ b/tests_lib/io/test_bulk_embedding.py
@@ -76,7 +76,10 @@ class TestEmbedderDefaults:
                 self._model = True
 
             def _embed_media_impl(self, media):
-                return np.array([float(Path(media["media_path"]).stat().st_size)], dtype=np.float32)
+                # Encode the size in the direction (the base wrapper L2-
+                # normalizes the result, so a 1-D magnitude would be lost);
+                # first/second recovers the size after normalization.
+                return np.array([float(Path(media["media_path"]).stat().st_size), 1.0], dtype=np.float32)
 
         emb = _Stub()
         emb._model = True
@@ -89,9 +92,7 @@ class TestEmbedderDefaults:
         vecs = emb.embed_media_bulk(medias)
         assert len(vecs) == 3
         assert all(v is not None for v in vecs)
-        assert vecs[0][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
-        assert vecs[1][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
-        assert vecs[2][0] == 3.0  # pyright: ignore[reportOptionalSubscript]
+        assert [round(float(v[0] / v[1])) for v in vecs] == [1, 2, 3]  # pyright: ignore[reportOptionalSubscript]
 
     def test_default_bulk_impl_emits_per_item_progress(self, tmp_path):
         """The default bulk loop must call _on_progress on each iteration
@@ -312,7 +313,9 @@ class TestEmbedMediasDictWrapper:
                 self._model = True
 
             def _embed_media_impl(self, media):
-                return np.array([float(media["tag"])], dtype=np.float32)
+                # Encode the tag in the direction so it survives the base
+                # wrapper's L2-normalization; first/second recovers it.
+                return np.array([float(media["tag"]), 1.0], dtype=np.float32)
 
         emb = _Stub()
         emb._model = True
@@ -322,9 +325,9 @@ class TestEmbedMediasDictWrapper:
 
         assert set(out.keys()) == {1, 2, 7}
         assert all(v is not None for v in out.values())
-        assert out[1][0] == 10.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[2][0] == 20.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[7][0] == 70.0  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[1][0] / out[1][1])) == 10  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[2][0] / out[2][1])) == 20  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[7][0] / out[7][1])) == 70  # pyright: ignore[reportOptionalSubscript]
 
     def test_handles_sparse_keys(self):
         """Non-contiguous keys (e.g. post-collapse_duplicates) round-trip."""
@@ -343,7 +346,7 @@ class TestEmbedMediasDictWrapper:
                 self._model = True
 
             def _embed_media_impl(self, media):
-                return np.array([float(media["tag"])], dtype=np.float32)
+                return np.array([float(media["tag"]), 1.0], dtype=np.float32)
 
         emb = _Stub()
         emb._model = True
@@ -352,7 +355,7 @@ class TestEmbedMediasDictWrapper:
         out = emb.embed_medias(medias)
         assert list(out.keys()) == [1, 3, 5]
         assert out[3] is not None
-        assert out[3][0] == 3.0
+        assert round(float(out[3][0] / out[3][1])) == 3
 
     def test_propagates_none_for_failed_embeddings(self):
         """A None vector from the underlying bulk call surfaces as None
@@ -424,11 +427,11 @@ class TestEmbedMediasDictWrapper:
                 self._model = True
 
             def _embed_media_impl(self, media):
-                return np.array([float(media["x"])], dtype=np.float32)
+                return np.array([float(media["x"]), 1.0], dtype=np.float32)
 
             def _embed_media_bulk_impl(self, medias):
                 captured.append(list(medias))
-                return [np.array([float(m["x"])], dtype=np.float32) for m in medias]
+                return [np.array([float(m["x"]), 1.0], dtype=np.float32) for m in medias]
 
         emb = _Stub()
         emb._model = True
@@ -440,6 +443,6 @@ class TestEmbedMediasDictWrapper:
         assert captured[0] == [{"x": 1}, {"x": 2}, {"x": 3}]
         assert set(out.keys()) == {10, 20, 30}
         assert all(v is not None for v in out.values())
-        assert out[10][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[20][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
-        assert out[30][0] == 3.0  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[10][0] / out[10][1])) == 1  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[20][0] / out[20][1])) == 2  # pyright: ignore[reportOptionalSubscript]
+        assert round(float(out[30][0] / out[30][1])) == 3  # pyright: ignore[reportOptionalSubscript]

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -21,6 +21,7 @@ import json
 from typing import Any, Callable, Optional
 
 from vtsearch.state import next_media_id
+from vtscore.embedding.normalize import l2_normalize
 from vtscore.state.core import _state_lock
 
 ProgressCallback = Callable[[str, str, int, int], None]
@@ -128,7 +129,7 @@ def _build_media_data(
         "media_type": media_type_id,
         "file_size": len(file_bytes),
         "md5": md5,
-        "embedding": embedding,
+        "embedding": None if embedding is None else l2_normalize(embedding),
         "embedder": embedder_name,
         "filename": entry.get("filename") or name,
         "category": entry.get("category", ""),

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -13,11 +13,10 @@ import hashlib
 from pathlib import Path
 from typing import Any, Iterator
 
-import numpy as np
-
 from vtscore.datasets.loader import (
     ProgressCallback,
 )
+from vtscore.embedding.normalize import l2_normalize
 from vtscore.security.pickle import safe_pickle_load
 
 
@@ -125,7 +124,7 @@ def _build_pickle_thin_media(
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", 0),
         "md5": media_info.get("md5", ""),
-        "embedding": np.array(media_info["embedding"]),
+        "embedding": l2_normalize(media_info["embedding"]),
         "media_bytes": None,
         "media_string": None,
         "media_path": media_path,
@@ -160,7 +159,7 @@ def _build_pickle_full_media(
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", len(media_bytes)),
         "md5": media_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),
-        "embedding": np.array(media_info["embedding"]),
+        "embedding": l2_normalize(media_info["embedding"]),
         "media_bytes": media_bytes,
         "media_string": media_string,
         "media_path": media_path or media_info.get("media_path"),

--- a/vtscore/embedding/normalize.py
+++ b/vtscore/embedding/normalize.py
@@ -1,0 +1,53 @@
+"""Canonical L2-normalization for embeddings (single ingest chokepoint).
+
+VTSearch is direction-only nearly everywhere: every similarity comparison
+treats embeddings as points on the unit sphere.  Rather than re-normalizing
+on every comparison (the old per-call cost in
+:mod:`vtscore.training.region_similarity`), we make the unit vector the
+*stored* form: every embedding written into ``medias[cid]["embedding"]`` and
+every text-query vector is L2-normalized exactly once, at ingest.
+
+This module is the **one** place that performs that normalization.  It is
+applied at each point a vector enters the system:
+
+* fresh embeds — :meth:`MediaEmbedder.embed_media` /
+  :meth:`~MediaEmbedder.embed_media_bulk` (covers every embedder subclass);
+* text queries — :meth:`MediaEmbedder.embed_text` (covers every caller,
+  funnelled or direct);
+* pickle-loaded stored vectors —
+  :func:`vtscore.datasets.loader_pickle._build_pickle_full_media` /
+  ``_build_pickle_thin_media``;
+* re-ingested-from-origin vectors —
+  :func:`vtscore.datasets.ingest._build_media_data`.
+
+Because the invariant holds at the store, downstream consumers (the cached
+embedding matrix, the diversity tree's k-means, MLP training, region
+similarity, and the VictoryTones UMAP projection) all consume unit vectors
+without re-normalizing.  See ``docs/design/victorytones-audio-browser.md``
+§Prerequisite for the full rationale and the behaviour changes this implies
+(angular diversity clustering; MLP input scale).
+
+The module imports only :mod:`numpy` so it stays a leaf with no risk of an
+import cycle through the embedding package façade.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def l2_normalize(vec: object) -> np.ndarray:
+    """Return *vec* as a unit-norm ``float32`` array.
+
+    A zero vector (or one whose norm is non-finite) is returned unchanged
+    as ``float32`` rather than dividing — that avoids minting ``inf`` /
+    ``nan`` rows that would poison every downstream consumer.  The function
+    is idempotent: normalizing an already-unit vector returns it unchanged
+    up to ``float32`` rounding, so applying it at several chokepoints (or to
+    an embedder that already normalizes its output) is harmless.
+    """
+    arr = np.asarray(vec, dtype=np.float32)
+    norm = float(np.linalg.norm(arr))
+    if norm == 0.0 or not np.isfinite(norm):
+        return arr
+    return arr / norm

--- a/vtscore/media/audio/embedder_clap.py
+++ b/vtscore/media/audio/embedder_clap.py
@@ -180,7 +180,7 @@ class AudioClapEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/audio/embedder_clap_general.py
+++ b/vtscore/media/audio/embedder_clap_general.py
@@ -160,7 +160,7 @@ class AudioClapGeneralEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/audio/embedder_clap_music.py
+++ b/vtscore/media/audio/embedder_clap_music.py
@@ -156,7 +156,7 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -592,10 +592,19 @@ class MediaEmbedder(ABC):
         time across all embedder types.  Subclasses must override
         :meth:`_embed_media_impl` (not this method).
 
+        The returned vector is **L2-normalized** here (via
+        :func:`vtscore.embedding.normalize.l2_normalize`) so that every
+        embedding stored in ``medias`` is unit-norm regardless of which
+        embedder produced it; subclasses must not (and need not) normalize
+        themselves.
+
         Returns ``None`` if the media cannot be embedded.
         """
+        from vtscore.embedding.normalize import l2_normalize  # noqa: PLC0415
+
         with self._embed_lock:
-            return self._embed_media_impl(media)
+            vec = self._embed_media_impl(media)
+        return None if vec is None else l2_normalize(vec)
 
     @abstractmethod
     def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
@@ -622,10 +631,19 @@ class MediaEmbedder(ABC):
         per request should override :meth:`_embed_media_bulk_impl`.  If
         they chunk internally (batching), they are responsible for
         emitting their own progress updates through :attr:`_on_progress`.
+
+        Every returned vector is **L2-normalized** here so the stored-as-
+        unit-norm invariant holds for the bulk path too (the default impl
+        already routes through :meth:`embed_media`, so re-normalizing is a
+        harmless no-op; overriding impls that batch raw outputs are covered
+        here).
         """
         if not medias:
             return []
-        return self._embed_media_bulk_impl(medias)
+        from vtscore.embedding.normalize import l2_normalize  # noqa: PLC0415
+
+        vectors = self._embed_media_bulk_impl(medias)
+        return [None if v is None else l2_normalize(v) for v in vectors]
 
     def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
         """Subclass hook: embed a list of media items.
@@ -660,7 +678,27 @@ class MediaEmbedder(ABC):
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.
 
-        The default implementation returns ``None`` (text sorting unavailable).
+        The result is **L2-normalized** here so query vectors are unit-norm
+        just like stored media embeddings; this is what lets
+        :mod:`vtscore.training.region_similarity` score with a plain dot
+        product instead of re-normalizing on every comparison.  Subclasses
+        override :meth:`_embed_text_impl` (not this method) and need not
+        normalize themselves.
+
+        Returns ``None`` when this embedder cannot embed text.
+        """
+        vec = self._embed_text_impl(text)
+        if vec is None:
+            return None
+        from vtscore.embedding.normalize import l2_normalize  # noqa: PLC0415
+
+        return l2_normalize(vec)
+
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
+        """Subclass hook: embed a text query.
+
+        Override this instead of :meth:`embed_text`.  The default returns
+        ``None`` (text sorting unavailable).
         """
         return None
 

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -144,7 +144,7 @@ class ImageClipEmbedder(MediaEmbedder):
                 label="CLIP",
             )
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -174,7 +174,7 @@ class ImageSiglipEmbedder(MediaEmbedder):
                 label="SigLIP",
             )
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -150,7 +150,7 @@ class ImageSiglip2Embedder(MediaEmbedder):
                 label="SigLIP 2",
             )
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -179,7 +179,7 @@ class TextBGEEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding passage (BGE)")
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -188,7 +188,7 @@ class TextE5Embedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding passage")
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -173,7 +173,7 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._tokenizer is None:

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -195,7 +195,7 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         """VideoMAE is vision-only - text queries are unsupported.
 
         Returns ``None`` so :func:`vtsearch.routes.media.embed.embed_text`

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -125,7 +125,7 @@ class VideoXClipEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", source_repr)
             return None
 
-    def embed_text(self, text: str) -> Optional[np.ndarray]:
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtscore/training/region_similarity.py
+++ b/vtscore/training/region_similarity.py
@@ -37,17 +37,20 @@ def score_against_query(
 ) -> tuple[float, Optional[tuple[float, float, float, float]]]:
     """Return ``(max_cosine_similarity, best_region_box)`` for *media*.
 
-    *query_vec* is the embedded query (text or example image), L2-norm
-    irrelevant - we cosine-normalise here.
+    *query_vec* **must already be L2-normalized**, as are all stored media
+    and region vectors (every embedding is normalized once at ingest - see
+    :mod:`vtscore.embedding.normalize`).  Cosine similarity therefore reduces
+    to a plain dot product, with no per-comparison normalization.  Callers
+    obtain a unit query from :meth:`MediaEmbedder.embed_text`,
+    :meth:`~MediaEmbedder.embed_media`, or a stored media embedding - all of
+    which are already unit-norm.
 
-    For patch-region media, we score every region vector and return the
-    max along with that region's bounding box.  For legacy single-vector
-    media, we score ``media["embedding"]`` and return
-    ``(score, (0, 0, 1, 1))``.  Missing / zero-norm embeddings yield
-    ``(0.0, None)``.
+    For patch-region media, we score every region vector and return the max
+    along with that region's bounding box.  For legacy single-vector media,
+    we score ``media["embedding"]`` and return ``(score, (0, 0, 1, 1))``.  A
+    zero/empty query, or a missing embedding, yields ``(0.0, None)``.
     """
-    q_norm = float(np.linalg.norm(query_vec))
-    if q_norm == 0:
+    if float(np.linalg.norm(query_vec)) == 0:
         return 0.0, None
 
     regions = media.get("patch_regions")
@@ -56,10 +59,7 @@ def score_against_query(
         best_box: Optional[tuple[float, float, float, float]] = None
         for r in regions:
             v = np.asarray(r.vec, dtype=np.float32)
-            v_norm = float(np.linalg.norm(v))
-            if v_norm == 0:
-                continue
-            sim = float(v @ query_vec) / (q_norm * v_norm)
+            sim = float(v @ query_vec)
             if sim > best_score:
                 best_score = sim
                 best_box = r.box
@@ -69,10 +69,7 @@ def score_against_query(
     if emb is None:
         return 0.0, None
     emb_arr = np.asarray(emb, dtype=np.float32)
-    e_norm = float(np.linalg.norm(emb_arr))
-    if e_norm == 0:
-        return 0.0, None
-    sim = float(emb_arr @ query_vec) / (q_norm * e_norm)
+    sim = float(emb_arr @ query_vec)
     return sim, (0.0, 0.0, 1.0, 1.0)
 
 
@@ -125,19 +122,17 @@ def cosine_sort_with_boxes(
         results.sort(key=lambda x: x["similarity"], reverse=True)
         return results, sims
 
-    # Fast path: pure single-vector cosine - same arithmetic as the
-    # original _cosine_sort, retained verbatim so SigLIP / CLIP /
-    # SigLIP2 datasets see zero overhead from this refactor.  The matrix
-    # is reused from the active DatasetContext cache when available.
+    # Fast path: pure single-vector cosine via one matrix-vector product.
+    # Both the stored embeddings and *query_vec* are unit-norm (normalized
+    # once at ingest - see vtscore.embedding.normalize), so cosine is just
+    # the dot product; no per-row normalization is needed.  A zero stored
+    # embedding (left at norm 0 by l2_normalize) dots to 0.0, preserving the
+    # old "zero-norm scores 0" behaviour.  The matrix is reused from the
+    # active DatasetContext cache when available.
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap
 
     all_ids, all_embs = get_embedding_matrix_for_snap(snap)
-    q_norm = np.linalg.norm(query_vec)
-    emb_norms = np.linalg.norm(all_embs, axis=1)
-    norm_products = emb_norms * q_norm
-    safe_norms = np.where(norm_products == 0, 1.0, norm_products)
-    similarities = np.dot(all_embs, query_vec) / safe_norms
-    similarities = np.where(norm_products == 0, 0.0, similarities)
+    similarities = np.dot(all_embs, query_vec)
     sims_list = similarities.tolist()
     results = [{"id": cid, "similarity": round(float(sim), 4)} for cid, sim in zip(all_ids, similarities, strict=True)]
     results.sort(key=lambda x: x["similarity"], reverse=True)

--- a/vtscore/training/svm.py
+++ b/vtscore/training/svm.py
@@ -177,10 +177,11 @@ def train_svm(
         inclusion_value: ``[-10, 10]`` bias toward including (positive) or
             excluding (negative) - translated to ``class_weight``.
         seed: Random seed for the SVM solver and the calibrator's CV splits.
-        standardize: When ``True``, fit a ``StandardScaler`` first.  Most
-            embedders (CLAP/CLIP/SigLIP/E5) emit L2-normalised vectors so
-            this is off by default; turn on if you're feeding raw or
-            unnormalised features.
+        standardize: When ``True``, fit a ``StandardScaler`` first.  Every
+            embedding is L2-normalised once at ingest (see
+            :mod:`vtscore.embedding.normalize`), so features are already
+            unit-norm and this is off by default; turn it on only if you're
+            feeding raw or unnormalised features from an external source.
 
     Returns:
         A fitted :class:`SVMClassifier`.


### PR DESCRIPTION
## What & why

The first slice of the VictoryTones plan (`docs/design/victorytones-audio-browser.md`): the **app-wide prerequisite** that L2-normalizes every embedding once, at ingest, so all similarity reduces to a plain dot product instead of re-normalizing on every comparison. This unblocks the planned UMAP projection (it can consume unit vectors and use plain Euclidean) and is a worthwhile cleanup on its own.

This PR is **backend-only**; it does not build VictoryTones itself (projection backend, app tier, frontend remain deferred — see the design doc's *Open follow-ups*).

## How

A single helper, `vtscore/embedding/normalize.py:l2_normalize` (numpy-only leaf; zero/non-finite norms pass through untouched; idempotent), applied at every point a vector enters the system:

- **Fresh embeds + queries** — the `MediaEmbedder` base wrappers `embed_media`, `embed_media_bulk`, and `embed_text` (now a thin wrapper over a new `_embed_text_impl` hook; every embedder subclass renamed `embed_text → _embed_text_impl`). One layer covers all embedders, so no subclass normalizes itself.
- **Stored vectors** — the pickle/re-ingest write paths `loader_pickle._build_pickle_{full,thin}_media` and `ingest._build_media_data`, so legacy pickles and re-ingest-from-origin also hold the invariant without re-embedding.

With the invariant established at the store, `vtscore/training/region_similarity.py` drops its per-comparison normalization (both the per-media `score_against_query` path and the vectorized `cosine_sort_with_boxes` fast path); only the zero-query guard remains. The `svm.py` standardize caveat is refreshed.

The chosen chokepoint is "normalize wherever a vector enters `medias` (plus query vectors at the embedder)", not the matrix boundary — this keeps the invariant true for every reader (matrix, diversity tree, MLP, region similarity, future projection).

## Backwards compatibility (intentional break, per repo policy)

Stored-embedding **magnitude** is no longer preserved — legacy pickles re-normalize on load. Two real behavior changes flow from this, both anticipated in the design:

- the **diversity tree**'s k-means now clusters on unit vectors (angular, not magnitude+direction), so diversity ordering users observe will shift;
- the **MLP** trains on unit-scale inputs, which can shift threshold calibration.

No test pins the old behavior.

## Tests

`./run-tests.sh` fully green (ruff, ruff format, codespell, deptry, pyright, pip-audit, frontend build, 4395 pytest passed / 1 skipped). New: `tests_lib/detectors/test_embedding_normalization.py`, `tests_lib/datasets/test_pickle_normalization.py`. Eleven existing tests that asserted raw (non-unit) embedding values — or used a removed `np.array` injection point — were updated to the unit-norm contract (bulk-alignment stubs now encode their index in the *direction* so it survives normalization).

https://claude.ai/code/session_01R2R9tTWG1fB8h8xw52YZJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2R9tTWG1fB8h8xw52YZJc)_