### PR TITLE
Fix VTSBrowse minimap viewport-rect mis-sync

### DIFF
--- a/docs/plans/vtsbrowse-minimap-sync-investigation.md
+++ b/docs/plans/vtsbrowse-minimap-sync-investigation.md
@@ -1,5 +1,82 @@
 # VTSBrowse minimap "viewed rectangle" mis-sync — investigation handoff
 
+> **Status: RESOLVED** (browser-confirmed and fixed). Driving a real browser on
+> the ESC-50 (S) audio dataset reproduced the mis-sync and pinned **two
+> independent root causes** — see *§Resolution* immediately below. The original
+> static-analysis handoff is kept underneath for the record.
+
+## Resolution (what was actually wrong, browser-confirmed)
+
+Running the app and instrumenting the live DOM/canvas on the ESC-50 audio
+projection surfaced two distinct, compounding defects. Both are fixed.
+
+### Root cause 1 — layout overflowed the window, hiding the minimap
+
+`frontend/src/styles.scss` set `zoom: 1.1` on the selector `html, body`. Because
+`body` nests inside `html`, the zoom **compounded to 1.21×** (the comment intends
+110%). On top of that, `app.component.scss` framed the shell with
+`height: 100vh`, and **`vh` units ignore an ancestor `zoom`**, so `100vh`
+resolved to `896 × 1.1 ≈ 1084px` and overflowed the real 896px window. The app
+shell was taller than the viewport, so the lower-right minimap (and the bottom
+of the canvas) were pushed **off-screen** — the "rectangle doesn't match" report
+was partly "you can't even see the minimap / it's clipped."
+
+Measured live: `100vh` = 1084px while `innerHeight` = 896; `app-root` rect =
+1084 vs computed height 896 (the 1.21× scale).
+
+**Fix:**
+- `styles.scss`: apply `zoom: 1.1` to **`html` alone** (not `html, body`) so it
+  no longer compounds — the app now renders at the intended 110%.
+- `app.component.scss`: `:host { height: 100vh }` → `height: 100%`. `100%` flows
+  through the `html`/`body` (both `height: 100%`) box tree and is scaled
+  correctly by the zoom, where `vh` is not. After the fix `app-root` rect = 896 =
+  window at multiple window sizes, and the minimap is always on-screen.
+
+### Root cause 2 — the canvas never refit to its real size (the rectangle bug)
+
+`fitToData()` ran **only** on the first `ngOnChanges(meta)`. Because the canvas is
+created via `@case('ready')` with `[meta]` **already bound**, that first
+`ngOnChanges` fires while `this.width === 0` (ResizeObserver hasn't delivered the
+real size yet), so the fit used the hardcoded **800×600 fallback** and was
+*never corrected*. The published `getVisibleBounds()` was therefore sized for
+800×600 but applied to the real ~1215×842 canvas — the minimap rectangle came
+out ~2× the data extent, with all four borders falling **outside** the 200×150
+minimap (only a faint 0.15-alpha wash, no visible rectangle). This is hypothesis
+2 from the original handoff, confirmed: the published bounds were wrong, not the
+rectangle transform.
+
+**Fix (browse-canvas.component.ts):** track `fittedAgainstRealSize`; in
+`resize()`, the first time the real size is known (and `meta` is present), call
+`fitToData()` once to reframe against the actual canvas, then redraw/republish.
+A `fittedAgainstRealSize` guard stops later window resizes from clobbering the
+user's pan/zoom. Verified in-browser: data fills the canvas on load; the
+rectangle is correctly sized, visible, and tracks pan **and** zoom; and a window
+resize after a clean fit preserves pan/zoom (the rect stays put and merely
+resizes to the new viewport instead of snapping back to whole-view).
+
+### Open follow-ups
+
+- **"Whole projection in view" reads as no rectangle.** When the canvas shows the
+  entire projection, the viewport rect (plus aspect-ratio letterboxing margin) is
+  slightly larger than the minimap in every direction, so its borders clip just
+  off-canvas and the user sees only a faint wash — semantically correct (you *are*
+  viewing everything) but not obviously a "rectangle." Optional polish: clamp the
+  rect to the minimap edges, or show an explicit "entire projection in view"
+  affordance.
+- **No automated regression guard.** The defects were lifecycle/CSS issues, not
+  pure-math errors (the transform math was always correct — its *inputs* were
+  wrong), so a pure-function unit test would not have caught them, and frontend
+  specs don't execute in this repo (no Karma/Chrome). A real guard would need an
+  integration/browser harness. Recorded here rather than shipped as a
+  non-executing spec.
+- **`overviewTiles()` `> 1024` runaway guard** (original hypothesis 3) did **not**
+  fire for this dataset — the overview heatmap painted fully. Left as-is; revisit
+  only if a pathological extent shows a half-blank minimap.
+
+---
+
+## Original static-analysis handoff (pre-browser)
+
 > **Status:** Investigated headlessly (no browser in this environment), root
 > cause **not yet confirmed**. This note records the static-analysis findings so
 > the next Claude — running where the rendered canvas can actually be *seen and

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,7 +1,12 @@
 :host {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  // `100%` (of html/body, both height:100%), NOT `100vh`: `vh` units ignore the
+  // ancestor `zoom`, so `100vh` under the 110% root zoom renders ~10% taller
+  // than the real viewport and overflows it, pushing fixed/bottom-anchored UI
+  // (e.g. the browse minimap) off-screen. `100%` flows through the box tree and
+  // is scaled correctly by the zoom.
+  height: 100%;
   overflow: hidden;
 }
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -72,6 +72,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // projection id, so toggling bin shape re-bins without re-fitting to data —
   // the pan/zoom is preserved. Only a genuinely new projection re-frames.
   private lastProjectionId = '';
+  // Whether the current framing was fit against the canvas's real measured size.
+  // `meta` can arrive (and trigger the initial `fitToData`) before the canvas
+  // has laid out, in which case the fit runs against the 800x600 fallback and
+  // the published viewport bounds are wrong. We refit once on the first real
+  // `resize()`; this flag stops later window resizes from clobbering the user's
+  // pan/zoom.
+  private fittedAgainstRealSize = false;
 
   private isPanning = false;
   private panStartX = 0;
@@ -219,6 +226,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     canvas.style.width = `${this.width}px`;
     canvas.style.height = `${this.height}px`;
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    // The initial fit may have run against the 800x600 fallback (meta arrived
+    // before layout). Now that the real size is known, refit to it so the
+    // framing and the viewport bounds published to the minimap match the actual
+    // canvas. Only on the first real measurement — a later window resize keeps
+    // the user's pan/zoom.
+    if (!this.fittedAgainstRealSize && this.meta && this.width > 0 && this.height > 0) {
+      this.fitToData();
+    }
     this.requestRedraw();
   }
 
@@ -237,6 +252,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.transform.zoom = Math.min(w / padW, h / padH) / this.displayScale;
     this.transform.centerX = (xmin + xmax) / 2;
     this.transform.centerY = (ymin + ymax) / 2;
+    // Mark whether this fit used the real canvas size (vs the 800x600 fallback),
+    // so `resize()` knows whether a corrective refit is still owed.
+    this.fittedAgainstRealSize = this.width > 0 && this.height > 0;
     this.updateActiveLevel();
   }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -14,16 +14,22 @@ html, body {
   margin: 0;
   padding: 0;
   height: 100%;
-  // Render the whole app at 110%, exactly as if the user had hit Ctrl/Cmd-"+".
-  // `zoom` scales everything uniformly (fonts, px paddings/borders, images,
-  // canvases, layout), so it matches real browser zoom without having to touch
-  // the hundreds of px-pinned values across components. Desktop-only app, and
-  // `zoom` is supported in all current desktop browsers (Chrome, Firefox 126+,
-  // Safari 18+), so no fallback is needed.
-  zoom: 1.1;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--bg-body);
   color: var(--text-primary);
+}
+
+// Render the whole app at 110%, exactly as if the user had hit Ctrl/Cmd-"+".
+// `zoom` scales everything uniformly (fonts, px paddings/borders, images,
+// canvases, layout), so it matches real browser zoom without having to touch
+// the hundreds of px-pinned values across components. Desktop-only app, and
+// `zoom` is supported in all current desktop browsers (Chrome, Firefox 126+,
+// Safari 18+), so no fallback is needed.
+//
+// Applied to `html` ALONE, not `html, body`: `zoom` compounds through the box
+// tree, so a rule on both elements multiplies to 1.21x (body nested in html).
+html {
+  zoom: 1.1;
 }
 
 // Honor OS-level "reduce motion" requests (also a useful escape hatch for


### PR DESCRIPTION
## Summary

The VTSBrowse minimap's "viewed rectangle" didn't match the actual on-screen view. Driving a real browser on the ESC-50 (S) audio projection reproduced it and pinned **two independent, compounding root causes**. Both are fixed and browser-verified.

### Root cause 1 — layout overflowed the window, hiding the minimap
`styles.scss` set `zoom: 1.1` on the `html, body` selector, so it **compounded to 1.21×** (body nests in html; the comment intends 110%). Combined with `app-root { height: 100vh }` — and `vh` ignores ancestor `zoom` — `100vh` rendered at `896 × 1.1 ≈ 1084px` and overflowed the real 896px window, pushing the bottom-anchored minimap (and the bottom of the canvas) **off-screen**.

- Apply `zoom: 1.1` to **`html` alone** so it no longer compounds (app now renders at the intended 110%).
- Frame the shell with `height: 100%` instead of `100vh` (`100%` flows through the `html`/`body` box tree and is scaled correctly by the zoom).

### Root cause 2 — the canvas never refit to its real size (the rectangle bug)
`fitToData()` ran only on the first `ngOnChanges(meta)`, which fires while `width === 0` (the canvas mounts with `[meta]` already bound, before `ResizeObserver` delivers the real size), so it fit against the **800×600 fallback** and was never corrected. The published `getVisibleBounds()` was therefore sized for 800×600 but applied to the real ~1215×842 canvas → the minimap rectangle came out ~2× the data extent with all borders off-canvas.

- Refit once on the first real `resize()`, guarded by `fittedAgainstRealSize` so later window resizes keep the user's pan/zoom.

## Verification (real browser, ESC-50 audio)
- Layout fits at multiple window sizes (896 and 760 tall); minimap always on-screen (`app-root` rect = window height).
- Data fills the canvas on load (refit to real size).
- The viewport rectangle is correctly sized, visible, and **tracks pan and zoom** (measured rect span matched the predicted geometry).
- A window resize after a clean fit **preserves pan/zoom** (rect stays centered and resizes to the new viewport instead of snapping back to whole-view).
- `./run-tests.sh` full suite: 4567 passed, 4 skipped.

## Note
The whole app now renders ~10% **smaller** (the documented 110%, not the accidental 121%). This is a visible, app-wide change — intended per the `styles.scss` comment.

Follow-ups (whole-projection rect clips off-canvas; no automated regression guard) are recorded in `docs/plans/vtsbrowse-minimap-sync-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)