### PR TITLE
Round ETA estimates to humble, single-unit chips

### DIFF
--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -21,22 +21,62 @@ export function formatProgressFraction(current: number, total: number): string {
 }
 
 /**
- * Format a remaining-seconds estimate into a compact ``~Hh Mm`` / ``~Mm Ss``
- * / ``~Ss`` chip. Returns an empty string for ``null``, non-positive, or
- * non-finite values so the caller can drop it from concatenation unconditionally.
+ * The fraction of an estimate we allow ourselves to claim as precision. An ETA
+ * is snapped to a "nice" step roughly this size relative to its own magnitude,
+ * so the bigger the estimate the coarser it reads: a ~5.5 min job rounds to the
+ * half-minute, a ~2 hr job to the half-hour. Keeping every chip deliberately
+ * approximate is the point — an under-specified ETA can't be held to a
+ * precision the backend never actually had.
+ */
+const ETA_ROUND_RATIO = 0.1;
+
+/** Nice rounding steps, expressed in the chosen display unit (sec/min/hr). */
+const ETA_NICE_STEPS = [0.5, 1, 2, 5, 10, 15, 30];
+
+/**
+ * Snap ``value`` to the nearest "nice" step whose size is about
+ * ``ETA_ROUND_RATIO`` of the value itself (never smaller than ``minStep``).
+ */
+function snapEta(value: number, minStep: number): number {
+  const target = value * ETA_ROUND_RATIO;
+  let step = minStep;
+  for (const candidate of ETA_NICE_STEPS) {
+    if (candidate >= minStep && candidate <= target) step = candidate;
+  }
+  return Math.round(value / step) * step;
+}
+
+/** Render a snapped magnitude with at most one decimal and no trailing ``.0``. */
+function etaUnit(value: number, unit: string): string {
+  const text = Number.isInteger(value) ? String(value) : value.toFixed(1);
+  return `~${text} ${unit} left`;
+}
+
+/**
+ * Format a remaining-seconds estimate into a deliberately humble, single-unit
+ * chip: ``~35 sec left`` / ``~5.5 min left`` / ``~2 hr left``. The value is
+ * rounded to a nice step that scales with its magnitude (see
+ * ``ETA_ROUND_RATIO``), so we never claim more precision than a noisy estimate
+ * deserves and never show an over-precise ``5 min 34 sec``-style breakdown.
+ * Returns an empty string for ``null``, non-positive, or non-finite values so
+ * the caller can drop it from concatenation unconditionally.
  */
 export function formatEta(seconds: number | null | undefined): string {
   if (seconds == null || !isFinite(seconds) || seconds <= 0) return '';
-  const total = Math.round(seconds);
-  if (total < 60) return `~${total}s left`;
-  if (total < 3600) {
-    const m = Math.floor(total / 60);
-    const s = total % 60;
-    return s > 0 ? `~${m}m ${s}s left` : `~${m}m left`;
+  // Sub-minute: round to a nice multiple of seconds (minimum 5s granularity).
+  if (seconds < 60) {
+    const s = snapEta(seconds, 5);
+    if (s < 60) return etaUnit(s, 'sec');
   }
-  const h = Math.floor(total / 3600);
-  const m = Math.floor((total % 3600) / 60);
-  return m > 0 ? `~${h}h ${m}m left` : `~${h}h left`;
+  // Minutes: round to the nice fraction of a minute (minimum half-minute).
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    const m = snapEta(minutes, 0.5);
+    if (m < 60) return etaUnit(m, 'min');
+  }
+  // Hours: round to the nice fraction of an hour (minimum half-hour).
+  const h = snapEta(seconds / 3600, 0.5);
+  return etaUnit(h, 'hr');
 }
 
 /**
@@ -46,7 +86,7 @@ export function formatEta(seconds: number | null | undefined): string {
  * Each piece is optional:
  *   - The ``[Step S/T]`` prefix appears only when ``total_steps > 1``.
  *   - The ``(C/T)`` fraction appears only when ``total > 0``.
- *   - The ``· ~Xs left`` tail appears only when ``eta_seconds > 0``; the
+ *   - The ``· ~5.5 min left`` tail appears only when ``eta_seconds > 0``; the
  *     backend gates this on at least 5s of elapsed work, so it stays hidden
  *     for short bars.
  *   - When none are present, returns the bare ``message`` (or
@@ -108,7 +148,7 @@ export function isProgressIndeterminate(
  *     The ETA tail is omitted here; it is returned separately as ``eta`` so the
  *     UI can pin it to the right of the progress bar where it stays visible
  *     even when a long file path ellipsizes the detail.
- *   - ``eta``: the bare ``~Xs left`` chip, or empty when no estimate is available.
+ *   - ``eta``: the bare ``~5.5 min left`` chip, or empty when no estimate is available.
  */
 export interface ProgressHeader {
   header: string;


### PR DESCRIPTION
## What

Progress ETAs no longer render over-precise compound breakdowns like `~5m 34s left`. `formatEta` now snaps the estimate to a single coarse unit rounded to a magnitude-scaled "nice" step:

- `~35 sec left`
- `~5.5 min left`
- `~2 hr left`

## How

A rounding ratio (`ETA_ROUND_RATIO = 0.1`) drives the granularity: each estimate is snapped to the nearest "nice" step (`0.5, 1, 2, 5, 10, 15, 30` in the chosen unit) that is roughly 10% of its own magnitude, with a per-unit minimum (5s / 0.5min / 0.5hr). Bigger estimates therefore round coarser — a multi-hour job rounds to the half-hour, a few-minute job to the half-minute — so the precision we claim always scales with the estimate.

Rounding is to the **nearest** nice value (per request), so `5min34sec → ~5.5 min` exactly. The goal is a deliberately approximate chip that can't be held to a precision the noisy backend estimate never actually had.

## Notes

- Single source of truth: all human-readable ETA formatting lives in `formatEta`; the backend only emits the numeric `eta_seconds`, and CLI bars use tqdm's own renderer. No backend changes needed.
- Frontend `build:prod` passes clean (no errors/warnings).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HsfPwvRCwCf8v17qR7CZfC)_