### PR TITLE
Cache tile membership per (projection, level) in-memory

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -835,16 +835,17 @@ and available to any future consumer of `vtscore`.
   - Backend: bins store only `count` + `rep_id`, so the full member id list per
     cell is re-derived on demand (`tile_member_ids` in `vtscore/projection/pyramid.py`)
     and attached to each cell in the tile payload (`member_ids`) — nothing new is
-    persisted; it rides the immutable, HTTP-cached tile.
+    persisted; it rides the immutable, HTTP-cached tile. The re-derivation is
+    backed by a per-(projection, level) membership cache (`_level_membership` /
+    `Pyramid._member_index`): one O(N) re-bin per level, shared across all that
+    level's tiles, held in-memory only (never persisted; re-derived from the
+    frozen coords on the next load), so panning a level after the first tile is a
+    dict lookup rather than a fresh O(N) scan.
   - *Open follow-ups:*
     - **Act on the selection.** This effort only *tracks* and *displays* the
       selection; the next pass wires it to an action (export the subset, seed a
       detector, build a subset projection from it, etc.). The selected ids are a
       plain `Set<number>` ready to hand off.
-    - **Per-tile membership recompute cost.** `tile_member_ids` re-bins the whole
-      coordinate array per tile request (O(N) each), fine for typical datasets and
-      cached after first fetch, but a per-(projection, level) assignment cache
-      would cut the first-viewport cost on very large datasets.
     - **Minimap selection overlay.** The minimap does not yet show which region is
       selected; a faint accent wash over selected cells there would aid orientation.
 - **Load + project on the dashboard before entering Browse.** The dashboard's

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -138,7 +138,7 @@ def test_tile_member_ids_caches_per_level():
 
     # Level 1 is now cached, holding *every* level-1 tile (not just the one asked for).
     assert level in pyr._member_index
-    assert set(pyr._member_index[level]) == {(t, u) for (l, t, u) in pyr.tiles if l == level}
+    assert set(pyr._member_index[level]) == {(t, u) for (lvl, t, u) in pyr.tiles if lvl == level}
 
     # A second fetch returns the same cached object — no recompute.
     assert tile_member_ids(pyr, proj, level, tx, ty) is pyr._member_index[level][(tx, ty)]

--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -123,6 +123,27 @@ def test_tile_member_ids_partition_each_tile(bin_shape):
     assert all_recovered == set(ids)
 
 
+def test_tile_member_ids_caches_per_level():
+    """The first tile fetched at a level fills the shared per-level cache."""
+    coords = _cluster_cloud()
+    proj = _projection(coords)
+    pyr = build_pyramid(proj, n_levels=4)
+    assert pyr._member_index == {}
+
+    # Pick a real, populated tile at level 1.
+    level = 1
+    (_lvl, tx, ty) = next(key for key in pyr.tiles if key[0] == level)
+    members = tile_member_ids(pyr, proj, level, tx, ty)
+    assert members  # non-empty for a real tile
+
+    # Level 1 is now cached, holding *every* level-1 tile (not just the one asked for).
+    assert level in pyr._member_index
+    assert set(pyr._member_index[level]) == {(t, u) for (l, t, u) in pyr.tiles if l == level}
+
+    # A second fetch returns the same cached object — no recompute.
+    assert tile_member_ids(pyr, proj, level, tx, ty) is pyr._member_index[level][(tx, ty)]
+
+
 def test_tile_member_ids_empty_for_missing_tile():
     proj = _projection(_cluster_cloud())
     pyr = build_pyramid(proj, n_levels=3)

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -364,9 +364,7 @@ def _level_membership(
     q, r = geom.assign(coords, radius)
     tx_all, ty_all = geom.tile_index(q, r, pyr.tile_span)
 
-    for txx, tyy, qq, rr, mid in zip(
-        tx_all.tolist(), ty_all.tolist(), q.tolist(), r.tolist(), ids.tolist()
-    ):
+    for txx, tyy, qq, rr, mid in zip(tx_all.tolist(), ty_all.tolist(), q.tolist(), r.tolist(), ids.tolist()):
         tile_cells = index.setdefault((int(txx), int(tyy)), {})
         tile_cells.setdefault((int(qq), int(rr)), []).append(int(mid))
 

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -106,6 +106,13 @@ class Pyramid:
     # (level, tx, ty) -> Tile
     tiles: dict[tuple[int, int, int], Tile]
     bin_shape: str = DEFAULT_BIN_SHAPE  # "hex" | "square" — which lattice was binned
+    # In-memory, process-scoped membership cache: level -> {(tx, ty): {(q, r): [ids]}}.
+    # Lazily filled by ``tile_member_ids`` (one O(N) re-bin per level, shared across
+    # that level's tiles) and never persisted — the frozen coords re-imply it on the
+    # next load. Excluded from equality/repr so it stays a pure cache.
+    _member_index: dict[int, dict[tuple[int, int], dict[tuple[int, int], list[int]]]] = field(
+        default_factory=dict, compare=False, repr=False
+    )
 
     def level_radius(self, level: int) -> float:
         """Cell radius at *level* (``base_radius / 2**level``)."""
@@ -320,6 +327,53 @@ def build_pyramid(
     )
 
 
+def _level_membership(
+    pyr: Pyramid,
+    projection: Projection,
+    level: int,
+) -> dict[tuple[int, int], dict[tuple[int, int], list[int]]]:
+    """All of *level*'s membership, ``{(tx, ty): {(q, r): [ids]}}``, cached in-memory.
+
+    A :class:`HexCell` stores only its ``count`` (density) and a single
+    ``rep_id`` — the per-cell member lists are computed during the build and
+    discarded, since persisting them would bloat the container with an index
+    that the frozen 2-D coordinates already imply.  So we re-derive them here by
+    re-binning *projection*'s coordinates at *level*'s radius.
+
+    A single :func:`_geometry_for` assignment pass already partitions *every*
+    point into its ``(tx, ty)`` tile and ``(q, r)`` cell, so we build the whole
+    level at once and memoize it on ``pyr._member_index``.  The first tile
+    fetched at a level pays the O(N) re-bin; every other tile at that level is
+    then a dict lookup — turning a per-tile O(N) scan into one O(N) pass per
+    level.  The cache is process-scoped and never persisted; the frozen layout
+    re-derives it on the next load.
+    """
+    cached = pyr._member_index.get(level)
+    if cached is not None:
+        return cached
+
+    coords = np.ascontiguousarray(projection.coords, dtype=np.float64)
+    index: dict[tuple[int, int], dict[tuple[int, int], list[int]]] = {}
+    if coords.shape[0] == 0:
+        pyr._member_index[level] = index
+        return index
+
+    ids = np.asarray(projection.ids, dtype=np.int64)
+    geom = _geometry_for(pyr.bin_shape)
+    radius = pyr.level_radius(level)
+    q, r = geom.assign(coords, radius)
+    tx_all, ty_all = geom.tile_index(q, r, pyr.tile_span)
+
+    for txx, tyy, qq, rr, mid in zip(
+        tx_all.tolist(), ty_all.tolist(), q.tolist(), r.tolist(), ids.tolist()
+    ):
+        tile_cells = index.setdefault((int(txx), int(tyy)), {})
+        tile_cells.setdefault((int(qq), int(rr)), []).append(int(mid))
+
+    pyr._member_index[level] = index
+    return index
+
+
 def tile_member_ids(
     pyr: Pyramid,
     projection: Projection,
@@ -329,33 +383,14 @@ def tile_member_ids(
 ) -> dict[tuple[int, int], list[int]]:
     """Media ids per cell for one tile, re-derived from the frozen layout.
 
-    A :class:`HexCell` stores only its ``count`` (density) and a single
-    ``rep_id`` — the per-cell member lists are computed during the build and
-    discarded, since persisting them would bloat the container with an index
-    that the frozen 2-D coordinates already imply.  The browse canvas needs the
-    full membership to render per-cell selection state (none / partial / full)
-    and to toggle a whole bin's contents, so we recompute it on demand here by
-    re-binning *projection*'s coordinates at *level*'s radius and grouping the
-    points that land in the requested ``(tx, ty)`` tile.
-
-    Returned keyed by ``(q, r)`` so the tile endpoint can hand each cell its
-    members.  Tiles are immutable for the dataset's life (the projection is
-    frozen at ingest), so this is computed once per tile and then HTTP-cached.
+    The browse canvas needs each cell's full membership to render per-cell
+    selection state (none / partial / full) and to toggle a whole bin's
+    contents.  Returned keyed by ``(q, r)`` so the tile endpoint can hand each
+    cell its members.  Backed by the per-level cache in :func:`_level_membership`
+    (computed once per level, shared across that level's tiles); the result is
+    also immutable for the dataset's life, so the tile endpoint HTTP-caches it.
     """
-    coords = np.ascontiguousarray(projection.coords, dtype=np.float64)
-    if coords.shape[0] == 0:
-        return {}
-    ids = np.asarray(projection.ids, dtype=np.int64)
-    geom = _geometry_for(pyr.bin_shape)
-    radius = pyr.level_radius(level)
-    q, r = geom.assign(coords, radius)
-    tx_all, ty_all = geom.tile_index(q, r, pyr.tile_span)
-    mask = (tx_all == tx) & (ty_all == ty)
-
-    members: dict[tuple[int, int], list[int]] = {}
-    for qq, rr, mid in zip(q[mask].tolist(), r[mask].tolist(), ids[mask].tolist()):
-        members.setdefault((int(qq), int(rr)), []).append(int(mid))
-    return members
+    return _level_membership(pyr, projection, level).get((tx, ty), {})
 
 
 def max_useful_levels(point_count: int) -> int:


### PR DESCRIPTION
## What & why

The browse canvas needs each bin's full member id list (to render none/partial/full selection state and toggle a whole bin). Bins only persist `count` + `rep_id`, so `tile_member_ids` re-derives membership from the frozen layout. The problem: it re-binned the **entire** coordinate array on **every** tile request (O(N) each), so serving all `T` tiles at a zoom level cost O(N·T) — even though a single `geom.assign` pass already partitions every point into its tile and cell at once.

### The evaluation

The prompt asked whether to "record all entries per bin when we build the bins." Persisting member lists *in the container* is the wrong call — it would bloat the pickle by ~L× the coords array (N·L ints) for an index the frozen 2-D coords already fully imply, against both the existing design intent and the repo's "No Persisted Vectors/MLPs" ethos. The right fix is the **in-memory** version, which the repo explicitly encourages: a per-(projection, level) membership cache.

This was already a documented, deferred follow-up in `docs/plans/vtsbrowse.md` ("a per-(projection, level) assignment cache would cut the first-viewport cost on very large datasets").

## Change

- `_level_membership()` builds a whole level's `{(tx, ty): {(q, r): [ids]}}` in one O(N) re-bin and memoizes it on `Pyramid._member_index`.
- `tile_member_ids()` now just slices that cache. The first tile fetched at a level pays the O(N) pass; every other tile at that level is a dict lookup — turning per-tile O(N) into one O(N) pass per level.
- The cache is in-memory and process-scoped (`compare=False`/`repr=False`), **never persisted**. The container format is unchanged; the frozen coords re-derive it on the next load.
- The route's public contract (`member_ids` per cell) is unchanged.

Updated the plan doc to mark the follow-up as shipped, and added a test covering the per-level caching behavior.

## Testing

`./run-tests.sh` — all 4596 pass (1 skipped, 2 xpassed).

https://claude.ai/code/session_018jctGJW2pcGMpGxHrMUiwo

---
_Generated by [Claude Code](https://claude.ai/code/session_018jctGJW2pcGMpGxHrMUiwo)_