### PR TITLE
Fix no-access-log: surface access log at INFO/DEBUG, add -v/--verbose

### DIFF
--- a/app.py
+++ b/app.py
@@ -589,6 +589,19 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="VTSearch \u2014 media explorer web app")
     parser.add_argument("--local", action="store_true", help="Run in local development mode")
     parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        dest="verbose",
+        help=(
+            "Increase log verbosity. -v turns on INFO logging, which includes "
+            "the dev-server access log (one line per HTTP request); -vv turns "
+            "on DEBUG. Only raises the level set by VTSEARCH_LOG_LEVEL, never "
+            "lowers it. Applies to both the web server and --autodetect."
+        ),
+    )
+    parser.add_argument(
         "--login",
         type=str,
         choices=["trivial", "api_key"],
@@ -894,6 +907,20 @@ if __name__ == "__main__":
         # No importer/exporter specified but there are unknown args; let
         # argparse report the error.
         parser.parse_args()
+
+    # -v/--verbose bumps the log level for this process. setup_logging() already
+    # ran at import time with the env-driven default (WARNING); re-run it at the
+    # higher level so the dev-server access log (werkzeug INFO) and our own
+    # INFO/DEBUG records start showing. Only raise verbosity, never lower it
+    # below an explicit VTSEARCH_LOG_LEVEL=debug, so -v on top of a debug env
+    # doesn't quiet things back down. Applies before both the autodetect CLI
+    # and server branches below.
+    verbose = getattr(args, "verbose", 0) or 0
+    if verbose:
+        target = logging.DEBUG if verbose >= 2 else logging.INFO
+        # Lower numeric level == more verbose; keep whichever is more verbose.
+        effective = min(target, logging.getLogger().level)
+        setup_logging(level=logging.getLevelName(effective))
 
     # --solo-media-type applies to both the autodetect CLI path and the
     # server path: validate and stash before any code reads the resolver.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -220,6 +220,23 @@ banner text (`LOCAL` vs. `PRODUCTION`); the bind address is the same either
 way. This entry point uses Flask's built-in dev server and is not
 recommended for production.
 
+**Verbose logging** (`-v` / `--verbose`): logging defaults to `WARNING`, which
+keeps the console quiet — including the per-request access log. Pass `-v` to
+raise the level to `INFO`, which turns on the dev-server access log (one
+`GET /api/... 200` line per request) plus VTSearch's own INFO records; `-vv`
+raises it to `DEBUG`. The flag only raises verbosity, so `-v` on top of
+`VTSEARCH_LOG_LEVEL=debug` stays at DEBUG. It applies to both the web server and
+`--autodetect`:
+
+```bash
+python app.py -v             # INFO + access log
+python app.py -vv            # DEBUG
+VTSEARCH_LOG_LEVEL=info python app.py   # same as -v, via env
+```
+
+Under gunicorn there is no `-v` flag; set `VTSEARCH_LOG_LEVEL=info` (or `debug`)
+to get the same access log.
+
 **Production (gunicorn)**: run the WSGI app under the bundled config:
 
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,7 +24,7 @@ installation and getting started, see [SETUP.md](SETUP.md).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VTSEARCH_SECRET_KEY` | `vtsearch-dev-key-change-in-production` | Flask session secret key (**set this to a random value in production**) |
-| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `INFO`/`DEBUG` also turn on the per-request access log. |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
 
 ### Gunicorn / WSGI (production)
@@ -107,7 +107,7 @@ Override the relevant config via environment variables:
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | `host:port` |
 | `VTSEARCH_THREADS` | `8` | Threads per worker; raise for more concurrent requests |
 | `VTSEARCH_TIMEOUT` | `0` | Worker timeout in seconds; `0` (default) disables. Long imports / training routinely exceed short timeouts. |
-| `VTSEARCH_LOG_LEVEL` | `warning` | Gunicorn log level |
+| `VTSEARCH_LOG_LEVEL` | `warning` | Gunicorn log level; `info`/`debug` also enable the gunicorn access log (streamed to stdout) |
 
 For larger tuning changes, edit `gunicorn.conf.py` directly.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -425,7 +425,7 @@ VTSearch reads several optional environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VTSEARCH_SECRET_KEY` | `vtsearch-dev-key-change-in-production` | Flask session secret key (set this in production) |
-| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`); `INFO`/`DEBUG` also enable the per-request access log. `python app.py -v`/`-vv` is the CLI shortcut. |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
 | `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn; triggers model init / settings sync at import time |
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |

--- a/docs/audits/standard-workflow-2026-06-04.md
+++ b/docs/audits/standard-workflow-2026-06-04.md
@@ -102,8 +102,8 @@ Arriving from a Find specifically to grab hits, the export defaults to All (838 
 **[P3 · `header-data-lag`] Header "Data:" label lags the loaded/active dataset.**
 After loading Caltech-101 (S) it stayed "Data: Select a dataset" until I entered a view, even though the New-Detector modal correctly knew the active media type was Image. The dashboard's row-checkbox selection and the header's "active dataset" are two separate notions of "selected", which can read as out-of-sync.
 
-**[P3 · `no-access-log`] No server-side request/activity logging in local mode.**
-The dev server log contains only the 6 boot lines — no access logs, no progress lines — for an entire session that downloaded, embedded ~1250 images, ran Find, and exported. Fine if intentional, but it makes "what did the server just do?" debugging harder; a quiet-by-default access log (or a `--verbose`) would help.
+**[P3 · `no-access-log`] No server-side request/activity logging in local mode.** **Fixed.**
+The dev server log contained only the 6 boot lines — no access logs, no progress lines — for an entire session that downloaded, embedded ~1250 images, ran Find, and exported. Root cause: `setup_logging()` pinned the `werkzeug` logger to `ERROR` unconditionally, so the access log was unreachable even with `VTSEARCH_LOG_LEVEL` turned up. `werkzeug` now follows the configured level (silenced at WARNING+, on at INFO/DEBUG), and a `-v`/`-vv` flag on `python app.py` raises the level for the session (`-v` → INFO + access log, `-vv` → DEBUG). gunicorn mirrors it: `VTSEARCH_LOG_LEVEL=info`/`debug` enables its access log too.
 
 ---
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -33,8 +33,13 @@ timeout = int(os.environ.get("VTSEARCH_TIMEOUT", "0"))
 graceful_timeout = 30
 keepalive = 5
 
-accesslog = None
 errorlog = "-"
 loglevel = os.environ.get("VTSEARCH_LOG_LEVEL", "warning").lower()
+
+# Access log mirrors the dev server (see vtsearch.logging_config.setup_logging):
+# quiet by default, on once the operator opts into INFO/DEBUG. At warning+ we
+# leave it disabled; at info/debug we stream gunicorn's access log to stdout so
+# request activity is visible in production logs too.
+accesslog = "-" if loglevel in ("debug", "info") else None
 
 proc_name = "vtsearch"

--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -348,6 +348,41 @@ class TestSetupLogging:
             setup_logging()
 
 
+class TestWerkzeugAccessLogLevel:
+    """werkzeug's INFO records are the dev-server access log. setup_logging
+    keeps them quiet by default (the ``no-access-log`` fix) but lets them
+    through once the level is raised to INFO/DEBUG, while huggingface_hub
+    stays pinned to ERROR regardless."""
+
+    def test_werkzeug_silenced_at_default_warning(self):
+        try:
+            setup_logging(level="WARNING")
+            assert logging.getLogger("werkzeug").level == logging.ERROR
+        finally:
+            setup_logging()
+
+    def test_werkzeug_follows_info_level(self):
+        try:
+            setup_logging(level="INFO")
+            assert logging.getLogger("werkzeug").level == logging.INFO
+        finally:
+            setup_logging()
+
+    def test_werkzeug_follows_debug_level(self):
+        try:
+            setup_logging(level="DEBUG")
+            assert logging.getLogger("werkzeug").level == logging.DEBUG
+        finally:
+            setup_logging()
+
+    def test_huggingface_hub_stays_quiet_even_at_debug(self):
+        try:
+            setup_logging(level="DEBUG")
+            assert logging.getLogger("huggingface_hub").level == logging.ERROR
+        finally:
+            setup_logging()
+
+
 class TestTransformersVocabTokenFilter:
     """Filter installed by setup_logging() drops only the bos/eos/pad
     vocab-range warning from transformers; everything else passes through."""

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -287,7 +287,18 @@ def setup_logging(
     root.setLevel(level_value)
 
     # Quiet down chatty libraries; preserved from app.py's old basicConfig.
-    logging.getLogger("werkzeug").setLevel(logging.ERROR)
+    #
+    # ``huggingface_hub`` stays pinned to ERROR regardless of level: its
+    # INFO/DEBUG output is download-progress chatter nobody asked for.
+    #
+    # ``werkzeug`` is different. Its INFO records *are* the dev-server access
+    # log (one ``"GET /api/... 200"`` line per request), so we only silence it
+    # at the default WARNING+ levels and let it through once the operator opts
+    # into INFO/DEBUG (``python app.py -v`` or ``VTSEARCH_LOG_LEVEL=info``).
+    # Pinning it to ERROR unconditionally was the ``no-access-log`` bug: there
+    # was no way to see request activity at all, even with the level turned up.
+    werkzeug_level = level_value if level_value <= logging.INFO else logging.ERROR
+    logging.getLogger("werkzeug").setLevel(werkzeug_level)
     logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
     logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
 


### PR DESCRIPTION
Fixes the `no-access-log` audit item (P3, `docs/audits/standard-workflow-2026-06-04.md`): a local dev-server session that downloaded, embedded ~1250 images, ran Find, and exported left only the 6 boot lines in the log — no access log, no way to see "what did the server just do?".

## Root cause

`setup_logging()` pinned the `werkzeug` logger to `ERROR` unconditionally. werkzeug's INFO records *are* the dev-server access log (`GET /api/... 200`), so the access log was unreachable even with `VTSEARCH_LOG_LEVEL` turned all the way up.

## What changed

- **`vtsearch/logging_config.py`** — werkzeug now follows the configured level: silenced (`ERROR`) at the default `WARNING`+, but let through at `INFO`/`DEBUG`. `huggingface_hub` stays pinned to `ERROR` regardless (its INFO/DEBUG output is download-progress chatter).
- **`app.py`** — new `-v`/`--verbose` count flag. `-v` → `INFO` (access log on), `-vv` → `DEBUG`. It only *raises* verbosity (so `-v` on top of `VTSEARCH_LOG_LEVEL=debug` stays at DEBUG) and applies to both the web server and `--autodetect`.
- **`gunicorn.conf.py`** — mirrors the dev server: `VTSEARCH_LOG_LEVEL=info`/`debug` enables gunicorn's access log (streamed to stdout); quiet otherwise.
- **Docs** — `docs/CLI.md` (new Verbose logging section), `docs/DEPLOYMENT.md`, `docs/SETUP.md` env tables note that INFO/DEBUG enable the access log; the audit item is marked Fixed.
- **Tests** — `tests/core/test_structured_logging.py` gains a `TestWerkzeugAccessLogLevel` class asserting werkzeug follows the level (ERROR at WARNING, INFO at INFO, DEBUG at DEBUG) while huggingface_hub stays quiet at DEBUG.

## Behavior

```
(default)  root=WARNING  werkzeug=ERROR  hf=ERROR
-v         root=INFO     werkzeug=INFO   hf=ERROR
-vv        root=DEBUG    werkzeug=DEBUG  hf=ERROR
```

## Testing

- `tests/core/test_structured_logging.py` — 30 passed (incl. 4 new).
- Full `tests/core/` group — 568 passed.
- `ruff check` / `ruff format --check` / `codespell` clean on changed files.
- Verified the `-v`/`-vv` argparse→level wiring and the gunicorn accesslog toggle in isolation.

Note: `./run-tests.sh` is blocked in this container by a pre-existing, environment-only OpenAPI snapshot drift (`UNPROCESSABLE_CONTENT` vs `_ENTITY`, a Python 3.13-vs-3.11 `http.HTTPStatus(422).name` difference). It is identical on `origin/dev` (`git diff origin/dev -- frontend/openapi.json` is empty) and unrelated to this change, so the snapshot was intentionally left untouched — regenerating it under 3.11 would corrupt the canonical spec.

https://claude.ai/code/session_01PzEXrfxNrvm71t7bcD77zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzEXrfxNrvm71t7bcD77zd)_