### PR TITLE
Add Age-Off column to Dashboard Datasets grid

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -18,6 +18,7 @@ import { TopBarStateService } from '../../services/top-bar-state.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { DashboardModalsService } from '../../services/dashboard-modals.service';
 import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
+import { SettingsStateService } from '../../services/settings-state.service';
 import { DatasetRegistryEntry, DemoDataset, DetectorRegistryEntry, ImporterInfo, LoadingTask, ProgressEvent } from '../../models/api.models';
 import { ProgressEventsService } from '../../services/progress-events.service';
 import {
@@ -102,11 +103,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
   datasetCols!: DashboardColumnsService['datasetCols'];
   detectorCols!: DashboardColumnsService['detectorCols'];
 
+  /** True when the server stamps datasets with an age-off (the
+   *  `dataset_max_age_days` setting is set). Gates the Age-Off column:
+   *  with no server age-off there is nothing to show, so the column is
+   *  dropped entirely. Mirrored from `SettingsStateService` in ngOnInit. */
+  serverSetsAgeOff = false;
+
   get visibleDatasetColumns(): DatasetColumn[] {
+    let cols = this.datasetCols.columnOrder;
     if (this.isDefaultLogin) {
-      return this.datasetCols.columnOrder.filter((c) => c !== 'created_by' && c !== 'readers');
+      cols = cols.filter((c) => c !== 'created_by' && c !== 'readers');
     }
-    return this.datasetCols.columnOrder;
+    if (!this.serverSetsAgeOff) {
+      cols = cols.filter((c) => c !== 'expires_at');
+    }
+    return cols;
   }
 
   get visibleDetectorColumns(): DetectorColumn[] {
@@ -159,6 +170,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     public modals: DashboardModalsService,
     public loadingTasksSvc: DashboardLoadingTasksService,
     private progressEvents: ProgressEventsService,
+    private settingsState: SettingsStateService,
     columnsService: DashboardColumnsService,
   ) {
     this.datasetCols = columnsService.datasetCols;
@@ -171,6 +183,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .subscribe((status) => {
         this.currentUser = status?.user || '';
         this.isDefaultLogin = status?.provider === 'default';
+      });
+    // Mirror the server's age-off setting so the Age-Off column appears
+    // only when the server actually stamps datasets with an expiry. The
+    // settings are loaded once at app startup (AppComponent); subscribing
+    // to the BehaviorSubject replays the latest value immediately.
+    this.settingsState.settings$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((settings) => {
+        this.serverSetsAgeOff = settings?.dataset_max_age_days != null;
       });
     // Auto-select newly added items whenever the dataset/model lists change
     this.datasetState.datasets$

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -98,6 +98,9 @@
       @case ('created_at') {
         <td>{{ formatDate(dataset.created_at) }}</td>
       }
+      @case ('expires_at') {
+        <td>{{ dataset.expires_at != null ? formatDate(dataset.expires_at) : 'Never' }}</td>
+      }
       @case ('created_by') {
         <td>{{ dataset.created_by || '-' }}</td>
       }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -240,6 +240,9 @@ export interface DatasetRegistryEntry {
   readers?: string[];
   /** Name of the embedder this dataset's media were vectorised with. */
   embedder?: string;
+  /** Unix timestamp (seconds) at which this dataset ages off and is
+   *  automatically removed; `null`/absent means it never expires. */
+  expires_at?: number | null;
   [key: string]: unknown;
 }
 

--- a/frontend/src/app/services/dashboard-columns.service.ts
+++ b/frontend/src/app/services/dashboard-columns.service.ts
@@ -6,6 +6,7 @@ export type DatasetColumn =
   | 'media_type'
   | 'num_items'
   | 'created_at'
+  | 'expires_at'
   | 'created_by'
   | 'readers'
   | 'loaded'
@@ -30,6 +31,7 @@ const DATASET_COLUMNS_DEFAULT: DatasetColumn[] = [
   'media_type',
   'num_items',
   'created_at',
+  'expires_at',
   'created_by',
   'readers',
   'loaded',
@@ -52,6 +54,7 @@ export const DATASET_COL_META: Record<string, ColMeta> = {
   media_type: { label: 'Type', title: 'Media type: audio, image, text, video, or document (click to sort)', sortable: true },
   num_items: { label: '# Items', title: 'Number of media items in the dataset (click to sort)', sortable: true },
   created_at: { label: 'Created', title: 'When the dataset was first imported (click to sort)', sortable: true },
+  expires_at: { label: 'Age-Off', title: 'When this dataset ages off and is automatically removed (click to sort)', sortable: true },
   created_by: { label: 'Creator', title: 'User who created this dataset (click to sort)', sortable: true },
   readers: { label: 'Readers', title: 'Users with access to this dataset (click to sort)', sortable: true },
   loaded: { label: 'Loaded?', title: 'Whether the dataset is currently loaded in memory', sortable: false },


### PR DESCRIPTION
## Summary

Surfaces each dataset's age-off (expiry) in the Dashboard Datasets table via a new **Age-Off** column, bound to the registry entry's `expires_at` timestamp.

- The column renders the formatted expiry date (same format as **Created**), and shows **"Never"** for datasets without an `expires_at` (e.g. those created before the server enabled age-offs).
- **The column only appears when the server actually stamps age-offs** — i.e. the `dataset_max_age_days` setting is set. With no server age-off there is nothing to show, so the column is dropped entirely (mirrors the existing pattern where `created_by`/`readers` are hidden in single-user mode).
- The dashboard mirrors the setting from `SettingsStateService` (already loaded at app startup by `AppComponent`), so no extra HTTP request is added.

## Changes

- `dashboard-columns.service.ts`: add `expires_at` to `DatasetColumn`, the default column order (after `created_at`), and column metadata (label "Age-Off", sortable).
- `dashboard.component.ts`: subscribe to `settings$` to track `serverSetsAgeOff`; filter `expires_at` out of `visibleDatasetColumns` unless the server sets age-offs.
- `dataset-card.component.html`: render the `expires_at` cell ("Never" when null).
- `api.models.ts`: type `expires_at?: number | null` on `DatasetRegistryEntry`.

## Testing

- `./run-tests.sh core` → ALL 686 TESTS PASSED, including the frontend `build:prod` typecheck (no errors, no budget warnings).

https://claude.ai/code/session_012sQGCXPVpDSDHo4s4U7f5N

---
_Generated by [Claude Code](https://claude.ai/code/session_012sQGCXPVpDSDHo4s4U7f5N)_