### PR TITLE
Add zoom-to-fit button and magnifying-glass zoom icons to VTSBrowser

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -540,6 +540,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * selection re-runs so the hexes keep their ~28px display size while each
    * covers a narrower span.
    */
+  /**
+   * Frame the whole projection: pick a zoom and pan so the current data just
+   * fits in the viewport (the same framing used on first load), then redraw.
+   */
+  zoomToFit(): void {
+    this.fitToData();
+    this.requestRedraw();
+    this.refreshHoverAfterZoom();
+  }
+
   zoomBy(factor: number, anchorX = this.width / 2, anchorY = this.height / 2): void {
     const [projX, projY] = this.screenToProj(anchorX, anchorY);
     const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -43,19 +43,27 @@
         <div class="browse-zoom">
           <button
             type="button"
-            class="browse-size-btn browse-size-btn--text"
-            (click)="zoomOut()"
-            title="Zoom out"
-            aria-label="Zoom out">
-            &minus;
-          </button>
-          <button
-            type="button"
-            class="browse-size-btn browse-size-btn--text"
+            class="browse-size-btn"
             (click)="zoomIn()"
             title="Zoom in"
             aria-label="Zoom in">
-            +
+            <vt-icon type="zoom-in" [size]="16"></vt-icon>
+          </button>
+          <button
+            type="button"
+            class="browse-size-btn"
+            (click)="zoomToFit()"
+            title="Zoom to fit"
+            aria-label="Zoom to fit">
+            <vt-icon type="zoom-fit" [size]="16"></vt-icon>
+          </button>
+          <button
+            type="button"
+            class="browse-size-btn"
+            (click)="zoomOut()"
+            title="Zoom out"
+            aria-label="Zoom out">
+            <vt-icon type="zoom-out" [size]="16"></vt-icon>
           </button>
         </div>
         <div class="browse-size">

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -148,13 +148,6 @@
   }
 }
 
-// +/- zoom glyphs need explicit sizing since they carry no icon child.
-.browse-size-btn--text {
-  font-size: var(--font-lg);
-  font-weight: var(--weight-medium);
-  line-height: 1;
-}
-
 // Hex/square glyph buttons carry a unicode shape rather than an icon child.
 .browse-size-btn--glyph {
   font-size: var(--font-md);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -298,6 +298,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.canvas?.zoomBy(1 / this.ZOOM_BUTTON_FACTOR);
   }
 
+  /** Choose a zoom and pan so the current data just fits in view. */
+  zoomToFit(): void {
+    this.canvas?.zoomToFit();
+  }
+
   /**
    * Issue the right build request for the current mode: a subset build (UMAP
    * over just the handed-off ids) when in subset mode, else the full-dataset

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -82,4 +82,10 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>',
   trophy:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4h12v4a6 6 0 0 1-12 0z"/><path d="M6 6H3a2 2 0 0 0 0 4h3"/><path d="M18 6h3a2 2 0 0 1 0 4h-3"/><line x1="10" y1="14" x2="10" y2="18"/><line x1="14" y1="14" x2="14" y2="18"/><rect x="7" y="18" width="10" height="3" rx="1"/></svg>',
+  'zoom-in':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><line x1="10" y1="7" x2="10" y2="13"/><line x1="7" y1="10" x2="13" y2="10"/></svg>',
+  'zoom-out':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><line x1="7" y1="10" x2="13" y2="10"/></svg>',
+  'zoom-fit':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><path d="M6 8V6h2"/><path d="M12 6h2v2"/><path d="M14 12v2h-2"/><path d="M8 14H6v-2"/></svg>',
 };

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -24,6 +24,7 @@ const KNOWN_TYPES = new Set([
   'thumbs-up', 'thumbs-down', 'factory',
   'house', 'lightning', 'flask', 'cubes', 'database',
   'checkbox-checked', 'search', 'trophy',
+  'zoom-in', 'zoom-out', 'zoom-fit',
 ]);
 
 function emojiToType(icon: string): string {


### PR DESCRIPTION
## Summary

Adds a **zoom-to-fit** control to the VTSBrowser zoom cluster and replaces the plain `+` / `−` text glyphs with magnifying-glass icons.

- **New "zoom to fit" button** between the zoom-in and zoom-out buttons. Clicking it reframes the view so the current data just fits the viewport (reusing the same `fitToData` framing used on first load), then redraws and refreshes hover.
- **Zoom-in** button now shows a magnifying glass with a `+`.
- **Zoom-out** button now shows a magnifying glass with a `−`.
- **Zoom-fit** button shows a magnifying glass with the four corners of a square.

## Changes

- `browse-canvas.component.ts`: expose a public `zoomToFit()` that calls the existing private `fitToData()` then redraws/refreshes hover.
- `browse-view.component.ts`: add a `zoomToFit()` handler delegating to the canvas.
- `browse-view.component.html`: replace the two text-glyph zoom buttons with three `vt-icon` buttons (zoom-in, zoom-fit, zoom-out), fit in the middle.
- `icon-svgs-extended.ts`: add `zoom-in`, `zoom-out`, `zoom-fit` SVGs (built on the existing `search` magnifying-glass).
- `icon.component.ts`: register the three new icon types in `KNOWN_TYPES`.
- `browse-view.component.scss`: remove the now-unused `.browse-size-btn--text` rule.

## Verification

`npm run build:prod` completes cleanly (no errors or budget warnings).

https://claude.ai/code/session_01RqsBDtmZGdd2RyH9GuqkoY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqsBDtmZGdd2RyH9GuqkoY)_