### PR TITLE
VTSBrowse audit fixes: clear_medias leak, hover-on-zoom, frontend hardening

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -76,6 +76,15 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private hoveredCell: HexCellPayload | null = null;
   private hoverDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Last known cursor position over the canvas (canvas-relative mx/my plus the
+  // viewport clientX/clientY) and whether the pointer is currently inside.
+  // Used to re-resolve the hover after a zoom changes which hex sits under a
+  // stationary cursor, so the preview/highlight don't go stale.
+  private lastMouseX = 0;
+  private lastMouseY = 0;
+  private lastClientX = 0;
+  private lastClientY = 0;
+  private pointerInside = false;
 
   private tileLoadSub: Subscription | null = null;
   private rafId = 0;
@@ -84,6 +93,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private boundMouseMove = this.onMouseMove.bind(this);
   private boundMouseUp = this.onMouseUp.bind(this);
+  // Stable references for the canvas listeners so ngOnDestroy can remove them
+  // (inline .bind(this) creates a fresh function each call, which
+  // removeEventListener can never match).
+  private boundMouseDown = this.onMouseDown.bind(this);
+  private boundWheel = this.onWheel.bind(this);
+  private boundCanvasMouseMove = this.onCanvasMouseMove.bind(this);
+  private boundCanvasMouseLeave = this.onCanvasMouseLeave.bind(this);
 
   private recenterSub: Subscription | null = null;
 
@@ -131,10 +147,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
     this.ngZone.runOutsideAngular(() => {
       const el = this.canvasRef.nativeElement;
-      el.addEventListener('mousedown', this.onMouseDown.bind(this));
-      el.addEventListener('wheel', this.onWheel.bind(this), { passive: false });
-      el.addEventListener('mousemove', this.onCanvasMouseMove.bind(this));
-      el.addEventListener('mouseleave', this.onCanvasMouseLeave.bind(this));
+      el.addEventListener('mousedown', this.boundMouseDown);
+      el.addEventListener('wheel', this.boundWheel, { passive: false });
+      el.addEventListener('mousemove', this.boundCanvasMouseMove);
+      el.addEventListener('mouseleave', this.boundCanvasMouseLeave);
     });
   }
 
@@ -162,6 +178,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.resizeObserver?.disconnect();
     if (this.rafId) cancelAnimationFrame(this.rafId);
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
+    const el = this.canvasRef.nativeElement;
+    el.removeEventListener('mousedown', this.boundMouseDown);
+    el.removeEventListener('wheel', this.boundWheel);
+    el.removeEventListener('mousemove', this.boundCanvasMouseMove);
+    el.removeEventListener('mouseleave', this.boundCanvasMouseLeave);
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
     this.thumbCache.clear();
@@ -512,6 +533,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
     this.updateActiveLevel();
     this.requestRedraw();
+    this.refreshHoverAfterZoom();
   }
 
   private onWheel(event: WheelEvent): void {
@@ -528,35 +550,62 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
+    this.lastMouseX = mx;
+    this.lastMouseY = my;
+    this.lastClientX = event.clientX;
+    this.lastClientY = event.clientY;
+    this.pointerInside = true;
 
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
-
     this.hoverDebounceTimer = setTimeout(() => {
-      const hit = this.hitTest(mx, my);
-      const prevQ = this.hoveredCell?.q;
-      const prevR = this.hoveredCell?.r;
-      this.hoveredCell = hit;
-      if (hit) {
-        if (hit.q !== prevQ || hit.r !== prevR) {
-          this.ngZone.run(() => {
-            // Anchor the preview at the cursor, not the hex centre, so the text
-            // pop-up sits right under where the user is pointing.
-            this.hexHover.emit({
-              cell: hit,
-              screenX: event.clientX,
-              screenY: event.clientY,
-            });
-          });
-          this.requestRedraw();
-        }
-      } else if (prevQ != null) {
-        this.ngZone.run(() => this.hexHover.emit(null));
-        this.requestRedraw();
-      }
+      this.emitHoverHit(mx, my, event.clientX, event.clientY);
     }, 30);
   }
 
+  /**
+   * Resolve the hex under the canvas-relative point ``(mx, my)`` and emit a
+   * hover event when it differs from the currently-hovered cell (clearing it
+   * when the point now hits empty space). ``clientX/clientY`` anchor the
+   * preview pop-up at the cursor. Shared by the mouse-move handler and the
+   * post-zoom refresh.
+   */
+  private emitHoverHit(mx: number, my: number, clientX: number, clientY: number): void {
+    const hit = this.hitTest(mx, my);
+    const prevQ = this.hoveredCell?.q;
+    const prevR = this.hoveredCell?.r;
+    this.hoveredCell = hit;
+    if (hit) {
+      if (hit.q !== prevQ || hit.r !== prevR) {
+        this.ngZone.run(() => {
+          this.hexHover.emit({ cell: hit, screenX: clientX, screenY: clientY });
+        });
+        this.requestRedraw();
+      }
+    } else if (prevQ != null) {
+      this.ngZone.run(() => this.hexHover.emit(null));
+      this.requestRedraw();
+    }
+  }
+
+  /**
+   * After a zoom (which can re-bin to a different level), the hex under a
+   * stationary cursor changes — re-resolve the hover so the preview and the
+   * highlighted hex track the new cell instead of going stale. When the
+   * pointer is off the canvas (e.g. the user clicked a +/- button), there is
+   * nothing to hover, so clear any lingering preview.
+   */
+  private refreshHoverAfterZoom(): void {
+    if (this.pointerInside) {
+      this.emitHoverHit(this.lastMouseX, this.lastMouseY, this.lastClientX, this.lastClientY);
+    } else if (this.hoveredCell) {
+      this.hoveredCell = null;
+      this.ngZone.run(() => this.hexHover.emit(null));
+      this.requestRedraw();
+    }
+  }
+
   private onCanvasMouseLeave(): void {
+    this.pointerInside = false;
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
     if (this.hoveredCell) {
       this.hoveredCell = null;

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -29,7 +29,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   audioSrc = '';
   textContent = '';
   count = 0;
-  private audioUnlocked = false;
+  private textLoadAbort: AbortController | null = null;
 
   constructor(private activeContext: ActiveContextService) {}
 
@@ -45,6 +45,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopAudio();
+    this.textLoadAbort?.abort();
   }
 
   private show(event: HexHoverEvent): void {
@@ -80,6 +81,8 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private hide(): void {
     this.visible = false;
     this.stopAudio();
+    this.textLoadAbort?.abort();
+    this.textLoadAbort = null;
     this.textContent = '';
   }
 
@@ -93,9 +96,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
       if (!el) return;
       el.loop = true;
       el.load();
-      el.play().catch(() => {
-        this.audioUnlocked = false;
-      });
+      el.play().catch(() => {});
     });
   }
 
@@ -110,8 +111,13 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
 
   private loadText(mediaId: number): void {
     this.textContent = `Loading...`;
+    // Cancel any in-flight text load so a slow earlier response can't clobber
+    // the preview after the cursor has moved to another hex.
+    this.textLoadAbort?.abort();
+    const abort = new AbortController();
+    this.textLoadAbort = abort;
     const url = this.activeContext.mediaUrl(`/api/medias/${mediaId}/paragraph`);
-    fetch(url)
+    fetch(url, { signal: abort.signal })
       .then((r) => r.json())
       .then((data) => {
         if (this.hover?.cell.rep_id === mediaId) {
@@ -119,20 +125,11 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
           this.textContent = text.length > 300 ? text.slice(0, 300) + '...' : text;
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        if (err?.name === 'AbortError') return;
         if (this.hover?.cell.rep_id === mediaId) {
           this.textContent = `Item #${mediaId}`;
         }
       });
-  }
-
-  onCanvasClick(): void {
-    if (!this.audioUnlocked) {
-      this.audioUnlocked = true;
-      const el = this.audioRef?.nativeElement;
-      if (el && this.audioSrc) {
-        el.play().catch(() => {});
-      }
-    }
   }
 }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -73,6 +73,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private polling = false;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private pollErrors = 0;
+  private static readonly MAX_POLL_ERRORS = 5;
 
   constructor(
     private projectionApi: ProjectionApiService,
@@ -125,6 +128,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    if (this.pollTimer) clearTimeout(this.pollTimer);
     this.tileCache.clear();
   }
 
@@ -259,12 +263,14 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private pollBuildStatus(): void {
     if (this.polling) return;
     this.polling = true;
+    this.pollErrors = 0;
     const poll = (): void => {
       this.projectionApi
         .getMeta()
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (meta) => {
+            this.pollErrors = 0;
             this.meta = meta;
             if (meta.media_type) this.mediaType = meta.media_type;
             this.tileCache.setProjectionId(meta.projection_id);
@@ -282,13 +288,23 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             this.buildProgress = meta.current ?? 0;
             this.buildTotal = meta.total ?? 0;
             this.buildMessage = meta.message ?? '';
-            setTimeout(poll, 1000);
+            this.pollTimer = setTimeout(poll, 1000);
           },
           error: () => {
-            setTimeout(poll, 2000);
+            this.pollErrors += 1;
+            // Give up after a run of failures rather than retrying forever.
+            if (this.pollErrors >= BrowseViewComponent.MAX_POLL_ERRORS) {
+              this.polling = false;
+              this.status = 'error';
+              this.errorMessage = 'Lost contact with the server while building the projection.';
+              return;
+            }
+            // Exponential backoff: 2s, 4s, 8s, … capped at 30s.
+            const delay = Math.min(2000 * 2 ** (this.pollErrors - 1), 30000);
+            this.pollTimer = setTimeout(poll, delay);
           },
         });
     };
-    setTimeout(poll, 1000);
+    this.pollTimer = setTimeout(poll, 1000);
   }
 }

--- a/tests_lib/core/test_clear_medias.py
+++ b/tests_lib/core/test_clear_medias.py
@@ -1,0 +1,43 @@
+"""Regression test: ``clear_medias()`` releases the projection + pyramid.
+
+``clear_medias()`` must null ``ctx._projection`` and ``ctx._pyramid`` so that:
+
+1. **Memory** — the hex-tile pyramid (the largest Browse artifact) is freed on
+   dataset unload, not left resident.
+2. **Correctness** — the projection build route serves a non-``None``
+   ``ctx._pyramid`` via a fast-path that does *not* re-check the media-id
+   signature, so a stale pyramid left over a reload-with-changed-contents would
+   otherwise be returned for the new data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.state import clear_medias
+from vtscore.state.core import (
+    DatasetContext,
+    get_active_context,
+    thread_dataset_context,
+)
+
+
+def test_clear_medias_releases_projection_and_pyramid():
+    ctx = DatasetContext("test_clear_projection")
+    with thread_dataset_context(ctx):
+        ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+        ctx._emb_matrix = np.ones((1, 4), dtype=np.float32)
+        ctx._emb_matrix_ids = [1]
+        ctx._projection = object()  # stand-in for a Projection
+        ctx._pyramid = object()  # stand-in for a Pyramid
+
+        assert get_active_context() is ctx
+        clear_medias()
+
+        # the new guard: projection + pyramid are released
+        assert ctx._projection is None
+        assert ctx._pyramid is None
+        # and the pre-existing clears still hold
+        assert ctx._emb_matrix is None
+        assert ctx._emb_matrix_ids is None
+        assert ctx.medias == {}

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -123,9 +123,15 @@ def get_media(media_id: int) -> dict[str, Any] | None:
 def clear_medias() -> None:
     """Clear all loaded medias from the active dataset's context.
 
-    Drops the cached embedding matrix, diversity tree, dataset display
-    name override, and the per-step progress model cache so RAM is
-    released immediately rather than waiting for the next access.
+    Drops the cached embedding matrix, the 2-D projection + hex-tile
+    pyramid, diversity tree, dataset display name override, and the
+    per-step progress model cache so RAM is released immediately rather
+    than waiting for the next access.
+
+    Clearing ``_projection``/``_pyramid`` is also a correctness guard: the
+    build route serves a non-``None`` ``_pyramid`` without re-checking the
+    media-id signature, so a stale pyramid left over a reload-with-changed-
+    contents would otherwise be returned for the new data.
     """
     from vtscore.detectors.labeling_progress import clear_progress_cache
 
@@ -134,6 +140,8 @@ def clear_medias() -> None:
         ctx.medias.clear()
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
+        ctx._projection = None
+        ctx._pyramid = None
         ctx.diversity_tree = None
         ctx.dataset_display_name = None
     # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the


### PR DESCRIPTION
Fixes from a verified VTSBrowse audit (plan: `docs/plans/vtsbrowse-audit-fixes.md`, on the pyramid PR). Each item was checked against the code; two agent-flagged "issues" (tile request-storm, high-severity listener leak) were investigated and rejected, so they're not here.

## 1. `clear_medias()` leaked the projection + tile pyramid  *(backend, highest value)*
`clear_medias()` dropped the embedding matrix and diversity tree but left `ctx._projection` and `ctx._pyramid` resident.
- **Memory:** unloading a dataset never freed the hex-tile pyramid — the largest Browse artifact — a real leak on RAM-tight deployments.
- **Correctness (latent):** the build route serves a non-`None` `ctx._pyramid` via a fast-path that does **not** re-check the media-id signature, so a stale pyramid left over a reload-with-changed-contents would be served for the new data.
- **Fix:** null both in `clear_medias()`; added a library-tier regression test.

## 2. Hover preview/highlight went stale on zoom  *(browse-canvas)*
`zoomBy()` changed the transform and re-ran level binning but never re-evaluated hover state, so zooming with a stationary cursor (buttons or wheel) left the "N items" tooltip pinned and the highlight on a stale hex (worse after a wheel-driven level change). Now re-resolves the hover at the cursor after each zoom (clearing it when the pointer is off-canvas).

## 3. Frontend hardening
- **browse-canvas:** canvas mouse listeners are stored as stable bound refs and removed in `ngOnDestroy` (inline `.bind(this)` could never be matched by `removeEventListener`).
- **browse-hover-preview:** the text-preview `fetch()` is now cancelled via `AbortController` so a slow earlier response can't clobber a newer hover; removed the dead `onCanvasClick()` audio-unlock path (zero callers).
- **browse-view:** `pollBuildStatus()` tracks its retry timer (cleared on destroy), backs off exponentially on error (2s→30s), and gives up after a run of failures instead of retrying forever off a detached `setTimeout`.

## Verification
- Python: `ruff` / `ruff format` / `codespell` clean; 39 tests pass (`tests_lib/core` incl. the new `clear_medias` test, `tests_lib/projection`, `tests/datasets/test_load_projection_stage.py`).
- Frontend: `npm run build:prod` succeeds with no errors/warnings (TS typecheck + Angular build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)