### PR TITLE
fix(browse-canvas): use effZoom for pyramid level selection to prevent hex size distortion on zoom

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -160,12 +160,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     return binGeometry(this.meta?.bin_shape);
   }
 
-  /**
-   * On-screen scale: the base zoom (driven by wheel/fit and feeding level
-   * selection) times the user's display-size multiplier. All projection↔screen
-   * conversions and the rendered hex radius use this; level selection uses the
-   * base ``transform.zoom`` alone so the binning is invariant to display size.
-   */
+  /** On-screen scale: base zoom × display-size multiplier. Used for all
+   * projection↔screen conversions, rendered hex radius, and level selection. */
   private get effZoom(): number {
     return this.transform.zoom * this.displayScale;
   }
@@ -222,10 +218,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       }
       this.requestRedraw();
     }
-    // Display-size changes only rescale rendering; the active level (binning)
-    // is left untouched on purpose, so the same hexes are simply drawn larger
-    // or smaller.
+    // Display-size changes rescale rendering and require a level re-selection:
+    // effZoom = transform.zoom * displayScale, so a larger displayScale raises
+    // the effective zoom and should switch to a finer pyramid level to keep
+    // hexes near the 28px target, not blow them up.
     if (changes['displayScale'] && !changes['displayScale'].firstChange) {
+      this.updateActiveLevel();
       this.requestRedraw();
     }
     // A colormap change only affects flat (non-thumbnail) shading; repaint.
@@ -307,7 +305,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     if (!this.meta || this.meta.levels.length === 0) return;
     const targetScreenRadius = 28;
     const idealLevel = Math.log2(
-      (this.meta.base_radius * this.transform.zoom) / targetScreenRadius,
+      (this.meta.base_radius * this.effZoom) / targetScreenRadius,
     );
     this.activeLevel = Math.max(
       0,


### PR DESCRIPTION
## Summary

- `updateActiveLevel()` was using `transform.zoom` alone to select the pyramid level, but the actual rendered hex radius is `radius * effZoom` (= `transform.zoom * displayScale`). With `displayScale > 1`, level transitions fired far too late — at `displayScale=2.5` a hex could swell to ~99px radius before the level switched, causing the hexes and disks to visually grow and appear to overlap.
- Fixed by switching `updateActiveLevel()` to use `effZoom` so the ~28px screen-radius target is in true screen pixels regardless of display scale.
- Also call `updateActiveLevel()` when `displayScale` changes in `ngOnChanges` — previously only `requestRedraw()` was called, leaving the active level stale until the next wheel event.

## Root cause detail

`fitToData()` sets `transform.zoom = fitZoom / displayScale` so that `effZoom = fitZoom` at initial load (correct framing for any display size). But `updateActiveLevel()` was computing:

```
idealLevel = log2(base_radius * transform.zoom / 28)
           = log2(base_radius * fitZoom / displayScale / 28)
```

So with `displayScale=2.5` the function targeted 28/2.5 ≈ 11px — meaning hexes grew to ~2.5× their intended size before the level switched. The fix uses `effZoom` = `transform.zoom * displayScale`, which always yields the correct screen-pixel target independent of display scale.

## Test plan

- [ ] Build passes: `npm run build:prod` — no errors or budget warnings
- [ ] All 4579 Python tests pass: `./run-tests.sh`
- [ ] Manual: open VTSBrowser, change display-size slider, verify hexes stay near their normal visual size rather than growing large before level switch
- [ ] Manual: zoom in/out at non-default display scale (e.g. 2.5×), verify level transitions are smooth and hexes don't balloon between steps

https://claude.ai/code/session_01MMtnd8eKSvH3VHitnK3LRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMtnd8eKSvH3VHitnK3LRB)_