### PR TITLE
Cache projection tiles to reduce VTSBrowse zoom/pan blanking

### DIFF
--- a/app.py
+++ b/app.py
@@ -347,10 +347,14 @@ def _no_cache_api(response):
     Without this, concurrent or rapid-fire fetches to the same endpoint
     (e.g. ``/api/datasets/registry``) can receive stale cached data,
     causing the frontend to miss newly loaded datasets.
+
+    Endpoints serving genuinely immutable data (e.g. frozen projection
+    tiles) opt out by setting their own ``Cache-Control`` in the view; we
+    defer to that rather than clobbering it with ``no-store``.
     """
     from flask import request
 
-    if request.path.startswith("/api/"):
+    if request.path.startswith("/api/") and "Cache-Control" not in response.headers:
         response.headers["Cache-Control"] = "no-store"
     return response
 

--- a/frontend/src/app/services/tile-cache.service.ts
+++ b/frontend/src/app/services/tile-cache.service.ts
@@ -15,7 +15,14 @@ export class TileCacheService {
 
   private cache = new Map<string, CacheEntry>();
   private inflight = new Map<string, Observable<TilePayload>>();
-  private readonly MAX_ENTRIES = 512;
+  // Deeper datasets carve more pyramid levels, so a small flat LRU thrashes:
+  // panning back over seen ground misses and the hex grid blanks. Hold more.
+  private readonly MAX_ENTRIES = 2048;
+  // Levels 0..PINNED_LEVELS-1 are the coarse top of the pyramid: a handful of
+  // tiles that cover the whole projection and are the cheapest thing to keep
+  // warm. Exempt them from eviction so a zoom/pan back to the overview is never
+  // a cache miss (and so they're available as a fallback layer later).
+  private readonly PINNED_LEVELS = 3;
   private projectionId = '';
   // The bin shape (hex/square) tiles are currently fetched for. It is part of
   // the cache key, so switching shapes keeps both binnings cached side by side
@@ -109,10 +116,14 @@ export class TileCacheService {
 
   private evict(): void {
     const target = Math.floor(this.MAX_ENTRIES * 0.75);
-    const entries = [...this.cache.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess);
-    const toRemove = entries.length - target;
-    for (let i = 0; i < toRemove; i++) {
-      this.cache.delete(entries[i][0]);
+    // Only coarse-but-not-pinned tiles are eviction candidates; pinned coarse
+    // levels stay resident. They're few, so they can't crowd out the budget.
+    const candidates = [...this.cache.entries()]
+      .filter(([, e]) => e.tile.level >= this.PINNED_LEVELS)
+      .sort((a, b) => a[1].lastAccess - b[1].lastAccess);
+    const toRemove = this.cache.size - target;
+    for (let i = 0; i < toRemove && i < candidates.length; i++) {
+      this.cache.delete(candidates[i][0]);
     }
   }
 }

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -269,6 +269,30 @@ class TestProjectionTiles:
 
         assert found_cells, "Expected at least one tile with cells"
 
+    def test_served_tile_is_cacheable(self, client):
+        ctx = get_active_context()
+        rng = np.random.default_rng(7)
+        ids = list(ctx.medias.keys())[:4]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("tile-cache-hdr", ids, coords, "pca")
+        ctx._projection = proj
+        ctx._pyramids = {"hex": build_pyramid(proj, n_levels=2)}
+
+        resp = client.get("/api/projection/tiles/hex/0/999/999")
+        assert resp.status_code == 200
+        # Frozen tiles are immutable for the dataset's life, so the browser may
+        # reuse them without a round-trip — but only keyed by the dataset header.
+        assert "max-age=" in resp.headers["Cache-Control"]
+        assert "immutable" in resp.headers["Cache-Control"]
+        assert "X-Dataset-Id" in resp.headers["Vary"]
+
+    def test_not_built_404_is_not_cached(self, client):
+        # A projection that isn't built yet will exist later, so the negative
+        # response must not be frozen into the browser's cache.
+        resp = client.get("/api/projection/tiles/hex/0/0/0")
+        assert resp.status_code == 404
+        assert "immutable" not in resp.headers.get("Cache-Control", "")
+
 
 class TestBinShapeToggle:
     """Hex/square bin-shape selection across build, meta, and tiles."""

--- a/vtsearch/routes/events.py
+++ b/vtsearch/routes/events.py
@@ -28,9 +28,9 @@ def progress_events() -> Response:
         stream_with_context(stream_progress_events()),
         mimetype="text/event-stream",
     )
-    # Long-lived; bypass the @after_request no-store header (already set,
-    # which is fine for SSE) and disable proxy buffering so events flush
-    # immediately instead of pooling behind nginx / gunicorn.
+    # Long-lived stream: set our own Cache-Control so the global @after_request
+    # hook defers instead of stamping no-store, and disable proxy buffering so
+    # events flush immediately instead of pooling behind nginx / gunicorn.
     response.headers["Cache-Control"] = "no-cache"
     response.headers["X-Accel-Buffering"] = "no"
     response.headers["Connection"] = "keep-alive"

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 
-from flask import request
+from flask import after_this_request, request
 from flask_smorest import Blueprint, abort
 
 from vtsearch.schemas.projection import (
@@ -431,6 +431,19 @@ def get_tile(shape: str, level: int, tx: int, ty: int):
         pyr = ctx._pyramids.get(shape)
     if pyr is None:
         abort(404, message="Projection not built yet — call POST /api/projection/build first.")
+
+    # Tiles are frozen at ingest, so let the browser serve repeat visits from its
+    # HTTP cache without a round-trip — this is what keeps the hex grid from
+    # blanking when you pan/zoom back over ground you've already seen. The tile
+    # URL omits the dataset id (it rides on the X-Dataset-Id header), so we must
+    # Vary on it or the cache could hand one dataset's tiles to another. Scoped
+    # to this response only, and registered after the 404 check so a not-yet-built
+    # projection is never cached. ``?subset`` is already part of the URL.
+    @after_this_request
+    def _cache_tile(response):  # type: ignore[unused-ignore]
+        response.headers["Cache-Control"] = "private, max-age=3600, immutable"
+        response.vary.add("X-Dataset-Id")
+        return response
 
     tile = pyr.get_tile(level, tx, ty)
     if tile is None:


### PR DESCRIPTION
## Why

Zooming/panning in VTSBrowse briefly blanks the hex grid to the background color before tiles repaint. The render loop only draws *cached* tiles and fires uncached ones async, so any tile not already in cache is a visible gap until its round-trip lands. This gets hit more often on larger datasets: deeper pyramids mean more `(level,tx,ty)` tiles competing for a small client cache, and there was nothing letting the browser reuse tiles across revisits.

These are the "quick caching wins" — they don't eliminate the first-time-into-a-region flash (that needs multi-resolution fallback rendering), but they remove the round-trip on revisited ground and stop coarse overview tiles from being evicted.

## What changed

**Server — immutable HTTP caching on the tile endpoint** (`vtsearch/routes/projection.py`)
- Tiles are frozen at ingest, so served tiles now carry `Cache-Control: private, max-age=3600, immutable` and `Vary: X-Dataset-Id`. The browser reuses them across pan/zoom revisits without a round-trip.
- The tile URL omits the dataset id (it rides on the `X-Dataset-Id` header), so `Vary` on that header is required — otherwise the cache could hand one dataset's tiles to another.
- Headers are registered via `after_this_request` (keeps the flask-smorest schema decorator intact) and only after the 404 check, so a not-yet-built projection is never cached.

**Server — global no-store hook defers to view-set Cache-Control** (`app.py`)
- The `@app.after_request` hook stamped `no-store` on every `/api/` path, which was clobbering the tile headers (and, as it turns out, the SSE route's own `no-cache`). It now only sets `no-store` when the view hasn't set its own `Cache-Control`. Mutable endpoints are unaffected (they don't set their own header). `events.py`'s stale comment is updated to match.

**Client — larger, level-aware tile cache** (`frontend/src/app/services/tile-cache.service.ts`)
- Grew the LRU from 512 → 2048 entries so deeper pyramids don't thrash on revisit.
- Coarse top-of-pyramid levels (0–2) are now exempt from eviction. They're few tiles, they cover the whole projection, and pinning them means a zoom-out to the overview is never a miss (and leaves them available as a fallback layer for a future multi-res change).

## Tests
- Added `test_served_tile_is_cacheable` and `test_not_built_404_is_not_cached` to `tests/api/test_projection.py`.
- Full suite green: `ALL 4582 TESTS PASSED` (ruff/format/codespell/deptry + frontend build all clean).

## Follow-ups (not in this PR)
The bigger structural fix — drawing the nearest cached coarser level as a placeholder so zoom never blanks at all — is deferred. The pinned coarse cache here is a deliberate stepping stone toward it.

https://claude.ai/code/session_01154mqahqs238cKHkoK5J4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01154mqahqs238cKHkoK5J4G)_