### PR TITLE
Unify clipboard export into a shared vt-clipboard-copy component

### DIFF
--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
@@ -1,0 +1,28 @@
+<div class="clipboard-copy">
+  @if (mode === 'list') {
+    <select class="form-select" [(ngModel)]="selectedColumnKey" title="Column to copy to clipboard">
+      @for (col of columns; track col.key) {
+        <option [value]="col.key">{{ col.label }}</option>
+      }
+    </select>
+  }
+  <select
+    class="form-select"
+    [(ngModel)]="delimiter"
+    [title]="mode === 'list' ? 'Separator between copied values' : 'Delimiter between columns'"
+  >
+    @for (opt of delimiterOptions; track opt.value) {
+      <option [value]="opt.value">{{ opt.label }}</option>
+    }
+  </select>
+  <button
+    class="btn"
+    [class.btn--primary]="buttonVariant === 'primary'"
+    [class.btn--secondary]="buttonVariant === 'secondary'"
+    (click)="copy()"
+    [disabled]="isDisabled"
+    title="Copy to clipboard"
+  >
+    {{ buttonText || copyLabel }}
+  </button>
+</div>

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.scss
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.scss
@@ -1,0 +1,6 @@
+.clipboard-copy {
+  display: flex;
+  gap: var(--space-md);
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
@@ -1,0 +1,126 @@
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+export interface ClipboardColumn {
+  key: string;
+  label: string;
+}
+
+interface DelimiterOption {
+  value: string;
+  label: string;
+  /** Only valid in list mode; a newline can't separate columns within a row. */
+  listOnly?: boolean;
+}
+
+/**
+ * Shared clipboard-copy control used by every export surface so the column
+ * model and delimiter vocabulary can't drift between modals. Two modes:
+ *
+ *  - `table`: a header row plus one delimited line per row, across all
+ *    `columns`. The delimiter separates columns; rows are newline-separated.
+ *  - `list`: a single column's values joined by the chosen separator. The
+ *    user picks which column from a dropdown.
+ *
+ * Rows are pre-flattened by the parent to `{ columnKey: value }` so this
+ * component stays agnostic about the source model (LabeledElement, hit, …).
+ */
+@Component({
+  selector: 'vt-clipboard-copy',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './clipboard-copy.component.html',
+  styleUrl: './clipboard-copy.component.scss',
+})
+export class ClipboardCopyComponent implements OnChanges, OnDestroy {
+  @Input() mode: 'table' | 'list' = 'table';
+  @Input() rows: Record<string, unknown>[] = [];
+  @Input() columns: ClipboardColumn[] = [];
+  /** Extra disable condition layered on top of the empty-data guards. */
+  @Input() disabled = false;
+  @Input() copyLabel = 'Copy';
+  @Input() buttonVariant: 'primary' | 'secondary' = 'primary';
+
+  /** Unified delimiter vocabulary, shared across both modes. */
+  static readonly DELIMITERS: DelimiterOption[] = [
+    { value: '\n', label: 'Newline (↵)', listOnly: true },
+    { value: ',', label: 'Comma (,)' },
+    { value: '\t', label: 'Tab (⇥)' },
+    { value: ' ', label: 'Space (␣)' },
+    { value: '|', label: 'Pipe (|)' },
+    { value: ';', label: 'Semicolon (;)' },
+  ];
+
+  delimiter = ',';
+  /** List mode: which single column to copy. */
+  selectedColumnKey = '';
+  buttonText = '';
+
+  private feedbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+  get delimiterOptions(): DelimiterOption[] {
+    return this.mode === 'list'
+      ? ClipboardCopyComponent.DELIMITERS
+      : ClipboardCopyComponent.DELIMITERS.filter((d) => !d.listOnly);
+  }
+
+  get isDisabled(): boolean {
+    if (this.disabled) return true;
+    if (this.rows.length === 0) return true;
+    if (this.mode === 'table') return this.columns.length === 0;
+    return !this.selectedColumnKey;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['mode']) {
+      // Default delimiter per mode: list → newline, table → comma.
+      this.delimiter = this.mode === 'list' ? '\n' : ',';
+    }
+    if (changes['columns'] && this.mode === 'list') {
+      // Keep the single-column selector pointed at a valid column.
+      if (!this.columns.some((c) => c.key === this.selectedColumnKey)) {
+        this.selectedColumnKey = this.columns[0]?.key ?? '';
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
+  }
+
+  async copy(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.buildText());
+      this.flash('Copied!');
+    } catch {
+      this.flash('Copy failed');
+    }
+  }
+
+  private buildText(): string {
+    if (this.mode === 'list') {
+      const key = this.selectedColumnKey;
+      return this.rows.map((r) => this.cell(r, key)).join(this.delimiter);
+    }
+    if (this.columns.length === 0) return '';
+    const header = this.columns.map((c) => c.label).join(this.delimiter);
+    const body = this.rows.map((r) =>
+      this.columns.map((c) => this.cell(r, c.key)).join(this.delimiter),
+    );
+    return [header, ...body].join('\n');
+  }
+
+  private cell(row: Record<string, unknown>, key: string): string {
+    return String(row[key] ?? '');
+  }
+
+  private flash(text: string): void {
+    this.buttonText = text;
+    if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
+    this.feedbackTimer = setTimeout(() => {
+      this.buttonText = '';
+      this.feedbackTimer = null;
+    }, 2000);
+  }
+}

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -81,22 +81,13 @@
       </div>
     }
 
-    <div class="copy-row">
-      <select class="form-select" [(ngModel)]="copyColumn" title="Column to copy to clipboard">
-        <option value="origin+name">Origin + Name</option>
-        <option value="name">Name</option>
-        <option value="md5">MD5</option>
-        <option value="filename">Filename</option>
-        <option value="origin">Origin</option>
-      </select>
-      <select class="form-select" [(ngModel)]="copySeparator" title="Separator between copied values">
-        <option value="newline">Newline</option>
-        <option value=",">Comma</option>
-        <option value="tab">Tab</option>
-        <option value="space">Space</option>
-      </select>
-      <button class="btn btn--secondary" (click)="copyToClipboard()" title="Copy selected column values to clipboard">{{ copyButtonText }}</button>
-    </div>
+    <vt-clipboard-copy
+      mode="list"
+      [rows]="clipboardRows"
+      [columns]="clipboardColumns"
+      buttonVariant="secondary"
+      copyLabel="Copy To Clipboard"
+    ></vt-clipboard-copy>
   </div>
 
   <div class="export-actions" modal-footer>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -64,13 +64,6 @@
   max-width: 300px;
 }
 
-.copy-row {
-  display: flex;
-  gap: var(--space-md);
-  align-items: center;
-  flex-wrap: wrap;
-}
-
 .export-actions {
   display: flex;
   gap: var(--space-md);

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -4,6 +4,10 @@ import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
+import {
+  ClipboardColumn,
+  ClipboardCopyComponent,
+} from '../../clipboard-copy/clipboard-copy.component';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import {
   AutoDetectHit,
@@ -15,7 +19,7 @@ import type { ExporterEntry } from '../../../generated/api-client/models/exporte
 @Component({
   selector: 'vt-autodetect-results-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, ClipboardCopyComponent],
   templateUrl: './autodetect-results-modal.component.html',
   styleUrl: './autodetect-results-modal.component.scss',
 })
@@ -28,9 +32,15 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   selectedExporter = '';
   exporterFields: ImporterField[] = [];
   exportFieldValues: Record<string, string> = {};
-  copyColumn = 'origin+name';
-  copySeparator = 'newline';
-  copyButtonText = 'Copy To Clipboard';
+
+  /** Columns offered by the shared clipboard control (single-column list mode). */
+  readonly clipboardColumns: ClipboardColumn[] = [
+    { key: 'origin+name', label: 'Origin + Name' },
+    { key: 'name', label: 'Name' },
+    { key: 'md5', label: 'MD5' },
+    { key: 'filename', label: 'Filename' },
+    { key: 'origin', label: 'Origin' },
+  ];
 
   private destroy$ = new Subject<void>();
 
@@ -123,44 +133,20 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   onSidesChange(): void {}
 
-  async copyToClipboard(): Promise<void> {
-    const hits = this.displayHits;
-    if (hits.length === 0) return;
-
-    const separatorMap: Record<string, string> = {
-      ',': ',',
-      tab: '\t',
-      space: ' ',
-      newline: '\n',
-    };
-    const sep = separatorMap[this.copySeparator] || '\n';
-
-    const values = hits.map((hit) => {
+  /** Displayed hits flattened to `{ columnKey: value }` rows for the
+   *  shared clipboard control. */
+  get clipboardRows(): Record<string, string>[] {
+    return this.displayHits.map((hit) => {
       const origin = this.formatOrigin(hit);
       const name = hit.origin_name || hit.filename || '';
-      switch (this.copyColumn) {
-        case 'origin+name':
-          return origin ? `${origin}  ${name}` : name;
-        case 'name':
-          return name;
-        case 'md5':
-          return hit.md5 || '';
-        case 'filename':
-          return hit.filename || '';
-        case 'origin':
-          return origin;
-        default:
-          return name;
-      }
+      return {
+        'origin+name': origin ? `${origin}  ${name}` : name,
+        name,
+        md5: hit.md5 || '',
+        filename: hit.filename || '',
+        origin,
+      };
     });
-
-    try {
-      await navigator.clipboard.writeText(values.join(sep));
-      this.copyButtonText = 'Copied!';
-    } catch {
-      this.copyButtonText = 'Copy failed';
-    }
-    setTimeout(() => (this.copyButtonText = 'Copy To Clipboard'), 2000);
   }
 
   close(): void {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -81,19 +81,6 @@
     }
   </div>
 
-  <!-- Delimiter -->
-  <div class="export-section">
-    <h3 title="Character used to separate columns in the exported text (comma, tab, or pipe)">Delimiter</h3>
-    <div class="delimiter-row">
-      @for (opt of delimiterOptions; track opt.value) {
-        <label class="delimiter-option">
-          <input type="radio" name="delimiter" [value]="opt.value" [(ngModel)]="delimiter" />
-          {{ opt.label }}
-        </label>
-      }
-    </div>
-  </div>
-
   <!-- Export Tabs -->
   <div class="export-section">
     <div class="export-tabs">
@@ -139,18 +126,13 @@
     <div class="tab-content">
       @if (activeTab === 'clipboard') {
         <div class="tab-pane">
-          <button
-            class="btn btn--primary"
-            (click)="copyToClipboard()"
+          <vt-clipboard-copy
+            mode="table"
+            [rows]="clipboardRows"
+            [columns]="clipboardColumns"
             [disabled]="!hasLabels || enabledColumns.length === 0"
-            title="Copy exported data to clipboard"
-          >
-            @if (copySuccess) {
-              <vt-icon type="check"></vt-icon> Copied!
-            } @else {
-              Copy
-            }
-          </button>
+            copyLabel="Copy"
+          ></vt-clipboard-copy>
         </div>
       } @else if (activeTabExporter) {
         <div class="tab-pane">

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -4,8 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
-import { IconComponent } from '../../icon/icon.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
+import {
+  ClipboardColumn,
+  ClipboardCopyComponent,
+} from '../../clipboard-copy/clipboard-copy.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
 import { DatasetStateService } from '../../../services/dataset-state.service';
@@ -26,7 +29,13 @@ export interface ColumnDef {
 @Component({
   selector: 'vt-export-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ModalComponent,
+    FieldHintIconComponent,
+    ClipboardCopyComponent,
+  ],
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',
 })
@@ -50,15 +59,6 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   /** Filter which labels to show/export. */
   labelFilter: 'good' | 'bad' | 'both' | 'corrections' = 'both';
 
-  /** Delimiter for text export. */
-  delimiter = ',';
-  delimiterOptions = [
-    { value: ',', label: 'Comma (,)' },
-    { value: '\t', label: 'Tab (\u21E5)' },
-    { value: '|', label: 'Pipe (|)' },
-    { value: ';', label: 'Semicolon (;)' },
-  ];
-
   /** Active export tab: 'clipboard' or an exporter name. */
   activeTab = 'clipboard';
 
@@ -66,9 +66,6 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   selectedExporter: ExporterEntry | null = null;
   formValues: Record<string, string> = {};
   submitting = false;
-
-  /** Copy feedback. */
-  copySuccess = false;
 
   /** Dataset display name for default filenames. */
   private datasetName = '';
@@ -218,30 +215,19 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return cols;
   }
 
-  /** Build delimited text from labels using selected columns. */
-  buildExportText(): string {
-    const cols = this.exportColumns;
-    if (cols.length === 0) return '';
-    const header = cols.map((c) => c.label).join(this.delimiter);
-    const rows = this.filteredLabels.map((entry) =>
-      cols.map((c) => this.getCellValue(entry, c)).join(this.delimiter),
-    );
-    return [header, ...rows].join('\n');
+  /** Columns passed to the shared clipboard control (table mode). */
+  get clipboardColumns(): ClipboardColumn[] {
+    return this.exportColumns.map((c) => ({ key: c.key, label: c.label }));
   }
 
-  /** Copy delimited text to clipboard. */
-  copyToClipboard(): void {
-    const text = this.buildExportText();
-    navigator.clipboard.writeText(text).then(
-      () => {
-        this.copySuccess = true;
-        this.status = `Copied ${this.filteredLabels.length} rows to clipboard.`;
-        setTimeout(() => (this.copySuccess = false), 2000);
-      },
-      () => {
-        this.error = 'Failed to copy to clipboard';
-      },
-    );
+  /** Labels flattened to `{ columnKey: value }` rows for the clipboard control. */
+  get clipboardRows(): Record<string, string>[] {
+    const cols = this.exportColumns;
+    return this.filteredLabels.map((entry) => {
+      const row: Record<string, string> = {};
+      for (const c of cols) row[c.key] = this.getCellValue(entry, c);
+      return row;
+    });
   }
 
   /** Build a descriptive default filename for export.


### PR DESCRIPTION
## Summary

Fixes the `duplicate-clipboard-export` audit item (`docs/audits/standard-workflow-2026-06-04.md`): the right-panel **Export** modal and the **auto-detect / Find results** modal each implemented their own clipboard copy with divergent column models and delimiter vocabularies, free to drift apart.

Both now embed one shared `vt-clipboard-copy` control with a single delimiter vocabulary and one copy implementation. The component supports both shapes each modal needs:

- **`table` mode** (Export modal): a header row plus one delimited line per row across all selected columns. Delimiter separates columns; rows are newline-separated.
- **`list` mode** (auto-detect results): a single chosen column's values joined by the selected separator.

Each modal flattens its own source rows (`LabeledElement` / auto-detect hit) into plain `{ columnKey: value }` records and passes them in, so the shared control stays model-agnostic. Existing per-modal behavior is preserved (Export keeps its multi-column table copy; auto-detect keeps its single-column quick-copy with the column dropdown).

## Unified delimiter vocabulary

One source of truth (`ClipboardCopyComponent.DELIMITERS`): Newline, Comma, Tab, Space, Pipe, Semicolon. `table` mode excludes Newline (a newline can't separate columns within a row). Defaults match prior behavior: `table` → Comma, `list` → Newline.

## Changes

- **New**: `frontend/src/app/components/clipboard-copy/` (`.ts` / `.html` / `.scss`).
- **export-modal**: removed its bespoke `delimiter`/`delimiterOptions`/`buildExportText`/`copyToClipboard`/`copySuccess` and the standalone "Delimiter" section; the clipboard tab now hosts `<vt-clipboard-copy mode="table">`. Dropped the now-unused `IconComponent` import.
- **autodetect-results-modal**: removed its bespoke `copyColumn`/`copySeparator`/`copyButtonText`/`copyToClipboard`; the copy row is now `<vt-clipboard-copy mode="list">`. Removed the dead `.copy-row` SCSS rule.

## Testing

- `npm run build:prod` — clean, no warnings (this is the exact frontend gate `run-tests.sh` applies).
- ruff / ruff format / codespell / deptry / pip-audit / pyright — all pass.
- The existing `autodetect-results-modal` spec only references members that were kept, so it still typechecks.

### Note: pre-existing OpenAPI snapshot drift (not addressed here)

`./run-tests.sh` is currently blocked before any test by OpenAPI snapshot drift unrelated to this change: in this environment `werkzeug 3.1.8` / `flask-smorest 0.47.0` regenerate the 422 response component as `UNPROCESSABLE_ENTITY`, while the committed `frontend/openapi.json` says `UNPROCESSABLE_CONTENT`. This PR touches no Python/API code and leaves `frontend/openapi.json` untouched, to keep it a focused frontend-only change.

https://claude.ai/code/session_01WkRxPfvJ892YybhjvgzZ1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkRxPfvJ892YybhjvgzZ1s)_