### PR TITLE
Auto-build UMAP projection on Browse instead of prompting

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -17,12 +17,9 @@
         @if (buildTotal > 0) {
           <span class="browse-status-count">{{ buildProgress }} / {{ buildTotal }}</span>
         }
-      </div>
-    }
-    @case ('empty') {
-      <div class="browse-status">
-        <p class="browse-status-message">No projection available for this dataset.</p>
-        <button class="btn btn--primary" (click)="onBuild()">Build Projection</button>
+        @if (buildMessage) {
+          <span class="browse-status-detail">{{ buildMessage }}</span>
+        }
       </div>
     }
     @case ('error') {

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -32,6 +32,11 @@
   font-variant-numeric: tabular-nums;
 }
 
+.browse-status-detail {
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+}
+
 .browse-info {
   position: absolute;
   bottom: var(--space-md);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -22,13 +22,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   meta: ProjectionMeta | null = null;
   mediaType = '';
   hoverEvent: HexHoverEvent | null = null;
-  status: 'loading' | 'building' | 'ready' | 'empty' | 'error' = 'loading';
+  status: 'loading' | 'building' | 'ready' | 'error' = 'loading';
   errorMessage = '';
   buildProgress = 0;
   buildTotal = 0;
+  buildMessage = '';
   datasetName = '';
 
   private destroy$ = new Subject<void>();
+  private polling = false;
 
   constructor(
     private projectionApi: ProjectionApiService,
@@ -69,44 +71,82 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   onBuild(): void {
     this.status = 'building';
+    this.buildProgress = 0;
+    this.buildTotal = 0;
+    this.buildMessage = '';
     this.projectionApi
       .build()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: () => {
+        next: (resp) => {
+          if (resp.status === 'ready') {
+            // Already built/persisted — re-read meta so the canvas renders.
+            this.loadProjection();
+            return;
+          }
           this.pollBuildStatus();
         },
         error: (err) => {
           this.status = 'error';
-          this.errorMessage = err?.error?.error || 'Failed to start projection build';
+          this.errorMessage =
+            err?.error?.message || err?.error?.error || 'Failed to start projection build';
         },
       });
   }
 
   private loadProjection(): void {
     this.status = 'loading';
+    this.polling = false;
     this.projectionApi
       .getMeta()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (meta) => {
-          this.meta = meta;
-          if (meta.media_type) this.mediaType = meta.media_type;
-          this.tileCache.setProjectionId(meta.projection_id);
-          this.status = meta.point_count > 0 ? 'ready' : 'empty';
-        },
+        next: (meta) => this.applyMeta(meta),
         error: (err) => {
+          // The meta endpoint reports "idle" rather than 404/409, but treat a
+          // missing projection defensively the same way: build it, don't ask.
           if (err.status === 404 || err.status === 409) {
-            this.status = 'empty';
+            this.onBuild();
           } else {
             this.status = 'error';
-            this.errorMessage = err?.error?.error || 'Failed to load projection';
+            this.errorMessage =
+              err?.error?.message || err?.error?.error || 'Failed to load projection';
           }
         },
       });
   }
 
+  /** Route a freshly-fetched meta to the right state, auto-building if absent. */
+  private applyMeta(meta: ProjectionMeta): void {
+    this.meta = meta;
+    if (meta.media_type) this.mediaType = meta.media_type;
+    this.tileCache.setProjectionId(meta.projection_id);
+
+    if (meta.point_count > 0) {
+      this.status = 'ready';
+      return;
+    }
+    if (meta.status === 'error') {
+      this.status = 'error';
+      this.errorMessage = meta.error || 'Projection build failed';
+      return;
+    }
+    if (meta.status === 'building') {
+      // A build is already in flight (e.g. started at ingest); track it.
+      this.status = 'building';
+      this.buildProgress = meta.current ?? 0;
+      this.buildTotal = meta.total ?? 0;
+      this.buildMessage = meta.message ?? '';
+      this.pollBuildStatus();
+      return;
+    }
+    // status === "idle": no projection yet. Build it automatically.
+    this.onBuild();
+  }
+
   private pollBuildStatus(): void {
+    if (this.polling) return;
+    this.polling = true;
     const poll = (): void => {
       this.projectionApi
         .getMeta()
@@ -116,13 +156,27 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             this.meta = meta;
             if (meta.media_type) this.mediaType = meta.media_type;
             this.tileCache.setProjectionId(meta.projection_id);
-            this.status = meta.point_count > 0 ? 'ready' : 'empty';
+            if (meta.point_count > 0) {
+              this.polling = false;
+              this.status = 'ready';
+              return;
+            }
+            if (meta.status === 'error') {
+              this.polling = false;
+              this.status = 'error';
+              this.errorMessage = meta.error || 'Projection build failed';
+              return;
+            }
+            this.buildProgress = meta.current ?? 0;
+            this.buildTotal = meta.total ?? 0;
+            this.buildMessage = meta.message ?? '';
+            setTimeout(poll, 1000);
           },
           error: () => {
             setTimeout(poll, 2000);
           },
         });
     };
-    setTimeout(poll, 3000);
+    setTimeout(poll, 1000);
   }
 }

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -28,6 +28,13 @@ export interface ProjectionMeta {
   point_count: number;
   levels: LevelMeta[];
   media_type?: string;
+  // Build lifecycle (idle | building | ready | error) and progress, populated
+  // by GET /api/projection/meta while a build is in flight.
+  status?: 'idle' | 'building' | 'ready' | 'error';
+  current?: number;
+  total?: number;
+  message?: string;
+  error?: string;
 }
 
 export interface ProjectionBuildResponse {


### PR DESCRIPTION
## What

When you Browse a dataset that has no UMAP projection yet, the browse view no longer asks whether to build one — it builds it automatically with a progress bar and then displays the browser.

## Before

Browsing a projection-less dataset landed on an `'empty'` state with a "No projection available for this dataset." message and a **Build Projection** button. The user had to opt in, and the in-flight build only ever showed an indeterminate bar (`buildProgress`/`buildTotal` were never populated from the meta endpoint).

## After

- Removed the `'empty'` state and its manual build button.
- `loadProjection()` routes the meta response by `status`:
  - `ready` → render the canvas
  - `building` → track an already-in-flight build (e.g. one kicked off at ingest)
  - `error` → surface the failure
  - `idle` → **auto-build, no prompt**
- `pollBuildStatus()` now populates `buildProgress` / `buildTotal` / `buildMessage` from the meta endpoint's `current` / `total` / `message`, so the progress bar is determinate and shows the current build stage; it also terminates on a failed job instead of polling forever.
- A genuinely un-projectable dataset (empty / no embeddings → backend `409`) shows an error message rather than a prompt, so we still never ask.

## Incidental fix

Build/load error messages were read from `err.error.error`, but flask-smorest's `abort()` surfaces messages under `err.error.message` (every other component reads `.message`). Now reads `.message` with `.error` as a fallback.

## Scope

Frontend-only: `browse-view` component (ts/html/scss) and the `ProjectionMeta` model (added `status` / `current` / `total` / `message` / `error`). No backend route or schema changes, so no OpenAPI snapshot drift. `npm run build:prod` passes with no warnings or errors.

https://claude.ai/code/session_018a8ThTazm3cGYRt6CGhjYF

---
_Generated by [Claude Code](https://claude.ai/code/session_018a8ThTazm3cGYRt6CGhjYF)_