### PR TITLE
Warn-and-prompt on a leftover :5000 listener at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -590,6 +590,159 @@ if os.environ.get("VTSEARCH_SERVER_INIT") == "1":
 
 
 # ---------------------------------------------------------------------------
+# Startup port preflight
+# ---------------------------------------------------------------------------
+#
+# A common dev annoyance is leaving an old ``python app.py`` running and only
+# discovering it when a fresh launch can't bind :5000. These helpers detect a
+# prior listener, identify its PID via ``/proc`` (Linux, best-effort, no extra
+# deps), and let the user kill it before we try to bind.
+
+
+def _port_is_free(port: int) -> bool:
+    """Return True if nothing is bound to ``0.0.0.0:port``.
+
+    Probes by attempting a plain bind (no ``SO_REUSEADDR``), so an existing
+    LISTEN socket surfaces as ``EADDRINUSE``.
+    """
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("0.0.0.0", port))
+        except OSError:
+            return False
+    return True
+
+
+def _listen_inodes_for_port(port: int) -> "set[str]":
+    """Socket inodes of LISTEN sockets bound to ``port`` (from ``/proc/net``)."""
+    port_hex = f"{port:04X}"
+    inodes: set[str] = set()
+    for proc_net in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(proc_net) as fh:
+                next(fh, None)  # header row
+                for line in fh:
+                    fields = line.split()
+                    # fields[3] == "0A" is TCP_LISTEN; fields[1] is HEXADDR:HEXPORT.
+                    if len(fields) >= 10 and fields[3] == "0A" and fields[1].rsplit(":", 1)[-1] == port_hex:
+                        inodes.add(fields[9])
+        except OSError:
+            continue
+    return inodes
+
+
+def _fd_points_to(fd_dir: str, fd: str, targets: "set[str]") -> bool:
+    """True if ``fd_dir/fd`` is a symlink to one of the ``socket:[inode]`` targets."""
+    try:
+        return os.readlink(f"{fd_dir}/{fd}") in targets
+    except OSError:
+        return False
+
+
+def _pids_owning_inodes(inodes: "set[str]") -> "list[int]":
+    """Scan ``/proc/<pid>/fd`` for any process holding one of ``inodes``."""
+    pids: list[int] = []
+    targets = {f"socket:[{inode}]" for inode in inodes}
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        fd_dir = f"/proc/{entry}/fd"
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            continue  # process gone or not ours to inspect
+        if any(_fd_points_to(fd_dir, fd, targets) for fd in fds):
+            pids.append(int(entry))
+    return pids
+
+
+def _find_listener_pids(port: int) -> "list[int]":
+    """Best-effort PIDs holding a LISTEN socket on ``port`` (Linux ``/proc``).
+
+    Returns an empty list if the port is free or if PID resolution fails (e.g.
+    ``/proc`` unavailable). Detection of *whether* the port is taken is done
+    separately via :func:`_port_is_free`; this only enriches the warning.
+    """
+    inodes = _listen_inodes_for_port(port)
+    return _pids_owning_inodes(inodes) if inodes else []
+
+
+def _describe_pid(pid: int) -> str:
+    """A short ``pid (cmdline)`` label, falling back to just the PID."""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            raw = fh.read()
+        cmdline = raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+    except OSError:
+        cmdline = ""
+    return f"{pid} ({cmdline})" if cmdline else str(pid)
+
+
+def _wait_for_free(port: int, deadline: float = 5.0) -> bool:
+    """Poll until ``port`` is free or ``deadline`` seconds elapse; return final state."""
+    import time
+
+    waited = 0.0
+    while waited < deadline and not _port_is_free(port):
+        time.sleep(0.2)
+        waited += 0.2
+    return _port_is_free(port)
+
+
+def _terminate_listeners(pids: "list[int]", port: int) -> bool:
+    """SIGTERM the listeners, escalate to SIGKILL if needed; return True once free."""
+    import signal
+
+    def _signal_all(sig: int) -> None:
+        for pid in pids:
+            try:
+                os.kill(pid, sig)
+            except OSError:
+                pass
+
+    _signal_all(signal.SIGTERM)
+    if _wait_for_free(port):
+        return True
+    _signal_all(signal.SIGKILL)
+    return _wait_for_free(port)
+
+
+def _preflight_port(port: int) -> None:
+    """Warn-and-prompt if ``port`` is already bound before we try to bind it.
+
+    If the user agrees, SIGTERM (then SIGKILL) the prior listener and wait for
+    the port to free. Non-interactive stdin or a declined prompt exits rather
+    than letting ``app.run`` crash with an opaque ``Address already in use``.
+    """
+    if _port_is_free(port):
+        return
+
+    pids = _find_listener_pids(port)
+    if pids:
+        listed = ", ".join(_describe_pid(p) for p in pids)
+        print(f"⚠️  Port {port} is already in use by PID {listed}.", flush=True)
+    else:
+        print(f"⚠️  Port {port} is already in use (could not identify the owning process).", flush=True)
+
+    if not pids or not sys.stdin.isatty():
+        # Nothing safe to kill, or no TTY to ask on: don't guess, just bail.
+        print(f"   Free port {port} and try again (e.g. `fuser -k {port}/tcp`).", flush=True)
+        sys.exit(1)
+
+    reply = input(f"   Kill PID {', '.join(str(p) for p in pids)} and continue? [y/N] ").strip().lower()
+    if reply not in ("y", "yes"):
+        print("   Leaving the existing instance alone; not starting.", flush=True)
+        sys.exit(1)
+
+    if not _terminate_listeners(pids, port):
+        print(f"   Could not free port {port}; aborting.", flush=True)
+        sys.exit(1)
+    print(f"   Freed port {port}; starting up.", flush=True)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1157,6 +1310,9 @@ if __name__ == "__main__":
                 flush=True,
             )
 
+        # Catch a leftover instance before the expensive model load, so the
+        # user is prompted up front instead of after a long startup.
+        _preflight_port(5000)
         initialize_server(mode_label="LOCAL" if args.local else "PRODUCTION")
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)

--- a/tests/core/test_startup_port_preflight.py
+++ b/tests/core/test_startup_port_preflight.py
@@ -1,0 +1,96 @@
+"""Tests for the startup port-collision preflight helpers in ``app.py``.
+
+These cover the detection + safe-exit paths (``_port_is_free``,
+``_find_listener_pids``, the non-TTY bail) and the real SIGTERM/SIGKILL
+``_terminate_listeners`` path against a throwaway child process. They use
+ephemeral ports so they never collide with a real instance on :5000.
+"""
+
+import io
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+import app as app_module
+
+
+def _listening_socket():
+    """Bind+listen on an OS-assigned ephemeral port; return ``(sock, port)``."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("0.0.0.0", 0))
+    sock.listen(1)
+    return sock, sock.getsockname()[1]
+
+
+def _free_ephemeral_port():
+    """Reserve then release an ephemeral port, returning its number."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("0.0.0.0", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+def test_port_is_free_reflects_binding():
+    sock, port = _listening_socket()
+    try:
+        assert app_module._port_is_free(port) is False
+    finally:
+        sock.close()
+    assert app_module._port_is_free(port) is True
+
+
+def test_find_listener_pids_identifies_self():
+    sock, port = _listening_socket()
+    try:
+        pids = app_module._find_listener_pids(port)
+    finally:
+        sock.close()
+    assert os.getpid() in pids
+
+
+def test_find_listener_pids_empty_for_free_port():
+    port = _free_ephemeral_port()
+    assert app_module._find_listener_pids(port) == []
+
+
+def test_preflight_returns_when_port_free():
+    port = _free_ephemeral_port()
+    # No listener: must return without prompting or exiting.
+    app_module._preflight_port(port)
+
+
+def test_preflight_bails_when_occupied_and_no_tty(monkeypatch):
+    sock, port = _listening_socket()
+    # A non-interactive stdin (StringIO.isatty() is False) must never prompt;
+    # the preflight should print guidance and exit(1) instead of hanging.
+    monkeypatch.setattr(sys, "stdin", io.StringIO())
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            app_module._preflight_port(port)
+        assert excinfo.value.code == 1
+    finally:
+        sock.close()
+
+
+def test_terminate_listeners_frees_port():
+    port = _free_ephemeral_port()
+    code = f"import socket, time; s = socket.socket(); s.bind(('0.0.0.0', {port})); s.listen(1); time.sleep(30)"
+    proc = subprocess.Popen([sys.executable, "-c", code])  # noqa: S603  # interpreter + constant literal code
+    try:
+        # Wait until the child is actually holding the port (poll, don't sleep-guess).
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and app_module._port_is_free(port):
+            time.sleep(0.05)
+        assert not app_module._port_is_free(port), "child never bound the port"
+
+        assert app_module._terminate_listeners([proc.pid], port) is True
+        assert app_module._port_is_free(port)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Problem

Leaving an old `python app.py` running is easy to miss — the only symptom is a fresh launch failing to bind `:5000` with an opaque `Address already in use`. (This came up directly: an instance had been running 19h before it was noticed.)

## What this does

Adds a startup preflight that runs **before** the expensive model load, in the server-launch path of `app.py`'s `__main__` block:

- If `:5000` is already bound, it identifies the owning PID(s) via `/proc` and prints them (with command line).
- It then prompts: `Kill PID … and continue? [y/N]`. On yes, it `SIGTERM`s the prior listener (escalating to `SIGKILL` if the port doesn't free within 5s), waits for the port to free, and proceeds.
- If stdin isn't a TTY (e.g. piped/cron) or the user declines, it exits cleanly with a `fuser -k 5000/tcp` hint instead of crashing on bind.

All detection is pure stdlib (a `socket` bind probe for occupancy + `/proc/net/tcp{,6}` and `/proc/<pid>/fd` parsing for the PID), so there's **no new dependency** and nothing for deptry to flag.

## Tests

`tests/core/test_startup_port_preflight.py` covers detection (`_port_is_free`, `_find_listener_pids`), the free-port no-op, the non-TTY safe-exit, and a real `SIGTERM`/`SIGKILL` `_terminate_listeners` path against a throwaway child process. Uses ephemeral ports so it never touches a real `:5000`. `./run-tests.sh core` → all 710 pass.

## Note for the user

For the quick shell-pipeline ask: `fuser -k 5000/tcp 2>/dev/null; python app.py --local` (or an alias) does the same kill-then-launch without this code. This PR is the in-app, opt-in-per-launch version you chose (warn-and-prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)