### PR TITLE
Show live elapsed time during the UMAP projection fit

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -817,6 +817,20 @@ and available to any future consumer of `vtscore`.
 ## Open follow-ups
 
 **Shipped:**
+- **Live elapsed-time during the UMAP fit (no more dead airtime).** The build
+  status bar used to sit frozen at `0/N` for the entire fit because
+  `fit_projection` emitted no progress between the start and end of the single
+  blocking `reducer.fit_transform()` call. It now runs the fit on a worker
+  thread and ticks an elapsed-seconds heartbeat (`vtscore/projection/umap_projection.py`,
+  `_umap_layout`) on a `_HEARTBEAT_SECONDS` (1 s) cadence — matching the browse
+  view's 1 s `/api/projection/meta` poll. The heartbeat reports `total=0`, which
+  switches the frontend `vt-progress-bar` to its animated *indeterminate* state
+  and shows `UMAP fit (N points) — Ns elapsed`. *Why not a true `done/total`
+  %:* UMAP's epoch loop runs inside numba with no per-epoch Python callback, so
+  a real fraction would require parsing UMAP's verbose/tqdm stdout — fragile
+  across versions. Elapsed-seconds + an animated bar was the robust floor (and
+  the user's explicitly-accepted fallback). If a real % is ever wanted, the
+  hook point is UMAP's `tqdm_kwds`/`verbose` epoch output.
 - **Item selection on the canvas (tracking only).** Supersedes the v1
   "no selection" scope (*§Locked decisions* / *§Interaction model*). Selection
   is held at the *media-id* granularity in `BrowseSelectionService`

--- a/tests_lib/projection/test_umap_projection.py
+++ b/tests_lib/projection/test_umap_projection.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import threading
+
 import numpy as np
 import pytest
 
+import vtscore.projection.umap_projection as up
 from vtscore.projection.umap_projection import Projection, fit_projection
 
 
@@ -90,3 +93,58 @@ def test_progress_callback_invoked():
     )
     assert seen  # at least one milestone reported
     assert all(evt[0] == "projecting" for evt in seen)
+
+
+def test_umap_fit_emits_elapsed_heartbeats(monkeypatch):
+    """While the (blocking) UMAP fit runs, fit_projection ticks elapsed-seconds
+    heartbeats so the browse view never shows dead airtime.
+
+    Synchronization is event-based (not sleep-based): a fake reducer blocks
+    until the test has observed at least one heartbeat, then releases.
+    """
+    import umap
+
+    release = threading.Event()  # lets the fake fit finish
+    saw_heartbeat = threading.Event()
+
+    class _FakeReducer:
+        def __init__(self, **_kwargs):
+            pass
+
+        def fit_transform(self, mat):
+            release.wait(timeout=5)
+            return np.zeros((mat.shape[0], 2), dtype=np.float32)
+
+    monkeypatch.setattr(umap, "UMAP", _FakeReducer)
+    monkeypatch.setattr(up, "_HEARTBEAT_SECONDS", 0.02)
+
+    seen: list[tuple[str, str, int, int]] = []
+
+    def _on_progress(status, message, current, total):
+        seen.append((status, message, current, total))
+        if "elapsed" in message:
+            saw_heartbeat.set()
+
+    n, d = 12, 8
+    result: list[Projection] = []
+
+    def _run():
+        result.append(fit_projection(_matrix(n, d), list(range(n)), on_progress=_on_progress))
+
+    worker = threading.Thread(target=_run, name="fit-under-test")
+    worker.start()
+    try:
+        assert saw_heartbeat.wait(timeout=5), "expected at least one elapsed heartbeat"
+    finally:
+        release.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+    proj = result[0]
+    assert proj.method == "umap"
+    assert proj.coords.shape == (n, 2)
+    # Heartbeats are indeterminate (total == 0) so the frontend bar animates
+    # instead of freezing at 0/N for the whole fit.
+    heartbeats = [evt for evt in seen if "elapsed" in evt[1]]
+    assert heartbeats
+    assert all(total == 0 for *_rest, total in heartbeats)

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -96,6 +96,54 @@ def _pca_layout(matrix: np.ndarray) -> np.ndarray:
     return np.ascontiguousarray(coords, dtype=np.float32)
 
 
+def _umap_layout(
+    mat: np.ndarray,
+    *,
+    n_neighbors: int,
+    min_dist: float,
+    random_state: int | None,
+    on_heartbeat: Callable[[int], None],
+) -> np.ndarray:
+    """Run UMAP on *mat*, ticking ``on_heartbeat(elapsed_seconds)`` while it runs.
+
+    UMAP's ``fit_transform`` is a single blocking call with no per-epoch hook,
+    so it runs on a worker thread and the caller's thread emits an
+    elapsed-seconds heartbeat on each ``_HEARTBEAT_SECONDS`` tick.  Anything the
+    worker raises is re-raised here.
+    """
+    import umap
+
+    reducer = umap.UMAP(
+        n_components=2,
+        n_neighbors=min(n_neighbors, mat.shape[0] - 1),
+        min_dist=min_dist,
+        metric="euclidean",
+        random_state=random_state,
+    )
+
+    fit_result: list[np.ndarray] = []
+    fit_error: list[Exception] = []
+
+    def _fit() -> None:
+        try:
+            fit_result.append(reducer.fit_transform(mat))
+        except Exception as exc:  # surfaced via fit_error below
+            fit_error.append(exc)
+
+    worker = threading.Thread(target=_fit, name="umap-fit", daemon=True)
+    started = time.monotonic()
+    worker.start()
+    while True:
+        worker.join(timeout=_HEARTBEAT_SECONDS)
+        if not worker.is_alive():
+            break
+        on_heartbeat(int(time.monotonic() - started))
+
+    if fit_error:
+        raise fit_error[0]
+    return np.ascontiguousarray(fit_result[0], dtype=np.float32)
+
+
 def fit_projection(
     matrix: np.ndarray,
     ids: list[int],
@@ -148,41 +196,16 @@ def fit_projection(
     # the whole fit (a non-zero total would freeze it at 0/N — the dead airtime
     # this code exists to kill); the message carries the live elapsed-seconds.
     _progress("projecting", f"UMAP fit ({n} points)", 0, 0)
-    import umap
 
-    reducer = umap.UMAP(
-        n_components=2,
-        n_neighbors=min(n_neighbors, n - 1),
-        min_dist=min_dist,
-        metric="euclidean",
-        random_state=random_state,
-    )
-
-    # UMAP's fit is a single blocking call with no per-epoch hook, so we run it
-    # on a worker thread and tick an elapsed-seconds heartbeat from here while
-    # it's alive.  Anything the worker raises is re-raised in this thread.
-    fit_result: list[np.ndarray] = []
-    fit_error: list[Exception] = []
-
-    def _fit() -> None:
-        try:
-            fit_result.append(reducer.fit_transform(mat))
-        except Exception as exc:  # surfaced via fit_error below
-            fit_error.append(exc)
-
-    worker = threading.Thread(target=_fit, name="umap-fit", daemon=True)
-    started = time.monotonic()
-    worker.start()
-    while True:
-        worker.join(timeout=_HEARTBEAT_SECONDS)
-        if not worker.is_alive():
-            break
-        elapsed = int(time.monotonic() - started)
+    def _heartbeat(elapsed: int) -> None:
         _progress("projecting", f"UMAP fit ({n} points) — {elapsed}s elapsed", 0, 0)
 
-    if fit_error:
-        raise fit_error[0]
-
-    coords = np.ascontiguousarray(fit_result[0], dtype=np.float32)
+    coords = _umap_layout(
+        mat,
+        n_neighbors=n_neighbors,
+        min_dist=min_dist,
+        random_state=random_state,
+        on_heartbeat=_heartbeat,
+    )
     _progress("projecting", "UMAP fit done", n, n)
     return Projection(projection_id, list(ids), coords, "umap")

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -126,7 +126,7 @@ def _umap_layout(
 
     def _fit() -> None:
         try:
-            fit_result.append(reducer.fit_transform(mat))
+            fit_result.append(np.asarray(reducer.fit_transform(mat)))
         except Exception as exc:  # surfaced via fit_error below
             fit_error.append(exc)
 

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -24,6 +24,8 @@ never pulls in numba's JIT until an actual fit runs.
 
 from __future__ import annotations
 
+import threading
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -32,6 +34,14 @@ import numpy as np
 
 # Matches the ingest progress-callback shape (status, message, current, total).
 ProgressCallback = Callable[[str, str, int, int], None]
+
+# How often the UMAP fit emits a "still working" heartbeat.  UMAP's
+# ``fit_transform`` is one opaque blocking call (the epoch loop runs inside
+# numba with no per-epoch Python callback), so there's no real fraction to
+# report; instead we tick elapsed seconds on this cadence so the UI shows a
+# live counter and an animated bar instead of dead airtime.  The browse view
+# polls ``/api/projection/meta`` once a second, so a 1 s heartbeat lines up.
+_HEARTBEAT_SECONDS = 1.0
 
 
 @dataclass(frozen=True)
@@ -134,7 +144,10 @@ def fit_projection(
         _progress("projecting", "PCA fallback done", n, n)
         return Projection(projection_id, list(ids), coords, "pca")
 
-    _progress("projecting", f"UMAP fit ({n} points)", 0, n)
+    # total=0 keeps the frontend bar in its animated *indeterminate* state for
+    # the whole fit (a non-zero total would freeze it at 0/N — the dead airtime
+    # this code exists to kill); the message carries the live elapsed-seconds.
+    _progress("projecting", f"UMAP fit ({n} points)", 0, 0)
     import umap
 
     reducer = umap.UMAP(
@@ -144,6 +157,32 @@ def fit_projection(
         metric="euclidean",
         random_state=random_state,
     )
-    coords = np.ascontiguousarray(reducer.fit_transform(mat), dtype=np.float32)
+
+    # UMAP's fit is a single blocking call with no per-epoch hook, so we run it
+    # on a worker thread and tick an elapsed-seconds heartbeat from here while
+    # it's alive.  Anything the worker raises is re-raised in this thread.
+    fit_result: list[np.ndarray] = []
+    fit_error: list[Exception] = []
+
+    def _fit() -> None:
+        try:
+            fit_result.append(reducer.fit_transform(mat))
+        except Exception as exc:  # surfaced via fit_error below
+            fit_error.append(exc)
+
+    worker = threading.Thread(target=_fit, name="umap-fit", daemon=True)
+    started = time.monotonic()
+    worker.start()
+    while True:
+        worker.join(timeout=_HEARTBEAT_SECONDS)
+        if not worker.is_alive():
+            break
+        elapsed = int(time.monotonic() - started)
+        _progress("projecting", f"UMAP fit ({n} points) — {elapsed}s elapsed", 0, 0)
+
+    if fit_error:
+        raise fit_error[0]
+
+    coords = np.ascontiguousarray(fit_result[0], dtype=np.float32)
     _progress("projecting", "UMAP fit done", n, n)
     return Projection(projection_id, list(ids), coords, "umap")


### PR DESCRIPTION
## Problem

Building the VTSBrowse projection felt dead. The build status bar sat frozen at `0/N` for the *entire* UMAP fit — often the longest, most opaque part of preparing the browse canvas.

**Root cause:** `fit_projection` emitted progress *before* and *after* the fit, but the fit itself is a single blocking `reducer.fit_transform()` call that produced no updates in between. Worse, the pre-fit milestone reported `total=N > 0`, so the frontend rendered a *determinate* bar pinned at 0/N for the whole duration.

## Fix

Run the UMAP fit on a worker thread and tick an **elapsed-seconds heartbeat** from the calling thread while it's alive (`vtscore/projection/umap_projection.py`, new `_umap_layout` helper):

- Heartbeat cadence is `_HEARTBEAT_SECONDS` (1 s), matching the browse view's existing 1 s `/api/projection/meta` poll.
- Heartbeats report `total=0`, which flips the existing `vt-progress-bar` into its **animated indeterminate** state instead of a frozen 0/N, and the message shows `UMAP fit (N points) — Ns elapsed`.
- Anything the worker raises is re-raised on the calling thread, so error handling is unchanged.

No frontend changes were needed — the progress pipeline (callback → async job → polling → progress bar) and the indeterminate-bar animation already existed; the fit just wasn't feeding them during its long stretch. The ingest-time build path inherits the same heartbeats automatically.

### Why elapsed-seconds and not a true `done/total` %

UMAP's epoch loop runs inside numba with no per-epoch Python callback, so a real fraction would require parsing UMAP's `verbose`/tqdm stdout — fragile across UMAP versions. Elapsed-seconds paired with an animated bar is the robust option (and the explicitly-accepted fallback). The `tqdm_kwds`/`verbose` hook point is noted in the plan doc if a real % is ever wanted.

## Tests

- New `test_umap_fit_emits_elapsed_heartbeats` in `tests_lib/projection/` — verifies heartbeats fire during a blocking fit, using `threading.Event` for synchronization (no `sleep`-based timing) and asserting heartbeats carry `total=0`.
- `./run-tests.sh projection` → all 54 pass.
- `./run-tests.sh api datasets` → green after building the frontend bundle (`npm run build:prod`); the only failures were stale-`static/` dashboard tests in the fresh container, unrelated to this change.

https://claude.ai/code/session_01SFz5ECiighCghG7KY2vbWc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFz5ECiighCghG7KY2vbWc)_