### PR TITLE
Make Add-Dataset MediaType dropdown an accessible listbox combobox

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
@@ -9,9 +9,13 @@
       type="button"
       [id]="mediaTypeFieldId"
       class="form-select media-type-trigger"
+      role="combobox"
       [attr.aria-haspopup]="'listbox'"
       [attr.aria-expanded]="open"
+      [attr.aria-controls]="listboxId"
+      [attr.aria-activedescendant]="activeDescendantId"
       (click)="toggle()"
+      (keydown)="onTriggerKeydown($event)"
     >
       <span class="media-type-trigger-content">
         @if (iconFor(mediaType)) {
@@ -22,14 +26,22 @@
       <span class="media-type-chevron" aria-hidden="true">▾</span>
     </button>
     @if (open) {
-      <ul class="media-type-options" role="listbox">
-        @for (opt of mediaTypeOptions; track opt) {
+      <ul
+        class="media-type-options"
+        role="listbox"
+        [id]="listboxId"
+        aria-label="Dataset MediaType"
+      >
+        @for (opt of mediaTypeOptions; track opt; let i = $index) {
           <li
             class="media-type-option"
             role="option"
+            [id]="optionId(i)"
             [class.selected]="opt === mediaType"
+            [class.active]="i === activeIndex"
             [attr.aria-selected]="opt === mediaType"
             (click)="select(opt)"
+            (mouseenter)="activeIndex = i"
           >
             @if (iconFor(opt)) {
               <vt-icon [icon]="iconFor(opt)" [size]="16"></vt-icon>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
@@ -99,6 +99,15 @@
     background: var(--bg-subtle);
   }
 
+  // Keyboard highlight (``aria-activedescendant`` target).  Distinct from
+  // ``.selected`` so arrow-key users can see where focus sits even on the
+  // currently-selected row; uses an inset ring rather than a background so
+  // it reads on top of the hover/selected fill.
+  &.active {
+    background: var(--bg-subtle);
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
+
   &.selected {
     background: var(--bg-subtle);
     font-weight: var(--weight-medium);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -62,7 +62,32 @@ export class ImportConfigComponent {
   /** Whether the custom dropdown is currently expanded. */
   open = false;
 
+  /** Index of the keyboard-highlighted option while the popup is open
+   *  (the ``aria-activedescendant`` target).  ``-1`` when the popup is
+   *  closed or no option is highlighted. */
+  activeIndex = -1;
+
   constructor(private hostEl: ElementRef<HTMLElement>) {}
+
+  /** ``id`` for the popup ``role="listbox"`` element, derived from the
+   *  trigger's id so it stays unique across the multiple flows the modal
+   *  may render at once. */
+  get listboxId(): string {
+    return `${this.mediaTypeFieldId}-listbox`;
+  }
+
+  /** ``id`` for the option at ``index`` so the combobox trigger can
+   *  point ``aria-activedescendant`` at the highlighted row. */
+  optionId(index: number): string {
+    return `${this.mediaTypeFieldId}-option-${index}`;
+  }
+
+  /** ``id`` of the currently active option, or ``null`` when the popup
+   *  is closed / nothing is highlighted (so ``aria-activedescendant`` is
+   *  dropped from the DOM rather than dangling). */
+  get activeDescendantId(): string | null {
+    return this.open && this.activeIndex >= 0 ? this.optionId(this.activeIndex) : null;
+  }
 
   /** Label for an option in the media-type dropdown.  Falls back to the
    *  option value when no label is supplied (e.g. the parent's
@@ -78,13 +103,93 @@ export class ImportConfigComponent {
   }
 
   toggle(): void {
-    this.open = !this.open;
+    if (this.open) {
+      this.close();
+    } else {
+      this.openPopup();
+    }
+  }
+
+  /** Open the popup and seed the keyboard highlight on the current
+   *  selection (or the first option) so arrow keys have a starting
+   *  point. */
+  private openPopup(): void {
+    this.open = true;
+    const selected = this.mediaTypeOptions.indexOf(this.mediaType);
+    this.activeIndex = selected >= 0 ? selected : 0;
+  }
+
+  private close(): void {
+    this.open = false;
+    this.activeIndex = -1;
   }
 
   select(opt: string): void {
-    this.open = false;
+    this.close();
     if (opt !== this.mediaType) {
       this.mediaTypeChange.emit(opt);
+    }
+  }
+
+  /** Move the keyboard highlight to ``index`` (clamped) and scroll it
+   *  into view within the popup. */
+  private setActiveIndex(index: number): void {
+    const last = this.mediaTypeOptions.length - 1;
+    if (last < 0) return;
+    this.activeIndex = Math.max(0, Math.min(last, index));
+    // Defer until the ``[id]`` binding has flushed so the lookup hits the
+    // freshly-highlighted row.
+    queueMicrotask(() => {
+      const el = this.hostEl.nativeElement.querySelector(`#${CSS.escape(this.optionId(this.activeIndex))}`);
+      (el as HTMLElement | null)?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  /** Keyboard handling for the combobox trigger.  Implements the
+   *  WAI-ARIA select-only combobox pattern: arrows / Home / End move the
+   *  ``aria-activedescendant`` highlight, Enter / Space commit it, and
+   *  Escape dismisses; DOM focus stays on the trigger throughout. */
+  onTriggerKeydown(event: KeyboardEvent): void {
+    if (!this.open) {
+      if (['ArrowDown', 'ArrowUp', 'Enter', ' ', 'Spacebar'].includes(event.key)) {
+        event.preventDefault();
+        this.openPopup();
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.setActiveIndex(this.activeIndex + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.setActiveIndex(this.activeIndex - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.setActiveIndex(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        this.setActiveIndex(this.mediaTypeOptions.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+      case 'Spacebar':
+        event.preventDefault();
+        if (this.activeIndex >= 0) {
+          this.select(this.mediaTypeOptions[this.activeIndex]);
+        }
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+      case 'Tab':
+        this.close();
+        break;
     }
   }
 
@@ -94,12 +199,6 @@ export class ImportConfigComponent {
     if (!this.open) return;
     const target = event.target as Node | null;
     if (target && this.hostEl.nativeElement.contains(target)) return;
-    this.open = false;
-  }
-
-  /** Close on Escape so keyboard users can dismiss the popup. */
-  @HostListener('document:keydown.escape')
-  onEscape(): void {
-    if (this.open) this.open = false;
+    this.close();
   }
 }


### PR DESCRIPTION
## Summary

Fixes the `mediatype-dropdown-a11y` finding from `docs/audits/standard-workflow-2026-06-04.md`. The custom MediaType "select" in the Add Dataset modal (a button + `<ul>` popup, used so each option can render its media-type icon — something native `<option>` can't host) was not operable or legible to assistive tech the way the native Embedder `<select>` in the same modal is.

## What changed

`frontend/.../import-config/import-config.component.{ts,html,scss}`:

- **Combobox/listbox wiring:** the trigger is now `role="combobox"` with `aria-controls` + `aria-activedescendant` pointing at the popup and its highlighted row; the `<ul>` carries `id` + `aria-label`; each `<li>` gets a stable `id` (already had `role="option"` / `aria-selected`).
- **Keyboard operation** (WAI-ARIA select-only combobox pattern): ArrowUp/Down, Home/End move the highlight; Enter/Space commit; Escape closes; Tab closes. DOM focus stays on the trigger throughout via `aria-activedescendant`. Opening seeds the highlight on the current selection.
- **Visual highlight:** an `.active` style (inset accent ring) shows the keyboard cursor distinctly from hover/selected; mouse hover keeps the two in sync.

This brings the widget to parity with the native Embedder select's accessibility while keeping the per-option icons.

## Testing

- `npm run build:prod` — clean, no TypeScript errors and no budget warnings.

https://claude.ai/code/session_016aJqB9xpgho761dp4r8Us1

---
_Generated by [Claude Code](https://claude.ai/code/session_016aJqB9xpgho761dp4r8Us1)_