### PR TITLE
VTSBrowse: track and display item selection on the canvas

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -817,6 +817,36 @@ and available to any future consumer of `vtscore`.
 ## Open follow-ups
 
 **Shipped:**
+- **Item selection on the canvas (tracking only).** Supersedes the v1
+  "no selection" scope (*§Locked decisions* / *§Interaction model*). Selection
+  is held at the *media-id* granularity in `BrowseSelectionService`
+  (`frontend/src/app/services/browse-selection.service.ts`, provided per
+  `BrowseViewComponent`, in-memory and session-scoped). A plain **click** toggles
+  the bin under the cursor — an unselected bin fully selects its contents, a
+  partially- or fully-selected bin fully clears them — and **Shift+drag** draws a
+  marquee that adds every bin whose centre falls inside it (plain drag still
+  pans). The canvas renders each bin's derived state (none / partial / full):
+  unselected bins are dimmed when a selection exists, fully-selected bins get a
+  solid accent ring, partially-selected bins a dashed one (memoized per cell
+  against `selection.version` so a pan stays O(visible cells)). A floating
+  `vt-browse-selection-panel` (top-left) shows the live count + a Clear button.
+  Selection clears when the projection changes (media-type switch / rebuild) but
+  survives a hex/square toggle, since ids are shape-independent.
+  - Backend: bins store only `count` + `rep_id`, so the full member id list per
+    cell is re-derived on demand (`tile_member_ids` in `vtscore/projection/pyramid.py`)
+    and attached to each cell in the tile payload (`member_ids`) — nothing new is
+    persisted; it rides the immutable, HTTP-cached tile.
+  - *Open follow-ups:*
+    - **Act on the selection.** This effort only *tracks* and *displays* the
+      selection; the next pass wires it to an action (export the subset, seed a
+      detector, build a subset projection from it, etc.). The selected ids are a
+      plain `Set<number>` ready to hand off.
+    - **Per-tile membership recompute cost.** `tile_member_ids` re-bins the whole
+      coordinate array per tile request (O(N) each), fine for typical datasets and
+      cached after first fetch, but a per-(projection, level) assignment cache
+      would cut the first-viewport cost on very large datasets.
+    - **Minimap selection overlay.** The minimap does not yet show which region is
+      selected; a faint accent wash over selected cells there would aid orientation.
 - **Load + project on the dashboard before entering Browse.** The dashboard's
   per-row `Browse` button no longer navigates straight to `/browse/:id` and
   lets the browse view discover a missing load/projection. It now mirrors the

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2719,6 +2719,15 @@
           "cy": {
             "type": "number"
           },
+          "member_ids": {
+            "default": null,
+            "description": "All media ids aggregated in this cell (for selection).",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "q": {
             "type": "integer"
           },

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
 import {
   densityColor,
   resolveColormap,
@@ -117,6 +118,21 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private panStartY = 0;
   private panStartCenterX = 0;
   private panStartCenterY = 0;
+  // Whether the current drag has moved past the click threshold. A mousedown +
+  // mouseup with no real movement is treated as a click (toggle the bin under
+  // the cursor) rather than a pan, so plain click selects without fighting pan.
+  private dragMoved = false;
+  private static readonly CLICK_MOVE_THRESHOLD = 4;
+
+  // Shift+drag draws a marquee rectangle (canvas-relative screen coords) that
+  // adds every bin whose centre falls inside it to the selection — the fast path
+  // for grabbing a region, since plain drag is reserved for panning.
+  private isMarquee = false;
+  private marquee: { x0: number; y0: number; x1: number; y1: number } | null = null;
+
+  // Accent colour resolved from the live theme once per frame, used for the
+  // selection rings and the marquee rectangle.
+  private selAccent = '#4f9dff';
 
   private hoveredCell: HexCellPayload | null = null;
   private hoverDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -150,12 +166,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private boundCanvasMouseLeave = this.onCanvasMouseLeave.bind(this);
 
   private recenterSub: Subscription | null = null;
+  private selectionSub: Subscription | null = null;
 
   constructor(
     private ngZone: NgZone,
     private tileCache: TileCacheService,
     private activeContext: ActiveContextService,
     private viewport: BrowseViewportService,
+    private selection: BrowseSelectionService,
   ) {}
 
   /** True when cells should be painted with the central item's thumbnail. */
@@ -189,6 +207,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.requestRedraw();
     });
 
+    // Repaint when the selection changes so the per-cell rings and the dimming
+    // of unselected cells track the live set.
+    this.selectionSub = this.selection.changed$.subscribe(() => this.requestRedraw());
+
     this.resizeObserver = new ResizeObserver(() => {
       this.ngZone.runOutsideAngular(() => this.resize());
     });
@@ -220,6 +242,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
         this.lastProjectionId = this.meta.projection_id;
         this.thumbCache.clear();
         this.thumbFailed.clear();
+        // A new projection (media-type switch / rebuild) re-lays-out every item,
+        // so the old selection no longer maps to what's on screen — drop it. A
+        // bin-shape toggle keeps the same projection id and selection, since the
+        // ids are shape-independent.
+        this.selection.clear();
         this.fitToData();
       } else {
         this.updateActiveLevel();
@@ -248,6 +275,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.tileLoadSub?.unsubscribe();
     this.recenterSub?.unsubscribe();
+    this.selectionSub?.unsubscribe();
     this.viewport.setViewport(null);
     this.resizeObserver?.disconnect();
     this.themeObserver?.disconnect();
@@ -449,18 +477,58 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
     // Resolve the colormap against the live theme once per frame, not per cell.
     const cmap = resolveColormap(this.colormap, this.effectiveTheme());
+    // Accent for selection rings + marquee, also resolved once per frame.
+    this.selAccent = this.themeColor('--accent-color') || '#4f9dff';
+    const selectionActive = this.selection.size > 0;
 
     for (const cell of allCells) {
       const [sx, sy] = this.projToScreen(cell.cx, cell.cy);
       if (sx < -screenRadius * 2 || sx > this.width + screenRadius * 2) continue;
       if (sy < -screenRadius * 2 || sy > this.height + screenRadius * 2) continue;
-      this.drawHex(ctx, sx, sy, screenRadius, cell, cmap);
+      this.drawHex(ctx, sx, sy, screenRadius, cell, cmap, selectionActive);
     }
+
+    if (this.marquee) this.drawMarquee(ctx);
 
     // Publish the region now on screen so the minimap can draw its viewport box.
     this.viewport.setViewport(this.getVisibleBounds());
 
     this.prefetchNeighbors(visibleTiles);
+  }
+
+  /** Selection state of a cell: 0 = none, 1 = partial, 2 = full. Memoized on
+   *  the cell against the selection version so a steady-state pan doesn't
+   *  re-scan every bin's members each frame. */
+  private selStateFor(cell: HexCellPayload): 0 | 1 | 2 {
+    const memo = cell as HexCellPayload & { _selVer?: number; _selState?: 0 | 1 | 2 };
+    if (memo._selVer === this.selection.version && memo._selState !== undefined) {
+      return memo._selState;
+    }
+    const members = this.cellMembers(cell);
+    const sel = this.selection.selectedCountIn(members);
+    const state: 0 | 1 | 2 = sel === 0 ? 0 : sel === members.length ? 2 : 1;
+    memo._selVer = this.selection.version;
+    memo._selState = state;
+    return state;
+  }
+
+  /** Translucent fill + dashed accent border for the in-progress marquee. */
+  private drawMarquee(ctx: CanvasRenderingContext2D): void {
+    const m = this.marquee!;
+    const x = Math.min(m.x0, m.x1);
+    const y = Math.min(m.y0, m.y1);
+    const w = Math.abs(m.x1 - m.x0);
+    const h = Math.abs(m.y1 - m.y0);
+    ctx.save();
+    ctx.fillStyle = this.selAccent;
+    ctx.globalAlpha = 0.12;
+    ctx.fillRect(x, y, w, h);
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = this.selAccent;
+    ctx.lineWidth = 1.5;
+    ctx.setLineDash([6, 4]);
+    ctx.strokeRect(x, y, w, h);
+    ctx.restore();
   }
 
   private drawHex(
@@ -470,6 +538,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     radius: number,
     cell: HexCellPayload,
     cmap: ResolvedColormap,
+    selectionActive: boolean,
   ): void {
     // A cell with one item is drawn as a disc (slightly smaller than the cell);
     // multi-item cells keep their full shape so they tile the space.
@@ -496,6 +565,17 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       ctx.fill();
     }
 
+    // When a selection exists, dim every bin with no selected member so the
+    // selected ones pop. Clipped so the wash stays inside the cell footprint.
+    const selState = selectionActive ? this.selStateFor(cell) : 0;
+    if (selectionActive && selState === 0) {
+      ctx.save();
+      ctx.clip();
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+      ctx.fill();
+      ctx.restore();
+    }
+
     const isHovered =
       this.hoveredCell && this.hoveredCell.q === cell.q && this.hoveredCell.r === cell.r;
     if (isHovered) {
@@ -509,6 +589,17 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       ctx.clip();
       ctx.strokeStyle = '#ffffff';
       ctx.lineWidth = 4;
+      ctx.stroke();
+      ctx.restore();
+    } else if (selState > 0) {
+      // Selected bin: an inset accent ring (solid when every member is
+      // selected, dashed when only some are — the "partial" state). Clipped so
+      // the band sits just inside the cell rather than bleeding onto neighbours.
+      ctx.save();
+      ctx.clip();
+      ctx.strokeStyle = this.selAccent;
+      ctx.lineWidth = 5;
+      if (selState === 1) ctx.setLineDash([6, 4]);
       ctx.stroke();
       ctx.restore();
     } else if (thumb && !single && this.thumbnailBorder > 0) {
@@ -642,9 +733,23 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private onMouseDown(event: MouseEvent): void {
     if (event.button !== 0) return;
-    this.isPanning = true;
     this.panStartX = event.clientX;
     this.panStartY = event.clientY;
+    this.dragMoved = false;
+
+    if (event.shiftKey) {
+      // Shift+drag: rubber-band a region to add to the selection. Suppress any
+      // hover preview while marqueeing so it doesn't flicker over the rectangle.
+      event.preventDefault();
+      const [mx, my] = this.canvasXY(event);
+      this.isMarquee = true;
+      this.marquee = { x0: mx, y0: my, x1: mx, y1: my };
+      document.addEventListener('mousemove', this.boundMouseMove);
+      document.addEventListener('mouseup', this.boundMouseUp);
+      return;
+    }
+
+    this.isPanning = true;
     this.panStartCenterX = this.transform.centerX;
     this.panStartCenterY = this.transform.centerY;
     document.addEventListener('mousemove', this.boundMouseMove);
@@ -652,19 +757,96 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private onMouseMove(event: MouseEvent): void {
+    if (this.isMarquee && this.marquee) {
+      const [mx, my] = this.canvasXY(event);
+      this.marquee.x1 = mx;
+      this.marquee.y1 = my;
+      this.dragMoved = true;
+      this.requestRedraw();
+      return;
+    }
     if (!this.isPanning) return;
     const dx = event.clientX - this.panStartX;
     const dy = event.clientY - this.panStartY;
+    if (
+      Math.abs(dx) > BrowseCanvasComponent.CLICK_MOVE_THRESHOLD ||
+      Math.abs(dy) > BrowseCanvasComponent.CLICK_MOVE_THRESHOLD
+    ) {
+      this.dragMoved = true;
+    }
     const z = this.effZoom;
     this.transform.centerX = this.panStartCenterX - dx / z;
     this.transform.centerY = this.panStartCenterY - dy / z;
     this.requestRedraw();
   }
 
-  private onMouseUp(): void {
-    this.isPanning = false;
+  private onMouseUp(event: MouseEvent): void {
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+
+    if (this.isMarquee) {
+      this.isMarquee = false;
+      this.commitMarquee();
+      this.marquee = null;
+      this.requestRedraw();
+      return;
+    }
+
+    const wasPanning = this.isPanning;
+    this.isPanning = false;
+    // A press that never crossed the move threshold is a click: toggle the bin
+    // under the cursor (no modifier — Shift is reserved for the marquee).
+    if (wasPanning && !this.dragMoved && !event.shiftKey) {
+      const [mx, my] = this.canvasXY(event);
+      this.toggleCellAt(mx, my);
+    }
+  }
+
+  /** Canvas-relative ``[x, y]`` for a mouse event. */
+  private canvasXY(event: MouseEvent): [number, number] {
+    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    return [event.clientX - rect.left, event.clientY - rect.top];
+  }
+
+  /** Member media ids of a cell, falling back to its representative. */
+  private cellMembers(cell: HexCellPayload): number[] {
+    return cell.member_ids && cell.member_ids.length > 0 ? cell.member_ids : [cell.rep_id];
+  }
+
+  /** Toggle the selection of the bin under canvas point ``(mx, my)``. */
+  private toggleCellAt(mx: number, my: number): void {
+    const cell = this.hitTest(mx, my);
+    if (!cell) return;
+    const members = this.cellMembers(cell);
+    // Mutate inside the zone so the selection panel's count updates.
+    this.ngZone.run(() => this.selection.toggleBin(members));
+    this.requestRedraw();
+  }
+
+  /** Add every bin whose centre falls inside the marquee rectangle. */
+  private commitMarquee(): void {
+    if (!this.marquee || !this.meta) return;
+    const [px0, py0] = this.screenToProj(this.marquee.x0, this.marquee.y0);
+    const [px1, py1] = this.screenToProj(this.marquee.x1, this.marquee.y1);
+    const minX = Math.min(px0, px1);
+    const maxX = Math.max(px0, px1);
+    const minY = Math.min(py0, py1);
+    const maxY = Math.max(py0, py1);
+
+    const level = this.activeLevel;
+    const ids: number[] = [];
+    for (const { tx, ty } of this.getVisibleTiles()) {
+      const tile = this.tileCache.getCached(level, tx, ty);
+      if (!tile) continue;
+      for (const cell of tile.cells) {
+        if (cell.cx >= minX && cell.cx <= maxX && cell.cy >= minY && cell.cy <= maxY) {
+          for (const id of this.cellMembers(cell)) ids.push(id);
+        }
+      }
+    }
+    if (ids.length > 0) {
+      this.ngZone.run(() => this.selection.addAll(ids));
+    }
   }
 
   /**
@@ -712,7 +894,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private onCanvasMouseMove(event: MouseEvent): void {
-    if (this.isPanning) return;
+    if (this.isPanning || this.isMarquee) return;
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -1,0 +1,42 @@
+// Selection count + Clear, pinned to the canvas's top-left corner (clear of the
+// top-right controls, the right-edge legend, and the bottom corners). Unlike the
+// other overlays it takes clicks, so it opts back into pointer events.
+.browse-selection {
+  position: absolute;
+  top: var(--space-md);
+  left: var(--space-md);
+  display: inline-flex;
+  gap: var(--space-sm);
+  align-items: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs) var(--space-sm);
+  pointer-events: auto;
+  opacity: 0.95;
+}
+
+.browse-selection-count {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.browse-selection-clear {
+  font-size: var(--font-xs);
+  line-height: 1;
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--transition-base), border-color var(--transition-base);
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+}

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
+
+/**
+ * Floating chip over the browse canvas that reports how many items are
+ * currently selected and offers a one-click Clear. Mirrors the legend/minimap
+ * overlay treatment (absolute, top-left), but unlike the purely-informational
+ * legend it must accept clicks, so it sets ``pointer-events: auto`` on itself.
+ * Hidden entirely while nothing is selected.
+ */
+@Component({
+  selector: 'vt-browse-selection-panel',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (count > 0) {
+      <div class="browse-selection">
+        <span class="browse-selection-count">{{ count | number }} selected</span>
+        <button
+          type="button"
+          class="browse-selection-clear"
+          (click)="clear()"
+          title="Clear selection"
+          aria-label="Clear selection">
+          Clear
+        </button>
+      </div>
+    }
+  `,
+  styleUrl: './browse-selection-panel.component.scss',
+})
+export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
+  /** Mirrored from the selection service so the template re-renders on change. */
+  count = 0;
+  private sub: Subscription | null = null;
+
+  constructor(private selection: BrowseSelectionService) {}
+
+  ngOnInit(): void {
+    this.count = this.selection.size;
+    this.sub = this.selection.changed$.subscribe(() => {
+      this.count = this.selection.size;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  clear(): void {
+    this.selection.clear();
+  }
+}

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -43,6 +43,7 @@
         [mediaType]="mediaType"
       />
       <vt-browse-legend [maxCount]="densityMax" [colormap]="colormap" />
+      <vt-browse-selection-panel />
       <div class="browse-controls">
         <div class="browse-zoom">
           <button

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -6,6 +6,7 @@ import { takeUntil } from 'rxjs/operators';
 import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
 import { BrowseLegendComponent } from '../browse-legend/browse-legend.component';
+import { BrowseSelectionPanelComponent } from '../browse-selection-panel/browse-selection-panel.component';
 import {
   BrowseMinimapComponent,
   MINIMAP_MAX_HEIGHT,
@@ -21,6 +22,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
 import {
   BROWSE_COLORMAP_IDS,
@@ -40,13 +42,15 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
     BrowseCanvasComponent,
     BrowseHoverPreviewComponent,
     BrowseLegendComponent,
+    BrowseSelectionPanelComponent,
     BrowseMinimapComponent,
     ProgressBarComponent,
     IconComponent,
   ],
-  // Scoped per browse view so the canvas and its minimap share one viewport
-  // channel without leaking across other instances of the view.
-  providers: [BrowseViewportService],
+  // Scoped per browse view so the canvas, its minimap, and the selection panel
+  // share one viewport channel and one selection set without leaking across
+  // other instances of the view.
+  providers: [BrowseViewportService, BrowseSelectionService],
   templateUrl: './browse-view.component.html',
   styleUrl: './browse-view.component.scss',
 })

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -8,6 +8,13 @@ export interface HexCellPayload {
   cy: number;
   count: number;
   rep_id: number;
+  /**
+   * All media ids aggregated in this cell. The canvas uses it to render the
+   * cell's selection state (none / partial / full) and to toggle the whole
+   * bin's contents. Re-derived server-side from the frozen layout, so it may be
+   * absent on a degenerate response; callers fall back to ``[rep_id]``.
+   */
+  member_ids?: number[];
 }
 
 export interface TilePayload {

--- a/frontend/src/app/services/browse-selection.service.ts
+++ b/frontend/src/app/services/browse-selection.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * Tracks which media items are selected in the VTSBrowse canvas.
+ *
+ * Selection is held at the *item* (media id) granularity, not the bin: bins
+ * split and merge as you zoom, so a bin's display state — none, partial, or
+ * fully selected — is *derived* from how many of its members are in this set,
+ * and a selection made at one zoom level stays coherent at every other. The
+ * set is in-memory and session-scoped: the service is provided per
+ * {@link BrowseViewComponent}, so navigating away drops it, and the canvas
+ * clears it when the underlying projection changes (media-type switch /
+ * rebuild).
+ *
+ * {@link version} bumps on every mutation so the canvas can memoize each cell's
+ * derived state and only recompute it when the selection actually changed,
+ * keeping the per-frame redraw O(visible cells) rather than O(members) during a
+ * pan.
+ */
+@Injectable()
+export class BrowseSelectionService {
+  private selected = new Set<number>();
+  private _version = 0;
+  private readonly changedSubject = new Subject<void>();
+
+  /** Emits after every change to the selection set. */
+  readonly changed$: Observable<void> = this.changedSubject.asObservable();
+
+  /** How many items are currently selected. */
+  get size(): number {
+    return this.selected.size;
+  }
+
+  /** A monotonically increasing token that changes on every mutation. */
+  get version(): number {
+    return this._version;
+  }
+
+  /** Whether a specific media id is selected. */
+  has(id: number): boolean {
+    return this.selected.has(id);
+  }
+
+  /** How many of *ids* are currently selected (the bin's selected-member count). */
+  selectedCountIn(ids: number[]): number {
+    let n = 0;
+    for (const id of ids) if (this.selected.has(id)) n++;
+    return n;
+  }
+
+  /**
+   * Toggle a bin's contents per the browse rule: clicking a bin with *no*
+   * members selected fully selects it; clicking a partially- or fully-selected
+   * bin fully clears it.
+   */
+  toggleBin(ids: number[]): void {
+    if (ids.length === 0) return;
+    if (this.selectedCountIn(ids) > 0) {
+      this.removeAll(ids);
+    } else {
+      this.addAll(ids);
+    }
+  }
+
+  /** Add every id in *ids* to the selection (marquee union). */
+  addAll(ids: number[]): void {
+    let changed = false;
+    for (const id of ids) {
+      if (!this.selected.has(id)) {
+        this.selected.add(id);
+        changed = true;
+      }
+    }
+    if (changed) this.bump();
+  }
+
+  /** Remove every id in *ids* from the selection. */
+  removeAll(ids: number[]): void {
+    let changed = false;
+    for (const id of ids) {
+      if (this.selected.delete(id)) changed = true;
+    }
+    if (changed) this.bump();
+  }
+
+  /** Drop the whole selection. */
+  clear(): void {
+    if (this.selected.size === 0) return;
+    this.selected.clear();
+    this.bump();
+  }
+
+  private bump(): void {
+    this._version++;
+    this.changedSubject.next();
+  }
+}

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -265,9 +265,35 @@ class TestProjectionTiles:
                 assert "cy" in cell
                 assert "count" in cell
                 assert "rep_id" in cell
+                # Each cell carries the full member id list (for selection), and
+                # it agrees with the cell's count and includes its representative.
+                assert "member_ids" in cell
+                assert len(cell["member_ids"]) == cell["count"]
+                assert cell["rep_id"] in cell["member_ids"]
             break
 
         assert found_cells, "Expected at least one tile with cells"
+
+    def test_tile_member_ids_cover_every_item(self, client):
+        """Across a level, the served cells' member ids partition the dataset."""
+        ctx = get_active_context()
+        rng = np.random.default_rng(11)
+        ids = list(ctx.medias.keys())[:6]
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("tile-members", ids, coords, "pca")
+        pyr = build_pyramid(proj, n_levels=2)
+        ctx._projection = proj
+        ctx._pyramids = {"hex": pyr}
+
+        recovered: list[int] = []
+        for level, tx, ty in pyr.tiles:
+            if level != 0:
+                continue
+            resp = client.get(f"/api/projection/tiles/hex/{level}/{tx}/{ty}")
+            assert resp.status_code == 200
+            for cell in resp.get_json()["cells"]:
+                recovered.extend(cell["member_ids"])
+        assert sorted(recovered) == sorted(ids)
 
     def test_served_tile_is_cacheable(self, client):
         ctx = get_active_context()

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from vtscore.projection.pyramid import BIN_SHAPES, Pyramid, build_pyramid, max_useful_levels
+from vtscore.projection.pyramid import (
+    BIN_SHAPES,
+    Pyramid,
+    build_pyramid,
+    max_useful_levels,
+    tile_member_ids,
+)
 from vtscore.projection.umap_projection import Projection
 
 
@@ -83,6 +89,50 @@ def test_tile_indexing_matches_get_tile():
         assert pyr.get_tile(level, tx, ty) is tile
         assert tile.level == level and tile.tx == tx and tile.ty == ty
     assert pyr.get_tile(999, 0, 0) is None
+
+
+@pytest.mark.parametrize("bin_shape", BIN_SHAPES)
+def test_tile_member_ids_partition_each_tile(bin_shape):
+    """Every tile's members reproduce each cell's count and union to its ids."""
+    coords = _cluster_cloud()
+    ids = list(range(1000, 1000 + coords.shape[0]))
+    proj = _projection(coords, ids=ids)
+    pyr = build_pyramid(proj, bin_shape=bin_shape, n_levels=4)
+
+    all_recovered: set[int] = set()
+    for (level, tx, ty), tile in pyr.tiles.items():
+        members = tile_member_ids(pyr, proj, level, tx, ty)
+        # Re-deriving membership must agree with the cell aggregates: one entry
+        # per cell, member count equals the stored count, and the representative
+        # is among the members.
+        assert set(members) == {(c.q, c.r) for c in tile.cells}
+        for cell in tile.cells:
+            cell_members = members[(cell.q, cell.r)]
+            assert len(cell_members) == cell.count
+            assert cell.rep_id in cell_members
+            all_recovered.update(cell_members)
+
+    # Across one level, every point is recovered exactly once.
+    level0_members: list[int] = []
+    for (level, tx, ty) in pyr.tiles:
+        if level != 0:
+            continue
+        for member_list in tile_member_ids(pyr, proj, level, tx, ty).values():
+            level0_members.extend(member_list)
+    assert sorted(level0_members) == sorted(ids)
+    assert all_recovered == set(ids)
+
+
+def test_tile_member_ids_empty_for_missing_tile():
+    proj = _projection(_cluster_cloud())
+    pyr = build_pyramid(proj, n_levels=3)
+    assert tile_member_ids(pyr, proj, 0, 999, 999) == {}
+
+
+def test_tile_member_ids_empty_projection():
+    proj = _projection(np.empty((0, 2), dtype=np.float32), ids=[])
+    pyr = build_pyramid(proj, n_levels=2)
+    assert tile_member_ids(pyr, proj, 0, 0, 0) == {}
 
 
 def test_empty_projection_yields_no_tiles_but_keeps_levels():

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -114,7 +114,7 @@ def test_tile_member_ids_partition_each_tile(bin_shape):
 
     # Across one level, every point is recovered exactly once.
     level0_members: list[int] = []
-    for (level, tx, ty) in pyr.tiles:
+    for level, tx, ty in pyr.tiles:
         if level != 0:
             continue
         for member_list in tile_member_ids(pyr, proj, level, tx, ty).values():

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -29,6 +29,7 @@ from vtscore.projection.pyramid import (
     Tile,
     build_pyramid,
     max_useful_levels,
+    tile_member_ids,
 )
 from vtscore.projection.squarebin import square_center, squarebin_assign
 from vtscore.projection.umap_projection import Projection, fit_projection
@@ -42,6 +43,7 @@ __all__ = [
     "LevelMeta",
     "build_pyramid",
     "max_useful_levels",
+    "tile_member_ids",
     "BIN_SHAPES",
     "DEFAULT_BIN_SHAPE",
     "hexbin_assign",

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -320,6 +320,44 @@ def build_pyramid(
     )
 
 
+def tile_member_ids(
+    pyr: Pyramid,
+    projection: Projection,
+    level: int,
+    tx: int,
+    ty: int,
+) -> dict[tuple[int, int], list[int]]:
+    """Media ids per cell for one tile, re-derived from the frozen layout.
+
+    A :class:`HexCell` stores only its ``count`` (density) and a single
+    ``rep_id`` — the per-cell member lists are computed during the build and
+    discarded, since persisting them would bloat the container with an index
+    that the frozen 2-D coordinates already imply.  The browse canvas needs the
+    full membership to render per-cell selection state (none / partial / full)
+    and to toggle a whole bin's contents, so we recompute it on demand here by
+    re-binning *projection*'s coordinates at *level*'s radius and grouping the
+    points that land in the requested ``(tx, ty)`` tile.
+
+    Returned keyed by ``(q, r)`` so the tile endpoint can hand each cell its
+    members.  Tiles are immutable for the dataset's life (the projection is
+    frozen at ingest), so this is computed once per tile and then HTTP-cached.
+    """
+    coords = np.ascontiguousarray(projection.coords, dtype=np.float64)
+    if coords.shape[0] == 0:
+        return {}
+    ids = np.asarray(projection.ids, dtype=np.int64)
+    geom = _geometry_for(pyr.bin_shape)
+    radius = pyr.level_radius(level)
+    q, r = geom.assign(coords, radius)
+    tx_all, ty_all = geom.tile_index(q, r, pyr.tile_span)
+    mask = (tx_all == tx) & (ty_all == ty)
+
+    members: dict[tuple[int, int], list[int]] = {}
+    for qq, rr, mid in zip(q[mask].tolist(), r[mask].tolist(), ids[mask].tolist()):
+        members.setdefault((int(qq), int(rr)), []).append(int(mid))
+    return members
+
+
 def max_useful_levels(point_count: int) -> int:
     """A generous ``n_levels`` ceiling for *point_count* clips.
 

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -425,10 +425,13 @@ def get_tile(shape: str, level: int, tx: int, ty: int):
 
     shape = _resolve_shape(shape)
     ctx = get_active_context()
-    if _is_subset(request.args.get("subset")):
+    subset = _is_subset(request.args.get("subset"))
+    if subset:
         pyr = ctx._subset_pyramids.get(shape)
+        proj = ctx._subset_projection
     else:
         pyr = ctx._pyramids.get(shape)
+        proj = ctx._projection
     if pyr is None:
         abort(404, message="Projection not built yet — call POST /api/projection/build first.")
 
@@ -449,7 +452,20 @@ def get_tile(shape: str, level: int, tx: int, ty: int):
     if tile is None:
         return {"level": level, "tx": tx, "ty": ty, "cells": []}
 
-    return tile.to_payload()
+    payload = tile.to_payload()
+    # Attach each cell its full member id list so the canvas can render
+    # per-cell selection state and toggle a whole bin. The pyramid keeps only
+    # counts + representatives, so this is re-derived on demand from the frozen
+    # layout (see ``tile_member_ids``); it rides along on the immutable,
+    # HTTP-cached tile response.
+    if proj is not None and payload["cells"]:
+        from vtscore.projection import tile_member_ids
+
+        members = tile_member_ids(pyr, proj, level, tx, ty)
+        for cell in payload["cells"]:
+            cell["member_ids"] = members.get((cell["q"], cell["r"]), [])
+
+    return payload
 
 
 def _persist_projection(dataset_id: str, proj, pyr) -> None:

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -47,6 +47,11 @@ class HexCellSchema(Schema):
     cy = fields.Float(required=True)
     count = fields.Integer(required=True)
     rep_id = fields.Integer(required=True)
+    member_ids = fields.List(
+        fields.Integer(),
+        load_default=None,
+        metadata={"description": "All media ids aggregated in this cell (for selection)."},
+    )
 
 
 class TileResponseSchema(Schema):


### PR DESCRIPTION
## What

Adds **media selection** to the VTSBrowse canvas. This effort *tracks and displays* the selection; acting on it (export, seed a detector, etc.) is a deliberate next step.

### Interaction
- **Click** toggles the bin under the cursor: an unselected bin fully selects its contents; a partially- or fully-selected bin fully clears them. (Plain click never panned, so no conflict.)
- **Shift+drag** draws a marquee that adds every bin whose centre falls inside it. **Plain drag still pans** — Shift is the only new gesture.
- A floating **selection panel** (top-left, mirrors the legend/minimap overlay style) shows the live `N selected` count and a **Clear** button.

### Visual state (tri-state)
Each bin's state is *derived* from how many of its members are selected, so it stays coherent across zoom (bins split/merge):
- **none** → dimmed when any selection exists,
- **full** → solid accent ring,
- **partial** → dashed accent ring.

State is memoized per cell against a selection version token, so a steady-state pan stays O(visible cells) rather than O(members).

### Model & lifecycle
- Selection is a `Set<number>` of media ids in `BrowseSelectionService`, provided per `BrowseViewComponent` — **in-memory, session-scoped**.
- Survives a hex/square toggle (ids are shape-independent); **clears on a projection change** (media-type switch / rebuild).

### Backend
Bins persist only `count` + `rep_id`. The full per-cell member id list is **re-derived on demand** (`tile_member_ids` in `vtscore/projection/pyramid.py`) and attached to each tile cell as `member_ids` — **nothing new is persisted**, and it rides the existing immutable, HTTP-cached tile response.

## Decisions (confirmed with the user)
Item-level granularity · in-memory/session lifetime · Shift+drag marquee · count + Clear panel.

## Tests
- `tests_lib/projection/test_pyramid.py`: `tile_member_ids` partitions each tile, member counts match, reps are members, level union == dataset ids (hex + square).
- `tests/api/test_projection.py`: tile endpoint returns `member_ids` agreeing with `count`/`rep_id` and covering every item.
- OpenAPI snapshot regenerated (`member_ids` field added).
- Full `./run-tests.sh` green (4595 passed); frontend `build:prod` clean, no warnings.

## Follow-ups (recorded in `docs/plans/vtsbrowse.md`)
Act on the selection · optional per-(projection, level) membership cache for very large datasets · minimap selection overlay.

https://claude.ai/code/session_01BDYegDYE9t8wNLvx83SKTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDYegDYE9t8wNLvx83SKTQ)_