### PR TITLE
Fix 400 when switching theme in VTSBrowser without a loaded detector

### DIFF
--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -62,6 +62,38 @@ class TestSettingsAPI:
         # SettingsUpdate schema catches the type mismatch → 422.
         assert res.status_code == 422
 
+    def test_update_inclusion_no_detector_browse_mode(self, client):
+        """A bulk settings save without an identified detector must not 400.
+
+        Reproduces the VTSBrowser theme-switch bug: the browser has a dataset
+        loaded but no detector, so Angular's ``activeContextInterceptor``
+        sends ``X-Dataset-Id`` but omits ``X-Detector-Id``. The settings-modal
+        ``save()`` echoes the whole settings blob back on every change
+        (including ``inclusion``, which routes to the active detector
+        context). With no detector identified, the route resolves the frozen
+        request-missing detector sentinel; applying ``inclusion`` used to
+        raise ``RequestMissingContextError`` → 400. The inclusion cache write
+        is now skipped when no detector is present (the value still persists
+        to the per-user settings store).
+        """
+        from vtscore.state.core import set_thread_detector_context
+
+        # Drop the thread-local detector context the conftest installs so the
+        # resolver falls through to the request-missing sentinel, matching a
+        # production Flask request thread with no detector.
+        set_thread_detector_context(None)
+        res = client.put(
+            "/api/settings",
+            json={"theme": "dark", "inclusion": 3},
+            headers={"X-Detector-Id": ""},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["inclusion"] == 3
+
+        # The value still persisted to the per-user settings store.
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["inclusion"] == 3
+
     def test_update_volume_invalid(self, client):
         res = client.put(
             "/api/settings",

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -856,7 +856,19 @@ def _get_inclusion() -> int | None:
 
 
 def _set_inclusion(value: int | None) -> None:
-    get_active_detector_context().inclusion = value
+    ctx = get_active_detector_context()
+    # ``inclusion`` is cached per-detector for fast reads, but its canonical
+    # persisted home is the per-user settings store (written by the caller's
+    # ``_persist_setting`` hook). When a Flask request identifies no detector
+    # (e.g. the VTSBrowser, which has a dataset but no loaded detector), the
+    # active context is the frozen request-missing sentinel; there is no
+    # detector to cache the value on, so skip the cache write rather than
+    # raising ``RequestMissingContextError``. The user-settings persist still
+    # runs, so an inclusion value echoed back by a bulk settings save is a
+    # harmless no-op instead of a 400.
+    if is_request_missing_detector_context(ctx):
+        return
+    ctx.inclusion = value
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Switching Light → Dark (or any settings change) while in the VTSBrowser raised:

> Refusing to mutate the request-missing detector context … `PUT /api/settings` … 400 BAD REQUEST

## Root cause

The settings-modal `onThemeChange()` calls `save()`, which echoes the **entire** `AppSettings` blob back via `PUT /api/settings` on every change. That blob includes `inclusion`, which the route dispatches through `vtscore.state.set_inclusion` → `get_active_detector_context().inclusion = value`.

In the VTSBrowser a **dataset is loaded but no detector is**, so Angular's `activeContextInterceptor` sends `X-Dataset-Id` but omits `X-Detector-Id`. The route then resolves the frozen *request-missing detector sentinel*, and assigning to its `inclusion` attribute raises `RequestMissingContextError` (mapped to 400).

`inclusion` is cached per-detector for fast reads, but its canonical persisted home is the per-user settings store. With no detector present there is simply nowhere to cache it.

## Fix

`vtscore/state/core.py::_set_inclusion` now skips the per-detector cache write when the active context is the request-missing sentinel. The per-user persist hook still runs, so an `inclusion` value echoed back by a bulk settings save is a harmless no-op instead of a 400. The real labeling-mode path (detector present) is unchanged — the value still caches on the detector context.

Verified by hand with a Flask test client (browse mode now 200; value still round-trips through GET; detector-mode caching intact).

## Tests

Added `test_update_inclusion_no_detector_browse_mode` to `tests/core/test_settings_api_routes.py`. The existing inclusion tests passed before this fix only because conftest installs a thread-local detector context that masks the production scenario; the new test drops that thread-local and sends an empty `X-Detector-Id` to exercise the real sentinel path.

`./run-tests.sh core detectors sorting` — all green (2119 tests + linters + frontend build).

https://claude.ai/code/session_016cjWZeUqWmZTUzG5H4A4ds

---
_Generated by [Claude Code](https://claude.ai/code/session_016cjWZeUqWmZTUzG5H4A4ds)_