### PR TITLE
Add live numeric density legend to VTSBrowse

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -67,6 +67,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input() colormap: BrowseColormapId = 'auto';
   @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
+  /**
+   * The densest visible cell's item count, emitted whenever it changes. Density
+   * shading is renormalized to this per frame (yellow = this many items, the
+   * darkest red = 1), so the legend reads it to label the ramp with live
+   * numbers that track pan/zoom.
+   */
+  @Output() densityMaxChanged = new EventEmitter<number>();
 
   /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
   private thumbCache = new Map<number, HTMLImageElement>();
@@ -82,6 +89,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private transform: ViewTransform = { centerX: 0, centerY: 0, zoom: 1 };
   private activeLevel = 0;
   private maxCount = 1;
+  // Last maxCount pushed out via densityMaxChanged, so the legend is only
+  // notified when the top of the scale actually moves (not every frame).
+  private lastEmittedMax = 0;
   // The projection id the view was last framed for. Hex and square share one
   // projection id, so toggling bin shape re-bins without re-fitting to data —
   // the pan/zoom is preserved. Only a genuinely new projection re-frames.
@@ -374,6 +384,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.maxCount = 1;
     for (const cell of allCells) {
       if (cell.count > this.maxCount) this.maxCount = cell.count;
+    }
+    if (this.maxCount !== this.lastEmittedMax) {
+      this.lastEmittedMax = this.maxCount;
+      this.ngZone.run(() => this.densityMaxChanged.emit(this.maxCount));
     }
 
     // Resolve the colormap against the live theme once per frame, not per cell.

--- a/frontend/src/app/components/browse-canvas/hex-render.util.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.ts
@@ -115,6 +115,18 @@ export function rgbString(c: RGB): string {
   return `rgb(${c[0]},${c[1]},${c[2]})`;
 }
 
+/**
+ * Build a CSS gradient stop list (``rgb(...) p%, …``) from a colormap ramp,
+ * low → high. Lets the on-screen legend build its swatch from the same colours
+ * the canvas fills cells with, so the two can't drift.
+ */
+export function gradientStops(ramp: readonly (readonly [number, number, number])[]): string {
+  const n = Math.max(ramp.length - 1, 1);
+  return ramp
+    .map(([r, g, b], i) => `rgb(${r},${g},${b}) ${Math.round((i / n) * 100)}%`)
+    .join(', ');
+}
+
 /** Map a normalized density ``t`` in [0, 1] to an ``rgb(...)`` string on *ramp*. */
 export function densityColor(t: number, ramp: RGB[]): string {
   const n = ramp.length - 1;

--- a/frontend/src/app/components/browse-legend/browse-legend.component.scss
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.scss
@@ -1,0 +1,80 @@
+// Vertical color key pinned to the middle of the canvas's right edge. Sits
+// clear of the top-right control cluster and the bottom-right minimap. Purely
+// informational, so it never intercepts pan/zoom on the canvas beneath it.
+.browse-legend {
+  position: absolute;
+  right: var(--space-md);
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+.browse-legend-title {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+// The swatch and its tick labels share one height so the labels line up with
+// the gradient they annotate.
+.browse-legend-body {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-xs);
+  height: 140px;
+}
+
+// The swatch itself: a tall, narrow stripe carrying the density ramp (dense at
+// the top).
+.browse-legend-bar {
+  width: 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+// Ramp tick labels are absolutely placed at their fractional height up the bar
+// and centered on that mark, so each number sits beside the color it denotes.
+.browse-legend-ticks {
+  position: relative;
+  min-width: 2.5ch;
+
+  .browse-legend-tick {
+    position: absolute;
+    left: 0;
+    transform: translateY(50%);
+  }
+}
+
+.browse-legend-tick {
+  font-size: var(--font-xs);
+  line-height: 1;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+// The one-item swatch: a dot in the colormap's dedicated single colour, the
+// same shape a lone cell is drawn as on the canvas.
+.browse-legend-single {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.browse-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  flex: none;
+}

--- a/frontend/src/app/components/browse-legend/browse-legend.component.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.ts
@@ -1,0 +1,132 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import {
+  gradientStops,
+  resolveColormap,
+  rgbString,
+  type BrowseColormapId,
+  type CanvasTheme,
+} from '../browse-canvas/hex-render.util';
+
+interface LegendTick {
+  /** Fractional height up the ramp, 0 (bottom) → 1 (top). */
+  t: number;
+  /** Item count this height maps to, formatted for display. */
+  label: string;
+}
+
+/**
+ * Vertical color key for the browse canvas. The canvas shades each cell by its
+ * item count: a one-item cell gets the colormap's dedicated ``single`` colour
+ * (drawn as a dot), and multi-item cells use the density ``ramp``, renormalized
+ * to the densest cell currently in view — so the ramp's top is {@link maxCount}
+ * items, log-spaced down. Because that top moves with pan/zoom, the legend
+ * can't show fixed numbers; it shows the *current* mapping and re-labels as
+ * ``maxCount`` changes.
+ *
+ * The ramp and singleton colours are resolved from the active {@link colormap}
+ * against the live theme (mirroring the canvas), so the key always matches what
+ * the canvas is painting — Heat, Ocean, or Grayscale, light or dark.
+ */
+@Component({
+  selector: 'vt-browse-legend',
+  standalone: true,
+  template: `
+    <div class="browse-legend" role="img" [attr.aria-label]="ariaLabel">
+      <span class="browse-legend-title">{{ title }}</span>
+      @if (ticks.length > 0) {
+        <div class="browse-legend-body">
+          <div class="browse-legend-bar" [style.background]="barGradient"></div>
+          <div class="browse-legend-ticks">
+            @for (tick of ticks; track tick.t) {
+              <span class="browse-legend-tick" [style.bottom.%]="tick.t * 100">{{
+                tick.label
+              }}</span>
+            }
+          </div>
+        </div>
+      }
+      <div class="browse-legend-single">
+        <span class="browse-legend-dot" [style.background]="singleColor"></span>
+        <span class="browse-legend-tick">1</span>
+      </div>
+    </div>
+  `,
+  styleUrl: './browse-legend.component.scss',
+})
+export class BrowseLegendComponent implements OnInit, OnDestroy {
+  /** Heading above the swatch — what the color encodes. */
+  @Input() title = 'Items per cell';
+  /** Item count the top of the ramp currently maps to. */
+  @Input() maxCount = 1;
+  /** Active density colormap preset; resolved against the live theme. */
+  @Input() colormap: BrowseColormapId = 'auto';
+
+  private readonly numberFormat = new Intl.NumberFormat();
+  /** Live theme, refreshed by a ``data-theme`` observer so the key repaints. */
+  private theme: CanvasTheme = 'dark';
+  private themeObserver: MutationObserver | null = null;
+
+  ngOnInit(): void {
+    this.theme = this.readTheme();
+    this.themeObserver = new MutationObserver(() => (this.theme = this.readTheme()));
+    this.themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.themeObserver?.disconnect();
+  }
+
+  /** The effective theme from the document, defaulting to dark (no ``system``). */
+  private readTheme(): CanvasTheme {
+    const t = document.documentElement.getAttribute('data-theme');
+    return t === 'light' || t === 'highviz' ? t : 'dark';
+  }
+
+  /** Colormap resolved for the current preset + theme (same as the canvas). */
+  private get resolved() {
+    return resolveColormap(this.colormap, this.theme);
+  }
+
+  /** Vertical gradient with the dense (last ramp stop) end at the top. */
+  get barGradient(): string {
+    return `linear-gradient(to top, ${gradientStops(this.resolved.ramp)})`;
+  }
+
+  /** The one-item cell colour, shown as a dot. */
+  get singleColor(): string {
+    return rgbString(this.resolved.single);
+  }
+
+  /**
+   * Tick labels for the ramp (multi-item cells, count ≥ 2). The canvas maps a
+   * count to a height via `t = ln(count) / ln(maxCount)`, so a height `t` reads
+   * back as `count = maxCount^t` and each label sits exactly at the color that
+   * count is painted with. Sampled top→bottom, deduped, and dropping anything
+   * that rounds below 2 (those are singletons, shown by the dot instead).
+   */
+  get ticks(): LegendTick[] {
+    const max = Math.max(Math.round(this.maxCount), 1);
+    if (max < 2) return [];
+    const seen = new Set<number>();
+    const out: LegendTick[] = [];
+    for (const t of [1, 0.75, 0.5, 0.25]) {
+      const count = Math.round(Math.pow(max, t));
+      if (count < 2 || seen.has(count)) continue;
+      seen.add(count);
+      out.push({ t, label: this.numberFormat.format(count) });
+    }
+    return out;
+  }
+
+  get ariaLabel(): string {
+    const max = Math.max(Math.round(this.maxCount), 1);
+    return max < 2
+      ? `${this.title}: every cell in view holds 1 item`
+      : `${this.title}: a dot is 1 item; the ramp runs up to ${this.numberFormat.format(
+          max,
+        )} items at its brightest`;
+  }
+}

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -35,11 +35,15 @@
         [displayScale]="hexDisplayScale"
         [colormap]="colormap"
         (hexHover)="onHexHover($event)"
+        (densityMaxChanged)="onDensityMaxChanged($event)"
       />
       <vt-browse-hover-preview
         [hover]="hoverEvent"
         [mediaType]="mediaType"
       />
+      @if (showLegend) {
+        <vt-browse-legend [maxCount]="densityMax" [colormap]="colormap" />
+      }
       <div class="browse-controls">
         <div class="browse-zoom">
           <button

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
+import { BrowseLegendComponent } from '../browse-legend/browse-legend.component';
 import {
   BrowseMinimapComponent,
   MINIMAP_MAX_HEIGHT,
@@ -33,6 +34,7 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
     CommonModule,
     BrowseCanvasComponent,
     BrowseHoverPreviewComponent,
+    BrowseLegendComponent,
     BrowseMinimapComponent,
     ProgressBarComponent,
     IconComponent,
@@ -49,6 +51,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   meta: ProjectionMeta | null = null;
   mediaType = '';
   hoverEvent: HexHoverEvent | null = null;
+  /**
+   * Top of the density scale for the legend: the densest cell currently in
+   * view, pushed up from the canvas. The legend labels the yellow end with it.
+   */
+  densityMax = 1;
   status: 'loading' | 'building' | 'ready' | 'error' = 'loading';
   errorMessage = '';
   buildProgress = 0;
@@ -203,6 +210,19 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   onHexHover(event: HexHoverEvent | null): void {
     this.hoverEvent = event;
+  }
+
+  onDensityMaxChanged(max: number): void {
+    this.densityMax = max;
+  }
+
+  /**
+   * The density legend only makes sense when cells are shaded by count. For
+   * image/video the canvas paints representative thumbnails instead, so the
+   * color ramp doesn't apply and the legend is hidden.
+   */
+  get showLegend(): boolean {
+    return this.mediaType !== 'image' && this.mediaType !== 'video';
   }
 
   get hexDisplayScale(): number {


### PR DESCRIPTION
## What

Adds a color legend to the VTSBrowse canvas so users can read what each cell color means — in actual item counts, not just "dark vs. bright."

A vertical, labeled stripe pinned to the middle of the canvas's right edge. It reuses the canvas's own colors (shared via `hex-render.util.ts`, so the two can't drift) and annotates them with **live numeric ticks**.

## Why this is numeric *and* live

The canvas shades each cell by item count, but **renormalized to the densest cell currently in view, every frame** (`browse-canvas.component.ts`): a one-item cell gets the colormap's `single` color, multi-item cells use the density `ramp`, and the ramp's top is the on-screen max. So "brightest" has no fixed meaning — at one zoom it might be ~900 items; zoom in, the binning gets finer, and it might be ~10.

A legend with hardcoded numbers would therefore be wrong. Instead:

- The canvas emits its current max (`densityMaxChanged`) whenever the top of the scale moves.
- The legend labels the ramp by inverting the canvas's mapping (`count = maxCount^t`), so each number sits exactly at the color that count is painted with, and re-labels as you pan/zoom.
- A separate dot shows the `single` (one-item) color, labeled `1`.

## Integration with the colormap system

This branch was rebased onto the new per-media colormap work on `dev` (Heat / Ocean / Grayscale / auto, theme-resolved). The legend now resolves the **active** colormap against the live theme — mirroring the canvas, including a `data-theme` observer — so the key always matches what's painted (right ramp, right singleton color, light or dark). The shared `gradientStops` helper builds the swatch from the same ramp the canvas fills with.

## Notes

- Hidden for **image/video** datasets, where cells are painted with representative thumbnails instead of density colors.
- When every visible cell holds a single item, only the `1` dot shows (no ramp).
- Pure frontend change. `./run-tests.sh core` passes (707 tests; lint, codespell, deptry, and the prod frontend build all clean).

https://claude.ai/code/session_01TJATJ61DyLhckfjKSfj4Gt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJATJ61DyLhckfjKSfj4Gt)_