### PR TITLE
Enable VTSBrowse for all media types, not just audio

### DIFF
--- a/docs/audits/standard-workflow-2026-06-04.md
+++ b/docs/audits/standard-workflow-2026-06-04.md
@@ -61,8 +61,8 @@ It's a document dataset surfaced under Image (top row, sorted by item count). Ei
 
 ### Browse / projection
 
-**[P1 · `browse-projection-contradiction`] The import offers a Browse projection that the dashboard then refuses to open.**
-The dataset-import Advanced panel shows a **"Build 2-D Browse projection now"** checkbox for image datasets (`import-advanced.component.html`), but on the dashboard the loaded image dataset's Browse/eye button is **disabled** with tooltip *"Browsing is only available for audio datasets."* This is confirmed-intentional gating (`dashboard.component.ts:792` — "Browsing currently only supports audio datasets") — so a user can pay to build a UMAP projection for an image dataset they can never browse. Resolve the contradiction: either **(a)** hide/disable the "Build projection" checkbox for media types Browse can't open, or **(b)** lift the audio-only gate (the projection + hex-tile pyramid is embedding-based and media-agnostic; `tests/projection` already covers it). The two surfaces currently disagree.
+**[P1 · `browse-projection-contradiction`] The import offers a Browse projection that the dashboard then refuses to open. — FIXED**
+The dataset-import Advanced panel shows a **"Build 2-D Browse projection now"** checkbox for image datasets (`import-advanced.component.html`), but on the dashboard the loaded image dataset's Browse/eye button was **disabled** with tooltip *"Browsing is only available for audio datasets."* This was confirmed-intentional gating (`dashboard.component.ts` — "Browsing currently only supports audio datasets") — so a user could pay to build a UMAP projection for an image dataset they could never browse. Resolved via option **(b)**: lifted the audio-only gate. The projection + hex-tile pyramid is embedding-based and media-agnostic, and the hover preview already adapts per media type (audio loops the clip, text loads a paragraph snippet, image/video paint thumbnails onto the hex, everything else falls back to `Item #N`). `DatasetCardComponent.canBrowse` is gone; the Browse button is enabled for every media type.
 
 ### Achievements / toasts
 
@@ -109,7 +109,7 @@ The dev server log contains only the 6 boot lines — no access logs, no progres
 
 ## Prioritized recommendations
 
-1. **Fix the Browse/projection contradiction** (`browse-projection-contradiction`, P1) — pick (a) hide the checkbox or (b) enable image browse. Users will hit this immediately.
+1. ~~**Fix the Browse/projection contradiction** (`browse-projection-contradiction`, P1) — pick (a) hide the checkbox or (b) enable image browse. Users will hit this immediately.~~ **Fixed:** lifted the audio-only gate (option b); Browse now opens for any media type.
 2. ~~**Make the demo picker context-aware** (`demo-mediatype-default`, P1) — default MediaType to the active/last-used type; stop forcing Audio.~~ **Fixed:** `buildDemoTabs()` now prefers the active context's `guessedMediaType` over the audio fallback.
 3. **Give the MediaType dropdown real listbox/option a11y** (`mediatype-dropdown-a11y`, P1) — align it with the Embedder combobox pattern.
 4. **De-dupe achievement unlock toasts** (`achievement-toast-replay`, P2) — fire once per real unlock; don't replay on every navigation; don't occlude the Labels panel.

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -789,8 +789,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   /** Launch the VTSBrowse view for a dataset. The browseContextGuard loads the
-   *  dataset context if needed. Browsing currently only supports audio datasets;
-   *  the dataset card disables the button for other media types. */
+   *  dataset context if needed. Browsing works for any media type — the UMAP
+   *  projection and hex-tile pyramid are embedding-based and media-agnostic. */
   browseDataset(dataset: DatasetRegistryEntry): void {
     this.router.navigate(['/browse', dataset.id]);
   }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -129,7 +129,7 @@
   }
   <td class="actions-col">
     <div class="actions-cell">
-    <button class="browse-btn" [class.disabled]="!canBrowse" [disabled]="!canBrowse" (click)="onBrowse($event)" [attr.aria-label]="canBrowse ? 'Browse dataset' : 'Browsing is only available for audio datasets'" [title]="canBrowse ? 'Browse dataset' : 'Browsing is only available for audio datasets'">
+    <button class="browse-btn" (click)="onBrowse($event)" aria-label="Browse dataset" title="Browse dataset">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
         <circle cx="12" cy="12" r="3"></circle>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -156,13 +156,8 @@ td.actions-col {
   justify-content: center;
   transition: color var(--transition-base), background var(--transition-base);
 
-  &:hover:not(.disabled) {
+  &:hover {
     background: var(--btn-icon-hover-bg);
-  }
-
-  &.disabled {
-    opacity: var(--opacity-disabled);
-    cursor: not-allowed;
   }
 }
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -122,16 +122,15 @@ describe('DatasetCardComponent', () => {
     expect(component.browse.emit).toHaveBeenCalled();
   });
 
-  it('should disable browse button and not emit for non-audio datasets', () => {
+  it('should emit browse for non-audio datasets too', () => {
     component.dataset = { ...mockDataset, media_type: 'image' };
     fixture.detectChanges();
     spyOn(component.browse, 'emit');
     const el = fixture.nativeElement as HTMLElement;
     const browseBtn = el.querySelector('.browse-btn') as HTMLButtonElement;
-    expect(component.canBrowse).toBeFalse();
-    expect(browseBtn.disabled).toBeTrue();
-    component.onBrowse(new MouseEvent('click'));
-    expect(component.browse.emit).not.toHaveBeenCalled();
+    expect(browseBtn.disabled).toBeFalse();
+    browseBtn.click();
+    expect(component.browse.emit).toHaveBeenCalled();
   });
 
   it('should format dates', () => {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -50,12 +50,6 @@ export class DatasetCardComponent implements OnChanges {
     return this.dataset?.created_by === this.currentUser;
   }
 
-  // Browsing (VTSBrowse) currently only supports audio datasets; the button is
-  // shown disabled for every other media type.
-  get canBrowse(): boolean {
-    return this.dataset?.media_type === 'audio';
-  }
-
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
   @Input() statsOpen = false;
@@ -139,7 +133,6 @@ export class DatasetCardComponent implements OnChanges {
 
   onBrowse(event: MouseEvent): void {
     event.stopPropagation();
-    if (!this.canBrowse) return;
     this.browse.emit();
   }
 


### PR DESCRIPTION
## Summary

Resolves the `browse-projection-contradiction` from `docs/audits/standard-workflow-2026-06-04.md` (P1).

The dataset-import Advanced panel offered a **"Build 2-D Browse projection now"** checkbox for any media type, but the dashboard then **disabled** the Browse/eye button for non-audio datasets with the tooltip *"Browsing is only available for audio datasets."* A user could therefore pay to build a UMAP projection for an image dataset they could never browse. The two surfaces disagreed.

This takes **option (b)** from the audit: lift the audio-only gate. The UMAP projection + hex-tile pyramid are embedding-based and media-agnostic, and `BrowseHoverPreviewComponent` already adapts its preview per media type:

- **audio** — loops the representative clip
- **text** — loads a paragraph snippet
- **image / video** — thumbnails are painted directly onto the hex
- **everything else** (e.g. document) — falls back to `Item #N`

## Changes

- Removed `DatasetCardComponent.canBrowse` and the disabled-button state; the Browse button is now enabled for every media type with a plain "Browse dataset" label.
- Dropped the now-dead `.browse-btn.disabled` SCSS rule and simplified the `:hover` selector.
- Updated the `dashboard.component.ts` doc comment and the dataset-card spec (the "non-audio is disabled" test now asserts non-audio datasets emit `browse`).
- Marked the audit finding (and its recommendation) as **FIXED**.

No backend change was needed — `vtsearch/routes/projection.py` and the hex-tile pyramid were already media-agnostic.

## Testing

- `npm run build:prod` — clean, no warnings or budget overruns.
- `ruff check .` — passes.

https://claude.ai/code/session_019guC1kgga42woY4bXCSiAx

---
_Generated by [Claude Code](https://claude.ai/code/session_019guC1kgga42woY4bXCSiAx)_