### PR TITLE
Add opt-in "build 2-D Browse projection now" checkbox to dataset importers

### DIFF
--- a/docs/design/vtsbrowse.md
+++ b/docs/design/vtsbrowse.md
@@ -9,9 +9,12 @@
 > persistence** shipped (inside the dataset container), **ZIP container
 > format** shipped (single `.pkl` file containing `medias.pkl` + `meta.json`
 > + optional `projection.npz`; all legacy raw-pickle and sidecar support
-> removed), **and dataset age-off** shipped (server setting
+> removed), **dataset age-off** shipped (server setting
 > `dataset_max_age_days`, `expires_at` timestamp on datasets, auto-removal
-> on load/list).
+> on load/list), **and opt-in projection-at-creation** shipped (a "Build
+> 2-D Browse projection now" checkbox in every dataset importer that runs
+> the UMAP + pyramid build inline as a load stage instead of lazily on
+> first Browse visit; defaults off).
 > This doc scopes VTSBrowse as a **module within
 > VTSearch** — new routes, services, and Angular components that add a Browse
 > mode alongside the existing Find and Train modes. See *§What shipped* and
@@ -671,6 +674,31 @@ and available to any future consumer of `vtscore`.
     reads via `read_container`.
   - Stage-file endpoint extracts `medias.pkl` from the ZIP for peeking.
   - Tests: `tests_lib/datasets/test_container.py`.
+
+- **Opt-in projection-at-creation.** A "Build 2-D Browse projection now"
+  checkbox in the Advanced block of every dataset importer lets the user
+  spend the UMAP + hex-tile compute up front (so Browse opens instantly)
+  instead of paying for it lazily on first Browse visit. Defaults **off**:
+  building the projection is a cost the user explicitly opts into.
+  - Frontend: the checkbox lives in the shared `vt-import-advanced`
+    component, so it appears uniformly across the generic-form,
+    server-folder, local-folder/files, and demo import flows. Its value
+    rides each flow's existing submit path (`runImporter` params,
+    `import-local-{folder,files}` multipart, `load-file` multipart,
+    `load-demo` body) as a `build_projection` `"true"`/`"false"` string.
+  - Backend: `build_projection` is a framework-level pass-through key
+    (like `clipper` / `embedder` / `dataset_name`), threaded through
+    `_run_importer_in_background` → `_run_origin_load_in_background` to a
+    new inline `_build_projection_stage`. The stage runs **after** the
+    dataset is registered, fits UMAP on the cached embedding matrix,
+    builds the hex-tile pyramid, caches both on the `DatasetContext`, and
+    persists them into the container via `_persist_projection_to_container`
+    (resolving the pkl path through the dataset registry). It is
+    **best-effort by contract**: the dataset is already saved and usable
+    before it runs, so a failure — or a cancel during the fit — leaves the
+    dataset intact and just defers the projection to the lazy Browse-time
+    build. Empty / embedding-less datasets are a silent no-op.
+  - Tests: `tests/datasets/test_load_projection_stage.py`.
 
 - **Dataset age-off.** Server setting `dataset_max_age_days` (default: None
   = never expire) stamps new datasets with an `expires_at` timestamp in

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1012,6 +1012,11 @@
       "DatasetLoadDemoRequest": {
         "additionalProperties": false,
         "properties": {
+          "build_projection": {
+            "default": "false",
+            "description": "When 'true', compute + persist the 2-D Browse projection at ingest.",
+            "type": "string"
+          },
           "clipper": {
             "default": "",
             "type": "string"
@@ -4984,6 +4989,10 @@
       "import_dataset_CombineDatasetsImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5020,6 +5029,10 @@
       "import_dataset_DemoDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5135,6 +5148,10 @@
       "import_dataset_HttpArchiveDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5179,6 +5196,10 @@
       "import_dataset_LocalFilesDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5205,6 +5226,10 @@
       "import_dataset_LocalFolderDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5234,6 +5259,10 @@
       "import_dataset_ReCallerDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5278,6 +5307,10 @@
       "import_dataset_ServerFilesDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5322,6 +5355,10 @@
       "import_dataset_ServerFolderDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true
@@ -5369,6 +5406,10 @@
       "import_dataset_SyntheticDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
           "clipper": {
             "default": null,
             "nullable": true

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -889,12 +889,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
       embedder?: string;
       clipper?: string;
       dataset_name?: string;
+      build_projection?: boolean;
     };
     const params: Record<string, string> = {};
     if (extras.embedder) params['embedder'] = extras.embedder;
     if (extras.clipper) params['clipper'] = extras.clipper;
     const userName = (extras.dataset_name || '').trim();
     if (userName) params['dataset_name'] = userName;
+    if (extras.build_projection) params['build_projection'] = 'true';
     this.datasetsCrudApi.loadDemo(demo.name, params).subscribe({
       next: (response) => {
         this.loadingTasksSvc.startProgressPolling(response.task_id);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -69,6 +69,8 @@
             [selectedClipper]="selectedDemoClipper"
             [selectedClipperParams]="{}"
             (clipperChooserRequested)="openClipperChooser('demo')"
+            [buildProjection]="buildProjection"
+            (buildProjectionChange)="buildProjection = $event"
           ></vt-import-advanced>
         </div>
       }
@@ -129,6 +131,8 @@
           [selectedClipper]="sfSelectedClipper"
           [selectedClipperParams]="sfClipperParamValues"
           (clipperChooserRequested)="openClipperChooser('sf')"
+          [buildProjection]="buildProjection"
+          (buildProjectionChange)="buildProjection = $event"
         ></vt-import-advanced>
       </div>
 
@@ -204,6 +208,8 @@
           [selectedClipper]="lfSelectedClipper"
           [selectedClipperParams]="lfClipperParamValues"
           (clipperChooserRequested)="openClipperChooser('lf')"
+          [buildProjection]="buildProjection"
+          (buildProjectionChange)="buildProjection = $event"
         ></vt-import-advanced>
       </div>
 
@@ -362,6 +368,8 @@
           [selectedClipper]="selectedClipper"
           [selectedClipperParams]="clipperParamValues"
           (clipperChooserRequested)="openClipperChooser('form')"
+          [buildProjection]="buildProjection"
+          (buildProjectionChange)="buildProjection = $event"
         ></vt-import-advanced>
       </div>
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -39,6 +39,11 @@ export class DatasetImporterModalComponent implements OnInit {
   selectedImporter: ImporterInfo | null = null;
   formValues: Record<string, any> = {};
   selectedFile: File | null = null;
+  /** "Build the 2-D Browse projection at ingest" toggle, shared across
+   *  every import flow (only one is visible at a time, so a single field
+   *  carries the choice and persists it when the user switches flows).
+   *  Defaults off per the opt-in cost tradeoff. */
+  buildProjection = false;
   submitting = false;
   error = '';
   /** Whether the user has manually edited the generic-form dataset_name
@@ -1174,6 +1179,7 @@ export class DatasetImporterModalComponent implements OnInit {
       embedder: this.selectedDemoEmbedder,
       clipper: this.selectedDemoClipper,
       dataset_name: userName,
+      build_projection: this.buildProjection,
     } as any);
     this.closed.emit();
   }
@@ -1499,6 +1505,7 @@ export class DatasetImporterModalComponent implements OnInit {
         formData.append('clipper_params', JSON.stringify(this.lfClipperParamValues));
       }
     }
+    formData.append('build_projection', this.buildProjection ? 'true' : 'false');
   }
 
   // --- Server folder browser ---
@@ -1974,6 +1981,7 @@ export class DatasetImporterModalComponent implements OnInit {
     if (this.sfSourceSpecs.length > 0) {
       params['source_specs'] = this.sfSourceSpecs;
     }
+    params['build_projection'] = this.buildProjection ? 'true' : 'false';
 
     this.datasetsCrudApi.runImporter('server_folder', params).subscribe({
       next: () => {
@@ -2016,11 +2024,12 @@ export class DatasetImporterModalComponent implements OnInit {
     if (this.formSourceSpecs.length > 0) {
       submitValues['source_specs'] = this.formSourceSpecs;
     }
+    submitValues['build_projection'] = this.buildProjection ? 'true' : 'false';
 
     // If there's a file field, use loadFile; otherwise runImporter
     const fileField = this.selectedImporter.fields?.find((f) => f.field_type === 'file');
     if (fileField && this.selectedFile) {
-      this.datasetsCrudApi.loadFile(this.selectedFile).subscribe({
+      this.datasetsCrudApi.loadFile(this.selectedFile, this.buildProjection).subscribe({
         next: () => {
           this.submitting = false;
           this.maybeOfferSaveImportDefaults('form');

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -63,3 +63,15 @@
     Details: {{ clipperDisplayName }}
   </button>
 }
+
+@if (advancedOpen) {
+  <label class="form-label projection-toggle" for="import-advanced-projection" title="Compute the 2-D Browse projection (UMAP layout + hex-tile map) while importing. Costs extra time up front but makes the Browse view open instantly. When off, the projection is built the first time you open Browse.">
+    <input
+      id="import-advanced-projection"
+      type="checkbox"
+      [ngModel]="buildProjection"
+      (ngModelChange)="onBuildProjectionChange($event)"
+    />
+    Build 2-D Browse projection now
+  </label>
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -65,7 +65,7 @@
 }
 
 @if (advancedOpen) {
-  <label class="form-label projection-toggle" for="import-advanced-projection" title="Compute the 2-D Browse projection (UMAP layout + hex-tile map) while importing. Costs extra time up front but makes the Browse view open instantly. When off, the projection is built the first time you open Browse.">
+  <label class="form-label" for="import-advanced-projection" title="Compute the 2-D Browse projection (UMAP layout + hex-tile map) while importing. Costs extra time up front but makes the Browse view open instantly. When off, the projection is built the first time you open Browse.">
     <input
       id="import-advanced-projection"
       type="checkbox"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -87,6 +87,14 @@ export class ImportAdvancedComponent {
    *  shared clipper chooser modal. */
   @Output() clipperChooserRequested = new EventEmitter<void>();
 
+  /** Two-way bound "compute the 2-D Browse projection at ingest" toggle.
+   *  Defaults off: building the UMAP layout + hex-tile pyramid up front
+   *  costs compute the user may not want to spend (Browse builds it lazily
+   *  on first visit otherwise).  Lives in the Advanced block because it is
+   *  a cost/latency tradeoff, not a routine import setting. */
+  @Input() buildProjection = false;
+  @Output() buildProjectionChange = new EventEmitter<boolean>();
+
   /** Whether the Advanced section is currently expanded.  Local state
    *  per instance; opening Advanced in one flow does not carry over
    *  to another (the user only ever sees one flow at a time). */
@@ -198,5 +206,10 @@ export class ImportAdvancedComponent {
   /** Fired by the clipper button to request the parent's chooser. */
   onClipperClick(): void {
     this.clipperChooserRequested.emit();
+  }
+
+  /** Fired by the projection checkbox on user toggle. */
+  onBuildProjectionChange(value: boolean): void {
+    this.buildProjectionChange.emit(value);
   }
 }

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -124,10 +124,12 @@ export class DatasetsCrudApiService {
     return loadDemoDatasetRoute(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));
   }
 
-  /** Multipart upload; see {@link importLocalFolder}. */
-  loadFile(file: File): Observable<DatasetLoadStartedResponse> {
+  /** Multipart upload; see {@link importLocalFolder}.  ``buildProjection``
+   *  opts into computing the 2-D Browse projection at ingest. */
+  loadFile(file: File, buildProjection = false): Observable<DatasetLoadStartedResponse> {
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('build_projection', buildProjection ? 'true' : 'false');
     return this.http.post<DatasetLoadStartedResponse>('/api/dataset/load-file', formData);
   }
 

--- a/tests/datasets/test_load_projection_stage.py
+++ b/tests/datasets/test_load_projection_stage.py
@@ -1,0 +1,142 @@
+"""Tests for the opt-in inline projection stage of the dataset-load pipeline.
+
+When a user ticks "Build 2-D Browse projection now" in any importer form,
+``_run_origin_load_in_background`` runs ``_build_projection_stage`` after the
+dataset is registered: it fits UMAP on the cached embedding matrix, builds the
+hex-tile pyramid, caches both on the context, and persists them into the
+dataset container.  The stage is best-effort — the dataset is already saved
+and usable before it runs, so a failure (or empty/embedding-less dataset)
+leaves the dataset intact and just defers the projection to the lazy
+Browse-time build.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+
+from vtscore.concurrency.progress import LoadingTasksTracker
+from vtscore.datasets.load_pipeline import (
+    _build_projection_stage,
+    _parse_bool,
+    _persist_projection_to_container,
+)
+from vtscore.projection import Projection
+from vtscore.state.core import DatasetContext
+
+
+def _make_tracker():
+    return LoadingTasksTracker().create_task("proj_task", "test")
+
+
+def _fake_fit_projection(matrix, ids, on_progress=None):
+    """Cheap stand-in for UMAP: a seeded random 2-D layout.
+
+    Calls ``on_progress`` once so the stage's progress wiring is exercised.
+    """
+    if on_progress is not None:
+        on_progress("projecting", "fitting", 1, 1)
+    rng = np.random.default_rng(42)
+    coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+    return Projection("fake-pid", list(ids), coords, "pca")
+
+
+class TestParseBool:
+    def test_true_string(self):
+        assert _parse_bool("true") is True
+        assert _parse_bool("True") is True
+        assert _parse_bool("  TRUE  ") is True
+
+    def test_false_and_none(self):
+        assert _parse_bool("false") is False
+        assert _parse_bool("0") is False
+        assert _parse_bool("") is False
+        assert _parse_bool(None) is False
+
+    def test_native_bool(self):
+        assert _parse_bool(True) is True
+        assert _parse_bool(False) is False
+
+
+class TestBuildProjectionStage:
+    def _ctx_with_embeddings(self, name: str) -> DatasetContext:
+        ctx = DatasetContext(name)
+        rng = np.random.default_rng(0)
+        for cid in (1, 2, 3, 4):
+            ctx.medias[cid] = {
+                "id": cid,
+                "media_type": "audio",
+                "embedding": rng.standard_normal(8).astype(np.float32),
+            }
+        return ctx
+
+    def test_caches_and_persists(self):
+        ctx = self._ctx_with_embeddings("proj_stage_ok")
+        with (
+            patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection),
+            patch("vtscore.datasets.load_pipeline._persist_projection_to_container") as mock_persist,
+        ):
+            _build_projection_stage(ctx, _make_tracker(), "ds-123")
+
+        assert ctx._projection is not None
+        assert ctx._projection.projection_id == "fake-pid"
+        assert ctx._pyramid is not None
+        assert ctx._pyramid.projection_id == "fake-pid"
+        mock_persist.assert_called_once()
+        # dataset_id and the freshly-built artifacts are forwarded for persistence.
+        args = mock_persist.call_args.args
+        assert args[0] == "ds-123"
+        assert args[1] is ctx._projection
+        assert args[2] is ctx._pyramid
+
+    def test_empty_dataset_is_noop(self):
+        ctx = DatasetContext("proj_stage_empty")
+        with (
+            patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection) as mock_fit,
+            patch("vtscore.datasets.load_pipeline._persist_projection_to_container") as mock_persist,
+        ):
+            _build_projection_stage(ctx, _make_tracker(), "ds-empty")
+
+        assert ctx._projection is None
+        assert ctx._pyramid is None
+        mock_fit.assert_not_called()
+        mock_persist.assert_not_called()
+
+
+class TestPersistProjectionToContainer:
+    def test_appends_to_registered_container(self, tmp_path):
+        import pickle as _pickle
+
+        from vtscore.datasets.container import read_projection, write_container
+
+        ids = [1, 2, 3]
+        rng = np.random.default_rng(7)
+        coords = rng.standard_normal((3, 2)).astype(np.float32)
+        proj = Projection("persist-pid", ids, coords, "pca")
+        from vtscore.projection import build_pyramid
+
+        pyr = build_pyramid(proj, n_levels=1)
+
+        pkl = tmp_path / "ds.pkl"
+        write_container(pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
+
+        with patch(
+            "vtscore.datasets.registry.get_dataset",
+            return_value={"pkl_path": str(pkl)},
+        ):
+            _persist_projection_to_container("ds-xyz", proj, pyr)
+
+        loaded = read_projection(str(pkl))
+        assert loaded is not None
+        loaded_proj, _loaded_pyr = loaded
+        assert loaded_proj.projection_id == "persist-pid"
+
+    def test_missing_registry_entry_is_noop(self):
+        proj = Projection("x", [1], np.zeros((1, 2), dtype=np.float32), "pca")
+        from vtscore.projection import build_pyramid
+
+        pyr = build_pyramid(proj, n_levels=1)
+        with patch("vtscore.datasets.registry.get_dataset", return_value=None):
+            # Must not raise even though there is no container to write to.
+            _persist_projection_to_container("nonexistent", proj, pyr)

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -185,6 +185,18 @@ def _origin_to_str(origin: dict | None) -> str:
     return importer_name
 
 
+def _parse_bool(value: Any) -> bool:
+    """Coerce a request-supplied flag to ``bool``.
+
+    Accepts native bools, the ``"true"``/``"false"`` strings that
+    checkbox fields serialize to (per :class:`PluginField`), and ``None``
+    (treated as ``False``).
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() == "true"
+
+
 def _normalize_media_type(value: str) -> str:
     """Normalize a media type string (folder_import_name or type_id) to a canonical type_id."""
     value = (value or "").strip()
@@ -1002,6 +1014,85 @@ def _build_diversity_tree_stage(ctx: DatasetContext, tracker) -> None:
     build_diversity_tree_for_context(ctx, on_progress=_progress)
 
 
+def _persist_projection_to_container(dataset_id: str, proj, pyr) -> None:
+    """Best-effort save of the freshly-built projection into the dataset container.
+
+    Mirrors ``vtsearch.routes.projection._persist_projection`` but resolves
+    the container path through the dataset registry from inside the load
+    pipeline.  Failures are swallowed (logged): the in-memory projection is
+    already cached on the context, and a missing on-disk copy just means the
+    next Browse open recomputes it.
+    """
+    from vtscore.datasets.registry import get_dataset  # noqa: PLC0415
+
+    entry = get_dataset(dataset_id)
+    if entry is None:
+        return
+    pkl_path = entry.get("pkl_path")
+    if not pkl_path:
+        return
+    try:
+        from vtscore.datasets.container import append_projection  # noqa: PLC0415
+
+        append_projection(pkl_path, proj, pyr)
+    except Exception:
+        traceback.print_exc()
+
+
+def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> None:
+    """Compute + persist the 2-D UMAP projection at ingest (opt-in).
+
+    Runs inline as a load stage (after the dataset is registered) so the
+    Browse canvas opens instantly instead of paying for the UMAP fit lazily
+    on first visit.  This mirrors the on-demand
+    ``POST /api/projection/build`` path: fit UMAP on the cached embedding
+    matrix, build the hex-tile pyramid, cache both on the context, and
+    persist them into the dataset container.
+
+    Best-effort by contract: the dataset is already registered and usable
+    before this runs, so any failure here (including a cancellation during
+    the fit) must leave the dataset intact and merely fall back to the lazy
+    Browse-time build.  The caller wraps this in a try/except for that
+    reason.
+    """
+    from vtscore.embedding.matrix import get_embedding_matrix  # noqa: PLC0415
+    from vtscore.projection import build_pyramid, fit_projection, max_useful_levels  # noqa: PLC0415
+
+    def _progress(current: int, total: int, message: str) -> None:
+        tracker.check_cancelled()
+        tracker.update(
+            "loading",
+            message,
+            current=current,
+            total=total,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
+
+    try:
+        sorted_ids, matrix = get_embedding_matrix(ctx)
+    except ValueError:
+        return
+    if matrix.size == 0:
+        return
+
+    _progress(0, 0, "Building 2-D projection…")
+    n_levels = max_useful_levels(len(sorted_ids))
+
+    def _on_fit_progress(status: str, message: str, current: int, total: int) -> None:
+        _progress(current, total, message or "Building 2-D projection…")
+
+    proj = fit_projection(matrix, list(sorted_ids), on_progress=_on_fit_progress)
+    _progress(0, 1, "Building hex-tile pyramid…")
+    pyr = build_pyramid(proj, n_levels=n_levels)
+    _progress(1, 1, "Projection ready")
+
+    ctx._projection = proj
+    ctx._pyramid = pyr
+
+    _persist_projection_to_container(dataset_id, proj, pyr)
+
+
 def _register_and_migrate(
     ctx: DatasetContext,
     tracker,
@@ -1129,6 +1220,7 @@ def _run_origin_load_in_background(
     embedder: str = "",
     created_by: str = "",
     media_type: str = "",
+    build_projection: bool = False,
 ) -> str:
     """Run a dataset load in a background thread with standard error handling.
 
@@ -1237,6 +1329,17 @@ def _run_origin_load_in_background(
                     context_id, registry_entry_id = _register_and_migrate(
                         ctx, tracker, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
                     )
+                    # Opt-in: compute + persist the 2-D Browse projection now,
+                    # so the Browse canvas opens instantly instead of building
+                    # UMAP lazily on first visit.  Best-effort and runs after
+                    # registration: the dataset is already saved and usable, so
+                    # a failure (or a cancel during the fit) leaves it intact
+                    # and just defers the projection to the lazy Browse path.
+                    if build_projection:
+                        try:
+                            _build_projection_stage(ctx, tracker, context_id)
+                        except Exception:
+                            traceback.print_exc()
                     # Embedder warm-up is fire-and-forget so the dashboard row goes
                     # green immediately.  Text sort waits behind its own progress
                     # bar on first use if the model isn't ready yet.
@@ -1339,6 +1442,7 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # importer stores it in the container metadata for readiness tracking).
     field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
+    build_projection = _parse_bool(field_values.pop("build_projection", None))
 
     # Extract media_type from field_values so in-progress tasks can expose it
     # to the frontend (used for guessing the type in subsequent add dialogs).
@@ -1363,6 +1467,7 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         embedder=embedder_name,
         created_by=created_by,
         media_type=media_type_hint,
+        build_projection=build_projection,
     )
 
 

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -59,6 +59,11 @@ datasets_load_bp = Blueprint(
 LOCAL_UPLOADS_DIR = DATA_DIR / "local_uploads"
 
 
+def _form_flag(raw: str | None) -> bool:
+    """Parse a multipart checkbox value (``"true"``/``"false"``) to ``bool``."""
+    return (raw or "").strip().lower() == "true"
+
+
 def _parse_clipper_params(raw: str) -> dict | None:
     if not raw:
         return None
@@ -212,6 +217,7 @@ def import_local_folder():
         embedder=field_values.get("embedder", ""),
         created_by=get_current_user(),
         media_type=_normalize_media_type(media_type),
+        build_projection=_form_flag(request.form.get("build_projection")),
     )
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
@@ -303,6 +309,7 @@ def import_local_files():
         embedder=field_values.get("embedder", ""),
         created_by=get_current_user(),
         media_type=_normalize_media_type(media_type),
+        build_projection=_form_flag(request.form.get("build_projection")),
     )
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
@@ -337,6 +344,8 @@ def load_demo_dataset_route(body: dict):
     field_values: dict = {"name": dataset_name}
     if user_dataset_name:
         field_values["dataset_name"] = user_dataset_name
+    if _form_flag(body.get("build_projection")):
+        field_values["build_projection"] = "true"
     # Inject media_type so the loading task exposes it to the frontend,
     # allowing the "guessed type" logic to consider in-progress loads.
     if converter_name:
@@ -378,7 +387,13 @@ def load_dataset_file():
     # Flask FileStorage stream is only valid during the request lifecycle.
     file_bytes = io.BytesIO(file.read())
     file_bytes.name = file.filename
-    task_id = _run_importer_in_background(importer, {"file": file_bytes})
+    task_id = _run_importer_in_background(
+        importer,
+        {
+            "file": file_bytes,
+            "build_projection": "true" if _form_flag(request.form.get("build_projection")) else "false",
+        },
+    )
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -297,7 +297,7 @@ def import_dataset(importer_name: str):
     field_values = validate_plugin_args(
         importer,
         file_mode="bytesio",
-        extra_keys=("source_specs", "clipper", "embedder", "dataset_name"),
+        extra_keys=("source_specs", "clipper", "embedder", "dataset_name", "build_projection"),
     )
 
     # ``clipper_params`` is multipart-encoded as a JSON string when the
@@ -331,7 +331,7 @@ register_plugin_typed_routes(
     path_template="/api/dataset/import/{plugin_name}",
     endpoint_prefix="import_dataset",
     delegate=import_dataset,
-    extra_keys=("source_specs", "clipper", "embedder", "dataset_name", "clipper_params"),
+    extra_keys=("source_specs", "clipper", "embedder", "dataset_name", "clipper_params", "build_projection"),
 )
 register_plugin_typed_routes(
     datasets_staging_bp,

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -344,6 +344,10 @@ class DatasetLoadDemoRequestSchema(Schema):
     clipper = fields.String(load_default="")
     converter = fields.String(load_default="")
     dataset_name = fields.String(load_default="")
+    build_projection = fields.String(
+        load_default="false",
+        metadata={"description": "When 'true', compute + persist the 2-D Browse projection at ingest."},
+    )
 
 
 class DatasetLoadFolderRequestSchema(Schema):


### PR DESCRIPTION
## Summary

Adds a **"Build 2-D Browse projection now"** checkbox to every dataset importer, letting the user decide whether to spend the UMAP + hex-tile compute at dataset creation or defer it to the first Browse visit (today's lazy behavior).

- **Defaults off** — building the projection is an opt-in cost.
- When **on**, the projection is computed **inline as a load stage** (not a follow-on background job), so the dataset isn't "done" until its projection is persisted.

## How it works

**Frontend.** The checkbox lives in the shared `vt-import-advanced` component (under "Advanced"), so it appears uniformly across all five import flows — generic form, server-folder, local-folder, local-files, and demo. Its value rides each flow's existing submit path as a `build_projection` `"true"`/`"false"` value (`runImporter` params, `import-local-{folder,files}` multipart, `load-file` multipart, `load-demo` body).

**Backend.** `build_projection` is a framework-level pass-through key (like `clipper` / `embedder` / `dataset_name`), threaded through `_run_importer_in_background` → `_run_origin_load_in_background` into a new `_build_projection_stage`. The stage runs **after** the dataset is registered: it fits UMAP on the cached embedding matrix, builds the hex-tile pyramid, caches both on the `DatasetContext`, and persists them into the dataset container via `_persist_projection_to_container` (reusing the exact artifacts the lazy `POST /api/projection/build` path produces).

It is **best-effort by contract**: the dataset is already saved and usable before the stage runs, so a failure — or a cancel during the fit — leaves the dataset intact and just defers the projection to the lazy first-Browse build. Empty / embedding-less datasets are a silent no-op.

## Notes

- `build_projection` is deliberately **excluded** from the "save these as import defaults" feature — it's a per-import cost decision, not a setting to auto-apply to every future import of a media type.
- No backwards-compat concerns: the field is new and defaults to off, so existing flows are unchanged.

## Files

- `vtscore/datasets/load_pipeline.py` — `_build_projection_stage`, `_persist_projection_to_container`, `_parse_bool`, and the `build_projection` plumbing.
- `vtsearch/routes/datasets/{load,staging}.py` — pass-through wiring across all import routes.
- `vtsearch/schemas/datasets.py` — `build_projection` on the demo request schema.
- Frontend: `import-advanced` + `dataset-importer-modal` components, `datasets-crud-api.service.ts`, `dashboard.component.ts` (demo flow).
- `frontend/openapi.json` — regenerated snapshot.
- `tests/datasets/test_load_projection_stage.py` — new coverage for the stage, persistence, and bool parsing.
- `docs/design/vtsbrowse.md` — status header + "What shipped" entry.

## Testing

`./run-tests.sh core datasets io api` → **all 2490 tests pass** (1 skipped), including ruff/codespell/deptry, the OpenAPI drift guard, and the frontend `build:prod` check.

https://claude.ai/code/session_017E2U9N3VDvJFSRKMy1vZ7w

---
_Generated by [Claude Code](https://claude.ai/code/session_017E2U9N3VDvJFSRKMy1vZ7w)_