### PR TITLE
Shrink/speed up dataset pickles: float32 array embeddings at protocol 5

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -714,6 +714,19 @@ and available to any future consumer of `vtscore`.
 ## Open follow-ups
 
 **Active:**
+- **Dataset pickle size — drop inline `media_bytes` when the media is reachable
+  on disk.** The dataset container still bakes a full copy of every audio/image/
+  video blob into `medias.pkl` even when the media also carries a `media_path`
+  (or lives under an external `*_dir`). For filesystem-backed datasets this is
+  the dominant size cost. A save-time "thin if resolvable" mode (mirror of the
+  existing load-time `thin=True`) would shrink those containers dramatically, at
+  the cost of making the `.pkl` no longer fully self-contained — so it needs a
+  portability decision (always inline, never inline, or a per-export flag).
+  *Shipped alongside this note:* embeddings now serialize as compact `float32`
+  ndarrays instead of Python float lists, and the dataset pickles use protocol 5
+  — ~20% smaller containers and a faster load (no per-vector `PyFloat`
+  reconstruction). The peek summarizer (`peek_pickle_dataset_summary`) was
+  updated to stub numpy reconstruction so it stays cheap on the new format.
 - **Empirical tuning pass:** choose validated defaults for the UMAP fit, the
   hex-tile pyramid, and the canvas renderer (the knobs *§Open problems →
   Empirical* deliberately left unset). Planned in detail, ready to execute on

--- a/tests/datasets/test_pickle_safety.py
+++ b/tests/datasets/test_pickle_safety.py
@@ -213,6 +213,35 @@ class TestSafePickleRoundTrip:
         assert len(loaded) == 1
         assert loaded[1]["md5"] == "abc123"
 
+    def test_embedding_stored_as_float32_array(self, tmp_path):
+        """Embeddings must serialise as compact float32 ndarrays, not Python
+        lists of boxed floats (smaller on disk, faster to load)."""
+        from vtscore.datasets.container import read_container
+
+        medias = {
+            1: {
+                "id": 1,
+                "media_type": "text",
+                "duration": 0,
+                "file_size": 0,
+                "md5": "abc",
+                # Pass a plain list to prove the exporter coerces to float32.
+                "embedding": [float(j) for j in range(16)],
+                "filename": "t.txt",
+                "category": "test",
+                "media_string": "hi",
+                "media_path": None,
+            },
+        }
+        pkl_path = tmp_path / "ds.pkl"
+        pkl_path.write_bytes(export_dataset_to_file(medias))
+
+        data, _meta = read_container(pkl_path)
+        emb = data["medias"][1]["embedding"]
+        assert isinstance(emb, np.ndarray)
+        assert emb.dtype == np.float32
+        assert emb.shape == (16,)
+
     def test_chunked_round_trip(self, tmp_path):
         """Chunked loading should also work through the restricted unpickler."""
         medias = {}
@@ -357,6 +386,38 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         assert peeked["medias"][0]["media_type"] == "audio"
         assert peeked["medias"][0]["audio"] == bytearray()
         assert len(peeked["medias"][0]["audio"]) == 0
+
+    @pytest.mark.parametrize("protocol", [3, 4, 5])
+    def test_numpy_array_embeddings_stripped(self, protocol):
+        """numpy-array embeddings (the on-disk format) must peek cleanly.
+
+        A real array reduces via ``_frombuffer`` / ``_reconstruct``, both of
+        which validate their data buffer against the declared shape. Since the
+        peek stubs that buffer to empty, the unpickler must swap the numpy
+        reconstruction for a placeholder instead of calling the real callable
+        (which would raise "cannot reshape array of size 0").
+        """
+        from vtscore.security.pickle import peek_pickle_dataset_summary
+
+        rng = np.random.default_rng(0)
+        data = {
+            "medias": {
+                i: {
+                    "media_type": "audio",
+                    "embedding": rng.standard_normal(64).astype(np.float32),
+                    "filename": f"m_{i}.wav",
+                }
+                for i in range(8)
+            }
+        }
+        raw = pickle.dumps(data, protocol=protocol)
+        peeked = peek_pickle_dataset_summary(io.BytesIO(raw))
+        assert len(peeked["medias"]) == 8
+        first = next(iter(peeked["medias"].values()))
+        assert first["media_type"] == "audio"
+        assert first["filename"] == "m_0.wav"
+        # The array is replaced by an empty placeholder, never materialised.
+        assert len(first["embedding"]) == 0
 
     def test_protocol_0_floats_stripped_quickly(self):
         """Protocol 0 ASCII floats fall through to the default handler if

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -56,7 +56,9 @@ def write_container(
         data = safe_pickle_load(io.BytesIO(medias_pickle_bytes))
         data.update(extra_pickle_keys)
         buf = io.BytesIO()
-        pickle.dump(data, buf)
+        # Match the protocol used by export_dataset_to_file (PEP 574, v5):
+        # this re-pickle round-trips the same numpy-array embeddings.
+        pickle.dump(data, buf, protocol=5)
         medias_pickle_bytes = buf.getvalue()
 
     if isinstance(dest, io.BytesIO):

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -136,6 +136,25 @@ from vtscore.converters.runner import apply_converter_to_demo as _apply_converte
 # Export
 # ---------------------------------------------------------------------------
 
+# Pickle protocol 5 (PEP 574) serialises numpy arrays via out-of-band buffers,
+# making it both smaller and faster than the interpreter default (4 on 3.11).
+# Available on every Python we support (>=3.10), so pin it explicitly.
+_PICKLE_PROTOCOL = 5
+
+
+def _embedding_for_pickle(embedding: Any) -> np.ndarray | None:
+    """Coerce an embedding to a compact ``float32`` ndarray for serialisation.
+
+    Storing the vector as a contiguous ``float32`` array (rather than the old
+    Python ``list`` of boxed floats) roughly halves its pickled footprint and
+    avoids reconstructing hundreds of ``PyFloat`` objects per media on load —
+    the load side already runs every embedding through ``l2_normalize`` /
+    ``np.asarray``, so it accepts arrays and legacy lists alike.
+    """
+    if embedding is None:
+        return None
+    return np.ascontiguousarray(embedding, dtype=np.float32)
+
 
 def export_dataset_to_file(
     medias: dict[int, dict[str, Any]],
@@ -182,9 +201,7 @@ def export_dataset_to_file(
                 "file_size": media["file_size"],
                 "md5": media["md5"],
                 "embedder": media.get("embedder", ""),
-                "embedding": media["embedding"].tolist()
-                if isinstance(media["embedding"], np.ndarray)
-                else media["embedding"],
+                "embedding": _embedding_for_pickle(media["embedding"]),
                 "filename": media.get("filename", f"media_{cid}.wav"),
                 "category": media.get("category", "unknown"),
                 "origin": media.get("origin"),
@@ -203,7 +220,7 @@ def export_dataset_to_file(
     }
 
     pkl_buf = io.BytesIO()
-    pickle.dump(data, pkl_buf)
+    pickle.dump(data, pkl_buf, protocol=_PICKLE_PROTOCOL)
     medias_pkl_bytes = pkl_buf.getvalue()
 
     meta = {

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -217,12 +217,18 @@ def load_demo_dataset(  # noqa: C901
     # from the pickle and store the dir path so reloading can find the files.
     # When a converter was applied, external_dir is no longer relevant (the
     # converted medias carry their own bytes/strings).
+    # Local import avoids a circular import at module load (loader imports
+    # loader_demo before this helper is defined).
+    from vtscore.datasets.loader import _embedding_for_pickle
+
     if external_dir is not None and not converter_name:
         pkl_data: dict[str, Any] = {
             "name": dataset_name,
             "medias": {
                 cid: {
-                    k: v.tolist() if isinstance(v, np.ndarray) else v
+                    k: _embedding_for_pickle(v)
+                    if k == "embedding"
+                    else (v.tolist() if isinstance(v, np.ndarray) else v)
                     for k, v in media.items()
                     if k not in ("media_bytes", "thumbnail_bytes")
                 }
@@ -234,7 +240,12 @@ def load_demo_dataset(  # noqa: C901
         pkl_data = {
             "name": dataset_name,
             "medias": {
-                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in media.items()}
+                cid: {
+                    k: _embedding_for_pickle(v)
+                    if k == "embedding"
+                    else (v.tolist() if isinstance(v, np.ndarray) else v)
+                    for k, v in media.items()
+                }
                 for cid, media in medias.items()
             },
         }
@@ -246,7 +257,7 @@ def load_demo_dataset(  # noqa: C901
     if external_dir is not None and not converter_name:
         extra_pickle_keys[mt.dir_key] = external_dir
 
-    medias_pkl_bytes = pickle.dumps(pkl_data)
+    medias_pkl_bytes = pickle.dumps(pkl_data, protocol=5)
     meta = {
         "format_version": 1,
         "embedder": resolved_name,

--- a/vtscore/security/pickle.py
+++ b/vtscore/security/pickle.py
@@ -36,6 +36,40 @@ _PICKLE_SAFE_CLASSES: set[tuple[str, str]] = {
 }
 
 
+# numpy reconstruction callables. A real array reduces either via
+# ``_frombuffer(buffer, dtype, shape, order)`` (protocol >=5) or via
+# ``_reconstruct(...)`` + a BUILD/``__setstate__`` that carries the raw bytes
+# (older protocols). Both consume the array's data buffer — which the peek
+# unpickler stubs out to empty — so calling the real callables raises (e.g.
+# "cannot reshape array of size 0"). The peek path swaps them for a stub.
+_PICKLE_NUMPY_RECONSTRUCT: set[tuple[str, str]] = {
+    ("numpy.core.multiarray", "_reconstruct"),
+    ("numpy.core.multiarray", "scalar"),
+    ("numpy", "_core.multiarray._reconstruct"),
+    ("numpy._core.multiarray", "_reconstruct"),
+    ("numpy._core.multiarray", "scalar"),
+    ("numpy.core.numeric", "_frombuffer"),
+    ("numpy._core.numeric", "_frombuffer"),
+}
+
+
+class _PeekStubArray(list):
+    """Placeholder a peek substitutes for a numpy array.
+
+    Subclasses ``list`` so it reads as an empty sequence (``len() == 0``), and
+    swallows ``__setstate__`` so the BUILD opcode that would feed an array its
+    (stubbed-empty) raw bytes is a no-op instead of a buffer-size error.
+    """
+
+    def __setstate__(self, state: object) -> None:
+        pass
+
+
+def _peek_stub_numpy(*args: Any, **kwargs: Any) -> _PeekStubArray:
+    """Stand-in for numpy's array/scalar reconstruction during a peek."""
+    return _PeekStubArray()
+
+
 class RestrictedUnpickler(pickle.Unpickler):
     """An ``Unpickler`` that refuses to instantiate classes outside an allowlist.
 
@@ -93,6 +127,10 @@ class _PeekUnpickler(pickle._Unpickler):
     dispatch: dict[int, Any] = pickle._Unpickler.dispatch.copy()
 
     def find_class(self, module: str, name: str) -> Any:
+        # Swap numpy's array/scalar reconstruction for a stub: the real
+        # callables validate their data buffer, which this peek has emptied.
+        if (module, name) in _PICKLE_NUMPY_RECONSTRUCT:
+            return _peek_stub_numpy
         if (module, name) in _PICKLE_SAFE_CLASSES:
             return pickle._Unpickler.find_class(self, module, name)
         raise pickle.UnpicklingError(

--- a/vtscore/training/svm.py
+++ b/vtscore/training/svm.py
@@ -82,14 +82,15 @@ def _make_base_estimator(
     if kernel == "rbf":
         from sklearn.svm import SVC  # noqa: PLC0415
 
-        # ``probability=False`` here - we attach our own calibrator outside
-        # so the calibration mode is uniform across kernels.
+        # No built-in Platt scaling: we attach our own calibrator outside so
+        # the calibration mode is uniform across kernels. sklearn>=1.9 removed
+        # the ``probability`` argument (deprecated), and disabled is the
+        # default, so there is nothing to pass.
         return SVC(
             C=C,
             kernel="rbf",
             gamma="scale",
             class_weight=class_weight,
-            probability=False,
             random_state=seed,
         )
     raise ValueError(f"Unsupported SVM kernel: {kernel!r}")


### PR DESCRIPTION
## Why

Dataset `.pkl` containers got bigger and slow to load. Investigating the save/load path turned up two cheap, high-leverage wins on the embedding storage; this PR ships those. (The bigger remaining size driver — inline `media_bytes` copied even when the media is reachable on disk — is intentionally **not** touched here; it changes the dataset-portability contract, so it's recorded as a deferred follow-up.)

## What changed

**Embeddings: Python lists → contiguous `float32` ndarrays, pickle protocol 5.**
Embeddings were serialized via `.tolist()`, i.e. a list of hundreds of boxed Python floats per vector. That's both larger on disk and slow to load — every vector had to be rebuilt into `PyFloat` objects before `l2_normalize` re-arrayed it. Now they serialize as compact `float32` arrays at protocol 5 (PEP 574). On a 500×512 synthetic dataset the container shrank ~20% (1.19 MB → 0.96 MB), and the load no longer pays the per-vector reconstruction cost.
- `loader.py` gains a `_embedding_for_pickle()` helper (coerces list/ndarray/None → contiguous `float32`), used by both `export_dataset_to_file` and the demo-cache path in `loader_demo.py`.
- `container.py`'s `extra_pickle_keys` re-pickle uses protocol 5 to match.
- **Backward compatible on read:** legacy list-embedding pickles still load (the load path runs every embedding through `l2_normalize` → `np.asarray`, which accepts both).

**Peek summarizer hardened for the new format.**
`peek_pickle_dataset_summary` cheaply reads a dataset's count/type without materializing embeddings by stubbing leaf bytes/floats to empty. numpy arrays reduce via `_frombuffer` / `_reconstruct`, which validate their data buffer against the declared shape — so an emptied buffer raised `cannot reshape array of size 0`. The peek now swaps numpy's reconstruction callables for a placeholder, keeping it cheap on array-format pickles (covered at protocols 3/4/5).

**Drop deprecated `SVC(probability=...)` (sklearn ≥ 1.9).**
Unrelated to the pickle work but it was blocking `pyright` in `run-tests.sh`: scikit-learn 1.9 deprecated `SVC`'s `probability` parameter and made its default the `"deprecated"` sentinel string, so `probability=False` is both a type error (param inferred as `str`) and a deprecation warning. Disabled is now the default and we attach our own calibrator outside the estimator, so the argument is simply removed.

## Tests

- New regression cover in `tests/datasets/test_pickle_safety.py`: exported embeddings are `float32` ndarrays, and peek strips numpy-array embeddings across protocols 3/4/5.
- `datasets`, `io`, `detectors` groups: **2521 passed**. `api` group: **429 passed**. `core` passes.
- Two pre-existing, environment-only gates were **not** addressed because they fail identically on pristine `dev` in this container and are not caused by this change: the OpenAPI snapshot drift (`UNPROCESSABLE_ENTITY` vs `UNPROCESSABLE_CONTENT` — a Python 3.11-vs-3.13 `http.HTTPStatus` phrase difference; regenerating here would *downgrade* the committed snapshot for everyone on 3.13) and the `test_dashboard.py` bundle-content assertions (cross-group test-isolation artifact; pass in isolation and within the `api` group).

## Follow-up (deferred, recorded in `docs/plans/vtsbrowse.md`)

Save-time "thin if resolvable" mode to drop inline `media_bytes` when the media is reachable on disk — the dominant size cost for filesystem-backed datasets — pending a portability decision (always inline / never inline / per-export flag).

https://claude.ai/code/session_01A3dS5UUUBeoJp7E2CXbpS6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3dS5UUUBeoJp7E2CXbpS6)_