### PR TITLE
Fix clipped-video player showing the full video in Find center panel

### DIFF
--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -1,3 +1,4 @@
+import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -44,5 +45,39 @@ describe('VideoPlayerComponent', () => {
     expect(video).toBeTruthy();
     expect(video.hasAttribute('controls')).toBeTrue();
     expect(video.hasAttribute('loop')).toBeTrue();
+  });
+
+  it('seeks into the clip window when clip extents arrive after the video loaded', () => {
+    // A clipped media first renders as a stub (no clip_start/clip_end), so the
+    // (loadedmetadata) event fires before the extents are known. The batch
+    // response then enriches the same media id with clip_start/clip_end on a
+    // later ngOnChanges. The player must snap into the window at that point.
+    const fakeVideo = {
+      volume: 0,
+      currentTime: 0,
+      paused: true,
+      play: () => Promise.resolve(),
+      pause: () => {},
+    } as unknown as HTMLVideoElement;
+    component.videoRef = { nativeElement: fakeVideo } as ElementRef<HTMLVideoElement>;
+
+    const stub: Media = { id: 7, media_type: 'video', filename: 'clip.mp4', md5: 'abc', custom_metadata: {} };
+    component.media = stub;
+    component.ngOnChanges({
+      media: { currentValue: stub, previousValue: null, firstChange: true, isFirstChange: () => true },
+    });
+    // Video loads against the stub: no clip window yet, so no seek.
+    component.onLoadedMetadata();
+    expect(fakeVideo.currentTime).toBe(0);
+
+    // Batch hydration delivers the clip extents for the same id.
+    const hydrated: Media = { ...stub, clip_start: 5, clip_end: 10 };
+    component.media = hydrated;
+    component.ngOnChanges({
+      media: { currentValue: hydrated, previousValue: stub, firstChange: false, isFirstChange: () => false },
+    });
+    expect(fakeVideo.currentTime).toBe(5);
+
+    component.ngOnDestroy();
   });
 });

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -26,14 +26,28 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   // ngOnChanges cycles rebuilding videoSrc (and yanking playback) for the
   // same id.
   private lastMediaId: number | null = null;
+  // Whether (loadedmetadata) has fired for the current videoSrc. Clip bounds
+  // (clip_start/clip_end) often arrive via batch hydration *after* the video
+  // has already loaded, on a later ngOnChanges with the same media id; in that
+  // case (loadedmetadata) does not fire again, so we (re)apply the bounds here.
+  private metadataLoaded = false;
 
   constructor(private activeContext: ActiveContextService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
-      this.lastMediaId = this.media.id;
-      this.videoError = false;
-      this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
+    if (changes['media'] && this.media) {
+      if (this.media.id !== this.lastMediaId) {
+        this.lastMediaId = this.media.id;
+        this.videoError = false;
+        this.metadataLoaded = false;
+        this.stopClipEnforcement();
+        this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
+      } else if (this.metadataLoaded) {
+        // Same media id, but metadata (e.g. clip_start/clip_end) may have just
+        // arrived via batch hydration. The video already loaded, so
+        // (loadedmetadata) won't fire again; apply the clip window now.
+        this.applyClipBounds();
+      }
     }
     if (changes['volume'] && this.videoRef?.nativeElement) {
       this.videoRef.nativeElement.volume = this.volume;
@@ -88,17 +102,33 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   onLoadedMetadata(): void {
     const video = this.videoRef?.nativeElement;
     if (!video) return;
+    this.metadataLoaded = true;
     video.volume = this.volume;
+    this.applyClipBounds();
+    this.syncPlaybackState();
+  }
 
-    // For clipped videos, seek to clip_start and enforce clip boundaries.
+  // Seek into the clip window and (re)start boundary enforcement when the media
+  // carries clip extents; otherwise tear enforcement down. Safe to call both on
+  // (loadedmetadata) and on later metadata-enrichment ngOnChanges cycles.
+  private applyClipBounds(): void {
+    const video = this.videoRef?.nativeElement;
+    if (!video) return;
+
     if (this.media?.clip_start != null) {
-      video.currentTime = this.media.clip_start;
+      const clipStart = this.media.clip_start;
+      const clipEnd = this.media.clip_end;
+      // Snap into the window only when currently outside it. This handles the
+      // initial seek and the case where the full video already started playing
+      // before clip extents arrived, without yanking a video already looping
+      // correctly within its window.
+      if (video.currentTime < clipStart || (clipEnd != null && video.currentTime >= clipEnd)) {
+        video.currentTime = clipStart;
+      }
       this.startClipEnforcement();
     } else {
       this.stopClipEnforcement();
     }
-
-    this.syncPlaybackState();
   }
 
   private startClipEnforcement(): void {


### PR DESCRIPTION
## Problem

Loading a dataset built on videos that are clipped into video-pieces (sub-clips with a `clip_start`/`clip_end` time window), the Find window's center panel played the **full video** instead of looping over just the clip's time window.

## Root cause

Media reaches the center panel as a **stub** (just `id`/`media_type`) and is later enriched with batch metadata (`clip_start`/`clip_end`) on a *later* `ngOnChanges` cycle with the **same media id**. The video player only set up clip-boundary enforcement inside `onLoadedMetadata`, which fires once when the `<video>` element loads — against the stub, before the clip extents exist. At that point `clip_start` was `null`, so `stopClipEnforcement()` ran and enforcement **never started**. When the extents arrived afterward, `loadedmetadata` did not fire again, so the clip window was never applied and the full video played.

## Fix

`VideoPlayerComponent` now re-applies clip bounds on metadata-enrichment `ngOnChanges` cycles (same id, after metadata already loaded), not only in `onLoadedMetadata`:

- New `applyClipBounds()` helper seeks into the window and (re)starts enforcement when clip extents are present, otherwise tears enforcement down.
- A `metadataLoaded` flag gates the re-apply so it only runs once the `<video>` has actually loaded.
- The seek only snaps into the window when playback is currently outside `[clip_start, clip_end)`, so it covers both the initial seek and the "full video already started before extents arrived" case without yanking a video that is already looping correctly.

## Tests

Added a spec covering the stub-then-hydrate flow: the player does not seek while the media is a stub, and snaps to `clip_start` once the clip extents arrive on a later `ngOnChanges` for the same id. Frontend `build:prod` passes clean (no errors/warnings).

https://claude.ai/code/session_012ocCP9Pgivi9nQ8dpBaTUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ocCP9Pgivi9nQ8dpBaTUZ)_