### PR TITLE
Surface model-load progress during clip embedding (no more frozen "(0/100) Embedding clips…")

### DIFF
--- a/tests_lib/io/test_clip_reembed_bulk.py
+++ b/tests_lib/io/test_clip_reembed_bulk.py
@@ -144,6 +144,60 @@ class TestBulkClipReembed:
             np.testing.assert_array_equal(clip["embedding"], expected)
 
 
+class TestClipReembedLoadingProgressPassthrough:
+    """The model is loaded lazily on the first ``embed_media_bulk`` call,
+    *after* the "Embedding clips…" line is on screen. While it loads (and
+    on first run downloads weights + warms up) the embedder emits
+    descriptive ``status="loading"`` messages. Those must reach the
+    ``on_progress`` callback verbatim — with the embedder's own
+    current/total — instead of being collapsed into a frozen
+    "Embedding clips… (0/N)"; only real per-clip progress is relabelled
+    to the "embedding" phase."""
+
+    def test_loading_messages_forwarded_verbatim(self):
+        from vtscore.datasets.load_pipeline import _apply_clipper
+
+        emb = mock.MagicMock()
+        emb._on_progress = lambda *a, **kw: None
+
+        def _bulk(medias):
+            # Simulate lazy load: descriptive "loading" progress (weight
+            # load reports 0/0; warmup reports a step ratio), then real
+            # per-clip "embedding" progress.
+            emb._on_progress("loading", "Loading test model weights…", 0, 0)
+            emb._on_progress("loading", "Warming up pipeline…", 2, 3)
+            for i, _ in enumerate(medias):
+                emb._on_progress("embedding", "", i + 1, len(medias))
+            return [np.full(512, float(i + 1), dtype=np.float32) for i, _ in enumerate(medias)]
+
+        emb.embed_media_bulk.side_effect = _bulk
+
+        calls: list[tuple[int, int, str]] = []
+        clips_dict = {1: _make_audio_media(1, duration=5.1)}
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            _apply_clipper(
+                clips_dict,
+                "sound_tiling",
+                {"duration": 2.0},
+                on_progress=lambda cur, tot, phase: calls.append((cur, tot, phase)),
+            )
+
+        phases = [c[2] for c in calls]
+        # Loading messages reach the callback unchanged, not collapsed to
+        # the "embedding" phase.
+        assert "Loading test model weights…" in phases
+        assert "Warming up pipeline…" in phases
+        # The weight-load step carries the embedder's own (0, 0), so it no
+        # longer renders as a frozen scaled clip count.
+        weight = next(c for c in calls if c[2] == "Loading test model weights…")
+        assert weight[:2] == (0, 0)
+        warmup = next(c for c in calls if c[2] == "Warming up pipeline…")
+        assert warmup[:2] == (2, 3)
+        # Real per-clip progress is still reported under the "embedding"
+        # phase, scaled against the clip list.
+        assert "embedding" in phases
+
+
 class TestBulkClipReembedFailureFallback:
     """When ``embed_media_bulk`` returns ``None`` for a clip, or the
     whole call raises, the affected clip keeps the parent embedding it

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -466,12 +466,25 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
         return
 
     def _clip_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-        if on_progress:
-            # Map the embedder's batch-level progress back to clip-list
-            # coordinates so the existing on_progress(current, total, phase)
-            # contract keeps reporting against total_clips.
-            scaled = min(total_clips, int(current * len(embed_indices) / max(1, total)))
-            on_progress(scaled, total_clips, "embedding")
+        if not on_progress:
+            return
+        if status == "loading":
+            # The model is loaded lazily on the first embed call, *after*
+            # the "Embedding clips…" line is already on screen. While it
+            # loads (and on first run downloads weights + JIT-warms up the
+            # pipeline) the embedder emits descriptive "loading" messages
+            # ("Loading … model weights…", "Warming up audio pipeline…").
+            # Forward those verbatim — with the embedder's own current/total —
+            # so the user sees what's actually happening instead of a frozen
+            # "Embedding clips… (0/N)". Scaling these load sub-steps against
+            # the clip list would be meaningless.
+            on_progress(current, total, message or "Loading model…")
+            return
+        # Real per-clip progress: map the embedder's batch-level progress back
+        # to clip-list coordinates so the existing on_progress(current, total,
+        # phase) contract keeps reporting against total_clips.
+        scaled = min(total_clips, int(current * len(embed_indices) / max(1, total)))
+        on_progress(scaled, total_clips, "embedding")
 
     original_cb = embedder._on_progress
     embedder._on_progress = _clip_progress
@@ -794,8 +807,13 @@ def _apply_clipper_stage(
             msg = "Clipping media…"
         elif phase == "converting":
             msg = "Converting media…"
-        else:
+        elif phase == "embedding":
             msg = "Embedding clips…"
+        else:
+            # A loading/warmup message forwarded verbatim from the embedder
+            # (e.g. "Loading CLAP model weights…", "Warming up audio
+            # pipeline…") while the model loads on the first embed call.
+            msg = phase
         tracker.update(
             "loading", msg, current=current, total=total, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
         )


### PR DESCRIPTION
## What's up with "(0/100) Embedding clips…" sitting for a long time?

It's almost certainly **not crashed** — it's loading (and on first run downloading) the embedding model, plus the audio JIT warmup. The progress bar just hid that.

### Root cause

The embedding model is loaded **lazily on the first `embed_media_bulk` call**, which happens *after* the "Embedding clips…" line is already on screen (`vtscore/datasets/load_pipeline.py`). For audio (CLAP), `_load_models_impl` does a lot before a single clip is embedded: import torch/transformers, load or **download** the model weights (the long pole), and a warmup pass whose own comment notes it "stalls for 10–30 s while numba compiles resampling kernels, making the embedding progress bar appear frozen."

The embedder *does* emit descriptive `status="loading"` messages during all of this ("Loading CLAP model weights…", "Warming up audio pipeline…", and even tqdm download bars). But the clip-embed progress wrapper (`_clip_progress`) **discarded `status`/`message` entirely** and always re-labelled the phase as "Embedding clips…", scaling `current` against the clip list. The longest sub-steps report `current=0, total=0`, which mapped straight to `0/100`. Net effect: a frozen `(0/100) Embedding clips…` during the genuinely slow, genuinely silent load.

### Fix

`_clip_progress` now forwards the embedder's `loading` status/message verbatim (with the embedder's own current/total), and only collapses to "Embedding clips…" for real per-clip progress. `_clipper_progress` maps the known phases (`clipping`/`converting`/`embedding`) and passes any other phase string through as the message. So the user now sees "Loading … model weights…" / "Warming up audio pipeline…" (and download bars) instead of a frozen counter.

### Tests

- Added `TestClipReembedLoadingProgressPassthrough` in `tests_lib/io/test_clip_reembed_bulk.py` verifying loading messages reach the callback verbatim with the embedder's own current/total, while per-clip progress still reports the `embedding` phase.
- Targeted run green: `tests_lib/io/test_clip_reembed_bulk.py` + `TestApplyClipperProgress` — 17/17 passed.

### Note

`./run-tests.sh` is currently blocked by a pre-existing OpenAPI snapshot drift that is 100% the HTTP-422 reason phrase (`UNPROCESSABLE_CONTENT`/"Unprocessable Content" ↔ `UNPROCESSABLE_ENTITY`), a Werkzeug/flask-smorest version artifact in the container with zero relation to this change. Regenerating it would bake the container's phrasing into the snapshot, so it was deliberately left untouched.

https://claude.ai/code/session_01PbjaLEDGvXvFUvPF4iYQHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbjaLEDGvXvFUvPF4iYQHX)_