### PR TITLE
Rename importer "Server" tab to "Files" (Folder / Manifest)

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -59,7 +59,7 @@ Click the hamburger menu (☰) in the top-left. You get two choices:
   existing datasets. Each importer asks for the fields it needs
   (path, URL, media type) in a small form.
 
-  The **Files Manifest** importer also accepts a `.npz` archive of
+  The **Files → Manifest** importer also accepts a `.npz` archive of
   pre-computed embedding vectors so you can import media you have
   already embedded offline without paying for embedding twice. See
   [Pre-computed embeddings (.npz)](#pre-computed-embeddings-npz) below.
@@ -79,7 +79,7 @@ Subsequent datasets of the same type reuse the cached model.
 If you have already embedded your media offline - for example with
 your own script using the same model VTSearch uses - you can skip the
 server-side re-embedding step by handing VTSearch a NumPy `.npz`
-archive of pre-computed vectors. The **Files Manifest** importer
+archive of pre-computed vectors. The **Files → Manifest** importer
 accepts this: instead of a `.txt`/`.list` paths file, point the
 *Paths File* field at a `.npz`. The archive holds both the media-file
 paths AND their vectors; VTSearch reads the paths from disk and reuses

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -143,7 +143,7 @@ describe('DatasetImporterModalComponent', () => {
 
   const mockTabs = [
     { id: 'services', label: 'Services', icon: 'lightning', order: 10 },
-    { id: 'server', label: 'Server', icon: 'server', order: 20 },
+    { id: 'server', label: 'Files', icon: 'folder', order: 20 },
     { id: 'local', label: 'Local', icon: 'house', order: 30 },
     { id: 'demo', label: 'Demo', icon: 'flask', order: 40 },
   ];

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -148,7 +148,7 @@ class TestImporterMetadata:
         imp = get_importer("server_files")
         assert imp is not None
         assert imp.name == "server_files"
-        assert imp.display_name == "Files Manifest"
+        assert imp.display_name == "Manifest"
         assert imp.picker_view == "form"
         assert imp.hidden_from_picker is False
 

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -192,7 +192,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
     """
 
     name = "server_files"
-    display_name = "Files Manifest"
+    display_name = "Manifest"
     description = (
         "Read a server-side file listing media paths (text file, one per line, "
         "OR a .npz archive that also supplies pre-computed embedding vectors) "

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -156,7 +156,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
     """
 
     name = "server_folder"
-    display_name = "File Folder"
+    display_name = "Folder"
     description = "Browse the server's filesystem and import media files from a directory"
     icon = "\U0001f4c1"  # 📁 - frontend renders as a folder icon
     picker_view = "server_folder"

--- a/vtscore/datasets/importers/tabs.py
+++ b/vtscore/datasets/importers/tabs.py
@@ -19,7 +19,7 @@ from typing import Any
 #: ``frontend/src/app/components/icon/icon.component.ts``).
 _PICKER_TABS: list[dict[str, Any]] = [
     {"id": "services", "label": "Services", "icon": "lightning", "order": 10},
-    {"id": "server", "label": "Server", "icon": "server", "order": 20},
+    {"id": "server", "label": "Files", "icon": "folder", "order": 20},
     {"id": "demo", "label": "Demo", "icon": "flask", "order": 40},
 ]
 


### PR DESCRIPTION
Now that the Local Folder and Local Files importers are hidden from the picker, the dataset-importer window tabs were updated to match.

## Changes
- Picker tab `server`: label `Server` → `Files`, icon `server` → `folder` (`vtscore/datasets/importers/tabs.py`).
- `server_folder` importer display name: `File Folder` → `Folder`.
- `server_files` importer display name: `Files Manifest` → `Manifest`.
- Updated the importer-modal spec mock tab and the `server_files` metadata test.
- Refreshed `USER_GUIDE.md` references to the manifest importer (now **Files → Manifest**).

The tab id stays `server` (so importer `category` values are untouched); only the user-facing label/icon and the two sub-tab display names change.

## Tests
`./run-tests.sh io core` — all 1424 passed (core includes the frontend build check).

https://claude.ai/code/session_01GdQwi2PfKimAGeSZG81wgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdQwi2PfKimAGeSZG81wgd)_