### PR TITLE
Fix Browse 404 on projection tiles

### DIFF
--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -22,9 +22,10 @@ export class ProjectionApiService {
     return this.http.post<ProjectionBuildResponse>('/api/projection/build', {});
   }
 
-  getTile(projectionId: string, level: number, tx: number, ty: number): Observable<TilePayload> {
-    return this.http.get<TilePayload>(
-      `/api/projection/tiles/${projectionId}/${level}/${tx}/${ty}`,
-    );
+  getTile(level: number, tx: number, ty: number): Observable<TilePayload> {
+    // The backend resolves the pyramid from the active dataset context, so the
+    // tile URL is keyed only by (level, tx, ty); the projection id is tracked
+    // client-side (TileCacheService) for cache invalidation, not in the path.
+    return this.http.get<TilePayload>(`/api/projection/tiles/${level}/${tx}/${ty}`);
   }
 }

--- a/frontend/src/app/services/tile-cache.service.ts
+++ b/frontend/src/app/services/tile-cache.service.ts
@@ -42,7 +42,7 @@ export class TileCacheService {
 
     if (!this.projectionId) return null;
 
-    const req$ = this.projectionApi.getTile(this.projectionId, level, tx, ty).pipe(
+    const req$ = this.projectionApi.getTile(level, tx, ty).pipe(
       tap((tile) => {
         this.inflight.delete(key);
         this.put(key, tile);


### PR DESCRIPTION
## Problem

Browsing any dataset (e.g. an audio demo dataset) failed with a red `404 Not Found` toast:

```
Status: 404 Not Found. Endpoint: GET /api/projection/tiles/<...>
```

## Root cause

The frontend built the tile URL with the projection id wedged into the path:

```
/api/projection/tiles/<projectionId>/<level>/<tx>/<ty>
```

But the backend route (`vtsearch/routes/projection.py`) is keyed only by `(level, tx, ty)`:

```
/api/projection/tiles/<int:level>/<int(signed=True):tx>/<int(signed=True):ty>
```

So every tile fetch had one extra path segment and matched no route → 404. The backend resolves the pyramid from the active dataset context, not from a URL id, which is also what the existing tests assert (`/api/projection/tiles/{level}/{tx}/{ty}`). This affected all media types, not just audio.

## Fix

Drop the stray `projectionId` segment from the tile request. The projection id is still tracked client-side in `TileCacheService` for cache invalidation when switching projections (the in-memory cache key is `level:tx:ty`), so it isn't needed in the URL.

- `frontend/src/app/services/projection-api.service.ts` — `getTile(level, tx, ty)` now requests `/api/projection/tiles/${level}/${tx}/${ty}`.
- `frontend/src/app/services/tile-cache.service.ts` — updated the single caller.

## Verification

`npm run build:prod` passes with no errors or warnings.

https://claude.ai/code/session_01DAz4aDmnMy1ftzaUYx7Rjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAz4aDmnMy1ftzaUYx7Rjk)_