### PR TITLE
Add +/- zoom buttons to the VTSBrowser

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -490,25 +490,37 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     document.removeEventListener('mouseup', this.boundMouseUp);
   }
 
+  /**
+   * Zoom the base view by ``factor`` (>1 zooms in, narrowing the span shown),
+   * keeping the projection point under screen coords ``(anchorX, anchorY)``
+   * fixed. Defaults to the viewport centre, which is what the on-screen +/-
+   * buttons use; the wheel passes the cursor position so it zooms toward the
+   * pointer. Like the wheel path, this changes the base zoom only — level
+   * selection re-runs so the hexes keep their ~28px display size while each
+   * covers a narrower span.
+   */
+  zoomBy(factor: number, anchorX = this.width / 2, anchorY = this.height / 2): void {
+    const [projX, projY] = this.screenToProj(anchorX, anchorY);
+    const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));
+    // Anchor the point under the cursor using the new *effective* zoom so the
+    // display-size multiplier keeps that pixel fixed while zooming.
+    const newEffZoom = newZoom * this.displayScale;
+
+    this.transform.centerX = projX - (anchorX - this.width / 2) / newEffZoom;
+    this.transform.centerY = projY - (anchorY - this.height / 2) / newEffZoom;
+    this.transform.zoom = newZoom;
+
+    this.updateActiveLevel();
+    this.requestRedraw();
+  }
+
   private onWheel(event: WheelEvent): void {
     event.preventDefault();
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
-
-    const [projX, projY] = this.screenToProj(mx, my);
     const factor = event.deltaY < 0 ? 1.15 : 1 / 1.15;
-    const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));
-    // Anchor the point under the cursor using the new *effective* zoom so the
-    // display-size multiplier keeps that pixel fixed while wheel-zooming.
-    const newEffZoom = newZoom * this.displayScale;
-
-    this.transform.centerX = projX - (mx - this.width / 2) / newEffZoom;
-    this.transform.centerY = projY - (my - this.height / 2) / newEffZoom;
-    this.transform.zoom = newZoom;
-
-    this.updateActiveLevel();
-    this.requestRedraw();
+    this.zoomBy(factor, mx, my);
   }
 
   private onCanvasMouseMove(event: MouseEvent): void {

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -39,25 +39,45 @@
         [hover]="hoverEvent"
         [mediaType]="mediaType"
       />
-      <div class="browse-size">
-        <button
-          type="button"
-          class="browse-size-btn"
-          [disabled]="atMinHexSize"
-          (click)="bumpHexSize(-1)"
-          title="Smaller hexes"
-          aria-label="Smaller hexes">
-          <vt-icon type="image" [size]="11"></vt-icon>
-        </button>
-        <button
-          type="button"
-          class="browse-size-btn"
-          [disabled]="atMaxHexSize"
-          (click)="bumpHexSize(1)"
-          title="Bigger hexes"
-          aria-label="Bigger hexes">
-          <vt-icon type="image" [size]="18"></vt-icon>
-        </button>
+      <div class="browse-controls">
+        <div class="browse-zoom">
+          <button
+            type="button"
+            class="browse-size-btn browse-size-btn--text"
+            (click)="zoomOut()"
+            title="Zoom out"
+            aria-label="Zoom out">
+            &minus;
+          </button>
+          <button
+            type="button"
+            class="browse-size-btn browse-size-btn--text"
+            (click)="zoomIn()"
+            title="Zoom in"
+            aria-label="Zoom in">
+            +
+          </button>
+        </div>
+        <div class="browse-size">
+          <button
+            type="button"
+            class="browse-size-btn"
+            [disabled]="atMinHexSize"
+            (click)="bumpHexSize(-1)"
+            title="Smaller hexes"
+            aria-label="Smaller hexes">
+            <vt-icon type="image" [size]="11"></vt-icon>
+          </button>
+          <button
+            type="button"
+            class="browse-size-btn"
+            [disabled]="atMaxHexSize"
+            (click)="bumpHexSize(1)"
+            title="Bigger hexes"
+            aria-label="Bigger hexes">
+            <vt-icon type="image" [size]="18"></vt-icon>
+          </button>
+        </div>
       </div>
       <div class="browse-info">
         <span class="browse-info-label">{{ datasetName }}</span>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -87,12 +87,20 @@
   }
 }
 
-// On-screen hex size control. Mirrors the grouped pill look of the Find view's
-// grid-size buttons (.vc-btn), reusing the same image icon at 11px / 18px.
-.browse-size {
+// Top-right control cluster: the zoom +/- pill sits beside the hex-size pill.
+.browse-controls {
   position: absolute;
   top: var(--space-md);
   right: var(--space-md);
+  display: inline-flex;
+  gap: var(--space-sm);
+}
+
+// Zoom (true span) control and on-screen hex size control. Both mirror the
+// grouped pill look of the Find view's grid-size buttons (.vc-btn); the hex
+// pill reuses the image icon at 11px / 18px, the zoom pill uses +/- glyphs.
+.browse-zoom,
+.browse-size {
   display: inline-flex;
 }
 
@@ -137,4 +145,11 @@
   vt-icon {
     line-height: 0;
   }
+}
+
+// +/- zoom glyphs need explicit sizing since they carry no icon child.
+.browse-size-btn--text {
+  font-size: var(--font-lg);
+  font-weight: var(--weight-medium);
+  line-height: 1;
 }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -39,6 +39,8 @@ import type { ProjectionMeta } from '../../models/projection.models';
   styleUrl: './browse-view.component.scss',
 })
 export class BrowseViewComponent implements OnInit, OnDestroy {
+  @ViewChild(BrowseCanvasComponent) private canvas?: BrowseCanvasComponent;
+
   meta: ProjectionMeta | null = null;
   mediaType = '';
   hoverEvent: HexHoverEvent | null = null;
@@ -61,6 +63,13 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   minimapVisible = true;
   minimapWidth = 200;
   minimapHeight = 150;
+
+  /**
+   * Per-click zoom step for the on-screen +/- buttons. Larger than the wheel's
+   * 1.15 per-tick factor so a single click makes a visible difference; button
+   * zoom anchors at the viewport centre (no cursor to zoom toward).
+   */
+  private readonly ZOOM_BUTTON_FACTOR = 1.4;
 
   private destroy$ = new Subject<void>();
   private polling = false;
@@ -160,6 +169,16 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   private clamp(value: number, lo: number, hi: number): number {
     return Math.max(lo, Math.min(hi, value));
+  }
+
+  /** Zoom in one step (narrower span, hexes keep their display size). */
+  zoomIn(): void {
+    this.canvas?.zoomBy(this.ZOOM_BUTTON_FACTOR);
+  }
+
+  /** Zoom out one step. */
+  zoomOut(): void {
+    this.canvas?.zoomBy(1 / this.ZOOM_BUTTON_FACTOR);
   }
 
   onBuild(): void {


### PR DESCRIPTION
## What

Adds on-screen **+ / −** zoom buttons to the VTSBrowser, beside the existing hex-size buttons (top-right).

"Zoom" here means narrowing the span of the projection shown while keeping the on-screen hexes at their roughly constant ~28px display size — each hex then covers a narrower span of the underlying data, because level selection re-runs and picks a finer pyramid level. This is the `transform.zoom` axis, distinct from the existing hex-size buttons (`displayScale`), which only paint hexes physically larger/smaller without changing the binning.

## Changes

- **`browse-canvas.component.ts`**: extracted a reusable public `zoomBy(factor, anchorX?, anchorY?)` that zooms while keeping the projection point under a given anchor fixed (defaults to the viewport centre). The existing cursor-anchored wheel handler now routes through it, so wheel and buttons share one code path.
- **`browse-view.component.ts`**: `ViewChild` on the canvas plus `zoomIn()` / `zoomOut()`, stepping by a 1.4× per-click factor (larger than the wheel's 1.15 per tick so a click is visible). Button zoom anchors at the centre.
- **`browse-view.component.html` / `.scss`**: a `+ / −` pill grouped beside the hex-size pill under a shared `.browse-controls` cluster, reusing the existing `.browse-size-btn` pill styling with a small text-glyph modifier.

Note: cursor-anchored mouse-wheel zoom already existed (`onWheel`); this PR only adds the on-screen buttons and refactors the shared zoom logic.

## Testing

- `npm run build:prod` passes clean (no TypeScript errors, no budget warnings).
- `./run-tests.sh core` is blocked only by a pre-existing OpenAPI snapshot drift caused by a werkzeug version mismatch in the fresh container (repo snapshot emits `UNPROCESSABLE_CONTENT`, the container's older werkzeug emits `UNPROCESSABLE_ENTITY`). This is unrelated to this frontend-only change and `frontend/openapi.json` is untouched; regenerating would wrongly downgrade the snapshot to match the stale container dep.

https://claude.ai/code/session_018H1oeZUC7kRfTMSTV1Zc5u

---
_Generated by [Claude Code](https://claude.ai/code/session_018H1oeZUC7kRfTMSTV1Zc5u)_