### PR TITLE
Darken light-mode Ocean colormap so VTSBrowse circles are distinguishable

### DIFF
--- a/frontend/src/app/components/browse-canvas/hex-render.util.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.ts
@@ -46,14 +46,15 @@ const HEAT_RAMP: RGB[] = [
   [255, 235, 70],
 ];
 
-// "Ocean": light-blue → dark-navy, with a neutral light grey for singletons.
+// "Ocean": medium-blue → dark-navy, with a neutral mid grey for singletons.
 // Darkness rises with density, which reads naturally on a light background
 // (more ink = more items) and keeps the hues disjoint from Heat's red/yellow —
 // so "this bin is blue" unambiguously means light mode + lots, and "yellow"
-// means dark mode + lots. This is the light-mode default.
+// means dark mode + lots. This is the light-mode default. The low end starts
+// at a clearly-saturated blue (not the near-white ColorBrewer "Blues" tail)
+// so even sparse cells separate from the ``#f0f2f5`` light-mode background;
+// the earlier pale start made one-item discs and low-density bins vanish.
 const OCEAN_RAMP: RGB[] = [
-  [222, 235, 247],
-  [198, 219, 239],
   [158, 202, 225],
   [107, 174, 214],
   [66, 146, 198],
@@ -61,7 +62,9 @@ const OCEAN_RAMP: RGB[] = [
   [8, 81, 156],
   [8, 48, 107],
 ];
-const OCEAN_SINGLE: RGB = [200, 205, 214];
+// A mid neutral grey — distinct from the blue ramp so a lone dot reads as
+// "exactly one", and dark enough to stay legible on the light-mode background.
+const OCEAN_SINGLE: RGB = [150, 158, 172];
 
 // "Grayscale": a neutral luminance ramp that always moves *away* from the
 // background so density stays legible — darker as it grows on a light canvas,


### PR DESCRIPTION
## Problem

In light mode the VTSBrowse canvas was nearly unreadable: one-item cells (drawn as circles) and low-density bins blended into the background.

The `auto` colormap resolves to **Ocean** in light mode, which started at the near-white tail of the ColorBrewer "Blues" scale:

- Lowest-density ramp stop: `[222, 235, 247]`
- Singleton disc color: `[200, 205, 214]`

Both sit almost on top of the light-mode background `#f0f2f5` = `[240, 242, 245]`, so the "1" color was visually indistinguishable from the "0" (empty) background.

## Fix

In `frontend/src/app/components/browse-canvas/hex-render.util.ts`:

- Drop the two palest Ocean ramp stops so the ramp now starts at a clearly-saturated `[158, 202, 225]`.
- Darken the singleton color to a mid neutral grey `[150, 158, 172]`, distinct from the blue ramp (so a lone dot still reads as "exactly one") and legible against the light background.

Both the canvas and the shared `vt-browse-legend` resolve from this same colormap, so the on-screen key stays in sync automatically. No other themes (Heat/dark, Grayscale) are affected.

Verified with `npm run build:prod` (clean, no warnings).

https://claude.ai/code/session_01Q8QJgz2CPaF8SW8Q11GcW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8QJgz2CPaF8SW8Q11GcW3)_