### PR TITLE
Add VTSBrowse projection routes (build, meta, tiles)

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,6 +94,7 @@ from vtsearch.routes import (  # noqa: E402
     main_bp,
     processors_crud_bp,
     processors_scoring_bp,
+    projection_bp,
     sessions_bp,
     settings_bp,
     settings_io_bp,
@@ -521,6 +522,7 @@ api.register_blueprint(detectors_registry_bp)
 api.register_blueprint(detector_scoring_bp)
 api.register_blueprint(detector_find_bp)
 api.register_blueprint(embed_bp)
+api.register_blueprint(projection_bp)
 app.register_blueprint(events_bp)
 
 

--- a/docs/design/vtsbrowse.md
+++ b/docs/design/vtsbrowse.md
@@ -1,14 +1,15 @@
 # Design: VTSBrowse — a UMAP hexbin Dataset Browser in VTSearch
 
 > **Status:** Prerequisite shipped (app-wide L2 normalization at ingest),
-> **Flask-free projection backend** (`vtscore/projection/`: UMAP fit +
-> hex-tile pyramid), **and the Angular browse canvas** (Canvas 2D renderer,
-> pan/zoom, hover preview, tile caching, `/browse/:datasetId` route). The
-> Browse routes (`/api/projection/{build,meta,tiles}`) and projection
-> persistence are not yet built. This doc scopes VTSBrowse as a **module
-> within VTSearch** — new routes, services, and Angular components that add a
-> Browse mode alongside the existing Find and Train modes. See *§What
-> shipped* and *§Open follow-ups* at the bottom for where things stand.
+> **Flask-free projection backend** shipped (`vtscore/projection/`: UMAP fit +
+> hex-tile pyramid), **Browse routes** shipped
+> (`vtsearch/routes/projection.py`: build, meta, tiles endpoints), **and the
+> Angular browse canvas** shipped (Canvas 2D renderer, pan/zoom, hover
+> preview, tile caching, `/browse/:datasetId` route). Projection persistence
+> is not yet built. This doc scopes VTSBrowse as a **module within
+> VTSearch** — new routes, services, and Angular components that add a Browse
+> mode alongside the existing Find and Train modes. See *§What shipped* and
+> *§Open follow-ups* at the bottom for where things stand.
 >
 > **Direction change (this revision):** the original sketch was a
 > *hover-to-hear grid* that reused VTSearch's left-panel media-list. The
@@ -570,12 +571,33 @@ and available to any future consumer of `vtscore`.
   - Tests: `tests_lib/projection/` (new `projection` group/marker) —
     `test_hexbin.py`, `test_umap_projection.py`, `test_pyramid.py`.
   - **Not yet built (next phases):** persistence of the projection + pyramid
-    with the dataset artifact (the carve-out), the Browse routes in
-    `vtsearch/routes/` (`/api/projection/{build,meta,tiles}` endpoints).
+    with the dataset artifact (the carve-out).
+
+- **Browse routes (HTTP layer).** The three projection endpoints landed under
+  `vtsearch/routes/projection.py` with a `projection_bp` Blueprint:
+  - `POST /api/projection/build` — kicks off a background UMAP + pyramid build
+    via the `projection_jobs` :class:`JobManager` singleton. Returns immediately
+    with a `job_id`; if a projection is already cached on the `DatasetContext`,
+    returns `"ready"` without rebuilding. Signature-keyed caching means
+    unchanged datasets short-circuit.
+  - `GET /api/projection/meta` — returns projection/pyramid metadata (bounds,
+    zoom levels, hex sizing, point count, `projection_id`, dataset `media_type`,
+    projection `method`) when ready; build progress (job_id, current, total,
+    message) when building; `"idle"` when no build has been requested.
+  - `GET /api/projection/tiles/<level>/<tx>/<ty>` — serves a tile's hex cells
+    as JSON (delegates to `Pyramid.get_tile` + `Tile.to_payload`). Empty tiles
+    return `{"cells": []}`. Route uses `signed=True` on `tx`/`ty` converters
+    since tile indices can be negative.
+  - Schemas live in `vtsearch/schemas/projection.py`.
+  - `DatasetContext` gained `_projection` and `_pyramid` cache slots (in-memory
+    only; reset per test by `conftest.reset_state`).
+  - `projection_jobs` added to `JOB_MANAGERS` so it participates in
+    `/api/jobs/active` introspection and `reset_all_async_jobs_for_tests()`.
+  - Tests: `tests/api/test_projection.py` (7 tests covering meta, build, tiles).
 
 - **Browse canvas frontend (Stage 3).** Angular components for the Canvas 2D
   hex-tile renderer, coded against the `Tile.to_payload()` / `Pyramid.meta()`
-  contracts from the projection backend. Backend routes are not yet wired.
+  contracts from the projection backend.
   - `BrowseCanvasComponent` — Canvas 2D renderer with:
     - Affine projection-space ↔ screen-space transform (pan = translate,
       zoom = scale about cursor).
@@ -592,7 +614,7 @@ and available to any future consumer of `vtscore`.
   - `BrowseViewComponent` — routed view with status states (loading,
     building, ready, empty, error), projection build trigger, dataset
     info overlay.
-  - `ProjectionApiService` — API calls for the future
+  - `ProjectionApiService` — API calls for
     `/api/projection/{build,meta,tiles}` endpoints.
   - `TileCacheService` — LRU tile cache (512 entries) with in-flight
     request dedup, shareReplay, and neighbor/level prefetching.
@@ -604,14 +626,14 @@ and available to any future consumer of `vtscore`.
   - `ContextSwitchService` updated to navigate within `/browse` when the
     dataset pulldown changes on the browse route.
   - **Not yet wired:** sibling highlighting (needs source-file group ids
-    in the tile payload or a server-side lookup endpoint), and the
-    backend routes themselves.
+    in the tile payload or a server-side lookup endpoint).
 
 ## Open follow-ups
-- **Browse routes + projection persistence:** the Flask routes
-  (`/api/projection/{build,meta,tiles}`) and persistence of the projection +
-  pyramid with the dataset artifact are the remaining backend work before the
-  browse canvas is functional end-to-end.
+- **Projection persistence:** persistence of the projection + pyramid with
+  the dataset artifact (the carve-out from "No Persisted Vectors/MLPs") is
+  the remaining backend work. Currently the projection is recomputed on each
+  app restart; persisting it with the dataset pickle makes the "compute once,
+  never again" guarantee real.
 - **Sibling highlighting:** hovering a hex should highlight hexes containing
   items from the same source file. Requires either source-file group ids in
   the tile payload or a server-side lookup endpoint keyed by group id. The

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11796,7 +11796,6 @@
           "name": "tx",
           "required": true,
           "schema": {
-            "minimum": 0,
             "type": "integer"
           }
         },
@@ -11805,7 +11804,6 @@
           "name": "ty",
           "required": true,
           "schema": {
-            "minimum": 0,
             "type": "integer"
           }
         }

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2635,6 +2635,38 @@
         ],
         "type": "object"
       },
+      "HexCell": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "cx": {
+            "type": "number"
+          },
+          "cy": {
+            "type": "number"
+          },
+          "q": {
+            "type": "integer"
+          },
+          "r": {
+            "type": "integer"
+          },
+          "rep_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "count",
+          "cx",
+          "cy",
+          "q",
+          "r",
+          "rep_id"
+        ],
+        "type": "object"
+      },
       "ImporterFieldOptionsRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3071,6 +3103,26 @@
         ],
         "type": "object"
       },
+      "LevelMeta": {
+        "additionalProperties": false,
+        "properties": {
+          "level": {
+            "type": "integer"
+          },
+          "n_cells": {
+            "type": "integer"
+          },
+          "radius": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "level",
+          "n_cells",
+          "radius"
+        ],
+        "type": "object"
+      },
       "LocalizeRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3439,6 +3491,112 @@
         },
         "required": [
           "processors"
+        ],
+        "type": "object"
+      },
+      "ProjectionBuildResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "job_id": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "projection_id": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProjectionMeta": {
+        "additionalProperties": false,
+        "properties": {
+          "base_radius": {
+            "default": null,
+            "nullable": true,
+            "type": "number"
+          },
+          "bounds": {
+            "default": null,
+            "items": {
+              "type": "number"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "current": {
+            "default": null,
+            "nullable": true,
+            "type": "integer"
+          },
+          "error": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "job_id": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "levels": {
+            "default": null,
+            "items": {
+              "$ref": "#/components/schemas/LevelMeta"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "media_type": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "method": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "point_count": {
+            "default": null,
+            "nullable": true,
+            "type": "integer"
+          },
+          "projection_id": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "idle | building | ready | error",
+            "type": "string"
+          },
+          "tile_span": {
+            "default": null,
+            "nullable": true,
+            "type": "number"
+          },
+          "total": {
+            "default": null,
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status"
         ],
         "type": "object"
       },
@@ -4060,6 +4218,33 @@
         },
         "required": [
           "suggestions"
+        ],
+        "type": "object"
+      },
+      "TileResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "cells": {
+            "items": {
+              "$ref": "#/components/schemas/HexCell"
+            },
+            "type": "array"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "tx": {
+            "type": "integer"
+          },
+          "ty": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cells",
+          "level",
+          "tx",
+          "ty"
         ],
         "type": "object"
       },
@@ -11516,6 +11701,116 @@
         ]
       }
     },
+    "/api/projection/build": {
+      "post": {
+        "description": "Returns immediately with a ``job_id`` for polling via\n``GET /api/projection/meta``.  If a projection is already cached on\nthe context, returns it without rebuilding.",
+        "operationId": "build_projection",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionBuildResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "409": {
+            "description": "Dataset is empty or has no embeddings."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Kick off a background UMAP + pyramid build for the active dataset.",
+        "tags": [
+          "projection"
+        ]
+      }
+    },
+    "/api/projection/meta": {
+      "get": {
+        "description": "When the projection is ready, includes bounds, zoom levels, hex sizing,\npoint count, and the dataset's media type (so the client knows which\nhover-preview behavior to use).",
+        "operationId": "projection_meta",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionMeta"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return projection/pyramid metadata and build status.",
+        "tags": [
+          "projection"
+        ]
+      }
+    },
+    "/api/projection/tiles/{level}/{tx}/{ty}": {
+      "get": {
+        "description": "Because the projection is frozen at ingest, tiles are immutable for the\nlife of the dataset and can be cached aggressively by the client.",
+        "operationId": "get_tile",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TileResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Tile not found or projection not ready."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return the hex cells for one tile at ``(level, tx, ty)``.",
+        "tags": [
+          "projection"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "level",
+          "required": true,
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "in": "path",
+          "name": "tx",
+          "required": true,
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "in": "path",
+          "name": "ty",
+          "required": true,
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        }
+      ]
+    },
     "/api/safe-thresholds": {
       "get": {
         "operationId": "get_safe_thresholds_route",
@@ -12633,6 +12928,10 @@
     {
       "description": "On-demand embedding of a media file (multipart) or text snippet (JSON). The dispatch route is dual-mode and not described in the spec; see the module docstring.",
       "name": "embed"
+    },
+    {
+      "description": "VTSBrowse projection: UMAP layout + hex-tile pyramid.",
+      "name": "projection"
     }
   ]
 }

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -1,0 +1,161 @@
+"""Tests for the VTSBrowse projection routes.
+
+``POST /api/projection/build``, ``GET /api/projection/meta``, and
+``GET /api/projection/tiles/<level>/<tx>/<ty>``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import app as app_module  # noqa: F401
+from vtscore.concurrency.async_jobs import projection_jobs
+from vtscore.projection import Projection, build_pyramid, max_useful_levels
+from vtscore.state.core import get_active_context
+
+
+def _wait_projection(timeout: float = 30.0) -> None:
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        job = projection_jobs.current()
+        if job is None:
+            return
+        if job.status in ("running", "pending"):
+            job.done_event.wait(timeout=0.05)
+            continue
+        time.sleep(0.01)
+        follow = projection_jobs.current()
+        if follow is None or follow.job_id == job.job_id:
+            return
+    raise TimeoutError(f"projection job did not finish within {timeout}s")
+
+
+class TestProjectionMeta:
+    """``GET /api/projection/meta`` status reporting."""
+
+    def test_idle_when_no_projection(self, client):
+        resp = client.get("/api/projection/meta")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "idle"
+
+    def test_ready_after_cache_populated(self, client):
+        ctx = get_active_context()
+        rng = np.random.default_rng(42)
+        ids = list(ctx.medias.keys())[:5]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("test-proj-id", ids, coords, "pca")
+        pyr = build_pyramid(proj, n_levels=2)
+        ctx._projection = proj
+        ctx._pyramid = pyr
+
+        resp = client.get("/api/projection/meta")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "ready"
+        assert body["projection_id"] == "test-proj-id"
+        assert body["point_count"] == len(ids)
+        assert len(body["levels"]) == 2
+        assert body["method"] == "pca"
+        assert isinstance(body["media_type"], str)
+
+
+class TestProjectionBuild:
+    """``POST /api/projection/build`` background job lifecycle."""
+
+    def test_empty_dataset_returns_409(self, client):
+        ctx = get_active_context()
+        saved = dict(ctx.medias)
+        ctx.medias.clear()
+        try:
+            resp = client.post("/api/projection/build")
+            assert resp.status_code == 409
+        finally:
+            ctx.medias.update(saved)
+
+    def test_build_and_poll(self, client):
+        resp = client.post("/api/projection/build")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] in ("building", "ready")
+
+        _wait_projection()
+
+        meta_resp = client.get("/api/projection/meta")
+        assert meta_resp.status_code == 200
+        meta = meta_resp.get_json()
+        assert meta["status"] == "ready"
+        assert "projection_id" in meta
+        assert meta["point_count"] > 0
+        assert len(meta["levels"]) >= 1
+
+    def test_cached_projection_skips_rebuild(self, client):
+        ctx = get_active_context()
+        rng = np.random.default_rng(99)
+        ids = list(ctx.medias.keys())[:3]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("cached-id", ids, coords, "trivial")
+        pyr = build_pyramid(proj, n_levels=1)
+        ctx._projection = proj
+        ctx._pyramid = pyr
+
+        resp = client.post("/api/projection/build")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "ready"
+        assert body["projection_id"] == "cached-id"
+
+
+class TestProjectionTiles:
+    """``GET /api/projection/tiles/<level>/<tx>/<ty>``."""
+
+    def test_404_when_not_built(self, client):
+        resp = client.get("/api/projection/tiles/0/0/0")
+        assert resp.status_code == 404
+
+    def test_empty_tile_returns_empty_cells(self, client):
+        ctx = get_active_context()
+        rng = np.random.default_rng(7)
+        ids = list(ctx.medias.keys())[:4]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("tile-test", ids, coords, "pca")
+        pyr = build_pyramid(proj, n_levels=2)
+        ctx._projection = proj
+        ctx._pyramid = pyr
+
+        resp = client.get("/api/projection/tiles/0/999/999")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["cells"] == []
+
+    def test_populated_tile(self, client):
+        ctx = get_active_context()
+        rng = np.random.default_rng(7)
+        ids = list(ctx.medias.keys())[:4]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("tile-test-2", ids, coords, "pca")
+        pyr = build_pyramid(proj, n_levels=2)
+        ctx._projection = proj
+        ctx._pyramid = pyr
+
+        found_cells = False
+        for (level, tx, ty), tile in pyr.tiles.items():
+            resp = client.get(f"/api/projection/tiles/{level}/{tx}/{ty}")
+            assert resp.status_code == 200
+            body = resp.get_json()
+            assert body["level"] == level
+            assert body["tx"] == tx
+            assert body["ty"] == ty
+            if body["cells"]:
+                found_cells = True
+                cell = body["cells"][0]
+                assert "q" in cell
+                assert "r" in cell
+                assert "cx" in cell
+                assert "cy" in cell
+                assert "count" in cell
+                assert "rep_id" in cell
+            break
+
+        assert found_cells, "Expected at least one tile with cells"

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import app as app_module  # noqa: F401
 from vtscore.concurrency.async_jobs import projection_jobs
-from vtscore.projection import Projection, build_pyramid, max_useful_levels
+from vtscore.projection import Projection, build_pyramid
 from vtscore.state.core import get_active_context
 
 

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -87,7 +87,7 @@ class TestProjectionBuild:
         finally:
             ctx.medias.update(saved)
 
-    @patch("vtsearch.routes.projection.fit_projection", side_effect=_fake_fit_projection)
+    @patch("vtscore.projection.umap_projection.fit_projection", side_effect=_fake_fit_projection)
     def test_build_and_poll(self, _mock_fit, client):
         resp = client.post("/api/projection/build")
         assert resp.status_code == 200

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -154,7 +154,7 @@ class TestProjectionTiles:
         ctx._pyramid = pyr
 
         found_cells = False
-        for (level, tx, ty) in pyr.tiles:
+        for level, tx, ty in pyr.tiles:
             resp = client.get(f"/api/projection/tiles/{level}/{tx}/{ty}")
             assert resp.status_code == 200
             body = resp.get_json()

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 
 import app as app_module  # noqa: F401
@@ -30,6 +32,17 @@ def _wait_projection(timeout: float = 30.0) -> None:
         if follow is None or follow.job_id == job.job_id:
             return
     raise TimeoutError(f"projection job did not finish within {timeout}s")
+
+
+def _fake_fit_projection(matrix, ids, **kwargs):
+    """PCA-like fast fake to avoid numba JIT from UMAP."""
+    from vtscore.projection.umap_projection import Projection
+
+    rng = np.random.default_rng(0)
+    coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+    import uuid
+
+    return Projection(uuid.uuid4().hex, list(ids), coords, "fake")
 
 
 class TestProjectionMeta:
@@ -74,7 +87,8 @@ class TestProjectionBuild:
         finally:
             ctx.medias.update(saved)
 
-    def test_build_and_poll(self, client):
+    @patch("vtsearch.routes.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_build_and_poll(self, _mock_fit, client):
         resp = client.post("/api/projection/build")
         assert resp.status_code == 200
         body = resp.get_json()
@@ -140,7 +154,7 @@ class TestProjectionTiles:
         ctx._pyramid = pyr
 
         found_cells = False
-        for (level, tx, ty), tile in pyr.tiles.items():
+        for (level, tx, ty) in pyr.tiles:
             resp = client.get(f"/api/projection/tiles/{level}/{tx}/{ty}")
             assert resp.status_code == 200
             body = resp.get_json()

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -337,6 +337,9 @@ learned_sort_jobs = JobManager("learned-sort")
 #: Background runner for ``/api/eval/train-and-score``.
 eval_jobs = JobManager("eval-train-score")
 
+#: Background runner for ``/api/projection/build`` (VTSBrowse UMAP + pyramid).
+projection_jobs = JobManager("projection")
+
 #: Logical name → :class:`JobManager` lookup used by ``/api/jobs/active`` to
 #: enumerate which (dataset_id, detector_id) pairs currently have background
 #: work in flight. The string keys are the public job-type names exposed in
@@ -345,6 +348,7 @@ eval_jobs = JobManager("eval-train-score")
 JOB_MANAGERS: dict[str, JobManager] = {
     "learned-sort": learned_sort_jobs,
     "eval": eval_jobs,
+    "projection": projection_jobs,
 }
 
 

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -278,6 +278,9 @@ class DatasetContext:
         # we don't rebuild a 10k-row matrix per call.
         "_emb_matrix_ids",
         "_emb_matrix",
+        # VTSBrowse: cached projection + pyramid (frozen at ingest).
+        "_projection",
+        "_pyramid",
     )
 
     def __init__(self, dataset_id: str = "") -> None:
@@ -287,6 +290,8 @@ class DatasetContext:
         self.dataset_display_name: str | None = None
         self._emb_matrix_ids: list[int] | None = None
         self._emb_matrix: Any = None  # np.ndarray | None
+        self._projection: Any = None  # Projection | None
+        self._pyramid: Any = None  # Pyramid | None
 
 
 class DetectorContext:

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -26,6 +26,7 @@ from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.media import embed_bp, media_server_bp, medias_bp
 from vtsearch.routes.processors import processors_crud_bp, processors_scoring_bp
+from vtsearch.routes.projection import projection_bp
 from vtsearch.routes.sessions import sessions_bp
 from vtsearch.routes.settings import settings_bp, settings_io_bp, sync_sources_bp
 from vtsearch.routes.sorting import sorting_bp
@@ -57,6 +58,7 @@ __all__ = [
     "media_server_bp",
     "medias_bp",
     "processors_crud_bp",
+    "projection_bp",
     "processors_scoring_bp",
     "sessions_bp",
     "settings_bp",

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -1,0 +1,169 @@
+"""VTSBrowse projection routes: build, meta, and tile endpoints.
+
+Kick off a background UMAP + hex-tile pyramid build for the active dataset,
+query its status/metadata, and stream tiles to the browse canvas.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask_smorest import Blueprint, abort
+
+from vtsearch.schemas.projection import (
+    ProjectionBuildResponseSchema,
+    ProjectionMetaSchema,
+    TileResponseSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+projection_bp = Blueprint(
+    "projection",
+    __name__,
+    description="VTSBrowse projection: UMAP layout + hex-tile pyramid.",
+)
+
+
+def _media_type_for(ctx) -> str:
+    """Return the media type of the first item in the dataset, or ``""``."""
+    if not ctx.medias:
+        return ""
+    first = next(iter(ctx.medias.values()))
+    return first.get("media_type", "audio")
+
+
+@projection_bp.route("/api/projection/build", methods=["POST"])
+@projection_bp.response(200, ProjectionBuildResponseSchema)
+@projection_bp.alt_response(409, description="Dataset is empty or has no embeddings.")
+def build_projection():
+    """Kick off a background UMAP + pyramid build for the active dataset.
+
+    Returns immediately with a ``job_id`` for polling via
+    ``GET /api/projection/meta``.  If a projection is already cached on
+    the context, returns it without rebuilding.
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs
+    from vtscore.embedding.matrix import get_embedding_matrix
+    from vtscore.projection import build_pyramid, fit_projection, max_useful_levels
+    from vtscore.state.core import get_active_context, thread_dataset_context
+
+    ctx = get_active_context()
+
+    if ctx._pyramid is not None:
+        return {
+            "status": "ready",
+            "projection_id": ctx._pyramid.projection_id,
+        }
+
+    if not ctx.medias:
+        abort(409, message="Dataset is empty — nothing to project.")
+
+    try:
+        sorted_ids, matrix = get_embedding_matrix(ctx)
+    except ValueError as exc:
+        abort(409, message=str(exc))
+
+    if matrix.size == 0:
+        abort(409, message="Dataset has no embeddings — nothing to project.")
+
+    sig = (ctx.dataset_id, tuple(sorted_ids))
+    cached = projection_jobs.cached_for(sig)
+    if cached is not None and cached.result is not None:
+        proj, pyr = cached.result
+        ctx._projection = proj
+        ctx._pyramid = pyr
+        return {"status": "ready", "projection_id": pyr.projection_id}
+
+    mat_copy = matrix.copy()
+    ids_copy = list(sorted_ids)
+
+    def _run(job):
+        with thread_dataset_context(ctx):
+            n_levels = max_useful_levels(len(ids_copy))
+
+            def _on_progress(status, message, current, total):
+                job.update_progress(current, total, message)
+
+            proj = fit_projection(
+                mat_copy,
+                ids_copy,
+                on_progress=_on_progress,
+            )
+            job.update_progress(0, 1, "building pyramid")
+            pyr = build_pyramid(proj, n_levels=n_levels)
+            job.update_progress(1, 1, "done")
+
+            ctx._projection = proj
+            ctx._pyramid = pyr
+            job.result = (proj, pyr)
+
+    job = projection_jobs.start(
+        sig,
+        _run,
+        dataset_id=ctx.dataset_id,
+    )
+    return {"status": "building", "job_id": job.job_id}
+
+
+@projection_bp.route("/api/projection/meta", methods=["GET"])
+@projection_bp.response(200, ProjectionMetaSchema)
+def projection_meta():
+    """Return projection/pyramid metadata and build status.
+
+    When the projection is ready, includes bounds, zoom levels, hex sizing,
+    point count, and the dataset's media type (so the client knows which
+    hover-preview behavior to use).
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs
+    from vtscore.state.core import get_active_context
+
+    ctx = get_active_context()
+
+    if ctx._pyramid is not None:
+        meta = ctx._pyramid.meta()
+        meta["status"] = "ready"
+        meta["media_type"] = _media_type_for(ctx)
+        meta["method"] = ctx._projection.method if ctx._projection else None
+        return meta
+
+    job = projection_jobs.current()
+    if job is not None and job.dataset_id == ctx.dataset_id:
+        if job.status in ("running", "pending"):
+            return {
+                "status": "building",
+                "job_id": job.job_id,
+                "current": job.current,
+                "total": job.total,
+                "message": job.message,
+            }
+        if job.status == "error":
+            return {"status": "error", "error": job.error or "projection build failed"}
+
+    return {"status": "idle"}
+
+
+@projection_bp.route("/api/projection/tiles/<int:level>/<int:tx>/<int:ty>", methods=["GET"])
+@projection_bp.response(200, TileResponseSchema)
+@projection_bp.alt_response(404, description="Tile not found or projection not ready.")
+def get_tile(level: int, tx: int, ty: int):
+    """Return the hex cells for one tile at ``(level, tx, ty)``.
+
+    Because the projection is frozen at ingest, tiles are immutable for the
+    life of the dataset and can be cached aggressively by the client.
+    """
+    from vtscore.state.core import get_active_context
+
+    ctx = get_active_context()
+    pyr = ctx._pyramid
+    if pyr is None:
+        abort(404, message="Projection not built yet — call POST /api/projection/build first.")
+
+    tile = pyr.get_tile(level, tx, ty)
+    if tile is None:
+        return {"level": level, "tx": tx, "ty": ty, "cells": []}
+
+    return tile.to_payload()
+
+
+__all__ = ["projection_bp"]

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -143,7 +143,7 @@ def projection_meta():
     return {"status": "idle"}
 
 
-@projection_bp.route("/api/projection/tiles/<int:level>/<int:tx>/<int:ty>", methods=["GET"])
+@projection_bp.route("/api/projection/tiles/<int:level>/<int(signed=True):tx>/<int(signed=True):ty>", methods=["GET"])
 @projection_bp.response(200, TileResponseSchema)
 @projection_bp.alt_response(404, description="Tile not found or projection not ready.")
 def get_tile(level: int, tx: int, ty: int):

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -1,0 +1,66 @@
+"""Schemas for the VTSBrowse projection endpoints."""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+
+class LevelMetaSchema(Schema):
+    level = fields.Integer(required=True)
+    radius = fields.Float(required=True)
+    n_cells = fields.Integer(required=True)
+
+
+class ProjectionMetaSchema(Schema):
+    """Response for ``GET /api/projection/meta``."""
+
+    status = fields.String(required=True, metadata={"description": "idle | building | ready | error"})
+    projection_id = fields.String(load_default=None)
+    bounds = fields.List(fields.Float(), load_default=None)
+    base_radius = fields.Float(load_default=None)
+    tile_span = fields.Float(load_default=None)
+    point_count = fields.Integer(load_default=None)
+    levels = fields.List(fields.Nested(LevelMetaSchema), load_default=None)
+    media_type = fields.String(load_default=None)
+    method = fields.String(load_default=None)
+    # Build progress (when status == "building")
+    job_id = fields.String(load_default=None)
+    current = fields.Integer(load_default=None)
+    total = fields.Integer(load_default=None)
+    message = fields.String(load_default=None)
+    error = fields.String(load_default=None)
+
+
+class ProjectionBuildResponseSchema(Schema):
+    """Response for ``POST /api/projection/build``."""
+
+    status = fields.String(required=True)
+    job_id = fields.String(load_default=None)
+    projection_id = fields.String(load_default=None)
+
+
+class HexCellSchema(Schema):
+    q = fields.Integer(required=True)
+    r = fields.Integer(required=True)
+    cx = fields.Float(required=True)
+    cy = fields.Float(required=True)
+    count = fields.Integer(required=True)
+    rep_id = fields.Integer(required=True)
+
+
+class TileResponseSchema(Schema):
+    """Response for ``GET /api/projection/tiles/<level>/<tx>/<ty>``."""
+
+    level = fields.Integer(required=True)
+    tx = fields.Integer(required=True)
+    ty = fields.Integer(required=True)
+    cells = fields.List(fields.Nested(HexCellSchema), required=True)
+
+
+__all__ = [
+    "HexCellSchema",
+    "LevelMetaSchema",
+    "ProjectionBuildResponseSchema",
+    "ProjectionMetaSchema",
+    "TileResponseSchema",
+]


### PR DESCRIPTION
## Summary

- Adds the HTTP layer for VTSBrowse's UMAP projection + hex-tile pyramid, completing the backend for the browse canvas
- `POST /api/projection/build` kicks off a background UMAP + pyramid build via a new `projection_jobs` JobManager singleton
- `GET /api/projection/meta` returns projection metadata (bounds, zoom levels, hex sizing, point count, media type) and build status
- `GET /api/projection/tiles/<level>/<tx>/<ty>` serves hex tile data for the canvas to stream while panning/zooming
- `DatasetContext` gains `_projection` and `_pyramid` in-memory cache slots
- Marshmallow schemas in `vtsearch/schemas/projection.py` for OpenAPI spec generation

## Test plan

- [x] 7 new tests in `tests/api/test_projection.py` covering meta (idle, ready), build (empty dataset 409, background job lifecycle, cached skip), and tiles (404 before build, empty tile, populated tile)
- [x] `./run-tests.sh api` passes (excluding 9 pre-existing dashboard failures that require a built frontend bundle)
- [x] `./run-tests.sh core` passes (682 tests)
- [x] `./run-tests.sh projection sorting` passes (280 tests)
- [x] Linting, formatting, pyright, OpenAPI snapshot all clean

https://claude.ai/code/session_01UoV7S5oh7Lona9N7YUf7YV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoV7S5oh7Lona9N7YUf7YV)_