### PR TITLE
Browse a Find run's positives as their own UMAP projection

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -793,6 +793,23 @@ and available to any future consumer of `vtscore`.
 
 ## Open follow-ups
 
+**Shipped:**
+- **Browse a Find run's positives as their own UMAP.** The Find right panel has
+  a `Browse` button next to `Export` (find mode only, disabled when the good
+  list is empty). It UMAPs *only* the positive items' high-d vectors — not the
+  whole-dataset layout filtered to the subset — into a fresh, ephemeral
+  projection. Backend: `POST /api/projection/build` takes an optional `ids`
+  list; the result lives in `_subset_*` slots on `DatasetContext` and is
+  **never persisted**; `meta`/`tiles` take `?subset=1` to serve it alongside
+  the full projection. Frontend: `BrowseSubsetService` hands the positive ids
+  (the current "good" list) from the Find view to the Browse view, which
+  threads subset mode through build/meta/tiles.
+  - *Known limitation:* the id handoff is in-memory, so a hard reload of
+    `/browse/:datasetId?subset=1` loses the subset and shows a "re-run Find"
+    message (the ephemeral projection would have to be recomputed anyway). If
+    reload-survival is wanted, persist the subset id list against a token in
+    the URL and rebuild from it on load.
+
 **Active:**
 - **Dataset pickle size — drop inline `media_bytes` when the media is reachable
   on disk.** The dataset container still bakes a full copy of every audio/image/

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -103,7 +103,7 @@
       </div>
       <div class="browse-info">
         <span class="browse-info-label">{{ datasetName }}</span>
-        <span class="browse-info-count">{{ meta?.point_count | number }} items</span>
+        <span class="browse-info-count">{{ meta?.point_count | number }} {{ countNoun }}</span>
       </div>
       @if (minimapVisible) {
         <vt-browse-minimap

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
@@ -19,6 +20,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
+import { BrowseSubsetService } from '../../services/browse-subset.service';
 import type { BinShape, ProjectionMeta } from '../../models/projection.models';
 
 @Component({
@@ -67,6 +69,16 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   binShape: BinShape = 'hex';
 
+  /**
+   * Subset mode: browse an ephemeral UMAP fit over just a handful of media
+   * (the positives of a Find run) instead of the full dataset. Set from the
+   * `?subset=1` query param plus a handoff from {@link BrowseSubsetService}.
+   * `subsetIds` is kept on the component so re-resolving the projection (e.g.
+   * a bin-shape switch) re-sends the same ids without a fresh handoff.
+   */
+  subset = false;
+  subsetIds: number[] = [];
+
   /** Overview minimap show/hide + size, mirrored from the settings set. */
   minimapVisible = true;
   minimapWidth = 200;
@@ -91,6 +103,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private activeContext: ActiveContextService,
     private datasetsRegistryApi: DatasetsRegistryApiService,
     private settingsState: SettingsStateService,
+    private route: ActivatedRoute,
+    private browseSubset: BrowseSubsetService,
   ) {}
 
   ngOnInit(): void {
@@ -115,6 +129,25 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       if (shape !== this.binShape) this.switchBinShape(shape, false);
     });
     this.settingsState.load();
+
+    // Subset mode: the Find view handed off a set of positive ids to project
+    // on their own. Detect it from the query param + the in-memory handoff.
+    this.subset = this.route.snapshot.queryParamMap.get('subset') === '1';
+    if (this.subset) {
+      const handoff = this.browseSubset.take();
+      if (handoff && handoff.ids.length > 0) {
+        this.subsetIds = handoff.ids;
+        this.datasetName = handoff.label;
+      } else {
+        // No handoff (e.g. a hard reload): the ephemeral subset is gone.
+        this.status = 'error';
+        this.errorMessage =
+          'This subset projection has expired. Re-run Find and click Browse to rebuild it.';
+        this.tileCache.setBinShape(this.binShape);
+        return;
+      }
+    }
+    this.tileCache.setSubset(this.subset);
     this.tileCache.setBinShape(this.binShape);
 
     this.datasetsRegistryApi
@@ -122,18 +155,23 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (status) => {
-          this.datasetName = status.display_name || '';
+          if (!this.subset) this.datasetName = status.display_name || '';
           this.mediaType = status.media_type || '';
         },
       });
 
     this.loadProjection();
 
-    this.activeContext.pair$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.loadProjection();
-      });
+    // The full-dataset projection re-resolves when the active pair changes via
+    // the top bar. A subset projection is tied to the ids that produced it, so
+    // ignore pair changes in subset mode.
+    if (!this.subset) {
+      this.activeContext.pair$
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.loadProjection();
+        });
+    }
   }
 
   ngOnDestroy(): void {
@@ -149,6 +187,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   get hexDisplayScale(): number {
     return this.HEX_SCALES[this.hexScaleIndex];
+  }
+
+  /** Noun for the item-count chip — "positives" for a Find-subset browse. */
+  get countNoun(): string {
+    return this.subset ? 'positives' : 'items';
   }
 
   get atMinHexSize(): boolean {
@@ -216,14 +259,13 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * reused, so the build call returns ready after a quick re-bin.
    */
   private ensureShape(): void {
-    this.projectionApi
-      .build(this.binShape)
+    this.buildRequest()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (resp) => {
           if (resp.status === 'ready') {
             this.projectionApi
-              .getMeta(this.binShape)
+              .getMeta(this.binShape, this.subset)
               .pipe(takeUntil(this.destroy$))
               .subscribe({
                 next: (meta) => this.applyMeta(meta),
@@ -256,13 +298,30 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.canvas?.zoomBy(1 / this.ZOOM_BUTTON_FACTOR);
   }
 
+  /**
+   * Issue the right build request for the current mode: a subset build (UMAP
+   * over just the handed-off ids) when in subset mode, else the full-dataset
+   * build.
+   */
+  private buildRequest() {
+    return this.subset
+      ? this.projectionApi.buildSubset(this.binShape, this.subsetIds)
+      : this.projectionApi.build(this.binShape);
+  }
+
   onBuild(): void {
+    if (this.subset && this.subsetIds.length === 0) {
+      // Nothing to rebuild (e.g. Retry after the handoff expired).
+      this.status = 'error';
+      this.errorMessage =
+        'This subset projection has expired. Re-run Find and click Browse to rebuild it.';
+      return;
+    }
     this.status = 'building';
     this.buildProgress = 0;
     this.buildTotal = 0;
     this.buildMessage = '';
-    this.projectionApi
-      .build(this.binShape)
+    this.buildRequest()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (resp) => {
@@ -285,7 +344,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.status = 'loading';
     this.polling = false;
     this.projectionApi
-      .getMeta(this.binShape)
+      .getMeta(this.binShape, this.subset)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (meta) => this.applyMeta(meta),
@@ -337,7 +396,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.pollErrors = 0;
     const poll = (): void => {
       this.projectionApi
-        .getMeta(this.binShape)
+        .getMeta(this.binShape, this.subset)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (meta) => {

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -69,6 +69,7 @@
       mode="find"
       (mediaSelected)="onMediaSelect($event)"
       (mediaVoted)="onHoverVote($event)"
+      (browse)="onBrowse()"
     />
   </div>
 </div>

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
 import { finalize, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
@@ -16,6 +17,7 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
+import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { ProgressEvent } from '../../models/api.models';
 import { formatProgressMessage } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
@@ -70,6 +72,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     public sortState: SortStateService,
     private settingsState: SettingsStateService,
     private progressEvents: ProgressEventsService,
+    private browseSubset: BrowseSubsetService,
+    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -389,6 +393,28 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // vote state has already been reconciled from the POST response inside
     // submitToggleVote, so a follow-up GET /api/votes only refreshes counts.
     this.voteState.loadVotes();
+  }
+
+  /**
+   * Browse the positive results of this Find run as their own UMAP projection.
+   * The positives are the current "good" list (the above-threshold items plus
+   * any manual corrections). We stash the ids for the browse view and navigate
+   * to `/browse/:datasetId?subset=1`, where they're UMAP'd on their own.
+   */
+  onBrowse(): void {
+    const datasetId = this.activeContext.datasetId;
+    if (!datasetId) return;
+    const ids = Array.from(this.voteState.goodVotes);
+    if (ids.length === 0) return;
+    const modelId = this.activeContext.modelId;
+    const detectorName =
+      this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
+    this.browseSubset.set({
+      datasetId,
+      ids,
+      label: `${detectorName} — positives`,
+    });
+    this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
   }
 
   /** Cancel the find-label scoring run; the HTTP request will surface

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -85,6 +85,9 @@
 
   <div class="export-row">
     <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" title="Export labeled items to clipboard, file, email, or webhook">Export</button>
+    @if (mode === 'find') {
+      <button class="panel-btn browse-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" title="Browse the positive results as their own 2-D UMAP projection (builds on click)">Browse</button>
+    }
   </div>
 </aside>
 

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -89,3 +89,8 @@
   flex: 1;
   text-align: center;
 }
+
+.browse-btn {
+  flex: 1;
+  text-align: center;
+}

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -56,6 +56,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Input() disabled = false;
   @Output() mediaSelected = new EventEmitter<number>();
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  /** Find mode: browse the positive results as their own UMAP projection. */
+  @Output() browse = new EventEmitter<void>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
@@ -158,6 +160,10 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   onExport(): void {
     this.showExport = true;
+  }
+
+  onBrowse(): void {
+    this.browse.emit();
   }
 
   onDetectorRenamed(newName: string): void {

--- a/frontend/src/app/services/browse-subset.service.ts
+++ b/frontend/src/app/services/browse-subset.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+
+/** A subset of media ids to browse as its own UMAP projection. */
+export interface BrowseSubset {
+  /** Dataset the ids belong to (guards against a stale handoff). */
+  datasetId: string;
+  /** Media ids to project (e.g. the positives of a Find run). */
+  ids: number[];
+  /** Human label for the browse header, e.g. the detector name. */
+  label: string;
+}
+
+/**
+ * Carries the subset selection from the Find view to the Browse view across a
+ * route navigation. The Find view stashes the positive ids here and navigates
+ * to `/browse/:datasetId?subset=1`; the Browse view reads them back on init.
+ *
+ * In-memory only: a hard reload of the browse page loses the handoff (the
+ * subset projection is ephemeral and recomputed on demand anyway), and the
+ * browse view shows a "re-run Find" message in that case.
+ */
+@Injectable({ providedIn: 'root' })
+export class BrowseSubsetService {
+  private pending: BrowseSubset | null = null;
+
+  set(subset: BrowseSubset): void {
+    this.pending = subset;
+  }
+
+  /** Read and clear the pending subset (single-shot handoff). */
+  take(): BrowseSubset | null {
+    const s = this.pending;
+    this.pending = null;
+    return s;
+  }
+}

--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -13,14 +13,20 @@ import type {
 export class ProjectionApiService {
   private http = inject(HttpClient);
 
-  getMeta(shape: BinShape): Observable<ProjectionMeta> {
+  getMeta(shape: BinShape, subset = false): Observable<ProjectionMeta> {
     // The browse view polls this to discover whether a projection exists
     // yet for the requested bin shape. A not-loaded / not-built dataset
     // answers 404/409, which the caller handles inline (→ "empty"/Build
     // affordance). Suppress the global error toast so that expected state
     // doesn't alarm the user.
+    //
+    // `subset=true` targets the ephemeral UMAP fit over a subset of the
+    // dataset's media (e.g. the positives of a Find run) rather than the
+    // full-dataset projection.
+    const params: Record<string, string> = { shape };
+    if (subset) params['subset'] = '1';
     return this.http.get<ProjectionMeta>('/api/projection/meta', {
-      params: { shape },
+      params,
       context: new HttpContext().set(SKIP_ERROR_TOAST, true),
     });
   }
@@ -29,10 +35,29 @@ export class ProjectionApiService {
     return this.http.post<ProjectionBuildResponse>('/api/projection/build', { shape });
   }
 
-  getTile(shape: BinShape, level: number, tx: number, ty: number): Observable<TilePayload> {
+  /**
+   * Build an ephemeral subset projection: UMAP the high-d vectors of just
+   * `ids` (e.g. the positives of a Find run) to 2-D. Returns immediately with
+   * a job id while the fit runs in the background; poll `getMeta(shape, true)`.
+   */
+  buildSubset(shape: BinShape, ids: number[]): Observable<ProjectionBuildResponse> {
+    return this.http.post<ProjectionBuildResponse>('/api/projection/build', { shape, ids });
+  }
+
+  getTile(
+    shape: BinShape,
+    level: number,
+    tx: number,
+    ty: number,
+    subset = false,
+  ): Observable<TilePayload> {
     // The backend resolves the pyramid from the active dataset context, so the
     // tile URL is keyed by (shape, level, tx, ty); the projection id is tracked
     // client-side (TileCacheService) for cache invalidation, not in the path.
-    return this.http.get<TilePayload>(`/api/projection/tiles/${shape}/${level}/${tx}/${ty}`);
+    const url = `/api/projection/tiles/${shape}/${level}/${tx}/${ty}`;
+    if (subset) {
+      return this.http.get<TilePayload>(url, { params: { subset: '1' } });
+    }
+    return this.http.get<TilePayload>(url);
   }
 }

--- a/frontend/src/app/services/tile-cache.service.ts
+++ b/frontend/src/app/services/tile-cache.service.ts
@@ -21,6 +21,10 @@ export class TileCacheService {
   // the cache key, so switching shapes keeps both binnings cached side by side
   // (they share one projection id, so the id alone can't tell them apart).
   private binShape: BinShape = 'hex';
+  // Whether tiles are fetched from the ephemeral subset projection (the
+  // positives of a Find run) rather than the full-dataset projection. The two
+  // have distinct projection ids, so the cache invalidates on switch.
+  private subset = false;
 
   readonly tileLoaded$ = new Subject<TilePayload>();
 
@@ -34,6 +38,10 @@ export class TileCacheService {
 
   setBinShape(shape: BinShape): void {
     this.binShape = shape;
+  }
+
+  setSubset(subset: boolean): void {
+    this.subset = subset;
   }
 
   getTile(level: number, tx: number, ty: number): Observable<TilePayload> | null {
@@ -50,7 +58,7 @@ export class TileCacheService {
 
     if (!this.projectionId) return null;
 
-    const req$ = this.projectionApi.getTile(this.binShape, level, tx, ty).pipe(
+    const req$ = this.projectionApi.getTile(this.binShape, level, tx, ty, this.subset).pipe(
       tap((tile) => {
         this.inflight.delete(key);
         this.put(key, tile);

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -361,3 +361,88 @@ class TestBinShapeToggle:
         assert sq_loaded is not None
         assert hex_loaded[1].bin_shape == "hex"
         assert sq_loaded[1].bin_shape == "square"
+
+
+class TestProjectionSubset:
+    """Subset projection: UMAP a handful of ids (the positives of a Find run).
+
+    Driven by ``POST /api/projection/build`` with an ``ids`` body and the
+    ``?subset=1`` selector on ``meta``/``tiles``.  The subset layout is
+    ephemeral (never persisted) and lives alongside the full projection.
+    """
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_subset_build_and_poll(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:4]
+
+        resp = client.post("/api/projection/build", json={"ids": ids})
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] in ("building", "ready")
+        _wait_projection()
+
+        meta = client.get("/api/projection/meta?subset=1").get_json()
+        assert meta["status"] == "ready"
+        assert meta["point_count"] == len(ids)
+        assert ctx._subset_projection is not None
+        assert ctx._subset_ids == ids
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_subset_does_not_clobber_full(self, _mock_fit, client):
+        """A full build and a subset build coexist in separate slots."""
+        ctx = get_active_context()
+        client.post("/api/projection/build")
+        _wait_projection()
+        full_proj = ctx._projection
+        assert full_proj is not None
+
+        ids = sorted(ctx.medias.keys())[:3]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+
+        # Full projection is untouched; subset is its own (smaller) layout.
+        assert ctx._projection is full_proj
+        assert ctx._subset_projection is not None
+        assert ctx._subset_projection is not full_proj
+        assert len(ctx._subset_projection.ids) == len(ids)
+
+        # Full meta still reports the full point count, not the subset's.
+        full_meta = client.get("/api/projection/meta").get_json()
+        assert full_meta["status"] == "ready"
+        assert full_meta["point_count"] == len(ctx.medias)
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_subset_tiles_served_with_flag(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:4]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+
+        pyr = ctx._subset_pyramids["hex"]
+        for level, tx, ty in pyr.tiles:
+            resp = client.get(f"/api/projection/tiles/hex/{level}/{tx}/{ty}?subset=1")
+            assert resp.status_code == 200
+            assert resp.get_json()["level"] == level
+            break
+        # Without the subset flag the full pyramid isn't built, so 404.
+        assert client.get("/api/projection/tiles/hex/0/0/0").status_code == 404
+
+    def test_subset_empty_ids_returns_409(self, client):
+        resp = client.post("/api/projection/build", json={"ids": []})
+        assert resp.status_code == 409
+
+    def test_subset_bad_ids_returns_400(self, client):
+        assert client.post("/api/projection/build", json={"ids": "nope"}).status_code == 400
+        assert client.post("/api/projection/build", json={"ids": ["a", "b"]}).status_code == 400
+
+    def test_subset_unknown_ids_returns_409(self, client):
+        """Ids that aren't in the dataset yield nothing to project."""
+        resp = client.post("/api/projection/build", json={"ids": [999990, 999991]})
+        assert resp.status_code == 409
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_subset_meta_idle_without_build(self, _mock_fit, client):
+        """Subset meta is idle until a subset build runs (even if full is ready)."""
+        client.post("/api/projection/build")
+        _wait_projection()
+        assert client.get("/api/projection/meta?subset=1").get_json()["status"] == "idle"

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -88,7 +88,7 @@ class TestProjectionBuild:
         finally:
             ctx.medias.update(saved)
 
-    @patch("vtscore.projection.umap_projection.fit_projection", side_effect=_fake_fit_projection)
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_build_and_poll(self, _mock_fit, client):
         resp = client.post("/api/projection/build")
         assert resp.status_code == 200
@@ -180,7 +180,7 @@ class TestProjectionPersistence:
                 return_value=str(fake_pkl),
             ),
             patch(
-                "vtscore.projection.umap_projection.fit_projection",
+                "vtscore.projection.fit_projection",
                 side_effect=_fake_fit_projection,
             ),
         ):
@@ -193,7 +193,7 @@ class TestProjectionPersistence:
             assert ctx._pyramids.get("hex") is not None
             assert ctx._pyramids["hex"].projection_id != "stale-pid"
 
-    @patch("vtscore.projection.umap_projection.fit_projection", side_effect=_fake_fit_projection)
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_build_persists_to_container(self, _mock_fit, client, tmp_path):
         """After a fresh build, the projection is persisted into the container."""
         import pickle as _pickle
@@ -335,7 +335,7 @@ class TestBinShapeToggle:
         assert client.get("/api/projection/tiles/triangle/0/0/0").status_code == 400
         assert client.post("/api/projection/build", json={"shape": "triangle"}).status_code == 400
 
-    @patch("vtscore.projection.umap_projection.fit_projection", side_effect=_fake_fit_projection)
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_square_persisted_alongside_hex(self, _mock_fit, client, tmp_path):
         """Building both shapes leaves both pyramids readable from the container."""
         import pickle as _pickle

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -14,6 +14,7 @@ import pytest
 from vtscore.embedding.matrix import (
     get_embedding_matrix,
     get_embedding_matrix_for_snap,
+    get_embedding_submatrix,
     invalidate_embedding_matrix,
 )
 from vtscore.state.core import DatasetContext, set_thread_dataset_context
@@ -55,6 +56,49 @@ class TestGetEmbeddingMatrixRaisesOnNoneEmbedding:
         assert mat[0, 0] == 1.0
         assert mat[1, 0] == 2.0
         assert mat[2, 0] == 3.0
+
+
+class TestGetEmbeddingSubmatrix:
+    """Subset matrix builder for VTSBrowse subset projections."""
+
+    def _ctx(self) -> DatasetContext:
+        ctx = DatasetContext("test_submatrix")
+        for cid in (1, 2, 3, 4):
+            ctx.medias[cid] = {"id": cid, "embedding": np.full(4, float(cid), dtype=np.float32)}
+        return ctx
+
+    def test_returns_only_requested_ids_sorted(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_submatrix(ctx, [3, 1])
+        assert ids == [1, 3]
+        assert mat.shape == (2, 4)
+        assert mat[0, 0] == 1.0
+        assert mat[1, 0] == 3.0
+
+    def test_dedups_and_drops_unknown_ids(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_submatrix(ctx, [2, 2, 99])
+        assert ids == [2]
+        assert mat.shape == (1, 4)
+
+    def test_empty_when_no_match(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_submatrix(ctx, [99, 100])
+        assert ids == []
+        assert mat.shape == (0, 0)
+
+    def test_raises_on_none_embedding(self):
+        ctx = self._ctx()
+        ctx.medias[2]["embedding"] = None
+        with pytest.raises(ValueError, match=r"media 2.*has no embedding"):
+            get_embedding_submatrix(ctx, [1, 2])
+
+    def test_does_not_populate_cache(self):
+        """Subset builds must not poison the context-wide matrix cache."""
+        ctx = self._ctx()
+        get_embedding_submatrix(ctx, [1, 2])
+        assert ctx._emb_matrix is None
+        assert ctx._emb_matrix_ids is None
 
 
 class TestGetEmbeddingMatrixForSnapRaisesOnNoneEmbedding:

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -79,6 +79,32 @@ def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
         return list(sorted_ids), matrix
 
 
+def get_embedding_submatrix(ctx: "DatasetContext", ids: list[int]) -> tuple[list[int], np.ndarray]:
+    """Return ``(sorted_ids, (N, D) float32 matrix)`` for a *subset* of *ctx*'s medias.
+
+    Unlike :func:`get_embedding_matrix`, this builds a fresh matrix over only
+    the requested *ids* (intersected with the dataset's current medias) and
+    never populates the context-wide cache - subset projections (e.g. the
+    positives of a Find run) are ephemeral.  The returned id list is sorted and
+    de-duplicated; ids absent from the dataset are dropped silently.
+
+    Returns ``([], np.empty((0, 0), dtype=np.float32))`` when nothing matches.
+    Raises ``ValueError`` if any requested media has ``embedding=None``.
+    """
+    with _state_lock:
+        medias = ctx.medias
+        sorted_ids = sorted({cid for cid in ids if cid in medias})
+        if not sorted_ids:
+            return [], np.empty((0, 0), dtype=np.float32)
+
+        first_emb = np.asarray(_require_embedding(sorted_ids[0], medias[sorted_ids[0]]), dtype=np.float32)
+        dim = int(first_emb.shape[-1])
+        matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
+        for i, cid in enumerate(sorted_ids):
+            matrix[i] = _require_embedding(cid, medias[cid])
+        return sorted_ids, matrix
+
+
 def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
     """Drop the cached matrix on *ctx*; next access rebuilds it."""
     with _state_lock:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -284,6 +284,17 @@ class DatasetContext:
         # browse hex/square toggle can keep both binnings cached at once.
         "_projection",
         "_pyramids",
+        # VTSBrowse subset projection: an ephemeral UMAP fit over just a subset
+        # of this dataset's media ids (e.g. the positives of a Find run),
+        # computed on demand and never persisted.  Held alongside the full
+        # projection so a user can browse the whole dataset and a subset
+        # independently.  ``_subset_ids`` is the sorted id list the cached
+        # subset layout was fit against (cache key); ``_subset_job_id`` tracks
+        # the in-flight background UMAP build for status polling.
+        "_subset_projection",
+        "_subset_pyramids",
+        "_subset_ids",
+        "_subset_job_id",
     )
 
     def __init__(self, dataset_id: str = "") -> None:
@@ -295,6 +306,10 @@ class DatasetContext:
         self._emb_matrix: Any = None  # np.ndarray | None
         self._projection: Any = None  # Projection | None
         self._pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid
+        self._subset_projection: Any = None  # Projection | None (ephemeral subset UMAP)
+        self._subset_pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid (subset)
+        self._subset_ids: list[int] | None = None  # sorted ids the subset layout is fit on
+        self._subset_job_id: str | None = None  # in-flight subset build job id
 
 
 class DetectorContext:

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -212,6 +212,24 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dic
     return {"status": "building", "job_id": job.job_id}
 
 
+def _dispatch_subset_build(ctx, ids_raw, bin_shape: str) -> dict:
+    """Validate the request body's ``ids`` and route to the subset build."""
+    if not isinstance(ids_raw, list):
+        abort(400, message="`ids` must be a list of media ids.")
+    try:
+        requested = [int(c) for c in ids_raw]
+    except (TypeError, ValueError):
+        abort(400, message="`ids` must be a list of integer media ids.")
+    if not requested:
+        abort(409, message="No items selected — nothing to project.")
+    if not ctx.medias:
+        abort(409, message="Dataset is empty — nothing to project.")
+    try:
+        return _build_subset(ctx, requested, bin_shape)
+    except ValueError as exc:
+        abort(409, message=str(exc))
+
+
 def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
     """Build (or reuse) an ephemeral UMAP projection over just *requested_ids*.
 
@@ -318,22 +336,8 @@ def build_projection():
 
     # Subset build: project only the supplied media ids (e.g. the positive
     # results of a Find run), fitting UMAP on just their high-d vectors.
-    ids_raw = body.get("ids")
-    if ids_raw is not None:
-        if not isinstance(ids_raw, list):
-            abort(400, message="`ids` must be a list of media ids.")
-        try:
-            requested = [int(c) for c in ids_raw]
-        except (TypeError, ValueError):
-            abort(400, message="`ids` must be a list of integer media ids.")
-        if not requested:
-            abort(409, message="No items selected — nothing to project.")
-        if not ctx.medias:
-            abort(409, message="Dataset is empty — nothing to project.")
-        try:
-            return _build_subset(ctx, requested, shape)
-        except ValueError as exc:
-            abort(409, message=str(exc))
+    if body.get("ids") is not None:
+        return _dispatch_subset_build(ctx, body["ids"], shape)
 
     cached = ctx._pyramids.get(shape)
     if cached is not None:

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -46,6 +46,40 @@ def _resolve_shape(value: str | None) -> str:
     return shape
 
 
+def _is_subset(value: str | None) -> bool:
+    """Whether a request targets the ephemeral subset projection."""
+    return str(value).lower() in ("1", "true", "yes")
+
+
+def _subset_meta(ctx, bin_shape: str) -> dict:
+    """Return projection/pyramid metadata + build status for the subset layout."""
+    from vtscore.concurrency.async_jobs import projection_jobs
+
+    pyr = ctx._subset_pyramids.get(bin_shape)
+    if pyr is not None:
+        meta = pyr.meta()
+        meta["status"] = "ready"
+        meta["media_type"] = _media_type_for(ctx)
+        meta["method"] = ctx._subset_projection.method if ctx._subset_projection else None
+        return meta
+
+    if ctx._subset_job_id:
+        job = projection_jobs.get(ctx._subset_job_id)
+        if job is not None:
+            if job.status in ("running", "pending"):
+                return {
+                    "status": "building",
+                    "job_id": job.job_id,
+                    "current": job.current,
+                    "total": job.total,
+                    "message": job.message,
+                }
+            if job.status == "error":
+                return {"status": "error", "error": job.error or "projection build failed"}
+
+    return {"status": "idle"}
+
+
 def _media_type_for(ctx) -> str:
     """Return the media type of the first item in the dataset, or ``""``."""
     if not ctx.medias:
@@ -178,6 +212,88 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dic
     return {"status": "building", "job_id": job.job_id}
 
 
+def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
+    """Build (or reuse) an ephemeral UMAP projection over just *requested_ids*.
+
+    Unlike the full-dataset path, the subset projection is computed from only
+    the high-dimensional vectors of the requested ids (e.g. the positives of a
+    Find run), held in dedicated ``_subset_*`` slots on the context, and never
+    persisted.  The shared 2-D layout is reused across bin shapes, so a shape
+    toggle re-bins in milliseconds instead of re-fitting UMAP.
+    """
+    from vtscore.embedding.matrix import get_embedding_submatrix
+    from vtscore.projection import build_pyramid
+
+    sorted_ids, matrix = get_embedding_submatrix(ctx, requested_ids)
+    if matrix.size == 0:
+        abort(409, message="None of the selected items have embeddings — nothing to project.")
+
+    if ctx._subset_ids == sorted_ids:
+        # Same subset: serve the cached pyramid, or re-bin the shared layout.
+        pyr = ctx._subset_pyramids.get(bin_shape)
+        if pyr is not None:
+            return {"status": "ready", "projection_id": pyr.projection_id}
+        proj = ctx._subset_projection
+        if proj is not None:
+            pyr = build_pyramid(proj, bin_shape=bin_shape)
+            ctx._subset_pyramids[bin_shape] = pyr
+            return {"status": "ready", "projection_id": pyr.projection_id}
+    else:
+        # A different subset was requested: drop the stale layout before fitting.
+        ctx._subset_projection = None
+        ctx._subset_pyramids = {}
+        ctx._subset_ids = sorted_ids
+        ctx._subset_job_id = None
+
+    return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape)
+
+
+def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dict:
+    """Start (or reuse) the background subset UMAP fit + pyramid build."""
+    from vtscore.concurrency.async_jobs import projection_jobs
+    from vtscore.projection import build_pyramid, fit_projection
+    from vtscore.state.core import thread_dataset_context
+
+    sig = (ctx.dataset_id, "subset", bin_shape, tuple(sorted_ids))
+
+    job_cached = projection_jobs.cached_for(sig)
+    if job_cached is not None and job_cached.result is not None:
+        proj, pyr = job_cached.result
+        ctx._subset_projection = proj
+        ctx._subset_pyramids[bin_shape] = pyr
+        return {"status": "ready", "projection_id": pyr.projection_id}
+
+    # Already building this exact subset + shape?  Reuse the in-flight job
+    # instead of queueing a duplicate fit.
+    if ctx._subset_job_id:
+        existing = projection_jobs.get(ctx._subset_job_id)
+        if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
+            return {"status": "building", "job_id": existing.job_id}
+
+    mat_copy = matrix.copy()
+    ids_copy = list(sorted_ids)
+
+    def _run(job):
+        with thread_dataset_context(ctx):
+
+            def _on_progress(status, message, current, total):
+                job.update_progress(current, total, message)
+
+            proj = fit_projection(mat_copy, ids_copy, on_progress=_on_progress)
+            job.update_progress(0, 1, "building pyramid")
+            pyr = build_pyramid(proj, bin_shape=bin_shape)
+            job.update_progress(1, 1, "done")
+
+            ctx._subset_projection = proj
+            ctx._subset_pyramids[bin_shape] = pyr
+            job.result = (proj, pyr)
+            # Subset projections are ephemeral — never persisted.
+
+    job = projection_jobs.start(sig, _run, dataset_id=ctx.dataset_id)
+    ctx._subset_job_id = job.job_id
+    return {"status": "building", "job_id": job.job_id}
+
+
 @projection_bp.route("/api/projection/build", methods=["POST"])
 @projection_bp.response(200, ProjectionBuildResponseSchema)
 @projection_bp.alt_response(409, description="Dataset is empty or has no embeddings.")
@@ -199,6 +315,25 @@ def build_projection():
     ctx = get_active_context()
     body = request.get_json(silent=True) or {}
     shape = _resolve_shape(body.get("shape"))
+
+    # Subset build: project only the supplied media ids (e.g. the positive
+    # results of a Find run), fitting UMAP on just their high-d vectors.
+    ids_raw = body.get("ids")
+    if ids_raw is not None:
+        if not isinstance(ids_raw, list):
+            abort(400, message="`ids` must be a list of media ids.")
+        try:
+            requested = [int(c) for c in ids_raw]
+        except (TypeError, ValueError):
+            abort(400, message="`ids` must be a list of integer media ids.")
+        if not requested:
+            abort(409, message="No items selected — nothing to project.")
+        if not ctx.medias:
+            abort(409, message="Dataset is empty — nothing to project.")
+        try:
+            return _build_subset(ctx, requested, shape)
+        except ValueError as exc:
+            abort(409, message=str(exc))
 
     cached = ctx._pyramids.get(shape)
     if cached is not None:
@@ -239,6 +374,9 @@ def projection_meta():
     ctx = get_active_context()
     shape = _resolve_shape(request.args.get("shape"))
 
+    if _is_subset(request.args.get("subset")):
+        return _subset_meta(ctx, shape)
+
     pyr = ctx._pyramids.get(shape)
     if pyr is not None:
         meta = pyr.meta()
@@ -248,6 +386,10 @@ def projection_meta():
         return meta
 
     job = projection_jobs.current()
+    # A subset build shares the single projection runner; don't report its
+    # progress as the full-dataset build's status.
+    if job is not None and job.job_id == ctx._subset_job_id:
+        job = None
     if job is not None and job.dataset_id == ctx.dataset_id:
         if job.status in ("running", "pending"):
             return {
@@ -279,7 +421,10 @@ def get_tile(shape: str, level: int, tx: int, ty: int):
 
     shape = _resolve_shape(shape)
     ctx = get_active_context()
-    pyr = ctx._pyramids.get(shape)
+    if _is_subset(request.args.get("subset")):
+        pyr = ctx._subset_pyramids.get(shape)
+    else:
+        pyr = ctx._pyramids.get(shape)
     if pyr is None:
         abort(404, message="Projection not built yet — call POST /api/projection/build first.")
 


### PR DESCRIPTION
## What

Adds a **Browse** button to the Find right panel, next to **Export**, that opens the Find run's positive results in VTSBrowse as a *fresh* 2-D UMAP — fit on **only the positives' high-d vectors**, not the whole-dataset projection filtered down to the subset.

As requested, clicking it kicks off a UMAP fit over just that subset (the user waits while it builds), then drops them into the existing browse canvas.

## Behavior

- The button shows **only in find mode** and is disabled when the good list is empty.
- "Positives" = the **current good list** (above-threshold items plus any manual corrections), per the chosen definition.
- It browses positives only; negatives are never sent.

## How

**Backend** (`vtsearch/routes/projection.py`, `vtscore/`)
- `POST /api/projection/build` accepts an optional `ids` list → builds an **ephemeral** subset projection by UMAP-ing just those vectors.
- The subset layout lives in new `_subset_*` slots on `DatasetContext` and is **never persisted** (honors the no-persisted-vectors rule); it coexists with the full-dataset projection.
- `GET /api/projection/meta` and `/tiles/...` take `?subset=1` to serve the subset alongside the full projection.
- New `get_embedding_submatrix(ctx, ids)` builds a fresh subset matrix without poisoning the context-wide cache.

**Frontend**
- New `BrowseSubsetService` hands the positive ids from the Find view to the Browse view; the Find view navigates to `/browse/:datasetId?subset=1`.
- The browse view threads subset mode through build/meta/tiles, polls the build, and labels the chip as "positives".

## Tests

- New `TestProjectionSubset` (build/poll, coexists-with-full, subset tiles, validation 400/409, idle-without-build).
- New `get_embedding_submatrix` library-tier tests.
- Also fixed a latent bug in the existing projection route tests: their `fit_projection` patch targeted `vtscore.projection.umap_projection.fit_projection`, but the route imports the name from the `vtscore.projection` package, so the stub never applied and the tests silently ran real UMAP (numba cold-start could exceed the 30s wait). Repointed to the effective binding.

Full suite green: `ALL 4570 TESTS PASSED` (frontend `build:prod` check included).

## Known limitation

The id handoff is in-memory, so a hard reload of the subset browse URL shows a "re-run Find" message rather than rebuilding. Recorded in `docs/plans/vtsbrowse.md`.

https://claude.ai/code/session_01MgBtJ38Ada9EsewG6h5pc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgBtJ38Ada9EsewG6h5pc6)_