### PR TITLE
Add on-screen hex display-size control to VTSBrowse

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -63,6 +63,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * flat density (viridis) shading.
    */
   @Input() mediaType = '';
+  /**
+   * User-controlled on-screen size multiplier for hexes. ``1`` is the default
+   * fit. This scales rendering (positions + hex radius) only; it deliberately
+   * does NOT feed level selection, so growing/shrinking the display never
+   * changes the binning, i.e. which vectors land in a given hex.
+   */
+  @Input() displayScale = 1;
   @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
 
   /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
@@ -108,6 +115,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     return this.mediaType === 'image' || this.mediaType === 'video';
   }
 
+  /**
+   * On-screen scale: the base zoom (driven by wheel/fit and feeding level
+   * selection) times the user's display-size multiplier. All projection↔screen
+   * conversions and the rendered hex radius use this; level selection uses the
+   * base ``transform.zoom`` alone so the binning is invariant to display size.
+   */
+  private get effZoom(): number {
+    return this.transform.zoom * this.displayScale;
+  }
+
   ngOnInit(): void {
     this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
 
@@ -136,6 +153,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.thumbCache.clear();
       this.thumbFailed.clear();
       this.fitToData();
+      this.requestRedraw();
+    }
+    // Display-size changes only rescale rendering; the active level (binning)
+    // is left untouched on purpose, so the same hexes are simply drawn larger
+    // or smaller.
+    if (changes['displayScale'] && !changes['displayScale'].firstChange) {
       this.requestRedraw();
     }
   }
@@ -176,7 +199,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const padH = dataH * (1 + padding * 2);
     const w = this.width || 800;
     const h = this.height || 600;
-    this.transform.zoom = Math.min(w / padW, h / padH);
+    // Fit so the *effective* zoom fills the viewport: divide out displayScale so
+    // a non-default display size still frames the whole projection on load.
+    this.transform.zoom = Math.min(w / padW, h / padH) / this.displayScale;
     this.transform.centerX = (xmin + xmax) / 2;
     this.transform.centerY = (ymin + ymax) / 2;
     this.updateActiveLevel();
@@ -195,14 +220,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private projToScreen(px: number, py: number): [number, number] {
-    const sx = (px - this.transform.centerX) * this.transform.zoom + this.width / 2;
-    const sy = (py - this.transform.centerY) * this.transform.zoom + this.height / 2;
+    const z = this.effZoom;
+    const sx = (px - this.transform.centerX) * z + this.width / 2;
+    const sy = (py - this.transform.centerY) * z + this.height / 2;
     return [sx, sy];
   }
 
   private screenToProj(sx: number, sy: number): [number, number] {
-    const px = (sx - this.width / 2) / this.transform.zoom + this.transform.centerX;
-    const py = (sy - this.height / 2) / this.transform.zoom + this.transform.centerY;
+    const z = this.effZoom;
+    const px = (sx - this.width / 2) / z + this.transform.centerX;
+    const py = (sy - this.height / 2) / z + this.transform.centerY;
     return [px, py];
   }
 
@@ -269,7 +296,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
     const level = this.activeLevel;
     const radius = this.meta.base_radius / Math.pow(2, level);
-    const screenRadius = radius * this.transform.zoom;
+    const screenRadius = radius * this.effZoom;
 
     const visibleTiles = this.getVisibleTiles();
     let allCells: HexCellPayload[] = [];
@@ -478,8 +505,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     if (!this.isPanning) return;
     const dx = event.clientX - this.panStartX;
     const dy = event.clientY - this.panStartY;
-    this.transform.centerX = this.panStartCenterX - dx / this.transform.zoom;
-    this.transform.centerY = this.panStartCenterY - dy / this.transform.zoom;
+    const z = this.effZoom;
+    this.transform.centerX = this.panStartCenterX - dx / z;
+    this.transform.centerY = this.panStartCenterY - dy / z;
     this.requestRedraw();
   }
 
@@ -498,9 +526,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const [projX, projY] = this.screenToProj(mx, my);
     const factor = event.deltaY < 0 ? 1.15 : 1 / 1.15;
     const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));
+    // Anchor the point under the cursor using the new *effective* zoom so the
+    // display-size multiplier keeps that pixel fixed while wheel-zooming.
+    const newEffZoom = newZoom * this.displayScale;
 
-    this.transform.centerX = projX - (mx - this.width / 2) / newZoom;
-    this.transform.centerY = projY - (my - this.height / 2) / newZoom;
+    this.transform.centerX = projX - (mx - this.width / 2) / newEffZoom;
+    this.transform.centerY = projY - (my - this.height / 2) / newEffZoom;
     this.transform.zoom = newZoom;
 
     this.updateActiveLevel();

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -32,12 +32,33 @@
       <vt-browse-canvas
         [meta]="meta"
         [mediaType]="mediaType"
+        [displayScale]="hexDisplayScale"
         (hexHover)="onHexHover($event)"
       />
       <vt-browse-hover-preview
         [hover]="hoverEvent"
         [mediaType]="mediaType"
       />
+      <div class="browse-size">
+        <button
+          type="button"
+          class="browse-size-btn"
+          [disabled]="atMinHexSize"
+          (click)="bumpHexSize(-1)"
+          title="Smaller hexes"
+          aria-label="Smaller hexes">
+          <vt-icon type="image" [size]="11"></vt-icon>
+        </button>
+        <button
+          type="button"
+          class="browse-size-btn"
+          [disabled]="atMaxHexSize"
+          (click)="bumpHexSize(1)"
+          title="Bigger hexes"
+          aria-label="Bigger hexes">
+          <vt-icon type="image" [size]="18"></vt-icon>
+        </button>
+      </div>
       <div class="browse-info">
         <span class="browse-info-label">{{ datasetName }}</span>
         <span class="browse-info-count">{{ meta?.point_count | number }} items</span>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -58,3 +58,55 @@
   font-weight: var(--weight-medium);
   color: var(--text-primary);
 }
+
+// On-screen hex size control. Mirrors the grouped pill look of the Find view's
+// grid-size buttons (.vc-btn), reusing the same image icon at 11px / 18px.
+.browse-size {
+  position: absolute;
+  top: var(--space-md);
+  right: var(--space-md);
+  display: inline-flex;
+}
+
+.browse-size-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 28px;
+  padding: 0 var(--space-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base),
+    border-color var(--transition-base);
+
+  &:not(:first-child) {
+    margin-left: -1px;
+  }
+
+  &:first-child {
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  &:last-child {
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+    z-index: 1;
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+
+  vt-icon {
+    line-height: 0;
+  }
+}

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { IconComponent } from '../icon/icon.component';
 import { ProjectionApiService } from '../../services/projection-api.service';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -14,7 +15,13 @@ import type { ProjectionMeta } from '../../models/projection.models';
 @Component({
   selector: 'vt-browse-view',
   standalone: true,
-  imports: [CommonModule, BrowseCanvasComponent, BrowseHoverPreviewComponent, ProgressBarComponent],
+  imports: [
+    CommonModule,
+    BrowseCanvasComponent,
+    BrowseHoverPreviewComponent,
+    ProgressBarComponent,
+    IconComponent,
+  ],
   templateUrl: './browse-view.component.html',
   styleUrl: './browse-view.component.scss',
 })
@@ -28,6 +35,14 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   buildTotal = 0;
   buildMessage = '';
   datasetName = '';
+
+  /**
+   * Discrete on-screen size multipliers for the hexes. ``1`` (index 2) is the
+   * default fit; the bigger/smaller buttons step through these. This only
+   * rescales the rendering — it never changes which vectors land in a hex.
+   */
+  private readonly HEX_SCALES = [0.5, 0.7, 1, 1.5, 2.2, 3];
+  hexScaleIndex = 2;
 
   private destroy$ = new Subject<void>();
   private polling = false;
@@ -67,6 +82,26 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   onHexHover(event: HexHoverEvent | null): void {
     this.hoverEvent = event;
+  }
+
+  get hexDisplayScale(): number {
+    return this.HEX_SCALES[this.hexScaleIndex];
+  }
+
+  get atMinHexSize(): boolean {
+    return this.hexScaleIndex === 0;
+  }
+
+  get atMaxHexSize(): boolean {
+    return this.hexScaleIndex === this.HEX_SCALES.length - 1;
+  }
+
+  /** Grow (+1) or shrink (-1) the on-screen hex size, clamped to the range. */
+  bumpHexSize(delta: 1 | -1): void {
+    this.hexScaleIndex = Math.max(
+      0,
+      Math.min(this.HEX_SCALES.length - 1, this.hexScaleIndex + delta),
+    );
   }
 
   onBuild(): void {


### PR DESCRIPTION
## Summary

Adds a bigger/smaller control to VTSBrowse so the user can grow or shrink how large the hexes are drawn **on screen**, without changing the binning (which vectors land in a given hex).

Two grouped buttons sit at the top-right of the browse canvas, reusing the exact image icon at 11px (smaller) and 18px (bigger) from the Find view's grid-size buttons.

## How it works

The canvas already auto-selects a level-of-detail to keep hexes near a target pixel size, and that level is what determines binning. The display-size control is decoupled from level selection:

- `BrowseCanvasComponent` gains a `displayScale` input and an `effZoom` getter (`transform.zoom * displayScale`).
- All projection↔screen conversions and the rendered hex radius use `effZoom`, so positions and hex size scale together (no overlap/gaps).
- **Level selection still uses the base `transform.zoom` alone**, so changing `displayScale` rescales rendering but never re-bins. The same hexes are simply drawn larger or smaller.
- `fitToData` divides out `displayScale` so a non-default size still frames the whole projection on load; wheel-zoom anchors the cursor using the effective zoom.

`BrowseViewComponent` owns the discrete size steps (`0.5 … 3`, default `1`) and renders the buttons, mirroring the `.vc-btn` pill styling.

## Testing

- `npm run build:prod` — clean, no TypeScript errors or budget warnings.
- Full `./run-tests.sh` is blocked before pytest by a **pre-existing** OpenAPI snapshot drift unrelated to this change: the committed snapshot (unchanged on `dev`) was regenerated against a newer Werkzeug ("Unprocessable Content"), while this ephemeral container ships Werkzeug 3.1.8 ("Unprocessable Entity"). This change touches no backend/route/schema files, so regenerating would wrongly revert that intentional snapshot commit.

https://claude.ai/code/session_01CF1ZmFT8A1RYebk2C6Tr4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1ZmFT8A1RYebk2C6Tr4C)_