### PR TITLE
Add ParaSpeechCLAP speech-style audio embedder

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -149,6 +149,7 @@ These are only downloaded if explicitly selected:
 | Model | Media type | HuggingFace ID | Approx. size |
 |-------|-----------|----------------|-------------|
 | CLAP Music & Speech | Audio | `laion/larger_clap_music_and_speech` | ~1.3 GB |
+| ParaSpeechCLAP (speech style) | Audio | `microsoft/wavlm-large` + `ibm-granite/granite-embedding-278m-multilingual` + `ajd12342/paraspeechclap-combined` | ~4.5 GB |
 | BGE | Text | `BAAI/bge-base-en-v1.5` | ~440 MB |
 
 All model downloads use `token=False`; no HuggingFace account or API

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -259,6 +259,7 @@ embedder per media type should override the `is_default` property to return
 |------|----------|-----------|---------|
 | `audio/embedder_clap.py` | `AudioClapEmbedder` | audio | ✅ |
 | `audio/embedder_clap_music.py` | `AudioClapMusicEmbedder` | audio | |
+| `audio/embedder_paraspeechclap.py` | `AudioParaSpeechClapEmbedder` | audio | |
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image | ✅ |
 | `text/embedder_e5.py` | `TextE5Embedder` | text | ✅ |
 | `text/embedder_bge.py` | `TextBGEEmbedder` | text | |
@@ -475,6 +476,7 @@ loaded via `spec_from_file_location` so discovery still works.
 |----------|------|------------|-------|------------|
 | `AudioClapEmbedder` | `clap` | `audio` | LAION CLAP (laion/clap-htsat-unfused) | 512 |
 | `AudioClapMusicEmbedder` | `clap_music` | `audio` | CLAP Music & Speech (laion/larger_clap_music_and_speech) | 512 |
+| `AudioParaSpeechClapEmbedder` | `paraspeechclap` | `audio` | ParaSpeechCLAP speech-style (WavLM-Large + Granite, ajd12342/paraspeechclap-combined) | 768 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |
 | `ImageDinov2SingleEmbedder` / `ImageDinov2PatchEmbedder` | `dinov2_single` / `dinov2_patch` | `image` | DINOv2 ViT-B/14 (facebook/dinov2-base), ungated | 768 |
 | `ImageDinov3SingleEmbedder` / `ImageDinov3PatchEmbedder` | `dinov3_single` / `dinov3_patch` | `image` | DINOv3 ViT-B/16 (facebook/dinov3-vitb16-pretrain-lvd1689m), HF-gated | 768 |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -120,7 +120,7 @@ Five media types are supported:
 
 | Media type | Default embedder | Model ID | Alternatives |
 |-----------|-----------------|----------|-------------|
-| Audio | CLAP | `laion/clap-htsat-unfused` | CLAP Music (`laion/larger_clap_music_and_speech`) |
+| Audio | CLAP | `laion/clap-htsat-unfused` | CLAP Music (`laion/larger_clap_music_and_speech`), ParaSpeechCLAP speech-style (`ajd12342/paraspeechclap-combined`) |
 | Image | SigLIP | `google/siglip-base-patch16-224` | CLIP (`openai/clip-vit-base-patch32`) |
 | Video | X-CLIP | `microsoft/xclip-base-patch32` | None |
 | Text | E5 | `intfloat/e5-base-v2` | BGE (`BAAI/bge-base-en-v1.5`) |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -78,6 +78,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 |------------------------|----------|-------|--------------|
 | Audio (`audio`) | `clap` (default) | LAION CLAP (`laion/clap-htsat-unfused`) | 512 |
 | Audio (`audio`) | `clap_music` | CLAP Music & Speech (`laion/larger_clap_music_and_speech`) | 512 |
+| Audio (`audio`) | `paraspeechclap` | ParaSpeechCLAP speech-style (WavLM + Granite, `ajd12342/paraspeechclap-combined`) | 768 |
 | Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |
 | Image (`image`) | `dinov2_single` / `dinov2_patch` | DINOv2 ViT-B/14 (`facebook/dinov2-base`) | 768 |
 | Image (`image`) | `dinov3_single` / `dinov3_patch` | DINOv3 ViT-B/16 (`facebook/dinov3-vitb16-pretrain-lvd1689m`, gated) | 768 |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,6 +8,7 @@ landed. Once a plan ships and its design notes are absorbed into
 Open the file for status; this index is just a filename list so it
 can't drift.
 
+- [audio-embedders.md](audio-embedders.md): Audio embedder candidates (CLAP / SpeechCLAP / AudioCLIP / Omni-Embed); ParaSpeechCLAP shipped
 - [browser-vision-testing.md](browser-vision-testing.md): Browser-vision testing via the Claude Chrome extension (style audit, edge states, e2e flows, long-op observability)
 - [cli-detector-converter.md](cli-detector-converter.md): CLI autodetect with converters and clippers
 - [cli-stream-massive-images.md](cli-stream-massive-images.md): CLI streaming for massive media sources

--- a/docs/plans/audio-embedders.md
+++ b/docs/plans/audio-embedders.md
@@ -1,0 +1,71 @@
+# Audio embedder candidates: CLAP / SpeechCLAP / AudioCLIP / Omni-Embed
+
+Status: **ParaSpeechCLAP shipped** (speech-style audio embedder). Other three
+candidates evaluated and declined; see below.
+
+## Background
+
+VTSearch shipped five audio embedders before this work:
+
+| Embedder | Model | Dim | Text queries? |
+|---|---|---|---|
+| `clap` (default) | `laion/clap-htsat-unfused` | 512 | ✅ |
+| `clap_general` | `laion/larger_clap_general` | 512 | ✅ |
+| `clap_music` | `laion/larger_clap_music_and_speech` | 512 | ✅ |
+| `ast` | `MIT/ast-finetuned-audioset-10-10-0.4593` | 768 | ❌ |
+| `whisper_encoder` | `openai/whisper-base` | 512 | ❌ |
+
+The four candidates raised were CLAP, SpeechCLAP, AudioCLIP, and Omni-Embed-Audio.
+
+## Decisions
+
+- **CLAP** — already covered by three laion variants; nothing to add.
+- **AudioCLIP** — declined. 2021 ESResNeXt+CLIP, not `transformers`-native,
+  weaker than CLAP for audio↔text, and its distinctive image branch is
+  irrelevant to audio search. High friction, ~no marginal value.
+- **Omni-Embed-Audio** (`nvidia/omni-embed-nemotron-3b`) — declined. ~5B params,
+  GPU-only (A100/H100), bf16 + flash-attention, NVIDIA non-commercial licence,
+  2048-dim. Conflicts with the CPU-runnable embedder model; non-commercial
+  licence is a dealbreaker.
+- **msclap** (Microsoft CLAP) — declined. The `msclap` pip package pins
+  `numpy<2.0.0` and pulls `torchaudio`, forcing an app-wide numpy downgrade,
+  and is not `transformers`-native. Capability overlaps heavily with the
+  existing laion CLAP variants. Harder integration for a smaller gain.
+- **ParaSpeechCLAP** — **shipped.** The only candidate that fills a genuine
+  gap: a text-queryable *speech-style* embedder (the existing `ast` /
+  `whisper_encoder` speech embedders have no paired text tower).
+
+## What shipped
+
+`paraspeechclap` audio embedder (`vtscore/media/audio/embedder_paraspeechclap.py`):
+
+- Maps speech clips and rich style descriptions ("a deep, raspy voice", "a
+  whispered, anxious style") into a shared 768-dim space.
+- Reconstructed from the released `ajd12342/paraspeechclap-combined` checkpoint
+  (MIT) via a vendored minimal architecture
+  (`vtscore/media/audio/_paraspeechclap_model.py`): WavLM-Large speech encoder
+  (`microsoft/wavlm-large`, MIT) + Granite text encoder
+  (`ibm-granite/granite-embedding-278m-multilingual`, Apache-2.0) + two
+  projection heads. No new pip dependencies (uses torch / transformers /
+  librosa / huggingface_hub, all already present).
+- `combined` variant chosen as the most versatile (covers both speaker-level
+  intrinsic attributes and utterance-level situational attributes).
+- Opt-in, not the default. Clips capped at 30 s to bound CPU memory/latency.
+
+## Open follow-ups
+
+- **Download size.** The embedder loads the WavLM + Granite base weights via
+  `from_pretrained` and then overlays the full fine-tuned checkpoint, so the
+  on-disk footprint is ~4.5 GB (base weights are downloaded then largely
+  overwritten). If the checkpoint is confirmed to carry the complete encoder
+  weights (upstream `inference.py` attempts `strict=True`, which implies it
+  does), the base loads could be switched to `AutoModel.from_config` to skip
+  ~2.3 GB of redundant downloads. Kept on `from_pretrained` for now for
+  robustness against a projections-only checkpoint.
+- **Variants.** Only `combined` is wired. The `intrinsic` (speaker-level) and
+  `situational` (utterance-level) checkpoints exist on HF and could be added as
+  separate embedders if users want sharper specialisation.
+- **Real-weights integration test.** Property/registration tests run without
+  downloading weights (mocked). A GPU-marked end-to-end test that loads the
+  real checkpoint and checks speech↔text similarity ordering would be valuable
+  but pulls ~4.5 GB, so it is deferred.

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -135,6 +135,8 @@ const EMBEDDER_PRETTY: Record<string, string> = {
   xclip: 'X-CLIP',
   'x-clip': 'X-CLIP',
   whisper: 'Whisper',
+  whisper_encoder: 'Whisper',
+  paraspeechclap: 'ParaSpeechCLAP',
   ast: 'AST',
   e5: 'E5',
   bge: 'BGE',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,9 +164,12 @@ DEP001 = [
 # import them directly for embedder weight-loading progress and EUPE
 # preprocessing transforms. Declaring them as first-party doesn't add
 # anything: the install path already pins them through the parent.
+# ``huggingface_hub`` ships with ``transformers`` and is imported directly by
+# the ParaSpeechCLAP embedder (``hf_hub_download`` for its checkpoint file).
 DEP003 = [
     "safetensors",
     "torchvision",
+    "huggingface_hub",
 ]
 # DEP002: declared but not imported. Tools we run via their CLIs
 # (pytest, ruff, …), runtime helpers loaded by name (gunicorn), or

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -355,6 +355,114 @@ class TestAudioWhisperEncoderEmbedderProperties:
         assert WHISPER_SAMPLE_RATE == 16000
 
 
+class TestAudioParaSpeechClapEmbedderProperties:
+    """Verify AudioParaSpeechClapEmbedder class properties and registration."""
+
+    def test_name(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        assert emb.name == "paraspeechclap"
+
+    def test_media_type_id(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        assert emb.media_type_id == "audio"
+
+    def test_supports_text_is_true(self):
+        """Unlike ast/whisper, ParaSpeechCLAP has a paired text tower."""
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        assert emb.supports_text is True
+
+    def test_is_not_default(self):
+        """CLAP remains the default audio embedder; ParaSpeechCLAP is opt-in."""
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        assert emb.is_default is False
+
+    def test_description_wrappers_non_empty(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        wrappers = emb.description_wrappers
+        assert len(wrappers) > 0
+        assert all("{text}" in w for w in wrappers)
+
+    def test_registered_in_registry(self):
+        from vtscore.media import get_embedder
+
+        emb = get_embedder("paraspeechclap")
+        assert emb.name == "paraspeechclap"
+        assert emb.media_type_id == "audio"
+
+    def test_listed_in_embedders_for_type(self):
+        from vtscore.media import embedders_for_type
+
+        embedders = embedders_for_type("audio")
+        names = [e.name for e in embedders]
+        assert "paraspeechclap" in names
+
+    def test_to_dict(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        d = emb.to_dict()
+        assert d == {
+            "name": "paraspeechclap",
+            "display_name": "ParaSpeechCLAP (speech style)",
+            "media_type_id": "audio",
+            "is_default": False,
+            "supports_text": True,
+            "supports_patch_regions": False,
+            "license_notice": None,
+        }
+
+    def test_load_models_idempotent(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        emb._model = MagicMock()
+        emb._feature_extractor = MagicMock()
+        emb._tokenizer = MagicMock()
+        emb.load_models()
+        assert isinstance(emb._model, MagicMock)
+
+    def test_embed_media_returns_none_when_not_loaded(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_media({"media_path": "/nonexistent.wav"})
+        assert result is None
+
+    def test_embed_text_returns_none_when_not_loaded(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+
+        emb = AudioParaSpeechClapEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_text("a deep, raspy voice")
+        assert result is None
+
+    def test_uses_correct_model_ids(self):
+        from vtscore.config import (
+            PARASPEECHCLAP_CHECKPOINT_REPO,
+            PARASPEECHCLAP_EMBED_DIM,
+            PARASPEECHCLAP_SAMPLE_RATE,
+            PARASPEECHCLAP_SPEECH_MODEL_ID,
+            PARASPEECHCLAP_TEXT_MODEL_ID,
+        )
+
+        assert PARASPEECHCLAP_SPEECH_MODEL_ID == "microsoft/wavlm-large"
+        assert PARASPEECHCLAP_TEXT_MODEL_ID == "ibm-granite/granite-embedding-278m-multilingual"
+        assert PARASPEECHCLAP_CHECKPOINT_REPO == "ajd12342/paraspeechclap-combined"
+        assert PARASPEECHCLAP_EMBED_DIM == 768
+        assert PARASPEECHCLAP_SAMPLE_RATE == 16000
+
+
 class TestTextBGEEmbedderProperties:
     """Verify TextBGEEmbedder class properties and registration."""
 
@@ -746,8 +854,8 @@ class TestAllEmbeddersRegistration:
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
         # variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 vision-only video embedder (videomae)
-        # + 3 audio embedders (ast, clap_general, whisper_encoder).
-        assert len(embedders) == 20
+        # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
+        assert len(embedders) == 21
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -757,7 +865,7 @@ class TestAllEmbeddersRegistration:
         dicts = all_embedders_dict()
         by_name = {d["name"]: d for d in dicts}
         # Cross-modal embedders advertise text support.
-        for name in ("siglip", "siglip2", "clip", "clap", "clap_general", "xclip"):
+        for name in ("siglip", "siglip2", "clip", "clap", "clap_general", "paraspeechclap", "xclip"):
             assert by_name[name]["supports_text"] is True, name
         # Vision-only / patch-based and speech-only embedders do not.
         for name in (
@@ -783,6 +891,7 @@ class TestAllEmbeddersRegistration:
             "clap_general",
             "ast",
             "whisper_encoder",
+            "paraspeechclap",
             "siglip",
             "siglip2",
             "clip",
@@ -805,7 +914,7 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import embedders_for_type
 
         names = {e.name for e in embedders_for_type("audio")}
-        assert names == {"clap", "clap_music", "clap_general", "ast", "whisper_encoder"}
+        assert names == {"clap", "clap_music", "clap_general", "ast", "whisper_encoder", "paraspeechclap"}
 
     def test_embedders_for_image(self):
         from vtscore.media import embedders_for_type
@@ -853,8 +962,8 @@ class TestAllEmbeddersRegistration:
         # 7 original + 8 image embedders (clip, siglip2, plus single/patch
         # variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 vision-only video embedder (videomae)
-        # + 3 audio embedders (ast, clap_general, whisper_encoder).
-        assert len(dicts) == 20
+        # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
+        assert len(dicts) == 21
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d
@@ -877,6 +986,7 @@ class TestEmbedderSentinelDiscovery:
         from vtscore.media.audio import embedder_clap
         from vtscore.media.audio import embedder_clap_general
         from vtscore.media.audio import embedder_clap_music
+        from vtscore.media.audio import embedder_paraspeechclap
         from vtscore.media.audio import embedder_whisper
         from vtscore.media.image import embedder_siglip
         from vtscore.media.text import embedder_bge
@@ -892,6 +1002,7 @@ class TestEmbedderSentinelDiscovery:
             embedder_clap,
             embedder_clap_general,
             embedder_clap_music,
+            embedder_paraspeechclap,
             embedder_whisper,
             embedder_siglip,
             embedder_bge,
@@ -1116,6 +1227,12 @@ class TestNewEmbeddersInheritance:
         from vtscore.media.embedder import MediaEmbedder
 
         assert issubclass(AudioWhisperEncoderEmbedder, MediaEmbedder)
+
+    def test_paraspeechclap_is_media_embedder(self):
+        from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
+        from vtscore.media.embedder import MediaEmbedder
+
+        assert issubclass(AudioParaSpeechClapEmbedder, MediaEmbedder)
 
     def test_embed_text_enriched_works(self):
         """embed_text_enriched (inherited from base) should work with mocked embed_text."""

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -148,6 +148,20 @@ AST_MODEL_ID = "MIT/ast-finetuned-audioset-10-10-0.4593"
 AST_SAMPLE_RATE = 16000  # AST expects 16 kHz mono
 WHISPER_MODEL_ID = "openai/whisper-base"
 WHISPER_SAMPLE_RATE = 16000  # Whisper expects 16 kHz mono
+# ParaSpeechCLAP: dual-encoder speech↔text "style" CLAP (MIT-licensed).
+# Unlike the AST / Whisper speech embedders, it has a paired text tower, so
+# text queries like "a deep, raspy voice" or "a whispered, anxious style" land
+# in the same space as the speech embeddings.  Reconstructed from the upstream
+# checkpoint via ``_paraspeechclap_model.py`` (WavLM speech + Granite text +
+# projection heads); the ``combined`` variant covers both speaker-level
+# (pitch/texture/clarity) and utterance-level (emotion/speaking-style) attributes.
+PARASPEECHCLAP_SPEECH_MODEL_ID = "microsoft/wavlm-large"
+PARASPEECHCLAP_TEXT_MODEL_ID = "ibm-granite/granite-embedding-278m-multilingual"
+PARASPEECHCLAP_CHECKPOINT_REPO = "ajd12342/paraspeechclap-combined"
+PARASPEECHCLAP_CHECKPOINT_FILE = "paraspeechclap-combined.pth.tar"
+PARASPEECHCLAP_EMBED_DIM = 768
+PARASPEECHCLAP_SAMPLE_RATE = 16000  # WavLM expects 16 kHz mono
+PARASPEECHCLAP_MAX_SAMPLES = 16000 * 30  # cap clips at 30 s to bound CPU memory/latency
 BGE_MODEL_ID = "BAAI/bge-base-en-v1.5"
 LANGUAGEBIND_VIDEO_MODEL_ID = "LanguageBind/LanguageBind_Video_V1.5_FT"
 VIDEOMAE_MODEL_ID = "OpenGVLab/VideoMAEv2-Base"

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -311,7 +311,7 @@ Each lives under `vtscore/media/<type>/` and self-registers:
 
 | Type     | Folder                       | Default embedder                | Other embedders ship in-tree                            |
 |----------|------------------------------|---------------------------------|---------------------------------------------------------|
-| audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `ast`, `whisper_encoder` |
+| audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `ast`, `whisper_encoder`, `paraspeechclap` |
 | image    | `vtscore/media/image/`       | `siglip` (`google/siglip-base-patch16-224`) | `clip`, `siglip2`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, `face` |
 | text     | `vtscore/media/text/`        | `e5` (`intfloat/multilingual-e5-base`) | `bge`                                            |
 | video    | `vtscore/media/video/`       | `xclip` (`microsoft/xclip-base-patch32`) | `videomae`, `languagebind`                       |

--- a/vtscore/media/audio/_paraspeechclap_model.py
+++ b/vtscore/media/audio/_paraspeechclap_model.py
@@ -1,0 +1,122 @@
+"""Vendored ParaSpeechCLAP model definition (dual-encoder speech↔text CLAP).
+
+ParaSpeechCLAP (`github.com/ajd12342/paraspeechclap`, MIT-licensed) maps speech
+and rich textual *style* descriptions ("a deep, raspy voice", "a whispered,
+anxious style") into a shared 768-dim space.  It pairs a WavLM-Large speech
+encoder with a Granite text encoder via two small residual projection heads.
+
+The upstream ``paraspeechclap`` package is not on PyPI and pulls in
+training-only deps (hydra, wandb, audtorch).  Rather than vendor the whole
+package, we reconstruct just the *inference* architecture here so VTSearch can
+load the released ``.pth.tar`` checkpoints with the dependencies it already
+has (torch + transformers).  Attribute names mirror upstream exactly so the
+checkpoint ``state_dict`` keys line up on ``load_state_dict``.
+
+This module imports torch/transformers at module scope, so it must only ever
+be imported lazily (from inside ``embedder_paraspeechclap._load_models_impl``),
+never at plugin-discovery time.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoConfig, AutoModel
+
+# A loader hook lets the embedder inject ``load_pretrained_local_first`` so the
+# base-encoder downloads honour VTSearch's offline-first / retry policy.  The
+# default just calls the function directly, keeping this module usable stand-alone.
+Loader = Callable[..., Any]
+
+
+def _default_loader(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    return fn(*args, **kwargs)
+
+
+class Projection(torch.nn.Module):
+    """Residual MLP head projecting an encoder output into the shared space."""
+
+    def __init__(self, d_in: int, d_out: int, p: float = 0.5) -> None:
+        super().__init__()
+        self.linear1 = torch.nn.Linear(d_in, d_out, bias=False)
+        self.linear2 = torch.nn.Linear(d_out, d_out, bias=False)
+        self.layer_norm = torch.nn.LayerNorm(d_out)
+        self.drop = torch.nn.Dropout(p)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        embed1 = self.linear1(x)
+        embed2 = self.drop(self.linear2(F.gelu(embed1)))
+        return self.layer_norm(embed1 + embed2)
+
+
+class SpeechEncoder(torch.nn.Module):
+    """Speech encoder (WavLM-Large) mean-pooled over the time axis."""
+
+    def __init__(self, model_name: str, loader: Loader = _default_loader) -> None:
+        super().__init__()
+        self.model_name = model_name
+        self.is_wavlm = "wavlm" in model_name.lower()
+        config = loader(AutoConfig.from_pretrained, model_name)
+        # LayerDrop is a training-time regulariser; disable it so inference is
+        # deterministic (and so the module graph matches the checkpoint).
+        config.layerdrop = 0.0
+        self.base = loader(AutoModel.from_pretrained, model_name, config=config)
+        self.hidden_size = self.base.config.hidden_size
+
+    def forward(self, x: torch.Tensor, attention_mask: torch.Tensor | None = None) -> torch.Tensor:
+        if self.is_wavlm:
+            # return_dict=False skips the (unused) extract_features tensor.
+            last_hidden_state = self.base(x, attention_mask=attention_mask, return_dict=False)[0]
+        else:
+            last_hidden_state = self.base(x, attention_mask=attention_mask).last_hidden_state
+        return torch.mean(last_hidden_state, dim=1)
+
+
+class TextEncoder(torch.nn.Module):
+    """Text encoder (Granite) using the CLS token of the last hidden state."""
+
+    def __init__(self, model_name: str, loader: Loader = _default_loader) -> None:
+        super().__init__()
+        self.base = loader(AutoModel.from_pretrained, model_name)
+
+    def forward(self, x: dict) -> torch.Tensor:
+        return self.base(**x).last_hidden_state[:, 0, :]
+
+
+class CLAP(torch.nn.Module):
+    """Dual-encoder CLAP: speech + text projected into a shared embedding space.
+
+    Only the inference getters (:meth:`get_audio_embedding`,
+    :meth:`get_text_embedding`) are kept from upstream; the contrastive loss
+    and logit-scale gradient path are training-only and omitted.  The
+    ``log_logit_scale`` parameter is still declared so the checkpoint loads
+    with ``strict=True``.
+    """
+
+    def __init__(
+        self,
+        speech_name: str,
+        text_name: str,
+        embedding_dim: int = 768,
+        projection_dropout: float = 0.5,
+        loader: Loader = _default_loader,
+    ) -> None:
+        super().__init__()
+        self.audio_branch = SpeechEncoder(speech_name, loader=loader)
+        self.text_branch = TextEncoder(text_name, loader=loader)
+        self.audio_projection = Projection(self.audio_branch.hidden_size, embedding_dim, p=projection_dropout)
+        self.text_projection = Projection(self.text_branch.base.config.hidden_size, embedding_dim, p=projection_dropout)
+        self.log_logit_scale = torch.nn.Parameter(torch.ones([]) * math.log(1 / 0.07))
+
+    def get_audio_embedding(
+        self, audio: torch.Tensor, attention_mask: torch.Tensor | None = None, normalize: bool = True
+    ) -> torch.Tensor:
+        emb = self.audio_projection(self.audio_branch(audio, attention_mask=attention_mask))
+        return F.normalize(emb, dim=-1) if normalize else emb
+
+    def get_text_embedding(self, text_input: dict, normalize: bool = True) -> torch.Tensor:
+        emb = self.text_projection(self.text_branch(text_input))
+        return F.normalize(emb, dim=-1) if normalize else emb

--- a/vtscore/media/audio/embedder_paraspeechclap.py
+++ b/vtscore/media/audio/embedder_paraspeechclap.py
@@ -1,0 +1,238 @@
+"""Audio embedder - ParaSpeechCLAP (speech ↔ text style search).
+
+ParaSpeechCLAP is a dual-encoder CLAP for *speech style*: it maps a spoken clip
+and a rich textual style description into a shared 768-dim space, so you can
+text-search a speech collection by voice/emotion/speaking-style ("a deep,
+raspy voice", "an enthusiastic, fast-paced delivery", "a whispered, anxious
+style").  This is the gap the other speech-capable audio embedders leave open:
+``ast`` and ``whisper_encoder`` have no paired text tower
+(:attr:`supports_text` is ``False``), so they cannot be driven by a text query.
+
+The model is reconstructed from the released ``combined`` checkpoint
+(``ajd12342/paraspeechclap-combined``, MIT) via the vendored architecture in
+:mod:`vtscore.media.audio._paraspeechclap_model`: a WavLM-Large speech encoder
+(``microsoft/wavlm-large``, MIT) + a Granite text encoder
+(``ibm-granite/granite-embedding-278m-multilingual``, Apache-2.0) + two small
+projection heads.  All three licences are permissive, so there is no
+:attr:`license_notice`.
+
+Heavier than the CLAP embedders (~600M params across the two towers), so it is
+opt-in, not the default.  Clips are capped at
+:data:`~vtscore.config.PARASPEECHCLAP_MAX_SAMPLES` to bound CPU memory; speech
+style is a global property, so the leading window is representative.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtscore.config import (
+    PARASPEECHCLAP_CHECKPOINT_FILE,
+    PARASPEECHCLAP_CHECKPOINT_REPO,
+    PARASPEECHCLAP_EMBED_DIM,
+    PARASPEECHCLAP_MAX_SAMPLES,
+    PARASPEECHCLAP_SAMPLE_RATE,
+    PARASPEECHCLAP_SPEECH_MODEL_ID,
+    PARASPEECHCLAP_TEXT_MODEL_ID,
+)
+from vtscore.media.embedder import (
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
+
+
+class AudioParaSpeechClapEmbedder(MediaEmbedder):
+    """Embeds speech and text-style queries into a shared 768-dim space.
+
+    * Speech clips → 768-dim vector via WavLM + audio projection head.
+    * Text style descriptions → 768-dim vector via Granite + text projection head.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Typed ``Any``: the vendored ``CLAP`` module and transformers
+        # processors have no stubs; runtime ``None`` checks guard every call.
+        self._model: Any = None
+        self._feature_extractor: Any = None
+        self._tokenizer: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "paraspeechclap"
+
+    @property
+    def display_name(self) -> str:
+        return "ParaSpeechCLAP (speech style)"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 4):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 4):
+            from transformers import AutoTokenizer, Wav2Vec2FeatureExtractor  # noqa: PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 4):
+            import librosa  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing soundfile…", 4, 4):
+            import soundfile  # noqa: F401, PLC0415
+
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
+
+        from vtscore.media.audio._paraspeechclap_model import CLAP  # noqa: PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading ParaSpeechCLAP encoders…")
+
+        # Build the two towers.  ``load_pretrained_local_first`` is threaded
+        # through the vendored builder so the WavLM/Granite downloads honour
+        # the offline-first + transient-error-retry policy.
+        with intercept_tqdm_progress(self._on_progress):
+            model = CLAP(
+                speech_name=PARASPEECHCLAP_SPEECH_MODEL_ID,
+                text_name=PARASPEECHCLAP_TEXT_MODEL_ID,
+                embedding_dim=PARASPEECHCLAP_EMBED_DIM,
+                loader=lambda fn, *a, **k: load_pretrained_local_first(fn, *a, cache_dir=cache_dir, **k),
+            )
+
+        # Overlay the fine-tuned ParaSpeechCLAP weights (encoders + projection
+        # heads) on top of the freshly-initialised towers.  ``strict=False``
+        # tolerates harmless buffer mismatches (e.g. ``position_ids``).
+        self._on_progress("loading", "Loading ParaSpeechCLAP checkpoint…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            checkpoint_path = load_pretrained_local_first(
+                hf_hub_download,
+                repo_id=PARASPEECHCLAP_CHECKPOINT_REPO,
+                filename=PARASPEECHCLAP_CHECKPOINT_FILE,
+                cache_dir=cache_dir,
+            )
+        state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        result = model.load_state_dict(state_dict, strict=False)
+        if result.missing_keys or result.unexpected_keys:
+            logging.getLogger(__name__).debug(
+                "ParaSpeechCLAP load_state_dict: %d missing, %d unexpected keys",
+                len(result.missing_keys),
+                len(result.unexpected_keys),
+            )
+        self._model = model.to("cpu")
+        self._model.eval()
+
+        self._on_progress("loading", "Loading ParaSpeechCLAP processors…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            self._feature_extractor = load_pretrained_local_first(
+                Wav2Vec2FeatureExtractor.from_pretrained, PARASPEECHCLAP_SPEECH_MODEL_ID, cache_dir=cache_dir
+            )
+            self._tokenizer = load_pretrained_local_first(
+                AutoTokenizer.from_pretrained, PARASPEECHCLAP_TEXT_MODEL_ID, cache_dir=cache_dir
+            )
+
+        # Warmup: run one dummy forward per tower so the first real embed call
+        # runs at steady-state speed and the progress bar does not appear to stall.
+        self._on_progress("loading", "Warming up ParaSpeechCLAP: speech tower…", 1, 2)
+        dummy_audio = np.zeros(PARASPEECHCLAP_SAMPLE_RATE, dtype=np.float32)
+        audio_inputs = self._feature_extractor(
+            dummy_audio, sampling_rate=PARASPEECHCLAP_SAMPLE_RATE, return_tensors="pt", padding="do_not_pad"
+        )
+        with torch.no_grad():
+            self._model.get_audio_embedding(audio_inputs.input_values, normalize=False)
+        self._on_progress("loading", "Warming up ParaSpeechCLAP: text tower…", 2, 2)
+        text_inputs = self._tokenizer(["warmup"], padding="longest", truncation=True, return_tensors="pt")
+        with torch.no_grad():
+            self._model.get_text_embedding(dict(text_inputs), normalize=False)
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    @property
+    def description_wrappers(self) -> list[str]:
+        # ParaSpeechCLAP was trained on style-description sentences; the first
+        # wrapper matches the upstream classification template most closely.
+        return [
+            "A person is speaking in a {text} style.",
+            "A person speaks in a {text} tone.",
+            "A person with a {text} voice is speaking.",
+            "{text}",
+        ]
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._feature_extractor is None:
+            return None
+        # Prefer in-memory bytes (set by clip re-embed) over a disk path.
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
+        try:
+            import librosa  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+
+            if audio_bytes is not None:
+                source: io.BytesIO | Path = io.BytesIO(bytes(audio_bytes))
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
+            audio_data, _sr = librosa.load(source, sr=PARASPEECHCLAP_SAMPLE_RATE, mono=True)
+            if len(audio_data) > PARASPEECHCLAP_MAX_SAMPLES:
+                audio_data = audio_data[:PARASPEECHCLAP_MAX_SAMPLES]
+            inputs = self._feature_extractor(
+                audio_data, sampling_rate=PARASPEECHCLAP_SAMPLE_RATE, return_tensors="pt", padding="do_not_pad"
+            )
+            device = next(self._model.parameters()).device
+            input_values = inputs.input_values.to(device)
+            with torch.no_grad():
+                emb = self._model.get_audio_embedding(input_values, normalize=False).detach().cpu().numpy()
+            return emb[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
+            return None
+
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._tokenizer is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            inputs = self._tokenizer([text], padding="longest", truncation=True, return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                emb = self._model.get_text_embedding(inputs, normalize=False).detach().cpu().numpy()[0]
+            return emb
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding text query for ParaSpeechCLAP")
+            return None
+
+
+EMBEDDER = AudioParaSpeechClapEmbedder()


### PR DESCRIPTION
## Summary

Investigated the four candidate audio embedders (CLAP, SpeechCLAP, AudioCLIP, Omni-Embed-Audio) and added the one that fills a genuine gap: a **text-queryable speech-style embedder**, `paraspeechclap`.

The existing speech-capable audio embedders (`ast`, `whisper_encoder`) have no paired text tower (`supports_text = False`), so a speech collection can't be searched by a text query describing voice/emotion/style. ParaSpeechCLAP maps speech clips and rich style descriptions ("a deep, raspy voice", "a whispered, anxious style") into a shared 768-dim space.

## Candidate decisions

- **CLAP** — already covered by three laion variants; nothing to add.
- **AudioCLIP** — declined (2021, not transformers-native, weaker than CLAP for audio↔text, image branch irrelevant).
- **Omni-Embed-Audio** (`nvidia/omni-embed-nemotron-3b`) — declined (~5B params, GPU-only, NVIDIA non-commercial licence).
- **msclap** — evaluated and declined (forces app-wide `numpy<2` + `torchaudio`, overlaps existing CLAP variants).
- **ParaSpeechCLAP** — shipped.

## Implementation

- `vtscore/media/audio/embedder_paraspeechclap.py` — the embedder (opt-in, not default; clips capped at 30 s to bound CPU memory).
- `vtscore/media/audio/_paraspeechclap_model.py` — a vendored minimal inference architecture (WavLM-Large speech + Granite text + projection heads) reconstructed from the released `ajd12342/paraspeechclap-combined` checkpoint (MIT). **No new pip dependencies** — uses torch / transformers / librosa / huggingface_hub, all already present.
- All three model licences (WavLM MIT, Granite Apache-2.0, checkpoint MIT) are permissive, so no `license_notice`.
- Tests, config constants, deptry config, frontend progress label, and docs updated.

Open follow-ups (download-size optimization, intrinsic/situational variants, real-weights GPU test) are recorded in `docs/plans/audio-embedders.md`.

## Testing

`./run-tests.sh` — **ALL 4514 TESTS PASSED** (1 skipped), including ruff, codespell, deptry, pyright, and the frontend `build:prod` check.

https://claude.ai/code/session_017vL25wF6acT63LSqUqyLii

---
_Generated by [Claude Code](https://claude.ai/code/session_017vL25wF6acT63LSqUqyLii)_