### PR TITLE
Rename VictoryTones to VTSBrowse, widen to all media types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Tests are grouped by folder under `tests/` and `tests_lib/`. Each folder is a py
 | `integration` | End-to-end workflows, thread safety, async jobs |
 | `cli` | CLI autodetect, load sort window, progress bars |
 | `converters` | Media converters (document, video, image) |
-| `projection` | VictoryTones UMAP projection + hex-tile pyramid (library tier) |
+| `projection` | VTSBrowse UMAP projection + hex-tile pyramid (library tier) |
 | `gpu` | CUDA-only tests (excluded by default) |
 
 **Recommended workflow**: Run `./run-tests.sh <group>` for the area you changed, then `./run-tests.sh` for the full suite.

--- a/docs/design/vtsbrowse.md
+++ b/docs/design/vtsbrowse.md
@@ -1,40 +1,54 @@
-# Design: VictoryTones — a UMAP hexbin Audio Browser on `vtscore`
+# Design: VTSBrowse — a UMAP hexbin Dataset Browser in VTSearch
 
 > **Status:** Prerequisite shipped (app-wide L2 normalization at ingest) **and
 > the Flask-free projection backend** (`vtscore/projection/`: UMAP fit +
-> hex-tile pyramid). The app tier (a `victorytones/` Flask app) and the Angular
-> browse canvas are not yet built. This doc scopes VictoryTones as a **second
-> app tier** in the VTSearch repo, built on the existing `vtscore` library
-> alongside
-> `vtsearch`. See *§What shipped* and *§Open follow-ups* at the bottom for
-> where things stand.
+> hex-tile pyramid). The Browse routes and Angular browse canvas are not yet
+> built. This doc scopes VTSBrowse as a **module within VTSearch** — new
+> routes, services, and Angular components that add a Browse mode alongside
+> the existing Find and Train modes. See *§What shipped* and *§Open
+> follow-ups* at the bottom for where things stand.
 >
 > **Direction change (this revision):** the original sketch was a
 > *hover-to-hear grid* that reused VTSearch's left-panel media-list. The
 > Browse experience is now a **UMAP 2-D projection rendered as a
-> pannable/zoomable hexbin density map**, where hovering a hex auditions a
-> representative clip from that region. The repo-structure decision and the
-> reuse/omit story are unchanged; the **frontend and a new projection +
+> pannable/zoomable hexbin density map**, where hovering a hex previews a
+> representative item from that region. The **frontend and a new projection +
 > tiling backend** are the substantive additions, captured in
 > *§Browse-canvas architecture* below.
 >
+> **Name change:** this feature was originally called "VictoryTones" and
+> scoped to audio only. It is now **VTSBrowse** and designed to support
+> browsing datasets of any MediaType (audio, text, image, video, document).
+>
+> **Architecture change:** the original design proposed VTSBrowse as a
+> *second app tier* (a separate Flask app and Angular build target). It is
+> now a **module within VTSearch** — Browse routes under the existing Flask
+> app, Browse components in the existing Angular app. VTSearch already has
+> "Find" and "Train" as dataset/detector workflows; Browse will be a
+> dataset-only workflow added to the same app.
+>
 > **Decisions locked** (see *§Locked decisions*): single-dataset v1,
-> MediaType fixed to Audio, **server-side hex tiling**, a **second Angular
-> build target**, **Canvas 2D** rendering, **browse-only** scope, and a
-> **projection frozen + persisted at ingest** (unseeded UMAP, computed once).
+> **server-side hex tiling**, **Canvas 2D** rendering, **browse-only** scope,
+> and a **projection frozen + persisted at ingest** (unseeded UMAP, computed
+> once).
 
 ## Problem / Goal
 
-We want an **Audio Browser** ("VictoryTones") for quickly auditioning and
-exploring a collection of audio by *content*. The center of the app is a
-**Browse canvas**: a 2-D UMAP projection of the audio content-embedding
-space, drawn as a tiled field of **hexagons**.
+We want a **Dataset Browser** ("VTSBrowse") for quickly exploring a
+collection of media by *content*. The center of the app is a **Browse
+canvas**: a 2-D UMAP projection of the content-embedding space, drawn as a
+tiled field of **hexagons**.
 
 - The canvas is **pannable and zoomable**.
-- Each hex's **color encodes how many audio clips fall in that region**
-  (density).
-- **Hovering a hex plays a representative ("central") clip** from that
-  region, on repeat, until the cursor moves to another hex.
+- Each hex's **color encodes how many items fall in that region** (density).
+- **Hovering a hex previews a representative ("central") item** from that
+  region. The preview behavior depends on the dataset's MediaType:
+  - **Audio:** plays the representative clip on repeat until the cursor
+    moves to another hex.
+  - **Text:** shows the text snippet in a mouse popup/tooltip.
+  - **Image:** shows a thumbnail of the image in a mouse popup.
+  - **Video:** shows a thumbnail (or a short looping clip) in a mouse popup.
+  - **Document:** shows a text excerpt or title in a mouse popup.
 - **Zooming in subdivides** the hexes into finer-grained cells over a
   narrower slice of the projection (level-of-detail), so the same screen
   always shows a readable number of hexes but reveals more structure as you
@@ -42,10 +56,12 @@ space, drawn as a tiled field of **hexagons**.
 
 It reuses the heavy lifting VTSearch already has:
 
-- the **DatasetImporters** (load audio from folders, pickles, archives, …),
-  with **MediaType fixed to Audio**;
-- the **audio MediaEmbedders** (LAION-CLAP, CLAP-Music, AST, Whisper) and the
-  cached **embedding matrix** that already backs sorting in VTSearch.
+- the **DatasetImporters** (load media from folders, pickles, archives, ...)
+  via the `PluginRegistry`;
+- the **MediaEmbedders** for all supported types (LAION-CLAP, CLAP-Music,
+  AST, Whisper for audio; SigLIP, CLIP, DINOv2/v3 for images; E5, BGE for
+  text; X-CLIP for video) and the cached **embedding matrix** that already
+  backs sorting in VTSearch.
 
 On top of that reused stack it adds two new pieces: a **UMAP projection** of
 the embedding matrix to 2-D, and a **server-side hex-tile pyramid** that the
@@ -55,106 +71,57 @@ It deliberately **does not** want most of VTSearch's apparatus: no
 LabelSets, no labels/votes, no detector training, no MLP, no eval, no
 achievements. It is a browser, not a trainable searcher.
 
-## Decision: in-repo second app tier (not a separate repo)
+## Decision: module within VTSearch (not a separate app)
 
-**Add `victorytones/` (an app tier) to this repo, consuming the same
-`vtscore`.** Do *not* spin up a separate repository that "references
-vtscore" — at least not now. Reasoning below.
+**VTSBrowse is a module added to VTSearch**, not a standalone app or a
+separate app tier. Browse routes live under `vtsearch/routes/`, Browse
+Angular components live in `frontend/src/app/`, and the projection backend
+stays in `vtscore/projection/` (library tier, Flask-free).
 
-### Why in-repo wins
+VTSearch already has two dataset/detector workflows — **Find** (text-seeded
+or detector-based search) and **Train** (vote on items to train a detector).
+Browse adds a third workflow that operates on a **dataset alone** (no
+detector required): explore the dataset's embedding space via a 2-D
+projection. The Browse canvas replaces the media-list and center panel with
+a hex-tile map; the rest of the VTSearch shell (header, dataset picker,
+settings) stays.
 
-1. **The reused code lives in `vtscore` and changes there.** Importers and
-   audio embedders are exactly what VictoryTones leans on, and exactly the
-   code most likely to evolve. Same-repo keeps both consumers in lockstep
-   under one test run (`./run-tests.sh`); a separate repo guarantees
-   version skew on the shared surface.
-2. **The repo is already "library tier + app tier."** `vtscore` is the
-   Flask-free library; `vtsearch` is the Flask app on top of it. Adding a
-   *second* app tier that also consumes `vtscore` is the grain of the
-   existing architecture — see `docs/ARCHITECTURE.md` §Directory map and
-   §Dependency graph — not a fork of it.
-3. **The Browse canvas is not in `vtscore` at all.** It's Angular, in the
-   app tier (`frontend/`). Either path reuses or re-implements frontend;
-   same-repo lets VictoryTones share Angular services and SCSS instead of
-   copy-pasting them into another repo.
-4. **Dropping labels/detectors is subtractive and trivial in-repo.** Those
-   are per-**detector** concerns (`DetectorContext`: votes, training,
-   model, threshold). VictoryTones simply never instantiates a
-   `DetectorContext`; it uses only `DatasetContext` (`medias`) + the
-   embedding matrix + a new projection + media serving. Nothing has to be
-   removed — it just isn't wired up.
+This is simpler than the original "second app tier" design (no separate
+Flask app, no second Angular build target, no separate `vtsbrowse/` package)
+and is the right fit because Browse is a mode of VTSearch, not a different
+product.
 
-### The fact that rules out "separate repo referencing vtscore" today
-
-**`vtscore` is not currently a standalone, distributable package.** It is
-Flask-free at *import* time (enforced by `./run-tests.sh vtscore-clean`),
-but several `vtscore` modules carry **lazy runtime back-imports into
-`vtsearch`**:
-
-| `vtscore` module | imports from `vtsearch` (lazily) |
-|------------------|----------------------------------|
-| `datasets/load_pipeline.py` | `vtsearch.auth`, `vtsearch.state` |
-| `datasets/ingest.py` | `vtsearch.state.next_media_id` |
-| `detectors/workflow.py`, `media_seeding.py`, `labelset_elements.py` | `vtsearch.state` |
-| `labels/sync.py` | `vtsearch.auth`, `vtsearch.achievements` |
-| `concurrency/async_jobs.py` | `vtsearch.auth` |
-| `exporters/_template.py` | `vtsearch.auth` |
-| `cli.py` | `vtsearch.achievements` |
-| `embedding/loader.py` | `vtsearch.logging_config` (optional bridge) |
-
-So "a separate repo that *references* vtscore" presumes an artifact that
-doesn't exist yet. To make it real you'd have to either vendor the **whole**
-VTSearch repo as a git dependency (you inherit `vtsearch` anyway), or first
-**sever those back-edges and publish `vtscore` to PyPI** — a real project
-that an audio browser does not by itself justify.
-
-Notably, the paths VictoryTones touches most are in that table:
-`datasets/load_pipeline.py` (dataset loading) reaches into `vtsearch.auth`
-and `vtsearch.state`. So even the in-repo version benefits from tidying
-those edges (see *§vtscore back-edges* below), but in-repo it keeps working
-as-is because `vtsearch` is present.
-
-### When to revisit (separate repo / published `vtscore`)
-
-Reconsider extraction the day independent distribution becomes a concrete
-requirement: a separate release cadence, a separate deploy target, a
-different owning team, or external consumers who should `pip install
-vtscore`. At that point the right sequence is **decouple + publish
-`vtscore` first, then build VictoryTones against the package** — and that
-work pays for itself because you'd need it regardless. Until then, in-repo
-avoids paying the decoupling tax up front for a benefit you don't yet need.
-
-## What VictoryTones reuses (from `vtscore`)
+## What VTSBrowse reuses
 
 - **Dataset importers** — `vtscore/datasets/importers/*` (server_folder,
-  local_folder, pickle, http_archive, demo, …) via the `PluginRegistry`.
-  Unchanged, **but constrained to MediaType Audio** in the UI.
-- **Audio media type + embedders** — `vtscore/media/audio/*`
-  (`embedder_clap`, `embedder_clap_music`, `embedder_ast`,
-  `embedder_whisper`) via the media/embedder registries in
-  `vtscore/media/__init__.py`. Unchanged. Output dimensionality `d` is
-  **512** (CLAP, CLAP-Music, Whisper) or **768** (AST); embeddings are now
+  local_folder, pickle, http_archive, demo, ...) via the `PluginRegistry`.
+  Unchanged; any MediaType the importer supports is available to browse.
+- **Media types + embedders** — all registered media types and their
+  embedders via the media/embedder registries in `vtscore/media/__init__.py`.
+  Audio (LAION-CLAP, CLAP-Music, AST, Whisper), image (SigLIP, CLIP,
+  DINOv2/v3), text (E5, BGE), video (X-CLIP). Unchanged. Embeddings are
   **L2-normalized at ingest** (see *§Prerequisite*), so the projection
-  consumes unit vectors directly.
+  consumes unit vectors directly regardless of media type.
 - **The embedding matrix** — `vtscore/embedding/matrix.py`
-  `get_embedding_matrix(ctx) → (sorted_ids, (N, d) float32)`, lazily built
+  `get_embedding_matrix(ctx) -> (sorted_ids, (N, d) float32)`, lazily built
   and cached on `DatasetContext` (`_emb_matrix` / `_emb_matrix_ids` in
   `vtscore/state/core.py`), invalidated when the media-id set changes. This
-  is the **direct input to UMAP**; row `i` ↔ `sorted_ids[i]`.
+  is the **direct input to UMAP**; row `i` <-> `sorted_ids[i]`.
 - **Media loading + embedding** — `vtscore/datasets/loader*.py`,
   `vtscore/embedding/{helpers,matrix,loader}.py`, and the
-  `load_pipeline → ingest → embed_media_bulk` flow.
-- **Audio serving** — `GET /api/medias/<id>/audio`
-  (`vtsearch/routes/media/list.py`) streams WAV bytes; reused verbatim for
-  hover playback.
-- **Clipper system** — `vtscore/media/audio/clipper.py` (tiling / silence /
-  VAD splitters). Each clip is embedded independently and carries
-  `clip_start`/`clip_end`, so **clipping directly controls map density**
-  (more clips → more points → a denser projection).
+  `load_pipeline -> ingest -> embed_media_bulk` flow.
+- **Media serving** — `GET /api/medias/<id>/audio`
+  (`vtsearch/routes/media/list.py`) streams WAV bytes for audio; analogous
+  endpoints serve image thumbnails, text content, etc. The browse canvas
+  uses whichever endpoint matches the dataset's MediaType for hover preview.
+- **Clipper system** (audio datasets) — `vtscore/media/audio/clipper.py`
+  (tiling / silence / VAD splitters). Each clip is embedded independently
+  and carries `clip_start`/`clip_end`, so **clipping directly controls map
+  density** (more clips -> more points -> a denser projection).
 - **Concurrency/progress** — `vtscore/concurrency/{progress,async_jobs}.py`
   for background dataset loads **and the background UMAP/tiling build**.
 
-## What VictoryTones omits (vs. `vtsearch`)
+## What Browse mode does not use
 
 - **No LabelSets / labels / votes** — no `good_votes`/`bad_votes`, no
   `label_history`, no `LabelSet`, no label importers/exporters.
@@ -168,37 +135,30 @@ avoids paying the decoupling tax up front for a benefit you don't yet need.
   transport. (This supersedes the earlier "reuse the media-list grid"
   sketch.)
 
-### Package name
+## New routes and components
 
-The package is `victorytones/` (not `vtvictorytones/`). The `vt` prefix on
-`vtscore`/`vtsearch` (and the `vt-` Angular selectors) plausibly derives
-from **V**ictory**T**ones itself, so `vtvictorytones` would read as
-"VictoryTones VictoryTones." VictoryTones is its own product, so it takes
-the brand name directly rather than a `vt`+role name like `vtsearch`. (If
-family-grouping under `vt*` ever matters more than the brand, `vtbrowser`
-was the runner-up.)
+Browse adds routes to the existing VTSearch Flask app and components to the
+existing Angular app. The projection backend stays in `vtscore/projection/`
+(library tier). v1 is **single-dataset** — Browse operates on whichever
+dataset is loaded in the active `DatasetContext`.
 
-## App-tier shape (`victorytones/`)
+### New API surface
 
-A thin Flask app paralleling `vtsearch`, importing only the `vtscore`
-slices above. v1 is **single-user** (`DefaultLoginProvider`) and
-**single-dataset** — no multi-dataset registry, no `X-Dataset-Id` headers.
-Minimum surface:
-
-- `POST /api/datasets/load` (or registry load) — load a dataset via an
-  importer / pickle (MediaType Audio), populate the one `DatasetContext`.
-  Reuses the existing load pipeline + progress.
-- `GET /api/medias/<id>/audio` — stream audio bytes (reused from
-  `vtsearch`, audio-only).
 - **`POST /api/projection/build`** — kick the background job that computes
   UMAP + the hex-tile pyramid for the loaded dataset; reports progress.
 - **`GET /api/projection/meta`** — projection bounds, available zoom
-  levels, hex sizing per level, point count, build status.
+  levels, hex sizing per level, point count, build status, **dataset
+  MediaType** (so the client knows which hover-preview behavior to use).
 - **`GET /api/projection/tiles/<level>/<tx>/<ty>`** — the hex aggregates
   for one tile at one zoom level (see *§Browse-canvas architecture*).
 
-No `/api/order` text-query endpoint in v1 (the projection *is* the
-ordering); a text-seeded "fly to this region" affordance is a follow-up.
+Existing endpoints (`/api/medias/<id>/audio`, `/api/medias/<id>`, dataset
+loading, etc.) are reused as-is. The Browse canvas uses whichever media
+endpoint matches the dataset's MediaType for hover preview.
+
+No `/api/order` text-query endpoint in the Browse flow (the projection *is*
+the ordering); a text-seeded "fly to this region" affordance is a
+follow-up.
 
 ## Prerequisite: normalize embeddings at ingest (app-wide)
 
@@ -207,8 +167,8 @@ direction-only nearly everywhere — it just normalizes lazily, at every
 comparison. We make that canonical: **L2-normalize each embedding once, at
 ingest, in every embedder's `embed` / `embed_text`** (audio, image, and the
 CLAP/CLIP text-query paths), then **drop the per-comparison normalization**.
-This is a VTSearch-wide change, not VictoryTones-local — done as a
-prerequisite so VictoryTones can consume unit vectors and use plain
+This is a VTSearch-wide change, not VTSBrowse-local — done as a
+prerequisite so VTSBrowse can consume unit vectors and use plain
 Euclidean UMAP.
 
 Why it's safe and arguably overdue:
@@ -234,7 +194,7 @@ Two real behavior changes to validate (not just no-ops):
   thresholds.
 
 **Sites to touch:** add an L2 step to the non-normalizing embedders' `embed`
-and `embed_text` (CLAP, CLAP-Music, CLIP, SigLIP, …); guard against the
+and `embed_text` (CLAP, CLAP-Music, CLIP, SigLIP, ...); guard against the
 zero-vector divide; remove the now-redundant normalization in
 `region_similarity.py`; refresh the `svm.py` docstring caveat. **Retest:**
 full `./run-tests.sh`, with attention to diversity ordering, MLP
@@ -245,7 +205,7 @@ PR.
 > **Shipped — see *§What shipped*.** Implemented as a single helper,
 > `vtscore/embedding/normalize.py:l2_normalize`, applied at the
 > `MediaEmbedder` base wrappers (`embed_media`, `embed_media_bulk`, and a new
-> `embed_text` → `_embed_text_impl` indirection so every subclass is covered
+> `embed_text` -> `_embed_text_impl` indirection so every subclass is covered
 > at one layer) **and** at the pickle/re-ingest write paths
 > (`loader_pickle._build_pickle_{full,thin}_media`, `ingest._build_media_data`).
 > `region_similarity` now scores by plain dot product. The chosen chokepoint
@@ -265,7 +225,7 @@ across each embedder; otherwise pickle loads silently bypass it.
 
 ## Browse-canvas architecture
 
-This is the heart of VictoryTones and the part with no precedent in
+This is the heart of VTSBrowse and the part with no precedent in
 `vtsearch`. It splits cleanly into a **projection stage** (run once per
 dataset at ingest, server-side, then frozen and persisted with the dataset),
 a **tile-pyramid stage** (server-side aggregation, persisted alongside the
@@ -293,7 +253,7 @@ Run `umap-learn` on the cached `(N, d)` embedding matrix to produce an
   session; freezing is what buys back stability without paying for a seeded,
   parallelism-disabled fit.)
 - **Cost & scheduling:** UMAP is O(N) with heavy constants — seconds at a
-  few thousand points, into minutes at 10⁵. It runs as a **background
+  few thousand points, into minutes at 10^5. It runs as a **background
   async job with progress** (`vtscore/concurrency`), never inline in a
   request. The canvas shows a building state until it's ready.
 - **Small-N edge cases:** `n_neighbors` must be `< N`; clamp for tiny
@@ -346,24 +306,24 @@ them as tiles**, rather than shipping the raw point cloud for the client to
 bin. The server builds a **multi-resolution pyramid** over the 2-D
 projection:
 
-- **Zoom levels `z = 0 … Zmax`.** Level 0 is the coarsest (whole projection
+- **Zoom levels `z = 0 ... Zmax`.** Level 0 is the coarsest (whole projection
   in a handful of big hexes); each deeper level **halves the hex edge
   length** in projection space, so a fixed screen always shows a comparable
   number of hexes while revealing finer structure as you descend — this is
-  the "zoom in → hexes subdivide" behavior.
+  the "zoom in -> hexes subdivide" behavior.
 - **Hex lattice anchored in projection (data) space**, using axial/cube
   coordinates with nearest-center rounding (the d3-hexbin algorithm,
   reimplemented — no d3 dependency). Anchoring in data space means **pure
   panning never changes hex membership**; only crossing a zoom-level
   boundary re-bins. (The canvas still pans continuously; it just swaps which
   precomputed level it draws as the scale crosses thresholds.)
-- **Per hex, the server precomputes:** axial coords (→ center), **count**
-  (for the density color), and a **representative media id** = the clip
-  whose projected point is nearest the hex centroid (this is the clip
-  hover-plays). Representative selection is per level, so the audition clip
+- **Per hex, the server precomputes:** axial coords (-> center), **count**
+  (for the density color), and a **representative media id** = the item
+  whose projected point is nearest the hex centroid (this is the item
+  hover-previews). Representative selection is per level, so the preview
   naturally generalizes/specializes as you zoom.
 - **Tiles** group hexes into a spatial grid per level: a tile is
-  `(level, tx, ty)` → the list of non-empty hexes inside it. This makes the
+  `(level, tx, ty)` -> the list of non-empty hexes inside it. This makes the
   payload **viewport-bounded** (the client fetches only the tiles covering
   what's on screen) and **trivially cacheable**: because the projection is
   frozen at ingest, a tile is **immutable for the life of the dataset**, so
@@ -371,7 +331,7 @@ projection:
   `projection_id` in the URL — no revalidation, no invalidation logic (see
   *§Tile-cache invalidation*).
 - **Build & storage:** the pyramid is computed in the same one-time ingest
-  job as the UMAP fit (one O(N · levels) pass after the projection) and
+  job as the UMAP fit (one O(N * levels) pass after the projection) and
   **persisted with the dataset artifact** alongside the coordinates — it is
   part of the carve-out above, not recomputed on load.
 
@@ -388,7 +348,7 @@ tile cache and prefetching neighbors.
 Freezing the projection at ingest **dissolves** what would otherwise be the
 trickiest caching question, so it is worth recording why there is nothing to
 solve here. A tile is keyed by `(level, tx, ty)`, and its contents (which
-hexes, their counts, their representative clips) are only meaningful relative
+hexes, their counts, their representative items) are only meaningful relative
 to one projection. In a world where the projection could be *re-fit* — and
 especially with our unseeded fit, where a re-fit is **guaranteed** to move
 every coordinate — a cached tile would silently become stale geometry, and
@@ -400,7 +360,7 @@ re-fit**, so a tile's contents are fixed for the entire life of the dataset
 artifact. Mechanically:
 
 - Each artifact has a `projection_id` minted at its one-time fit. It goes in
-  the tile URL (e.g. `…/tiles/{projection_id}/{level}/{tx}/{ty}`), so tiles
+  the tile URL (e.g. `.../{projection_id}/{level}/{tx}/{ty}`), so tiles
   from different datasets can never collide in any cache.
 - Within a dataset that `projection_id` is a **stable constant**, so tiles
   are served with a long-lived `Cache-Control: max-age` (effectively
@@ -418,13 +378,13 @@ anyone.
 
 ### Stage 3 — Canvas renderer (client-side, **Canvas 2D**)
 
-- **Transform model.** Maintain a projection-space ↔ screen-space affine
+- **Transform model.** Maintain a projection-space <-> screen-space affine
   transform: **pan = translate**, **zoom = scale about the cursor**. From
   the continuous scale, pick the **nearest discrete pyramid level** to
   fetch; render its hexes through the current transform. Pan within a level
   is a cheap retransform of already-fetched tiles.
 - **Tile streaming.** On each viewport change, compute the covering tiles
-  for the active level, fetch any missing ones (`GET …/tiles/z/tx/ty`),
+  for the active level, fetch any missing ones (`GET .../tiles/z/tx/ty`),
   keep them in an **LRU cache**, and prefetch adjacent tiles + the
   neighboring levels for snappy zoom.
 - **Drawing.** Raw **Canvas 2D** (matching the existing
@@ -435,14 +395,22 @@ anyone.
   constant by construction (level-of-detail), this stays well within
   budget. WebGL is
   the escape hatch if a future requirement blows past it.
-- **Density color.** Map `count` → a perceptually-uniform ramp (viridis /
+- **Density color.** Map `count` -> a perceptually-uniform ramp (viridis /
   magma) on a **log or sqrt scale**, because density is heavy-tailed. Wire
   the ramp endpoints to theme CSS variables as the charts service does.
-- **Hover-to-hear.** On hex hover, play the hex's representative id via
-  `/api/medias/<id>/audio` with `loop = true`; **hard-cut/replace** on
-  moving to the next hex; **debounce** so sweeping the canvas doesn't
-  machine-gun audio. Browsers block autoplay until a user gesture, so the
-  first canvas click **unlocks** the audio element / `AudioContext`.
+- **Hover preview.** On hex hover, preview the hex's representative item.
+  The preview strategy is **media-type-dependent**:
+  - **Audio:** play via `/api/medias/<id>/audio` with `loop = true`;
+    **hard-cut/replace** on moving to the next hex; **debounce** so sweeping
+    the canvas doesn't machine-gun audio. Browsers block autoplay until a
+    user gesture, so the first canvas click **unlocks** the audio element /
+    `AudioContext`.
+  - **Text:** show the text content (or a truncated snippet) in a tooltip
+    anchored to the cursor or hex. No audio playback.
+  - **Image:** show a thumbnail of the image in a popup anchored to the
+    cursor or hex.
+  - **Video:** show a thumbnail (or a short looping preview clip) in a popup.
+  - **Document:** show the document title or a text excerpt in a tooltip.
 - **Initial framing.** Fit-to-bounds of the projection on first paint, at
   the level whose hex count best fills the viewport.
 
@@ -451,56 +419,53 @@ anyone.
 | Decision | Choice | Notes |
 |----------|--------|-------|
 | Dataset scope (v1) | **Single dataset** | No registry / `X-Dataset-Id` headers; one `DatasetContext`. |
-| Media type | **Audio, fixed** | Importer UI constrained to Audio; no media-type picker. |
+| Media type | **Any supported MediaType** | The browser works with whatever MediaType the dataset uses; hover preview adapts per type. |
 | Hex binning location | **Server-side tiles** | Pyramid + tile endpoint; viewport-bounded payload; scales to large N. |
-| Frontend packaging | **Second Angular build target** | Separate app, its own `outputPath`/`index`/`main`; served by the `victorytones` Flask app. Shares SCSS/services where practical, not the VTSearch shell. |
+| Frontend packaging | **In-app components** | Browse components live in the existing Angular app; no second build target. The Browse canvas replaces the media-list + center panel when Browse mode is active. |
 | Renderer | **Canvas 2D** | No new viz dependency; WebGL deferred. |
 | Embedding normalization | **App-wide L2 at ingest** | Normalize in every `embed`/`embed_text`; drop per-comparison normalization. See *§Prerequisite*. |
-| Canvas point = one clip | **Clip, not file** | Each point is a clip media item (`clip_start`/`clip_end` from the audio clipper); sibling clips of one source file land independently on the map. |
-| Hover audio | **Local clip only** | Hovering a point plays *that clip's* `[clip_start, clip_end]` slice, never the whole source file — even when other clips of the same file sit elsewhere on the canvas. |
-| Product scope (v1) | **Browse-only** | Pan / zoom / hover-to-listen + sibling highlight. No selection, voting, detector training, or ranking in v1; handoff to VTSearch's train-a-detector flow is a deferred follow-up. |
-| Hex color | **Density (count)** | Color = clip count per hex (log/sqrt-scaled), which the tile pyramid already aggregates for free. No detector/query needed; a second visual channel (opacity/outline) is reserved for hover + sibling highlight. |
-| Sibling highlight | **On hover** | Hovering a clip highlights the other clips of the same source file wherever they fall on the canvas. Requires a per-point source-file group id; see *§Interaction model*. |
+| Canvas point = one item | **Item (clip for audio), not file** | Each point is a media item; for audio, sibling clips of one source file land independently on the map. |
+| Hover preview | **Local item only** | Hovering a point previews *that item* only, not its parent file — even when other items from the same source sit elsewhere on the canvas. |
+| Product scope (v1) | **Browse-only** | Pan / zoom / hover-to-preview + sibling highlight. No selection, voting, detector training, or ranking in v1; handoff to VTSearch's train-a-detector flow is a deferred follow-up. |
+| Hex color | **Density (count)** | Color = item count per hex (log/sqrt-scaled), which the tile pyramid already aggregates for free. No detector/query needed; a second visual channel (opacity/outline) is reserved for hover + sibling highlight. |
+| Sibling highlight | **On hover** | Hovering an item highlights the other items from the same source file wherever they fall on the canvas. Requires a per-point source-file group id; see *§Interaction model*. |
 | UMAP seeding | **Unseeded (fast)** | No `random_state`; numba parallelism stays on. Safe only because the projection is frozen at ingest, so the fit never re-runs for a given dataset. |
 | Projection lifetime | **Frozen at ingest, persisted** | UMAP + pyramid computed once and stored with the dataset artifact (carve-out from "No Persisted Vectors/MLPs"; covers 2D coords + pyramid only). Never recomputed; legacy datasets compute-once on first open. Dissolves tile-cache invalidation. |
 
-### Notes on the second Angular build target
+### Notes on frontend integration
 
-`frontend/angular.json` currently defines a single `frontend` application
-that builds to `../static` (served by `vtsearch`). VictoryTones adds a
-**second project** (e.g. `victorytones`) with its own `browser` entry
-(`main.ts`), `index.html`, and `outputPath` (e.g. `../static-vt`, served by
-the `victorytones` Flask app), reusing the shared SCSS tokens and any
-framework-agnostic services. Two build targets means two `npm run build`
-outputs; `run-tests.sh`'s frontend build check must cover both. This is
-heavier than a single in-app route but keeps the browser free of the
-VTSearch shell (left panel, center panel, detector/dashboard UI), which it
-does not use.
+Browse components (the hex-tile canvas, hover-preview overlays, projection
+build status) are standard Angular components in `frontend/src/app/`. They
+share the existing SCSS tokens, services, and build pipeline — no second
+build target. When Browse mode is active, the Browse canvas replaces the
+media-list and center panel; the VTSearch shell (header, dataset picker,
+settings sidebar) stays visible.
 
 ## Interaction model (v1)
 
-VictoryTones v1 is **browse-only**: the only interactions are spatial
+VTSBrowse v1 is **browse-only**: the only interactions are spatial
 navigation (pan/zoom) and two hover behaviors. There is no selection, voting,
 detector, or ranking — those belong to the deferred VTSearch handoff (see
 *§Open follow-ups*).
 
-- **Hover → listen.** Hovering a point plays that clip's
-  `[clip_start, clip_end]` slice (locked above).
-- **Hover → highlight siblings.** Simultaneously, the other clips of the same
-  source file are highlighted wherever they sit. This needs each rendered
-  point to carry a **source-file group id** (derivable from the clip's origin
-  / source path — clips already record their parent), so the renderer can
+- **Hover -> preview.** Hovering a point previews that item (audio plays the
+  clip; text/image/video/document show a popup). See *§Stage 3* for the
+  per-media-type preview strategy.
+- **Hover -> highlight siblings.** Simultaneously, the other items from the
+  same source file are highlighted wherever they sit. This needs each rendered
+  point to carry a **source-file group id** (derivable from the item's origin
+  / source path — items already record their parent), so the renderer can
   light up matching points without a round-trip.
-- **Color → density.** Hex fill encodes clip count, taken straight from the
+- **Color -> density.** Hex fill encodes item count, taken straight from the
   pyramid's per-hex aggregation; hover/sibling state rides a separate channel
   (outline or opacity bump) so it reads on top of the density fill.
 
 **Binning interaction (resolve at implementation).** Sibling highlight and
 per-point hover are only literally per-point at the deepest zoom, where the
-renderer draws individual clips. At aggregated zoom levels a "point" is a
-hex of many clips, so both behaviors must degrade gracefully: hovering a hex
-should highlight the **hexes that contain** sibling clips (not invisible
-points), and the listen target becomes a representative clip of the hovered
+renderer draws individual items. At aggregated zoom levels a "point" is a
+hex of many items, so both behaviors must degrade gracefully: hovering a hex
+should highlight the **hexes that contain** sibling items (not invisible
+points), and the preview target becomes a representative item of the hovered
 hex (exact pick is part of the empirical hover policy). The tile payload
 therefore needs enough per-hex identity to answer "which hexes hold a sibling
 of this group?" — either ship source-file group ids down to the hex level, or
@@ -510,7 +475,7 @@ serve sibling lookups from a small server endpoint keyed by group id.
 
 **Empirical (deferred to experimentation, not design blockers).** These have
 no defensible a-priori value; we set them by running UMAP/the pyramid on
-real audio datasets and looking at the output. The design must leave them as
+real datasets and looking at the output. The design must leave them as
 tunable parameters, not bake in constants:
 
 - **UMAP knobs:** `n_neighbors`, `min_dist`, and the small-N fallback
@@ -519,8 +484,9 @@ tunable parameters, not bake in constants:
   (hexes per tile), and the density color scale (log vs sqrt, colormap).
 - **Performance ceiling / target N** for v1 — sets whether Canvas 2D
   culling is sufficient or WebGL is needed sooner.
-- **Hover audio policy:** debounce window, loop, hard-cut vs. crossfade,
-  volume source, autoplay-unlock gesture.
+- **Hover preview policy:** debounce window; for audio: loop, hard-cut vs.
+  crossfade, volume source, autoplay-unlock gesture; for text/image/video:
+  popup size, truncation, fade timing.
 
 **Design (resolve before scaffold).** All resolved — see *§Locked decisions*.
 For the record:
@@ -532,32 +498,16 @@ For the record:
   immutable input piles (combining them produces a new artifact, not an
   in-place rebuild).
 - **Tile-cache invalidation** — settled: a non-problem by construction (frozen
-  projection ⇒ immutable tiles); `projection_id` survives only as a stable
+  projection => immutable tiles); `projection_id` survives only as a stable
   cache-namespacing key. See *§Tile-cache invalidation*.
 
-## `vtscore` back-edges to address
+## Library-tier placement
 
-Even in-repo, the dataset-load path VictoryTones depends on
-(`datasets/load_pipeline.py`, `datasets/ingest.py`) reaches into
-`vtsearch.auth` / `vtsearch.state`. Two acceptable approaches:
-
-1. **Leave as-is for v1.** Because VictoryTones is in the same repo,
-   `vtsearch` is importable, so the lazy back-imports resolve. Cheapest;
-   defers the cleanup.
-2. **Parameterize the seams.** Where `vtscore` reaches back for user
-   context (`get_current_user`), id allocation (`next_media_id`), or the
-   active context, accept these as injected callables/params instead of
-   importing `vtsearch`. This is the same work a future published
-   `vtscore` needs, done incrementally and motivated by a real second
-   consumer.
-
-Recommendation: start with (1) to ship the browser, but treat each
-back-edge VictoryTones actually exercises as a candidate for (2) — it
-both de-risks a future extraction and removes a hidden `vtsearch`
-dependency from the load path. The UMAP + tiling code itself is new and
-should be written **Flask-free** (it belongs in `vtscore`, e.g.
-`vtscore/projection/`), so it can live under `./run-tests.sh
-vtscore-clean` from day one.
+The UMAP + tiling code is **Flask-free** and lives in `vtscore/projection/`
+(library tier), covered by `./run-tests.sh vtscore-clean`. Browse routes
+in `vtsearch/routes/` call into the library tier for projection/pyramid
+computation. This keeps the heavy compute code testable without the app
+and available to any future consumer of `vtscore`.
 
 ## What shipped
 
@@ -568,7 +518,7 @@ vtscore-clean` from day one.
     zero / non-finite norms pass through untouched; idempotent).
   - Applied at the `MediaEmbedder` base: `embed_media` and `embed_media_bulk`
     normalize fresh outputs; `embed_text` became a thin wrapper over a new
-    `_embed_text_impl` hook (every embedder subclass renamed `embed_text →
+    `_embed_text_impl` hook (every embedder subclass renamed `embed_text ->
     _embed_text_impl`) so the normalization lives in one place.
   - Applied at the stored-vector write paths so pickle/legacy loads and
     re-ingest-from-origin also hold the invariant:
@@ -591,19 +541,19 @@ vtscore-clean` from day one.
 - **Projection backend (Stages 1 + 2), Flask-free.** The browse-canvas compute
   core landed under `vtscore/projection/` (library tier — covered by
   `./run-tests.sh vtscore-clean`), with no app/HTTP wiring yet.
-  - `umap_projection.py` — `fit_projection(matrix, ids, …) → Projection`
+  - `umap_projection.py` — `fit_projection(matrix, ids, ...) -> Projection`
     (Stage 1). Plain Euclidean UMAP on the ingest-normalized matrix; **unseeded
     by default** (`random_state=None`) per the locked decision, with an optional
     seed for reproducible/test fits. `n_neighbors` is clamped to `N-1`; below
     `min_n_for_umap` it falls back to a deterministic **PCA-2** layout, and the
-    degenerate `N ≤ 2` / scalar-embedding cases fall back to a trivial layout.
+    degenerate `N <= 2` / scalar-embedding cases fall back to a trivial layout.
     Each fit mints a `projection_id`. An optional `on_progress` callback matches
     the ingest `(status, message, current, total)` convention.
   - `hexbin.py` — the **d3-hexbin** assignment rule reimplemented vectorized in
-    NumPy (no d3 dependency): `hexbin_assign(points, radius) → (q, r)` integer
-    cell keys (`q = round(2·pi)` to keep d3's half-integer column index
+    NumPy (no d3 dependency): `hexbin_assign(points, radius) -> (q, r)` integer
+    cell keys (`q = round(2*pi)` to keep d3's half-integer column index
     integral) and `hex_center(q, r, radius)` to invert.
-  - `pyramid.py` — `build_pyramid(projection, …) → Pyramid` (Stage 2). Builds
+  - `pyramid.py` — `build_pyramid(projection, ...) -> Pyramid` (Stage 2). Builds
     `n_levels` zoom levels (each halving the hex radius), aggregating per hex:
     axial key, center, **count** (density), and a **representative media id**
     (member nearest the cell centroid, ties broken to the smaller id). Hexes are
@@ -613,18 +563,18 @@ vtscore-clean` from day one.
     parameters, not baked constants, per *§Open problems*; `max_useful_levels()`
     is an advisory `n_levels` ceiling.
   - **New dependency:** `umap-learn` (added to `[project.dependencies]` with the
-    `umap-learn → umap` deptry module-name mapping). Imported lazily so the
+    `umap-learn -> umap` deptry module-name mapping). Imported lazily so the
     package import never triggers numba's JIT until a fit runs.
   - Tests: `tests_lib/projection/` (new `projection` group/marker) —
     `test_hexbin.py`, `test_umap_projection.py`, `test_pyramid.py`.
   - **Not yet built (next phases):** persistence of the projection + pyramid
-    with the dataset artifact (the carve-out), the `victorytones/` Flask app and
-    its `/api/projection/{build,meta,tiles}` endpoints, and the Canvas 2D
-    frontend (Stage 3).
+    with the dataset artifact (the carve-out), the Browse routes in
+    `vtsearch/routes/` (`/api/projection/{build,meta,tiles}` endpoints), and
+    the Canvas 2D frontend components (Stage 3).
 
 ## Open follow-ups
 - **VTSearch detector handoff:** v1 is browse-only. The deferred feature is
-  letting a user select/vote clips on the canvas to seed VTSearch's existing
+  letting a user select/vote items on the canvas to seed VTSearch's existing
   train-a-detector flow (and, once a detector exists, optionally recolor hexes
   by detector score instead of density). Adds selection + vote UI and a
   bridge into the detector context; explicitly out of v1.
@@ -632,6 +582,5 @@ vtscore-clean` from day one.
   canvas to the nearest region (reuses `embed_text_query` + cosine). Out of
   v1 scope; the projection is the only ordering in v1.
 - **WebGL renderer** if the Canvas 2D ceiling is hit.
-- If/when independent distribution is required, open a companion plan for
-  **`vtscore` decoupling + PyPI publish** (sever the back-edges in the
-  table above) and migrate VictoryTones to depend on the package.
+- If/when independent distribution of the projection backend is required,
+  open a companion plan for **`vtscore` decoupling + PyPI publish**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,7 @@ markers = [
     "integration: end-to-end workflows, thread safety",
     "cli: CLI autodetect, load sort window, progress",
     "converters: document and media converters",
-    "projection: VictoryTones UMAP projection and hex-tile pyramid",
+    "projection: VTSBrowse UMAP projection and hex-tile pyramid",
 ]
 addopts = "-m 'not gpu and not slow'"
 

--- a/tests_lib/datasets/test_pickle_normalization.py
+++ b/tests_lib/datasets/test_pickle_normalization.py
@@ -6,7 +6,7 @@ raw (non-unit) embeddings.  The pickle loader is one of the ingest
 chokepoints that re-establishes the "every stored embedding is unit-norm"
 invariant, so a legacy pickle opens with unit vectors without re-embedding.
 
-See ``docs/design/victorytones-audio-browser.md`` §Prerequisite
+See ``docs/design/vtsbrowse.md`` §Prerequisite
 (Chokepoint placement: the pickle/import write path must be covered).
 """
 

--- a/tests_lib/detectors/test_embedding_normalization.py
+++ b/tests_lib/detectors/test_embedding_normalization.py
@@ -1,4 +1,4 @@
-"""App-wide L2-normalization-at-ingest invariant (VictoryTones prerequisite).
+"""App-wide L2-normalization-at-ingest invariant (VTSBrowse prerequisite).
 
 Every embedding that enters the system is L2-normalized exactly once, so
 downstream similarity is a plain dot product.  These tests pin the four
@@ -12,7 +12,7 @@ guarantees that make that safe, all model-free:
 * :mod:`vtscore.training.region_similarity` scores with a dot product (no
   per-comparison normalization) and still guards the zero-query case.
 
-See ``docs/design/victorytones-audio-browser.md`` §Prerequisite.
+See ``docs/design/vtsbrowse.md`` §Prerequisite.
 """
 
 from __future__ import annotations

--- a/vtscore/embedding/normalize.py
+++ b/vtscore/embedding/normalize.py
@@ -22,8 +22,8 @@ applied at each point a vector enters the system:
 
 Because the invariant holds at the store, downstream consumers (the cached
 embedding matrix, the diversity tree's k-means, MLP training, region
-similarity, and the VictoryTones UMAP projection) all consume unit vectors
-without re-normalizing.  See ``docs/design/victorytones-audio-browser.md``
+similarity, and the VTSBrowse UMAP projection) all consume unit vectors
+without re-normalizing.  See ``docs/design/vtsbrowse.md``
 §Prerequisite for the full rationale and the behaviour changes this implies
 (angular diversity clustering; MLP input scale).
 

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -1,7 +1,7 @@
-"""VictoryTones projection backend: UMAP layout + hex-tile pyramid.
+"""VTSBrowse projection backend: UMAP layout + hex-tile pyramid.
 
-The Flask-free core of the VictoryTones browse canvas (see
-``docs/design/victorytones-audio-browser.md``).  Two stages:
+The Flask-free core of the VTSBrowse browse canvas (see
+``docs/design/vtsbrowse.md``).  Two stages:
 
 - :func:`fit_projection` (Stage 1) reduces a dataset's ``(N, d)`` embedding
   matrix to a frozen ``(N, 2)`` :class:`Projection`.
@@ -11,7 +11,7 @@ The Flask-free core of the VictoryTones browse canvas (see
 
 Persistence of the projection + pyramid (the carve-out from the
 "No Persisted Vectors or MLPs" rule) and the HTTP endpoints live in the
-VictoryTones app tier, not here.
+VTSearch Browse routes, not here.
 """
 
 from __future__ import annotations

--- a/vtscore/projection/hexbin.py
+++ b/vtscore/projection/hexbin.py
@@ -1,6 +1,6 @@
 """Vectorized d3-hexbin binning over a 2-D point cloud (no d3 dependency).
 
-VictoryTones renders the UMAP projection as a field of hexagons whose color
+VTSBrowse renders the UMAP projection as a field of hexagons whose color
 encodes density.  To do that the server has to assign every projected point to
 a hex cell.  This module reimplements the `d3-hexbin
 <https://github.com/d3/d3-hexbin>`_ assignment algorithm in NumPy so a whole
@@ -12,7 +12,7 @@ spacing ``dx = r·√3`` and row spacing ``dy = 1.5·r``; odd rows are offset by
 half a column.  Anchoring in data space is what makes pure panning free in the
 renderer (membership only changes when the radius changes, i.e. across a zoom
 level), per *§Browse-canvas architecture* in
-``docs/design/victorytones-audio-browser.md``.
+``docs/design/vtsbrowse.md``.
 
 A bin is identified by an integer pair ``(q, r)`` where ``q = round(2·pi)``
 (d3's column index ``pi`` can be a half-integer after the edge correction, so we

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -1,9 +1,9 @@
-"""Stage 2 of the VictoryTones browse canvas: the hex-tile pyramid.
+"""Stage 2 of the VTSBrowse browse canvas: the hex-tile pyramid.
 
 Given a frozen :class:`~vtscore.projection.umap_projection.Projection`, build a
 multi-resolution pyramid of hexagon aggregates that the canvas streams as it
 pans and zooms.  Per *§Browse-canvas architecture* in
-``docs/design/victorytones-audio-browser.md``:
+``docs/design/vtsbrowse.md``:
 
 - **Zoom levels** ``z = 0 … n_levels-1``.  Level 0 is coarsest (the whole
   projection in a handful of big hexes); each deeper level *halves the hex
@@ -19,7 +19,7 @@ pans and zooms.  Per *§Browse-canvas architecture* in
   tile is immutable for the life of the dataset and trivially cacheable.
 
 This module is pure NumPy (Flask-free) and does no I/O; persistence and the
-HTTP tile endpoint live in the VictoryTones app tier.
+HTTP tile endpoint live in the VTSearch Browse routes.
 """
 
 from __future__ import annotations

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -1,9 +1,9 @@
-"""Stage 1 of the VictoryTones browse canvas: project the embedding matrix to 2-D.
+"""Stage 1 of the VTSBrowse browse canvas: project the embedding matrix to 2-D.
 
 Runs UMAP on the cached ``(N, d)`` embedding matrix
 (:func:`vtscore.embedding.matrix.get_embedding_matrix`) to produce an
 ``(N, 2)`` layout.  Because embeddings are L2-normalized at ingest (see
-*§Prerequisite* in ``docs/design/victorytones-audio-browser.md``), Euclidean
+*§Prerequisite* in ``docs/design/vtsbrowse.md``), Euclidean
 distance on the unit sphere is monotonic in cosine distance, so UMAP uses the
 plain ``"euclidean"`` metric with no per-fit normalization.
 


### PR DESCRIPTION
## Summary

- Renames "VictoryTones" to "VTSBrowse" across all code, tests, config, and documentation
- Widens the design from audio-only to any MediaType — hover previews adapt per type (audio plays a clip, text/image/video/document show popups)
- Changes the architecture from a "second app tier" (separate Flask app + Angular build target) to a **module within VTSearch** — Browse routes in the existing Flask app, Browse components in the existing Angular app, alongside Find and Train

### Files changed

- `docs/design/victorytones-audio-browser.md` → `docs/design/vtsbrowse.md` (renamed + rewritten)
- `vtscore/projection/__init__.py`, `hexbin.py`, `pyramid.py`, `umap_projection.py` — docstring updates
- `vtscore/embedding/normalize.py` — docstring updates
- `tests_lib/detectors/test_embedding_normalization.py`, `tests_lib/datasets/test_pickle_normalization.py` — docstring updates
- `CLAUDE.md` — test group description updated
- `pyproject.toml` — pytest marker description updated

## Test plan

- [x] `./run-tests.sh core` — 682 passed
- [x] `./run-tests.sh projection` — 26 passed
- [x] Verified no remaining references to "VictoryTones" (except the historical name-change note in the design doc)

https://claude.ai/code/session_01HRZpVicKEpEsdMu1ZMwYPD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRZpVicKEpEsdMu1ZMwYPD)_