### PR TITLE
Remove duplicated progress fraction from progress messages

### DIFF
--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -106,9 +106,7 @@ def download_ucsf_documents(  # noqa: C901
             try:
                 _core.download_file_with_progress(url, pdf_path, 0, on_progress)
                 downloaded += 1
-                on_progress(
-                    "downloading", f"Downloaded {doc_id}.pdf", downloaded, total_docs
-                )
+                on_progress("downloading", f"Downloaded {doc_id}.pdf", downloaded, total_docs)
             except Exception:
                 # Skip failed downloads silently.
                 pdf_path.unlink(missing_ok=True)

--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -107,7 +107,7 @@ def download_ucsf_documents(  # noqa: C901
                 _core.download_file_with_progress(url, pdf_path, 0, on_progress)
                 downloaded += 1
                 on_progress(
-                    "downloading", f"Downloaded {doc_id}.pdf ({downloaded}/{total_docs})", downloaded, total_docs
+                    "downloading", f"Downloaded {doc_id}.pdf", downloaded, total_docs
                 )
             except Exception:
                 # Skip failed downloads silently.

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -262,7 +262,7 @@ def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
 
         try:
             url = f"{_core.KTH_BASE_URL}{zip_name}"
-            on_progress("downloading", f"Downloading KTH {action} ({i + 1}/{total})...", i, total)
+            on_progress("downloading", f"Downloading KTH {action}...", i, total)
             _core.download_file_with_progress(url, zip_path, 0, on_progress)
 
             on_progress("downloading", f"Extracting KTH {action}...", i + 1, total)

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -655,7 +655,7 @@ class MediaEmbedder(ABC):
         total = len(medias)
         results: list[Optional[np.ndarray]] = []
         for i, m in enumerate(medias):
-            self._on_progress("embedding", f"Embedding {i + 1}/{total}...", i + 1, total)
+            self._on_progress("embedding", "Embedding...", i + 1, total)
             results.append(self.embed_media(m))
         return results
 
@@ -758,7 +758,7 @@ class MediaEmbedder(ABC):
         total = len(medias)
         results: list[Optional["PatchEmbedOutput"]] = []  # noqa: F821
         for i, m in enumerate(medias):
-            self._on_progress("embedding", f"Patch-embedding {i + 1}/{total}...", i + 1, total)
+            self._on_progress("embedding", "Patch-embedding...", i + 1, total)
             results.append(self.patch_forward(m))
         return results
 

--- a/vtscore/media/image/_image_bulk.py
+++ b/vtscore/media/image/_image_bulk.py
@@ -99,7 +99,7 @@ def bulk_embed_image_files(
             chunk_indices.append(idx)
             chunk_images.append(img)
 
-        on_progress("embedding", f"Embedding {label} {end}/{total}...", end, total)
+        on_progress("embedding", f"Embedding {label}...", end, total)
 
         if not chunk_images:
             start = end
@@ -166,7 +166,7 @@ def bulk_patch_forward_image_files(
             chunk_indices.append(idx)
             chunk_images.append(img)
 
-        on_progress("embedding", f"Patch-embedding {label} {end}/{total}...", end, total)
+        on_progress("embedding", f"Patch-embedding {label}...", end, total)
 
         if not chunk_images:
             start = end

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -149,7 +149,7 @@ class TextBGEEmbedder(MediaEmbedder):
             return [None] * len(medias)
 
         total = len(medias)
-        self._on_progress("embedding", f"Embedding BGE {len(ready_indices)}/{total}...", 0, total)
+        self._on_progress("embedding", "Embedding BGE...", 0, total)
         with self._embed_lock:
             try:
                 vectors = self._model.encode(
@@ -164,7 +164,7 @@ class TextBGEEmbedder(MediaEmbedder):
         results: list[Optional[np.ndarray]] = [None] * len(medias)
         for slot, vec in zip(ready_indices, vectors):
             results[slot] = np.asarray(vec)
-        self._on_progress("embedding", f"Embedding BGE {total}/{total}...", total, total)
+        self._on_progress("embedding", "Embedding BGE...", total, total)
         return results
 
     def embed_text_passage(self, text: str) -> Optional[np.ndarray]:

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -158,7 +158,7 @@ class TextE5Embedder(MediaEmbedder):
             return [None] * len(medias)
 
         total = len(medias)
-        self._on_progress("embedding", f"Embedding E5 {len(ready_indices)}/{total}...", 0, total)
+        self._on_progress("embedding", "Embedding E5...", 0, total)
         with self._embed_lock:
             try:
                 vectors = self._model.encode(
@@ -173,7 +173,7 @@ class TextE5Embedder(MediaEmbedder):
         results: list[Optional[np.ndarray]] = [None] * len(medias)
         for slot, vec in zip(ready_indices, vectors):
             results[slot] = np.asarray(vec)
-        self._on_progress("embedding", f"Embedding E5 {total}/{total}...", total, total)
+        self._on_progress("embedding", "Embedding E5...", total, total)
         return results
 
     def embed_text_passage(self, text: str) -> Optional[np.ndarray]:

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -429,7 +429,6 @@ def _partition_find_results(media_results: dict[int, dict]) -> tuple[list[dict],
 def _score_dataset(
     ds: dict,
     detector_configs: list[dict],
-    datasets_total: int,
     scored_units: int,
     total_scoring_units: int,
 ) -> tuple[list[dict], list[dict], int, int, str]:
@@ -459,10 +458,7 @@ def _score_dataset(
     media_results = _seed_media_results(all_ids, temp_medias, ds["name"])
 
     for dc in detector_configs:
-        score_label = f'Scoring with "{dc["name"]}" on "{ds["name"]}"'
-        if datasets_total > 1 or len(detector_configs) > 1:
-            score_label += f" ({scored_units}/{new_total} items)"
-        score_label += "…"
+        score_label = f'Scoring with "{dc["name"]}" on "{ds["name"]}"…'
         update_find_progress(
             "running",
             score_label,
@@ -544,10 +540,7 @@ def multi_find(body: dict):
     scored_units = 0
 
     for di, ds in enumerate(datasets):
-        ds_label = f'Loading dataset "{ds["name"]}"'
-        if len(datasets) > 1:
-            ds_label += f" ({di + 1}/{len(datasets)})"
-        ds_label += "…"
+        ds_label = f'Loading dataset "{ds["name"]}"…'
         update_find_progress(
             "running",
             ds_label,
@@ -560,7 +553,6 @@ def multi_find(body: dict):
         positives, negatives, scored_units, added_units, ds_media_type = _score_dataset(
             ds,
             detector_configs,
-            len(datasets),
             scored_units,
             total_scoring_units,
         )

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -360,8 +360,7 @@ def _maybe_start_label_reembed(det_ctx, entry: dict) -> str | None:
 
                 def _embed_progress(name: str, done: int, total: int) -> None:
                     tracker.check_cancelled()
-                    msg = f"{base_msg} ({done}/{total})" if total else base_msg
-                    tracker.update("loading", msg, done, total, step=1, total_steps=1)
+                    tracker.update("loading", base_msg, done, total, step=1, total_steps=1)
 
                 # ``populate_label_embeddings`` clears the cache when it detects
                 # the embedder change, so this rebuilds against the new embedder
@@ -551,7 +550,7 @@ def load_detector_route(body: dict):  # noqa: C901
                                 tracker.check_cancelled()
                                 tracker.update(
                                     "loading",
-                                    f"Embedding labels… ({done}/{total})",
+                                    "Embedding labels…",
                                     done,
                                     total,
                                     step=3,


### PR DESCRIPTION
## Problem

Progress bars rendered the same `current/total` fraction twice, e.g.:

```
(64/81) Embedding SigLIP 64/81...
```

The frontend `formatProgressMessage` (and the CLI JSON renderer) already
prepend `(current/total)` derived from the progress event's `current`/`total`
fields. Several backend progress messages *also* baked that fraction into the
message text, so it appeared once in the parenthesized prefix and again in the
message body (flagged as finding O4 in `docs/reviews/2026-05-28-longops.md`).

## Fix

Stripped the redundant embedded fraction from every progress message that
passes `current`/`total` alongside it. The fraction now shows exactly once,
supplied by the renderer:

- `vtscore/media/embedder.py` — `Embedding...` / `Patch-embedding...`
- `vtscore/media/image/_image_bulk.py` — `Embedding {label}...` / `Patch-embedding {label}...` (the SigLIP case)
- `vtscore/media/text/embedder_e5.py`, `embedder_bge.py` — `Embedding E5/BGE...`
- `vtsearch/routes/detectors/registry.py` — re-embed + label-embedding progress
- `vtsearch/routes/detectors/find.py` — per-dataset load + per-detector scoring labels (also dropped the now-unused `datasets_total` param)
- `vtscore/datasets/downloader/video.py` (KTH), `documents.py` (UCSF) — download progress

Left alone: the arXiv downloader, which shows a *per-category* fraction in the
message while the prefix shows *overall* progress (two genuinely different
numbers, not a duplicate), and projection's `(N points)` total counts.

## Testing

`./run-tests.sh` — all pass except `test_projection.py::test_build_and_poll`,
a pre-existing flaky async-poll test that passes in isolation and is unrelated
to these changes (no projection code touched).

https://claude.ai/code/session_01AiHjK6dJhWyf8SLvkjaE2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiHjK6dJhWyf8SLvkjaE2D)_