### PR TITLE
VictoryTones projection backend: UMAP + hex-tile pyramid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Tests are grouped by folder under `tests/` and `tests_lib/`. Each folder is a py
 | `integration` | End-to-end workflows, thread safety, async jobs |
 | `cli` | CLI autodetect, load sort window, progress bars |
 | `converters` | Media converters (document, video, image) |
+| `projection` | VictoryTones UMAP projection + hex-tile pyramid (library tier) |
 | `gpu` | CUDA-only tests (excluded by default) |
 
 **Recommended workflow**: Run `./run-tests.sh <group>` for the area you changed, then `./run-tests.sh` for the full suite.

--- a/docs/design/victorytones-audio-browser.md
+++ b/docs/design/victorytones-audio-browser.md
@@ -1,9 +1,11 @@
 # Design: VictoryTones — a UMAP hexbin Audio Browser on `vtscore`
 
-> **Status:** Prerequisite shipped (app-wide L2 normalization at ingest);
-> VictoryTones itself (projection backend, app tier, frontend) not yet
-> built. This doc scopes VictoryTones as a **second app tier** in the
-> VTSearch repo, built on the existing `vtscore` library alongside
+> **Status:** Prerequisite shipped (app-wide L2 normalization at ingest) **and
+> the Flask-free projection backend** (`vtscore/projection/`: UMAP fit +
+> hex-tile pyramid). The app tier (a `victorytones/` Flask app) and the Angular
+> browse canvas are not yet built. This doc scopes VictoryTones as a **second
+> app tier** in the VTSearch repo, built on the existing `vtscore` library
+> alongside
 > `vtsearch`. See *§What shipped* and *§Open follow-ups* at the bottom for
 > where things stand.
 >
@@ -585,6 +587,40 @@ vtscore-clean` from day one.
     stored-embedding magnitude — legacy pickles re-normalize on load.
   - Tests: `tests_lib/detectors/test_embedding_normalization.py`,
     `tests_lib/datasets/test_pickle_normalization.py`.
+
+- **Projection backend (Stages 1 + 2), Flask-free.** The browse-canvas compute
+  core landed under `vtscore/projection/` (library tier — covered by
+  `./run-tests.sh vtscore-clean`), with no app/HTTP wiring yet.
+  - `umap_projection.py` — `fit_projection(matrix, ids, …) → Projection`
+    (Stage 1). Plain Euclidean UMAP on the ingest-normalized matrix; **unseeded
+    by default** (`random_state=None`) per the locked decision, with an optional
+    seed for reproducible/test fits. `n_neighbors` is clamped to `N-1`; below
+    `min_n_for_umap` it falls back to a deterministic **PCA-2** layout, and the
+    degenerate `N ≤ 2` / scalar-embedding cases fall back to a trivial layout.
+    Each fit mints a `projection_id`. An optional `on_progress` callback matches
+    the ingest `(status, message, current, total)` convention.
+  - `hexbin.py` — the **d3-hexbin** assignment rule reimplemented vectorized in
+    NumPy (no d3 dependency): `hexbin_assign(points, radius) → (q, r)` integer
+    cell keys (`q = round(2·pi)` to keep d3's half-integer column index
+    integral) and `hex_center(q, r, radius)` to invert.
+  - `pyramid.py` — `build_pyramid(projection, …) → Pyramid` (Stage 2). Builds
+    `n_levels` zoom levels (each halving the hex radius), aggregating per hex:
+    axial key, center, **count** (density), and a **representative media id**
+    (member nearest the cell centroid, ties broken to the smaller id). Hexes are
+    grouped into `(level, tx, ty)` **tiles**; `Tile.to_payload()` /
+    `Pyramid.meta()` emit JSON-friendly dicts for the future tile/meta endpoints.
+    Tunable knobs (`n_levels`, `base_cols`/`base_radius`, `tile_span`) are
+    parameters, not baked constants, per *§Open problems*; `max_useful_levels()`
+    is an advisory `n_levels` ceiling.
+  - **New dependency:** `umap-learn` (added to `[project.dependencies]` with the
+    `umap-learn → umap` deptry module-name mapping). Imported lazily so the
+    package import never triggers numba's JIT until a fit runs.
+  - Tests: `tests_lib/projection/` (new `projection` group/marker) —
+    `test_hexbin.py`, `test_umap_projection.py`, `test_pyramid.py`.
+  - **Not yet built (next phases):** persistence of the projection + pyramid
+    with the dataset artifact (the carve-out), the `victorytones/` Flask app and
+    its `/api/projection/{build,meta,tiles}` endpoints, and the Canvas 2D
+    frontend (Stage 3).
 
 ## Open follow-ups
 - **VTSearch detector handoff:** v1 is browse-only. The deferred feature is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "requests",
     "tqdm",
     "scikit-learn",
+    "umap-learn",
     "transformers",
     "pandas",
     "pyyaml",
@@ -133,6 +134,7 @@ extend_exclude = [
 # module differs from the PyPI package.
 [tool.deptry.package_module_name_map]
 "scikit-learn" = "sklearn"
+"umap-learn" = "umap"
 "opencv-python-headless" = "cv2"
 "PyMuPDF" = "fitz"
 "Pillow" = "PIL"
@@ -203,6 +205,7 @@ markers = [
     "integration: end-to-end workflows, thread safety",
     "cli: CLI autodetect, load sort window, progress",
     "converters: document and media converters",
+    "projection: VictoryTones UMAP projection and hex-tile pyramid",
 ]
 addopts = "-m 'not gpu and not slow'"
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 #   ./run-tests.sh vtscore-clean  # run tests_lib/ with Flask import blocked
 #
 # Available groups: core, api, sorting, datasets, io, detectors,
-#                   downloads, integration, cli, converters
+#                   downloads, integration, cli, converters, projection
 #
 # Each group is a folder under tests/ AND tests_lib/. Marker assignment is
 # automatic: any file at tests[_lib]/<group>/test_*.py gets marked <group>

--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -26,14 +26,19 @@ def _unique_bytes(media_id: int) -> bytes:
 
 def _make_audio_media(media_id: int) -> dict:
     raw = _unique_bytes(media_id)
+    # 2-dim *unit-norm* embedding whose dim 0 strictly decreases with id
+    # (0.9, 0.8, 0.7, 0.6, 0.5 for ids 1..5).  Embeddings are L2-normalized at
+    # ingest, so we store a unit vector to make that normalization a no-op and
+    # keep dim 0 the clean, id-ordered signal the stubbed MLP thresholds on.
+    e0 = 1.0 - 0.1 * media_id
+    e1 = (1.0 - e0 * e0) ** 0.5
     return {
         "id": media_id,
         "media_type": "audio",
         "duration": 1.0,
         "file_size": len(raw),
         "md5": hashlib.md5(raw).hexdigest(),
-        # 2-dim embedding: [id, id + 0.5].  The stubbed MLP reads dim 0.
-        "embedding": [float(media_id), float(media_id) + 0.5],
+        "embedding": [e0, e1],
         "media_bytes": None,
         "media_string": None,
         "media_path": None,
@@ -87,11 +92,13 @@ def _clean_detectors_dir():
 
 @pytest.fixture
 def _stub_split_training(monkeypatch):
-    """Train a deterministic MLP whose logit is ``3 - embedding[0]``.
+    """Train a deterministic MLP whose logit is ``100 * (embedding[0] - 0.65)``.
 
-    With embeddings ``[id, id + 0.5]`` and threshold 0.5 (sigmoid), media
-    ids 1/2/3 score above threshold (good) and 4/5 below (bad), giving a
-    fixed positive/negative split to assert against.
+    With the unit-norm embeddings from ``_make_audio_media`` (dim 0 = 0.9, 0.8,
+    0.7, 0.6, 0.5 for ids 1..5) and threshold 0.5 (sigmoid), the 0.65 boundary
+    puts ids 1/2/3 above threshold (good) and 4/5 below (bad), giving a fixed
+    positive/negative split to assert against.  The wide ``100`` scale keeps the
+    sigmoid margins clear of float-precision wobble.
     """
     import torch
     from torch import nn
@@ -101,8 +108,8 @@ def _stub_split_training(monkeypatch):
     def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
         linear = nn.Linear(2, 1)
         with torch.no_grad():
-            linear.weight.data = torch.tensor([[-1.0, 0.0]])
-            linear.bias.data = torch.tensor([3.0])
+            linear.weight.data = torch.tensor([[100.0, 0.0]])
+            linear.bias.data = torch.tensor([-65.0])
         mlp = nn.Sequential(linear)
         mlp.eval()
         return {name: {"mlp": mlp, "threshold": 0.5} for name in detector_names}

--- a/tests_lib/projection/test_hexbin.py
+++ b/tests_lib/projection/test_hexbin.py
@@ -1,0 +1,66 @@
+"""Tests for the vectorized d3-hexbin binning (``vtscore.projection.hexbin``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.projection.hexbin import hex_center, hexbin_assign
+
+
+def test_assign_shapes_and_dtype():
+    rng = np.random.default_rng(42)
+    pts = rng.standard_normal((200, 2))
+    q, r = hexbin_assign(pts, radius=0.3)
+    assert q.shape == (200,)
+    assert r.shape == (200,)
+    assert q.dtype == np.int64
+    assert r.dtype == np.int64
+
+
+def test_center_round_trips_to_same_cell():
+    # A point placed at a cell's center must bin back to that cell.
+    rng = np.random.default_rng(1)
+    pts = rng.standard_normal((500, 2)) * 5.0
+    radius = 0.7
+    q, r = hexbin_assign(pts, radius)
+    cx, cy = hex_center(q, r, radius)
+    centers = np.stack([cx, cy], axis=1)
+    q2, r2 = hexbin_assign(centers, radius)
+    assert np.array_equal(q, q2)
+    assert np.array_equal(r, r2)
+
+
+def test_origin_maps_to_a_cell_at_origin_center():
+    q, r = hexbin_assign(np.array([[0.0, 0.0]]), radius=1.0)
+    cx, cy = hex_center(q, r, radius=1.0)
+    assert float(cx[0]) == pytest.approx(0.0, abs=1e-9)
+    assert float(cy[0]) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_nearby_points_share_a_cell():
+    radius = 2.0
+    # Two points well within one hex of each other collapse to one cell.
+    pts = np.array([[0.05, 0.05], [-0.05, 0.1]])
+    q, r = hexbin_assign(pts, radius)
+    assert q[0] == q[1] and r[0] == r[1]
+
+
+def test_smaller_radius_yields_more_distinct_cells():
+    rng = np.random.default_rng(7)
+    pts = rng.standard_normal((1000, 2)) * 3.0
+    coarse_q, coarse_r = hexbin_assign(pts, radius=1.0)
+    fine_q, fine_r = hexbin_assign(pts, radius=0.25)
+    n_coarse = len(np.unique(np.stack([coarse_q, coarse_r], axis=1), axis=0))
+    n_fine = len(np.unique(np.stack([fine_q, fine_r], axis=1), axis=0))
+    assert n_fine > n_coarse
+
+
+def test_invalid_radius_raises():
+    with pytest.raises(ValueError):
+        hexbin_assign(np.zeros((3, 2)), radius=0.0)
+
+
+def test_invalid_shape_raises():
+    with pytest.raises(ValueError):
+        hexbin_assign(np.zeros((3, 3)), radius=1.0)

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -1,0 +1,126 @@
+"""Tests for Stage-2 hex-tile pyramid (``vtscore.projection.pyramid``)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.projection.pyramid import Pyramid, build_pyramid, max_useful_levels
+from vtscore.projection.umap_projection import Projection
+
+
+def _projection(coords: np.ndarray, ids: list[int] | None = None, pid: str = "pid-test") -> Projection:
+    if ids is None:
+        ids = list(range(coords.shape[0]))
+    return Projection(pid, ids, np.ascontiguousarray(coords, dtype=np.float32), "test")
+
+
+def _cluster_cloud(seed: int = 0) -> np.ndarray:
+    """Three well-separated Gaussian blobs in 2-D."""
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 8.0]])
+    pts = np.concatenate([c + rng.standard_normal((100, 2)) * 0.5 for c in centers])
+    return pts.astype(np.float32)
+
+
+def test_every_point_counted_at_each_level():
+    coords = _cluster_cloud()
+    proj = _projection(coords)
+    pyr = build_pyramid(proj, n_levels=5)
+    assert isinstance(pyr, Pyramid)
+    assert pyr.point_count == coords.shape[0]
+    for lvl in range(5):
+        total = sum(cell.count for (level, _tx, _ty), tile in pyr.tiles.items() if level == lvl for cell in tile.cells)
+        assert total == coords.shape[0], f"level {lvl} lost points"
+
+
+def test_finer_levels_have_more_cells():
+    pyr = build_pyramid(_projection(_cluster_cloud()), n_levels=5)
+    n_cells = [lm.n_cells for lm in pyr.levels]
+    # Coarsest level has the fewest cells; each level resolves at least as many.
+    assert n_cells[0] <= n_cells[-1]
+    assert n_cells[0] >= 1
+    assert max(n_cells) > min(n_cells)
+
+
+def test_level_radius_halves():
+    pyr = build_pyramid(_projection(_cluster_cloud()), n_levels=4, base_radius=8.0)
+    assert pyr.level_radius(0) == 8.0
+    assert pyr.level_radius(1) == 4.0
+    assert pyr.level_radius(3) == 1.0
+    assert pyr.levels[2].radius == 2.0
+
+
+def test_representative_is_member_nearest_centroid():
+    # Two points; one is the centroid-nearest, both share a (big) hex.
+    coords = np.array([[0.0, 0.0], [0.1, 0.0]], dtype=np.float32)
+    proj = _projection(coords, ids=[100, 200])
+    pyr = build_pyramid(proj, n_levels=1, base_radius=100.0)
+    tiles = list(pyr.tiles.values())
+    assert len(tiles) == 1
+    cells = tiles[0].cells
+    assert len(cells) == 1
+    cell = cells[0]
+    assert cell.count == 2
+    # centroid is at (0.05, 0); the point at (0.0,0) and (0.1,0) are equidistant,
+    # tie-break to the smaller id.
+    assert cell.rep_id == 100
+
+
+def test_rep_ids_are_valid_ids():
+    coords = _cluster_cloud()
+    ids = list(range(1000, 1000 + coords.shape[0]))
+    pyr = build_pyramid(_projection(coords, ids=ids), n_levels=4)
+    valid = set(ids)
+    for tile in pyr.tiles.values():
+        for cell in tile.cells:
+            assert cell.rep_id in valid
+
+
+def test_tile_indexing_matches_get_tile():
+    pyr = build_pyramid(_projection(_cluster_cloud()), n_levels=4)
+    for (level, tx, ty), tile in pyr.tiles.items():
+        assert pyr.get_tile(level, tx, ty) is tile
+        assert tile.level == level and tile.tx == tx and tile.ty == ty
+    assert pyr.get_tile(999, 0, 0) is None
+
+
+def test_empty_projection_yields_no_tiles_but_keeps_levels():
+    proj = _projection(np.empty((0, 2), dtype=np.float32), ids=[])
+    pyr = build_pyramid(proj, n_levels=3)
+    assert pyr.tiles == {}
+    assert len(pyr.levels) == 3
+    assert pyr.point_count == 0
+
+
+def test_meta_is_json_friendly():
+    pyr = build_pyramid(_projection(_cluster_cloud(), pid="abc123"), n_levels=3)
+    meta = pyr.meta()
+    assert meta["projection_id"] == "abc123"
+    assert len(meta["levels"]) == 3
+    assert len(meta["bounds"]) == 4
+    assert meta["point_count"] == 300
+    # payloads are plain Python scalars (no numpy types leaking into JSON)
+    tile = next(iter(pyr.tiles.values()))
+    payload = tile.to_payload()
+    cell0 = payload["cells"][0]
+    assert isinstance(cell0["q"], int)
+    assert isinstance(cell0["count"], int)
+    assert isinstance(cell0["cx"], float)
+    assert isinstance(cell0["rep_id"], int)
+
+
+def test_coincident_points_use_fallback_radius():
+    # All points identical: zero extent must not crash (radius falls back to 1).
+    coords = np.zeros((10, 2), dtype=np.float32)
+    pyr = build_pyramid(_projection(coords), n_levels=2)
+    assert pyr.base_radius > 0
+    total = sum(cell.count for t in pyr.tiles.values() for cell in t.cells if t.level == 0)
+    assert total == 10
+
+
+def test_max_useful_levels_bounds():
+    assert max_useful_levels(0) == 1
+    assert max_useful_levels(1) == 1
+    assert 1 <= max_useful_levels(100) <= 12
+    assert max_useful_levels(10_000) >= max_useful_levels(100)
+    assert max_useful_levels(10**9) <= 12

--- a/tests_lib/projection/test_umap_projection.py
+++ b/tests_lib/projection/test_umap_projection.py
@@ -1,0 +1,92 @@
+"""Tests for Stage-1 projection (``vtscore.projection.umap_projection``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.projection.umap_projection import Projection, fit_projection
+
+
+def _matrix(n: int, d: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n, d)).astype(np.float32)
+
+
+def test_empty_dataset():
+    proj = fit_projection(np.empty((0, 8), dtype=np.float32), [])
+    assert isinstance(proj, Projection)
+    assert proj.coords.shape == (0, 2)
+    assert proj.method == "trivial"
+    assert proj.ids == []
+    assert proj.bounds == (0.0, 0.0, 0.0, 0.0)
+    assert proj.projection_id  # minted regardless
+
+
+def test_single_point_is_trivial_at_origin():
+    proj = fit_projection(_matrix(1, 8), [5])
+    assert proj.coords.shape == (1, 2)
+    assert proj.method == "trivial"
+    assert proj.ids == [5]
+    np.testing.assert_array_equal(proj.coords, np.zeros((1, 2), dtype=np.float32))
+
+
+def test_two_points_trivial():
+    proj = fit_projection(_matrix(2, 8), [1, 2])
+    assert proj.coords.shape == (2, 2)
+    assert proj.method == "trivial"
+
+
+def test_small_n_uses_pca_fallback():
+    proj = fit_projection(_matrix(6, 8, seed=3), [10, 11, 12, 13, 14, 15], min_n_for_umap=10)
+    assert proj.method == "pca"
+    assert proj.coords.shape == (6, 2)
+    assert np.isfinite(proj.coords).all()
+    # PCA is deterministic: a second fit on the same matrix gives the same layout.
+    proj2 = fit_projection(_matrix(6, 8, seed=3), [10, 11, 12, 13, 14, 15], min_n_for_umap=10)
+    np.testing.assert_allclose(proj.coords, proj2.coords, atol=1e-5)
+
+
+def test_scalar_embeddings_fall_back_to_trivial():
+    # d < 2 can't support PCA-2; trivial layout instead of crashing.
+    proj = fit_projection(_matrix(20, 1), list(range(20)))
+    assert proj.method == "trivial"
+    assert proj.coords.shape == (20, 2)
+
+
+def test_ids_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        fit_projection(_matrix(5, 8), [1, 2, 3])
+
+
+def test_umap_fit_shape_and_metadata():
+    # A real (seeded, reproducible) UMAP fit on a small synthetic set.
+    n, d = 60, 12
+    proj = fit_projection(_matrix(n, d, seed=11), list(range(n)), n_neighbors=10, random_state=7)
+    assert proj.method == "umap"
+    assert proj.coords.shape == (n, 2)
+    assert proj.coords.dtype == np.float32
+    assert np.isfinite(proj.coords).all()
+    assert len(proj.ids) == n
+    xmin, ymin, xmax, ymax = proj.bounds
+    assert xmax >= xmin and ymax >= ymin
+
+
+def test_n_neighbors_clamped_below_n():
+    # n_neighbors larger than N-1 must not blow up: it's clamped.
+    n, d = 15, 8
+    proj = fit_projection(_matrix(n, d, seed=2), list(range(n)), n_neighbors=100, random_state=1)
+    assert proj.method == "umap"
+    assert proj.coords.shape == (n, 2)
+
+
+def test_progress_callback_invoked():
+    seen: list[tuple[str, str, int, int]] = []
+    fit_projection(
+        _matrix(6, 8),
+        list(range(6)),
+        min_n_for_umap=10,
+        on_progress=lambda s, m, c, t: seen.append((s, m, c, t)),
+    )
+    assert seen  # at least one milestone reported
+    assert all(evt[0] == "projecting" for evt in seen)

--- a/vtscore/plugins/inventory.py
+++ b/vtscore/plugins/inventory.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 
 @dataclass
@@ -370,8 +370,15 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+if TYPE_CHECKING:
+    # ``FAMILIES`` is produced at access time by ``__getattr__`` above; declare
+    # it here so static analysis (and ``from … import FAMILIES`` callers) see a
+    # real, typed module member rather than an unresolved ``__all__`` entry.
+    FAMILIES: tuple[str, ...]
+
+
 __all__ = [
-    "FAMILIES",  # noqa: F822 - exposed dynamically via module __getattr__
+    "FAMILIES",
     "FamilyProvider",
     "PluginEntry",
     "family_flag",

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -1,0 +1,41 @@
+"""VictoryTones projection backend: UMAP layout + hex-tile pyramid.
+
+The Flask-free core of the VictoryTones browse canvas (see
+``docs/design/victorytones-audio-browser.md``).  Two stages:
+
+- :func:`fit_projection` (Stage 1) reduces a dataset's ``(N, d)`` embedding
+  matrix to a frozen ``(N, 2)`` :class:`Projection`.
+- :func:`build_pyramid` (Stage 2) aggregates that projection into a
+  multi-resolution :class:`Pyramid` of hex :class:`Tile` / :class:`HexCell`
+  records the canvas streams while panning and zooming.
+
+Persistence of the projection + pyramid (the carve-out from the
+"No Persisted Vectors or MLPs" rule) and the HTTP endpoints live in the
+VictoryTones app tier, not here.
+"""
+
+from __future__ import annotations
+
+from vtscore.projection.hexbin import hex_center, hexbin_assign
+from vtscore.projection.pyramid import (
+    HexCell,
+    LevelMeta,
+    Pyramid,
+    Tile,
+    build_pyramid,
+    max_useful_levels,
+)
+from vtscore.projection.umap_projection import Projection, fit_projection
+
+__all__ = [
+    "Projection",
+    "fit_projection",
+    "Pyramid",
+    "Tile",
+    "HexCell",
+    "LevelMeta",
+    "build_pyramid",
+    "max_useful_levels",
+    "hexbin_assign",
+    "hex_center",
+]

--- a/vtscore/projection/hexbin.py
+++ b/vtscore/projection/hexbin.py
@@ -1,0 +1,101 @@
+"""Vectorized d3-hexbin binning over a 2-D point cloud (no d3 dependency).
+
+VictoryTones renders the UMAP projection as a field of hexagons whose color
+encodes density.  To do that the server has to assign every projected point to
+a hex cell.  This module reimplements the `d3-hexbin
+<https://github.com/d3/d3-hexbin>`_ assignment algorithm in NumPy so a whole
+``(N, 2)`` array is binned in one vectorized pass.
+
+The lattice is anchored in *projection (data) space*, parameterized by a single
+hexagon *radius* ``r`` (center → vertex).  Pointy-top hexagons tile with column
+spacing ``dx = r·√3`` and row spacing ``dy = 1.5·r``; odd rows are offset by
+half a column.  Anchoring in data space is what makes pure panning free in the
+renderer (membership only changes when the radius changes, i.e. across a zoom
+level), per *§Browse-canvas architecture* in
+``docs/design/victorytones-audio-browser.md``.
+
+A bin is identified by an integer pair ``(q, r)`` where ``q = round(2·pi)``
+(d3's column index ``pi`` can be a half-integer after the edge correction, so we
+double it to stay integral) and ``r = pj`` is the row index.  :func:`hex_center`
+inverts that key back to the cell's center in projection space.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+# 2·sin(π/3): the column spacing of a pointy-top hex lattice is ``radius · SQRT3``.
+SQRT3 = math.sqrt(3.0)
+
+
+def hexbin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.ndarray]:
+    """Assign each point in *points* to a hex cell of the given *radius*.
+
+    *points* is an ``(M, 2)`` float array of projection-space coordinates.
+    Returns ``(q, r)``: two int64 arrays of length ``M`` holding the integer
+    cell key for each point, where ``q = round(2·pi)`` (doubled column index)
+    and ``r = pj`` (row index).  Feed the same ``(q, r)`` to :func:`hex_center`
+    to recover the cell center.
+
+    This is the d3-hexbin rounding rule, vectorized: round to the nearest row,
+    then the nearest (row-offset) column, and where the point lands in the outer
+    third of a row, compare against the staggered neighbor and snap to whichever
+    center is closer.
+    """
+    if radius <= 0:
+        raise ValueError(f"hex radius must be positive, got {radius!r}")
+    pts = np.asarray(points, dtype=np.float64)
+    if pts.ndim != 2 or pts.shape[1] != 2:
+        raise ValueError(f"points must be (M, 2), got shape {pts.shape}")
+
+    dx = radius * SQRT3
+    dy = radius * 1.5
+
+    px0 = pts[:, 0] / dx
+    py0 = pts[:, 1] / dy
+
+    pj = np.round(py0)
+    pj_odd = (pj.astype(np.int64) & 1) == 1
+    px = px0 - np.where(pj_odd, 0.5, 0.0)
+    pi = np.round(px)
+    py1 = py0 - pj
+
+    # Edge correction: only points more than a third of a row away from the
+    # row center can be closer to a staggered neighbor's center.
+    needs_check = np.abs(py1) * 3.0 > 1.0
+    px1 = px - pi
+    pi2 = pi + np.where(px < pi, -0.5, 0.5)
+    pj2 = pj + np.where(py0 < pj, -1.0, 1.0)
+    px2 = px - pi2
+    py2 = py0 - pj2
+    closer_to_neighbor = (px1 * px1 + py1 * py1) > (px2 * px2 + py2 * py2)
+    swap = needs_check & closer_to_neighbor
+
+    # When we snap to the neighbor the column shifts by ±0.5 depending on the
+    # parity of the *original* row (d3's ``(pj & 1 ? 1 : -1) / 2``).
+    pi_corrected = pi2 + np.where(pj_odd, 0.5, -0.5)
+    pi_final = np.where(swap, pi_corrected, pi)
+    pj_final = np.where(swap, pj2, pj)
+
+    q = np.round(pi_final * 2.0).astype(np.int64)
+    r = pj_final.astype(np.int64)
+    return q, r
+
+
+def hex_center(q: np.ndarray | int, r: np.ndarray | int, radius: float) -> tuple[np.ndarray, np.ndarray]:
+    """Inverse of :func:`hexbin_assign`: the projection-space center of cell ``(q, r)``.
+
+    Accepts scalars or arrays.  Returns ``(cx, cy)`` as float64 (scalars in,
+    scalars out via 0-d arrays' ``.item()``-friendly values).
+    """
+    dx = radius * SQRT3
+    dy = radius * 1.5
+    q_arr = np.asarray(q, dtype=np.float64)
+    r_arr = np.asarray(r, dtype=np.float64)
+    pi = q_arr / 2.0
+    r_odd = (r_arr.astype(np.int64) & 1) == 1
+    cx = (pi + np.where(r_odd, 0.5, 0.0)) * dx
+    cy = r_arr * dy
+    return cx, cy

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -1,0 +1,243 @@
+"""Stage 2 of the VictoryTones browse canvas: the hex-tile pyramid.
+
+Given a frozen :class:`~vtscore.projection.umap_projection.Projection`, build a
+multi-resolution pyramid of hexagon aggregates that the canvas streams as it
+pans and zooms.  Per *§Browse-canvas architecture* in
+``docs/design/victorytones-audio-browser.md``:
+
+- **Zoom levels** ``z = 0 … n_levels-1``.  Level 0 is coarsest (the whole
+  projection in a handful of big hexes); each deeper level *halves the hex
+  radius*, revealing finer structure while keeping the on-screen hex count
+  roughly constant.
+- **Per hex** the server precomputes its axial key ``(q, r)`` and center, the
+  **count** of points in it (the density channel), and a **representative**
+  media id — the clip whose projected point is nearest the cell's centroid,
+  which is what hover-to-hear auditions.  Representatives are per level, so the
+  audition clip generalizes as you zoom out.
+- **Tiles** group hexes into a spatial grid per level so the client fetches
+  only the tiles covering its viewport.  Because the projection is frozen, a
+  tile is immutable for the life of the dataset and trivially cacheable.
+
+This module is pure NumPy (Flask-free) and does no I/O; persistence and the
+HTTP tile endpoint live in the VictoryTones app tier.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from vtscore.projection.hexbin import SQRT3, hex_center, hexbin_assign
+from vtscore.projection.umap_projection import Projection
+
+
+@dataclass(frozen=True)
+class HexCell:
+    """One aggregated hexagon at one zoom level."""
+
+    q: int  # doubled column key (see hexbin)
+    r: int  # row key
+    cx: float  # center in projection space
+    cy: float
+    count: int  # number of clips in this cell (density)
+    rep_id: int  # representative media id (nearest clip to the cell centroid)
+
+    def to_payload(self) -> dict[str, Any]:
+        """JSON-serializable form for the tile endpoint."""
+        return {
+            "q": self.q,
+            "r": self.r,
+            "cx": self.cx,
+            "cy": self.cy,
+            "count": self.count,
+            "rep_id": self.rep_id,
+        }
+
+
+@dataclass(frozen=True)
+class Tile:
+    """The non-empty hexes inside one ``(level, tx, ty)`` spatial cell."""
+
+    level: int
+    tx: int
+    ty: int
+    cells: list[HexCell]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "level": self.level,
+            "tx": self.tx,
+            "ty": self.ty,
+            "cells": [c.to_payload() for c in self.cells],
+        }
+
+
+@dataclass(frozen=True)
+class LevelMeta:
+    """Sizing/summary for one zoom level, surfaced via the meta endpoint."""
+
+    level: int
+    radius: float
+    n_cells: int
+
+
+@dataclass(frozen=True)
+class Pyramid:
+    """The full hex-tile pyramid for one frozen projection."""
+
+    projection_id: str
+    bounds: tuple[float, float, float, float]
+    base_radius: float
+    tile_span: float  # columns/rows of hexes per tile (projection-index units)
+    point_count: int
+    levels: list[LevelMeta]
+    # (level, tx, ty) -> Tile
+    tiles: dict[tuple[int, int, int], Tile]
+
+    def level_radius(self, level: int) -> float:
+        """Hex radius at *level* (``base_radius / 2**level``)."""
+        return self.base_radius / (2.0**level)
+
+    def get_tile(self, level: int, tx: int, ty: int) -> Tile | None:
+        """The tile at ``(level, tx, ty)``, or ``None`` if it holds no hexes."""
+        return self.tiles.get((level, tx, ty))
+
+    def meta(self) -> dict[str, Any]:
+        """JSON-serializable projection/pyramid summary for ``/api/projection/meta``."""
+        return {
+            "projection_id": self.projection_id,
+            "bounds": list(self.bounds),
+            "base_radius": self.base_radius,
+            "tile_span": self.tile_span,
+            "point_count": self.point_count,
+            "levels": [{"level": lm.level, "radius": lm.radius, "n_cells": lm.n_cells} for lm in self.levels],
+        }
+
+
+def _base_radius_for(bounds: tuple[float, float, float, float], base_cols: float) -> float:
+    """Level-0 hex radius so the larger extent spans ~``base_cols`` columns."""
+    xmin, ymin, xmax, ymax = bounds
+    extent = max(xmax - xmin, ymax - ymin)
+    if extent <= 0 or base_cols <= 0:
+        return 1.0  # all points coincide (or degenerate) — any positive radius works
+    return (extent / base_cols) / SQRT3
+
+
+def _tile_index(q: np.ndarray, r: np.ndarray, tile_span: float) -> tuple[np.ndarray, np.ndarray]:
+    """Map hex keys to integer tile coords ``(tx, ty)``.
+
+    ``q`` is the doubled column key, so the column position is ``q / 2``; tiles
+    bin ``tile_span`` hex columns/rows each.
+    """
+    tx = np.floor((q / 2.0) / tile_span).astype(np.int64)
+    ty = np.floor(r / tile_span).astype(np.int64)
+    return tx, ty
+
+
+def _build_level(level: int, coords: np.ndarray, ids: np.ndarray, radius: float, tile_span: float) -> list[Tile]:
+    """Aggregate *coords* into hexes at one *level* and group them into tiles."""
+    q, r = hexbin_assign(coords, radius)
+    keys = np.stack([q, r], axis=1)
+    uniq, inverse = np.unique(keys, axis=0, return_inverse=True)
+    inverse = inverse.ravel()
+    n_hexes = uniq.shape[0]
+
+    counts = np.bincount(inverse, minlength=n_hexes)
+    # Contiguous segments of point indices grouped by hex, points within a
+    # segment ordered by ascending row index (== ascending id, since ids are
+    # sorted) so representative tie-breaks are deterministic.
+    order = np.argsort(inverse, kind="stable")
+    seg_starts = np.cumsum(counts) - counts
+
+    centers_x, centers_y = hex_center(uniq[:, 0], uniq[:, 1], radius)
+    tx_all, ty_all = _tile_index(uniq[:, 0], uniq[:, 1], tile_span)
+
+    tiles: dict[tuple[int, int], list[HexCell]] = {}
+    for h in range(n_hexes):
+        members = order[seg_starts[h] : seg_starts[h] + counts[h]]
+        pts = coords[members]
+        centroid = pts.mean(axis=0)
+        rep_local = int(np.argmin(np.sum((pts - centroid) ** 2, axis=1)))
+        rep_id = int(ids[members[rep_local]])
+        cell = HexCell(
+            q=int(uniq[h, 0]),
+            r=int(uniq[h, 1]),
+            cx=float(centers_x[h]),
+            cy=float(centers_y[h]),
+            count=int(counts[h]),
+            rep_id=rep_id,
+        )
+        tiles.setdefault((int(tx_all[h]), int(ty_all[h])), []).append(cell)
+
+    return [Tile(level=level, tx=tx, ty=ty, cells=cells) for (tx, ty), cells in tiles.items()]
+
+
+def build_pyramid(
+    projection: Projection,
+    *,
+    n_levels: int = 6,
+    base_cols: float = 6.0,
+    base_radius: float | None = None,
+    tile_span: float = 16.0,
+) -> Pyramid:
+    """Build the hex-tile :class:`Pyramid` for a frozen *projection*.
+
+    ``n_levels`` zoom levels are produced (``z = 0 … n_levels-1``), each
+    halving the hex radius.  ``base_radius`` (level 0) defaults to a value
+    sized so the projection's larger extent spans ~``base_cols`` hex columns;
+    pass it explicitly to override.  ``tile_span`` is the number of hex
+    columns/rows grouped into one tile.  All of these are tunable knobs, not
+    baked constants (see *§Open problems* in the design doc).
+
+    Empty projections yield a pyramid with no tiles.
+    """
+    if n_levels < 1:
+        raise ValueError(f"n_levels must be >= 1, got {n_levels}")
+
+    coords = np.ascontiguousarray(projection.coords, dtype=np.float64)
+    ids = np.asarray(projection.ids, dtype=np.int64)
+    bounds = projection.bounds
+    r0 = base_radius if base_radius is not None else _base_radius_for(bounds, base_cols)
+
+    levels: list[LevelMeta] = []
+    tiles: dict[tuple[int, int, int], Tile] = {}
+
+    for level in range(n_levels):
+        radius = r0 / (2.0**level)
+        if coords.shape[0] == 0:
+            levels.append(LevelMeta(level=level, radius=radius, n_cells=0))
+            continue
+        level_tiles = _build_level(level, coords, ids, radius, tile_span)
+        n_cells = sum(len(t.cells) for t in level_tiles)
+        levels.append(LevelMeta(level=level, radius=radius, n_cells=n_cells))
+        for t in level_tiles:
+            tiles[(t.level, t.tx, t.ty)] = t
+
+    return Pyramid(
+        projection_id=projection.projection_id,
+        bounds=bounds,
+        base_radius=r0,
+        tile_span=tile_span,
+        point_count=int(coords.shape[0]),
+        levels=levels,
+        tiles=tiles,
+    )
+
+
+def max_useful_levels(point_count: int, base_cols: float = 6.0) -> int:
+    """A reasonable ``n_levels`` ceiling for *point_count* clips.
+
+    Heuristic: keep descending until a level could resolve roughly one clip per
+    hex.  Each level multiplies the hex count by ~4 (radius halves in 2-D), and
+    level 0 spans ~``base_cols**2`` hexes, so ``log4(point_count / base_cols**2)``
+    extra levels suffice.  Clamped to ``[1, 12]``.  Advisory only — callers
+    pass the result as ``n_levels`` to :func:`build_pyramid`.
+    """
+    if point_count <= 1:
+        return 1
+    level0_hexes = max(base_cols * base_cols, 1.0)
+    extra = math.log(max(point_count / level0_hexes, 1.0), 4.0)
+    return max(1, min(12, 1 + int(math.ceil(extra))))

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -1,0 +1,149 @@
+"""Stage 1 of the VictoryTones browse canvas: project the embedding matrix to 2-D.
+
+Runs UMAP on the cached ``(N, d)`` embedding matrix
+(:func:`vtscore.embedding.matrix.get_embedding_matrix`) to produce an
+``(N, 2)`` layout.  Because embeddings are L2-normalized at ingest (see
+*§Prerequisite* in ``docs/design/victorytones-audio-browser.md``), Euclidean
+distance on the unit sphere is monotonic in cosine distance, so UMAP uses the
+plain ``"euclidean"`` metric with no per-fit normalization.
+
+Determinism follows the locked design decision: the fit is **unseeded by
+default** (``random_state=None``), which keeps UMAP's numba parallelism on.
+That is safe only because the projection is computed exactly once per dataset
+and then frozen/persisted — it never re-runs, so its non-reproducibility never
+surfaces.  Callers (e.g. tests) may pass a ``random_state`` for a reproducible
+fit at the cost of parallelism.
+
+Tiny datasets can't support a neighbor graph (UMAP needs ``n_neighbors < N``),
+so below ``min_n_for_umap`` this falls back to a deterministic PCA-2 layout —
+or a trivial layout for the degenerate ``N ≤ 1`` cases — rather than failing.
+
+This module is Flask-free and imports ``umap`` lazily so importing the package
+never pulls in numba's JIT until an actual fit runs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+# Matches the ingest progress-callback shape (status, message, current, total).
+ProgressCallback = Callable[[str, str, int, int], None]
+
+
+@dataclass(frozen=True)
+class Projection:
+    """A frozen 2-D layout of a dataset's embedding matrix.
+
+    ``coords[i]`` is the projected point for media id ``ids[i]``.  ``method``
+    records how it was produced (``"umap"``, ``"pca"``, or ``"trivial"``) and
+    ``projection_id`` is minted at the one-time fit so tiles derived from it can
+    be namespaced/cached against it (see *§Tile-cache invalidation*).
+    """
+
+    projection_id: str
+    ids: list[int]
+    coords: np.ndarray  # (N, 2) float32
+    method: str
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        """``(xmin, ymin, xmax, ymax)`` of the layout; zeros when empty."""
+        if self.coords.shape[0] == 0:
+            return (0.0, 0.0, 0.0, 0.0)
+        xmin, ymin = self.coords.min(axis=0)
+        xmax, ymax = self.coords.max(axis=0)
+        return (float(xmin), float(ymin), float(xmax), float(ymax))
+
+
+def _trivial_layout(n: int) -> np.ndarray:
+    """A deterministic layout for ``n`` points when there's nothing to project.
+
+    One point sits at the origin; a handful spread along a line so they don't
+    all collapse to a single hex.
+    """
+    if n <= 1:
+        return np.zeros((n, 2), dtype=np.float32)
+    xs = np.linspace(0.0, 1.0, n, dtype=np.float32)
+    return np.stack([xs, np.zeros(n, dtype=np.float32)], axis=1)
+
+
+def _pca_layout(matrix: np.ndarray) -> np.ndarray:
+    """PCA-2 fallback for small-N datasets, padded to 2 columns when ``d < 2``."""
+    from sklearn.decomposition import PCA
+
+    n, d = matrix.shape
+    n_components = min(2, n, d)
+    if n_components < 1:
+        return _trivial_layout(n)
+    coords = PCA(n_components=n_components).fit_transform(matrix)
+    if coords.shape[1] < 2:
+        pad = np.zeros((n, 2 - coords.shape[1]), dtype=coords.dtype)
+        coords = np.concatenate([coords, pad], axis=1)
+    return np.ascontiguousarray(coords, dtype=np.float32)
+
+
+def fit_projection(
+    matrix: np.ndarray,
+    ids: list[int],
+    *,
+    n_neighbors: int = 15,
+    min_dist: float = 0.1,
+    min_n_for_umap: int = 10,
+    random_state: int | None = None,
+    on_progress: ProgressCallback | None = None,
+) -> Projection:
+    """Project the ``(N, d)`` embedding *matrix* to a frozen 2-D :class:`Projection`.
+
+    ``ids[i]`` labels row ``i`` of *matrix* (as returned by
+    :func:`~vtscore.embedding.matrix.get_embedding_matrix`).  ``n_neighbors`` is
+    clamped to ``N - 1`` so it stays valid on small datasets.  Below
+    ``min_n_for_umap`` points the layout falls back to PCA-2 (deterministic).
+
+    ``random_state`` defaults to ``None`` (unseeded, parallel — the production
+    path); pass an int for a reproducible fit.  ``on_progress`` receives coarse
+    ``(status, message, current, total)`` milestones if provided.
+    """
+    mat = np.ascontiguousarray(matrix, dtype=np.float32)
+    if mat.ndim != 2:
+        raise ValueError(f"matrix must be 2-D (N, d), got shape {mat.shape}")
+    n = mat.shape[0]
+    if len(ids) != n:
+        raise ValueError(f"ids length {len(ids)} != matrix rows {n}")
+
+    projection_id = uuid.uuid4().hex
+
+    def _progress(status: str, message: str, current: int, total: int) -> None:
+        if on_progress is not None:
+            on_progress(status, message, current, total)
+
+    if n == 0:
+        return Projection(projection_id, [], np.empty((0, 2), dtype=np.float32), "trivial")
+
+    if n <= 2 or mat.shape[1] < 2:
+        # Too few points (or scalar embeddings) for either UMAP or PCA-2.
+        _progress("projecting", "trivial layout", n, n)
+        return Projection(projection_id, list(ids), _trivial_layout(n), "trivial")
+
+    if n < min_n_for_umap:
+        _progress("projecting", f"PCA fallback ({n} points)", 0, n)
+        coords = _pca_layout(mat)
+        _progress("projecting", "PCA fallback done", n, n)
+        return Projection(projection_id, list(ids), coords, "pca")
+
+    _progress("projecting", f"UMAP fit ({n} points)", 0, n)
+    import umap
+
+    reducer = umap.UMAP(
+        n_components=2,
+        n_neighbors=min(n_neighbors, n - 1),
+        min_dist=min_dist,
+        metric="euclidean",
+        random_state=random_state,
+    )
+    coords = np.ascontiguousarray(reducer.fit_transform(mat), dtype=np.float32)
+    _progress("projecting", "UMAP fit done", n, n)
+    return Projection(projection_id, list(ids), coords, "umap")


### PR DESCRIPTION
Builds the **Flask-free projection backend** for VictoryTones — Stages 1 & 2 of the browse canvas in `docs/design/victorytones-audio-browser.md`. This is the foundation only: no app/HTTP wiring, no persistence, no frontend yet (those are the next phases, recorded in the design doc).

## What landed

New `vtscore/projection/` package (library tier — runs under `./run-tests.sh vtscore-clean`):

- **`umap_projection.py`** — `fit_projection(matrix, ids, …) → Projection` (Stage 1). Plain Euclidean UMAP on the ingest-normalized embedding matrix, **unseeded by default** per the locked decision (optional `random_state` for reproducible/test fits). `n_neighbors` clamped to `N-1`; below `min_n_for_umap` it falls back to deterministic **PCA-2**, and degenerate `N ≤ 2` / scalar-embedding cases fall back to a trivial layout. Each fit mints a `projection_id`. Optional `on_progress` callback matches the ingest `(status, message, current, total)` convention. `umap` is imported lazily so package import never triggers numba's JIT.
- **`hexbin.py`** — the **d3-hexbin** assignment rule reimplemented vectorized in NumPy (no d3 dependency): `hexbin_assign(points, radius) → (q, r)` integer cell keys and `hex_center(q, r, radius)` to invert.
- **`pyramid.py`** — `build_pyramid(projection, …) → Pyramid` (Stage 2). Builds `n_levels` zoom levels (each halving the hex radius), aggregating per hex: axial key, center, **count** (density), and a **representative media id** (member nearest the cell centroid, ties → smaller id). Hexes grouped into `(level, tx, ty)` **tiles**; `Tile.to_payload()` / `Pyramid.meta()` emit JSON-friendly dicts for the future tile/meta endpoints. Tuning knobs (`n_levels`, `base_cols`/`base_radius`, `tile_span`) are parameters, not baked constants.

## Dependency & test wiring

- Adds **`umap-learn`** to `[project.dependencies]` with the `umap-learn → umap` deptry module-name mapping.
- New **`projection`** test group/marker; tests under `tests_lib/projection/` (`test_hexbin.py`, `test_umap_projection.py`, `test_pyramid.py`).
- Design-doc status + *What shipped* updated; `CLAUDE.md` / `run-tests.sh` test-group lists updated.

## Drive-by fix (unrelated, pre-existing)

`tests/cli/test_cli_streaming.py` was already failing on `dev`: the shipped L2-normalization-at-ingest prerequisite squashed the fixture's raw `[id, id+0.5]` embeddings at pickle load, so the stub MLP's `3 - embedding[0]` logit stopped separating the medias. Fixed by storing **unit-norm** embeddings (normalization now a no-op) and retargeting the stub MLP boundary, preserving the intended 1,2,3 / 4,5 split.

## Backwards compatibility

Purely additive (new package, new optional-at-import dependency). No breaking changes.

## Testing

`./run-tests.sh` — **ALL 4440 tests pass** (1 skipped), including the full ruff / pyright / deptry / pip-audit / codespell / OpenAPI / Dockerfile preamble.

https://claude.ai/code/session_01UumYntrDzMeJz8KBjK5Tcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UumYntrDzMeJz8KBjK5Tcj)_