### PR TITLE
Default demo media-type picker to the active context type

### DIFF
--- a/docs/audits/standard-workflow-2026-06-04.md
+++ b/docs/audits/standard-workflow-2026-06-04.md
@@ -40,9 +40,9 @@ Severity: **P1** = should fix, user-visible/contradictory · **P2** = papercut/p
 
 ### Dataset import / demo picker
 
-**[P1 · `demo-mediatype-default`] Demo MediaType filter is context-blind — always defaults to Audio.**
+**[P1 · `demo-mediatype-default`] Demo MediaType filter is context-blind — always defaults to Audio.** *(FIXED)*
 Opening "Add Dataset → Demo → Downloaded Media" always lands on **Audio** (shows ESC-50/GTZAN/UrbanSound). I hit this twice: even on the *second* import, with an Image dataset **and** an Image detector already active, it still defaulted to Audio and I had to manually switch the MediaType dropdown to Image. It should default to the active context's media type (or the last-used type).
-*Pointer:* `frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.*`
+*Fix:* `buildDemoTabs()` now prefers the dashboard-supplied `guessedMediaType` (the active context's single media type) ahead of the `'audio'` fallback, so a loaded Image dataset/detector lands the demo picker on Image. See `dataset-importer-modal.component.ts`.
 
 **[P1 · `mediatype-dropdown-a11y`] MediaType dropdown is inaccessible (and undriveable by a11y tooling).**
 The MediaType selector renders its options as `<li class="media-type-option">` with no `role="option"`, no owning `role="listbox"` semantics — the options never appear in the accessibility tree (a screen reader sees an empty popup; I had to click them via JS). Contrast with the **Embedder** select in the same modal's Advanced panel, which *is* a proper accessible combobox with option roles. Two different dropdown patterns in one form; make the MediaType one match.
@@ -108,7 +108,7 @@ The dev server log contains only the 6 boot lines — no access logs, no progres
 ## Prioritized recommendations
 
 1. **Fix the Browse/projection contradiction** (`browse-projection-contradiction`, P1) — pick (a) hide the checkbox or (b) enable image browse. Users will hit this immediately.
-2. **Make the demo picker context-aware** (`demo-mediatype-default`, P1) — default MediaType to the active/last-used type; stop forcing Audio.
+2. ~~**Make the demo picker context-aware** (`demo-mediatype-default`, P1) — default MediaType to the active/last-used type; stop forcing Audio.~~ **Fixed:** `buildDemoTabs()` now prefers the active context's `guessedMediaType` over the audio fallback.
 3. **Give the MediaType dropdown real listbox/option a11y** (`mediatype-dropdown-a11y`, P1) — align it with the Embedder combobox pattern.
 4. **De-dupe achievement unlock toasts** (`achievement-toast-replay`, P2) — fire once per real unlock; don't replay on every navigation; don't occlude the Labels panel.
 5. **Signal that "# MEDIA" is an estimate** (`media-count-estimate`, P2) — "~N" or a range; or compute the true per-slice count.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -475,6 +475,29 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.filteredDemos.length).toBe(0);
   });
 
+  it('should default the demo media-type tab to the active context type when known', () => {
+    flushImporters();
+    // The dashboard passes the active context's single media type (e.g. an
+    // Image dataset/detector already loaded) as guessedMediaType.
+    component.guessedMediaType = 'image';
+
+    component.openDemoPicker();
+    httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
+    httpMock.expectOne('/api/dataset/demo-list').flush({ datasets: mockDemos });
+
+    // buildDemoTabs pre-selects the guessed type instead of falling back to
+    // audio, so the image embedder/clipper fetches fire for that tab.
+    httpMock.expectOne(req =>
+      req.url === '/api/embedders' && req.params.get('media_type') === 'image',
+    ).flush({ embedders: mockImageEmbedders });
+    httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
+    httpMock.expectOne(req =>
+      req.url === '/api/dataset/demo-list' && req.params.get('embedder') === mockImageEmbedders[0].name,
+    ).flush({ datasets: mockDemos });
+
+    expect(component.activeTab).toBe('image');
+  });
+
   it('should filter demos by the explicitly selected media-type tab', () => {
     flushImporters();
     openAndFlushDemoPicker();

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -922,14 +922,18 @@ export class DatasetImporterModalComponent implements OnInit {
       this.demoTabs = [solo];
     }
     // Pre-select a media-type tab so the demo table shows results instead
-    // of sitting empty.  Prefer the solo type, then ``"audio"``, then
-    // the first tab.
+    // of sitting empty.  Prefer the solo type, then the active context's
+    // guessed media type (from existing datasets/detectors), then
+    // ``"audio"``, then the first tab.
     if (this.demoTabs.length > 0) {
       const needsSelect = !this.activeTab || (solo && this.activeTab !== solo);
       if (needsSelect) {
+        const guessed = this.guessedMediaType;
         const preferred = solo && this.demoTabs.includes(solo)
           ? solo
-          : (this.demoTabs.includes('audio') ? 'audio' : this.demoTabs[0]);
+          : (guessed && this.demoTabs.includes(guessed)
+            ? guessed
+            : (this.demoTabs.includes('audio') ? 'audio' : this.demoTabs[0]));
         this.selectDemoTabWithEmbedder(preferred);
       }
     }


### PR DESCRIPTION
Fixes the `demo-mediatype-default` (P1) finding from the 2026-06-04 standard-workflow audit.

## Problem

Opening **Add Dataset → Demo** always landed on the **Audio** media-type tab, even with an Image dataset and an Image detector already loaded. `buildDemoTabs()` only honored the solo-media-type lock before falling straight back to `'audio'`, ignoring the active context entirely, so users had to manually switch the dropdown every time.

## Fix

`buildDemoTabs()` now prefers the dashboard-supplied `guessedMediaType` (the active context's single media type, derived from loaded datasets/detectors/in-progress loads) ahead of the `'audio'` fallback. Preference order is now: solo lock → active-context type → audio → first tab.

When the context is ambiguous (zero or multiple media types in use), `guessedMediaType` is `''`, so behavior is unchanged and the audio fallback still applies.

## Changes

- `dataset-importer-modal.component.ts` — extend the `buildDemoTabs()` pre-select logic.
- `dataset-importer-modal.component.spec.ts` — add a test documenting the context-aware default.
- `docs/audits/standard-workflow-2026-06-04.md` — mark the finding fixed.

## Testing

- `npm run build:prod` passes clean (no errors, no `▲ WARNING` budget lines).
- Note: `./run-tests.sh` blocks on a pre-existing OpenAPI snapshot drift unrelated to this change — this container ships Werkzeug 3.1.8 (422 reason phrase "Unprocessable Entity" → `UNPROCESSABLE_ENTITY`) while the committed snapshot was regenerated for a newer Werkzeug ("Unprocessable Content" → `UNPROCESSABLE_CONTENT`, commit d9a8054). This change is frontend-TS + docs only and cannot affect the Python-derived snapshot; regenerating here would incorrectly revert that maintainer work.

https://claude.ai/code/session_01HeXWMPMzE29nNpomFuCnrq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeXWMPMzE29nNpomFuCnrq)_