### PR TITLE
Browse: load the dataset instead of erroring when it isn't loaded

### DIFF
--- a/frontend/src/app/guards/browse-context.guard.ts
+++ b/frontend/src/app/guards/browse-context.guard.ts
@@ -38,8 +38,15 @@ export const browseContextGuard: CanActivateFn = (route) => {
         return of(router.parseUrl('/dashboard'));
       }
 
+      // Fast-path only when the dataset is genuinely loaded in the
+      // backend. A matching *active* id is not sufficient: the dataset
+      // may have been unloaded/evicted since it was last active, in
+      // which case short-circuiting here would let the browse view fire
+      // requests that 409 `dataset_not_loaded`. When `loaded` is false
+      // we fall through to `applyActivePair`, which loads it first.
       if (
         activeContext.datasetId === datasetId &&
+        dataset.loaded &&
         !contextSwitch.switching
       ) {
         return of(true);

--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 import type { ProjectionMeta, ProjectionBuildResponse, TilePayload } from '../models/projection.models';
 
 @Injectable({ providedIn: 'root' })
@@ -9,7 +9,13 @@ export class ProjectionApiService {
   private http = inject(HttpClient);
 
   getMeta(): Observable<ProjectionMeta> {
-    return this.http.get<ProjectionMeta>('/api/projection/meta');
+    // The browse view polls this to discover whether a projection exists
+    // yet. A not-loaded / not-built dataset answers 404/409, which the
+    // caller handles inline (→ "empty"/Build affordance). Suppress the
+    // global error toast so that expected state doesn't alarm the user.
+    return this.http.get<ProjectionMeta>('/api/projection/meta', {
+      context: new HttpContext().set(SKIP_ERROR_TOAST, true),
+    });
   }
 
   build(): Observable<ProjectionBuildResponse> {


### PR DESCRIPTION
## Problem

Clicking **Browse** on an audio dataset that wasn't loaded into the backend popped a red **"Dataset is not loaded"** error toast instead of just loading the dataset.

## Causes & fixes

1. **Route guard fast-path skipped the load.** `browseContextGuard` returned `true` whenever the *active* dataset id matched the URL, without checking the dataset was actually loaded in the backend. If the dataset had been unloaded/evicted since it was last active, the guard short-circuited and `browse-view` fired projection requests that 409'd `dataset_not_loaded`. The fast-path now also requires `dataset.loaded`; otherwise it falls through to `applyActivePair`, which loads the dataset before activating the route.

2. **The status probe toasted handled errors.** `ProjectionApiService.getMeta()` (polled by the browse view to discover whether a projection exists) had no toast suppression, so a 404/409 — which the view already handles inline as the "empty / click Build" state — still triggered the global `errorInterceptor` toast. `getMeta()` now sets `SKIP_ERROR_TOAST`.

Also removed an unused `map` import in the projection service.

## Testing

- `npm run build:prod` — clean, no warnings.
- `codespell` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)