### PR TITLE
fix(import): unify server path policy, gate required fields, add server path browsers

### DIFF
--- a/docs/plans/server-import-ux.md
+++ b/docs/plans/server-import-ux.md
@@ -1,0 +1,73 @@
+# Server / Services dataset-import UX
+
+Status: **Phase 1 shipped.** Came out of a hands-on audit of the three real-world
+import paths (Services extension plugin, server folder, server file with
+pre-computed vectors), driving the live UI. The Demo importer is well-trodden;
+these three are what real deployments use and were comparatively rough.
+
+## What shipped
+
+1. **Unified Server-tab path policy.** `server_folder`'s `path` field
+   (`field_type="folder"`) is now validated through
+   `validate_server_filepath` exactly like `server_files`' `server_path`
+   field, instead of bypassing validation entirely. Both Server importers
+   now confine to `SERVER_ROOTS` (single-user) / the per-user data dir
+   (multi-user). This also closed a multi-user confinement hole where
+   `server_folder` accepted any absolute path.
+   - `validate_server_filepath` now checks the resolved path against **every**
+     entry of `SERVER_ROOTS` (not just `[0]`), so `VTSEARCH_SERVER_ROOTS=/a:/b`
+     actually permits both roots. The error message names the allowed roots and
+     points at `VTSEARCH_SERVER_ROOTS`.
+   - **BREAKING:** importing a folder outside the install dir now requires
+     setting `VTSEARCH_SERVER_ROOTS` to include it (previously folder imports
+     accepted any server-readable path). `server_files` already behaved this way.
+   - Fixed the misleading `get_file_access_base_dir` docstring/comment that
+     called single-user mode "unrestricted" — it confines to `SERVER_ROOTS`.
+
+2. **Client-side required-field gating** in the generic `form` picker view.
+   Import is disabled until every required field has a value
+   (`formCanSubmit`), instead of letting an empty required field submit and
+   surface a raw 422 toast. Mirrors what the `server_folder` view already did
+   via `sfAbsolutePath`.
+
+3. **Server path browser** for both Server importers, delivering on the
+   "Browse the server's filesystem" copy that previously fronted a plain
+   text box:
+   - `server_files` (paths file): the `server_path` field now renders
+     `<vt-file-browser>` (text input + Browse button + inline `/api/browse`
+     folder browser, filtered by the field's `accept` extensions). Browse is
+     rooted at `SERVER_ROOTS[0]`, matching `server_files` validation.
+   - `server_folder` (path): a "Browse…" toggle reveals `<vt-folder-browser>`
+     backed by `/api/browse-media-files?source=server_fs`, which returns
+     `root_path` so the picked folder resolves to a true absolute path fed
+     into the existing typed-path + detection flow. Typing/pasting a path
+     still works.
+
+## Open follow-ups
+
+- **Browse-root vs. import-root seam (server_folder).** The `server_folder`
+  browser + media-type detection are rooted at `/` (the `server_fs` source in
+  `_resolve_browse_root`), but import validation now confines to `SERVER_ROOTS`.
+  So you can navigate to and select a folder *outside* `SERVER_ROOTS` and only
+  get rejected at Import (with a clear message). The `server_files` side has no
+  such seam (its `/api/browse` root and validation root are both
+  `SERVER_ROOTS[0]`). Closing this for `server_folder` means re-rooting
+  `server_fs` browse/detect at `SERVER_ROOTS[0]` **and** reworking the `sf-*`
+  path flow to pass root-relative paths (today `sfApplyPathInput` anchors at
+  `/` and detection resolves against `/`). Deferred because that path-model
+  rework is broad and the current behavior is correct, just not maximally tidy.
+
+- **Empty Services tab.** The base `DatasetImporter.category` default is
+  `"services"`, and every services-category importer ships
+  `hidden_from_picker=True` (recaller, http_archive, pickle, combine_datasets),
+  so a stock install shows an empty Services tab ("No importers in this
+  category."). `visibleImporterTabs` renders all declared tabs unconditionally,
+  contradicting `tabs.py`'s documented "only show tabs with ≥1 visible
+  importer." Follow-up: hide tabs with zero visible importers and/or give the
+  Services tab an empty-state that explains it's the extension surface. (Audited
+  but intentionally not changed in Phase 1.)
+
+- **Relative-entry resolution in server_files manifests.** Relative paths inside
+  a `.txt`/`.npz` resolve against the **manifest file's own directory**, not
+  CWD — easy to trip. Consider documenting in the field hint or resolving
+  against a more predictable base.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -92,6 +92,27 @@
 
     <ng-container sfAfter>
       <div class="form-group">
+        <button
+          type="button"
+          class="btn btn--secondary"
+          (click)="sfBrowserOpen = !sfBrowserOpen"
+          title="Browse the server's filesystem and pick a folder"
+        >{{ sfBrowserOpen ? 'Hide browser' : 'Browse…' }}</button>
+        @if (sfBrowserOpen) {
+          <div class="sf-folder-browser-panel">
+            <vt-folder-browser
+              [browse]="sfFolderBrowseFn"
+              [showFiles]="true"
+              [showPathFooter]="true"
+              rootLabel="Server root"
+              (pathChange)="onSfFolderPicked($event)"
+            ></vt-folder-browser>
+            <p class="form-hint">Navigate into a folder to select it; its media is imported.</p>
+          </div>
+        }
+      </div>
+
+      <div class="form-group">
         <label class="form-label" for="sf-recursive" title="When enabled, subdirectories of the chosen folder are scanned recursively. When disabled, only files directly inside the chosen folder are imported.">
           <input
             id="sf-recursive"
@@ -251,14 +272,12 @@
             </label>
 
             @if (field.field_type === 'server_path') {
-              <input
-                [id]="'field-' + field.key"
-                type="text"
-                class="form-input"
-                [ngModel]="formValues[field.key] || ''"
-                (ngModelChange)="formOnServerPathSelected(field.key, $event)"
+              <vt-file-browser
+                [value]="formValues[field.key] || ''"
+                [extensions]="field.accept || ''"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
-              />
+                (pathSelected)="formOnServerPathSelected(field.key, $event)"
+              ></vt-file-browser>
             } @else if (field.field_type === 'file') {
               <input
                 [id]="'field-' + field.key"
@@ -382,7 +401,7 @@
   @if (activePickerView !== 'demo' && activePickerView !== 'local_folder' && activePickerView !== 'local_files' && activePickerView !== 'server_folder' && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
-      <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+      <button class="btn btn--primary" (click)="submit()" [disabled]="submitting || !formCanSubmit">
         @if (submitting) {
           Importing...
         } @else {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -7,6 +7,10 @@ import { ImportAdvancedComponent } from './import-advanced/import-advanced.compo
 import { ImportConfigComponent } from './import-config/import-config.component';
 import { SourcePickerComponent } from './source-picker/source-picker.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
+import { FileBrowserComponent } from '../../file-browser/file-browser.component';
+import { FolderBrowserComponent, FolderBrowserBrowseFn } from '../../folder-browser/folder-browser.component';
+import { DatasetsUiApiService } from '../../../services/datasets-ui-api.service';
+import { map } from 'rxjs/operators';
 import { DatasetsCrudApiService } from '../../../services/datasets-crud-api.service';
 import { DatasetsListingsApiService } from '../../../services/datasets-listings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
@@ -17,7 +21,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent, FieldHintIconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent, FieldHintIconComponent, FileBrowserComponent, FolderBrowserComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -186,7 +190,46 @@ export class DatasetImporterModalComponent implements OnInit {
     private datasetsListingsApi: DatasetsListingsApiService,
     private settingsState: SettingsStateService,
     private toastService: ToastService,
+    private datasetsUiApi: DatasetsUiApiService,
   ) {}
+
+  /** Whether the inline server-filesystem folder browser is expanded under
+   *  the server_folder path input. */
+  sfBrowserOpen = false;
+
+  /** Browse function for the server_folder folder browser.  Backed by
+   *  ``/api/browse-media-files?source=server_fs`` so it shares the exact
+   *  root the importer + media-type detection use (filesystem root in
+   *  single-user mode, the user's data dir in multi-user mode) and returns
+   *  ``root_path``, letting the browser resolve a true absolute path. */
+  readonly sfFolderBrowseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.datasetsUiApi.browseMediaFiles('server_fs', path).pipe(
+      map((res) => ({
+        directories: res.directories,
+        files: res.files,
+        rootPath: res.root_path,
+      })),
+    );
+
+  /** Apply a folder picked in the inline browser.  ``pathChange`` gives the
+   *  path relative to ``rootPath``; reassemble the absolute path the same way
+   *  the browser's footer does, feed it into the typed-path input, and run
+   *  the normal apply (which triggers media-type detection). */
+  onSfFolderPicked(evt: { path: string; rootPath: string }): void {
+    const { path, rootPath } = evt;
+    let absolute: string;
+    if (!rootPath) {
+      absolute = path;
+    } else if (!path) {
+      absolute = rootPath;
+    } else if (rootPath === '/') {
+      absolute = '/' + path;
+    } else {
+      absolute = rootPath + '/' + path;
+    }
+    this.sfPathInputValue = absolute;
+    this.sfApplyPathInput();
+  }
 
   /** Saved import defaults for the active user, keyed by canonical
    *  type_id. Used to silently pre-fill the embedder/clipper/source-spec
@@ -2007,6 +2050,25 @@ export class DatasetImporterModalComponent implements OnInit {
       this.formValues[fieldName] = input.files[0].name;
       this.maybeApplyDerivedDatasetName();
     }
+  }
+
+  /** True when every required field on the active generic-form importer has
+   *  a value.  Drives the Import button's disabled state so missing input is
+   *  caught client-side instead of surfacing as a server-side 422 after the
+   *  user clicks Import.  Mirrors the proactive gating the server_folder view
+   *  already does via ``sfAbsolutePath``. */
+  get formCanSubmit(): boolean {
+    const fields = this.selectedImporter?.fields ?? [];
+    for (const f of fields) {
+      if (!f.required) continue;
+      if (f.field_type === 'file') {
+        if (!this.selectedFile) return false;
+      } else {
+        const v = this.formValues[f.key];
+        if (v === undefined || v === null || String(v).trim() === '') return false;
+      }
+    }
+    return true;
   }
 
   submit(): void {

--- a/tests/api/test_path_validation.py
+++ b/tests/api/test_path_validation.py
@@ -66,6 +66,69 @@ class TestValidateServerFilepath:
         with pytest.raises(ValueError, match="must be within"):
             validate_server_filepath("escape_link/passwd", base_dir=tmp_path)
 
+    def test_accepts_path_in_any_configured_root(self, tmp_path, monkeypatch):
+        """With base_dir=None, a path inside ANY of SERVER_ROOTS is accepted."""
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        root_a.mkdir()
+        root_b.mkdir()
+        # SERVER_ROOTS is imported lazily inside the function, so patch the source.
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root_a, root_b))
+
+        # A path under the *second* configured root must validate, not just the first.
+        target = root_b / "media" / "clip.wav"
+        result = validate_server_filepath(str(target))
+        assert result == target.resolve()
+
+    def test_rejects_path_outside_all_roots(self, tmp_path, monkeypatch):
+        root_a = tmp_path / "a"
+        root_a.mkdir()
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root_a,))
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath(str(tmp_path / "outside" / "x.wav"))
+
+
+class TestFolderFieldValidation:
+    """The server_folder importer's ``folder`` field must be path-validated
+    just like the server_files ``server_path`` field (unified policy)."""
+
+    def test_folder_field_outside_roots_rejected(self, tmp_path, monkeypatch):
+        from vtscore.datasets.importers.server_folder import ServerFolderDatasetImporter
+        from vtscore.plugins.normalize import normalize_field_values
+
+        root = tmp_path / "allowed"
+        root.mkdir()
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root,))
+        # Single-user (default provider) -> base_dir is None -> SERVER_ROOTS apply.
+        from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
+
+        original = get_login_provider()
+        try:
+            set_login_provider(DefaultLoginProvider())
+            imp = ServerFolderDatasetImporter()
+            with pytest.raises(ValueError, match="must be within"):
+                normalize_field_values(imp, {"path": "/tmp/outside_the_root", "media_type": "image"})
+        finally:
+            set_login_provider(original)
+
+    def test_folder_field_inside_root_accepted(self, tmp_path, monkeypatch):
+        from vtscore.datasets.importers.server_folder import ServerFolderDatasetImporter
+        from vtscore.plugins.normalize import normalize_field_values
+
+        root = tmp_path / "allowed"
+        (root / "media").mkdir(parents=True)
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root,))
+        from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
+
+        original = get_login_provider()
+        try:
+            set_login_provider(DefaultLoginProvider())
+            imp = ServerFolderDatasetImporter()
+            out = normalize_field_values(imp, {"path": str(root / "media"), "media_type": "image"})
+            assert out["path"] == str(root / "media")
+        finally:
+            set_login_provider(original)
+
 
 # ---------------------------------------------------------------------------
 # get_file_access_base_dir

--- a/tests/cli/test_cli_dry_run.py
+++ b/tests/cli/test_cli_dry_run.py
@@ -203,6 +203,12 @@ class TestDryRunPickle:
 
 
 class TestDryRunImporter:
+    @pytest.fixture(autouse=True)
+    def _permissive_server_roots(self, monkeypatch):
+        """server_folder's ``path`` field is validated against SERVER_ROOTS;
+        these dry-run tests use dummy absolute paths to exercise CLI wiring."""
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
+
     def test_dry_run_importer_prints_params(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 import hashlib
 import io
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vtscore.datasets.importers.base import SourceSpec
 
@@ -899,6 +902,12 @@ class TestConverterAcceptsParams:
 
 
 class TestImportAPISourceSpecs:
+    @pytest.fixture(autouse=True)
+    def _permissive_server_roots(self, monkeypatch):
+        """server_folder's ``path`` field is validated against SERVER_ROOTS;
+        the dummy ``/tmp/test`` path here only exercises route wiring."""
+        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
+
     def test_import_endpoint_passes_source_specs(self, client):
         with patch("vtsearch.routes.datasets.staging._run_importer_in_background") as mock_run:
             resp = client.post(

--- a/tests/io/test_chunked_web_flow.py
+++ b/tests/io/test_chunked_web_flow.py
@@ -15,13 +15,23 @@ Three pieces:
 """
 
 import io
+from pathlib import Path
 from typing import Any, Iterator
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField
 from vtscore.datasets.load_pipeline import auto_chunk_size, consume_chunks_into
+
+
+@pytest.fixture(autouse=True)
+def _permissive_server_roots(monkeypatch):
+    """server_folder's ``path`` field is now validated against SERVER_ROOTS.
+    These tests use dummy absolute paths purely to exercise route→pipeline
+    wiring, so widen the allowed roots to the filesystem root."""
+    monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
 
 
 # ===========================================================================

--- a/vtscore/plugins/normalize.py
+++ b/vtscore/plugins/normalize.py
@@ -104,7 +104,7 @@ def _validate_field_value(field_type: str, value: str) -> None:
         from vtscore.security.url_validation import validate_url  # noqa: PLC0415
 
         validate_url(value)
-    elif field_type == "server_path":
+    elif field_type in ("server_path", "folder"):
         from vtscore.security.path_validation import (  # noqa: PLC0415
             get_file_access_base_dir,
             validate_server_filepath,

--- a/vtscore/security/path_validation.py
+++ b/vtscore/security/path_validation.py
@@ -17,9 +17,10 @@ def get_file_access_base_dir() -> Path | None:
     """Return the base directory for file-access validation.
 
     In single-user mode (:class:`~vtsearch.auth.DefaultLoginProvider`) this
-    returns ``None``, which causes :func:`validate_server_filepath` to fall
-    back to :data:`vtscore.config.SERVER_ROOTS[0]` (``Path.cwd()`` by
-    default).
+    returns ``None``, which causes :func:`validate_server_filepath` to confine
+    paths to :data:`vtscore.config.SERVER_ROOTS` (just ``Path.cwd()`` unless the
+    operator widens it via ``VTSEARCH_SERVER_ROOTS``).  ``None`` does *not* mean
+    "unrestricted" -- it means "use the configured server roots".
 
     In multi-user mode (any non-default provider) this returns the current
     user's data directory so that each user is confined to their own
@@ -29,22 +30,23 @@ def get_file_access_base_dir() -> Path | None:
 
     provider = get_login_provider()
     if isinstance(provider, DefaultLoginProvider):
-        return None  # single-user: unrestricted (CWD)
+        return None  # single-user: confine to the configured SERVER_ROOTS
     return get_user_data_dir()
 
 
 def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) -> Path:
-    """Validate that *filepath_str* resolves within *base_dir*.
+    """Validate that *filepath_str* resolves within an allowed root.
 
     Parameters
     ----------
     filepath_str:
         User-supplied file path (absolute or relative).
     base_dir:
-        The directory the resolved path must reside in.
-        Defaults to :data:`vtscore.config.SERVER_ROOTS[0]` (which itself
-        falls back to ``Path.cwd()`` when ``VTSEARCH_SERVER_ROOTS`` is
-        unset).
+        A single directory the resolved path must reside in.  When given
+        (e.g. the per-user data dir in multi-user mode) it is the only
+        allowed root.  When ``None`` the allowed roots are
+        :data:`vtscore.config.SERVER_ROOTS` (every entry is accepted), which
+        default to ``(Path.cwd(),)`` unless ``VTSEARCH_SERVER_ROOTS`` is set.
 
     Returns
     -------
@@ -54,30 +56,35 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
     Raises
     ------
     ValueError
-        If the resolved path is outside *base_dir*.
+        If the resolved path is outside every allowed root.
     """
-    if base_dir is None:
+    if base_dir is not None:
+        roots: tuple[Path, ...] = (base_dir,)
+    else:
         from vtscore.config import SERVER_ROOTS  # noqa: PLC0415
 
-        base_dir = SERVER_ROOTS[0]
+        roots = SERVER_ROOTS
 
     path = Path(filepath_str)
 
-    # Resolve relative paths against base_dir, absolute paths as-is
+    # Resolve relative paths against the primary root, absolute paths as-is.
     if not path.is_absolute():
-        path = base_dir / path
+        path = roots[0] / path
 
     resolved = path.resolve()
-    base_resolved = base_dir.resolve()
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return resolved
+        except ValueError:
+            continue
 
-    try:
-        resolved.relative_to(base_resolved)
-    except ValueError:
-        raise ValueError(
-            f"Path must be within '{base_resolved}'. The given path resolves outside the allowed directory."
-        )
-
-    return resolved
+    allowed = ", ".join(f"'{r.resolve()}'" for r in roots)
+    raise ValueError(
+        f"The given path resolves outside the allowed directory. Paths must be within {allowed}. "
+        f"To import media from another location, set the VTSEARCH_SERVER_ROOTS environment variable "
+        f"(os.pathsep-separated) to include it."
+    )
 
 
 def sanitize_template_value(value: str) -> str:


### PR DESCRIPTION
## Why

A hands-on audit of the three import paths real deployments actually use — a **Services** extension plugin, a **server folder**, and a **server file with pre-computed vectors** — surfaced inconsistencies the well-trodden Demo importer hides. This PR fixes three of them (driven live in the browser).

## What changed

1. **Unified Server-tab path policy.** `server_folder`'s `path` field (`field_type="folder"`) now validates through `validate_server_filepath` exactly like `server_files`' `server_path` field, instead of bypassing validation entirely. Both confine to `SERVER_ROOTS` (single-user) / the per-user data dir (multi-user) — closing a multi-user confinement hole where folder imports accepted any absolute path.
   - `validate_server_filepath` now checks the resolved path against **every** `SERVER_ROOTS` entry (not just `[0]`), so `VTSEARCH_SERVER_ROOTS=/a:/b` permits both. The error names the allowed roots and points at `VTSEARCH_SERVER_ROOTS`.
   - Fixed the misleading `get_file_access_base_dir` docstring that called single-user "unrestricted" (it confines to `SERVER_ROOTS`).
   - ⚠️ **BREAKING:** importing a folder outside the install dir now requires `VTSEARCH_SERVER_ROOTS` to include it. `server_files` already behaved this way; this makes Folder consistent.

2. **Client-side required-field gating** in the generic `form` picker. Import is disabled until required fields are filled (`formCanSubmit`), instead of letting an empty required field submit and surface a raw **422** toast. Mirrors what `server_folder` already did via `sfAbsolutePath`.

3. **Server path browsers**, delivering on the "Browse the server's filesystem" copy that previously fronted a plain text box:
   - `server_files` → `<vt-file-browser>` (text input + Browse + inline `/api/browse`, filtered by `accept` extensions).
   - `server_folder` → a **Browse…** toggle backed by `/api/browse-media-files?source=server_fs`, whose `root_path` lets the picked folder resolve to a true absolute path fed into the existing typed-path + detection flow. Typing/pasting still works.

## Verified

- Drove all three import paths live (server_folder, server_files via `.txt` list and `.npz` precomputed vectors, Services empty-state).
- Live: in-`SERVER_ROOTS` folder import accepted (200); out-of-root rejected (400 with the actionable message); both browsers open and select correctly.
- Targeted backend suite: **1779 passed, 4 skipped** (path-validation, normalize, importers, CLI/route wiring). Added folder-field + multi-root validation tests. `ruff` + `codespell` clean; prod frontend build typechecks.

## Follow-ups (tracked in `docs/plans/server-import-ux.md`)

- `server_folder` browse/detect are rooted at `/` while import validates against `SERVER_ROOTS`, so you can browse to and select an out-of-root folder and only get rejected at Import. Closing it needs a `sf-*` path-model rework (deferred; current behavior is correct).
- The **Services** tab is empty in a stock install (base default `category="services"` + all services importers `hidden_from_picker`), and empty tabs render anyway. Audited but intentionally left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)