### PR TITLE
Fix missing right-pane thumbnails for thin-loaded (local-folder) image detectors

### DIFF
--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -233,6 +233,77 @@ class TestLabelElementThumbnail:
         res = client.get(f"/api/detectors/cross-ds-model/labels/{target['id']}/thumbnail")
         assert res.status_code == 404
 
+    def test_serves_in_dataset_image_with_only_media_path(self, client, tmp_path):
+        """Regression: a thin-loaded image (``media_path`` set, ``media_bytes``
+        absent) - e.g. a local-folder import - must serve a thumbnail, just as
+        the center viewer's ``/api/medias/<id>/image`` does. The in-memory fast
+        path used to read ``media_bytes`` only and, finding none, fell through
+        to origin resolution that 404s, so the right pane showed no thumbnails
+        even though clicking an entry rendered the full image fine.
+        """
+        import hashlib
+
+        from helpers import make_png_bytes
+
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.store import _detector_path, _write_detector
+        from vtsearch.state import medias
+
+        png = make_png_bytes(color=(10, 20, 30))
+        img_file = tmp_path / "folder_img.png"
+        img_file.write_bytes(png)
+        md5 = hashlib.md5(png).hexdigest()  # noqa: S324 - identity key, not security
+
+        origin = {"importer": "folder", "params": {"path": str(tmp_path)}}
+        cid = 987654
+        media = {
+            "id": cid,
+            "media_type": "image",
+            "embedder": "siglip",
+            "md5": md5,
+            "filename": "folder_img.png",
+            # Thin load: only a path on disk, no bytes held in memory.
+            "media_path": str(img_file),
+            "origin": origin,
+            "origin_name": "folder_img.png",
+        }
+
+        name = "folder-img-model"
+        labelset = {
+            "labels": [
+                {
+                    "md5": md5,
+                    "label": "good",
+                    "origin": origin,
+                    "origin_name": "folder_img.png",
+                    "filename": "folder_img.png",
+                }
+            ]
+        }
+        _write_detector(
+            _detector_path(name),
+            {
+                "name": name,
+                "text_query": "",
+                "media_type": "image",
+                "examples": [],
+                "labelset": labelset,
+            },
+        )
+        element_id = stable_element_id(LabelSet.from_dict(labelset).elements[0])
+
+        saved = dict(medias)
+        medias[cid] = media
+        try:
+            res = client.get(f"/api/detectors/{name}/labels/{element_id}/thumbnail")
+            assert res.status_code == 200, res.get_json()
+            assert res.mimetype == "image/png"
+            assert res.data == png
+        finally:
+            medias.clear()
+            medias.update(saved)
+
 
 # ---------------------------------------------------------------------------
 # Cross-dataset: voting in dataset B preserves dataset A's labels on disk

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -408,29 +408,32 @@ def preview_detector_label(name: str, element_id: str):
 def _in_memory_thumbnail_response(media: dict, media_type: str):
     """Build a small thumbnail send_file from an in-memory media dict.
 
-    Images: serves the cached ``media_bytes``. Audio/video/document: defers
-    to the media-type's ``image_response`` (cached waveform / midframe PNG).
-    Returns ``None`` if no thumbnail can be produced from memory.
+    Images: serve the resolved media bytes via the media type's
+    ``media_response``, which lazily reads from ``media_path`` / ``media_url``
+    when ``media_bytes`` is not held in memory (thin-loaded datasets, e.g. a
+    local folder import). This mirrors the center viewer's
+    ``/api/medias/<id>/image`` byte resolution so a thumbnail never 404s for an
+    item the center can display. Audio/video/document: defer to the media
+    type's ``image_response`` (cached waveform / midframe PNG). Returns
+    ``None`` if no thumbnail can be produced.
     """
-    if media_type == "image":
-        media_bytes = media.get("media_bytes")
-        if not media_bytes:
-            return None
-        filename = media.get("filename", "") or ""
-        suffix = Path(filename).suffix.lower()
-        mimetype = _MIMETYPE_BY_SUFFIX.get(suffix) or "image/jpeg"
-        return send_file(
-            io.BytesIO(media_bytes),
-            mimetype=mimetype,
-            download_name=f"media_{media.get('id', 0)}{suffix or '.jpg'}",
-        )
-
     from vtscore.media import get as get_media_type  # noqa: PLC0415
 
     try:
         mt = get_media_type(media_type)
     except KeyError:
         return None
+
+    if media_type == "image":
+        resp = mt.media_response(media)
+        if not resp.data:
+            return None
+        return send_file(
+            io.BytesIO(resp.data),
+            mimetype=resp.mimetype,
+            download_name=resp.download_name,
+        )
+
     image_response_fn = getattr(mt, "image_response", None)
     if image_response_fn is None:
         return None

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -426,7 +426,7 @@ def _in_memory_thumbnail_response(media: dict, media_type: str):
 
     if media_type == "image":
         resp = mt.media_response(media)
-        if not resp.data:
+        if not isinstance(resp.data, (bytes, bytearray)) or not resp.data:
             return None
         return send_file(
             io.BytesIO(resp.data),


### PR DESCRIPTION
## Problem

When training a detector on an image dataset imported from a local folder, the right-pane labelset list showed **no thumbnails** for any labeled element, even though clicking an entry rendered the full image in the center view just fine.

## Root cause

The two views resolve image bytes differently:

- **Center viewer** (`GET /api/medias/<id>/image`) resolves bytes via `_resolve_bytes`, which falls back to `media_path` when `media_bytes` isn't held in memory.
- **Right-pane thumbnail** (`GET /api/detectors/<name>/labels/<element_id>/thumbnail`) used an in-memory fast path that, for images, read **only** `media.get("media_bytes")` and returned `None` when it was absent, then fell through to origin resolution that 404s.

Local-folder imports are **thin-loaded**: they store `media_path` instead of loading bytes into `media_bytes`. So every image thumbnail 404'd while the center view (with its `media_path` fallback) worked. The frontend then permanently recorded each failed URL, so the thumbnails never came back for the rest of the session.

## Fix

Route the image branch of `_in_memory_thumbnail_response` through the image media type's `media_response`, which resolves `media_bytes -> media_path -> media_url` — the same precedence the center viewer uses. A thumbnail now serves for any item the center can display.

## Test

Added `test_serves_in_dataset_image_with_only_media_path` to `tests/detectors/test_labelset_elements_api.py`: an in-dataset image whose media holds only `media_path` (no `media_bytes`) now returns `200` with the PNG bytes from the thumbnail endpoint.

## Verification

- `./run-tests.sh detectors` — all 1157 pass (incl. ruff/codespell/deptry/pyright).
- Full `./run-tests.sh` — 4535 pass; the one failure (`tests/api/test_projection.py::TestProjectionBuild::test_build_and_poll`, an async build-and-poll timing test unrelated to this change) passes in isolation, i.e. it's a pre-existing flake.

https://claude.ai/code/session_018WdyGfiL9eGY5BZr4ZNfYL

---
_Generated by [Claude Code](https://claude.ai/code/session_018WdyGfiL9eGY5BZr4ZNfYL)_