### PR TITLE
session-start: hard-reset fresh harness-cut branches instead of rebasing main-only reverts

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -38,24 +38,44 @@ elif [ "$current_branch" = "dev" ] || [ "$current_branch" = "main" ]; then
   notify "ℹ session-start: on $current_branch; skipping dev rebase."
 elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
   skip_reason="working tree dirty (would clobber changes)"
-elif git rev-parse --verify --quiet "refs/remotes/origin/$current_branch" >/dev/null \
-    && [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch")" ]; then
-  skip_reason="local $current_branch differs from origin/$current_branch (pushed work would be orphaned)"
 else
   notify "ℹ session-start: fetching origin..."
   if ! git fetch origin --prune 2>&1 | sed 's/^/  /' >&2; then
     skip_reason="fetch failed"
   elif git merge-base --is-ancestor origin/dev HEAD 2>/dev/null; then
     notify "✓ session-start: $current_branch already includes origin/dev; nothing to do."
+  elif ! git rev-parse --verify --quiet "refs/remotes/origin/$current_branch" >/dev/null; then
+    # No origin/<branch>: a brand-new branch the harness just cut off `main`
+    # (the GitHub default). At session start, before Claude has pushed
+    # anything, EVERY commit unique to this branch relative to `dev` was
+    # inherited from `main` — there is no Claude work to preserve. That
+    # inherited history can include `main`-only cleanup/revert commits (e.g.
+    # "revert the accidental main merges") that *conflict* when replayed onto
+    # `dev`, because they try to undo work that legitimately lives on `dev`.
+    # `git cherry` flags such a revert `+` ("not patch-equivalent to dev"),
+    # which sends the cherry heuristic below down the rebase path and produces
+    # phantom conflicts — exactly the speed bump this branch was created to
+    # fix. Since nothing pushed is at risk, hard-reset to origin/dev
+    # unconditionally instead of attempting a doomed rebase.
+    notify "ℹ session-start: $current_branch has no origin counterpart (fresh branch cut off main); hard-resetting to origin/dev (inherited main-only commits carry no Claude work)..."
+    if git reset --hard origin/dev 2>&1 | sed 's/^/  /' >&2; then
+      notify "✓ session-start: hard-reset $current_branch to origin/dev."
+    else
+      skip_reason="hard-reset to origin/dev failed"
+    fi
+  elif [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch")" ]; then
+    # The branch exists on origin and HEAD differs from it: it carries real
+    # pushed work that a reset/rebase here could orphan. Stay conservative and
+    # leave it to Claude to reconcile by hand.
+    skip_reason="local $current_branch differs from origin/$current_branch (pushed work would be orphaned)"
   else
-    # Decide rebase vs hard-reset. The harness cuts new branches off `main`,
-    # so a fresh branch typically carries merge-commit duplicates of PRs that
-    # already landed on `dev`. `git cherry origin/dev HEAD` flags each
-    # unique-to-branch commit as `+` (genuinely new) or `-` (patch-equivalent
-    # to a commit already on dev). All-`-` means a rebase would just produce
-    # phantom conflicts against the already-merged work; hard-reset is the
-    # safe and correct move. Any `+` line means there's real local work to
-    # preserve, so fall back to a normal rebase.
+    # In sync with origin/<branch> but behind dev. Decide rebase vs hard-reset.
+    # `git cherry origin/dev HEAD` flags each unique-to-branch commit as `+`
+    # (genuinely new) or `-` (patch-equivalent to a commit already on dev).
+    # All-`-` means a rebase would just produce phantom conflicts against the
+    # already-merged work; hard-reset is the safe and correct move. Any `+`
+    # line means there's real pushed work to preserve, so fall back to a
+    # normal rebase.
     cherry_out=$(git cherry origin/dev HEAD 2>/dev/null || echo "")
     if [ -n "$cherry_out" ] && ! echo "$cherry_out" | grep -q '^+'; then
       dup_count=$(echo "$cherry_out" | grep -c '^-' || true)


### PR DESCRIPTION
## What the hook reported

This session opened with:

```
‼ session-start: DID NOT rebase onto origin/dev (rebase failed (aborted, branch left as-is)).
```

## Root cause

The SessionStart hook cuts working branches off `main` (the GitHub default), then rebases them onto `origin/dev`. At the time this branch was cut, `main`'s tip was a **cleanup merge** (#1767) whose payload — `034a743f "Revert main to post-#1745 state"` — undoes feature PRs that had been accidentally merged into `main` instead of `dev`. Those features live, correctly, on `dev`.

The hook's rebase-vs-reset heuristic uses `git cherry origin/dev HEAD`: a `-` line means a commit is patch-equivalent to one already on `dev` (safe to discard via hard-reset), a `+` line means "genuinely new" and triggers a rebase. The revert commit is **not** patch-equivalent to anything on `dev`, so `git cherry` flags it `+`, and the hook attempted to replay it onto `dev`. But the revert's pre-image doesn't match `dev`'s live files, so the replay exploded into modify/delete and content conflicts (`browse-view`, `projection.models.ts`, `vtscore/datasets/container.py`, `openapi.json`, …) and aborted — handing the conflict to Claude on every fresh session.

The heuristic's blind spot: a `+` from `git cherry` means "not patch-equivalent to dev," **not** "Claude's intentional work." A revert of `dev`'s own work is the pathological case — unique, but the opposite of something we want on `dev`.

## Fix

Key the decision on whether `origin/<branch>` exists, and check it **after** the fetch (so the remote-tracking ref is fresh on a newly cloned container):

- **No `origin/<branch>`** → a brand-new harness-cut branch. Before Claude has pushed anything, every commit unique vs `dev` was inherited from `main` and carries no work to preserve, so **hard-reset to `origin/dev` unconditionally** rather than attempting a doomed rebase.
- **`origin/<branch>` exists and differs from HEAD** → real pushed work that a reset could orphan; stay conservative and leave it for manual reconciliation (unchanged behavior).
- **`origin/<branch>` exists and matches HEAD** → apply the existing `git cherry` heuristic (rebase only when there's genuinely new pushed work).

## Verification

- `bash -n` passes.
- Reconstructed the exact failure (a throwaway branch parked on `main`'s cleanup tip `6836d616`, with no origin counterpart) and ran the fixed hook: it now hard-resets cleanly to `origin/dev` with no conflict, instead of aborting.

This branch itself was reset onto `origin/dev` before the fix was applied, so the PR diff is the hook change alone.

https://claude.ai/code/session_01FPuXpLnU4RrTMvXvpAMDog

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuXpLnU4RrTMvXvpAMDog)_