### PR TITLE
Render GUI at 110% via root zoom

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -14,6 +14,13 @@ html, body {
   margin: 0;
   padding: 0;
   height: 100%;
+  // Render the whole app at 110%, exactly as if the user had hit Ctrl/Cmd-"+".
+  // `zoom` scales everything uniformly (fonts, px paddings/borders, images,
+  // canvases, layout), so it matches real browser zoom without having to touch
+  // the hundreds of px-pinned values across components. Desktop-only app, and
+  // `zoom` is supported in all current desktop browsers (Chrome, Firefox 126+,
+  // Safari 18+), so no fallback is needed.
+  zoom: 1.1;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--bg-body);
   color: var(--text-primary);


### PR DESCRIPTION
## What

Adds `zoom: 1.1` to the root `html, body` rule in `frontend/src/styles.scss` so the entire app renders at 110% — the same look you get by hitting Ctrl/Cmd-`+` in the browser, but baked in.

## Why this approach

`zoom` scales **everything** uniformly (fonts, px paddings/borders, images, canvases, layout), exactly like browser zoom. This avoids the alternative of bumping the root `font-size`, which would only scale the rem/em-based values and leave the ~494 px-pinned values across components fixed — producing an uneven look and forcing edits across many files. The `zoom` approach is a single declaration and touches no component styles.

`zoom` is supported in all current desktop browsers (Chrome, Firefox 126+, Safari 18+), and VTSearch is desktop-only, so no fallback is needed.

## Testing

- `./run-tests.sh core` — all 693 tests pass, including the frontend production build.
- Worth a manual smoke-test of the crop/canvas tools (media-crop-modal, audio/image crop overlays) since those convert mouse events to element coordinates; modern browsers handle `zoom` correctly here but it's the one area to eyeball.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jBaENoeo6XV7RQ1ULn2Wb)_