### PR TITLE
Unrestricted server file access in single-user (no-auth) mode

### DIFF
--- a/docs/plans/server-import-ux.md
+++ b/docs/plans/server-import-ux.md
@@ -1,6 +1,14 @@
 # Server / Services dataset-import UX
 
-Status: **Phase 1 shipped.** Came out of a hands-on audit of the three real-world
+Status: **Phase 1 shipped.** Single-user path confinement (item 1 below) was
+later **reversed**: in single-user / no-auth mode server-path import, export,
+and browse are now unrestricted (the lone trusted user may reach any
+server-readable path), and `SERVER_ROOTS` / `VTSEARCH_SERVER_ROOTS` were
+removed. Multi-user per-user confinement is unchanged. The "Browse-root vs.
+import-root seam" follow-up below is therefore moot for single-user mode
+(browse is now rooted at `/`, matching the unrestricted import validation).
+
+Came out of a hands-on audit of the three real-world
 import paths (Services extension plugin, server folder, server file with
 pre-computed vectors), driving the live UI. The Demo importer is well-trodden;
 these three are what real deployments use and were comparatively rough.

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -69,9 +69,6 @@ DEVICE: str
 def resolve_device() -> str:
     """Resolve DEVICE='auto' to the concrete torch device string for this host."""
 
-SERVER_ROOTS: tuple[Path, ...]
-"""Allowed filesystem roots for server-path importers. Honours $VTSEARCH_SERVER_ROOTS."""
-
 MAX_UPLOAD_MB: int
 """HTTP request size cap in MB; 0 = unlimited. Honours $VTSEARCH_MAX_UPLOAD_MB."""
 
@@ -1089,12 +1086,13 @@ def cap_workers_by_memory(
 Defensive helpers. Used at every external-input boundary; no app coupling.
 
 ```python
-def get_file_access_base_dir() -> Path:
-    """The single base directory under which validate_server_filepath permits paths."""
+def get_file_access_base_dir() -> Path | None:
+    """Per-user base dir validate_server_filepath confines to; None (unrestricted)
+    in single-user / no-auth mode."""
 
-def validate_server_filepath(filepath_str: str, base_dir: Path) -> Path:
-    """Resolve `filepath_str` and assert it stays inside `base_dir`.
-    Raises on escape attempts."""
+def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) -> Path:
+    """Resolve `filepath_str`. When `base_dir` is given, assert it stays inside
+    `base_dir` (raises on escape); when None, the path is unrestricted."""
 
 def sanitize_template_value(value: str) -> str:
     """Sanitise a value before substituting it into a filesystem-path template."""

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -138,9 +138,9 @@ export class DatasetImporterModalComponent implements OnInit {
 
   // Server folder picker state. The user types or browses to an absolute
   // server path, stored verbatim in ``sfFolderPath``. It is sent to the
-  // detection / submit endpoints as-is; the backend resolves it against the
-  // configured server root and rejects anything outside, so the picker and
-  // the importer agree on what is in-bounds.
+  // detection / submit endpoints as-is. In single-user / no-auth mode the
+  // backend accepts any server-readable path; in multi-user mode it confines
+  // to the user's data dir and rejects anything outside.
   sfFolderPath = '';
   sfBrowseError = '';
   sfMediaType = '';
@@ -1609,8 +1609,8 @@ export class DatasetImporterModalComponent implements OnInit {
       return;
     }
     // Keep the typed value as an absolute server path (trailing slash
-    // trimmed). The backend resolves it against the configured server root
-    // and rejects anything outside.
+    // trimmed). The backend accepts any path in single-user mode and confines
+    // to the user's data dir in multi-user mode.
     this.sfFolderPath = raw.replace(/\/+$/, '') || '/';
     this.sfBrowseError = '';
     if (!this.sfDatasetNameDirty) {

--- a/tests/api/test_error_recovery.py
+++ b/tests/api/test_error_recovery.py
@@ -635,7 +635,12 @@ class TestVoteEdgeCases:
 
 
 class TestPathTraversalPrevention:
-    """Label-file endpoints must reject paths outside the data directory."""
+    """Label-file endpoints must reject paths outside the user's data dir.
+
+    Path confinement only applies in multi-user mode; single-user / no-auth
+    mode is unrestricted, so these tests force multi-user mode (a provider
+    confined to a tmp dir) to exercise the boundary.
+    """
 
     def _make_label_file(self, paths):
         """Build an in-memory label JSON file with the given file paths."""
@@ -645,29 +650,65 @@ class TestPathTraversalPrevention:
         content = json.dumps({"labels": labels}).encode("utf-8")
         return io.BytesIO(content)
 
+    def _multi_user_provider(self, user_dir):
+        """A LoginProvider that confines every request to *user_dir*."""
+        from vtsearch.auth import LoginProvider
+
+        class _Provider(LoginProvider):
+            name = "test_multi_traversal"
+
+            def get_user(self, request):
+                return "testuser"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return user_dir
+
+        return _Provider()
+
     # -- /api/label-file-sort ------------------------------------------------
 
-    def test_label_file_sort_rejects_absolute_escape(self, client):
-        """Absolute paths outside DATA_DIR must be skipped."""
-        buf = self._make_label_file(["/etc/passwd", "/etc/shadow"])
-        resp = client.post(
-            "/api/label-file-sort",
-            data={"file": (buf, "labels.json")},
-            content_type="multipart/form-data",
-        )
-        # All paths rejected → too few valid files → 400
-        assert resp.status_code == 400
-        # Migrated to flask-smorest: handler-level rejects surface under
-        # ``message``, not the legacy ``error`` key.
-        message = resp.get_json()["message"]
-        assert "2 valid" in message or "loaded 0" in message
+    def test_label_file_sort_rejects_absolute_escape(self, client, tmp_path):
+        """Absolute paths outside the user dir must be skipped."""
+        from vtsearch.auth import get_login_provider, set_login_provider
 
-    def test_label_file_sort_rejects_relative_traversal(self, client):
-        """Relative paths that traverse out of DATA_DIR must be skipped."""
-        buf = self._make_label_file(["../../etc/passwd", "../../../etc/shadow"])
-        resp = client.post(
-            "/api/label-file-sort",
-            data={"file": (buf, "labels.json")},
-            content_type="multipart/form-data",
-        )
-        assert resp.status_code == 400
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = get_login_provider()
+        try:
+            set_login_provider(self._multi_user_provider(user_dir))
+            buf = self._make_label_file(["/etc/passwd", "/etc/shadow"])
+            resp = client.post(
+                "/api/label-file-sort",
+                data={"file": (buf, "labels.json")},
+                content_type="multipart/form-data",
+            )
+            # All paths rejected → too few valid files → 400
+            assert resp.status_code == 400
+            # Migrated to flask-smorest: handler-level rejects surface under
+            # ``message``, not the legacy ``error`` key.
+            message = resp.get_json()["message"]
+            assert "2 valid" in message or "loaded 0" in message
+        finally:
+            set_login_provider(original)
+
+    def test_label_file_sort_rejects_relative_traversal(self, client, tmp_path):
+        """Relative paths that traverse out of the user dir must be skipped."""
+        from vtsearch.auth import get_login_provider, set_login_provider
+
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = get_login_provider()
+        try:
+            set_login_provider(self._multi_user_provider(user_dir))
+            buf = self._make_label_file(["../../etc/passwd", "../../../etc/shadow"])
+            resp = client.post(
+                "/api/label-file-sort",
+                data={"file": (buf, "labels.json")},
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 400
+        finally:
+            set_login_provider(original)

--- a/tests/api/test_path_validation.py
+++ b/tests/api/test_path_validation.py
@@ -47,14 +47,22 @@ class TestValidateServerFilepath:
         result = validate_server_filepath("data/output/file.csv", base_dir=tmp_path)
         assert result == (tmp_path / "data" / "output" / "file.csv").resolve()
 
-    def test_defaults_to_cwd(self):
+    def test_relative_defaults_to_cwd(self):
+        """With base_dir=None, a relative path resolves against the CWD."""
         cwd = Path.cwd()
         result = validate_server_filepath("some_file.json")
         assert result == (cwd / "some_file.json").resolve()
 
-    def test_rejects_absolute_outside_cwd(self):
-        with pytest.raises(ValueError, match="must be within"):
-            validate_server_filepath("/etc/passwd")
+    def test_unrestricted_accepts_absolute_anywhere(self):
+        """With base_dir=None (single-user / no-auth) any absolute path is allowed."""
+        result = validate_server_filepath("/etc/passwd")
+        assert result == Path("/etc/passwd")
+
+    def test_unrestricted_accepts_outside_cwd(self, tmp_path):
+        """base_dir=None permits paths far outside the process CWD."""
+        target = tmp_path / "anywhere" / "clip.wav"
+        result = validate_server_filepath(str(target))
+        assert result == target.resolve()
 
     def test_rejects_symlink_escape(self, tmp_path):
         """A symlink that points outside base_dir should be rejected."""
@@ -66,66 +74,58 @@ class TestValidateServerFilepath:
         with pytest.raises(ValueError, match="must be within"):
             validate_server_filepath("escape_link/passwd", base_dir=tmp_path)
 
-    def test_accepts_path_in_any_configured_root(self, tmp_path, monkeypatch):
-        """With base_dir=None, a path inside ANY of SERVER_ROOTS is accepted."""
-        root_a = tmp_path / "a"
-        root_b = tmp_path / "b"
-        root_a.mkdir()
-        root_b.mkdir()
-        # SERVER_ROOTS is imported lazily inside the function, so patch the source.
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root_a, root_b))
-
-        # A path under the *second* configured root must validate, not just the first.
-        target = root_b / "media" / "clip.wav"
-        result = validate_server_filepath(str(target))
-        assert result == target.resolve()
-
-    def test_rejects_path_outside_all_roots(self, tmp_path, monkeypatch):
-        root_a = tmp_path / "a"
-        root_a.mkdir()
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root_a,))
-        with pytest.raises(ValueError, match="must be within"):
-            validate_server_filepath(str(tmp_path / "outside" / "x.wav"))
-
 
 class TestFolderFieldValidation:
-    """The server_folder importer's ``folder`` field must be path-validated
-    just like the server_files ``server_path`` field (unified policy)."""
+    """The server_folder importer's ``folder`` field is path-validated through
+    the same primitive as the server_files ``server_path`` field (unified
+    policy). In single-user / no-auth mode that validation is unrestricted."""
 
-    def test_folder_field_outside_roots_rejected(self, tmp_path, monkeypatch):
+    def test_folder_field_outside_cwd_accepted_single_user(self, tmp_path):
+        """In single-user mode the importer accepts a folder anywhere on disk."""
         from vtscore.datasets.importers.server_folder import ServerFolderDatasetImporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        root = tmp_path / "allowed"
-        root.mkdir()
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root,))
-        # Single-user (default provider) -> base_dir is None -> SERVER_ROOTS apply.
+        # Single-user (default provider) -> base_dir is None -> unrestricted.
         from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
 
+        outside = tmp_path / "anywhere" / "media"
+        outside.mkdir(parents=True)
         original = get_login_provider()
         try:
             set_login_provider(DefaultLoginProvider())
             imp = ServerFolderDatasetImporter()
-            with pytest.raises(ValueError, match="must be within"):
-                normalize_field_values(imp, {"path": "/tmp/outside_the_root", "media_type": "image"})
+            out = normalize_field_values(imp, {"path": str(outside), "media_type": "image"})
+            assert out["path"] == str(outside)
         finally:
             set_login_provider(original)
 
-    def test_folder_field_inside_root_accepted(self, tmp_path, monkeypatch):
+    def test_folder_field_outside_user_dir_rejected_multi_user(self, tmp_path):
+        """In multi-user mode the importer still confines to the user data dir."""
         from vtscore.datasets.importers.server_folder import ServerFolderDatasetImporter
         from vtscore.plugins.normalize import normalize_field_values
+        from vtsearch.auth import LoginProvider, get_login_provider, set_login_provider
 
-        root = tmp_path / "allowed"
-        (root / "media").mkdir(parents=True)
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (root,))
-        from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
+        user_dir = tmp_path / "alice"
+        user_dir.mkdir()
+
+        class MultiUserProvider(LoginProvider):
+            name = "multi"
+
+            def get_user(self, request):
+                return "alice"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return user_dir
 
         original = get_login_provider()
         try:
-            set_login_provider(DefaultLoginProvider())
+            set_login_provider(MultiUserProvider())
             imp = ServerFolderDatasetImporter()
-            out = normalize_field_values(imp, {"path": str(root / "media"), "media_type": "image"})
-            assert out["path"] == str(root / "media")
+            with pytest.raises(ValueError, match="must be within"):
+                normalize_field_values(imp, {"path": "/tmp/outside_the_user_dir", "media_type": "image"})
         finally:
             set_login_provider(original)
 
@@ -139,7 +139,7 @@ class TestGetFileAccessBaseDir:
     """Test that get_file_access_base_dir returns the correct base for each provider."""
 
     def test_default_provider_returns_none(self):
-        """DefaultLoginProvider → None (unrestricted, falls back to CWD)."""
+        """DefaultLoginProvider → None (unrestricted file access)."""
         from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
 
         original = get_login_provider()
@@ -354,24 +354,22 @@ class TestMultiUserFileRestriction:
 
             set_login_provider(original)
 
-    def test_default_provider_allows_any_path(self, client):
-        """DefaultLoginProvider allows any path within CWD (single-user mode)."""
+    def test_default_provider_allows_any_path(self, client, tmp_path):
+        """DefaultLoginProvider (single-user) allows any path, even outside CWD."""
         from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
 
         original = get_login_provider()
         try:
             set_login_provider(DefaultLoginProvider())
-            # Paths within CWD should be accepted (even if the file doesn't exist,
-            # the path validation itself should pass)
-            cwd = Path.cwd()
-            resp = client.post(
-                "/api/dataset/load-folder",
-                json={"path": str(cwd / "some_folder"), "media_type": "audio"},
-            )
-            # Should not get a "must be within" error; may get "Invalid folder path"
-            # since the folder doesn't exist, but not a path-validation error.
+            # A path well outside the process CWD must not be rejected on
+            # path-validation grounds (it may 400 for "Invalid folder path"
+            # since the folder doesn't exist, but never "must be within").
             # ``load-folder`` is on flask-smorest, so the human-readable text
             # lives under ``message``.
+            resp = client.post(
+                "/api/dataset/load-folder",
+                json={"path": str(tmp_path / "elsewhere" / "some_folder"), "media_type": "audio"},
+            )
             if resp.status_code == 400:
                 assert "must be within" not in resp.get_json().get("message", "")
         finally:

--- a/tests/cli/test_cli_dry_run.py
+++ b/tests/cli/test_cli_dry_run.py
@@ -203,12 +203,6 @@ class TestDryRunPickle:
 
 
 class TestDryRunImporter:
-    @pytest.fixture(autouse=True)
-    def _permissive_server_roots(self, monkeypatch):
-        """server_folder's ``path`` field is validated against SERVER_ROOTS;
-        these dry-run tests use dummy absolute paths to exercise CLI wiring."""
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
-
     def test_dry_run_importer_prints_params(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,9 +155,10 @@ _ALL_MEDIA_TYPES = _all_types()
 def _allow_test_tmp_paths(monkeypatch):
     """Allow tests to use system temp dirs with server file-path validation.
 
-    In production, ``validate_server_filepath`` restricts paths to
-    ``Path.cwd()``.  During tests, temp files live in the system temp
-    directory, so we widen the check to also accept that tree.
+    With ``base_dir=None`` (single-user / no-auth mode) ``validate_server_filepath``
+    is already unrestricted, so system temp paths pass unchanged.  This wrapper
+    only matters for the ``base_dir=None`` path historically; when a specific
+    ``base_dir`` is given (e.g. multi-user mode) the restriction is honoured.
     """
     import tempfile
     from pathlib import Path
@@ -170,10 +171,8 @@ def _allow_test_tmp_paths(monkeypatch):
         try:
             return _original(filepath_str, base_dir)
         except ValueError:
-            # Also allow the system temp directory (where pytest tmp_path lives),
-            # but only when base_dir was not explicitly set (i.e. only for the
-            # default CWD fallback).  When a specific base_dir is given (e.g. in
-            # multi-user mode) we must honour that restriction.
+            # When a specific base_dir is given (multi-user mode) we must honour
+            # that restriction; only widen for the unrestricted default case.
             if base_dir is not None:
                 raise
             return _original(filepath_str, Path(tempfile.gettempdir()))

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -809,8 +809,6 @@ class TestEffectiveSourceSpecs:
         assert specs[0].source_type == "image"
 
     def test_rejects_invalid_converter(self):
-        import pytest
-
         from vtscore.datasets.importers.server_folder import IMPORTER
 
         with pytest.raises(ValueError, match="Unknown converter"):
@@ -826,8 +824,6 @@ class TestEffectiveSourceSpecs:
     def test_rejects_target_mismatch(self):
         """A converter whose target_type doesn't match the output media_type
         is rejected; e.g. video2audio applied to an image-output dataset."""
-        import pytest
-
         from vtscore.datasets.importers.server_folder import IMPORTER
 
         with pytest.raises(ValueError, match="produces"):
@@ -843,8 +839,6 @@ class TestEffectiveSourceSpecs:
     def test_rejects_direct_row_with_wrong_type(self):
         """A no-converter row whose source_type differs from the output type
         is rejected; that's the form a stale UI submission would take."""
-        import pytest
-
         from vtscore.datasets.importers.server_folder import IMPORTER
 
         with pytest.raises(ValueError, match="does not match"):
@@ -959,8 +953,6 @@ class TestServerFilesEffectiveSourceSpecs:
         assert specs[1].params == {"n_clips": "5"}
 
     def test_rejects_target_mismatch(self):
-        import pytest
-
         from vtscore.datasets.importers.server_files import IMPORTER
 
         with pytest.raises(ValueError, match="produces"):

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import hashlib
 import io
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -902,12 +901,6 @@ class TestConverterAcceptsParams:
 
 
 class TestImportAPISourceSpecs:
-    @pytest.fixture(autouse=True)
-    def _permissive_server_roots(self, monkeypatch):
-        """server_folder's ``path`` field is validated against SERVER_ROOTS;
-        the dummy ``/tmp/test`` path here only exercises route wiring."""
-        monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
-
     def test_import_endpoint_passes_source_specs(self, client):
         with patch("vtsearch.routes.datasets.staging._run_importer_in_background") as mock_run:
             resp = client.post(

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -476,13 +476,39 @@ class TestCombineEndpoint:
         data = resp.get_json()
         assert data["ok"] is True
 
-    def test_path_traversal_rejected(self, client):
-        """Paths outside the allowed directory must be rejected."""
-        resp = client.post(
-            "/api/dataset/combine",
-            json={"datasets": ["/etc/passwd", "/etc/shadow"]},
-        )
-        assert resp.status_code == 400
+    def test_path_traversal_rejected(self, client, tmp_path):
+        """In multi-user mode, paths outside the user dir must be rejected.
+
+        Path confinement only applies in multi-user mode; single-user / no-auth
+        mode is unrestricted, so this forces multi-user to exercise the boundary.
+        """
+        from vtsearch.auth import LoginProvider, get_login_provider, set_login_provider
+
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+
+        class _Provider(LoginProvider):
+            name = "test_multi_combine"
+
+            def get_user(self, request):
+                return "testuser"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return user_dir
+
+        original = get_login_provider()
+        try:
+            set_login_provider(_Provider())
+            resp = client.post(
+                "/api/dataset/combine",
+                json={"datasets": ["/etc/passwd", "/etc/shadow"]},
+            )
+            assert resp.status_code == 400
+        finally:
+            set_login_provider(original)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -159,34 +159,30 @@ class TestDatasetEndpoints:
             file_names2 = [f["name"] for f in data2["files"]]
             assert "sound.wav" in file_names2
 
-    def test_browse_media_files_server_fs_confined_to_server_root(self, client, tmp_path, monkeypatch):
-        """``source=server_fs`` is confined to the configured server root.
+    def test_browse_media_files_server_fs_unrestricted_single_user(self, client, tmp_path):
+        """``source=server_fs`` is unrestricted in single-user / no-auth mode.
 
-        In single-user mode the picker is rooted at ``SERVER_ROOTS[0]`` (not
-        the filesystem root ``/``) so it can never list a folder the
-        ``server_folder`` importer would reject at load time. Browsing the
-        root lists its subdirectories; a path that escapes the root is
-        rejected here rather than only at import.
+        The picker is rooted at the filesystem root (``/``) so the user can
+        browse to any absolute folder on the server, matching the now
+        unrestricted ``server_folder`` import validation.
         """
-        import vtscore.config
-
         sub = tmp_path / "subdir"
         sub.mkdir()
         (sub / "track.wav").write_bytes(b"RIFF" + b"\x00" * 64)
-        monkeypatch.setattr(vtscore.config, "SERVER_ROOTS", (tmp_path.resolve(),))
 
+        # Browsing with no sub-path reports the filesystem root.
         resp = client.get("/api/browse-media-files?source=server_fs&path=")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["root_path"] == str(tmp_path.resolve())
-        dir_names = [d["name"] for d in data["directories"]]
-        assert "subdir" in dir_names
+        assert data["root_path"] == "/"
         # default_path is reported on every server_fs response.
         assert "default_path" in data
 
-        # A traversal that escapes the server root is rejected outright.
-        resp = client.get("/api/browse-media-files?source=server_fs&path=../../etc")
-        assert resp.status_code == 400
+        # An arbitrary absolute path (well outside the CWD) is browsable.
+        resp = client.get(f"/api/browse-media-files?source=server_fs&path={tmp_path}")
+        assert resp.status_code == 200
+        dir_names = [d["name"] for d in resp.get_json()["directories"]]
+        assert "subdir" in dir_names
 
     def test_select_browsed_file_copies_to_example_media(self, client, tmp_path):
         """POST /api/browse-media-files/select copies the file to example_media."""
@@ -292,30 +288,21 @@ class TestDatasetEndpoints:
         resp = client.get("/api/dataset/detect-media-type?source=demo:nonexistent_xyz&path=")
         assert resp.status_code == 404
 
-    def test_detect_media_type_server_fs_confined_to_server_root(self, client, tmp_path, monkeypatch):
-        """``server_fs`` detection is confined to the configured server root.
+    def test_detect_media_type_server_fs_unrestricted_single_user(self, client, tmp_path):
+        """``server_fs`` detection runs against any absolute path in single-user mode.
 
-        Detection used to run from ``/``, so it would happily scan a folder
-        the importer rejects at load. It must now reject an absolute path that
-        resolves outside ``SERVER_ROOTS`` exactly as the importer does, while
-        still detecting media inside the root via its absolute path.
+        With no per-user boundary to enforce, detection scans whatever absolute
+        folder the user supplies, matching the unrestricted importer.
         """
-        import vtscore.config
-
         root = tmp_path / "media"
         root.mkdir()
         (root / "a.wav").write_bytes(b"RIFF")
         (root / "b.wav").write_bytes(b"RIFF")
-        monkeypatch.setattr(vtscore.config, "SERVER_ROOTS", (tmp_path.resolve(),))
 
-        # In-root absolute path is detected.
+        # An absolute path well outside the CWD is detected, not rejected.
         resp = client.get(f"/api/dataset/detect-media-type?source=server_fs&path={root}")
         assert resp.status_code == 200
         assert resp.get_json()["dominant"] == "audio"
-
-        # An absolute path outside the server root is rejected, not scanned.
-        resp = client.get("/api/dataset/detect-media-type?source=server_fs&path=/etc")
-        assert resp.status_code == 400
 
     def test_detect_media_type_directory_cap(self, tmp_path):
         """The helper stops walking after ``max_dirs`` directories, even when

--- a/tests/io/test_chunked_web_flow.py
+++ b/tests/io/test_chunked_web_flow.py
@@ -15,23 +15,13 @@ Three pieces:
 """
 
 import io
-from pathlib import Path
 from typing import Any, Iterator
 from unittest.mock import patch
 
 import numpy as np
-import pytest
 
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField
 from vtscore.datasets.load_pipeline import auto_chunk_size, consume_chunks_into
-
-
-@pytest.fixture(autouse=True)
-def _permissive_server_roots(monkeypatch):
-    """server_folder's ``path`` field is now validated against SERVER_ROOTS.
-    These tests use dummy absolute paths purely to exercise route→pipeline
-    wiring, so widen the allowed roots to the filesystem root."""
-    monkeypatch.setattr("vtscore.config.SERVER_ROOTS", (Path("/"),))
 
 
 # ===========================================================================

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -48,6 +48,30 @@ EMPTY_RESULTS = {
 }
 
 
+def _multi_user_provider(user_dir: Path):
+    """A LoginProvider that confines every request to *user_dir*.
+
+    Path confinement only applies in multi-user mode; single-user / no-auth
+    mode is unrestricted. These tests force multi-user mode to exercise the
+    boundary.
+    """
+    from vtsearch.auth import LoginProvider
+
+    class _Provider(LoginProvider):
+        name = "test_multi_exporter"
+
+        def get_user(self, request):
+            return "testuser"
+
+        def is_authenticated(self, request):
+            return True
+
+        def get_user_data_dir(self, username, base_data_dir):
+            return user_dir
+
+    return _Provider()
+
+
 # ---------------------------------------------------------------------------
 # ExporterField
 # ---------------------------------------------------------------------------
@@ -619,31 +643,49 @@ class TestExportEndpoint:
         # bodies surfaces as 422 (``exporter_name`` required).
         assert res.status_code == 422
 
-    def test_path_traversal_absolute_rejected(self, client):
-        """Absolute paths outside the allowed directory must be rejected."""
-        res = client.post(
-            "/api/exporters/export",
-            json={
-                "exporter_name": "server_json_file",
-                "field_values": {"filepath": "/etc/passwd"},
-                "results": SAMPLE_RESULTS,
-            },
-        )
-        assert res.status_code == 400
-        msg = res.get_json()["message"].lower()
-        assert "outside" in msg or "must be within" in msg
+    def test_path_traversal_absolute_rejected(self, client, tmp_path):
+        """In multi-user mode, absolute paths outside the user dir are rejected."""
+        from vtsearch.auth import get_login_provider, set_login_provider
 
-    def test_path_traversal_relative_rejected(self, client):
-        """Relative paths that escape the base directory must be rejected."""
-        res = client.post(
-            "/api/exporters/export",
-            json={
-                "exporter_name": "server_json_file",
-                "field_values": {"filepath": "../../../etc/shadow"},
-                "results": SAMPLE_RESULTS,
-            },
-        )
-        assert res.status_code == 400
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = get_login_provider()
+        try:
+            set_login_provider(_multi_user_provider(user_dir))
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": "/etc/passwd"},
+                    "results": SAMPLE_RESULTS,
+                },
+            )
+            assert res.status_code == 400
+            msg = res.get_json()["message"].lower()
+            assert "outside" in msg or "must be within" in msg
+        finally:
+            set_login_provider(original)
+
+    def test_path_traversal_relative_rejected(self, client, tmp_path):
+        """In multi-user mode, relative paths that escape the user dir are rejected."""
+        from vtsearch.auth import get_login_provider, set_login_provider
+
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = get_login_provider()
+        try:
+            set_login_provider(_multi_user_provider(user_dir))
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": "../../../etc/shadow"},
+                    "results": SAMPLE_RESULTS,
+                },
+            )
+            assert res.status_code == 400
+        finally:
+            set_login_provider(original)
 
     def test_export_oserror_returns_500_and_logs_traceback(self, client, caplog):
         """An OSError from an exporter should return 500 and log the full traceback."""

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -20,8 +20,39 @@ from __future__ import annotations
 
 import json
 import threading
+from contextlib import contextmanager
 
 import pytest
+
+
+@contextmanager
+def _multi_user_mode(user_dir):
+    """Activate a multi-user login provider confined to *user_dir*.
+
+    Path confinement only applies in multi-user mode; single-user / no-auth
+    mode is unrestricted. Tests that exercise the ``../`` traversal boundary
+    must run inside this context.
+    """
+    from vtsearch.auth import LoginProvider, get_login_provider, set_login_provider
+
+    class _Provider(LoginProvider):
+        name = "test_multi_sync"
+
+        def get_user(self, request):
+            return "alice"
+
+        def is_authenticated(self, request):
+            return True
+
+        def get_user_data_dir(self, username, base_data_dir):
+            return user_dir
+
+    original = get_login_provider()
+    set_login_provider(_Provider())
+    try:
+        yield
+    finally:
+        set_login_provider(original)
 
 
 # ---------------------------------------------------------------------------
@@ -249,29 +280,30 @@ class TestServerFileSettingsSource:
         assert "alice.settings.json" in result
         assert "{username}" not in result
 
-    def test_resolved_template_path_outside_base_dir_rejected(self, monkeypatch):
+    def test_resolved_template_path_outside_base_dir_rejected(self, tmp_path):
         """Regression for ``logical-bug-audit.md`` C9.
 
         A template containing ``../`` survives per-value sanitization (because
         no template variable is involved), so the resolved path must also be
         validated against the file-access base directory before any file
-        operation runs.
+        operation runs. Confinement is multi-user-only, so force that mode.
         """
         from vtsearch.settings_io.sources import get_settings_source
 
-        monkeypatch.setattr("vtsearch.auth.get_current_user", lambda: "alice")
-
+        user_dir = tmp_path / "alice"
+        user_dir.mkdir()
         traversal_template = "../../../../etc/{username}.settings.json"
 
-        src = get_settings_source("server_json_file")
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src._normalize({"filepath": traversal_template})
+        with _multi_user_mode(user_dir):
+            src = get_settings_source("server_json_file")
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src._normalize({"filepath": traversal_template})
 
-        src = get_settings_source("server_json_file")
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src.load({"filepath": traversal_template})
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src.save({"volume": 0.5}, {"filepath": traversal_template})
+            src = get_settings_source("server_json_file")
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src.load({"filepath": traversal_template})
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src.save({"volume": 0.5}, {"filepath": traversal_template})
 
 
 # ---------------------------------------------------------------------------
@@ -359,40 +391,43 @@ class TestServerFileLabelsetSource:
         with pytest.raises(ValueError, match="labels"):
             src.load({"filepath": str(filepath)})
 
-    def test_resolved_template_path_outside_base_dir_rejected(self):
+    def test_resolved_template_path_outside_base_dir_rejected(self, tmp_path):
         """Regression for ``logical-bug-audit.md`` C9.
 
         A template containing ``../`` survives per-value sanitization (because
         the sanitized detector_name has no separators), so the resolved path
         must also be validated against the file-access base directory before
-        any file operation runs.
+        any file operation runs. Confinement is multi-user-only, so force that mode.
         """
         from vtscore.datasets.labelset import LabelSet
         from vtscore.labels.sources import get_labelset_source
         from vtscore.labels.sources.server_json_file import resolve_filepath_for
 
+        user_dir = tmp_path / "alice"
+        user_dir.mkdir()
         traversal_template = "../../../../etc/{detector_name}.labels.json"
 
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            resolve_filepath_for(
-                {"filepath": traversal_template},
-                detector_id="abc",
-                detector_name="evil",
-            )
+        with _multi_user_mode(user_dir):
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                resolve_filepath_for(
+                    {"filepath": traversal_template},
+                    detector_id="abc",
+                    detector_name="evil",
+                )
 
-        src = get_labelset_source("server_json_file")
+            src = get_labelset_source("server_json_file")
 
-        # The base-class normalize also validates when no template
-        # variable is present (so a bare "../" template is rejected too).
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src._normalize({"filepath": "../../../../etc/passwd"})
+            # The base-class normalize also validates when no template
+            # variable is present (so a bare "../" template is rejected too).
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src._normalize({"filepath": "../../../../etc/passwd"})
 
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src.load({"filepath": "../../../../etc/passwd"})
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src.load_full({"filepath": "../../../../etc/passwd"})
-        with pytest.raises(ValueError, match="outside the allowed directory"):
-            src.save(LabelSet([]), {"filepath": "../../../../etc/passwd"})
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src.load({"filepath": "../../../../etc/passwd"})
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src.load_full({"filepath": "../../../../etc/passwd"})
+            with pytest.raises(ValueError, match="outside the allowed directory"):
+                src.save(LabelSet([]), {"filepath": "../../../../etc/passwd"})
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -62,31 +62,12 @@ def resolve_device() -> str:
         return "cpu"
 
 
-def _parse_server_roots(value: str | None) -> tuple[Path, ...]:
-    """Parse ``VTSEARCH_SERVER_ROOTS`` into a tuple of resolved Paths.
-
-    Splits on :data:`os.pathsep` (``:`` on Unix, ``;`` on Windows).  Empty
-    segments are ignored.  When the env var is unset or empty the tuple
-    contains a single entry (``Path.cwd()`` at import time) which
-    reproduces the historical "anything under CWD" behaviour exactly.
-    """
-    if not value:
-        return (Path.cwd().resolve(),)
-    roots: list[Path] = []
-    for segment in value.split(os.pathsep):
-        segment = segment.strip()
-        if segment:
-            roots.append(Path(segment).resolve())
-    return tuple(roots) if roots else (Path.cwd().resolve(),)
-
-
-# Allowed roots for the server file browser and server-path importers/exporters.
-# In single-user mode these define the directories the user is permitted to
-# read from and write to via the API.  The first entry is the default browse
-# root (what ``/api/browse`` shows when no ``path`` parameter is provided).
-# Multi-user mode is unaffected; each user is still confined to their own
-# ``data/<username>/`` subtree regardless of this setting.
-SERVER_ROOTS: tuple[Path, ...] = _parse_server_roots(os.environ.get("VTSEARCH_SERVER_ROOTS"))
+# Server-side file access is governed by the active login provider, not a
+# configurable allow-list.  In single-user / no-auth mode the lone trusted user
+# may read from and write to any server-readable path (server-path importers,
+# exporters, and the file browser are unrestricted).  In multi-user mode each
+# user is confined to their own ``data/<username>/`` subtree.  See
+# :func:`vtscore.security.path_validation.get_file_access_base_dir`.
 
 # Maximum size (in megabytes) accepted for a single HTTP request body.  Wired
 # into Flask's ``MAX_CONTENT_LENGTH`` config in ``app.py``.  ``0`` (the

--- a/vtscore/docs/extending/README.md
+++ b/vtscore/docs/extending/README.md
@@ -113,10 +113,12 @@ one directly when running outside an app context, or call
 
 **Validate filesystem paths at the boundary.** Any plugin that accepts
 a user-supplied server path must run it through
-`vtscore.security.validate_server_filepath` ([`vtscore/security/path_validation.py:35`](../../security/path_validation.py))
-so a malicious path can't escape the configured `SERVER_ROOTS`. When
-splicing a template variable like `{detector_name}` into a path, also
-call `sanitize_template_value` ([`vtscore/security/path_validation.py:82`](../../security/path_validation.py)).
+`vtscore.security.validate_server_filepath` ([`vtscore/security/path_validation.py`](../../security/path_validation.py)),
+passing `base_dir=get_file_access_base_dir()`, so a malicious path can't
+escape the current user's data directory in multi-user mode (single-user
+/ no-auth mode is unrestricted). When splicing a template variable like
+`{detector_name}` into a path, also call `sanitize_template_value`
+([`vtscore/security/path_validation.py`](../../security/path_validation.py)).
 
 **Validate URLs.** Any plugin that makes an outbound HTTP request must
 call `vtscore.security.validate_url` ([`vtscore/security/url_validation.py:30`](../../security/url_validation.py))

--- a/vtscore/docs/extending/labelset-sources.md
+++ b/vtscore/docs/extending/labelset-sources.md
@@ -112,9 +112,11 @@ filepath = filepath.replace("{detector_name}", sanitize_template_value(name))
 ```
 
 When resolving paths in `load()` / `save()`, also call
-`validate_server_filepath(filepath)` so the final resolved path stays
-inside `SERVER_ROOTS`. The built-in server-JSON source's
-`resolve_filepath_for()` helper is a useful pattern to copy.
+`validate_server_filepath(filepath, base_dir=get_file_access_base_dir())`
+so the final resolved path stays inside the current user's data directory
+in multi-user mode (single-user / no-auth mode is unrestricted). The
+built-in server-JSON source's `resolve_filepath_for()` helper is a useful
+pattern to copy.
 
 ## Circular-trigger prevention (`_syncing` guard)
 

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -122,22 +122,27 @@ The interpolation helper lives at
 substitution to a user-supplied path string. Don't roll your own
 regex - `resolve_export_filepath` also sanitises substituted values
 via `sanitize_template_value` so a malicious `{detector_name}`
-containing `../` can't escape the configured `SERVER_ROOTS`.
+containing `../` can't escape the per-user data directory in
+multi-user mode.
 
 ## Server-path and URL validation
 
 Any exporter that accepts a file path **must** validate it through
 `vtscore.security.validate_server_filepath`
-([`vtscore/security/path_validation.py:35`](../../security/path_validation.py)).
-This refuses paths that resolve outside the configured
-`SERVER_ROOTS` (defaulting to the process CWD, overridable via
-`VTSEARCH_SERVER_ROOTS`):
+([`vtscore/security/path_validation.py`](../../security/path_validation.py)),
+passing the active base dir from `get_file_access_base_dir()`. In
+multi-user mode this confines the path to the current user's data
+directory; in single-user / no-auth mode the base dir is `None` and the
+path is unrestricted:
 
 ```python
-from vtscore.security.path_validation import validate_server_filepath
+from vtscore.security.path_validation import (
+    get_file_access_base_dir,
+    validate_server_filepath,
+)
 
-path = validate_server_filepath(field_values["filepath"])
-# Raises ValueError if outside SERVER_ROOTS - let it propagate.
+path = validate_server_filepath(field_values["filepath"], base_dir=get_file_access_base_dir())
+# Raises ValueError if it escapes the user's data dir (multi-user) - let it propagate.
 ```
 
 Any exporter that makes an outbound HTTP request **must** validate

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -173,27 +173,20 @@ at all. When `DEVICE` is anything other than `"auto"`, the env var's
 value is returned unchanged - this is how you pin to `"cuda:1"` or
 `"mps"` for a specific run.
 
-## Server-path roots
+## Server-path access
 
-```python
-SERVER_ROOTS: tuple[Path, ...]
-```
+There is no configurable server-root allow-list. Server-side filesystem
+access (importers, exporters, the file browser) is governed entirely by
+the active login provider:
 
-Allowed roots for server-side filesystem importers, exporters, and the
-file browser. Parsed from `VTSEARCH_SERVER_ROOTS` (PATH-separated:
-`:` on Unix, `;` on Windows). When unset, defaults to a single-element
-tuple `(Path.cwd().resolve(),)`, which reproduces the historical
-"anything under the launch directory" behaviour.
+- **Single-user / no-auth mode** (`DefaultLoginProvider`): unrestricted.
+  The lone trusted user may read from and write to any server-readable
+  path, and the file browser is rooted at the filesystem root (`/`).
+- **Multi-user mode** (any non-default provider): each user is confined
+  to their own `<get_user_data_dir(user)>/...` subtree.
 
-```bash
-# Restrict to two specific roots:
-export VTSEARCH_SERVER_ROOTS=/srv/data:/srv/imports
-```
-
-The first entry is what `/api/browse` shows when no `path` parameter
-is provided. Multi-user mode is unaffected - each user is still
-confined to their own `<get_user_data_dir(user)>/...` subtree
-regardless of this setting.
+See `vtscore.security.path_validation.get_file_access_base_dir` and
+`validate_server_filepath`.
 
 ## Embedder model identifiers
 
@@ -239,7 +232,6 @@ Every env var consulted by `vtscore.config`, in one place:
 | `VTSEARCH_MODELS_DIR`       | Override `MODELS_CACHE_DIR`. Independent of `VTSEARCH_DATA_DIR`.                                |
 | `VTSEARCH_TORCH_THREADS`    | Set `TORCH_THREADS` (and therefore OMP / MKL caps). Floor of 1.                                 |
 | `VTSEARCH_DEVICE`           | Set `DEVICE`. `"auto"` is the default; pin to `"cuda"`, `"cuda:0"`, `"cpu"`, or `"mps"`.        |
-| `VTSEARCH_SERVER_ROOTS`     | PATH-separated list of allowed roots for server-path importers/exporters.                       |
 | `VTSEARCH_MAX_UPLOAD_MB`    | Set `MAX_UPLOAD_MB`. `0` = unlimited.                                                           |
 | `VTSEARCH_TRAIN_EPOCHS`     | Set `TRAIN_EPOCHS` (MLP training upper bound).                                                  |
 | `VTSEARCH_TRAIN_PATIENCE`   | Set `TRAIN_PATIENCE` (early-stop patience). `0` disables.                                       |

--- a/vtscore/docs/packages/security.md
+++ b/vtscore/docs/packages/security.md
@@ -29,21 +29,21 @@ form.
 
 | Function | Description |
 |----------|-------------|
-| `get_file_access_base_dir() -> Path \| None` | Resolve the per-user base directory; `None` in single-user mode |
-| `validate_server_filepath(filepath_str, base_dir=None) -> Path` | Resolve and assert containment; raises on escape |
+| `get_file_access_base_dir() -> Path \| None` | Resolve the per-user base directory; `None` (unrestricted) in single-user mode |
+| `validate_server_filepath(filepath_str, base_dir=None) -> Path` | Resolve and (when `base_dir` is given) assert containment; raises on escape |
 | `sanitize_template_value(value) -> str` | Replace path separators / `..` tokens with `_` |
 | `rglob_follow_symlinks(root, pattern) -> list[Path]` | `Path.rglob`-equivalent that descends into symlinked directories |
 | `glob_top_level(root, pattern) -> list[Path]` | Non-recursive variant; direct children of `root` only |
 
 ### `get_file_access_base_dir()`
 
-In single-user mode (`DefaultLoginProvider`) it returns `None`, which
-causes `validate_server_filepath` to fall back to
-`vtscore.config.SERVER_ROOTS[0]` - typically `Path.cwd()`, configurable
-via `VTSEARCH_SERVER_ROOTS`. In multi-user mode it returns the current
-user's data directory so each user is confined to their own
-`data/<username>/` subtree. This is the only function in the package
-that imports `vtsearch.auth`.
+In single-user / no-auth mode (`DefaultLoginProvider`) it returns `None`,
+which tells `validate_server_filepath` to apply **no** confinement: the
+lone trusted user may read from and write to any server-readable path.
+There is no per-user boundary to protect, so the app does not impose one.
+In multi-user mode it returns the current user's data directory so each
+user is confined to their own `data/<username>/` subtree. This is the only
+function in the package that imports `vtsearch.auth`.
 
 ### `validate_server_filepath(filepath_str, base_dir=None)`
 
@@ -54,12 +54,16 @@ resolved = validate_server_filepath(user_supplied_path, get_file_access_base_dir
 # resolved is the canonical Path; reading from it is safe
 ```
 
-Contract: relative paths resolve against `base_dir`, absolute are used
-as-is, `Path.resolve()` is called (follows symlinks, normalises `..`),
-and `resolved.relative_to(base_resolved)` is checked - if it raises
+Contract: when `base_dir` is `None` (the single-user / no-auth case) the
+path is **unrestricted** - relative paths resolve against the process CWD,
+absolute paths are used as-is, and the canonical `Path.resolve()` is
+returned with no containment check. When `base_dir` is a path (multi-user)
+relative paths resolve against it, absolute are used as-is, `Path.resolve()`
+is called (follows symlinks, normalises `..`), and
+`resolved.relative_to(base_resolved)` is checked - if it raises
 `ValueError`, the path escaped and we re-raise. Symlinks are followed
-during resolution, so a symlinked file inside `base_dir` whose target
-is outside is rejected.
+during resolution, so a symlinked file inside `base_dir` whose target is
+outside is rejected.
 
 ### `sanitize_template_value(value)`
 

--- a/vtscore/security/path_validation.py
+++ b/vtscore/security/path_validation.py
@@ -16,11 +16,11 @@ from typing import Iterator
 def get_file_access_base_dir() -> Path | None:
     """Return the base directory for file-access validation.
 
-    In single-user mode (:class:`~vtsearch.auth.DefaultLoginProvider`) this
-    returns ``None``, which causes :func:`validate_server_filepath` to confine
-    paths to :data:`vtscore.config.SERVER_ROOTS` (just ``Path.cwd()`` unless the
-    operator widens it via ``VTSEARCH_SERVER_ROOTS``).  ``None`` does *not* mean
-    "unrestricted" -- it means "use the configured server roots".
+    In single-user / no-auth mode (:class:`~vtsearch.auth.DefaultLoginProvider`)
+    this returns ``None``, which tells :func:`validate_server_filepath` to apply
+    **no** confinement: the lone trusted user may read from and write to any
+    server-readable path.  There is no per-user boundary to protect, so the app
+    does not impose one.
 
     In multi-user mode (any non-default provider) this returns the current
     user's data directory so that each user is confined to their own
@@ -30,23 +30,24 @@ def get_file_access_base_dir() -> Path | None:
 
     provider = get_login_provider()
     if isinstance(provider, DefaultLoginProvider):
-        return None  # single-user: confine to the configured SERVER_ROOTS
+        return None  # single-user / no-auth: unrestricted file access
     return get_user_data_dir()
 
 
 def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) -> Path:
-    """Validate that *filepath_str* resolves within an allowed root.
+    """Resolve *filepath_str*, optionally asserting it stays within *base_dir*.
 
     Parameters
     ----------
     filepath_str:
         User-supplied file path (absolute or relative).
     base_dir:
-        A single directory the resolved path must reside in.  When given
-        (e.g. the per-user data dir in multi-user mode) it is the only
-        allowed root.  When ``None`` the allowed roots are
-        :data:`vtscore.config.SERVER_ROOTS` (every entry is accepted), which
-        default to ``(Path.cwd(),)`` unless ``VTSEARCH_SERVER_ROOTS`` is set.
+        The single directory the resolved path must reside in.  When ``None``
+        (the single-user / no-auth case; see :func:`get_file_access_base_dir`)
+        the path is **unrestricted**: it is resolved (relative paths against the
+        process CWD) and returned without any containment check.  When a path is
+        given (the per-user data dir in multi-user mode) it is the only allowed
+        root and an escape raises.
 
     Returns
     -------
@@ -56,35 +57,29 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
     Raises
     ------
     ValueError
-        If the resolved path is outside every allowed root.
+        If *base_dir* is given and the resolved path escapes it.
     """
-    if base_dir is not None:
-        roots: tuple[Path, ...] = (base_dir,)
-    else:
-        from vtscore.config import SERVER_ROOTS  # noqa: PLC0415
-
-        roots = SERVER_ROOTS
-
     path = Path(filepath_str)
 
-    # Resolve relative paths against the primary root, absolute paths as-is.
+    if base_dir is None:
+        # Single-user / no-auth mode: every server-readable path is allowed.
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        return path.resolve()
+
+    # Multi-user: confine to base_dir.  Resolve relative paths against it.
     if not path.is_absolute():
-        path = roots[0] / path
+        path = base_dir / path
 
     resolved = path.resolve()
-    for root in roots:
-        try:
-            resolved.relative_to(root.resolve())
-            return resolved
-        except ValueError:
-            continue
-
-    allowed = ", ".join(f"'{r.resolve()}'" for r in roots)
-    raise ValueError(
-        f"The given path resolves outside the allowed directory. Paths must be within {allowed}. "
-        f"To import media from another location, set the VTSEARCH_SERVER_ROOTS environment variable "
-        f"(os.pathsep-separated) to include it."
-    )
+    try:
+        resolved.relative_to(base_dir.resolve())
+    except ValueError:
+        raise ValueError(
+            f"The given path resolves outside the allowed directory. "
+            f"Paths must be within '{base_dir.resolve()}'."
+        ) from None
+    return resolved
 
 
 def sanitize_template_value(value: str) -> str:

--- a/vtscore/security/path_validation.py
+++ b/vtscore/security/path_validation.py
@@ -76,8 +76,7 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
         resolved.relative_to(base_dir.resolve())
     except ValueError:
         raise ValueError(
-            f"The given path resolves outside the allowed directory. "
-            f"Paths must be within '{base_dir.resolve()}'."
+            f"The given path resolves outside the allowed directory. Paths must be within '{base_dir.resolve()}'."
         ) from None
     return resolved
 

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -285,13 +285,10 @@ def _resolve_browse_root(source: str) -> Path | None:
 
         base = get_file_access_base_dir()
         if base is None:
-            # Single-user mode: confine the picker to the configured server
-            # root rather than the filesystem root, so browsing/detection
-            # reject out-of-root folders the same way the importer does on
-            # load. SERVER_ROOTS[0] is the primary root, matching /api/browse.
-            from vtscore.config import SERVER_ROOTS  # noqa: PLC0415
-
-            return SERVER_ROOTS[0]
+            # Single-user / no-auth mode: root the picker at the filesystem
+            # root so the user can browse to any folder, matching the
+            # unrestricted server_folder import validation.
+            return Path("/")
         return base.resolve()
 
     return None
@@ -300,11 +297,10 @@ def _resolve_browse_root(source: str) -> Path | None:
 def _default_browse_path() -> str:
     """Initial relative sub-path the browse picker opens at.
 
-    Always the root itself (``""``). Every browse source now resolves to a
-    meaningful directory (a demo folder, the saved-datasets dir, or the
-    configured server root), so there is nothing to skip past; the old
-    ``server_fs`` home-directory shortcut only existed to save clicks when
-    the picker was rooted at the filesystem root ``/``.
+    Always the root itself (``""``). Every browse source resolves to a
+    meaningful directory (a demo folder, the saved-datasets dir, the user's
+    data dir in multi-user mode, or the filesystem root in single-user mode),
+    so there is nothing to skip past.
     """
     return ""
 

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -40,16 +40,14 @@ file_browser_bp = Blueprint(
 def _get_browse_root() -> Path:
     """Return the root directory users are allowed to browse.
 
-    In single-user mode this is the first entry of
-    :data:`vtscore.config.SERVER_ROOTS` (which defaults to
-    ``Path.cwd()`` when the env var is unset).  In multi-user mode it is
-    the current user's data directory.
+    In single-user / no-auth mode this is the filesystem root (``/``) so the
+    lone trusted user can navigate to any folder on the server, matching the
+    unrestricted server-path import validation.  In multi-user mode it is the
+    current user's data directory, confining the browser to that subtree.
     """
     base = _paths.get_file_access_base_dir()
     if base is None:
-        from vtscore.config import SERVER_ROOTS  # noqa: PLC0415
-
-        return SERVER_ROOTS[0]
+        return Path("/")
     return base
 
 


### PR DESCRIPTION
## What

When authentication mode is "none" (`DefaultLoginProvider` / single-user), server-path importers, exporters, and the file browser no longer confine paths to the install directory. The lone trusted user may ingest from — and write to — any server-readable path. There's no per-user boundary to protect in this mode, so the app stops imposing one.

Previously, single-user mode confined paths to `SERVER_ROOTS` (defaulting to the process CWD), so importing a folder from anywhere else required setting `VTSEARCH_SERVER_ROOTS`. Now you can just point the importer (or the Browse picker) at any folder.

**Multi-user mode is unchanged**: each user is still confined to their own `data/<username>/` subtree.

## How

- `validate_server_filepath(path, base_dir=None)` now treats `None` as **unrestricted** (resolve relative paths against CWD, return without a containment check) instead of confining to `SERVER_ROOTS`. A non-`None` `base_dir` (multi-user) still enforces confinement and raises on escape.
- `get_file_access_base_dir()` returns `None` in single-user mode (now meaning "unrestricted") and the per-user data dir in multi-user mode — unchanged signature, updated semantics/docstring.
- The file browser (`/api/browse`) and the `server_fs` browse/detect source are rooted at `/` in single-user mode so the picker can reach any folder; in multi-user mode they stay rooted at the user's data dir.
- **Removed** `SERVER_ROOTS` and the `VTSEARCH_SERVER_ROOTS` env var — they were only ever a single-user concept and are now vestigial (multi-user never used them).

## Tests & docs

- Rewrote the path-traversal / confinement tests to run under a multi-user login provider (where the boundary still lives); rewrote the `server_fs` browse/detect tests to assert the new unrestricted single-user behavior; updated `test_path_validation.py` for the unrestricted `base_dir=None` contract.
- Removed now-needless `_permissive_server_roots` monkeypatch fixtures.
- Updated `vtscore`/app docs and the `server-import-ux.md` plan status note to reflect the reversal.
- Verified the frontend builds clean (no TS errors, no budget warnings).

## Backwards compatibility (breaking)

`SERVER_ROOTS` / `VTSEARCH_SERVER_ROOTS` are gone, and single-user mode no longer rejects out-of-tree paths. Operators who relied on `VTSEARCH_SERVER_ROOTS` to lock down a single-user deployment will need to switch to a multi-user login provider for confinement.

## Test status

Targeted groups pass. Remaining failures in this container are pre-existing and environmental (verified identical on `dev`): MLP-training tests trip a torch `getpass.getuser()`/`getpwuid` lookup because the container runs as uid 0 with no passwd entry; the frontend-bundle dashboard tests pass once `static/` is built.

https://claude.ai/code/session_017MQKjktbSoJ7T2Sr21TnoW

---
_Generated by [Claude Code](https://claude.ai/code/session_017MQKjktbSoJ7T2Sr21TnoW)_