### PR TITLE
Fix header data lag: always re-derive grid media-type label

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { SimpleChange } from '@angular/core';
 import { LeftPanelComponent } from './left-panel.component';
+import type { Media } from '../../models/api.models';
 
 describe('LeftPanelComponent', () => {
   let component: LeftPanelComponent;
@@ -119,5 +124,50 @@ describe('LeftPanelComponent', () => {
     spyOn(component.mediaSelect, 'emit');
     component.mediaSelect.emit(42);
     expect(component.mediaSelect.emit).toHaveBeenCalledWith(42);
+  });
+
+  describe('grid header (mediaTypeName)', () => {
+    const stub = (media_type: string): Media => ({ id: 1, media_type }) as Media;
+
+    function setMedias(medias: Media[]): void {
+      component.medias = medias;
+      component.ngOnChanges({
+        medias: new SimpleChange(undefined, medias, false),
+      });
+    }
+
+    it('derives the type label from the first grid item', () => {
+      setMedias([stub('audio')]);
+      expect(component.mediaTypeName).toBe('Audio');
+    });
+
+    it('resets to "Media" when the grid empties (no stale type label)', () => {
+      setMedias([stub('audio')]);
+      expect(component.mediaTypeName).toBe('Audio');
+      // Switching to an empty grid must clear the previous type, not keep it.
+      setMedias([]);
+      expect(component.mediaTypeName).toBe('Media');
+    });
+
+    it('re-derives when the grid switches media type', () => {
+      setMedias([stub('audio')]);
+      expect(component.mediaTypeName).toBe('Audio');
+      setMedias([stub('image')]);
+      expect(component.mediaTypeName).toBe('Image');
+    });
+
+    it('upgrades from the fallback to the display name when type metadata loads after the grid', () => {
+      const httpMock = TestBed.inject(HttpTestingController);
+      // The grid populates before the getMediaTypes() request (fired in
+      // ngOnInit) resolves, so the header first shows the capitalized fallback.
+      setMedias([stub('audio')]);
+      expect(component.mediaTypeName).toBe('Audio');
+
+      // Metadata arrives late with a custom display name: the header must
+      // upgrade instead of staying stuck on the fallback.
+      const req = httpMock.expectOne((r) => r.url.includes('/api/media-types'));
+      req.flush({ media_types: [{ type_id: 'audio', name: 'Sound Clips' }] });
+      expect(component.mediaTypeName).toBe('Sound Clips');
+    });
   });
 });

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -109,7 +109,6 @@ export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
   mediaTypeName = 'Media';
   textSortAvailable = true;
   private mediaTypeInfos: MediaTypeInfo[] = [];
-  private currentTypeId = '';
   private embedderInfos: EmbedderInfo[] = [];
   private readonly destroy$ = new Subject<void>();
 
@@ -157,13 +156,22 @@ export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.destroy$.complete();
   }
 
+  /**
+   * Re-derive the media-type label shown in the grid header from the current
+   * grid contents.  Always recomputes (no memo on the type id) so the header
+   * never lags behind the grid: it resets to ``'Media'`` when the grid empties,
+   * and upgrades from the capitalized fallback to the proper display name once
+   * the media-type metadata finishes loading (which can arrive *after* the
+   * first batch of medias).
+   */
   private updateMediaTypeName(): void {
     const typeId = this.medias.length > 0 ? this.medias[0].media_type : '';
-    if (typeId && typeId !== this.currentTypeId) {
-      this.currentTypeId = typeId;
-      const info = this.mediaTypeInfos.find((mt) => mt.type_id === typeId);
-      this.mediaTypeName = info?.name ?? typeId.charAt(0).toUpperCase() + typeId.slice(1);
+    if (!typeId) {
+      this.mediaTypeName = 'Media';
+      return;
     }
+    const info = this.mediaTypeInfos.find((mt) => mt.type_id === typeId);
+    this.mediaTypeName = info?.name ?? typeId.charAt(0).toUpperCase() + typeId.slice(1);
   }
 
   /**


### PR DESCRIPTION
## Problem

The left-panel grid header (`"<Type>s (<count>)"`, e.g. `Audios (1,204)`) lagged behind the grid below it. The count binds directly so it stayed correct, but the **type label** was cached behind a `typeId !== currentTypeId` guard in `LeftPanelComponent.updateMediaTypeName()`. That guard left the label stale in two cases:

1. **Grid empties.** When the grid became empty (`typeId` resolves to `''`), the guard's `typeId &&` short-circuit skipped the update, so the previous type stuck — an empty/cleared grid kept reading e.g. `Audios (0)` instead of `Media (0)`.
2. **Late metadata.** When the media-type metadata (`GET /api/media-types`) resolved *after* the first batch of medias arrived, the guard saw `typeId === currentTypeId` and short-circuited, freezing the header on the capitalized fallback (`Audio`) instead of upgrading to the real display name (e.g. `Sound Clips`).

This affects both the label view and the find view, which share `vt-left-panel`.

## Fix

Drop the memo and recompute the label unconditionally on every grid change (and on metadata load): reset to `'Media'` when the grid is empty, otherwise resolve the display name from the loaded type infos, falling back to the capitalized `type_id`. The lookup is a `find` over a handful of media types, so removing the guard has no meaningful cost.

## Tests

Added regression specs to `left-panel.component.spec.ts` covering: type label derived from the first grid item, reset to `Media` on empty, re-derivation on a media-type switch, and the late-metadata upgrade from fallback to display name.

Verified `npm run build:prod` (clean, no warnings) and `tsc -p tsconfig.spec.json --noEmit` (spec typecheck) both pass.

https://claude.ai/code/session_01A29HnkkeXgTidMjgtfpMj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01A29HnkkeXgTidMjgtfpMj9)_