### PR TITLE
Add read-only Server Settings tab to the Settings window

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -154,6 +154,7 @@
             "items": {
               "type": "string"
             },
+            "readOnly": true,
             "type": "array"
           },
           "calibrate_count": {
@@ -163,6 +164,7 @@
             "type": "number"
           },
           "detectors_dir": {
+            "readOnly": true,
             "type": "string"
           },
           "disable_achievements": {
@@ -207,6 +209,16 @@
             },
             "type": "object"
           },
+          "hidden_plugins": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "readOnly": true,
+            "type": "object"
+          },
           "hide_autopilot": {
             "type": "boolean"
           },
@@ -227,9 +239,11 @@
             "type": "object"
           },
           "max_concurrent_dataset_downloads": {
+            "readOnly": true,
             "type": "integer"
           },
           "max_concurrent_dataset_embeddings": {
+            "readOnly": true,
             "type": "integer"
           },
           "panel_pct_left": {
@@ -248,6 +262,7 @@
             "type": "boolean"
           },
           "saved_datasets_dir": {
+            "readOnly": true,
             "type": "string"
           },
           "show_metadata": {
@@ -12061,7 +12076,7 @@
     },
     "/api/settings": {
       "get": {
-        "description": "Augments the persisted dict with ``effective_solo_media_type``, which is\nthe resolver's view of the per-user value plus the CLI fallback. The\nfrontend reads only this key when deciding whether to hide mediaType\npickers; the raw ``solo_media_type`` / ``solo_media_type_explicit``\npair is still exposed for the settings UI to render the current state.",
+        "description": "Augments the persisted dict with the resolver-computed read-only views\n(effective solo mediaType / embedder, effective hidden plugins) via\n:func:`_with_effective`. The frontend reads the ``effective_*`` keys\nwhen deciding whether to hide pickers; the raw ``solo_media_type`` /\n``solo_media_type_explicit`` pair is still exposed for the settings UI\nto render the current state.",
         "operationId": "get_settings",
         "responses": {
           "200": {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -36,6 +36,14 @@
           <vt-icon type="upload" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'imports'"></vt-icon>
           Data Imports
         </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'server'"
+          (click)="activeSettingsTab = 'server'"
+          title="Settings fixed when the server started; shared by everyone and read-only here">
+          <vt-icon type="server" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'server'"></vt-icon>
+          Server
+        </button>
       </nav>
 
       <div class="settings-panel">
@@ -223,6 +231,52 @@
             <input type="number" class="form-input" [ngModel]="settings.autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" title="Target diversity level for the exploration phase" />
           </div>
 
+        }
+
+        <!-- Server Settings (read-only) -->
+        @if (activeSettingsTab === 'server') {
+          <h3>Server Settings</h3>
+          <p class="info-text">
+            These are fixed when the server starts (via config file, environment, or CLI flags)
+            and shared by everyone. They&rsquo;re shown here for reference and can&rsquo;t be changed.
+          </p>
+
+          <div class="form-group">
+            <label class="form-label" title="Root directory where saved datasets are stored on the server">Saved datasets directory</label>
+            <div class="server-value server-value--mono">{{ settings.saved_datasets_dir || '—' }}</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="Root directory where detector configurations are stored on the server">Detectors directory</label>
+            <div class="server-value server-value--mono">{{ settings.detectors_dir || '—' }}</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="Maximum number of dataset downloads the server runs in parallel">Max concurrent dataset downloads</label>
+            <div class="server-value">{{ settings.max_concurrent_dataset_downloads ?? '—' }}</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="Maximum number of dataset embedding jobs the server runs in parallel">Max concurrent dataset embeddings</label>
+            <div class="server-value">{{ settings.max_concurrent_dataset_embeddings ?? '—' }}</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="Detectors automatically run against each dataset as it is imported">Auto-run detectors</label>
+            @if (autorunDetectorsDisplay) {
+              <div class="server-value">{{ autorunDetectorsDisplay }}</div>
+            } @else {
+              <div class="server-value server-value--empty">None</div>
+            }
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="Plugins hidden from pickers and listings for this deployment (still callable by name). Combines the persisted setting with any --hide-plugin CLI flags.">Hidden plugins</label>
+            @if (hiddenPluginsDisplay.length > 0) {
+              <ul class="server-list">
+                @for (row of hiddenPluginsDisplay; track row.family) {
+                  <li><span class="server-list__key">{{ row.family }}:</span> {{ row.names }}</li>
+                }
+              </ul>
+            } @else {
+              <div class="server-value server-value--empty">None</div>
+            }
+          </div>
         }
 
       </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -153,6 +153,51 @@
 }
 
 
+// Read-only value display for the Server Settings tab. Styled to read as
+// a static, non-editable field (muted surface, no focus affordance) so
+// it's visually distinct from the editable controls in the other tabs
+// while still sitting under a `.form-label` like every other setting.
+.server-value {
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--font-md);
+  word-break: break-word;
+
+  &--mono {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-size: var(--font-sm);
+    word-break: break-all;
+  }
+
+  &--empty {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+}
+
+// Hidden-plugins breakdown: one `family: name, name` row per plugin
+// family. Shares the muted-surface look of `.server-value` so the whole
+// Server tab reads as a single read-only group.
+.server-list {
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm) var(--space-xs) var(--space-xl);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-size: var(--font-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+
+  &__key {
+    font-weight: var(--weight-medium);
+    color: var(--text-secondary);
+  }
+}
+
 .settings-tab-icon {
   transition: transform var(--transition-slow) ease;
   transform: rotate(0deg);

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -306,6 +306,28 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     return this.settings.effective_solo_media_type || null;
   }
 
+  /** Comma-separated list of auto-run detector names for the read-only
+   *  Server tab, or ``''`` when none are configured (so the template can
+   *  fall back to a muted "None"). */
+  get autorunDetectorsDisplay(): string {
+    const list = (this.settings as Record<string, unknown>)['autorun_detectors'] as string[] | undefined;
+    return list && list.length ? list.join(', ') : '';
+  }
+
+  /** Effective hidden-plugins map flattened to ``[{family, names}]`` rows
+   *  (sorted by family, empty families dropped) for the read-only Server
+   *  tab. ``names`` is the comma-joined plugin names within the family. */
+  get hiddenPluginsDisplay(): { family: string; names: string }[] {
+    const raw = (this.settings as Record<string, unknown>)['hidden_plugins'] as
+      | Record<string, string[]>
+      | undefined;
+    if (!raw) return [];
+    return Object.keys(raw)
+      .filter((family) => (raw[family] || []).length > 0)
+      .sort()
+      .map((family) => ({ family, names: (raw[family] || []).join(', ') }));
+  }
+
   async resetDefaults(): Promise<void> {
     const ok = await this.dialog.confirmDestructive(
       'Reset all settings to factory defaults?',

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -510,3 +510,62 @@ class TestSettingsAPI:
         assert "saved_datasets_dir" not in data
         assert "detectors_dir" not in data
         assert "detectors_dir" not in data
+
+
+class TestServerSettingsReadOnly:
+    """The read-only "Server" settings tab is fed by GET /api/settings.
+
+    These assert the server-tier keys are exposed on read and ignored on
+    write so the frontend can render them as immutable reference values.
+    """
+
+    def test_get_settings_includes_server_tier(self, client):
+        data = client.get("/api/settings").get_json()
+        for key in (
+            "saved_datasets_dir",
+            "detectors_dir",
+            "max_concurrent_dataset_downloads",
+            "max_concurrent_dataset_embeddings",
+            "autorun_detectors",
+            "hidden_plugins",
+        ):
+            assert key in data, key
+
+    def test_hidden_plugins_reflects_persisted_setting(self, client):
+        from vtsearch import settings as settings_mod
+
+        settings_mod.set_cli_hidden_plugins(None)
+        try:
+            settings_mod.set_hidden_plugins({"converters": ["audio2image"]})
+            data = client.get("/api/settings").get_json()
+            assert data["hidden_plugins"] == {"converters": ["audio2image"]}
+        finally:
+            settings_mod.set_cli_hidden_plugins(None)
+
+    def test_hidden_plugins_unions_cli_flags(self, client):
+        from vtsearch import settings as settings_mod
+
+        settings_mod.set_cli_hidden_plugins(None)
+        try:
+            settings_mod.set_hidden_plugins({"converters": ["audio2image"]})
+            settings_mod.add_cli_hidden_plugin("converters", "video2image")
+            settings_mod.add_cli_hidden_plugin("embedders", "clap")
+            data = client.get("/api/settings").get_json()
+            # Effective view: persisted ∪ CLI, names sorted within each family.
+            assert data["hidden_plugins"]["converters"] == ["audio2image", "video2image"]
+            assert data["hidden_plugins"]["embedders"] == ["clap"]
+        finally:
+            settings_mod.set_cli_hidden_plugins(None)
+
+    def test_hidden_plugins_is_not_writable_via_api(self, client):
+        from vtsearch import settings as settings_mod
+
+        settings_mod.set_cli_hidden_plugins(None)
+        try:
+            res = client.put("/api/settings", json={"hidden_plugins": {"embedders": ["clap"]}})
+            # Unknown-on-write key is silently dropped (schema excludes it).
+            assert res.status_code == 200
+            assert settings_mod.get_hidden_plugins() == {}
+            assert res.get_json()["hidden_plugins"] == {}
+        finally:
+            settings_mod.set_cli_hidden_plugins(None)

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -189,21 +189,39 @@ def _apply_dir(key: str, value: str, setter) -> None:
     setter(value.strip())
 
 
+def _with_effective(data: dict) -> dict:
+    """Overlay the resolver-computed (read-only) views onto *data*.
+
+    Centralises the augmentation shared by the GET and PUT responses:
+
+    * ``effective_solo_media_type`` / ``effective_solo_embedder_per_media_type``
+      - the per-user values layered over their CLI fallbacks; the frontend
+      reads these to decide whether to hide mediaType / embedder pickers.
+    * ``hidden_plugins`` - the persisted server setting unioned with any
+      ``--hide-plugin`` CLI flags, normalised to sorted lists so the
+      "Server" settings tab can render what's actually in force.
+    """
+    data["effective_solo_media_type"] = settings.get_effective_solo_media_type()
+    data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
+    data["hidden_plugins"] = {
+        family: sorted(names) for family, names in settings.get_effective_hidden_plugins().items()
+    }
+    return data
+
+
 @settings_bp.route("/api/settings", methods=["GET"])
 @settings_bp.response(200, AppSettingsSchema)
 def get_settings():
     """Return the merged server + per-user settings dict.
 
-    Augments the persisted dict with ``effective_solo_media_type``, which is
-    the resolver's view of the per-user value plus the CLI fallback. The
-    frontend reads only this key when deciding whether to hide mediaType
-    pickers; the raw ``solo_media_type`` / ``solo_media_type_explicit``
-    pair is still exposed for the settings UI to render the current state.
+    Augments the persisted dict with the resolver-computed read-only views
+    (effective solo mediaType / embedder, effective hidden plugins) via
+    :func:`_with_effective`. The frontend reads the ``effective_*`` keys
+    when deciding whether to hide pickers; the raw ``solo_media_type`` /
+    ``solo_media_type_explicit`` pair is still exposed for the settings UI
+    to render the current state.
     """
-    data = settings.get_all()
-    data["effective_solo_media_type"] = settings.get_effective_solo_media_type()
-    data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
-    return data
+    return _with_effective(settings.get_all())
 
 
 #: Keys whose value is computed on read and silently ignored on write
@@ -289,10 +307,7 @@ def update_settings(body: dict):
     for key, value in body.items():
         _apply_one_key(key, value)
 
-    data = settings.get_all()
-    data["effective_solo_media_type"] = settings.get_effective_solo_media_type()
-    data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
-    return data
+    return _with_effective(settings.get_all())
 
 
 @settings_bp.route("/api/settings/defaults", methods=["GET"])

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -69,12 +69,21 @@ class AppSettingsSchema(Schema):
     panel_pct_left = _PerMediaTypeNumberDict()
     panel_pct_right = _PerMediaTypeNumberDict()
 
-    # Server-tier
-    saved_datasets_dir = fields.String()
-    detectors_dir = fields.String()
-    max_concurrent_dataset_downloads = fields.Integer()
-    max_concurrent_dataset_embeddings = fields.Integer()
-    autorun_detectors = fields.List(fields.String())
+    # Server-tier. These are fixed at server start (config file /
+    # environment / CLI flags) and shared across all users; the frontend
+    # surfaces them read-only in the "Server" settings tab. They are not
+    # in ``SettingsUpdateSchema``, so the API rejects attempts to change
+    # them.
+    saved_datasets_dir = fields.String(dump_only=True)
+    detectors_dir = fields.String(dump_only=True)
+    max_concurrent_dataset_downloads = fields.Integer(dump_only=True)
+    max_concurrent_dataset_embeddings = fields.Integer(dump_only=True)
+    autorun_detectors = fields.List(fields.String(), dump_only=True)
+    # Effective ``{plugin_family: [name, ...]}`` hide map (the persisted
+    # ``hidden_plugins`` server setting unioned with any ``--hide-plugin``
+    # CLI flags). Populated by the route from
+    # ``settings.get_effective_hidden_plugins()``; read-only.
+    hidden_plugins = fields.Dict(keys=fields.String(), values=fields.List(fields.String()), dump_only=True)
 
     # Per-user, ``{media_type_id: embedder_name}``; the dataset-importer
     # modal pre-selects the last embedder the user picked for each media


### PR DESCRIPTION
## What & why

Server-tier settings are fixed when the server starts (config file / environment / CLI flags) and shared across all users, so there's no UI to change them. This adds a new read-only **Server** tab to the Settings window so users can *see* those values, displayed like any other setting.

## What landed

**Frontend**
- New "Server" tab (`server` icon) in the settings modal, rendering each server-tier value as a static, read-only field under the usual `.form-label`:
  - Saved datasets directory, Detectors directory (mono path style)
  - Max concurrent dataset downloads / embeddings
  - Auto-run detectors (comma-joined, or a muted "None")
  - Hidden plugins (`family: name, name` rows, or "None")
- An intro line explaining these are fixed at server start and can't be changed here.

**Backend**
- `AppSettingsSchema`: server-tier fields marked `dump_only`, plus a new `dump_only` `hidden_plugins` dict field. (`AppSettingsSchema` is response-only, so this only documents intent in the OpenAPI doc.)
- Route: centralised the GET/PUT response augmentation into `_with_effective(...)`, which now also exposes the **effective** `hidden_plugins` map (persisted server setting unioned with any `--hide-plugin` CLI flags, names sorted). `hidden_plugins` stays absent from `SettingsUpdateSchema`, so it's read-only over the API.
- Regenerated the OpenAPI snapshot (`frontend/openapi.json`).

**Tests**
- New `TestServerSettingsReadOnly` in `tests/core/test_settings_api_routes.py`: server-tier keys present on read, `hidden_plugins` reflects persisted + CLI union, and writes to `hidden_plugins` are silently dropped.

## Testing

- `./run-tests.sh core` → all pass (includes frontend `build:prod`, ruff/codespell/deptry, OpenAPI snapshot check).
- `./run-tests.sh api io` → all pass except `test_projection.py::test_build_and_poll`, a timing-sensitive async UMAP-build test that passes in isolation and is unrelated to these changes (no projection code touched).

https://claude.ai/code/session_016FRwdPLGUp45eDotguBAFK

---
_Generated by [Claude Code](https://claude.ai/code/session_016FRwdPLGUp45eDotguBAFK)_