### PR TITLE
fix: virtualize media gallery so large datasets don't freeze the UI

### DIFF
--- a/docs/plans/scalability-plan.md
+++ b/docs/plans/scalability-plan.md
@@ -1,9 +1,11 @@
 # Scalability Implementation Plan
 
-**Status:** Open; none of the phases below shipped yet.  Separately, the
-CLI-specific streaming work (lazy folder enumeration, per-chunk embed, and
-streaming export — partial fixes for S20/S15/S13 on the `--autodetect` target
-side) **has** shipped; see
+**Status:** Mostly open.  **§3.3 (S16) virtual grid mode has shipped** — the
+gallery now virtualizes both grid and list and no longer freezes the UI at a
+few hundred items (added §3.4/S17 as the deferred backend cancel/progress
+follow-up surfaced by that work).  Separately, the CLI-specific streaming work
+(lazy folder enumeration, per-chunk embed, and streaming export — partial
+fixes for S20/S15/S13 on the `--autodetect` target side) **has** shipped; see
 [`cli-stream-massive-images.md`](cli-stream-massive-images.md).
 
 **Parent:** [`scalability.md`](scalability.md); the brainstorm that defines
@@ -510,40 +512,64 @@ flag.
 
 ---
 
-### 3.3  Virtual grid mode (S16)
+### 3.3  Virtual grid mode (S16) — **SHIPPED**
 
 **File:** `frontend/src/app/components/left-panel/media-list/`
 
-**Problem:** Grid mode renders every item into the DOM.  At > 500 items
-Chrome layout stalls; at > 5 000 items the tab may crash.
+**Problem:** Grid mode rendered every item into the DOM, and list mode only
+virtualized above 500 items.  Reproduced live: switching Caltech-101 (S)
+(412 items) to grid froze the main thread for **~1.8 s** (all 412
+`vt-media-item` components mounted at once); entering the view in list mode
+froze it for **~1.1 s**.  During the freeze the whole page — including the
+dataset-load **Cancel** button — is unresponsive, which is what reads to
+users as "the app totally froze while loading."
 
-**Fix:** Use `CdkVirtualScrollViewport` in grid mode with a fixed-height
-row that holds `floor(viewport_width / item_width)` grid cells.
+**Shipped fix:** Chunk `cachedOrderedItems` into fixed-width rows and run
+them through a `CdkVirtualScrollViewport` (the CDK scroller is 1-D, so each
+virtual item is one row of `gridColumns` cards).  Columns are derived from
+the measured viewport width + goal width; the row stride (`itemSize`) is
+measured from a real rendered card via a `ResizeObserver` (handles
+icon-size changes for free).  The threshold marker gets its own full-width
+row.  Grid-aware `scrollToIndex` / selected-scroll / metadata prefetch.
+The list threshold was lowered from 500 → **150** so entering a view or
+switching to list never renders hundreds of rows synchronously; grid
+virtualizes above 80.
 
-The CDK virtual scroller works with 1D lists, not 2D grids.  The standard
-approach is to group items into row arrays and give the viewport a list
-of rows:
+After: list↔grid toggles peak at ~169 ms (was ~1129 ms), the grid switch at
+~18 ms (was ~1814 ms), with ~20–34 components in the DOM instead of 412.
 
-```typescript
-// Computed when cachedOrderedItems changes
-get virtualRows(): MediaItem[][] {
-  const cols = Math.floor(this.viewportWidth / this.gridIconSize);
-  const rows: MediaItem[][] = [];
-  for (let i = 0; i < this.cachedOrderedItems.length; i += cols) {
-    rows.push(this.cachedOrderedItems.slice(i, i + cols));
-  }
-  return rows;
-}
-```
+---
 
-The template renders each row as a flex container with `cols` items.
-`itemSize` is set to `this.gridIconSize + gap`.
+### 3.4  Load Cancel responsiveness during pickle read (S17) — open follow-up
 
-Existing breakpoints (`VIRTUAL_SCROLL_THRESHOLD = 500`) apply to both list
-and grid mode.
+**Files:** `vtscore/datasets/container.py` (`read_container`),
+`vtscore/datasets/loader_pickle.py`, `vtscore/datasets/load_pipeline.py`
 
-**Risk:** medium; requires layout changes to the grid template and dynamic
-`itemSize` computation when icon-size settings change.
+**Problem (found while investigating the S16 freeze, deferred for now):** the
+dataset load runs in a daemon thread and streams progress over SSE, so for
+the demo datasets the dashboard load stays responsive with a working Cancel.
+But on a large `.pkl` two things still read as "frozen, Cancel does nothing":
+
+1. **`read_container` is one un-cancellable, no-progress step.** It does a
+   full ZIP `zf.read("medias.pkl")` (DEFLATE decompress of the whole blob) +
+   `safe_pickle_load` of the entire dict.  While it runs the bar sits at
+   "Reading…" and — because the dev server is a single process holding the
+   GIL through that pure-Python work — the Cancel/SSE endpoints can't be
+   serviced.  So the progress bar appears stuck and Cancel is inert until it
+   finishes.
+2. **Cancel is unchecked for the whole import phase.** `_run_importer(...)`
+   runs the entire pickle-conversion loop with no `tracker.check_cancelled()`
+   inside; the first cancel check is only *after* it returns
+   (`load_pipeline.py`, right after `_run_importer`).  So even once the read
+   finishes, a click during conversion doesn't abort until the loop ends.
+
+**Fix direction:** add `check_cancelled()` inside the
+`load_dataset_from_pickle` conversion loop (it already reports progress every
+`_progress_interval` items — check cancel there too), and give the
+read/decompress phase coarse progress + a cancellation point (e.g. stream the
+ZIP member, or at minimum surface an indeterminate "Reading…" state the user
+understands is uninterruptible).  Overlaps with **S15 (streaming pickle
+load)** below.
 
 ---
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -19,7 +19,7 @@
       }
     }
   </div>
-} @else if (useVirtualScroll) {
+} @else if (useListVirtual) {
   <!-- Virtual scrolling for large datasets in list mode -->
   <cdk-virtual-scroll-viewport [itemSize]="listItemHeight" class="media-list virtual-scroll-viewport">
     <ng-container *cdkVirtualFor="let item of cachedOrderedItems; trackBy: trackByMediaId">
@@ -41,6 +41,39 @@
         (contextRequest)="onMediaContextRequest($event)"
       />
     </ng-container>
+  </cdk-virtual-scroll-viewport>
+} @else if (useGridVirtual) {
+  <!-- Virtual scrolling for large galleries: cards are chunked into rows so
+       only the visible rows are mounted, instead of every thumbnail at once. -->
+  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual">
+    <div
+      class="grid-virtual-row"
+      *cdkVirtualFor="let row of gridRows; trackBy: trackByGridRow"
+      [style.height.px]="gridRowHeight"
+      [style.--grid-goal-width]="gridGoalWidth + 'px'"
+      [style.grid-template-columns]="row.kind === 'threshold' ? null : 'repeat(' + gridColumns + ', var(--grid-goal-width, 80px))'"
+    >
+      @if (row.kind === 'threshold') {
+        <div class="media-threshold-line" title="Decision boundary between predicted good and bad items" aria-label="Good/Bad threshold">
+          <span class="threshold-label">threshold</span>
+        </div>
+      } @else {
+        @for (item of row.items; track trackByMediaId($index, item)) {
+          <vt-media-item
+            [media]="item.media"
+            [active]="selectedId === item.media.id"
+            [voteLabel]="getVoteLabel(item.media.id)"
+            [score]="item.score"
+            [bestRegion]="item.bestRegion"
+            [viewMode]="viewMode"
+            [focusMode]="focusMode"
+            (select)="onMediaSelect($event)"
+            (vote)="onMediaVote($event)"
+            (contextRequest)="onMediaContextRequest($event)"
+          />
+        }
+      }
+    </div>
   </cdk-virtual-scroll-viewport>
 } @else {
   <!-- Plain DOM rendering for small datasets or grid mode -->

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -27,6 +27,26 @@
   overflow-x: hidden;
 }
 
+// Virtualized grid: each CDK item is a single row of cards (laid out with the
+// same column template as the plain grid), so only on-screen rows are mounted.
+.grid-virtual {
+  padding-inline: var(--space-xs);
+}
+
+.grid-virtual-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
+  gap: var(--space-xs);
+  align-content: start;
+  justify-content: start;
+  box-sizing: border-box;
+
+  // The threshold marker occupies a whole row on its own.
+  .media-threshold-line {
+    grid-column: 1 / -1;
+  }
+}
+
 .media-threshold-line {
   display: flex;
   align-items: center;

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -6,6 +6,8 @@ import {
   ElementRef,
   ViewChild,
   AfterViewChecked,
+  ChangeDetectorRef,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -23,12 +25,39 @@ import { SkeletonComponent } from '../../skeleton/skeleton.component';
 import { SortedItem } from '../left-panel.component';
 import { prefersReducedMotion } from '../../../utils/reduced-motion';
 
-/** Threshold above which we switch from plain DOM to CDK virtual scrolling (list mode only). */
-const VIRTUAL_SCROLL_THRESHOLD = 500;
+/**
+ * Item count above which list mode switches from plain DOM to CDK virtual
+ * scrolling.  Each list row still mounts a thumbnail ``<img>`` and its
+ * component, so a few hundred rendered at once blocks the main thread for
+ * ~1s.  Kept low enough that entering a view or switching to list never
+ * freezes; small lists stay plain DOM so ``scrollIntoView`` stays exact.
+ */
+const VIRTUAL_SCROLL_THRESHOLD = 150;
+/**
+ * Item count above which grid mode switches to CDK virtual scrolling.  Grid
+ * cards are even heavier than list rows, so this is lower still — a few
+ * hundred thumbnails rendered at once froze the gallery for ~1.8s.
+ */
+const GRID_VIRTUAL_THRESHOLD = 80;
 /** Approximate height of a single media-item row in list mode (px). */
 const LIST_ITEM_HEIGHT = 28;
+/** Horizontal/vertical gap between grid cards (px); mirrors ``--space-xs``. */
+const GRID_GAP_PX = 4;
+/** Fallback grid-row stride before the first real card is measured (px). */
+const GRID_ROW_HEIGHT_FALLBACK = 100;
 /** Extra items to prefetch beyond the visible viewport edges. */
 const PREFETCH_BUFFER = 50;
+
+/** One ordered entry in the flat media list. */
+interface OrderedItem {
+  media: Media;
+  score: number | null;
+  showThreshold: boolean;
+  bestRegion: number[] | null;
+}
+
+/** One virtualized grid row: a run of cards, or the full-width threshold marker. */
+type GridRow = { kind: 'items'; items: OrderedItem[] } | { kind: 'threshold' };
 
 @Component({
   selector: 'vt-media-list',
@@ -56,7 +85,14 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
 
   /** Cached ordered items, rebuilt only when inputs change, not on every CD cycle. */
-  cachedOrderedItems: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+  cachedOrderedItems: OrderedItem[] = [];
+
+  /** Grid mode only: ``cachedOrderedItems`` chunked into rows for virtual scrolling. */
+  gridRows: GridRow[] = [];
+  /** Number of cards per grid row, derived from the viewport width and goal width. */
+  gridColumns = 1;
+  /** Measured stride of one virtualized grid row (px); fed to CDK as ``itemSize``. */
+  gridRowHeight = GRID_ROW_HEIGHT_FALLBACK;
 
   readonly listItemHeight = LIST_ITEM_HEIGHT;
 
@@ -64,6 +100,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   private pendingScrollPct: number | null = null;
   private readonly destroy$ = new Subject<void>();
   private scrollSubscribed = false;
+  private resizeObserver?: ResizeObserver;
+  private observedViewportEl?: HTMLElement;
+  /** True once ``gridRowHeight`` has been measured from a real rendered card. */
+  private gridHeightMeasured = false;
 
   /** Mirror of ``MediaStateService.loading``; drives the skeleton rows when the
    *  list is empty during the initial /api/medias/ids fetch. */
@@ -73,6 +113,8 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   constructor(
     private metadataCache: MediaMetadataCacheService,
     private mediaState: MediaStateService,
+    private cdr: ChangeDetectorRef,
+    private zone: NgZone,
   ) {}
 
   ngOnInit(): void {
@@ -91,13 +133,28 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
     this.destroy$.next();
     this.destroy$.complete();
   }
 
-  /** Whether to use CDK virtual scrolling (list mode with many items). */
-  get useVirtualScroll(): boolean {
+  /** Whether list mode is virtualizing (many lightweight rows). */
+  get useListVirtual(): boolean {
     return this.viewMode === 'list' && this.cachedOrderedItems.length > VIRTUAL_SCROLL_THRESHOLD;
+  }
+
+  /** Whether grid mode is virtualizing (many heavy thumbnail cards). */
+  get useGridVirtual(): boolean {
+    return this.viewMode === 'grid' && this.cachedOrderedItems.length > GRID_VIRTUAL_THRESHOLD;
+  }
+
+  /**
+   * Whether either mode is virtualizing via a ``CdkVirtualScrollViewport``.
+   * Shared plumbing (scroll restoration, ``scrollToIndex``, prefetch) keys off
+   * this; the list/grid getters above pick the specific index math.
+   */
+  get useVirtualScroll(): boolean {
+    return this.useListVirtual || this.useGridVirtual;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -112,13 +169,21 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
       this.pendingScrollPct = maxScroll > 0 ? el.scrollTop / maxScroll : 0;
     }
 
+    // A wider/narrower goal width changes how many cards fit per grid row and
+    // the height of each card, so recompute columns and re-measure the stride.
+    if (changes['gridGoalWidth'] && !changes['gridGoalWidth'].firstChange) {
+      this.gridHeightMeasured = false;
+      this.recomputeGridColumns();
+    }
+
     // Rebuild cache only when relevant inputs change.
     if (
       changes['medias'] ||
       changes['sortOrder'] ||
       changes['threshold'] ||
       changes['showScores'] ||
-      changes['viewMode']
+      changes['viewMode'] ||
+      changes['gridGoalWidth']
     ) {
       this.rebuildOrderedItems();
     }
@@ -133,7 +198,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     const enrich = (id: number): Media | undefined =>
       this.metadataCache.get(id) ?? stubMap.get(id);
 
-    const items: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+    const items: OrderedItem[] = [];
 
     if (this.sortOrder && this.sortOrder.length > 0) {
       let thresholdInserted = false;
@@ -162,9 +227,57 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     }
 
     this.cachedOrderedItems = items;
+    this.rebuildGridRows();
 
     // Prefetch metadata for the initial visible window.
     this.prefetchVisibleMetadata();
+  }
+
+  /**
+   * Chunk ``cachedOrderedItems`` into fixed-width rows for the virtualized
+   * grid.  The threshold marker becomes its own full-width row so it still
+   * separates predicted-good from predicted-bad cards; every row keeps the
+   * same stride so CDK's fixed-size strategy scrolls accurately.
+   */
+  private rebuildGridRows(): void {
+    if (this.viewMode !== 'grid') {
+      this.gridRows = [];
+      return;
+    }
+    const cols = Math.max(1, this.gridColumns);
+    const rows: GridRow[] = [];
+    let current: OrderedItem[] = [];
+    const flush = () => {
+      if (current.length) {
+        rows.push({ kind: 'items', items: current });
+        current = [];
+      }
+    };
+    for (const item of this.cachedOrderedItems) {
+      if (item.showThreshold) {
+        flush();
+        rows.push({ kind: 'threshold' });
+      }
+      current.push(item);
+      if (current.length === cols) flush();
+    }
+    flush();
+    this.gridRows = rows;
+  }
+
+  /**
+   * Recompute how many cards fit across the grid viewport.  Returns ``true``
+   * when the column count changed (so callers know to rebuild the rows).
+   */
+  private recomputeGridColumns(): boolean {
+    const el = this.virtualViewport?.elementRef.nativeElement ?? this.listContainer?.nativeElement;
+    if (!el) return false;
+    const inner = el.clientWidth - 2 * GRID_GAP_PX;
+    if (inner <= 0) return false;
+    const cols = Math.max(1, Math.floor((inner + GRID_GAP_PX) / (this.gridGoalWidth + GRID_GAP_PX)));
+    if (cols === this.gridColumns) return false;
+    this.gridColumns = cols;
+    return true;
   }
 
   getVoteLabel(id: number): 'good' | 'bad' | null {
@@ -186,6 +299,18 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   ngAfterViewChecked(): void {
+    // Keep the grid viewport measured: a ResizeObserver tracks width (→ column
+    // count) and the first rendered card's height (→ CDK row stride).  Tear it
+    // down when we leave grid-virtual mode so the list viewport isn't probed
+    // for grid cards that don't exist.
+    if (this.useGridVirtual && this.virtualViewport) {
+      this.setupGridViewport();
+    } else if (this.observedViewportEl) {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = undefined;
+      this.observedViewportEl = undefined;
+    }
+
     const scrollEl =
       this.virtualViewport?.elementRef.nativeElement ?? this.listContainer?.nativeElement;
 
@@ -199,10 +324,12 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
       this.pendingScrollToSelected = false;
       const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
       if (this.useVirtualScroll && this.virtualViewport) {
-        // In virtual-scroll mode, find the index and scroll to it.
+        // In virtual-scroll mode, find the index and scroll to it.  Grid items
+        // are chunked into rows, so map the item index to its row first.
         const idx = this.cachedOrderedItems.findIndex((i) => i.media.id === this.selectedId);
         if (idx >= 0) {
-          this.virtualViewport.scrollToIndex(idx, behavior);
+          const target = this.useGridVirtual ? this.itemIndexToRow(idx) : idx;
+          this.virtualViewport.scrollToIndex(target, behavior);
         }
       } else if (this.listContainer) {
         const activeEl = this.listContainer.nativeElement.querySelector('.media-item.active');
@@ -221,10 +348,70 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     }
   }
 
+  /** Observe the grid viewport for width/height changes (runs outside Angular). */
+  private setupGridViewport(): void {
+    const vp = this.virtualViewport?.elementRef.nativeElement;
+    if (!vp || this.observedViewportEl === vp) {
+      // Already observing the right element.  Re-measure only until the row
+      // height has been captured from a real card, so the steady state doesn't
+      // force a reflow on every change-detection cycle.
+      if (!this.gridHeightMeasured) this.measureGridLayout();
+      return;
+    }
+    this.resizeObserver?.disconnect();
+    this.observedViewportEl = vp;
+    this.gridHeightMeasured = false;
+    this.zone.runOutsideAngular(() => {
+      this.resizeObserver = new ResizeObserver(() => this.measureGridLayout());
+      this.resizeObserver.observe(vp);
+    });
+    this.measureGridLayout();
+  }
+
+  /**
+   * Recompute the grid's column count (from viewport width) and row stride
+   * (from a rendered card), applying changes in a fresh CD tick.  Guarded so
+   * it converges instead of looping: it only re-renders when something moved.
+   */
+  private measureGridLayout(): void {
+    let changed = this.recomputeGridColumns();
+    if (changed) this.rebuildGridRows();
+
+    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const card = vp?.querySelector('vt-media-item .media-item') as HTMLElement | null;
+    if (card) {
+      const measured = Math.round(card.getBoundingClientRect().height + GRID_GAP_PX);
+      if (measured > 0) {
+        this.gridHeightMeasured = true;
+        if (Math.abs(measured - this.gridRowHeight) > 1) {
+          this.gridRowHeight = measured;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      this.zone.run(() => this.cdr.detectChanges());
+    }
+  }
+
+  /** Map a flat item index to the grid row that contains it (best-effort). */
+  private itemIndexToRow(itemIdx: number): number {
+    const target = this.cachedOrderedItems[itemIdx];
+    if (target) {
+      for (let r = 0; r < this.gridRows.length; r++) {
+        const row = this.gridRows[r];
+        if (row.kind === 'items' && row.items.includes(target)) return r;
+      }
+    }
+    return Math.floor(itemIdx / Math.max(1, this.gridColumns));
+  }
+
   scrollToIndex(index: number): void {
     const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
     if (this.useVirtualScroll && this.virtualViewport) {
-      this.virtualViewport.scrollToIndex(index, behavior);
+      const target = this.useGridVirtual ? this.itemIndexToRow(index) : index;
+      this.virtualViewport.scrollToIndex(target, behavior);
       // After scrolling, select the item at this index.
       const item = this.cachedOrderedItems[index];
       if (item) {
@@ -250,15 +437,20 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     return item.media.id;
   }
 
+  trackByGridRow(index: number, _row: GridRow): number {
+    return index;
+  }
+
   /**
    * Ask the metadata cache to prefetch items around the currently visible
    * viewport range.
    *
-   * When the list is short enough to skip virtual scrolling (or we're in
-   * grid mode), every item is rendered into the DOM, so every item is
-   * "visible"; prefetch the lot. Without this, small datasets keep
-   * showing ``#284`` placeholders forever because the only other hydration
-   * trigger is an explicit click via ``selectMedia()``.
+   * When the collection is small enough to skip virtual scrolling (plain DOM
+   * list or grid), every item is rendered, so every item is "visible";
+   * prefetch the lot. Without this, small datasets keep showing ``#284``
+   * placeholders forever because the only other hydration trigger is an
+   * explicit click via ``selectMedia()``.  When virtualized (list or grid),
+   * only the rows around the viewport are prefetched.
    *
    * ``MediaMetadataCacheService.ensureLoaded()`` already de-dupes
    * already-cached and already-pending ids, so calling it on every
@@ -276,6 +468,26 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
     const viewportEl = this.virtualViewport.elementRef.nativeElement;
     const viewportHeight = viewportEl.clientHeight || 600;
+
+    if (this.useGridVirtual) {
+      // Grid: the virtualized units are rows of ``gridColumns`` cards.
+      const startRow = this.virtualViewport.measureScrollOffset('top') / this.gridRowHeight;
+      const visibleRows = Math.ceil(viewportHeight / this.gridRowHeight);
+      const cols = Math.max(1, this.gridColumns);
+      const bufferRows = Math.ceil(PREFETCH_BUFFER / cols);
+      const fromRow = Math.max(0, Math.floor(startRow) - bufferRows);
+      const toRow = Math.min(this.gridRows.length, Math.ceil(startRow) + visibleRows + bufferRows);
+      const ids: number[] = [];
+      for (let r = fromRow; r < toRow; r++) {
+        const row = this.gridRows[r];
+        if (row.kind === 'items') {
+          for (const item of row.items) ids.push(item.media.id);
+        }
+      }
+      this.metadataCache.ensureLoaded(ids);
+      return;
+    }
+
     const startIndex = this.virtualViewport.measureScrollOffset('top') / this.listItemHeight;
     const visibleCount = Math.ceil(viewportHeight / this.listItemHeight);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,8 +229,9 @@ exclude_lines = [
 
 [tool.codespell]
 # Skip generated, binary, frontend node_modules (including nested
-# node_modules npm installs), and serialized formats.
-skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,static,model_cache,.git,*.ipynb,package-lock.json"
+# node_modules npm installs), serialized formats, and any in-repo
+# virtualenv (third-party site-packages must never be spell-checked).
+skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,static,model_cache,.git,*.ipynb,package-lock.json,*venv*,.venv,venv"
 # Domain terms (clap/siglip/xclip = embedder names; wrest/caller/recaller =
 # extension scaffold names), legitimate code identifiers (numer/denom in
 # slope formulas, medias as the global state proxy, goup as a TS method),


### PR DESCRIPTION
## What & why

Investigated a reported "total freeze" while loading a pickled dataset. Driving the app in a browser with a main-thread jank recorder, the **dataset load itself is not what freezes** — it runs in a daemon thread with live SSE progress and a working Cancel. The freeze is the **media gallery render**: switching Caltech-101 (S) (412 items) to grid blocked the main thread for **~1.8 s** (all 412 `vt-media-item` components mounted at once), and entering the view in list mode blocked it ~1.1 s. During that block the whole page — including the load Cancel button — is dead, which reads as "the app totally froze."

Root cause: only **list** mode above **500** items used CDK virtual scrolling. Grid mode never virtualized, and sub-500 list mode rendered every row at once. Each item mounts a thumbnail `<img>` + component, so a few hundred at once is seconds of work. Confirmed empirically that `content-visibility: auto` barely helped (1.8 s → 1.6 s) — the cost is Angular component instantiation, so real virtualization is required.

## Change

`frontend/src/app/components/left-panel/media-list/`:
- **Virtualize grid mode** by chunking ordered items into fixed-width rows and running the rows through `CdkVirtualScrollViewport` (the CDK scroller is 1-D, so each virtual item is one row of `gridColumns` cards). Columns are derived from the measured viewport width + goal width; the row stride is measured from a real rendered card via a `ResizeObserver` (adapts to icon-size changes). The threshold marker gets its own full-width row.
- **Lower the list threshold 500 → 150** so entering a view / switching to list never renders hundreds of rows synchronously. Grid virtualizes above 80.
- Grid-aware `scrollToIndex` / selected-scroll / metadata prefetch.

Also: `chore(codespell)` — add `venv` to the codespell skip list (the suite was failing on typos inside third-party `./venv/` packages).

## Verification (live, in-browser)

| Action | Before | After |
|---|---|---|
| Switch to grid (412 items) | **1814 ms** block, 412 in DOM | **18 ms**, ~20 in DOM |
| list↔grid toggles ×6 | up to **1129 ms** | **169 ms** peak, none >250 ms |
| Incremental scroll | n/a | smooth, ~22 in DOM, one ~156 ms img-decode hitch |

Renders identically (2 columns, thumbnails + captions); scroll height and bottom items are correct. `npm run build:prod` clean (no warnings), spec tsconfig typechecks, `./run-tests.sh` green except one pre-existing flaky `test_projection.py::test_build_and_poll` (timing-based poll; passes in isolation; my change is frontend-only).

## Follow-up (deferred, recorded in plan)

While here I found that on a *large* `.pkl`, `read_container` is one un-cancellable, no-progress, GIL-holding decompress+unpickle, and the import loop never checks cancel — so a big load can still look frozen with an inert Cancel. Captured as **S17** in `docs/plans/scalability-plan.md` §3.4 (not addressed here per scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)