### PR TITLE
Clip VTSBrowse hover highlight inside the bin

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -477,9 +477,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const isHovered =
       this.hoveredCell && this.hoveredCell.q === cell.q && this.hoveredCell.r === cell.r;
     if (isHovered) {
+      // Clip so the highlight replaces the cell's own edge pixels rather than
+      // bleeding outward onto its neighbours. A centred stroke straddles the
+      // path (half its width spills over the next cell, which later cells then
+      // paint over inconsistently); clipping keeps the full stroke inside, so
+      // doubling the width yields a 2px band that reads as an inset border and
+      // never changes the cell's footprint.
+      ctx.save();
+      ctx.clip();
       ctx.strokeStyle = '#ffffff';
-      ctx.lineWidth = 2;
+      ctx.lineWidth = 4;
       ctx.stroke();
+      ctx.restore();
     } else if (thumb && !single && this.thumbnailBorder > 0) {
       // Pile thumbnail: a band whose colormap colour encodes how many items are
       // stacked under this tile. Clipped to the cell so the full width sits just


### PR DESCRIPTION
## Problem

When mousing around in VTSBrowse, the highlight around the hovered bin bumped into neighbouring bins — sometimes drawing over them, sometimes under — looking crowded and inconsistent.

The cause: the hover highlight used a **centred** `ctx.stroke()` with `lineWidth = 2`. Canvas strokes straddle the path, so half the width (1px) spilled *outward* onto the next cell. Because all cells are drawn in a single loop, a later-drawn neighbour then painted over the spilled pixels — hence the random over/under appearance.

## Fix

Clip the highlight stroke to the cell before stroking (and double the width to 4px so a 2px band shows inside). This makes the highlight **replace** the cell's own edge pixels as an inset border rather than **extend** beyond the cell, so the bin's footprint never changes and nothing bleeds onto neighbours.

This mirrors the existing pile-thumbnail border block directly below it, which already uses the same `save` → `clip` → doubled `lineWidth` → `stroke` → `restore` pattern for exactly this reason. Works cleanly for singleton cells too (the traced path there is the inscribed disc, yielding a clean inset ring).

## Testing

- `npm run build:prod` succeeds with no errors or warnings.

https://claude.ai/code/session_01Aa92eQChJDgeF7oGyfKfg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aa92eQChJDgeF7oGyfKfg7)_