### PR TITLE
Pin setuptools<82 in install scripts to silence pip conflict error

### DIFF
--- a/scripts/install-cpu.sh
+++ b/scripts/install-cpu.sh
@@ -23,7 +23,7 @@ vts_progress_step "Checking Python version (>= 3.10)"
 source "$SCRIPT_DIR/_check-python.sh"
 
 vts_progress_step "Upgrading pip / setuptools / wheel"
-pip install --upgrade pip setuptools wheel --progress-bar on
+pip install --upgrade pip "setuptools<82" wheel --progress-bar on
 
 vts_progress_step "Installing runtime + dev dependencies (this may take several minutes)"
 pip install -r "$REPO_ROOT/requirements/base.txt" --progress-bar on

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -28,7 +28,7 @@ vts_progress_step "Checking Python version (>= 3.10)"
 source "$SCRIPT_DIR/_check-python.sh"
 
 vts_progress_step "Upgrading pip / setuptools / wheel"
-pip install --upgrade pip setuptools wheel --progress-bar on
+pip install --upgrade pip "setuptools<82" wheel --progress-bar on
 
 vts_progress_step "Pre-installing binary-only wheels (numpy, scipy) from PyPI"
 pip install --only-binary :all: \


### PR DESCRIPTION
## Summary

- `torch 2.12.0` requires `setuptools<82`; the install scripts were unconditionally upgrading to the latest setuptools (82.x), causing pip to print a red `ERROR` conflict warning at the end of every install
- Pins `setuptools<82` in both `install-gpu.sh` and `install-cpu.sh` so the upgrade stays within torch's constraint

https://claude.ai/code/session_013UgWM6jNHm3haEX5nbWRCb

---
_Generated by [Claude Code](https://claude.ai/code/session_013UgWM6jNHm3haEX5nbWRCb)_