### PR TITLE
Show progress during startup ML library import pause

### DIFF
--- a/app.py
+++ b/app.py
@@ -549,7 +549,9 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
     server boot; there is no server-wide user to sync for.
     """
     print(f"\U0001f680 Running in {mode_label} mode", flush=True)
+    print("  Loading ML libraries...", end="", flush=True)
     initialize_models()
+    print(" done", flush=True)
     # ``--solo-media-type`` (process-level CLI fallback) tells us which
     # mediaType's default embedder to warm even if no datasets or detectors
     # are registered yet. Per-user explicit values are not consulted here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,4 +237,4 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # slope formulas, medias as the global state proxy, goup as a TS method),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable).
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser"
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod"


### PR DESCRIPTION
## Summary

- Adds `Loading ML libraries... done` line during `initialize_server()` so the ~15-second silence after "Running in PRODUCTION mode" is no longer silent
- Adds `lod` (Level of Detail) to the codespell ignore list to fix a pre-existing spell-check failure on the vtsbrowse toponymy design doc

## What was happening

The pause is caused by `initialize_models()` importing `transformers.utils.logging` for the first time (via `install_transformers_logging_bridge()`), which pulls in the full `transformers` package. On a cold disk this can take 10-15 seconds. There was no output at all during this time, making it look like the process had stalled.

The fix is a two-line wrap in `initialize_server()` — the right place since `initialize_models()` is a library function also called from tests and eval scripts where startup chatter would be noise.

https://claude.ai/code/session_01JnnG28mCDXccbgDh97nVNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnnG28mCDXccbgDh97nVNy)_