### PR TITLE
LabBench: age off new datasets after 1 month

### DIFF
--- a/docker/Dockerfile.labbench
+++ b/docker/Dockerfile.labbench
@@ -20,7 +20,8 @@
 #     See ``vtsearch.settings.get_effective_hidden_plugins`` for the
 #     merge semantics; the same effect is achievable at runtime with
 #     ``--hide-plugin converters:audio2image --hide-plugin importers:demo``
-#     in dev-mode invocations.
+#     in dev-mode invocations. It also sets ``dataset_max_age_days = 30``
+#     so every new dataset ages off ~1 month after creation.
 #
 # Build (from repo root):
 #   docker build -f docker/Dockerfile.labbench -t vtsearch:labbench .
@@ -106,6 +107,12 @@ RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_ver
 #   Hidden plugins remain importable by name for any backend code that
 #   names them directly; this is a UI declutter, not a security gate.
 #
+# * ``dataset_max_age_days=30`` gives every dataset created on this
+#   server a ~1-month age-off: it's stamped with an ``expires_at`` 30
+#   days out and auto-removed from the registry once that passes. This
+#   keeps the shared LabBench volume from accumulating stale datasets
+#   indefinitely. Users can change or clear it in Settings.
+#
 # Per-user tier (``data/default/user_settings.json``; the
 # ``DefaultLoginProvider`` resolves to the ``default`` user):
 #
@@ -122,6 +129,7 @@ RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_ver
 RUN mkdir -p /app/data /app/data/default && \
     printf '%s\n' \
       '{' \
+      '  "dataset_max_age_days": 30,' \
       '  "hidden_plugins": {' \
       '    "converters": ["audio2image"],' \
       '    "importers": ["demo"]' \


### PR DESCRIPTION
## What

Seeds `dataset_max_age_days = 30` into the LabBench container's server-tier `data/settings.json`, so every dataset created on a LabBench server is stamped with an `expires_at` ~1 month out and auto-removed from the registry once it passes.

## Why

The shared LabBench data volume would otherwise accumulate stale datasets indefinitely. A 1-month age-off keeps it tidy without any manual cleanup. Users can still change or clear the value from Settings.

## Notes

- The age-off mechanism already exists: `dataset_max_age_days` (int days, `None` = never) drives the `expires_at` stamp in `vtscore/datasets/load_pipeline.py` and the expiry sweep in `vtsearch/routes/datasets/registry.py`. This change only seeds a default for the LabBench image.
- Only the seeded `data/settings.json` block and the surrounding Dockerfile comments changed; no behavior change for non-LabBench deployments.
- Docker copies the seed into a fresh named volume on first creation, so existing volumes are unaffected — this applies to new deployments.

https://claude.ai/code/session_01KvyDrPom37XMyYALMUSKrN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvyDrPom37XMyYALMUSKrN)_