### PR TITLE
Load and project a dataset before browsing from the dashboard

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -817,6 +817,22 @@ and available to any future consumer of `vtscore`.
 ## Open follow-ups
 
 **Shipped:**
+- **Load + project on the dashboard before entering Browse.** The dashboard's
+  per-row `Browse` button no longer navigates straight to `/browse/:id` and
+  lets the browse view discover a missing load/projection. It now mirrors the
+  Train button: `BrowsePrepService` (`frontend/src/app/services/browse-prep.service.ts`)
+  loads the dataset (if needed) and builds its `hex` projection — surfacing
+  progress inline on the dataset's grid row (load phase via the existing SSE
+  loading-task row; projection phase via a synthesized row polling
+  `GET /api/projection/meta`) — and only navigates once both are ready. A load
+  or projection failure is shown inline on the row (Dismiss to clear); we never
+  leave the dashboard for a half-prepared browse window. The `browseContextGuard`
+  and the browse view's own `loadProjection()` stay as the fallback for
+  deep-links / top-bar pulldown navigation (they find the projection already
+  built and render instantly). *Known limitation:* the prep always builds the
+  `hex` shape; if the user's per-media `browse_bin_shape` is `square`, the browse
+  view re-bins the (already-fit) shared layout in-view — a millisecond rebin, no
+  UMAP re-fit.
 - **Browse a Find run's positives as their own UMAP.** The Find right panel has
   a `Browse` button next to `Export` (find mode only, disabled when the good
   list is empty). It UMAPs *only* the positive items' high-d vectors — not the

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -142,7 +142,8 @@
                 [columnOrder]="visibleDatasetColumns"
                 [selected]="isDatasetSelected(dataset.id)"
                 [dimmed]="isLoading && !isDatasetSelected(dataset.id)"
-                [loadingTask]="loadingTasksSvc.getInlineTask(dataset.id)"
+                [loadingTask]="browsePrep.displayTask(dataset.id) ?? loadingTasksSvc.getInlineTask(dataset.id)"
+                [taskKind]="browsePrep.taskKind(dataset.id)"
                 [statsOpen]="modals.stats.open && modals.stats.datasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId === dataset.id"
                 (rowClick)="!isLoading && toggleDatasetSelection(dataset.id, $event)"
@@ -153,8 +154,8 @@
                 (load)="loadDataset(dataset)"
                 (browse)="browseDataset(dataset)"
                 (security)="editDatasetSecurity(dataset)"
-                (cancelTask)="loadingTasksSvc.cancelLoadingTask($event)"
-                (dismissTask)="loadingTasksSvc.dismissLoadingTask($event)"
+                (cancelTask)="onCancelDatasetTask($event)"
+                (dismissTask)="onDismissDatasetTask($event)"
               />
             }
           </tbody>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -18,6 +18,7 @@ import { TopBarStateService } from '../../services/top-bar-state.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { DashboardModalsService } from '../../services/dashboard-modals.service';
 import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
+import { BrowsePrepService } from '../../services/browse-prep.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { DatasetRegistryEntry, DemoDataset, DetectorRegistryEntry, ImporterInfo, LoadingTask, ProgressEvent } from '../../models/api.models';
 import { ProgressEventsService } from '../../services/progress-events.service';
@@ -169,6 +170,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private newThingFlows: NewThingFlowsService,
     public modals: DashboardModalsService,
     public loadingTasksSvc: DashboardLoadingTasksService,
+    public browsePrep: BrowsePrepService,
     private progressEvents: ProgressEventsService,
     private settingsState: SettingsStateService,
     columnsService: DashboardColumnsService,
@@ -788,11 +790,34 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Launch the VTSBrowse view for a dataset. The browseContextGuard loads the
-   *  dataset context if needed. Browsing works for any media type — the UMAP
-   *  projection and hex-tile pyramid are embedding-based and media-agnostic. */
+  /** Launch the VTSBrowse view for a dataset. Loads the dataset (if needed)
+   *  AND builds its projection first — with progress shown inline on the
+   *  dataset's row — so missing loads or projections surface here on the
+   *  dashboard, not after we've navigated into the browse window. Only once
+   *  both are ready does `BrowsePrepService` navigate to `/browse/:id`.
+   *  Browsing works for any media type — the UMAP projection and hex-tile
+   *  pyramid are embedding-based and media-agnostic. */
   browseDataset(dataset: DatasetRegistryEntry): void {
-    this.router.navigate(['/browse', dataset.id]);
+    this.browsePrep.prepareAndBrowse(dataset.id);
+  }
+
+  /** Cancel a dataset load row. Routes the browse-prep projection row to
+   *  `BrowsePrepService`; everything else is a real SSE load task. */
+  onCancelDatasetTask(taskId: string): void {
+    if (this.browsePrep.ownsTask(taskId)) {
+      this.browsePrep.cancel();
+    } else {
+      this.loadingTasksSvc.cancelLoadingTask(taskId);
+    }
+  }
+
+  /** Dismiss an errored dataset row (see `onCancelDatasetTask`). */
+  onDismissDatasetTask(taskId: string): void {
+    if (this.browsePrep.ownsTask(taskId)) {
+      this.browsePrep.dismiss();
+    } else {
+      this.loadingTasksSvc.dismissLoadingTask(taskId);
+    }
   }
 
   loadDetector(model: DetectorRegistryEntry): void {
@@ -989,6 +1014,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return (
       this.trainLoading ||
       this.findLoading ||
+      this.browsePrep.preparing ||
       this.contextSwitch.switching ||
       this.datasetState.loading
     );

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -53,7 +53,7 @@
         @if (taskProgressInfo.eta) {
           <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
         }
-        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel this dataset load">Cancel</button>
+        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" [title]="taskKind === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'">Cancel</button>
       </div>
     </div>
   </td>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -5,6 +5,7 @@ import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import {
   ProgressHeader,
+  ProgressKind,
   formatProgressHeader,
   isProgressIndeterminate,
 } from '../../../utils/format-progress';
@@ -25,6 +26,9 @@ export class DatasetCardComponent implements OnChanges {
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;
+  /** Which progress vocabulary to render the inline row with. ``projection``
+   *  is used while the Browse button pre-builds the dataset's projection. */
+  @Input() taskKind: ProgressKind = 'dataset';
 
   @HostBinding('class.loading-error')
   get hasLoadingError(): boolean {
@@ -158,7 +162,7 @@ export class DatasetCardComponent implements OnChanges {
   get taskProgressInfo(): ProgressHeader {
     const task = this.loadingTask;
     if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
-    return formatProgressHeader(task, 'dataset', task.embedder);
+    return formatProgressHeader(task, this.taskKind, task.embedder);
   }
 
   get taskIsIndeterminate(): boolean {

--- a/frontend/src/app/services/browse-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-prep.service.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { Observable, Subject, of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { BrowsePrepService } from './browse-prep.service';
+import { ActiveContextService } from './active-context.service';
+import { ContextSwitchService } from './context-switch.service';
+import { ProgressEventsService } from './progress-events.service';
+import { ProjectionApiService } from './projection-api.service';
+import { LoadingTask } from '../models/api.models';
+import type { ProjectionBuildResponse, ProjectionMeta } from '../models/projection.models';
+
+/**
+ * The Browse button must raise missing-load / missing-projection problems on
+ * the dashboard: it loads AND projects a dataset (showing progress on the
+ * row) before navigating to the browse view. These tests pin that contract:
+ * navigation happens only once both phases settle, and failures surface inline
+ * instead of leaking into the browse window.
+ */
+describe('BrowsePrepService', () => {
+  let service: BrowsePrepService;
+  let router: Router;
+
+  let applyPair$: Subject<void>;
+  let loadingTasks: LoadingTask[];
+  // Reassigned per test to script the projection meta/build responses.
+  let metaProvider: () => Observable<ProjectionMeta>;
+  let buildProvider: () => Observable<ProjectionBuildResponse>;
+
+  const DS = 'ds1';
+
+  function meta(overrides: Partial<ProjectionMeta>): ProjectionMeta {
+    return {
+      projection_id: 'p',
+      bounds: [0, 0, 1, 1],
+      base_radius: 1,
+      tile_span: 1,
+      point_count: 0,
+      levels: [],
+      ...overrides,
+    };
+  }
+
+  function erroredTask(): LoadingTask {
+    return {
+      status: 'idle',
+      message: '',
+      current: 0,
+      total: 0,
+      task_id: 't',
+      name: 'n',
+      created_at: 0,
+      dataset_id: DS,
+      error: 'boom',
+    };
+  }
+
+  beforeEach(() => {
+    applyPair$ = new Subject<void>();
+    loadingTasks = [];
+    metaProvider = () => of(meta({ status: 'idle' }));
+    buildProvider = () => of({ status: 'building' });
+
+    const contextSwitchStub = {
+      applyActivePair: (): Observable<void> => applyPair$,
+    };
+    const activeContextStub = { modelId: '' };
+    const progressEventsStub = {
+      get loadingTasks(): LoadingTask[] {
+        return loadingTasks;
+      },
+    };
+    const projectionApiStub = {
+      getMeta: (): Observable<ProjectionMeta> => metaProvider(),
+      build: (): Observable<ProjectionBuildResponse> => buildProvider(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: ContextSwitchService, useValue: contextSwitchStub },
+        { provide: ActiveContextService, useValue: activeContextStub },
+        { provide: ProgressEventsService, useValue: progressEventsStub },
+        { provide: ProjectionApiService, useValue: projectionApiStub },
+      ],
+    });
+
+    service = TestBed.inject(BrowsePrepService);
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
+  });
+
+  it('navigates once the projection is already built', () => {
+    metaProvider = () => of(meta({ status: 'ready', point_count: 42 }));
+
+    service.prepareAndBrowse(DS);
+    expect(service.preparing).toBeTrue();
+    applyPair$.next(); // load completes
+
+    expect(router.navigate).toHaveBeenCalledWith(['/browse', DS]);
+    expect(service.preparing).toBeFalse();
+  });
+
+  it('builds the projection, polls until ready, then navigates', fakeAsync(() => {
+    // idle → build (building) → poll → ready
+    metaProvider = () => of(meta({ status: 'idle' }));
+    buildProvider = () => of({ status: 'building' });
+
+    service.prepareAndBrowse(DS);
+    applyPair$.next();
+
+    // After the build kicks off we are projecting and have not navigated.
+    expect(service.taskKind(DS)).toBe('projection');
+    expect(service.displayTask(DS)?.status).toBe('building');
+    expect(router.navigate).not.toHaveBeenCalled();
+
+    // Next poll reports the layout is ready.
+    metaProvider = () => of(meta({ status: 'ready', point_count: 7 }));
+    tick(1000);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/browse', DS]);
+  }));
+
+  it('surfaces a projection build failure inline without navigating', () => {
+    metaProvider = () => of(meta({ status: 'idle' }));
+    buildProvider = () =>
+      throwError(() => new HttpErrorResponse({ status: 409, error: { message: 'no embeddings' } }));
+
+    service.prepareAndBrowse(DS);
+    applyPair$.next();
+
+    const task = service.displayTask(DS);
+    expect(task?.error).toBe('no embeddings');
+    expect(service.ownsTask(task!.task_id)).toBeTrue();
+    expect(router.navigate).not.toHaveBeenCalled();
+    // Error is terminal-but-dismissable, so the dashboard isn't held loading.
+    expect(service.preparing).toBeFalse();
+  });
+
+  it('bails out silently when the dataset load failed (SSE shows the error)', () => {
+    loadingTasks = [erroredTask()];
+    let metaCalled = false;
+    metaProvider = () => {
+      metaCalled = true;
+      return of(meta({}));
+    };
+
+    service.prepareAndBrowse(DS);
+    applyPair$.next();
+
+    expect(metaCalled).toBeFalse();
+    expect(service.displayTask(DS)).toBeNull();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('defers the load-phase row to the real SSE task', () => {
+    service.prepareAndBrowse(DS);
+    // No real task yet → placeholder so the row gives immediate feedback.
+    expect(service.displayTask(DS)?.status).toBe('loading');
+    // Once the SSE task appears, defer to it.
+    loadingTasks = [{ ...erroredTask(), status: 'loading', error: '' }];
+    expect(service.displayTask(DS)).toBeNull();
+  });
+});

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -108,6 +108,15 @@ export class BrowsePrepService {
           }
           this.startProjection(datasetId);
         },
+        complete: () => {
+          // The switch was superseded/cancelled before emitting (e.g. a
+          // competing context switch). Don't leave the prep latched in the
+          // loading phase, which would keep the dashboard disabled forever.
+          const s = this.stateSubject.value;
+          if (s && s.datasetId === datasetId && s.phase === 'loading') {
+            this.clear();
+          }
+        },
       });
   }
 

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -1,0 +1,299 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ActiveContextService } from './active-context.service';
+import { ContextSwitchService } from './context-switch.service';
+import { ProgressEventsService } from './progress-events.service';
+import { ProjectionApiService } from './projection-api.service';
+import { LoadingTask } from '../models/api.models';
+import type { ProgressKind } from '../utils/format-progress';
+import type { ProjectionMeta } from '../models/projection.models';
+
+/** Which step of the browse preparation we're on. */
+type Phase = 'loading' | 'projecting' | 'error';
+
+interface BrowsePrepState {
+  datasetId: string;
+  phase: Phase;
+  current: number;
+  total: number;
+  message: string;
+  error: string;
+}
+
+/** task_id prefix for the synthetic projection-phase row, so the dashboard
+ *  can route its Cancel/Dismiss clicks back here instead of to a real
+ *  dataset-load task. */
+const SENTINEL_PREFIX = '__browseprep__';
+
+/** Bin shape we pre-build. The 2-D UMAP layout is shared across shapes, so
+ *  if the browse view later wants squares it re-bins the frozen layout in
+ *  milliseconds rather than re-fitting UMAP. */
+const PREP_SHAPE = 'hex' as const;
+
+const MAX_POLL_ERRORS = 5;
+
+/**
+ * Orchestrates the Dashboard's "Browse" button: load the dataset (if needed)
+ * **and** build its projection, surfacing progress on the dataset's grid row,
+ * and only navigate to the browse view once both are ready. Mirrors how the
+ * Train button loads a dataset before entering the label view — the user's
+ * complaint about a missing load or missing projection is raised on the
+ * dashboard, never after we've left it for the browse window.
+ *
+ * Progress for the **load** phase rides the existing SSE loading-task channel
+ * (the same row the Load button shows); this service only synthesizes a row
+ * for the **projection** phase, which the projection job exposes via meta
+ * polling rather than that channel.
+ */
+@Injectable({ providedIn: 'root' })
+export class BrowsePrepService {
+  private readonly stateSubject = new BehaviorSubject<BrowsePrepState | null>(null);
+  readonly state$ = this.stateSubject.asObservable();
+
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private pollErrors = 0;
+
+  constructor(
+    private router: Router,
+    private activeContext: ActiveContextService,
+    private contextSwitch: ContextSwitchService,
+    private progressEvents: ProgressEventsService,
+    private projectionApi: ProjectionApiService,
+  ) {}
+
+  /** True while a browse preparation is in flight (not counting the
+   *  terminal error state, which waits for the user to dismiss). */
+  get preparing(): boolean {
+    const s = this.stateSubject.value;
+    return !!s && s.phase !== 'error';
+  }
+
+  /**
+   * Begin preparing *datasetId* for browsing: ensure it's loaded and active,
+   * then ensure its projection is built, then navigate to the browse view.
+   * No-ops if a preparation is already running.
+   */
+  prepareAndBrowse(datasetId: string): void {
+    if (this.preparing) return;
+    this.clearTimer();
+    this.stateSubject.next({
+      datasetId,
+      phase: 'loading',
+      current: 0,
+      total: 0,
+      message: 'Loading dataset…',
+      error: '',
+    });
+
+    // Preserve the active detector (browsing doesn't need one, but clearing it
+    // would clobber the user's selection); this mirrors browseContextGuard.
+    this.contextSwitch
+      .applyActivePair(datasetId, this.activeContext.modelId || '')
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          if (!this.isCurrent(datasetId)) return;
+          // A failed load leaves an errored task on the SSE row, which the
+          // dashboard already shows; bail out silently rather than stacking a
+          // second (projection) error on top of it.
+          const loadFailed = this.progressEvents.loadingTasks.some(
+            (t) => t.dataset_id === datasetId && !!t.error,
+          );
+          if (loadFailed) {
+            this.clear();
+            return;
+          }
+          this.startProjection(datasetId);
+        },
+      });
+  }
+
+  /** Cancel an in-flight preparation (Cancel button on the projection row). */
+  cancel(): void {
+    this.clear();
+  }
+
+  /** Dismiss a finished-with-error preparation (Dismiss button on the row). */
+  dismiss(): void {
+    this.clear();
+  }
+
+  /** True when *taskId* is this service's synthetic projection row. */
+  ownsTask(taskId: string): boolean {
+    return taskId.startsWith(SENTINEL_PREFIX);
+  }
+
+  /** Which progress vocabulary the dashboard should render the row with. */
+  taskKind(datasetId: string): ProgressKind {
+    const s = this.stateSubject.value;
+    return s && s.datasetId === datasetId && s.phase !== 'loading' ? 'projection' : 'dataset';
+  }
+
+  /**
+   * The synthetic loading-task row to show for *datasetId*, or ``null`` to
+   * defer to the real SSE load task. We only own the row during the
+   * projection phase (and a brief pre-load "Preparing…" flash before the SSE
+   * task appears); the load phase is the real task's to render.
+   */
+  displayTask(datasetId: string): LoadingTask | null {
+    const s = this.stateSubject.value;
+    if (!s || s.datasetId !== datasetId) return null;
+
+    if (s.phase === 'loading') {
+      // Defer to the real SSE task once it shows; until then, a placeholder
+      // so the row gives immediate feedback instead of flashing blank.
+      const hasReal = this.progressEvents.loadingTasks.some(
+        (t) => t.dataset_id === datasetId && t.status !== 'idle',
+      );
+      if (hasReal) return null;
+      return this.synthTask(datasetId, 'loading', 'Loading dataset…', 0, 0, '');
+    }
+    if (s.phase === 'error') {
+      return this.synthTask(datasetId, 'idle', '', 0, 0, s.error);
+    }
+    return this.synthTask(datasetId, 'building', s.message, s.current, s.total, '');
+  }
+
+  // --- projection phase ---
+
+  private startProjection(datasetId: string): void {
+    this.patch({ phase: 'projecting', current: 0, total: 0, message: 'Building projection…' });
+    this.pollErrors = 0;
+    this.projectionApi
+      .getMeta(PREP_SHAPE)
+      .pipe(take(1))
+      .subscribe({
+        next: (meta) => this.handleMeta(datasetId, meta),
+        error: (err) => this.fail(datasetId, this.errMessage(err, 'Failed to load projection')),
+      });
+  }
+
+  private handleMeta(datasetId: string, meta: ProjectionMeta): void {
+    if (!this.isCurrent(datasetId)) return;
+
+    if (meta.point_count > 0) {
+      this.finish(datasetId);
+      return;
+    }
+    if (meta.status === 'error') {
+      this.fail(datasetId, meta.error || 'Projection build failed');
+      return;
+    }
+    if (meta.status === 'building') {
+      this.patch({
+        current: meta.current ?? 0,
+        total: meta.total ?? 0,
+        message: meta.message || 'Building projection…',
+      });
+      this.schedulePoll(datasetId);
+      return;
+    }
+    // status === "idle": nothing built yet. Kick off the build.
+    this.projectionApi
+      .build(PREP_SHAPE)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          if (!this.isCurrent(datasetId)) return;
+          if (resp.status === 'ready') {
+            this.finish(datasetId);
+            return;
+          }
+          this.schedulePoll(datasetId);
+        },
+        error: (err) => this.fail(datasetId, this.errMessage(err, 'Failed to start projection build')),
+      });
+  }
+
+  private schedulePoll(datasetId: string): void {
+    this.clearTimer();
+    this.pollTimer = setTimeout(() => {
+      if (!this.isCurrent(datasetId)) return;
+      this.projectionApi
+        .getMeta(PREP_SHAPE)
+        .pipe(take(1))
+        .subscribe({
+          next: (meta) => {
+            this.pollErrors = 0;
+            this.handleMeta(datasetId, meta);
+          },
+          error: () => {
+            this.pollErrors += 1;
+            if (this.pollErrors >= MAX_POLL_ERRORS) {
+              this.fail(datasetId, 'Lost contact with the server while building the projection.');
+              return;
+            }
+            this.schedulePoll(datasetId);
+          },
+        });
+    }, 1000);
+  }
+
+  private finish(datasetId: string): void {
+    this.clear();
+    this.router.navigate(['/browse', datasetId]);
+  }
+
+  private fail(datasetId: string, message: string): void {
+    if (!this.isCurrent(datasetId)) return;
+    this.clearTimer();
+    this.patch({ phase: 'error', error: message });
+  }
+
+  // --- helpers ---
+
+  private isCurrent(datasetId: string): boolean {
+    const s = this.stateSubject.value;
+    return !!s && s.datasetId === datasetId && s.phase !== 'error';
+  }
+
+  private patch(partial: Partial<BrowsePrepState>): void {
+    const s = this.stateSubject.value;
+    if (!s) return;
+    this.stateSubject.next({ ...s, ...partial });
+  }
+
+  private clear(): void {
+    this.clearTimer();
+    this.stateSubject.next(null);
+  }
+
+  private clearTimer(): void {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  private synthTask(
+    datasetId: string,
+    status: string,
+    message: string,
+    current: number,
+    total: number,
+    error: string,
+  ): LoadingTask {
+    return {
+      status,
+      message,
+      current,
+      total,
+      task_id: `${SENTINEL_PREFIX}${datasetId}`,
+      name: '',
+      created_at: 0,
+      dataset_id: datasetId,
+      error,
+    };
+  }
+
+  private errMessage(err: unknown, fallback: string): string {
+    if (err instanceof HttpErrorResponse) {
+      const body = err.error as { message?: string; error?: string } | undefined;
+      return body?.message || body?.error || fallback;
+    }
+    return fallback;
+  }
+}

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -118,7 +118,7 @@ export interface ProgressHeader {
 }
 
 /** Which load flow this progress event belongs to. */
-export type ProgressKind = 'dataset' | 'detector';
+export type ProgressKind = 'dataset' | 'detector' | 'projection';
 
 const EMBEDDER_PRETTY: Record<string, string> = {
   siglip: 'SigLIP',
@@ -169,12 +169,25 @@ export function formatProgressHeader(
   const prog = progress ?? {};
   const status = (prog.status ?? '').toLowerCase();
   const message = prog.message ?? '';
-  const what = kind === 'detector' ? 'Loading detector' : 'Loading dataset';
+  const what =
+    kind === 'detector'
+      ? 'Loading detector'
+      : kind === 'projection'
+        ? 'Building projection'
+        : 'Loading dataset';
 
   let phase = '';
   let subtitle = '';
 
-  if (status === 'downloading') {
+  if (kind === 'projection') {
+    if (/pyramid|tiling|binning/i.test(message)) {
+      phase = 'tiling layout';
+      subtitle = 'Binning the 2-D layout into the hex/square tile pyramid.';
+    } else {
+      phase = 'running UMAP';
+      subtitle = 'Projecting embeddings to 2-D so the dataset can be browsed as a map.';
+    }
+  } else if (status === 'downloading') {
     if (/extract/i.test(message)) {
       phase = 'unpacking archive';
       subtitle = 'Extracting the downloaded archive into the dataset cache.';


### PR DESCRIPTION
## Problem

Clicking **Browse** on a dataset in the dashboard grid navigated straight to `/browse/:id` and let the browse view discover any missing load/projection *after* leaving the dashboard. If the dataset wasn't loaded you'd land in the browse window staring at a "Dataset not loaded" error, then bounce back to a dashboard row that span forever.

The Browse button should be the moment we complain about a missing load **or** a missing projection — exactly like the Train button, which loads a dataset (with a progress bar) before entering the label view.

## Change

The dashboard Browse button now mirrors the Train flow: it **loads** the dataset (if needed) **and builds its projection** before navigating, surfacing progress inline on the dataset's grid row, and only enters the browse view once both are ready. A load or projection failure is shown inline on the row (Dismiss to clear) — we never leave the dashboard for a half-prepared browse window.

- **New `BrowsePrepService`** (`frontend/src/app/services/browse-prep.service.ts`) orchestrates the flow:
  1. `applyActivePair(...)` to load + activate the dataset (preserving the active detector, like `browseContextGuard`).
  2. Build the `hex` projection, polling `GET /api/projection/meta` until the layout is ready.
  3. Navigate to `/browse/:id`.
  - The **load phase** rides the existing SSE loading-task row (same one the Load button shows). The **projection phase** is a synthesized row, since projection jobs are polled via meta rather than the SSE channel.
  - Failures surface inline; a superseded/cancelled switch can't latch the dashboard in a loading state.
- **`format-progress.ts`** gains a `projection` progress kind ("Building projection · running UMAP / tiling layout") so the row reads correctly during the projection phase.
- **`dataset-card`** gains a `taskKind` input; the dashboard routes Cancel/Dismiss on the synthetic projection row back to `BrowsePrepService`.

The `browseContextGuard` and the browse view's own `loadProjection()` stay as the fallback for deep-links and top-bar pulldown navigation — they find the projection already built and render instantly.

### Known limitation
Prep always builds the `hex` shape. If a user's per-media `browse_bin_shape` is `square`, the browse view re-bins the (already-fit) shared layout in-view — a millisecond rebin, no UMAP re-fit. Noted in `docs/plans/vtsbrowse.md`.

## Tests
- New `browse-prep.service.spec.ts` covering: navigate-when-already-built, build→poll→ready, inline build-failure (no navigation), silent bail-out on load failure, and load-phase row deferral.
- `./run-tests.sh core` → `ALL 707 TESTS PASSED`; `npm run build:prod` clean (no TS errors / budget warnings); `tsc -p tsconfig.spec.json` clean.

https://claude.ai/code/session_01Ljqm4z1YXPMzMaSaekHqYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljqm4z1YXPMzMaSaekHqYL)_