### PR TITLE
Confine server_fs browse/detect to SERVER_ROOTS

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -136,12 +136,12 @@ export class DatasetImporterModalComponent implements OnInit {
    *  auto-overwriting it from the picked folder name). */
   private lfDatasetNameDirty = false;
 
-  // Server folder picker state. The user types an absolute server path; we
-  // split it into ``sfBrowseRootPath`` (always ``/`` here) and ``sfBrowsePath``
-  // (the typed path with the leading slash stripped) so the existing
-  // detection / submit / dataset-name helpers keep working unchanged.
-  sfBrowsePath = '';
-  sfBrowseRootPath = '';
+  // Server folder picker state. The user types or browses to an absolute
+  // server path, stored verbatim in ``sfFolderPath``. It is sent to the
+  // detection / submit endpoints as-is; the backend resolves it against the
+  // configured server root and rejects anything outside, so the picker and
+  // the importer agree on what is in-bounds.
+  sfFolderPath = '';
   sfBrowseError = '';
   sfMediaType = '';
   sfMediaTypeOptions: string[] = [];
@@ -1338,7 +1338,7 @@ export class DatasetImporterModalComponent implements OnInit {
 
   sfOnRecursiveChange(recursive: boolean): void {
     this.sfRecursive = recursive;
-    if (this.sfBrowseRootPath) {
+    if (this.sfFolderPath) {
       this.sfRunDetection();
     }
   }
@@ -1559,8 +1559,7 @@ export class DatasetImporterModalComponent implements OnInit {
 
   openServerFolderBrowser(importer?: ImporterInfo): void {
     this.selectedImporter = importer || this.importers.find((i) => i.name === 'server_folder') || null;
-    this.sfBrowsePath = '';
-    this.sfBrowseRootPath = '';
+    this.sfFolderPath = '';
     this.sfBrowseError = '';
     this.sfDetection = null;
     this.sfSubmitting = false;
@@ -1592,9 +1591,8 @@ export class DatasetImporterModalComponent implements OnInit {
   }
 
   /** Current value of the editable absolute-path input. Two-way bound to
-   *  the typed path input; ``sfApplyPathInput`` splits it into the
-   *  ``sfBrowseRootPath`` / ``sfBrowsePath`` pair the submit + detection
-   *  helpers already consume. */
+   *  the typed path input; ``sfApplyPathInput`` stores it in
+   *  ``sfFolderPath`` for the submit + detection helpers to consume. */
   sfPathInputValue = '';
 
   /** Apply the value typed into the absolute-path input. The path is not
@@ -1602,8 +1600,7 @@ export class DatasetImporterModalComponent implements OnInit {
   sfApplyPathInput(): void {
     const raw = (this.sfPathInputValue || '').trim();
     if (!raw) {
-      this.sfBrowsePath = '';
-      this.sfBrowseRootPath = '';
+      this.sfFolderPath = '';
       this.sfBrowseError = '';
       this.sfDetection = null;
       if (!this.sfDatasetNameDirty) {
@@ -1611,12 +1608,10 @@ export class DatasetImporterModalComponent implements OnInit {
       }
       return;
     }
-    // Treat the typed value as an absolute server path. Anchor the root
-    // at "/" and put the rest into sfBrowsePath so sfAbsolutePath returns
-    // the user-typed value verbatim.
-    const rel = raw.replace(/^\/+/, '').replace(/\/+$/, '');
-    this.sfBrowseRootPath = '/';
-    this.sfBrowsePath = rel;
+    // Keep the typed value as an absolute server path (trailing slash
+    // trimmed). The backend resolves it against the configured server root
+    // and rejects anything outside.
+    this.sfFolderPath = raw.replace(/\/+$/, '') || '/';
     this.sfBrowseError = '';
     if (!this.sfDatasetNameDirty) {
       this.sfDatasetName = this.sfDerivedDatasetName();
@@ -1635,7 +1630,7 @@ export class DatasetImporterModalComponent implements OnInit {
    *  and apply it to the sf-* form (output media-type + source specs). */
   private sfRunDetection(): void {
     const token = ++this.sfDetectionToken;
-    this.datasetsCrudApi.detectMediaType('server_fs', this.sfBrowsePath, this.sfRecursive).subscribe({
+    this.datasetsCrudApi.detectMediaType('server_fs', this.sfFolderPath, this.sfRecursive).subscribe({
       next: (res) => {
         if (token !== this.sfDetectionToken) return;
         this.sfDetection = res;
@@ -1669,8 +1664,8 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Derive a default dataset name from the currently selected server folder.
    *  Returns the leaf path component, or empty string when at the root. */
   private sfDerivedDatasetName(): string {
-    if (!this.sfBrowsePath) return '';
-    const parts = this.sfBrowsePath.split('/').filter(Boolean);
+    if (!this.sfFolderPath) return '';
+    const parts = this.sfFolderPath.split('/').filter(Boolean);
     return parts.length > 0 ? parts[parts.length - 1] : '';
   }
 
@@ -1680,11 +1675,7 @@ export class DatasetImporterModalComponent implements OnInit {
   }
 
   get sfAbsolutePath(): string {
-    if (!this.sfBrowseRootPath) return '';
-    if (!this.sfBrowsePath) return this.sfBrowseRootPath;
-    // Avoid "//foo" when the picker is rooted at the filesystem root.
-    if (this.sfBrowseRootPath === '/') return '/' + this.sfBrowsePath;
-    return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
+    return this.sfFolderPath;
   }
 
   sfOnMediaTypeChange(mediaType: string): void {

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -128,33 +128,34 @@ class TestDatasetEndpoints:
             file_names2 = [f["name"] for f in data2["files"]]
             assert "sound.wav" in file_names2
 
-    def test_browse_media_files_server_fs_lists_filesystem(self, client, tmp_path):
-        """``source=server_fs`` should let the picker walk the whole filesystem.
+    def test_browse_media_files_server_fs_confined_to_server_root(self, client, tmp_path, monkeypatch):
+        """``source=server_fs`` is confined to the configured server root.
 
-        The single-user mode root is ``/`` so any directory readable by the
-        server process should be listable via its absolute path stripped of
-        the leading slash.
+        In single-user mode the picker is rooted at ``SERVER_ROOTS[0]`` (not
+        the filesystem root ``/``) so it can never list a folder the
+        ``server_folder`` importer would reject at load time. Browsing the
+        root lists its subdirectories; a path that escapes the root is
+        rejected here rather than only at import.
         """
+        import vtscore.config
+
         sub = tmp_path / "subdir"
         sub.mkdir()
         (sub / "track.wav").write_bytes(b"RIFF" + b"\x00" * 64)
+        monkeypatch.setattr(vtscore.config, "SERVER_ROOTS", (tmp_path.resolve(),))
 
-        # tmp_path is absolute (e.g. /tmp/pytest-of-user/.../test_x0).
-        # Strip the leading "/" to get the relative path under "/".
-        rel = str(tmp_path).lstrip("/")
-        resp = client.get(f"/api/browse-media-files?source=server_fs&path={rel}")
+        resp = client.get("/api/browse-media-files?source=server_fs&path=")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["root_path"] == "/"
+        assert data["root_path"] == str(tmp_path.resolve())
         dir_names = [d["name"] for d in data["directories"]]
-        file_names = [f["name"] for f in data["files"]]
         assert "subdir" in dir_names
-        # No media files at this level.
-        assert "track.wav" not in file_names
-
-        # default_path is reported on every server_fs response. It points
-        # at the server user's home dir when it exists.
+        # default_path is reported on every server_fs response.
         assert "default_path" in data
+
+        # A traversal that escapes the server root is rejected outright.
+        resp = client.get("/api/browse-media-files?source=server_fs&path=../../etc")
+        assert resp.status_code == 400
 
     def test_select_browsed_file_copies_to_example_media(self, client, tmp_path):
         """POST /api/browse-media-files/select copies the file to example_media."""
@@ -259,6 +260,31 @@ class TestDatasetEndpoints:
         """GET /api/dataset/detect-media-type returns 404 for an unknown source."""
         resp = client.get("/api/dataset/detect-media-type?source=demo:nonexistent_xyz&path=")
         assert resp.status_code == 404
+
+    def test_detect_media_type_server_fs_confined_to_server_root(self, client, tmp_path, monkeypatch):
+        """``server_fs`` detection is confined to the configured server root.
+
+        Detection used to run from ``/``, so it would happily scan a folder
+        the importer rejects at load. It must now reject an absolute path that
+        resolves outside ``SERVER_ROOTS`` exactly as the importer does, while
+        still detecting media inside the root via its absolute path.
+        """
+        import vtscore.config
+
+        root = tmp_path / "media"
+        root.mkdir()
+        (root / "a.wav").write_bytes(b"RIFF")
+        (root / "b.wav").write_bytes(b"RIFF")
+        monkeypatch.setattr(vtscore.config, "SERVER_ROOTS", (tmp_path.resolve(),))
+
+        # In-root absolute path is detected.
+        resp = client.get(f"/api/dataset/detect-media-type?source=server_fs&path={root}")
+        assert resp.status_code == 200
+        assert resp.get_json()["dominant"] == "audio"
+
+        # An absolute path outside the server root is rejected, not scanned.
+        resp = client.get("/api/dataset/detect-media-type?source=server_fs&path=/etc")
+        assert resp.status_code == 400
 
     def test_detect_media_type_directory_cap(self, tmp_path):
         """The helper stops walking after ``max_dirs`` directories, even when

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -233,10 +233,11 @@ def _resolve_browse_root(source: str) -> Path | None:
 
     * ``demo:<name>``: the ``required_folder`` of the named demo dataset.
     * ``folder``: the configured ``saved_datasets_dir``.
-    * ``server_fs``: the whole server filesystem (single-user mode) or the
-      current user's data directory (multi-user mode). Matches the actual
-      runtime scope of the ``server_folder``/``server_files`` importers,
-      which accept any absolute path readable by the server process.
+    * ``server_fs``: the configured server root (single-user mode) or the
+      current user's data directory (multi-user mode). Matches the scope
+      the ``server_folder``/``server_files`` importers enforce at import
+      time, so the picker can never browse to a folder the importer would
+      later reject.
 
     Returns ``None`` if the source is unrecognised or the directory does not
     exist.
@@ -263,33 +264,28 @@ def _resolve_browse_root(source: str) -> Path | None:
 
         base = get_file_access_base_dir()
         if base is None:
-            return Path("/")
+            # Single-user mode: confine the picker to the configured server
+            # root rather than the filesystem root, so browsing/detection
+            # reject out-of-root folders the same way the importer does on
+            # load. SERVER_ROOTS[0] is the primary root, matching /api/browse.
+            from vtscore.config import SERVER_ROOTS  # noqa: PLC0415
+
+            return SERVER_ROOTS[0]
         return base.resolve()
 
     return None
 
 
-def _default_browse_path(source: str, root: Path) -> str:
-    """Pick a sensible initial relative path for *source* under *root*.
+def _default_browse_path() -> str:
+    """Initial relative sub-path the browse picker opens at.
 
-    For ``server_fs`` in single-user mode (root == ``/``) we start the
-    picker at the server user's home directory if it exists, saving the
-    user three or four clicks to drill down from ``/``. Falls back to the
-    root itself otherwise.
+    Always the root itself (``""``). Every browse source now resolves to a
+    meaningful directory (a demo folder, the saved-datasets dir, or the
+    configured server root), so there is nothing to skip past; the old
+    ``server_fs`` home-directory shortcut only existed to save clicks when
+    the picker was rooted at the filesystem root ``/``.
     """
-    if source != "server_fs":
-        return ""
-    try:
-        home = Path.home().resolve()
-    except (RuntimeError, OSError):
-        return ""
-    try:
-        rel = home.relative_to(root)
-    except ValueError:
-        return ""
-    if not home.is_dir():
-        return ""
-    return str(rel) if str(rel) != "." else ""
+    return ""
 
 
 @datasets_ui_bp.route("/api/browse-media-files")
@@ -356,7 +352,7 @@ def browse_media_files(query: dict):
         "directories": directories,
         "files": files,
         "root_path": str(root),
-        "default_path": _default_browse_path(source, root),
+        "default_path": _default_browse_path(),
     }
 
 


### PR DESCRIPTION
## Problem

The `server_folder` importer's folder browser (`/api/browse-media-files?source=server_fs`) and media-type detection (`/api/dataset/detect-media-type?source=server_fs`) resolved paths from the filesystem root `/` in single-user mode. Import, however, validates the chosen path against `SERVER_ROOTS` (`vtscore.security.path_validation.validate_server_filepath`).

The result: you could browse to, and run detection on, a folder **outside** the allowed roots, and only get rejected at the final Import step.

## Fix

Root the `server_fs` browse source at `SERVER_ROOTS[0]` in single-user mode instead of `/` (`vtsearch/routes/datasets/ui.py:_resolve_browse_root`). This matches the existing `/api/browse` convention and the scope the importer enforces at load, so out-of-root folders are now rejected during browsing and detection — not just at import. Multi-user mode is unchanged (still confined to the user's data dir).

- `_default_browse_path` is simplified: the old "start at the user's home dir" shortcut only existed to save clicks when rooted at `/`; every source now opens at a meaningful directory.
- **Frontend** (`dataset-importer-modal`): the typed server-path input no longer strips the leading slash on the assumption of a `/` root. It keeps the absolute path verbatim and sends it to detection/submit; the backend resolves it against the server root and rejects anything outside. The `sfBrowseRootPath`/`sfBrowsePath` pair collapses into a single `sfFolderPath`.

## Backwards compatibility

This narrows the `server_fs` browser/detector from "anywhere on the filesystem" to "within the configured server root(s)". With the default single root (cwd) the browser is unchanged in practice; operators who relied on browsing the whole filesystem should set `VTSEARCH_SERVER_ROOTS` to widen the scope. When `SERVER_ROOTS` has multiple entries, the picker is confined to the primary root (`[0]`), consistent with `/api/browse`; other roots remain importable via a typed path.

## Tests

- Rewrote `test_browse_media_files_server_fs_*` to assert the picker is rooted at `SERVER_ROOTS[0]` and that a path escaping the root returns 400.
- Added `test_detect_media_type_server_fs_confined_to_server_root` covering in-root detection plus 400 for an out-of-root absolute path.
- `./run-tests.sh core datasets` — all 1343 tests pass (ruff/codespell/deptry + frontend build clean).

https://claude.ai/code/session_01FjChLL6kPcpGzykrbtZUEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjChLL6kPcpGzykrbtZUEs)_