### PR TITLE
VTSBrowser: darkred→yellow heatmap, singleton discs, finer overview

### DIFF
--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -83,7 +83,9 @@ resolution rather than relying on a closed-form estimate.
 |------|---------------|----------|
 | Target on-screen hex radius (level picker) | `28` px | `updateActiveLevel`, `:163` |
 | Density scale | log (`log(count)/log(maxCount)`) | `drawHex`, `:284` |
-| Colormap | viridis, 14-stop LUT | `VIRIDIS`, `:27` |
+| Colormap | darkred→yellow, 8-stop LUT (black left free for "None"/empty space) | `HEATMAP`, `hex-render.util.ts` |
+| Singleton cell shape | inscribed disc (`HEX_INRADIUS_RATIO`), hex otherwise | `traceCellPath`, `hex-render.util.ts` |
+| Minimap overview level | level whose hexes ≈ `5` px (finer-grained than level 0) | `overviewLevel`, `browse-minimap.component.ts` |
 | Hover debounce | `30` ms | `onCanvasMouseMove`, `:445` |
 | Hex hit radius | `1 × radius` | `hitTest`, `:490` |
 
@@ -193,7 +195,9 @@ can't:
   `targetScreenRadius=28` level-picker land on the right level? Sweep it (e.g.
   22 / 28 / 36) if levels feel off.
 - **Density colormap:** is **log** the right compression, or does **sqrt** read
-  better for the actual count distributions seen in Phase A? Viridis vs magma.
+  better for the actual count distributions seen in Phase A? The ramp is now
+  darkred→yellow (black left free to mean empty/"None"); revisit the stop count
+  and endpoints if the sweep says so.
 - **Hover feel:** debounce window (does sweeping machine-gun previews at 30 ms?
   try 50–80 ms), audio loop hard-cut vs a short fade, text-snippet length,
   popup placement.

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -15,7 +15,7 @@ import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
-import { SQRT3, traceHexPath, viridisColor } from './hex-render.util';
+import { SQRT3, traceCellPath, densityColor } from './hex-render.util';
 import type {
   HexCellPayload,
   ProjectionMeta,
@@ -41,7 +41,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Active dataset media type. For ``image`` and ``video`` the representative
    * item's thumbnail is painted directly onto each hex; other types keep the
-   * flat density (viridis) shading.
+   * flat density (darkred→yellow) shading.
    */
   @Input() mediaType = '';
   /**
@@ -350,9 +350,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     radius: number,
     cell: HexCellPayload,
   ): void {
-    traceHexPath(ctx, cx, cy, radius);
+    // A cell with one item is drawn as a disc (slightly smaller than the hex);
+    // multi-item cells stay hexes so they tile the space.
+    const single = cell.count === 1;
+    traceCellPath(ctx, cx, cy, radius, single);
 
-    // Image / video: paint the central item's thumbnail clipped to the hex.
+    // Image / video: paint the central item's thumbnail clipped to the cell.
     // Until it loads, fall back to the density shading below so the cell is
     // never blank.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
@@ -363,7 +366,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       ctx.restore();
     } else {
       const t = Math.log(cell.count) / Math.log(this.maxCount || 2);
-      ctx.fillStyle = viridisColor(Math.max(0, Math.min(1, t)));
+      ctx.fillStyle = densityColor(Math.max(0, Math.min(1, t)));
       ctx.fill();
     }
 

--- a/frontend/src/app/components/browse-canvas/hex-render.util.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.ts
@@ -8,33 +8,30 @@ const DEG30 = Math.PI / 6;
 /** Pointy-top hexagon vertex angles (matches the projection's hex layout). */
 export const HEX_ANGLES = Array.from({ length: 6 }, (_, i) => (Math.PI / 3) * i - DEG30);
 
-const VIRIDIS: [number, number, number][] = [
-  [68, 1, 84],
-  [72, 35, 116],
-  [64, 67, 135],
-  [52, 94, 141],
-  [41, 120, 142],
-  [33, 145, 140],
-  [42, 168, 131],
-  [68, 190, 112],
-  [94, 201, 98],
-  [128, 213, 79],
-  [166, 222, 52],
-  [199, 227, 33],
-  [229, 228, 32],
-  [253, 231, 37],
+// Dark-red → yellow density ramp. The low end is a deep red rather than black
+// so that pure black stays free to mean "nothing here" (None): empty space on
+// the canvas reads as absence, while any occupied hex is at least dark red.
+const HEATMAP: [number, number, number][] = [
+  [90, 0, 0],
+  [140, 12, 0],
+  [185, 28, 0],
+  [220, 60, 0],
+  [240, 105, 0],
+  [250, 150, 5],
+  [255, 195, 25],
+  [255, 235, 70],
 ];
 
-/** Map a normalized density ``t`` in [0, 1] to a viridis ``rgb(...)`` string. */
-export function viridisColor(t: number): string {
-  const n = VIRIDIS.length - 1;
+/** Map a normalized density ``t`` in [0, 1] to a darkred→yellow ``rgb(...)`` string. */
+export function densityColor(t: number): string {
+  const n = HEATMAP.length - 1;
   const idx = t * n;
   const lo = Math.floor(idx);
   const hi = Math.min(lo + 1, n);
   const frac = idx - lo;
-  const r = Math.round(VIRIDIS[lo][0] + (VIRIDIS[hi][0] - VIRIDIS[lo][0]) * frac);
-  const g = Math.round(VIRIDIS[lo][1] + (VIRIDIS[hi][1] - VIRIDIS[lo][1]) * frac);
-  const b = Math.round(VIRIDIS[lo][2] + (VIRIDIS[hi][2] - VIRIDIS[lo][2]) * frac);
+  const r = Math.round(HEATMAP[lo][0] + (HEATMAP[hi][0] - HEATMAP[lo][0]) * frac);
+  const g = Math.round(HEATMAP[lo][1] + (HEATMAP[hi][1] - HEATMAP[lo][1]) * frac);
+  const b = Math.round(HEATMAP[lo][2] + (HEATMAP[hi][2] - HEATMAP[lo][2]) * frac);
   return `rgb(${r},${g},${b})`;
 }
 
@@ -53,4 +50,34 @@ export function traceHexPath(
     else ctx.lineTo(x, y);
   }
   ctx.closePath();
+}
+
+/**
+ * A hex's inscribed-circle radius as a fraction of its circumradius
+ * (``radius``). A disc of this radius is the largest circle that fits inside
+ * the hex, so a singleton drawn as a disc reads slightly smaller than the hex
+ * it replaces.
+ */
+export const HEX_INRADIUS_RATIO = SQRT3 / 2;
+
+/**
+ * Trace one cell's outline as the current path. A cell holding a single media
+ * item (``single``) is drawn as the hex's inscribed disc — barely smaller than
+ * the hex, and visibly so since a disc has less area than the hex around it —
+ * so singletons read as distinct dots. Every other cell keeps the full hex.
+ */
+export function traceCellPath(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  single: boolean,
+): void {
+  if (single) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * HEX_INRADIUS_RATIO, 0, Math.PI * 2);
+    ctx.closePath();
+  } else {
+    traceHexPath(ctx, cx, cy, radius);
+  }
 }

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -14,7 +14,7 @@ import {
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { BrowseViewportService, ViewportBounds } from '../../services/browse-viewport.service';
-import { SQRT3, traceHexPath, viridisColor } from '../browse-canvas/hex-render.util';
+import { SQRT3, traceCellPath, densityColor } from '../browse-canvas/hex-render.util';
 import { IconComponent } from '../icon/icon.component';
 import type { HexCellPayload, ProjectionMeta } from '../../models/projection.models';
 
@@ -26,13 +26,15 @@ export const MINIMAP_MAX_HEIGHT = 450;
 
 /**
  * Lower-right overview for the browse canvas: a density heatmap of the whole
- * projection at its coarsest level, with a rectangle marking the region the
- * main canvas is currently showing. Clicking/dragging the minimap recenters
- * the main view; a corner handle resizes it and a close button hides it.
+ * projection, with a rectangle marking the region the main canvas is currently
+ * showing. Clicking/dragging the minimap recenters the main view; a corner
+ * handle resizes it and a close button hides it.
  *
- * The heatmap reads the coarsest (level 0) hex tiles — the fewest, largest
- * bins — straight from the shared :class:`TileCacheService`, so it reuses
- * whatever the main canvas has already fetched and never holds its own copy.
+ * The heatmap picks the pyramid level whose hexes land near a small target
+ * on-screen size, so the whole projection is shown as a fine-grained field of
+ * many hexes (not the handful of level-0 bins). Tiles for that level are read
+ * straight from the shared :class:`TileCacheService`, so it reuses whatever the
+ * main canvas has already fetched and never holds its own copy.
  */
 @Component({
   selector: 'vt-browse-minimap',
@@ -83,7 +85,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
     this.resizeCanvas();
 
-    // Coarse tiles arrive asynchronously; repaint as the cache fills. The
+    // Overview tiles arrive asynchronously; repaint as the cache fills. The
     // viewport box updates on every pan/zoom the main canvas publishes.
     this.tileLoadSub = this.tileCache.tileLoaded$.subscribe(() => this.requestRedraw());
     this.viewportSub = this.viewport.viewport$.subscribe((b) => {
@@ -91,7 +93,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
       this.requestRedraw();
     });
 
-    this.requestCoarseTiles();
+    this.requestOverviewTiles();
     this.requestRedraw();
   }
 
@@ -102,7 +104,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
       this.requestRedraw();
     }
     if (changes['meta'] && !changes['meta'].firstChange) {
-      this.requestCoarseTiles();
+      this.requestOverviewTiles();
       this.requestRedraw();
     }
   }
@@ -125,19 +127,41 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
   }
 
-  // --- Coarse-tile coverage -------------------------------------------------
+  // --- Overview-tile coverage -----------------------------------------------
 
-  /** Fetch every level-0 tile spanning the projection bounds (idempotent). */
-  private requestCoarseTiles(): void {
+  /**
+   * Target on-screen radius (minimap px) for the overview's hexes. Small enough
+   * that the whole projection reads as a fine field of many bins rather than
+   * the few large level-0 hexes, while still resolving structure at a glance.
+   */
+  private static readonly OVERVIEW_TARGET_HEX_PX = 5;
+
+  /**
+   * Pyramid level to render in the overview: the one whose hexes are nearest
+   * the small target on-screen size for the current minimap scale. Deeper than
+   * level 0 (so the map is finer-grained), clamped to the available levels.
+   */
+  private overviewLevel(f: { scale: number }): number {
+    if (!this.meta || this.meta.levels.length === 0) return 0;
+    const basePx = this.meta.base_radius * f.scale; // level-0 hex radius in px
+    const ideal = Math.log2(basePx / BrowseMinimapComponent.OVERVIEW_TARGET_HEX_PX);
+    return Math.max(0, Math.min(this.meta.levels.length - 1, Math.round(ideal)));
+  }
+
+  /** Fetch every tile of the overview level spanning the bounds (idempotent). */
+  private requestOverviewTiles(): void {
     if (!this.meta || this.meta.point_count === 0) return;
-    for (const { tx, ty } of this.coarseTiles()) {
-      this.tileCache.getTile(0, tx, ty)?.subscribe();
+    const f = this.fit();
+    if (!f) return;
+    const level = this.overviewLevel(f);
+    for (const { tx, ty } of this.overviewTiles(level)) {
+      this.tileCache.getTile(level, tx, ty)?.subscribe();
     }
   }
 
-  private coarseTiles(): { tx: number; ty: number }[] {
+  private overviewTiles(level: number): { tx: number; ty: number }[] {
     if (!this.meta) return [];
-    const radius = this.meta.base_radius; // level 0 = coarsest, largest hexes
+    const radius = this.meta.base_radius / Math.pow(2, level);
     const tileW = this.meta.tile_span * radius * SQRT3;
     const tileH = this.meta.tile_span * radius * 1.5;
     const [xmin, ymin, xmax, ymax] = this.meta.bounds;
@@ -199,15 +223,16 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
 
     const f = this.fit();
     if (f) {
-      const cells = this.coarseCells();
+      const level = this.overviewLevel(f);
+      const cells = this.overviewCells(level);
       let maxCount = 1;
       for (const c of cells) if (c.count > maxCount) maxCount = c.count;
-      const hexR = this.meta!.base_radius * f.scale;
+      const hexR = (this.meta!.base_radius / Math.pow(2, level)) * f.scale;
       for (const cell of cells) {
         const [sx, sy] = this.projToMap(cell.cx, cell.cy, f);
-        traceHexPath(ctx, sx, sy, hexR);
+        traceCellPath(ctx, sx, sy, hexR, cell.count === 1);
         const t = Math.log(cell.count) / Math.log(maxCount || 2);
-        ctx.fillStyle = viridisColor(Math.max(0, Math.min(1, t)));
+        ctx.fillStyle = densityColor(Math.max(0, Math.min(1, t)));
         ctx.fill();
       }
       this.drawViewportRect(ctx, f);
@@ -219,11 +244,11 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     ctx.strokeRect(0.5, 0.5, this.width - 1, this.height - 1);
   }
 
-  /** Pull all cached level-0 cells covering the extent. */
-  private coarseCells(): HexCellPayload[] {
+  /** Pull all cached cells of the overview *level* covering the extent. */
+  private overviewCells(level: number): HexCellPayload[] {
     const out: HexCellPayload[] = [];
-    for (const { tx, ty } of this.coarseTiles()) {
-      const tile = this.tileCache.getCached(0, tx, ty);
+    for (const { tx, ty } of this.overviewTiles(level)) {
+      const tile = this.tileCache.getCached(level, tx, ty);
       if (tile) out.push(...tile.cells);
     }
     return out;


### PR DESCRIPTION
## What changed

Three tweaks to the VTSBrowser hex-tile heatmap, all in the shared render util + the two canvases that use it.

### 1. Default colormap → darkred → yellow
Replaced the viridis 14-stop LUT with an 8-stop darkred→yellow ramp (`HEATMAP` / `densityColor` in `hex-render.util.ts`). The low end is a deep red rather than near-black, which leaves **pure black free to mean "nothing here" (None)** — empty space on the canvas now reads as absence, while any occupied cell is at least dark red.

### 2. Single-item cells render as discs
A cell holding exactly one media item is now drawn as the hex's **inscribed disc** (`traceCellPath` with `HEX_INRADIUS_RATIO = √3/2`) instead of a hexagon. The disc radius is the hex's inradius — barely smaller than the hex's circumradius, and visibly smaller in area — so singletons read as distinct dots. Multi-item cells keep the full hex so they continue to tile the space. Applies to both the main canvas and the minimap, and to both the density-shaded and thumbnail-clipped paths.

### 3. Finer-grain overview (minimap)
The minimap previously always rendered level 0 (a handful of giant bins). It now picks the pyramid level whose hexes land near a small target on-screen size (~5 px) via `overviewLevel()`, so the whole projection is still shown but as a much finer field of many hexes. The level adapts to the minimap's current size and is clamped to the available pyramid levels (small datasets with only level 0 are unaffected). The existing >1024-tile fan-out guard still applies.

## Notes
- Frontend-only (plus a tuning-doc refresh in `docs/plans/vtsbrowse-empirical-tuning.md`); no backend/pyramid changes.
- Renamed `viridisColor` → `densityColor` and `traceHexPath` usage → `traceCellPath` at call sites (breaking the old export names — no compat shim kept, per repo policy).

## Testing
- `npm run build:prod` — clean, no warnings.
- `./run-tests.sh core` — 691 passed (includes ruff / codespell / deptry / frontend build gates).

https://claude.ai/code/session_01GsifA23LK64UdxTanSXCkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsifA23LK64UdxTanSXCkD)_