### PR TITLE
Fix VTBrowser hex hover cursor desync from html{zoom:1.1} double-scaling

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -262,8 +262,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const canvas = this.canvasRef.nativeElement;
     canvas.width = this.width * this.dpr;
     canvas.height = this.height * this.dpr;
-    canvas.style.width = `${this.width}px`;
-    canvas.style.height = `${this.height}px`;
+    // getBoundingClientRect() returns viewport-coordinate px (CSS layout × root zoom).
+    // canvas.style.width/height must be in CSS px, so divide out the root zoom to
+    // avoid the canvas being visually double-scaled (once by html{zoom:N}, once by
+    // the explicit style override), which would shift hit-test coordinates off the
+    // cursor by the zoom factor.
+    const rootZoom = parseFloat(getComputedStyle(document.documentElement).zoom) || 1;
+    canvas.style.width = `${this.width / rootZoom}px`;
+    canvas.style.height = `${this.height / rootZoom}px`;
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
     // The initial fit may have run against the 800x600 fallback (meta arrived
     // before layout). Now that the real size is known, refit to it so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,4 +237,4 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # slope formulas, medias as the global state proxy, goup as a TS method),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable).
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser"
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod"


### PR DESCRIPTION
## Summary

- `resize()` used `getBoundingClientRect()` on the canvas parent, which returns viewport-coordinate px (CSS layout × root zoom). Writing that value directly to `canvas.style.width/height` — which expects CSS px — caused the canvas to be visually stretched by the zoom factor a second time (once by `html { zoom: 1.1 }`, once by the explicit style override).
- A hex drawn at canvas-coord 550 (center of 1100px viewport canvas) appeared visually at 605px, so hit-testing resolved to the hex ~10% to the right/south of the actual cursor — experienced as the cursor being "left and north" of the highlighted/playing hex.
- Fix: divide `getBoundingClientRect()` width/height by `getComputedStyle(document.documentElement).zoom` before writing to `canvas.style.width/height`. `this.width/height` stay in viewport-coordinate px (consistent with `clientX/Y` and mouse-handler `getBoundingClientRect` calls); the CSS style values are now correctly in CSS px so the canvas fills its container without extra zoom.
- Also adds `lod` to the codespell ignore list (LOD = Level of Detail, a standard graphics/GIS term used in a plan doc that codespell was flagging as a typo).

## Test plan

- [ ] Open VTBrowser and hover over hex tiles — highlighted hex should track the cursor precisely
- [ ] Scroll-to-zoom anchor point should stay fixed under the cursor
- [ ] Pan should feel correctly calibrated
- [ ] `./run-tests.sh core` passes (verified: 707/707)

https://claude.ai/code/session_01W4u2JjmbSwWx46E3QnC7sG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4u2JjmbSwWx46E3QnC7sG)_