### PR TITLE
Auto-depth VTSBrowse pyramid: resolve to one clip per hex

### DIFF
--- a/docs/plans/vtsbrowse-audit-fixes.md
+++ b/docs/plans/vtsbrowse-audit-fixes.md
@@ -1,0 +1,110 @@
+# VTSBrowse audit — queued fixes
+
+Status: **planned, not yet applied** (paused behind an unrelated in-flight
+`build_pyramid` auto-depth change in the working tree). Apply on a feature
+branch off `dev`; the files below are disjoint from the auto-depth WIP, so they
+commit cleanly on their own.
+
+This came out of a live-driving + targeted-code audit of VTSBrowse (the hex-tile
+UMAP browse view). The feature is well-built; these are the genuinely
+worth-fixing items. Two agent claims were investigated and **rejected** (see
+bottom) — don't re-raise them.
+
+## Findings & fixes, in priority order
+
+### 1. `clear_medias()` leaks the projection + tile pyramid  (HIGH value)
+
+- **Where:** `vtscore/state/__init__.py` — `clear_medias()` (around lines
+  132–138).
+- **What:** The function's docstring says it drops caches "so RAM is released
+  immediately," and it clears `medias`, `_emb_matrix`, `_emb_matrix_ids`,
+  `diversity_tree`, and `dataset_display_name` — but it leaves `ctx._projection`
+  (2-D coords) and `ctx._pyramid` (the **entire hex-tile pyramid — the largest
+  Browse artifact**) resident.
+- **Two consequences, both verified in code:**
+  - *Memory:* on the RAM-tight box (~3.7 GB), unloading a dataset never frees
+    its tiles.
+  - *Correctness (latent):* the build route short-circuits on
+    `if ctx._pyramid is not None:` at `vtsearch/routes/projection.py:86` and
+    returns `{"status": "ready"}` **before** the signature check at line ~108.
+    So if the same `dataset_id` context is reloaded with changed contents and
+    the projection isn't rebuilt, the **stale pyramid is served** (hexes for the
+    old data). Reload path: `clear_dataset` → `clear_all` → `clear_medias`
+    (`vtscore/datasets/load_pipeline.py:152`); `_pyramid` is only re-set on load
+    when `build_projection` is requested (`load_pipeline.py:1107–1108`).
+- **Fix:** add to `clear_medias()`, inside the `_state_lock` block:
+  ```python
+  ctx._projection = None
+  ctx._pyramid = None
+  ```
+- **Test:** add a regression test asserting `clear_medias()` nulls both — put it
+  in a **state** test file (e.g. `tests_lib/` for the state core), **NOT** in
+  `tests_lib/projection/test_pyramid.py` (that file has unrelated WIP). Build a
+  context with a non-null `_pyramid`, call `clear_medias`, assert both `None`.
+
+### 2. Hover preview/highlight goes stale on zoom  (MEDIUM)
+
+- **Where:** `frontend/src/app/components/browse-canvas/browse-canvas.component.ts`
+  — `zoomBy()` (~line 502), used by the +/- buttons and the mouse wheel.
+- **What:** `zoomBy()` changes the transform and re-runs `updateActiveLevel()`
+  (which can re-bin to a different hex level) and redraws, but never clears or
+  re-evaluates hover state (`hoveredCell` / `hexHover` emit). Hover is only
+  updated on `onCanvasMouseMove` (~526) or cleared on `onCanvasMouseLeave`
+  (~559). So zooming with the cursor stationary leaves the "N items" tooltip
+  pinned at its old screen spot and the hex highlight on stale `q/r` coords —
+  which, after a wheel-driven level change, can point at the wrong/nonexistent
+  hex. (Reproduced live: the "3 items" tooltip persisted across a button zoom.)
+- **Fix (preferred):** track the last cursor position on `onCanvasMouseMove`;
+  at the end of `zoomBy()` (after `updateActiveLevel()`), re-run `hitTest()` at
+  that position and emit the updated `hexHover` (or `null`). Keeps the preview
+  live and correct as you wheel-zoom.
+- **Fix (minimal fallback):** clear hover at the end of `zoomBy()` —
+  `this.hoveredCell = null; this.ngZone.run(() => this.hexHover.emit(null));`.
+
+### 3. Frontend hardening bundle  (LOW–MED)
+
+- **AbortController on hover-preview text fetch** —
+  `frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts:111`.
+  `loadText()` uses bare `fetch()` with no cancellation; rapid hover can race
+  responses (partially guarded by the `rep_id` check). Store an
+  `AbortController`, abort the previous request when a new load starts, abort in
+  `ngOnDestroy`.
+- **`pollBuildStatus` retry hygiene** —
+  `frontend/src/app/components/browse-view/browse-view.component.ts:259`. Uses a
+  recursive `setTimeout(poll, 2000)` on error with no cap/backoff, not tied to
+  `takeUntil(destroy$)`; a scheduled retry can fire after navigation. Convert to
+  a `timer()`/`interval()` pipeline with `takeUntil(destroy$)`, add a retry cap
+  + backoff.
+- **Canvas listener cleanup** — `browse-canvas.component.ts:134–137`. The four
+  canvas listeners are added with inline `.bind(this)` (fresh refs) and are not
+  removed in `ngOnDestroy` (~158). Store bound handlers as fields (like the
+  existing `boundMouseMove`/`boundMouseUp` at 85–86) and remove all four in
+  `ngOnDestroy`. (Practical leak is small — the routed canvas DOM is torn down
+  with the component — but the inline binds make proper cleanup impossible.)
+- **Delete dead `onCanvasClick()`** —
+  `browse-hover-preview.component.ts:129`. Confirmed zero callers (grep). Remove
+  it (and any now-unused autoplay-unlock scaffolding) unless wiring it up is
+  intended.
+
+## Verification / process notes
+
+- Base on `dev`, feature branch, PR → `dev` (repo convention; `main` is
+  protected). Auto-open the PR when done.
+- Local `./run-tests.sh` is blocked by the codespell/stray-`venv` gotcha; run
+  targeted instead: `pytest tests_lib/projection` + the relevant state tests,
+  `ruff check <changed>`, `codespell --toml pyproject.toml <changed>`, and
+  `cd frontend && npm run build:prod` to typecheck + rebuild `static/`.
+- Frontend serves the **pre-built** bundle in `static/`; rebuild after TS edits
+  or the running app won't reflect them. The prod build needs ~700 MB free —
+  stop the app first (CLAP holds RAM) on the tight box.
+
+## Rejected agent claims (do not re-raise)
+
+- *"Tile request storm / no dedup" (claimed HIGH):* **false.**
+  `frontend/src/app/services/tile-cache.service.ts` has an `inflight` map +
+  `shareReplay(1)` dedup and a 512-entry LRU (`evict()` by `lastAccess`). The
+  ~26 tiles seen on one zoom were distinct visible+prefetch tiles, each fetched
+  once. The only real (minor) gap is no **cancellation** of now-offscreen
+  in-flight requests on rapid pan/zoom — LOW.
+- *"Listener leak is HIGH":* **overstated** — see #3; real but low-impact
+  because the routed component's DOM is destroyed with it.

--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -65,14 +65,17 @@ The knobs, their current values, and their source of truth as of this plan:
 
 | Knob | Current default | Notes |
 |------|-----------------|-------|
-| `n_levels` | from `max_useful_levels(N)` in the route (`projection.py:121`) | Clamped `[1, 12]`. Heuristic `1 + ceil(log4(N / base_cols²))`. |
+| `n_levels` | **auto-depth** (`None`) | Default `None` makes `build_pyramid` descend until every occupied hex holds a single clip (one-clip-per-hex at deepest zoom), stopping early on co-located clips. Pass an int for fixed depth. |
+| `max_useful_levels(N)` | `1 + ceil(log2 N)`, clamped `[1, 14]` | Runaway-guard **ceiling** for the auto-depth descent only — not the operating depth. Replaced the old `log4(N / base_cols²)` heuristic, which assumed uniform 2-D fill and bottomed out ~1 level short of single clips for clustered embeddings (e.g. ~3 levels / ~5 clips-per-hex for the 245-clip ESC-50 demo). |
 | `base_cols` | `6.0` | Level-0 spans ~6 hex columns across the larger extent. Drives `base_radius`. |
 | `base_radius` | derived (`None` → `_base_radius_for`) | Override path exists but unused. |
 | `tile_span` | `16.0` | Hex columns/rows per tile. Payload-size vs round-trip-count tradeoff. |
 
-`max_useful_levels`/`build_pyramid` are called in
-`vtsearch/routes/projection.py:121,132` with only `n_levels` passed;
-`base_cols`/`tile_span` use the function defaults.
+`build_pyramid(proj)` is called with **no** `n_levels` (auto-depth) in
+`vtsearch/routes/projection.py:131` and `vtscore/datasets/load_pipeline.py:1104`;
+`base_cols`/`tile_span` use the function defaults. Auto-depth resolves the
+former `n_levels` tuning question — the descent self-terminates at single-clip
+resolution rather than relying on a closed-form estimate.
 
 ### Canvas renderer (Stage 3) — `frontend/src/app/components/browse-canvas/browse-canvas.component.ts`
 
@@ -109,8 +112,9 @@ internal) vs *stay constants*. A reasonable cut:
 - **Server settings** (`ServerSettings` + `CoreConfig`, like `dataset_max_age_days`):
   `projection_n_neighbors`, `projection_min_dist`. These materially change the
   map and a user/operator might want to set them per deployment.
-- **Derived, not exposed:** `n_levels` (already auto from `max_useful_levels`),
-  `base_radius` (derived from `base_cols`).
+- **Derived, not exposed:** `n_levels` (auto-depth — descends to single-clip
+  resolution; `max_useful_levels` is only the guard ceiling), `base_radius`
+  (derived from `base_cols`).
 - **Constants for now, revisit only if the sweep says so:** `base_cols`,
   `tile_span`, `min_n_for_umap`.
 

--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -565,15 +565,19 @@ and available to any future consumer of `vtscore`.
     NumPy (no d3 dependency): `hexbin_assign(points, radius) -> (q, r)` integer
     cell keys (`q = round(2*pi)` to keep d3's half-integer column index
     integral) and `hex_center(q, r, radius)` to invert.
-  - `pyramid.py` — `build_pyramid(projection, ...) -> Pyramid` (Stage 2). Builds
-    `n_levels` zoom levels (each halving the hex radius), aggregating per hex:
-    axial key, center, **count** (density), and a **representative media id**
-    (member nearest the cell centroid, ties broken to the smaller id). Hexes are
-    grouped into `(level, tx, ty)` **tiles**; `Tile.to_payload()` /
-    `Pyramid.meta()` emit JSON-friendly dicts for the future tile/meta endpoints.
-    Tunable knobs (`n_levels`, `base_cols`/`base_radius`, `tile_span`) are
-    parameters, not baked constants, per *§Open problems*; `max_useful_levels()`
-    is an advisory `n_levels` ceiling.
+  - `pyramid.py` — `build_pyramid(projection, ...) -> Pyramid` (Stage 2). By
+    default (**auto-depth**, `n_levels=None`) it descends — each level halving the
+    hex radius — until every occupied hex holds a single clip, so the deepest
+    level resolves one-clip-per-hex (enabling hover-to-hear of individual
+    sounds); it stops early when a halving no longer separates any co-located
+    clips, capped by `max_useful_levels()` as a runaway guard. Pass an int
+    `n_levels` for fixed depth. Each level aggregates per hex: axial key, center,
+    **count** (density), and a **representative media id** (member nearest the
+    cell centroid, ties broken to the smaller id). Hexes are grouped into
+    `(level, tx, ty)` **tiles**; `Tile.to_payload()` / `Pyramid.meta()` emit
+    JSON-friendly dicts for the tile/meta endpoints. Tunable knobs
+    (`base_cols`/`base_radius`, `tile_span`) are parameters, not baked constants,
+    per *§Open problems*.
   - **New dependency:** `umap-learn` (added to `[project.dependencies]` with the
     `umap-learn -> umap` deptry module-name mapping). Imported lazily so the
     package import never triggers numba's JIT until a fit runs.

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -121,6 +121,64 @@ def test_coincident_points_use_fallback_radius():
 def test_max_useful_levels_bounds():
     assert max_useful_levels(0) == 1
     assert max_useful_levels(1) == 1
-    assert 1 <= max_useful_levels(100) <= 12
+    assert 1 <= max_useful_levels(100) <= 14
     assert max_useful_levels(10_000) >= max_useful_levels(100)
-    assert max_useful_levels(10**9) <= 12
+    assert max_useful_levels(10**9) <= 14
+    # Generous enough that a dense small cloud separates before the cap: the old
+    # log4 ceiling bottomed out at 3 levels for ~245 clips (the ESC-50 demo),
+    # leaving ~5 clips merged per hex at max zoom.  log2 sizing gives real
+    # headroom.
+    assert max_useful_levels(245) >= 8
+
+
+def _grid_cloud(side: int = 4, spacing: float = 1.0) -> np.ndarray:
+    """``side x side`` distinct points on a regular grid (deterministic)."""
+    xs, ys = np.meshgrid(np.arange(side) * spacing, np.arange(side) * spacing)
+    return np.stack([xs.ravel(), ys.ravel()], axis=1).astype(np.float32)
+
+
+def test_auto_depth_resolves_to_single_clip_hexes():
+    # The fix: with no explicit n_levels, the build descends until every hex
+    # holds exactly one clip, so hover-to-hear can audition individual sounds.
+    coords = _grid_cloud(side=4, spacing=1.0)  # 16 well-separated points
+    pyr = build_pyramid(_projection(coords), base_radius=4.0)
+    deepest = max(lm.level for lm in pyr.levels)
+    deepest_cells = [c for (lvl, _, _), t in pyr.tiles.items() if lvl == deepest for c in t.cells]
+    assert deepest_cells, "deepest level has no cells"
+    assert max(c.count for c in deepest_cells) == 1, "deepest level still merges clips"
+    assert sum(c.count for c in deepest_cells) == coords.shape[0]
+    # Coarser levels genuinely aggregate — this isn't a one-level pyramid.
+    assert pyr.levels[0].n_cells < coords.shape[0]
+
+
+def test_fixed_shallow_depth_still_merges_clips():
+    # Contrast: a too-shallow fixed depth leaves clips merged — exactly the
+    # bottoming-out the auto path now avoids.
+    coords = _grid_cloud(side=4, spacing=1.0)
+    pyr = build_pyramid(_projection(coords), n_levels=2, base_radius=4.0)
+    assert len(pyr.levels) == 2  # explicit depth is honored exactly
+    cells = [c for t in pyr.tiles.values() for c in t.cells]
+    assert max(c.count for c in cells) > 1
+
+
+def test_auto_depth_stops_early_for_separated_data():
+    # Three points 100 apart resolve at the very first level; the build must not
+    # grind all the way to the cap.
+    coords = np.array([[0.0, 0.0], [100.0, 0.0], [0.0, 100.0]], dtype=np.float32)
+    pyr = build_pyramid(_projection(coords))
+    assert len(pyr.levels) <= 2
+    cells = [c for t in pyr.tiles.values() for c in t.cells]
+    assert max(c.count for c in cells) == 1
+
+
+def test_auto_depth_terminates_on_coincident_points():
+    # Identical points can never be separated by any radius; the build must stop
+    # (saturation guard) rather than descend to the cap.
+    coords = np.zeros((10, 2), dtype=np.float32)
+    pyr = build_pyramid(_projection(coords))
+    assert len(pyr.levels) < max_useful_levels(10)
+    # Every level holds the same single, unsplittable hex of all 10 clips.
+    for lvl in {level for level, _, _ in pyr.tiles}:
+        cells = [c for (level, _, _), t in pyr.tiles.items() if level == lvl for c in t.cells]
+        assert len(cells) == 1
+        assert cells[0].count == 10

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -1074,7 +1074,7 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     reason.
     """
     from vtscore.embedding.matrix import get_embedding_matrix  # noqa: PLC0415
-    from vtscore.projection import build_pyramid, fit_projection, max_useful_levels  # noqa: PLC0415
+    from vtscore.projection import build_pyramid, fit_projection  # noqa: PLC0415
 
     def _progress(current: int, total: int, message: str) -> None:
         tracker.check_cancelled()
@@ -1095,14 +1095,13 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
         return
 
     _progress(0, 0, "Building 2-D projection…")
-    n_levels = max_useful_levels(len(sorted_ids))
 
     def _on_fit_progress(status: str, message: str, current: int, total: int) -> None:
         _progress(current, total, message or "Building 2-D projection…")
 
     proj = fit_projection(matrix, list(sorted_ids), on_progress=_on_fit_progress)
     _progress(0, 1, "Building hex-tile pyramid…")
-    pyr = build_pyramid(proj, n_levels=n_levels)
+    pyr = build_pyramid(proj)
     _progress(1, 1, "Projection ready")
 
     ctx._projection = proj

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -178,23 +178,36 @@ def _build_level(level: int, coords: np.ndarray, ids: np.ndarray, radius: float,
 def build_pyramid(
     projection: Projection,
     *,
-    n_levels: int = 6,
+    n_levels: int | None = None,
     base_cols: float = 6.0,
     base_radius: float | None = None,
     tile_span: float = 16.0,
 ) -> Pyramid:
     """Build the hex-tile :class:`Pyramid` for a frozen *projection*.
 
-    ``n_levels`` zoom levels are produced (``z = 0 … n_levels-1``), each
-    halving the hex radius.  ``base_radius`` (level 0) defaults to a value
-    sized so the projection's larger extent spans ~``base_cols`` hex columns;
-    pass it explicitly to override.  ``tile_span`` is the number of hex
-    columns/rows grouped into one tile.  All of these are tunable knobs, not
-    baked constants (see *§Open problems* in the design doc).
+    Zoom levels are produced ``z = 0 … L-1``, each halving the hex radius.
 
-    Empty projections yield a pyramid with no tiles.
+    - **Auto depth (default, ``n_levels=None``):** descend until every occupied
+      hex holds a single clip, so the deepest level resolves the dataset to
+      one-clip-per-hex and hover-to-hear can audition individual sounds.
+      Descent also stops if a radius halving no longer separates any points
+      (co-located clips) and is capped at :func:`max_useful_levels` as a
+      runaway guard.  This is the production path: a closed-form level count
+      can't be used because occupied-hex growth depends on the (unknown a
+      priori) shape of the projected cloud — clustered, manifold-like
+      embeddings grow far slower per level than a uniform 2-D fill would, so a
+      fixed estimate systematically bottoms out before reaching single clips.
+    - **Fixed depth (``n_levels`` an int):** produce exactly that many levels.
+
+    ``base_radius`` (level 0) defaults to a value sized so the projection's
+    larger extent spans ~``base_cols`` hex columns; pass it explicitly to
+    override.  ``tile_span`` is the number of hex columns/rows grouped into one
+    tile.  All of these are tunable knobs, not baked constants (see
+    *§Open problems* in the design doc).
+
+    Empty projections yield a pyramid with no tiles (one level when auto).
     """
-    if n_levels < 1:
+    if n_levels is not None and n_levels < 1:
         raise ValueError(f"n_levels must be >= 1, got {n_levels}")
 
     coords = np.ascontiguousarray(projection.coords, dtype=np.float64)
@@ -202,10 +215,15 @@ def build_pyramid(
     bounds = projection.bounds
     r0 = base_radius if base_radius is not None else _base_radius_for(bounds, base_cols)
 
+    adaptive = n_levels is None
+    max_levels = max_useful_levels(int(coords.shape[0])) if adaptive else n_levels
+
     levels: list[LevelMeta] = []
     tiles: dict[tuple[int, int, int], Tile] = {}
 
-    for level in range(n_levels):
+    prev_n_cells: int | None = None
+    prev_max_count: int | None = None
+    for level in range(max_levels):
         radius = r0 / (2.0**level)
         if coords.shape[0] == 0:
             levels.append(LevelMeta(level=level, radius=radius, n_cells=0))
@@ -215,6 +233,20 @@ def build_pyramid(
         levels.append(LevelMeta(level=level, radius=radius, n_cells=n_cells))
         for t in level_tiles:
             tiles[(t.level, t.tx, t.ty)] = t
+
+        if adaptive:
+            max_count = max((c.count for t in level_tiles for c in t.cells), default=0)
+            # Fully resolved: every hex holds a single clip, so deeper levels
+            # would only reproduce this one at finer (wasted) radii.
+            if max_count <= 1:
+                break
+            # No progress across a radius halving — neither the hex count nor
+            # the densest cell improved — means the remaining co-located clips
+            # can never be separated; stop rather than grind to the cap.
+            if n_cells == prev_n_cells and max_count == prev_max_count:
+                break
+            prev_n_cells = n_cells
+            prev_max_count = max_count
 
     return Pyramid(
         projection_id=projection.projection_id,
@@ -227,17 +259,21 @@ def build_pyramid(
     )
 
 
-def max_useful_levels(point_count: int, base_cols: float = 6.0) -> int:
-    """A reasonable ``n_levels`` ceiling for *point_count* clips.
+def max_useful_levels(point_count: int) -> int:
+    """A generous ``n_levels`` ceiling for *point_count* clips.
 
-    Heuristic: keep descending until a level could resolve roughly one clip per
-    hex.  Each level multiplies the hex count by ~4 (radius halves in 2-D), and
-    level 0 spans ~``base_cols**2`` hexes, so ``log4(point_count / base_cols**2)``
-    extra levels suffice.  Clamped to ``[1, 12]``.  Advisory only — callers
-    pass the result as ``n_levels`` to :func:`build_pyramid`.
+    Used by :func:`build_pyramid`'s auto-depth path purely as a runaway guard:
+    the build descends until each hex holds a single clip, and this only bounds
+    how deep it may ever go (e.g. when many clips project to the same point and
+    can never be separated).  Sized off ``log2`` of the point count with
+    headroom and clamped to ``[1, 14]`` — deep enough that any non-degenerate
+    cloud separates before the cap, while over-estimating stays harmless because
+    the adaptive descent stops as soon as the data resolves.
+
+    The old heuristic assumed each level quadruples the occupied-hex count (a
+    uniform 2-D fill); real, clustered embeddings grow far slower (~2x), so that
+    estimate stopped one or more levels short of single-clip resolution.
     """
     if point_count <= 1:
         return 1
-    level0_hexes = max(base_cols * base_cols, 1.0)
-    extra = math.log(max(point_count / level0_hexes, 1.0), 4.0)
-    return max(1, min(12, 1 + int(math.ceil(extra))))
+    return max(1, min(14, 1 + int(math.ceil(math.log(point_count, 2.0)))))

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -78,7 +78,7 @@ def build_projection():
     """
     from vtscore.concurrency.async_jobs import projection_jobs
     from vtscore.embedding.matrix import get_embedding_matrix
-    from vtscore.projection import build_pyramid, fit_projection, max_useful_levels
+    from vtscore.projection import build_pyramid, fit_projection
     from vtscore.state.core import get_active_context, thread_dataset_context
 
     ctx = get_active_context()
@@ -118,7 +118,6 @@ def build_projection():
 
     def _run(job):
         with thread_dataset_context(ctx):
-            n_levels = max_useful_levels(len(ids_copy))
 
             def _on_progress(status, message, current, total):
                 job.update_progress(current, total, message)
@@ -129,7 +128,7 @@ def build_projection():
                 on_progress=_on_progress,
             )
             job.update_progress(0, 1, "building pyramid")
-            pyr = build_pyramid(proj, n_levels=n_levels)
+            pyr = build_pyramid(proj)
             job.update_progress(1, 1, "done")
 
             ctx._projection = proj


### PR DESCRIPTION
## What & why

Makes the VTSBrowse hex-tile pyramid **auto-depth**: `build_pyramid()` now descends (halving the hex radius each level) until every occupied hex holds a single clip, so the deepest zoom resolves **one-clip-per-hex** and hover-to-hear can audition individual sounds.

The old fixed `n_levels = max_useful_levels(N)` used a `log4` heuristic that assumed a uniform 2-D fill; real, clustered embeddings grow occupied-hex count far slower (~2×), so it bottomed out ~1 level short of single clips — e.g. ~3 levels / ~5 clips-per-hex for the 245-clip ESC-50 demo.

## How

- `build_pyramid(proj)` (default `n_levels=None`) descends until `max_count <= 1`, with two early stops: a **saturation guard** (no change in hex count *and* densest cell across a halving → co-located clips that can't separate) and `max_useful_levels()` as a **runaway-guard ceiling** (now `1 + ceil(log2 N)`, clamped `[1,14]`).
- An explicit int `n_levels` still produces fixed depth (unchanged for callers/tests that want it).
- Production callers (build route + load pipeline) now call `build_pyramid(proj)` with no `n_levels`.

## Verification

- **Tests:** 53 projection tests green (35 library-tier + 18 app-tier), including new auto-depth coverage (single-clip resolution, fixed-depth contrast, early stop for separated data, termination on coincident points). `ruff` / `ruff format` / `codespell` / `deptry` / `pyright` all clean.
- **End-to-end on ESC-50 (245 clips):** pyramid builds 7 levels with `n_cells` `[30, 57, 104, 153, 217, 236, 245]`; the deepest level has **245 cells (one per clip)**, a deepest cell has `count == 1`, and its representative clip serves a valid `audio/wav` (hover-to-hear works).

## Notes

- Finishes WIP started in a prior session.
- Bundles a docs-only planning file (`docs/plans/vtsbrowse-audit-fixes.md`) capturing a separate, verified VTSBrowse audit (e.g. `clear_medias()` leaves `_projection`/`_pyramid` resident — a memory leak + latent stale-pyramid serve; stale hover-on-zoom) to be fixed on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)