### PR TITLE
Light theme: make surfaces read as raised against a grayer desk

### DIFF
--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.scss
@@ -1,6 +1,6 @@
 .hint {
   font-size: var(--font-xs);
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
   margin-bottom: var(--space-md);
 }
 
@@ -12,7 +12,7 @@
 
 .loading {
   font-size: var(--font-xs);
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
   margin: var(--space-md) 0;
 }
 
@@ -25,8 +25,8 @@ canvas {
   display: block;
   width: 100%;
   height: 120px;
-  background: rgba(0, 0, 0, 0.04);
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   touch-action: none;
   user-select: none;
@@ -39,14 +39,14 @@ canvas {
   margin-top: var(--space-md);
   font-family: monospace;
   font-size: var(--font-md);
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--text-primary);
 
   .separator {
-    color: rgba(0, 0, 0, 0.4);
+    color: var(--text-dim);
   }
 
   .dur {
-    color: rgba(0, 0, 0, 0.5);
+    color: var(--text-muted);
   }
 }
 
@@ -59,10 +59,11 @@ canvas {
   button {
     padding: var(--space-md) var(--space-xl);
     border-radius: var(--radius-md);
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--border-secondary);
     cursor: pointer;
     font-size: var(--font-lg);
-    background: white;
+    background: var(--bg-secondary-btn);
+    color: var(--text-primary);
 
     &:disabled {
       opacity: var(--opacity-disabled);
@@ -71,7 +72,7 @@ canvas {
 
     &.primary {
       background: var(--accent);
-      color: white;
+      color: var(--btn-primary-text);
       border-color: transparent;
     }
     &.cancel {

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
@@ -5,7 +5,7 @@
   min-height: 120px;
   max-height: 50vh;
   margin-bottom: var(--space-lg);
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--bg-subtle);
   border-radius: var(--radius-md);
   padding: var(--space-md);
 }
@@ -25,12 +25,12 @@
 .generic-preview {
   font-family: monospace;
   font-size: var(--font-md);
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
 }
 
 .filename {
   font-size: var(--font-md);
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
   text-align: center;
   margin-bottom: var(--space-xl);
   word-break: break-all;
@@ -44,10 +44,11 @@
   button {
     padding: var(--space-md) var(--space-xl);
     border-radius: var(--radius-md);
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--border-secondary);
     cursor: pointer;
     font-size: var(--font-lg);
-    background: white;
+    background: var(--bg-secondary-btn);
+    color: var(--text-primary);
 
     &:disabled {
       opacity: var(--opacity-disabled);
@@ -56,12 +57,12 @@
 
     &.primary {
       background: var(--accent);
-      color: white;
+      color: var(--btn-primary-text);
       border-color: transparent;
     }
 
     &.secondary {
-      background: white;
+      background: var(--bg-secondary-btn);
     }
 
     &.cancel {

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -161,15 +161,24 @@
 }
 
 [data-theme="light"] {
-  --bg-body: #f0f2f5;
+  // Neutral ramp. The desk (--bg-body) is a clearly-grayed slate so that white
+  // surfaces (cards, modals, dropdowns) and the lighter side panels read as
+  // *raised* against it - mirroring the dark theme, where --bg-surface sits a
+  // visible step above the near-black --bg-body. A near-white desk (the old
+  // #f0f2f5) made white cards blend into the background. Elevation order, low
+  // to high: hover < body < subtle < panel < surface.
+  --bg-body: #e4e7ef;
   --bg-surface: #ffffff;
-  --bg-panel: #f5f6fa;
-  --bg-hover: #e4e6f0;
-  --bg-subtle: #eaecf2;
-  --bg-secondary-btn: #e0e2ea;
-  --border: #d0d3dc;
-  --border-secondary: #c0c3cc;
-  --border-subtle: #c8cad6;
+  --bg-panel: #f1f3f8;
+  --bg-hover: #dbe0ec;
+  --bg-subtle: #edeff4;
+  --bg-secondary-btn: #dde1ec;
+  // Border ramp, faintest to strongest: subtle < border < secondary. (Unlike
+  // dark, where "fainter" means darker/closer-to-bg, here fainter means
+  // lighter/closer-to-the-white-surface the line sits on.)
+  --border: #c9cdd9;
+  --border-secondary: #b4b9c7;
+  --border-subtle: #dadde6;
   --text-primary: #1a1a2e;
   --text-secondary: #555;
   --text-muted: #666;
@@ -203,7 +212,7 @@
   --status-green-dot: #43a047;
   --status-green-label: #2e7d32;
   --status-green-sub: #66bb6a;
-  --scrollbar-thumb: #c0c3cc;
+  --scrollbar-thumb: #bcc1ce;
   --scrollbar-thumb-hover: #5a68d8;
   --badge-embedding: #c99000;
   --btn-icon-hover-bg: rgba(0, 0, 0, 0.07);


### PR DESCRIPTION
## Problem

In **dark** mode the Dashboard's Dataset/Detector grids (`.dashboard-section`, `--bg-surface`) clearly float above the body — the surface sits a visible lightness step above the near-black `--bg-body`. In **light** mode the desk was near-white (`#f0f2f5`) and the cards are pure white, so the cards blended into the background and didn't read as having their own surface. The WCAG *ratio* was actually identical between themes, but bright-on-bright reads much flatter to the eye than dark-on-darker, so light mode looked uniformly white.

## Fix

Re-derived the light-theme neutral ramp in `frontend/src/scss/_variables.scss` so white surfaces and the lighter side panels read as raised against a clearly-grayed desk, mirroring dark mode:

- `--bg-body` `#f0f2f5` → `#e4e7ef` (grayer desk)
- `--bg-panel` `#f5f6fa` → `#f1f3f8`
- `--bg-hover` `#e4e6f0` → `#dbe0ec`
- `--bg-subtle` `#eaecf2` → `#edeff4`
- `--bg-secondary-btn` `#e0e2ea` → `#dde1ec`
- `--scrollbar-thumb` `#c0c3cc` → `#bcc1ce`

Also corrected the **inverted border ramp**: light mode had `--border-subtle` (`#c8cad6`) *darker* (more prominent) than the default `--border` (`#d0d3dc`), the opposite of its "faintest divider" role. Now `subtle < border < secondary` from faintest to strongest:

- `--border` → `#c9cdd9`
- `--border-secondary` → `#b4b9c7`
- `--border-subtle` → `#dadde6`

Elevation order low→high is now `hover < body < subtle < panel < surface` (documented inline).

## Drive-by theming fix

While checking colors throughout, found the media-crop and audio-crop overlay modals pinned to hardcoded `white` / `rgba(0,0,0,…)` for buttons, text, previews, and the waveform canvas — a latent **dark/highviz** defect (white buttons with invisible labels on a dark modal). Re-pointed them at the theme tokens (`--bg-secondary-btn`, `--text-primary`, `--bg-subtle`, `--border`, `--btn-primary-text`, etc.). The image-crop `.crop-mask` scrim is left as a deliberate theme-independent `rgba(0,0,0,0.5)` image dimmer.

## Testing

`./run-tests.sh core` — all 708 tests pass (includes the frontend `build:prod` + ruff/codespell/deptry checks).

https://claude.ai/code/session_01SGGwYpx3gxj9kzzsUDT3m5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGGwYpx3gxj9kzzsUDT3m5)_