### PR TITLE
Don't let one unreadable cached pkl 500 the whole demo catalog

### DIFF
--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -396,6 +396,35 @@ class TestDemoDatasetReadiness:
             except OSError:
                 pass
 
+    def test_corrupt_cached_pkl_does_not_crash_demo_list(self, client):
+        """A corrupt cached pkl must not 500 the catalog; it degrades to unknown metadata.
+
+        Regression: ``read_pkl_embedder`` used to raise ``BadZipFile`` on a non-zip
+        file, and that unhandled exception 500'd ``GET /api/dataset/demo-list``
+        entirely — one bad cache file blanked the whole demo listing. The demo is
+        still listed; its embedder just reports empty.
+        """
+        from vtscore.config import EMBEDDINGS_DIR
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        pkl_file = EMBEDDINGS_DIR / "esc50_s.pkl"
+        # Not a zip container — what a truncated download or legacy raw pickle
+        # looks like on disk.
+        pkl_file.write_bytes(b"\x80\x05not-a-zip-container")
+        try:
+            resp = client.get("/api/dataset/demo-list")
+            assert resp.status_code == 200, "one corrupt cache file must not 500 the whole catalog"
+            data = resp.get_json()
+            ds = next((d for d in data["datasets"] if d["name"] == "esc50_s"), None)
+            assert ds is not None, "the demo is still listed despite an unreadable cache file"
+            assert ds["pkl_embedder"] == "", "unreadable cache degrades to empty embedder, not an exception"
+        finally:
+            pkl_file.unlink(missing_ok=True)
+            try:
+                EMBEDDINGS_DIR.rmdir()
+            except OSError:
+                pass
+
     def test_audio_pkl_with_empty_esc50_shows_needs_download(self, client):
         """Audio pkl exists and ESC-50 audio dir exists but is empty → needs_download."""
         import pickle

--- a/tests_lib/datasets/test_container.py
+++ b/tests_lib/datasets/test_container.py
@@ -152,3 +152,17 @@ class TestContainerMetaReaders:
         path = tmp_path / "dataset.pkl"
         write_container(path, _medias_pkl_bytes(), _meta())
         assert read_pkl_clipper(path) == "test_clipper"
+
+    def test_meta_readers_return_none_for_unreadable_pkl(self, tmp_path):
+        """A corrupt / legacy non-zip pkl must degrade to None, not raise.
+
+        The demo catalog reads metadata from every cached file; one unreadable
+        file used to raise ``BadZipFile`` and 500 the whole listing.
+        """
+        from vtscore.datasets.loader_pickle import read_pkl_clipper, read_pkl_embedder
+
+        path = tmp_path / "legacy.pkl"
+        # A raw (non-zip) pickle: old on-disk format, no zip magic.
+        path.write_bytes(b"\x80\x05not-a-zip-container")
+        assert read_pkl_embedder(path) is None
+        assert read_pkl_clipper(path) is None

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import gc
 import hashlib
+import logging
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -16,6 +17,8 @@ from vtscore.datasets.loader import (
     ProgressCallback,
 )
 from vtscore.embedding.normalize import l2_normalize
+
+logger = logging.getLogger(__name__)
 
 
 def _read_pickle_dataset(file_path: Path) -> dict[str, Any]:
@@ -368,17 +371,28 @@ def load_dataset_from_pickle_chunked(
             yield chunk_medias
 
 
-def read_pkl_clipper(pkl_path: Path) -> str | None:
-    """Return the clipper name from the container's ``meta.json``."""
+def _read_pkl_meta_safe(pkl_path: Path) -> dict[str, Any]:
+    """Read a container's ``meta.json``, returning ``{}`` if it can't be read.
+
+    A cached ``.pkl`` may be corrupt, truncated, or a legacy non-zip pickle.
+    The demo catalog reads metadata from every cached file to report each
+    demo's embedder/clipper, so one unreadable file must not raise and take
+    down the whole listing — it degrades to "metadata unknown" instead.
+    """
     from vtscore.datasets.container import read_meta
 
-    meta = read_meta(pkl_path)
-    return meta.get("clipper") or None
+    try:
+        return read_meta(pkl_path)
+    except Exception:
+        logger.warning("Could not read container metadata from %s; treating as unknown", pkl_path, exc_info=True)
+        return {}
+
+
+def read_pkl_clipper(pkl_path: Path) -> str | None:
+    """Return the clipper name from the container's ``meta.json``, or ``None`` if unreadable."""
+    return _read_pkl_meta_safe(pkl_path).get("clipper") or None
 
 
 def read_pkl_embedder(pkl_path: Path) -> str | None:
-    """Return the embedder name from the container's ``meta.json``."""
-    from vtscore.datasets.container import read_meta
-
-    meta = read_meta(pkl_path)
-    return meta.get("embedder") or None
+    """Return the embedder name from the container's ``meta.json``, or ``None`` if unreadable."""
+    return _read_pkl_meta_safe(pkl_path).get("embedder") or None


### PR DESCRIPTION
## Problem

`GET /api/dataset/demo-list` reads embedder/clipper metadata from **every** cached embedding pkl in `EMBEDDINGS_DIR`. `read_pkl_embedder`/`read_pkl_clipper` opened each file as a zip container and let any failure propagate. So a single corrupt, truncated, or legacy non-zip pickle raised `BadZipFile` and **500'd the entire endpoint** — the UI then showed "No demo datasets available" with nothing loadable, even though every *other* cached demo was fine.

Found while driving the live app: one stale legacy `data/embeddings/esc50_s.pkl` blanked the whole demo catalog.

## Fix

Route both metadata readers through a shared `_read_pkl_meta_safe()` helper that catches read failures, logs a warning, and returns `{}` — so the reader degrades to `None` instead of raising. One bad file now just reports empty metadata; the rest of the catalog lists normally. The two readers are used **only** by the demo-list route, so the blast radius is contained.

## Tests

- `tests_lib/datasets/test_container.py` — readers return `None` (no raise) for a non-zip pickle.
- `tests/datasets/test_datasets.py` — `demo-list` returns **200** (not 500) with the demo still listed when its cache file is corrupt.

`./run-tests.sh datasets` equivalent (`tests/datasets` + `tests_lib/datasets`): **78 passed, 3 skipped**. ruff/format/codespell clean on the diff.

## Out of scope (intentional)

Loading a *legacy raw-pickle dataset* still errors (`read_container` expects a zip). That's a one-off migration artifact; future installs only ever write the zip format, so per discussion it's deliberately not addressed here. Two related browse bugs found during the same session (projection tile-URL mismatch, post-build view refresh) were already fixed on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)