### PR TITLE
feat(datasets): scale CPU embed-concurrency default by cores and RAM

### DIFF
--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -118,12 +118,17 @@ class TestSettingsModule:
         assert "max_concurrent_dataset_downloads" not in raw
 
     def test_max_concurrent_embeddings_default_from_hardware(self, isolated_settings):
-        """CPU-only boxes default to 1; CUDA boxes default to min(2, gpu_count)."""
-        from vtscore.embedding.loader import _detect_cuda_devices
+        """The default mirrors the hardware-derived value and is not persisted.
 
-        gpus = _detect_cuda_devices()
-        expected = max(1, min(2, gpus)) if gpus > 0 else 1
-        assert settings_mod.get_max_concurrent_dataset_embeddings() == expected
+        The concrete scaling (GPU count, CPU cores, total RAM) is unit-tested in
+        ``tests_lib/embedding/test_concurrency_defaults.py``; here we only assert
+        the settings layer surfaces that value and doesn't write it to disk.
+        """
+        from vtscore.embedding.loader import default_concurrent_embeddings
+
+        assert settings_mod.get_max_concurrent_dataset_embeddings() == default_concurrent_embeddings()
+        raw = isolated_settings.read_text() if isolated_settings.exists() else ""
+        assert "max_concurrent_dataset_embeddings" not in raw
 
     def test_max_concurrent_explicit_value_wins_over_hardware_default(self, isolated_settings):
         """An explicit ``set_*`` call overrides the hardware-derived default."""

--- a/tests_lib/datasets/test_concurrency_defaults.py
+++ b/tests_lib/datasets/test_concurrency_defaults.py
@@ -1,0 +1,74 @@
+"""Hardware-derived default for ``max_concurrent_dataset_embeddings``.
+
+Unit-tests the scaling logic in
+:func:`vtscore.embedding.loader.default_concurrent_embeddings` in isolation by
+faking the GPU count, CPU core count, and total RAM. The settings layer's
+integration with this value (surfaced via ``get_max_concurrent_dataset_embeddings``
+and never persisted) is covered in ``tests/core/test_settings.py``.
+
+The guard these tests pin down: a memory- or core-starved box must resolve to a
+single embed worker (the old fully-serial behaviour), so raising the default for
+capable hardware never freezes a small one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.embedding import loader
+
+GIB = 1024 * 1024 * 1024
+
+
+@pytest.fixture
+def fake_hw(monkeypatch):
+    """Pin (gpus, cpus, total RAM) and return the resolved default."""
+
+    def _resolve(*, gpus: int, cpus: int, ram_gib: float) -> int:
+        monkeypatch.setattr(loader, "_detect_cuda_devices", lambda: gpus)
+        monkeypatch.setattr(loader.os, "cpu_count", lambda: cpus)
+        monkeypatch.setattr(loader, "_total_memory_bytes", lambda: int(ram_gib * GIB))
+        return loader.default_concurrent_embeddings()
+
+    return _resolve
+
+
+class TestDefaultConcurrentEmbeddings:
+    def test_small_cpu_box_stays_serial(self, fake_hw):
+        # The 2-core / 3.7 GB laptop this guard exists for: both factors floor to 1.
+        assert fake_hw(gpus=0, cpus=2, ram_gib=3.7) == 1
+
+    def test_ram_starved_many_cores_stays_serial(self, fake_hw):
+        # 32 cores but only 3 GB RAM -> RAM is the binding constraint.
+        assert fake_hw(gpus=0, cpus=32, ram_gib=3.0) == 1
+
+    def test_core_starved_huge_ram_stays_serial(self, fake_hw):
+        # 256 GB RAM but 2 cores -> cores are the binding constraint.
+        assert fake_hw(gpus=0, cpus=2, ram_gib=256) == 1
+
+    def test_midrange_workstation_scales_to_two(self, fake_hw):
+        # 8 cores / 16 GB -> min(8 // 4, 16 // 4) = min(2, 4) = 2.
+        assert fake_hw(gpus=0, cpus=8, ram_gib=16) == 2
+
+    def test_large_box_caps_at_four(self, fake_hw):
+        # 64 cores / 256 GB would compute far higher; the cap holds it at 4.
+        assert fake_hw(gpus=0, cpus=64, ram_gib=256) == 4
+
+    def test_unreadable_ram_falls_back_to_serial(self, fake_hw):
+        # _total_memory_bytes() == 0 (couldn't read) -> conservative 1 even on a
+        # many-core box, rather than guessing generously.
+        assert fake_hw(gpus=0, cpus=64, ram_gib=0) == 1
+
+    def test_single_gpu_unaffected_by_cpu_ram(self, fake_hw):
+        # GPU path returns early and ignores the CPU/RAM scaling.
+        assert fake_hw(gpus=1, cpus=2, ram_gib=3.7) == 1
+
+    def test_multi_gpu_caps_at_two(self, fake_hw):
+        assert fake_hw(gpus=4, cpus=64, ram_gib=256) == 2
+
+
+class TestTotalMemoryBytes:
+    def test_reads_a_positive_value_on_this_host(self):
+        # On any real CI/dev box /proc/meminfo or sysconf yields > 0; the
+        # zero-fallback path is exercised via the mocked test above.
+        assert loader._total_memory_bytes() > 0

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -67,18 +67,66 @@ def default_concurrent_downloads() -> int:
     return max(1, min(4, os.cpu_count() or 1))
 
 
+# A single CPU embed job holds an embedder model plus an N x D fp32 working
+# set; budgeting ~4 GiB of total RAM per concurrent job keeps memory-starved
+# boxes at one worker while letting roomy workstations run a few in parallel.
+_RAM_BYTES_PER_CPU_EMBED = 4 * 1024 * 1024 * 1024
+
+# Upper bound on the CPU embed default regardless of how big the box is; a
+# hand override in ``data/settings.json`` can still go higher (clamped to 16).
+_MAX_CPU_EMBED_DEFAULT = 4
+
+
+def _total_memory_bytes() -> int:
+    """Best-effort total physical RAM in bytes, or ``0`` if it can't be read.
+
+    Uses ``MemTotal`` (Linux ``/proc/meminfo``) with an ``SC_PHYS_PAGES``
+    sysconf fallback. Total (not *available*) RAM is the right signal for a
+    startup default: it's stable, whereas free memory swings with whatever
+    else happens to be running when the setting is first resolved.
+    """
+    try:
+        with open("/proc/meminfo", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return pages * page_size
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
 def default_concurrent_embeddings() -> int:
     """Default for ``max_concurrent_dataset_embeddings`` derived from hardware.
 
-    The embed phase is CPU/GPU- and RAM-bound. On CPU-only boxes one worker
-    keeps the box hot without thrashing; with GPUs we allow one task per
-    visible CUDA device (capped at 2) so two datasets can embed in parallel
-    on a multi-GPU rig without overcommitting a single device's VRAM.
+    The embed phase is CPU/GPU- and RAM-bound, so the default scales with the
+    scarcer of the two resources:
+
+    * **GPU boxes** allow one task per visible CUDA device (capped at 2) so two
+      datasets can embed in parallel on a multi-GPU rig without overcommitting a
+      single device's VRAM.
+    * **CPU-only boxes** allow roughly one job per 4 cores and one job per
+      ``_RAM_BYTES_PER_CPU_EMBED`` of total RAM, whichever is smaller, capped at
+      :data:`_MAX_CPU_EMBED_DEFAULT`. Constrained machines (few cores or little
+      RAM) still resolve to 1 - preserving the old fully-serial behaviour where
+      a second concurrent embed would thrash or OOM - while workstations get
+      genuine parallel embedding with no config change. When total RAM can't be
+      read we fall back to 1 rather than guess generously.
     """
     gpus = _detect_cuda_devices()
-    if gpus <= 0:
-        return 1
-    return max(1, min(2, gpus))
+    if gpus > 0:
+        return max(1, min(2, gpus))
+
+    by_cpu = (os.cpu_count() or 1) // 4
+    total_ram = _total_memory_bytes()
+    by_ram = total_ram // _RAM_BYTES_PER_CPU_EMBED if total_ram else 1
+    return max(1, min(_MAX_CPU_EMBED_DEFAULT, by_cpu, by_ram))
 
 
 def initialize_models() -> None:


### PR DESCRIPTION
## What & why

Investigating a request to handle parallelism better at dataset ingest. Driving the live UI confirmed the real lockdown: with the default gates (download=2, embed=1 on a CPU box), two concurrent imports both *start* but the second parks on **"Waiting for other datasets to finish embedding…"** — the embedding phase is hard-serialized on any CPU-only host regardless of how capable it is.

`default_concurrent_embeddings()` was returning `1` unconditionally on the CPU path. This makes it scale.

## Change

- CPU path now scales by the **scarcer of cores and total RAM**: ~1 job per 4 cores and ~1 job per 4 GiB total RAM, capped at 4.
- Memory- or core-starved boxes still resolve to **1** — preserving the old fully-serial behaviour where a second concurrent embed would thrash or OOM (e.g. a 2-core / 3.7 GB laptop stays at 1).
- Unreadable RAM falls back to 1 rather than guessing generously.
- New `_total_memory_bytes()` reader (`MemTotal` with an `SC_PHYS_PAGES` fallback).
- GPU path unchanged (`min(2, gpus)`).
- The two caps remain server-fixed / read-only in the UI; this only raises the *default* on capable hardware. Raising them further is still a `data/settings.json` override.

## Tests

- New `tests_lib/datasets/test_concurrency_defaults.py` pins the scaling: small-box, RAM-starved, core-starved, midrange→2, cap→4, unreadable-RAM→1, single/multi-GPU.
- Updated `tests/core/test_settings.py` to assert the settings layer surfaces the hardware value and never persists it.
- `tests_lib/datasets`, `tests/datasets`, `tests/core/test_settings*`: **733 passed, 4 skipped**.

## Not done here (follow-ups worth considering)

- The caps are still read-only in the UI and have no env/CLI override; only `data/settings.json` raises them.
- No memory-aware *runtime* gating (admit a second embed only if free RAM clears a threshold) — the default is a startup-time estimate from total RAM, not live pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)