### PR TITLE
Default export filter to Good-only

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -56,8 +56,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   /** Column definitions with selection state, built dynamically from API response. */
   columns: ColumnDef[] = [];
 
-  /** Filter which labels to show/export. */
-  labelFilter: 'good' | 'bad' | 'both' | 'corrections' = 'both';
+  /** Filter which labels to show/export. Defaults to good-only. */
+  labelFilter: 'good' | 'bad' | 'both' | 'corrections' = 'good';
 
   /** Active export tab: 'clipboard' or an exporter name. */
   activeTab = 'clipboard';


### PR DESCRIPTION
## Summary

The Export modal's category filter defaulted to **All** (`labelFilter = 'both'`), meaning every export started by including both good and bad labels. This changes the default to **Good-only** (`labelFilter = 'good'`), so opening the modal pre-selects the Good radio and previews/exports positive examples by default. Users can still switch to All / Bad / Corrections.

## Change

- `export-modal.component.ts`: initial `labelFilter` is now `'good'` instead of `'both'`.

## Testing

- `npm run build:prod` completes with no errors or warnings.

https://claude.ai/code/session_01Es8Syv6ccjr9gKHd4VK4Ef

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es8Syv6ccjr9gKHd4VK4Ef)_