### PR TITLE
Add Expand panels for Around the Clock & Multi Media; rename achievements

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -38,6 +38,18 @@
             },
             "type": "array"
           },
+          "hours": {
+            "items": {
+              "$ref": "#/components/schemas/_HourEntry"
+            },
+            "type": "array"
+          },
+          "media_types": {
+            "items": {
+              "$ref": "#/components/schemas/_MediaTypeEntry"
+            },
+            "type": "array"
+          },
           "pending_announcements": {
             "items": {
               "$ref": "#/components/schemas/_PendingAnnouncement"
@@ -54,6 +66,8 @@
         "required": [
           "achievements",
           "docs",
+          "hours",
+          "media_types",
           "pending_announcements",
           "tier_names"
         ],
@@ -4854,6 +4868,24 @@
         ],
         "type": "object"
       },
+      "_HourEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "hour": {
+            "description": "Hour of day, UTC (0-23).",
+            "type": "integer"
+          },
+          "seen": {
+            "description": "Whether the user has voted in this hour bucket.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "hour",
+          "seen"
+        ],
+        "type": "object"
+      },
       "_LabelSet": {
         "additionalProperties": true,
         "properties": {
@@ -4866,6 +4898,27 @@
         },
         "required": [
           "labels"
+        ],
+        "type": "object"
+      },
+      "_MediaTypeEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "seen": {
+            "description": "Whether the user has voted on this media type.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "seen"
         ],
         "type": "object"
       },

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -41,7 +41,7 @@
             </div>
             <span class="achievement-progress-label">{{ row.progressLabel }}</span>
           </div>
-          @if (row.id === 'docs_read' && docsExpanded) {
+          @if (row.id === 'docs_read' && isExpanded('docs_read')) {
             <div class="docs-panel">
               <ul class="docs-list">
                 @for (doc of docs; track doc.id) {

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -24,13 +24,13 @@
               class="achievement-tier"
               [attr.data-tier-idx]="row.tier_idx"
               [title]="row.lockReason || null">{{ row.tierName }}</span>
-            @if (row.id === 'docs_read') {
+            @if (isExpandable(row.id)) {
               <button
                 type="button"
-                class="docs-expand-toggle"
-                (click)="toggleDocsExpanded()"
-                [attr.aria-expanded]="docsExpanded">
-                {{ docsExpanded ? 'Collapse' : 'Expand' }}
+                class="expand-toggle"
+                (click)="toggleExpanded(row.id)"
+                [attr.aria-expanded]="isExpanded(row.id)">
+                {{ isExpanded(row.id) ? 'Collapse' : 'Expand' }}
               </button>
             }
           </div>
@@ -81,6 +81,34 @@
                   {{ phraseStatus.message }}
                 </p>
               }
+            </div>
+          }
+          @if (row.id === 'media_types_touched' && isExpanded('media_types_touched')) {
+            <div class="detail-panel">
+              <ul class="ticks-list">
+                @for (mt of mediaTypes; track mt.id) {
+                  <li class="ticks-list-item" [class.ticks-list-item--on]="mt.seen">
+                    <span class="ticks-list-status" [attr.aria-label]="mt.seen ? 'voted' : 'not yet'">
+                      {{ mt.seen ? '✓' : '○' }}
+                    </span>
+                    <span class="ticks-list-name">{{ mt.name }}</span>
+                  </li>
+                }
+              </ul>
+            </div>
+          }
+          @if (row.id === 'hours_voted' && isExpanded('hours_voted')) {
+            <div class="detail-panel">
+              <ul class="hours-grid">
+                @for (h of hours; track h.hour) {
+                  <li
+                    class="hour-chip"
+                    [class.hour-chip--on]="h.seen"
+                    [attr.aria-label]="(h.seen ? 'voted at ' : 'no vote at ') + h.hour + ':00 UTC'">
+                    {{ h.hour.toString().padStart(2, '0') }}
+                  </li>
+                }
+              </ul>
             </div>
           }
         </div>

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -117,7 +117,7 @@
   white-space: nowrap;
 }
 
-.docs-expand-toggle {
+.expand-toggle {
   margin-left: auto;
   font-size: var(--font-xs);
   padding: var(--space-2xs) var(--space-md);
@@ -132,11 +132,73 @@
   }
 }
 
-.docs-panel {
+.docs-panel,
+.detail-panel {
   margin-top: var(--space-md);
   padding: var(--space-md) var(--space-lg);
   background: var(--bg-subtle);
   border-radius: var(--radius-md);
+}
+
+// "Multi Media" media-type checklist.
+.ticks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.ticks-list-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  font-size: var(--font-md);
+}
+
+.ticks-list-item--on {
+  color: var(--accent);
+}
+
+.ticks-list-status {
+  width: 1rem;
+  text-align: center;
+  font-weight: var(--weight-semibold);
+}
+
+.ticks-list-name {
+  font-weight: var(--weight-medium);
+}
+
+// "Around the Clock" 24-hour grid.
+.hours-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--space-xs);
+}
+
+.hour-chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xs) 0;
+  font-size: var(--font-xs);
+  font-family: var(--font-mono, monospace);
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.hour-chip--on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--btn-primary-text);
+  font-weight: var(--weight-semibold);
 }
 
 .docs-list {

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -9,6 +9,11 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import type { AchievementEntry } from '../../generated/api-client/models/achievement-entry';
 import type { AchievementState } from '../../generated/api-client/models/achievement-state';
 import type { DocEntry } from '../../generated/api-client/models/doc-entry';
+import type { MediaTypeEntry } from '../../generated/api-client/models/media-type-entry';
+import type { HourEntry } from '../../generated/api-client/models/hour-entry';
+
+/** Achievement rows that carry an expandable detail panel. */
+const EXPANDABLE_IDS = new Set(['docs_read', 'media_types_touched', 'hours_voted']);
 
 const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum'];
 
@@ -30,10 +35,13 @@ interface AchievementRow extends AchievementEntry {
 export class AchievementsTabComponent implements OnInit, OnDestroy {
   rows: AchievementRow[] = [];
   docs: DocEntry[] = [];
+  mediaTypes: MediaTypeEntry[] = [];
+  hours: HourEntry[] = [];
   loading = true;
   totalScore = 0;
 
-  docsExpanded = false;
+  /** Ids of achievement rows whose detail panel is currently expanded. */
+  private readonly expandedIds = new Set<string>();
   phraseInput = '';
   phraseStatus: { kind: 'idle' | 'success' | 'already' | 'wrong'; message: string } = {
     kind: 'idle',
@@ -67,8 +75,22 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  toggleDocsExpanded(): void {
-    this.docsExpanded = !this.docsExpanded;
+  /** Whether *id*'s row supports an expandable detail panel. */
+  isExpandable(id: string): boolean {
+    return EXPANDABLE_IDS.has(id);
+  }
+
+  /** Whether *id*'s detail panel is currently open. */
+  isExpanded(id: string): boolean {
+    return this.expandedIds.has(id);
+  }
+
+  toggleExpanded(id: string): void {
+    if (this.expandedIds.has(id)) {
+      this.expandedIds.delete(id);
+    } else {
+      this.expandedIds.add(id);
+    }
   }
 
   docRawUrl(docId: string): string {
@@ -104,6 +126,8 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   private applyState(state: AchievementState): void {
     this.rows = state.achievements.map((a) => this.toRow(a));
     this.docs = state.docs;
+    this.mediaTypes = state.media_types;
+    this.hours = state.hours;
     this.loading = state.achievements.length === 0;
     this.totalScore = state.achievements.reduce(
       (sum, a) => sum + (a.tier_idx >= 0 ? 1 << a.tier_idx : 0),

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -17,6 +17,8 @@ const EMPTY_STATE: AchievementState = {
   achievements: [],
   pending_announcements: [],
   docs: [],
+  media_types: [],
+  hours: [],
 };
 
 /**

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -58,6 +58,17 @@ class TestEmptyState:
             "api",
         }
         assert all(d["read"] is False for d in state["docs"])
+        # media_types / hours breakdowns are present and all-unticked.
+        assert [m["id"] for m in state["media_types"]] == [
+            "audio",
+            "image",
+            "text",
+            "video",
+            "document",
+        ]
+        assert all(m["seen"] is False for m in state["media_types"])
+        assert [h["hour"] for h in state["hours"]] == list(range(24))
+        assert all(h["seen"] is False for h in state["hours"])
 
     def test_known_categories_present(self):
         ids = {a["id"] for a in achievements.get_full_state()["achievements"]}
@@ -235,6 +246,18 @@ class TestMediaTypesTouched:
         assert mt_state["tier_idx"] == 3  # Platinum
         assert mt_state["next_threshold"] is None
 
+    def test_media_types_breakdown_marks_seen(self):
+        achievements.record_vote("det", "audio")
+        achievements.record_vote("det", "video")
+        seen = {m["id"]: m["seen"] for m in achievements.get_full_state()["media_types"]}
+        assert seen == {
+            "audio": True,
+            "image": False,
+            "text": False,
+            "video": True,
+            "document": False,
+        }
+
 
 class TestHoursVoted:
     def test_first_vote_credits_one_hour(self):
@@ -258,6 +281,14 @@ class TestHoursVoted:
         assert hv["counter"] == 24
         assert hv["tier_idx"] == 3  # Platinum at 24
         assert hv["next_threshold"] is None
+
+    def test_hours_breakdown_marks_seen(self):
+        for hour in (0, 9, 23):
+            achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, hour))
+        hours = achievements.get_full_state()["hours"]
+        assert [h["hour"] for h in hours] == list(range(24))
+        seen_hours = {h["hour"] for h in hours if h["seen"]}
+        assert seen_hours == {0, 9, 23}
 
 
 class TestVoteStreak:
@@ -642,7 +673,7 @@ class TestActionHooks:
 
         The app applies labels to every media item in Find mode, but those are
         system-generated scores (the user did not cast them), so they must not
-        inflate the Votes Cast or Marathoner achievements.
+        inflate the Get Out the Vote or Marathoner achievements.
         """
         from helpers import setup_trainable_model_in_registry
         from vtsearch.state import snapshot_medias

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -42,42 +42,42 @@ ACHIEVEMENTS: list[dict[str, Any]] = [
     },
     {
         "id": "votes_cast",
-        "name": "Votes Cast",
+        "name": "Get Out the Vote",
         "description": "Every Good or Bad you cast on a media item.",
         "icon": "checkbox-checked",
         "tiers": [100, 1000, 10000, 100000],
     },
     {
         "id": "detectors_trained",
-        "name": "Detectors Trained",
+        "name": "Detector Collector",
         "description": "Each detector you trained, counted on its first vote.",
         "icon": "graduation",
         "tiers": [2, 20, 200, 2000],
     },
     {
         "id": "detectors_imported",
-        "name": "Detectors Imported",
+        "name": "Detector Getter",
         "description": "Detectors built up from imported labels.",
         "icon": "robot",
         "tiers": [1, 10, 100, 1000],
     },
     {
         "id": "find_media",
-        "name": "Find Media",
+        "name": "Finders Keepers",
         "description": "Media items scored by Find (GUI and CLI combined).",
         "icon": "search",
         "tiers": [200, 2000, 20000, 200000],
     },
     {
         "id": "days_active",
-        "name": "Days Active",
+        "name": "Your Days are Numbered",
         "description": "Distinct UTC calendar days on which you cast at least one vote.",
         "icon": "lightning",
         "tiers": [2, 20, 200, 2000],
     },
     {
         "id": "media_types_touched",
-        "name": "Media Types Touched",
+        "name": "Multi Media",
         "description": "Distinct media types you've voted on (audio, image, text, video, document).",
         "icon": "palette",
         "tiers": [2, 3, 4, 5],
@@ -120,6 +120,21 @@ EXCLUDED_DATASET_IMPORTERS: frozenset[str] = frozenset({"demo", "synthetic"})
 #: Marathoner streak alive.  Anything strictly greater than this resets the
 #: streak counter to 1 on the next vote.
 STREAK_GAP_SECONDS: float = 10 * 60
+
+#: Canonical media types tracked by the "Multi Media" achievement, in display
+#: order, paired with their human-readable labels.  The achievement's tiers
+#: (max 5) assume exactly these five types; :func:`get_full_state` reports a
+#: per-type ticked flag so the UI can show which ones the user has voted on.
+MEDIA_TYPES: list[dict[str, str]] = [
+    {"id": "audio", "name": "Audio"},
+    {"id": "image", "name": "Image"},
+    {"id": "text", "name": "Text"},
+    {"id": "video", "name": "Video"},
+    {"id": "document", "name": "Document"},
+]
+
+#: Hours of the day (UTC) tracked by the "Around the Clock" achievement.
+HOURS_OF_DAY: tuple[int, ...] = tuple(range(24))
 
 #: Readme Reader docs.  Each entry pairs a doc with the code phrase printed at
 #: the bottom of it.  The phrase is matched server-side: the user pastes their
@@ -465,7 +480,14 @@ def get_full_state() -> dict[str, Any]:
                 },
                 ...
             ],
+            "docs": [{"id", "name", "path", "read"}, ...],
+            "media_types": [{"id", "name", "seen"}, ...],
+            "hours": [{"hour": <0..23>, "seen": <bool>}, ...],
         }
+
+    The ``media_types`` and ``hours`` arrays back the "Multi Media" and
+    "Around the Clock" expandable panels: each entry's ``seen`` flag says
+    whether the user has cast a vote in that media type / hour-of-day bucket.
     """
     if _is_disabled():
         zeroed: list[dict[str, Any]] = []
@@ -487,6 +509,8 @@ def get_full_state() -> dict[str, Any]:
             "achievements": zeroed,
             "pending_announcements": [],
             "docs": [{"id": d["id"], "name": d["name"], "path": d["path"], "read": False} for d in DOCS],
+            "media_types": [{"id": m["id"], "name": m["name"], "seen": False} for m in MEDIA_TYPES],
+            "hours": [{"hour": h, "seen": False} for h in HOURS_OF_DAY],
         }
     username = get_current_user()
     _ensure_user_loaded(username)
@@ -531,11 +555,17 @@ def get_full_state() -> dict[str, Any]:
                 )
         read_ids = set(state.get("docs_read_ids", []))
         docs = [{"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids} for d in DOCS]
+        seen_types = set(state.get("media_types_seen", []))
+        media_types = [{"id": m["id"], "name": m["name"], "seen": m["id"] in seen_types} for m in MEDIA_TYPES]
+        seen_hours = set(state.get("hours_seen", []))
+        hours = [{"hour": h, "seen": h in seen_hours} for h in HOURS_OF_DAY]
         return {
             "tier_names": list(TIER_NAMES),
             "achievements": achievements,
             "pending_announcements": pending,
             "docs": docs,
+            "media_types": media_types,
+            "hours": hours,
         }
 
 

--- a/vtsearch/schemas/achievements.py
+++ b/vtsearch/schemas/achievements.py
@@ -42,6 +42,17 @@ class _DocEntrySchema(Schema):
     read = fields.Boolean(required=True)
 
 
+class _MediaTypeEntrySchema(Schema):
+    id = fields.String(required=True)
+    name = fields.String(required=True)
+    seen = fields.Boolean(required=True, metadata={"description": "Whether the user has voted on this media type."})
+
+
+class _HourEntrySchema(Schema):
+    hour = fields.Integer(required=True, metadata={"description": "Hour of day, UTC (0-23)."})
+    seen = fields.Boolean(required=True, metadata={"description": "Whether the user has voted in this hour bucket."})
+
+
 class AchievementStateSchema(Schema):
     """Response for ``GET /api/achievements``."""
 
@@ -49,6 +60,8 @@ class AchievementStateSchema(Schema):
     achievements = fields.List(fields.Nested(_AchievementEntrySchema), required=True)
     pending_announcements = fields.List(fields.Nested(_PendingAnnouncementSchema), required=True)
     docs = fields.List(fields.Nested(_DocEntrySchema), required=True)
+    media_types = fields.List(fields.Nested(_MediaTypeEntrySchema), required=True)
+    hours = fields.List(fields.Nested(_HourEntrySchema), required=True)
 
 
 class AcknowledgeRequestSchema(Schema):


### PR DESCRIPTION
## What changed

Extends the Achievements window's "Expand" affordance (previously exclusive to Readme Reader) to two more achievements, and gives six achievements cleverer names.

### Expandable breakdowns
- **Around the Clock** (`hours_voted`) now has an **Expand** button that reveals a 24-cell grid of hours (UTC, `00`–`23`); cells you've cast a vote in are highlighted.
- **Multi Media** (`media_types_touched`) now has an **Expand** button that reveals a checklist of the five media types (Audio, Image, Text, Video, Document) with a ✓/○ for each one you've voted on.

Both reuse the same toggle button and panel styling as Readme Reader. The per-row expand state was generalized from a single `docsExpanded` boolean to a `Set` of expanded ids, so all three panels collapse/expand independently.

### Renames (display names only; ids unchanged)
| id | old name | new name |
|----|----------|----------|
| `media_types_touched` | Media Types Touched | Multi Media |
| `votes_cast` | Votes Cast | Get Out the Vote |
| `detectors_trained` | Detectors Trained | Detector Collector |
| `detectors_imported` | Detectors Imported | Detector Getter |
| `find_media` | Find Media | Finders Keepers |
| `days_active` | Days Active | Your Days are Numbered |

## How it works

`get_full_state()` now returns two new top-level arrays, `media_types` (`{id, name, seen}`) and `hours` (`{hour, seen}`), derived on the fly from the already-persisted `media_types_seen` / `hours_seen` lists — no new persisted state. The schema and OpenAPI snapshot were updated accordingly.

## Tests

- New backend tests assert the `media_types` / `hours` breakdowns are present (empty state) and correctly mark `seen` after votes.
- `./run-tests.sh core` (693 passed, incl. frontend prod build) and `./run-tests.sh api` (437 passed, incl. OpenAPI snapshot drift) are green.

https://claude.ai/code/session_01UtsSkB5Y4uhNysqHq6hESg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtsSkB5Y4uhNysqHq6hESg)_