### PR TITLE
Hide Local importers; rename Server Folder/Files importer cards

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -59,10 +59,9 @@ Click the hamburger menu (☰) in the top-left. You get two choices:
   existing datasets. Each importer asks for the fields it needs
   (path, URL, media type) in a small form.
 
-  Two of the file-list importers - **Server Files** and **Local
-  Files** - also accept a `.npz` archive of pre-computed embedding
-  vectors so you can import media you have already embedded offline
-  without paying for embedding twice. See
+  The **Files Manifest** importer also accepts a `.npz` archive of
+  pre-computed embedding vectors so you can import media you have
+  already embedded offline without paying for embedding twice. See
   [Pre-computed embeddings (.npz)](#pre-computed-embeddings-npz) below.
 
 Loading a dataset does three things: downloads or reads the media,
@@ -80,16 +79,11 @@ Subsequent datasets of the same type reuse the cached model.
 If you have already embedded your media offline - for example with
 your own script using the same model VTSearch uses - you can skip the
 server-side re-embedding step by handing VTSearch a NumPy `.npz`
-archive of pre-computed vectors. Two importers accept this:
-
-- **Server Files** - instead of a `.txt`/`.list` paths file, point
-  the *Paths File* field at a `.npz`. The archive holds both the
-  media-file paths AND their vectors; VTSearch reads the paths from
-  disk and reuses the supplied vectors.
-- **Local Files** - alongside the media files you upload, attach a
-  `.npz` to the optional *Pre-computed embeddings* file picker. Files
-  whose name matches an NPZ key reuse the supplied vector; files
-  without a matching entry are embedded normally on the server.
+archive of pre-computed vectors. The **Files Manifest** importer
+accepts this: instead of a `.txt`/`.list` paths file, point the
+*Paths File* field at a `.npz`. The archive holds both the media-file
+paths AND their vectors; VTSearch reads the paths from disk and reuses
+the supplied vectors.
 
 VTSearch accepts two NPZ layouts:
 

--- a/tests/io/test_local_folder_upload.py
+++ b/tests/io/test_local_folder_upload.py
@@ -210,26 +210,25 @@ class TestFolderImporterPickerVisibility:
         # The Server Folder card is part of the picker (not hidden).
         assert importers["server_folder"]["hidden_from_picker"] is False
 
-    def test_local_folder_importer_card_exists(self, client):
-        """The Local Folder card is registered as its own importer so the
-        picker can render it from the importer registry without hard-coded
-        markup."""
+    def test_local_folder_importer_hidden_from_picker(self, client):
+        """The Local Folder card is still registered as its own importer but
+        is hidden from the picker (the browser-upload Local tab is retired)."""
         resp = client.get("/api/dataset/all-importers")
         importers = {imp["name"]: imp for imp in resp.get_json()["importers"]}
         assert "local_folder" in importers
         local = importers["local_folder"]
         assert local["picker_view"] == "local_folder"
-        assert local["hidden_from_picker"] is False
+        assert local["hidden_from_picker"] is True
         assert "browser" in local["description"].lower()
 
-    def test_local_files_importer_card_exists(self, client):
-        """The Local Files card mirrors Local Folder with a multi-file picker."""
+    def test_local_files_importer_hidden_from_picker(self, client):
+        """The Local Files card mirrors Local Folder and is likewise hidden."""
         resp = client.get("/api/dataset/all-importers")
         importers = {imp["name"]: imp for imp in resp.get_json()["importers"]}
         assert "local_files" in importers
         local = importers["local_files"]
         assert local["picker_view"] == "local_files"
-        assert local["hidden_from_picker"] is False
+        assert local["hidden_from_picker"] is True
         assert "browser" in local["description"].lower()
 
     def test_server_files_importer_card_exists(self, client):

--- a/tests/io/test_picker_tabs.py
+++ b/tests/io/test_picker_tabs.py
@@ -23,7 +23,9 @@ def restore_tabs():
 class TestBuiltinTabs:
     def test_built_in_tabs_present(self):
         ids = {t["id"] for t in list_picker_tabs()}
-        assert {"services", "server", "local", "demo"} <= ids
+        assert {"services", "server", "demo"} <= ids
+        # The Local tab is hidden along with its (browser-upload) importers.
+        assert "local" not in ids
 
     def test_built_in_tabs_have_labels_and_icons(self):
         for tab in list_picker_tabs():
@@ -67,7 +69,8 @@ class TestApiResponse:
         assert "tabs" in data
         assert isinstance(data["tabs"], list)
         ids = {t["id"] for t in data["tabs"]}
-        assert {"services", "server", "local", "demo"} <= ids
+        assert {"services", "server", "demo"} <= ids
+        assert "local" not in ids
 
     def test_tab_entries_have_id_and_label(self, client):
         resp = client.get("/api/dataset/all-importers")

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -148,7 +148,7 @@ class TestImporterMetadata:
         imp = get_importer("server_files")
         assert imp is not None
         assert imp.name == "server_files"
-        assert imp.display_name == "Files"
+        assert imp.display_name == "Files Manifest"
         assert imp.picker_view == "form"
         assert imp.hidden_from_picker is False
 

--- a/vtscore/datasets/importers/local_files/__init__.py
+++ b/vtscore/datasets/importers/local_files/__init__.py
@@ -34,6 +34,7 @@ class LocalFilesDatasetImporter(DatasetImporter):
 
     name = "local_files"
     display_name = "Files"
+    hidden_from_picker = True
     description = (
         "Upload a single file from this computer (your browser machine) that lists the media "
         "to import: a UTF-8 text file with one server-side path per line, or a .npz archive "

--- a/vtscore/datasets/importers/local_folder/__init__.py
+++ b/vtscore/datasets/importers/local_folder/__init__.py
@@ -37,6 +37,7 @@ class LocalFolderDatasetImporter(DatasetImporter):
 
     name = "local_folder"
     display_name = "Folder"
+    hidden_from_picker = True
     description = "Upload a folder of media files from this computer (your browser machine) to the server."
     icon = "\U0001f4c1"  # 📁 - frontend renders as a folder icon
     ui_mode = "custom"

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -192,7 +192,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
     """
 
     name = "server_files"
-    display_name = "Files"
+    display_name = "Files Manifest"
     description = (
         "Read a server-side file listing media paths (text file, one per line, "
         "OR a .npz archive that also supplies pre-computed embedding vectors) "

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -156,7 +156,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
     """
 
     name = "server_folder"
-    display_name = "Folder"
+    display_name = "File Folder"
     description = "Browse the server's filesystem and import media files from a directory"
     icon = "\U0001f4c1"  # 📁 - frontend renders as a folder icon
     picker_view = "server_folder"

--- a/vtscore/datasets/importers/tabs.py
+++ b/vtscore/datasets/importers/tabs.py
@@ -20,7 +20,6 @@ from typing import Any
 _PICKER_TABS: list[dict[str, Any]] = [
     {"id": "services", "label": "Services", "icon": "lightning", "order": 10},
     {"id": "server", "label": "Server", "icon": "server", "order": 20},
-    {"id": "local", "label": "Local", "icon": "house", "order": 30},
     {"id": "demo", "label": "Demo", "icon": "flask", "order": 40},
 ]
 


### PR DESCRIPTION
## What changed

- **Hide the Local Folder and Local Files dataset importers.** Both now set `hidden_from_picker = True`, so they no longer appear in any plugin picker (the Add Dataset modal *or* the New Detector example-media picker, both of which filter on that flag).
- **Drop the now-empty `local` picker tab.** Removed the `local` entry from `vtscore/datasets/importers/tabs.py`, so the "Local" tab disappears entirely rather than rendering as an empty tab.
- **Rename the Server Folder importer card to "File Folder"** (`server_folder.display_name`).
- **Rename the Server Files importer card to "Files Manifest"** (`server_files.display_name`).

## Notes

- Per discussion, the Local cards are hidden everywhere (Add Dataset and New Detector flows), not just the Add Dataset modal.
- Updated the affected backend tests (`test_picker_tabs.py`, `test_local_folder_upload.py`, `test_server_files_importer.py`) and the user guide to match the new names and the retired Local tab.
- The `local_folder` / `local_files` importer classes still exist (the browser-upload endpoint and its server-side delegation are untouched); they are simply no longer surfaced in the picker.

## Testing

- `./run-tests.sh` — all 4535 tests pass (includes ruff/codespell/deptry gates and the frontend build check).

https://claude.ai/code/session_01DjYD7DN1ittv1v8aPVVsnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjYD7DN1ittv1v8aPVVsnr)_