### PR TITLE
Pin OpenAPI 422 response name across Python versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,7 +145,10 @@ app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-
 
 from flask_smorest import Api  # noqa: E402
 
-from vtsearch.openapi_postprocess import assign_operation_ids  # noqa: E402
+from vtsearch.openapi_postprocess import (  # noqa: E402
+    assign_operation_ids,
+    normalize_unprocessable_response,
+)
 
 api = Api(app)
 
@@ -163,6 +166,7 @@ _apispec_to_dict = api.spec.to_dict
 def _to_dict_with_operation_ids() -> dict:
     spec = _apispec_to_dict()
     assign_operation_ids(app, spec)
+    normalize_unprocessable_response(spec)
     return spec
 
 

--- a/tests/api/test_openapi_snapshot.py
+++ b/tests/api/test_openapi_snapshot.py
@@ -18,15 +18,15 @@ from vtsearch.openapi_postprocess import normalize_unprocessable_response
 class TestUnprocessableResponseNormalization:
     """The 422 response component is pinned regardless of Python version."""
 
-    def test_spec_uses_canonical_422_name(self):
-        spec = app_module.api.spec.to_dict()
+    def test_spec_uses_canonical_422_name(self, client):
+        spec = client.get("/api/openapi.json").get_json()
         responses = spec["components"]["responses"]
         assert "UNPROCESSABLE_CONTENT" in responses
         assert "UNPROCESSABLE_ENTITY" not in responses
         assert responses["UNPROCESSABLE_CONTENT"]["description"] == "Unprocessable Content"
 
-    def test_no_refs_point_at_legacy_name(self):
-        spec = app_module.api.spec.to_dict()
+    def test_no_refs_point_at_legacy_name(self, client):
+        spec = client.get("/api/openapi.json").get_json()
         legacy_ref = "#/components/responses/UNPROCESSABLE_ENTITY"
         assert legacy_ref not in _all_refs(spec)
 

--- a/tests/api/test_openapi_snapshot.py
+++ b/tests/api/test_openapi_snapshot.py
@@ -1,0 +1,96 @@
+"""Guards on the post-processed OpenAPI spec served at ``/api/openapi.json``.
+
+The spec is the source of the checked-in ``frontend/openapi.json`` snapshot
+that ``./run-tests.sh`` diffs against. flask-smorest derives the 422 response
+component name and description from ``http.HTTPStatus(422)``, which Python 3.13
+renamed from ``UNPROCESSABLE_ENTITY`` / "Unprocessable Entity" to the RFC 9110
+spelling ``UNPROCESSABLE_CONTENT`` / "Unprocessable Content". Without
+normalization the regenerated snapshot drifts purely because of the interpreter
+version. These tests pin the canonical form so the drift guard is stable.
+"""
+
+from __future__ import annotations
+
+import app as app_module  # noqa: F401  (triggers conftest side effects)
+from vtsearch.openapi_postprocess import normalize_unprocessable_response
+
+
+class TestUnprocessableResponseNormalization:
+    """The 422 response component is pinned regardless of Python version."""
+
+    def test_spec_uses_canonical_422_name(self):
+        spec = app_module.api.spec.to_dict()
+        responses = spec["components"]["responses"]
+        assert "UNPROCESSABLE_CONTENT" in responses
+        assert "UNPROCESSABLE_ENTITY" not in responses
+        assert responses["UNPROCESSABLE_CONTENT"]["description"] == "Unprocessable Content"
+
+    def test_no_refs_point_at_legacy_name(self):
+        spec = app_module.api.spec.to_dict()
+        legacy_ref = "#/components/responses/UNPROCESSABLE_ENTITY"
+        assert legacy_ref not in _all_refs(spec)
+
+    def test_normalizes_legacy_python311_spec(self):
+        """A spec emitted by flask-smorest on Python < 3.13 is rewritten."""
+        spec = {
+            "components": {
+                "responses": {
+                    "UNPROCESSABLE_ENTITY": {
+                        "description": "Unprocessable Entity",
+                        "content": {},
+                    }
+                }
+            },
+            "paths": {
+                "/api/thing": {
+                    "post": {
+                        "responses": {
+                            "422": {"$ref": "#/components/responses/UNPROCESSABLE_ENTITY"}
+                        }
+                    }
+                }
+            },
+        }
+
+        normalize_unprocessable_response(spec)
+
+        responses = spec["components"]["responses"]
+        assert set(responses) == {"UNPROCESSABLE_CONTENT"}
+        assert responses["UNPROCESSABLE_CONTENT"]["description"] == "Unprocessable Content"
+        ref = spec["paths"]["/api/thing"]["post"]["responses"]["422"]["$ref"]
+        assert ref == "#/components/responses/UNPROCESSABLE_CONTENT"
+
+    def test_idempotent_on_canonical_spec(self):
+        """Running against an already-canonical spec changes nothing."""
+        spec = {
+            "components": {
+                "responses": {
+                    "UNPROCESSABLE_CONTENT": {
+                        "description": "Unprocessable Content",
+                        "content": {},
+                    }
+                }
+            },
+        }
+
+        normalize_unprocessable_response(spec)
+
+        assert set(spec["components"]["responses"]) == {"UNPROCESSABLE_CONTENT"}
+        assert (
+            spec["components"]["responses"]["UNPROCESSABLE_CONTENT"]["description"]
+            == "Unprocessable Content"
+        )
+
+
+def _all_refs(node) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                refs.add(value)
+            else:
+                refs |= _all_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            refs |= _all_refs(item)
+    return refs

--- a/tests/api/test_openapi_snapshot.py
+++ b/tests/api/test_openapi_snapshot.py
@@ -42,13 +42,7 @@ class TestUnprocessableResponseNormalization:
                 }
             },
             "paths": {
-                "/api/thing": {
-                    "post": {
-                        "responses": {
-                            "422": {"$ref": "#/components/responses/UNPROCESSABLE_ENTITY"}
-                        }
-                    }
-                }
+                "/api/thing": {"post": {"responses": {"422": {"$ref": "#/components/responses/UNPROCESSABLE_ENTITY"}}}}
             },
         }
 
@@ -76,10 +70,7 @@ class TestUnprocessableResponseNormalization:
         normalize_unprocessable_response(spec)
 
         assert set(spec["components"]["responses"]) == {"UNPROCESSABLE_CONTENT"}
-        assert (
-            spec["components"]["responses"]["UNPROCESSABLE_CONTENT"]["description"]
-            == "Unprocessable Content"
-        )
+        assert spec["components"]["responses"]["UNPROCESSABLE_CONTENT"]["description"] == "Unprocessable Content"
 
 
 def _all_refs(node) -> set[str]:

--- a/vtsearch/openapi_postprocess.py
+++ b/vtsearch/openapi_postprocess.py
@@ -76,6 +76,59 @@ def _operation_ids_for_view(name: str, op_keys: list[tuple[str, str]]) -> dict[t
     return assigned
 
 
+# flask-smorest names the 422 validation-error response component (and writes
+# its ``description``) from ``http.HTTPStatus(422)``. Python 3.13 renamed that
+# member from ``UNPROCESSABLE_ENTITY`` / "Unprocessable Entity" to the RFC 9110
+# spelling ``UNPROCESSABLE_CONTENT`` / "Unprocessable Content", so the generated
+# spec — component key, every ``$ref`` to it, and the description — depends on
+# the interpreter running the dump. Pin it to the modern name so the snapshot is
+# byte-identical across Python versions and ``./run-tests.sh`` doesn't report
+# environment-only drift.
+_CANONICAL_422_NAME = "UNPROCESSABLE_CONTENT"
+_CANONICAL_422_DESCRIPTION = "Unprocessable Content"
+_LEGACY_422_NAME = "UNPROCESSABLE_ENTITY"
+
+_RESPONSE_REF_PREFIX = "#/components/responses/"
+
+
+def _rewrite_response_refs(node: Any, old_ref: str, new_ref: str) -> None:
+    """Recursively rewrite every ``$ref`` equal to ``old_ref`` to ``new_ref``."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and value == old_ref:
+                node[key] = new_ref
+            else:
+                _rewrite_response_refs(value, old_ref, new_ref)
+    elif isinstance(node, list):
+        for item in node:
+            _rewrite_response_refs(item, old_ref, new_ref)
+
+
+def normalize_unprocessable_response(spec: dict[str, Any]) -> None:
+    """Pin the 422 response component to a Python-version-independent name.
+
+    Renames the legacy ``UNPROCESSABLE_ENTITY`` component (emitted by
+    flask-smorest on Python < 3.13) to the canonical ``UNPROCESSABLE_CONTENT``,
+    rewrites every ``$ref`` that pointed at it, and forces the canonical
+    description. A no-op when the spec already uses the canonical name.
+    """
+    responses = spec.get("components", {}).get("responses")
+    if not isinstance(responses, dict):
+        return
+
+    if _LEGACY_422_NAME in responses and _CANONICAL_422_NAME not in responses:
+        responses[_CANONICAL_422_NAME] = responses.pop(_LEGACY_422_NAME)
+        _rewrite_response_refs(
+            spec,
+            _RESPONSE_REF_PREFIX + _LEGACY_422_NAME,
+            _RESPONSE_REF_PREFIX + _CANONICAL_422_NAME,
+        )
+
+    canonical = responses.get(_CANONICAL_422_NAME)
+    if isinstance(canonical, dict) and "description" in canonical:
+        canonical["description"] = _CANONICAL_422_DESCRIPTION
+
+
 def assign_operation_ids(app: Flask, spec: dict[str, Any]) -> None:
     """Mutate ``spec`` to assign an ``operationId`` to every operation.
 


### PR DESCRIPTION
## Problem

`./run-tests.sh` was blocked by the OpenAPI snapshot drift guard on any Python 3.11 container. flask-smorest derives the 422 validation-error response component name — and its `description` — from `http.HTTPStatus(422)`. Python 3.13 renamed that enum member from `UNPROCESSABLE_ENTITY` / "Unprocessable Entity" to the RFC 9110 spelling `UNPROCESSABLE_CONTENT` / "Unprocessable Content".

The checked-in `frontend/openapi.json` snapshot was generated on Python 3.13 (`UNPROCESSABLE_CONTENT`), so regenerating it on Python 3.11 produced `UNPROCESSABLE_ENTITY` and the drift check failed — an environment-only diff that has nothing to do with the actual API surface.

## Fix

Add `normalize_unprocessable_response()` to `vtsearch/openapi_postprocess.py` and call it from the same `api.spec.to_dict` wrapper that already assigns operation IDs (so both the live `/api/openapi.json` endpoint and `scripts/dump_openapi.py` see it). It pins the 422 response component to the canonical `UNPROCESSABLE_CONTENT` name:

- renames the legacy `UNPROCESSABLE_ENTITY` component key when present,
- rewrites every `$ref` that pointed at it,
- forces the canonical `"Unprocessable Content"` description.

It's a no-op when the spec is already canonical, so the spec is now byte-identical regardless of the interpreter running the dump. The checked-in snapshot is unchanged (it was already canonical); regeneration on Python 3.11 now matches it exactly.

## Tests

- New `tests/api/test_openapi_snapshot.py` covers the live spec (canonical name, no legacy `$ref`s), the legacy-spec rewrite path, and idempotency.
- `./run-tests.sh` is fully green (4497 passed); the OpenAPI drift check — which runs before pytest — now passes on Python 3.11.

https://claude.ai/code/session_01Vx2bGHKXuyxFMez7c4hJeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vx2bGHKXuyxFMez7c4hJeT)_