### PR TITLE
Browser: "Remove from Good" cull + "Back to Find"

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3404,6 +3404,56 @@
         ],
         "type": "object"
       },
+      "MediaVoteBulkRequest": {
+        "properties": {
+          "ids": {
+            "description": "Media ids to apply the target vote to.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "target": {
+            "description": "Absolute target state applied to every id: ``good``, ``bad``, or ``none``. Idempotent.",
+            "enum": [
+              "good",
+              "bad",
+              "none"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "ids",
+          "target"
+        ],
+        "type": "object"
+      },
+      "MediaVoteBulkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "changed": {
+            "description": "How many ids actually changed state (idempotent re-applies and missing ids excluded).",
+            "type": "integer"
+          },
+          "missing": {
+            "description": "Requested ids that were not present in the loaded dataset.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "changed",
+          "missing",
+          "ok"
+        ],
+        "type": "object"
+      },
       "MediaVoteRequest": {
         "properties": {
           "region_box": {
@@ -11549,6 +11599,47 @@
           }
         },
         "summary": "Return a lightweight listing of all loaded medias.",
+        "tags": [
+          "medias"
+        ]
+      }
+    },
+    "/api/medias/vote-bulk": {
+      "post": {
+        "description": "Mirrors ``/api/medias/<id>/vote`` for a batch: each id is set to\n``target`` with the same idempotent semantics, then the detector\nlabelset is persisted **once** rather than per id.  Bulk votes are\nimage-level (no region boxes).  Powers the Browser's \"Remove from Good\"\ncull, which marks a hand-selected set of false-positives ``bad`` and\ndrops them from the browse.\n\nIds that aren't in the loaded dataset are skipped and reported back in\n``missing``; ``changed`` counts only the ids whose state actually moved\n(idempotent re-applies don't count).",
+        "operationId": "vote_media_bulk",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MediaVoteBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaVoteBulkResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "No ids supplied."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Apply one absolute vote target to many medias in a single request.",
         "tags": [
           "medias"
         ]

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3663,6 +3663,11 @@
             "nullable": true,
             "type": "array"
           },
+          "content_version": {
+            "default": 0,
+            "description": "Monotonic version of the projection's membership. Stays at 0 for full-dataset projections; bumped when items are removed from a subset browse in place. Combined with ``projection_id`` to bust the immutable tile cache without re-framing the canvas.",
+            "type": "integer"
+          },
           "current": {
             "default": null,
             "nullable": true,
@@ -4239,6 +4244,32 @@
         },
         "required": [
           "status"
+        ],
+        "type": "object"
+      },
+      "SubsetRemoveRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "ids": {
+            "description": "Media ids to drop from the current subset browse.",
+            "items": {
+              "type": "integer"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "shape": {
+            "default": "hex",
+            "description": "Bin shape whose updated meta to return (hex | square).",
+            "enum": [
+              "hex",
+              "square"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "ids"
         ],
         "type": "object"
       },
@@ -12007,6 +12038,47 @@
           }
         },
         "summary": "Return projection/pyramid metadata and build status for a bin shape.",
+        "tags": [
+          "projection"
+        ]
+      }
+    },
+    "/api/projection/subset/remove": {
+      "post": {
+        "description": "Re-bins the frozen subset layout onto its existing grid minus the removed\npoints: the remaining points keep their exact 2-D positions and bins, only\ncounts/representatives change.  The ``projection_id`` (layout identity) is\npreserved so the canvas keeps the user's pan/zoom; a bumped\n``content_version`` busts the otherwise-immutable tile cache.  Returns the\nupdated subset meta for *shape*.\n\nPowers the Browser's \"Remove from Good\" cull, which marks the items Bad via\n``/api/medias/vote-bulk`` and then calls this to make them disappear.",
+        "operationId": "remove_from_subset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubsetRemoveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionMeta"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "409": {
+            "description": "No subset projection is currently built."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Drop ids from the current subset browse **without re-fitting UMAP**.",
         "tags": [
           "projection"
         ]

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -13,6 +13,19 @@
     </button>
   </div>
 
+  @if (canRemoveGood) {
+    <div class="bsp-actions">
+      <button
+        type="button"
+        class="btn btn--danger btn--sm bsp-remove-good"
+        [disabled]="count === 0"
+        (click)="onRemoveGood()"
+        title="Mark the selected items Bad in the Find results and remove them from this browse">
+        Remove from Good ({{ count | number }})
+      </button>
+    </div>
+  }
+
   <div class="bsp-toolbar">
     <span class="bsp-sort-label" title="Choose how the selected items are ordered">Sort:</span>
     <label for="bsp-sort-select" class="sr-only">Sort selected items</label>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -55,6 +55,15 @@
   }
 }
 
+.bsp-actions {
+  padding: 0 var(--space-lg) var(--space-sm);
+  flex-shrink: 0;
+}
+
+.bsp-remove-good {
+  width: 100%;
+}
+
 .bsp-toolbar {
   display: flex;
   align-items: center;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -44,6 +44,17 @@ interface SelectionEntry {
 export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   /** Active media type, used to resolve the per-type view-mode + size prefs. */
   @Input() mediaType = '';
+
+  /**
+   * Whether to offer the "Remove from Good" cull action. Only meaningful when
+   * browsing a Find run's positives (subset mode): the action marks the
+   * selected items Bad in the detector's labels and drops them from the
+   * browse. The browse view owns the actual mutation + re-projection.
+   */
+  @Input() canRemoveGood = false;
+
+  /** Emitted when the user confirms the "Remove from Good" cull. */
+  @Output() removeGood = new EventEmitter<void>();
 
   count = 0;
   sortMode: SelectionSortMode = 'time-desc';
@@ -150,6 +161,12 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
 
   clear(): void {
     this.selection.clear();
+  }
+
+  /** Ask the browse view to mark the selected items Bad and remove them. */
+  onRemoveGood(): void {
+    if (this.count === 0) return;
+    this.removeGood.emit();
   }
 
   /** Clicking a selected item drops it from the selection. */

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -31,6 +31,15 @@
     @case ('ready') {
       <div class="browse-content" #content [style.--browse-panel-width]="panelWidth + 'px'">
         <div class="browse-main">
+          @if (subset) {
+            <button
+              type="button"
+              class="btn btn--secondary btn--sm browse-back"
+              (click)="backToFind()"
+              title="Return to the Find view (keeps any items you removed from Good)">
+              &larr; Back to Find
+            </button>
+          }
           <vt-browse-canvas
             [meta]="meta"
             [mediaType]="mediaType"
@@ -129,6 +138,8 @@
           <vt-browse-selection-panel
             class="browse-side-selection"
             [mediaType]="mediaType"
+            [canRemoveGood]="subset"
+            (removeGood)="onRemoveGood()"
           />
           <div class="browse-side-meta">
             <vt-browse-legend [maxCount]="densityMax" [colormap]="colormap" />

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -37,6 +37,15 @@
   color: var(--text-muted);
 }
 
+// Top-left affordance that returns to the Find view this browse came from
+// (subset mode only). Anchored to ``.browse-main`` like the other overlays.
+.browse-back {
+  position: absolute;
+  top: var(--space-md);
+  left: var(--space-md);
+  z-index: 2;
+}
+
 .browse-info {
   position: absolute;
   bottom: var(--space-md);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -503,11 +503,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       )
       .then((ok) => {
         if (!ok) return;
+        // 1) Mark them Bad in the detector's labels (one bulk request).
         this.mediasApi
           .voteBulk(ids, 'bad')
           .pipe(takeUntil(this.destroy$))
           .subscribe({
-            next: () => this.applyRemoval(ids),
+            next: () => this.dropFromBrowse(ids),
             error: () =>
               this.toast.error({ message: 'Failed to remove the selected items from Good.' }),
           });
@@ -515,25 +516,36 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * After the server has marked *removedIds* Bad, drop them from the subset
-   * and re-fit the projection. A subset build with a different id set re-runs
-   * UMAP (see ``vtsearch/routes/projection.py``), so the canvas reflects the
-   * smaller set; we clear the selection since those items no longer exist here.
+   * Drop *removedIds* from the browse after they've been marked Bad. The
+   * remaining items keep their exact 2-D positions and bins — the server
+   * re-bins the frozen layout in place (no UMAP re-fit), returning the same
+   * ``projection_id`` with a bumped ``content_version`` so only the tile cache
+   * refreshes while the canvas holds the user's pan/zoom.
    */
-  private applyRemoval(removedIds: number[]): void {
+  private dropFromBrowse(removedIds: number[]): void {
     const removed = new Set(removedIds);
-    this.subsetIds = this.subsetIds.filter((id) => !removed.has(id));
+    const remaining = this.subsetIds.filter((id) => !removed.has(id));
     this.selection.clear();
     this.toast.success({
       message: `Removed ${removedIds.length} item${removedIds.length === 1 ? '' : 's'} from Good.`,
     });
-    if (this.subsetIds.length === 0) {
+    this.subsetIds = remaining;
+    if (remaining.length === 0) {
+      // Nothing left to project; the cull emptied the browse.
       this.status = 'error';
-      this.errorMessage = 'All positives were removed. Re-run Find to start over.';
+      this.errorMessage = 'All positives were removed. Go back to Find to start over.';
       return;
     }
-    // Re-fit the subset projection over the reduced id set.
-    this.onBuild();
+    this.projectionApi
+      .subsetRemove(this.binShape, removedIds)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (meta) => this.applyMeta(meta),
+        error: () =>
+          this.toast.error({
+            message: 'Items were removed from Good, but the browse view could not refresh.',
+          }),
+      });
   }
 
   /**
@@ -582,6 +594,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       this.applyBrowsePrefsForMediaType();
     }
     this.tileCache.setProjectionId(meta.projection_id);
+    this.tileCache.setContentVersion(meta.content_version ?? 0);
 
     if (meta.point_count > 0) {
       this.status = 'ready';

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
@@ -18,6 +18,9 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
+import { MediasApiService } from '../../services/medias-api.service';
+import { VtDialogService } from '../../services/dialog.service';
+import { ToastService } from '../../services/toast.service';
 import {
   BROWSE_COLORMAP_IDS,
   DEFAULT_THUMBNAIL_BORDER,
@@ -154,7 +157,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private datasetsRegistryApi: DatasetsRegistryApiService,
     private settingsState: SettingsStateService,
     private route: ActivatedRoute,
+    private router: Router,
     private browseSubset: BrowseSubsetService,
+    private selection: BrowseSelectionService,
+    private mediasApi: MediasApiService,
+    private dialog: VtDialogService,
+    private toast: ToastService,
     private ngZone: NgZone,
   ) {}
 
@@ -474,6 +482,74 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             err?.error?.message || err?.error?.error || 'Failed to start projection build';
         },
       });
+  }
+
+  /**
+   * Cull the hand-selected items from a Find-positives browse: confirm, mark
+   * them Bad in the detector's labels (so they leave the Find view's Good
+   * list), then drop them from this browse by re-fitting the subset over the
+   * reduced id set. Subset mode only — wired up via the selection panel's
+   * ``canRemoveGood`` affordance, which is itself gated on ``subset``.
+   */
+  onRemoveGood(): void {
+    const ids = this.selection.ids();
+    if (ids.length === 0) return;
+    const n = ids.length;
+    this.dialog
+      .confirmDestructive(
+        `Remove ${n} item${n === 1 ? '' : 's'} from Good?`,
+        "(They'll be marked Bad in the Find results and removed from this browse. The underlying media is unaffected.)",
+        'Remove',
+      )
+      .then((ok) => {
+        if (!ok) return;
+        this.mediasApi
+          .voteBulk(ids, 'bad')
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: () => this.applyRemoval(ids),
+            error: () =>
+              this.toast.error({ message: 'Failed to remove the selected items from Good.' }),
+          });
+      });
+  }
+
+  /**
+   * After the server has marked *removedIds* Bad, drop them from the subset
+   * and re-fit the projection. A subset build with a different id set re-runs
+   * UMAP (see ``vtsearch/routes/projection.py``), so the canvas reflects the
+   * smaller set; we clear the selection since those items no longer exist here.
+   */
+  private applyRemoval(removedIds: number[]): void {
+    const removed = new Set(removedIds);
+    this.subsetIds = this.subsetIds.filter((id) => !removed.has(id));
+    this.selection.clear();
+    this.toast.success({
+      message: `Removed ${removedIds.length} item${removedIds.length === 1 ? '' : 's'} from Good.`,
+    });
+    if (this.subsetIds.length === 0) {
+      this.status = 'error';
+      this.errorMessage = 'All positives were removed. Re-run Find to start over.';
+      return;
+    }
+    // Re-fit the subset projection over the reduced id set.
+    this.onBuild();
+  }
+
+  /**
+   * Return to the Find view this browse was launched from, preserving the
+   * cull: the flag tells the Find view to skip its automatic re-scoring (which
+   * would re-promote the removed items) and just show the updated labels.
+   */
+  backToFind(): void {
+    const datasetId = this.activeContext.datasetId;
+    const detectorId = this.activeContext.modelId;
+    this.browseSubset.markReturningToFind();
+    if (datasetId && detectorId) {
+      this.router.navigate(['/find', datasetId, detectorId]);
+    } else {
+      this.router.navigate(['/dashboard']);
+    }
   }
 
   private loadProjection(): void {

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -103,8 +103,15 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       });
 
-    // Run find-label to score and label all medias
-    this.runFindLabel();
+    // Run find-label to score and label all medias — unless we're returning
+    // from the Browser after a "Remove from Good" cull. In that case the
+    // backend vote lists already reflect the removed items (now Bad), and the
+    // loadVotes() above refreshes them; re-running find here would re-score
+    // with the unchanged model and re-promote those items to Good, undoing
+    // the cull. Keep the cull instead (the user's decision).
+    if (!this.browseSubset.consumeReturningToFind()) {
+      this.runFindLabel();
+    }
 
     // Reload + rescore when the active pair changes via the top-bar
     // switcher or a route-param swap (`/find/:ds/:det` → `/find/:ds2/:det2`).

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -40,6 +40,14 @@ export interface ProjectionMeta {
   point_count: number;
   levels: LevelMeta[];
   media_type?: string;
+  /**
+   * Membership version of this projection. 0 for full-dataset layouts; bumped
+   * when items are removed from a subset browse in place. Combined with
+   * ``projection_id`` to form the tile cache token, so an in-place edit busts
+   * the immutable tile cache without changing the layout identity (which would
+   * make the canvas re-frame the viewport).
+   */
+  content_version?: number;
   // Build lifecycle (idle | building | ready | error) and progress, populated
   // by GET /api/projection/meta while a build is in flight.
   status?: 'idle' | 'building' | 'ready' | 'error';

--- a/frontend/src/app/services/browse-subset.service.ts
+++ b/frontend/src/app/services/browse-subset.service.ts
@@ -22,6 +22,7 @@ export interface BrowseSubset {
 @Injectable({ providedIn: 'root' })
 export class BrowseSubsetService {
   private pending: BrowseSubset | null = null;
+  private returningToFind = false;
 
   set(subset: BrowseSubset): void {
     this.pending = subset;
@@ -32,5 +33,24 @@ export class BrowseSubsetService {
     const s = this.pending;
     this.pending = null;
     return s;
+  }
+
+  /**
+   * Flag the reverse handoff: the user clicked "Back to Find" from the browse
+   * view after culling false-positives. The Find view consumes this on init
+   * to SKIP its automatic re-run of detector scoring — which would otherwise
+   * re-promote the just-removed items back to Good with the unchanged model —
+   * and instead just refresh the (already-updated) vote lists. Single-shot,
+   * like {@link take}.
+   */
+  markReturningToFind(): void {
+    this.returningToFind = true;
+  }
+
+  /** Read and clear the returning-to-Find flag (single-shot). */
+  consumeReturningToFind(): boolean {
+    const r = this.returningToFind;
+    this.returningToFind = false;
+    return r;
   }
 }

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -62,6 +62,26 @@ export class MediasApiService {
     );
   }
 
+  /**
+   * Apply one absolute vote target to many medias in a single request.
+   *
+   * Mirrors {@link vote} for a batch (idempotent, image-level — no region
+   * boxes), persisting the detector labelset once server-side.  Used by the
+   * Browser's "Remove from Good" cull.  Stays on plain HttpClient (like
+   * {@link addToPile}) because the bulk route isn't modelled in the generated
+   * client; the active-context interceptor still attaches the dataset /
+   * detector headers the route requires.
+   */
+  voteBulk(
+    ids: number[],
+    target: 'good' | 'bad' | 'none',
+  ): Observable<{ ok: boolean; changed: number; missing: number[] }> {
+    return this.http.post<{ ok: boolean; changed: number; missing: number[] }>(
+      '/api/medias/vote-bulk',
+      { ids, target },
+    );
+  }
+
   /** Multipart upload; stays on plain HttpClient because ng-openapi-gen
    *  doesn't model multipart bodies (the generated function's ``$Params``
    *  has no ``body`` field at all). */

--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -44,20 +44,34 @@ export class ProjectionApiService {
     return this.http.post<ProjectionBuildResponse>('/api/projection/build', { shape, ids });
   }
 
+  /**
+   * Remove ids from the current subset projection in place — no UMAP re-fit.
+   * The server re-bins the frozen layout minus those points and returns the
+   * updated meta (same ``projection_id``, bumped ``content_version``).
+   */
+  subsetRemove(shape: BinShape, ids: number[]): Observable<ProjectionMeta> {
+    return this.http.post<ProjectionMeta>('/api/projection/subset/remove', { shape, ids });
+  }
+
   getTile(
     shape: BinShape,
     level: number,
     tx: number,
     ty: number,
     subset = false,
+    cacheToken = '',
   ): Observable<TilePayload> {
     // The backend resolves the pyramid from the active dataset context, so the
-    // tile URL is keyed by (shape, level, tx, ty); the projection id is tracked
-    // client-side (TileCacheService) for cache invalidation, not in the path.
+    // tile URL is keyed by (shape, level, tx, ty). Tiles are served
+    // ``immutable``, so ``cacheToken`` (``<projection_id>:<content_version>``)
+    // rides along as ``?v=`` to give each projection — and each in-place edit of
+    // a subset — a distinct URL, busting the HTTP cache when content changes.
     const url = `/api/projection/tiles/${shape}/${level}/${tx}/${ty}`;
-    if (subset) {
-      return this.http.get<TilePayload>(url, { params: { subset: '1' } });
-    }
-    return this.http.get<TilePayload>(url);
+    const params: Record<string, string> = {};
+    if (subset) params['subset'] = '1';
+    if (cacheToken) params['v'] = cacheToken;
+    return Object.keys(params).length
+      ? this.http.get<TilePayload>(url, { params })
+      : this.http.get<TilePayload>(url);
   }
 }

--- a/frontend/src/app/services/tile-cache.service.ts
+++ b/frontend/src/app/services/tile-cache.service.ts
@@ -24,6 +24,11 @@ export class TileCacheService {
   // a cache miss (and so they're available as a fallback layer later).
   private readonly PINNED_LEVELS = 3;
   private projectionId = '';
+  // Membership version of the current (subset) projection. Bumped server-side
+  // when items are removed from a subset browse in place; the layout identity
+  // (projectionId) is kept stable so the canvas doesn't re-frame, so this is
+  // what distinguishes "same layout, different contents" for the tile cache.
+  private contentVersion = 0;
   // The bin shape (hex/square) tiles are currently fetched for. It is part of
   // the cache key, so switching shapes keeps both binnings cached side by side
   // (they share one projection id, so the id alone can't tell them apart).
@@ -40,11 +45,22 @@ export class TileCacheService {
       this.cache.clear();
       this.inflight.clear();
       this.projectionId = id;
+      this.contentVersion = 0;
     }
   }
 
   setBinShape(shape: BinShape): void {
     this.binShape = shape;
+  }
+
+  /**
+   * Update the membership version. Entries are keyed by it, so a change makes
+   * the prior version's tiles unreachable (refetched on demand) without
+   * clearing the whole cache — and rides along on the tile URL so the HTTP
+   * cache refreshes too.
+   */
+  setContentVersion(version: number): void {
+    this.contentVersion = version;
   }
 
   setSubset(subset: boolean): void {
@@ -65,7 +81,7 @@ export class TileCacheService {
 
     if (!this.projectionId) return null;
 
-    const req$ = this.projectionApi.getTile(this.binShape, level, tx, ty, this.subset).pipe(
+    const req$ = this.projectionApi.getTile(this.binShape, level, tx, ty, this.subset, this.cacheToken()).pipe(
       tap((tile) => {
         this.inflight.delete(key);
         this.put(key, tile);
@@ -101,10 +117,16 @@ export class TileCacheService {
     this.cache.clear();
     this.inflight.clear();
     this.projectionId = '';
+    this.contentVersion = 0;
   }
 
   private key(level: number, tx: number, ty: number): string {
-    return `${this.binShape}:${level}:${tx}:${ty}`;
+    return `${this.binShape}:${this.contentVersion}:${level}:${tx}:${ty}`;
+  }
+
+  /** Cache-bust token for the tile URL: ``<projection_id>:<content_version>``. */
+  private cacheToken(): string {
+    return `${this.projectionId}:${this.contentVersion}`;
   }
 
   private put(key: string, tile: TilePayload): void {

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -496,3 +496,73 @@ class TestProjectionSubset:
         client.post("/api/projection/build")
         _wait_projection()
         assert client.get("/api/projection/meta?subset=1").get_json()["status"] == "idle"
+
+
+class TestSubsetRemove:
+    """``POST /api/projection/subset/remove``: cull ids without re-fitting UMAP."""
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_remove_drops_ids_and_keeps_coords(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:5]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+
+        before = ctx._subset_projection
+        proj_id_before = before.projection_id
+        # Coordinates of an id we will KEEP must be byte-for-byte unchanged.
+        keep_id = ids[-1]
+        keep_coord = before.coords[before.ids.index(keep_id)].copy()
+
+        removed = ids[:2]
+        resp = client.post("/api/projection/subset/remove", json={"ids": removed})
+        assert resp.status_code == 200
+        meta = resp.get_json()
+
+        # Same layout identity, bumped content version, smaller point count.
+        assert meta["projection_id"] == proj_id_before
+        assert meta["content_version"] == 1
+        assert meta["point_count"] == len(ids) - len(removed)
+
+        after = ctx._subset_projection
+        assert set(after.ids) == set(ids) - set(removed)
+        assert ctx._subset_ids == sorted(set(ids) - set(removed))
+        # The kept point did not move — no re-fit happened.
+        np.testing.assert_array_equal(after.coords[after.ids.index(keep_id)], keep_coord)
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_remove_bumps_version_each_call(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:6]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+
+        m1 = client.post("/api/projection/subset/remove", json={"ids": [ids[0]]}).get_json()
+        m2 = client.post("/api/projection/subset/remove", json={"ids": [ids[1]]}).get_json()
+        assert m1["content_version"] == 1
+        assert m2["content_version"] == 2
+        assert m2["projection_id"] == m1["projection_id"]
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_remove_rebuilds_both_shapes(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:6]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+        # Build the square binning too, so both shapes are present.
+        client.post("/api/projection/build", json={"ids": ids, "shape": "square"})
+        _wait_projection()
+        assert set(ctx._subset_pyramids) == {"hex", "square"}
+
+        client.post("/api/projection/subset/remove", json={"ids": [ids[0]], "shape": "square"})
+        # Both shapes re-binned over the reduced layout.
+        assert ctx._subset_pyramids["hex"].point_count == len(ids) - 1
+        assert ctx._subset_pyramids["square"].point_count == len(ids) - 1
+
+    def test_remove_without_subset_returns_409(self, client):
+        resp = client.post("/api/projection/subset/remove", json={"ids": [1]})
+        assert resp.status_code == 409
+
+    def test_remove_empty_ids_rejected(self, client):
+        resp = client.post("/api/projection/subset/remove", json={"ids": []})
+        assert resp.status_code == 422

--- a/tests/core/test_votes.py
+++ b/tests/core/test_votes.py
@@ -112,6 +112,52 @@ class TestVoteClip:
         assert 2 not in app_module.good_votes
 
 
+class TestVoteBulk:
+    """POST /api/medias/vote-bulk: apply one target to many ids at once.
+
+    Powers the Browser's "Remove from Good" cull (mark a hand-selected set of
+    false-positives Bad in a single request).
+    """
+
+    def test_bulk_mark_bad_moves_from_good(self, client):
+        client.post("/api/medias/1/vote", json={"target": "good"})
+        client.post("/api/medias/2/vote", json={"target": "good"})
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 2], "target": "bad"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["changed"] == 2
+        assert data["missing"] == []
+        assert 1 in app_module.bad_votes
+        assert 2 in app_module.bad_votes
+        assert 1 not in app_module.good_votes
+        assert 2 not in app_module.good_votes
+
+    def test_bulk_idempotent_not_counted(self, client):
+        client.post("/api/medias/1/vote", json={"target": "bad"})
+        # 1 is already bad → no change; 2 transitions none→bad → one change.
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 2], "target": "bad"})
+        assert resp.get_json()["changed"] == 1
+        assert 1 in app_module.bad_votes
+        assert 2 in app_module.bad_votes
+
+    def test_bulk_reports_missing_ids(self, client):
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 9999], "target": "bad"})
+        data = resp.get_json()
+        assert data["missing"] == [9999]
+        assert data["changed"] == 1
+        assert 1 in app_module.bad_votes
+
+    def test_bulk_empty_ids_rejected(self, client):
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [], "target": "bad"})
+        assert resp.status_code == 400
+
+    def test_bulk_invalid_target_rejected(self, client):
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [1], "target": "meh"})
+        assert resp.status_code == 422
+        assert "target" in resp.get_json()["errors"]["json"]
+
+
 class TestGetVotes:
     def test_empty_votes(self, client):
         resp = client.get("/api/votes")

--- a/tests_lib/projection/test_subset_edit.py
+++ b/tests_lib/projection/test_subset_edit.py
@@ -1,0 +1,108 @@
+"""Tests for in-place subset edits: ``remove_ids`` + ``rebin_like``.
+
+These back the Browser's "Remove from Good" cull, which drops hand-selected
+false-positives from a subset browse *without* re-fitting UMAP: the surviving
+points keep their exact 2-D coordinates and bins; only counts/membership change.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.projection import build_pyramid, rebin_like, remove_ids
+from vtscore.projection.umap_projection import Projection
+
+
+def _projection(seed: int = 0, n: int = 60, pid: str = "pid-test") -> Projection:
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 8.0]])
+    pts = np.concatenate([c + rng.standard_normal((n // 3, 2)) * 0.5 for c in centers]).astype(np.float32)
+    return Projection(pid, list(range(pts.shape[0])), np.ascontiguousarray(pts), "test")
+
+
+def test_remove_ids_preserves_id_and_coords():
+    proj = _projection()
+    removed = {0, 5, 17}
+
+    out = remove_ids(proj, removed)
+
+    # Layout identity is intentionally preserved (the canvas keys its
+    # re-frame decision on it).
+    assert out.projection_id == proj.projection_id
+    assert set(out.ids) == set(proj.ids) - removed
+    assert out.coords.shape[0] == len(proj.ids) - len(removed)
+    # Every surviving point keeps its exact coordinate — nothing is re-fit.
+    for mid in out.ids:
+        np.testing.assert_array_equal(out.coords[out.ids.index(mid)], proj.coords[proj.ids.index(mid)])
+
+
+def test_remove_ids_keeps_order():
+    proj = _projection()
+    out = remove_ids(proj, {proj.ids[3]})
+    assert out.ids == [i for i in proj.ids if i != proj.ids[3]]
+
+
+def test_remove_ids_ignores_unknown():
+    proj = _projection()
+    out = remove_ids(proj, {999998, 999999})
+    assert out.ids == proj.ids
+    np.testing.assert_array_equal(out.coords, proj.coords)
+
+
+def test_rebin_like_keeps_bins_for_survivors():
+    proj = _projection()
+    template = build_pyramid(proj, n_levels=5)
+
+    removed = {proj.ids[0], proj.ids[1], proj.ids[2]}
+    reduced = remove_ids(proj, removed)
+    rebinned = rebin_like(reduced, template)
+
+    # Same grid geometry — never a re-fit-driven reshape.
+    assert rebinned.bin_shape == template.bin_shape
+    assert rebinned.base_radius == template.base_radius
+    assert rebinned.tile_span == template.tile_span
+    assert rebinned.bounds == template.bounds
+    assert len(rebinned.levels) == len(template.levels)
+    assert rebinned.point_count == proj.point_count - len(removed)
+
+    # Each surviving id lands in the SAME (q, r) cell it occupied before.
+    for level in range(len(template.levels)):
+        before = {
+            mid: (q, r)
+            for (q, r), members in _members(template, proj, level).items()
+            for mid in members
+        }
+        after = {
+            mid: (q, r)
+            for (q, r), members in _members(rebinned, reduced, level).items()
+            for mid in members
+        }
+        for mid in reduced.ids:
+            assert after[mid] == before[mid], f"id {mid} moved bins at level {level}"
+
+
+def test_rebin_like_drops_emptied_cells():
+    # One isolated point far from the rest gets its own cell; removing it must
+    # drop that cell entirely rather than leave an empty bin.
+    coords = np.array([[0.0, 0.0], [0.1, 0.0], [100.0, 100.0]], dtype=np.float32)
+    proj = Projection("pid", [1, 2, 3], coords, "test")
+    template = build_pyramid(proj, n_levels=3)
+    total_cells_before = sum(len(t.cells) for t in template.tiles.values())
+
+    rebinned = rebin_like(remove_ids(proj, {3}), template)
+    total_cells_after = sum(len(t.cells) for t in rebinned.tiles.values())
+    assert rebinned.point_count == 2
+    assert total_cells_after < total_cells_before
+
+
+def _members(pyr, proj, level: int) -> dict[tuple[int, int], list[int]]:
+    """All ``(q, r) -> [ids]`` for a level, flattening the per-tile index."""
+    from vtscore.projection import tile_member_ids
+
+    out: dict[tuple[int, int], list[int]] = {}
+    for tlevel, tx, ty in pyr.tiles:
+        if tlevel != level:
+            continue
+        for qr, ids in tile_member_ids(pyr, proj, level, tx, ty).items():
+            out[qr] = ids
+    return out

--- a/tests_lib/projection/test_subset_edit.py
+++ b/tests_lib/projection/test_subset_edit.py
@@ -63,7 +63,7 @@ def test_rebin_like_keeps_bins_for_survivors():
     assert rebinned.tile_span == template.tile_span
     assert rebinned.bounds == template.bounds
     assert len(rebinned.levels) == len(template.levels)
-    assert rebinned.point_count == proj.point_count - len(removed)
+    assert rebinned.point_count == len(proj.ids) - len(removed)
 
     # Each surviving id lands in the SAME (q, r) cell it occupied before.
     for level in range(len(template.levels)):

--- a/tests_lib/projection/test_subset_edit.py
+++ b/tests_lib/projection/test_subset_edit.py
@@ -67,16 +67,8 @@ def test_rebin_like_keeps_bins_for_survivors():
 
     # Each surviving id lands in the SAME (q, r) cell it occupied before.
     for level in range(len(template.levels)):
-        before = {
-            mid: (q, r)
-            for (q, r), members in _members(template, proj, level).items()
-            for mid in members
-        }
-        after = {
-            mid: (q, r)
-            for (q, r), members in _members(rebinned, reduced, level).items()
-            for mid in members
-        }
+        before = {mid: (q, r) for (q, r), members in _members(template, proj, level).items() for mid in members}
+        after = {mid: (q, r) for (q, r), members in _members(rebinned, reduced, level).items() for mid in members}
         for mid in reduced.ids:
             assert after[mid] == before[mid], f"id {mid} moved bins at level {level}"
 

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -29,10 +29,11 @@ from vtscore.projection.pyramid import (
     Tile,
     build_pyramid,
     max_useful_levels,
+    rebin_like,
     tile_member_ids,
 )
 from vtscore.projection.squarebin import square_center, squarebin_assign
-from vtscore.projection.umap_projection import Projection, fit_projection
+from vtscore.projection.umap_projection import Projection, fit_projection, remove_ids
 
 __all__ = [
     "Projection",
@@ -43,6 +44,8 @@ __all__ = [
     "LevelMeta",
     "build_pyramid",
     "max_useful_levels",
+    "rebin_like",
+    "remove_ids",
     "tile_member_ids",
     "BIN_SHAPES",
     "DEFAULT_BIN_SHAPE",

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import numpy as np
@@ -325,6 +325,30 @@ def build_pyramid(
         tiles=tiles,
         bin_shape=bin_shape,
     )
+
+
+def rebin_like(projection: Projection, template: Pyramid) -> Pyramid:
+    """Re-bin *projection* onto *template*'s exact grid, without re-fitting UMAP.
+
+    Reuses the template pyramid's ``base_radius``, ``tile_span``, ``bin_shape``,
+    level count **and** ``bounds`` so every surviving point lands in the same
+    ``(q, r)`` cell — and the canvas's coord→screen transform (driven by
+    ``bounds``) is unchanged, so nothing moves on screen.  Only counts,
+    representatives, and now-empty cells differ.  This is the cheap operation
+    behind removing items from a subset browse: the 2-D layout is frozen; we
+    just recompute which items fall in which (unchanged) bins.
+    """
+    pyr = build_pyramid(
+        projection,
+        bin_shape=template.bin_shape,
+        n_levels=len(template.levels),
+        base_radius=template.base_radius,
+        tile_span=template.tile_span,
+    )
+    # Keep the original extent so the client never re-frames; bins are assigned
+    # from absolute coords + radius (origin-independent), so a stable ``bounds``
+    # is purely a metadata/transform concern, not a binning one.
+    return replace(pyr, bounds=template.bounds)
 
 
 def _level_membership(

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 import numpy as np
@@ -67,6 +67,29 @@ class Projection:
         xmin, ymin = self.coords.min(axis=0)
         xmax, ymax = self.coords.max(axis=0)
         return (float(xmin), float(ymin), float(xmax), float(ymax))
+
+
+def remove_ids(projection: Projection, remove: Iterable[int]) -> Projection:
+    """Return *projection* with *remove* ids (and their points) dropped.
+
+    The remaining points keep their **exact** 2-D coordinates — this never
+    re-fits the layout.  The ``projection_id`` is deliberately preserved so the
+    layout keeps its identity (the browse canvas reads it to decide whether to
+    re-frame the viewport: a content edit must not move points on screen).  Tile
+    freshness is handled separately by a content-version cache token, since the
+    counts/membership do change.
+
+    Used to cull hand-selected false-positives from a Find-positives subset
+    browse without re-running UMAP.
+    """
+    remove_set = {int(i) for i in remove}
+    keep = [i for i, mid in enumerate(projection.ids) if int(mid) not in remove_set]
+    new_ids = [int(projection.ids[i]) for i in keep]
+    if projection.coords.shape[0]:
+        new_coords = np.ascontiguousarray(projection.coords[keep], dtype=np.float32)
+    else:
+        new_coords = projection.coords
+    return Projection(projection.projection_id, new_ids, new_coords, projection.method)
 
 
 def _trivial_layout(n: int) -> np.ndarray:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -295,6 +295,7 @@ class DatasetContext:
         "_subset_pyramids",
         "_subset_ids",
         "_subset_job_id",
+        "_subset_content_version",
     )
 
     def __init__(self, dataset_id: str = "") -> None:
@@ -310,6 +311,12 @@ class DatasetContext:
         self._subset_pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid (subset)
         self._subset_ids: list[int] | None = None  # sorted ids the subset layout is fit on
         self._subset_job_id: str | None = None  # in-flight subset build job id
+        # Bumped on each in-place edit of the subset layout (e.g. removing
+        # false-positives from a Find browse).  The layout/``projection_id`` is
+        # kept stable so the canvas preserves the viewport; this counter changes
+        # only the tile cache key/URL so stale tiles aren't served (the tile URL
+        # is otherwise cached ``immutable``).  Reset to 0 on a fresh subset fit.
+        self._subset_content_version: int = 0
 
 
 class DetectorContext:

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -32,6 +32,8 @@ from vtsearch.schemas.media import (
     MediaBatchResponseSchema,
     MediaIdsListResponseSchema,
     MediaParagraphResponseSchema,
+    MediaVoteBulkRequestSchema,
+    MediaVoteBulkResponseSchema,
     MediaVoteRequestSchema,
     MediaVoteResponseSchema,
 )
@@ -593,6 +595,66 @@ def vote_media(body: dict, media_id: int):
         logging.getLogger(__name__).exception("vote_media: labelset source scheduling failed")
 
     return {"ok": True, "state": new_state, "click_time": click_time}
+
+
+@medias_bp.route("/api/medias/vote-bulk", methods=["POST"])
+@medias_bp.arguments(MediaVoteBulkRequestSchema)
+@medias_bp.response(200, MediaVoteBulkResponseSchema)
+@medias_bp.alt_response(400, description="No ids supplied.")
+@require_dataset_header
+@require_detector_header
+def vote_media_bulk(body: dict):
+    """Apply one absolute vote target to many medias in a single request.
+
+    Mirrors ``/api/medias/<id>/vote`` for a batch: each id is set to
+    ``target`` with the same idempotent semantics, then the detector
+    labelset is persisted **once** rather than per id.  Bulk votes are
+    image-level (no region boxes).  Powers the Browser's "Remove from Good"
+    cull, which marks a hand-selected set of false-positives ``bad`` and
+    drops them from the browse.
+
+    Ids that aren't in the loaded dataset are skipped and reported back in
+    ``missing``; ``changed`` counts only the ids whose state actually moved
+    (idempotent re-applies don't count).
+    """
+    target = body["target"]
+    ids = body["ids"]
+    if not ids:
+        abort(400, message="No ids supplied")
+
+    changed = 0
+    missing: list[int] = []
+    for media_id in ids:
+        if get_media(media_id) is None:
+            missing.append(media_id)
+            continue
+        old, new, _click_time = set_vote(media_id, target)
+        if old != new:
+            changed += 1
+
+    # Persist the resulting labelset once for the whole batch.  Mirrors the
+    # single-vote route's H30 handling: a write failure surfaces as a 500
+    # rather than leaving the in-memory votes silently un-persisted.
+    from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
+
+    try:
+        sync_labels_to_loaded_detector()
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).exception("vote_media_bulk: detector label sync failed")
+        abort(500, message=f"Failed to persist votes to detector store: {exc}")
+
+    from vtscore.labels.sync import sync_to_labelset_source
+
+    try:
+        sync_to_labelset_source()
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).exception("vote_media_bulk: labelset source scheduling failed")
+
+    return {"ok": True, "changed": changed, "missing": missing}
 
 
 @medias_bp.route("/api/medias/add-to-pile", methods=["POST"])

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -19,6 +19,7 @@ from flask_smorest import Blueprint, abort
 from vtsearch.schemas.projection import (
     ProjectionBuildResponseSchema,
     ProjectionMetaSchema,
+    SubsetRemoveRequestSchema,
     TileResponseSchema,
 )
 
@@ -61,6 +62,7 @@ def _subset_meta(ctx, bin_shape: str) -> dict:
         meta["status"] = "ready"
         meta["media_type"] = _media_type_for(ctx)
         meta["method"] = ctx._subset_projection.method if ctx._subset_projection else None
+        meta["content_version"] = getattr(ctx, "_subset_content_version", 0)
         return meta
 
     if ctx._subset_job_id:
@@ -262,6 +264,7 @@ def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
         ctx._subset_pyramids = {}
         ctx._subset_ids = sorted_ids
         ctx._subset_job_id = None
+        ctx._subset_content_version = 0  # fresh layout — reset the tile cache token
 
     return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape)
 
@@ -361,6 +364,46 @@ def build_projection():
     return _start_umap_build(ctx, sorted_ids, matrix, shape)
 
 
+@projection_bp.route("/api/projection/subset/remove", methods=["POST"])
+@projection_bp.arguments(SubsetRemoveRequestSchema)
+@projection_bp.response(200, ProjectionMetaSchema)
+@projection_bp.alt_response(409, description="No subset projection is currently built.")
+def remove_from_subset(body: dict):
+    """Drop ids from the current subset browse **without re-fitting UMAP**.
+
+    Re-bins the frozen subset layout onto its existing grid minus the removed
+    points: the remaining points keep their exact 2-D positions and bins, only
+    counts/representatives change.  The ``projection_id`` (layout identity) is
+    preserved so the canvas keeps the user's pan/zoom; a bumped
+    ``content_version`` busts the otherwise-immutable tile cache.  Returns the
+    updated subset meta for *shape*.
+
+    Powers the Browser's "Remove from Good" cull, which marks the items Bad via
+    ``/api/medias/vote-bulk`` and then calls this to make them disappear.
+    """
+    from vtscore.projection import rebin_like
+    from vtscore.projection import remove_ids as _remove_ids
+    from vtscore.state.core import get_active_context
+
+    ctx = get_active_context()
+    shape = _resolve_shape(body.get("shape"))
+    ids = body["ids"]
+
+    proj = ctx._subset_projection
+    if proj is None:
+        abort(409, message="No subset projection to update — build it first.")
+
+    new_proj = _remove_ids(proj, ids)
+    ctx._subset_projection = new_proj
+    ctx._subset_ids = list(new_proj.ids)
+    ctx._subset_job_id = None
+    ctx._subset_content_version = getattr(ctx, "_subset_content_version", 0) + 1
+    # Re-bin every shape that was already built, each on its own preserved grid.
+    ctx._subset_pyramids = {s: rebin_like(new_proj, pyr) for s, pyr in ctx._subset_pyramids.items()}
+
+    return _subset_meta(ctx, shape)
+
+
 @projection_bp.route("/api/projection/meta", methods=["GET"])
 @projection_bp.response(200, ProjectionMetaSchema)
 def projection_meta():
@@ -387,6 +430,7 @@ def projection_meta():
         meta["status"] = "ready"
         meta["media_type"] = _media_type_for(ctx)
         meta["method"] = ctx._projection.method if ctx._projection else None
+        meta["content_version"] = 0  # full-dataset layouts are never edited in place
         return meta
 
     job = projection_jobs.current()

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -197,6 +197,58 @@ class MediaVoteResponseSchema(Schema):
 
 
 # ---------------------------------------------------------------------------
+# /api/medias/vote-bulk
+# ---------------------------------------------------------------------------
+
+
+class MediaVoteBulkRequestSchema(Schema):
+    """Body for ``POST /api/medias/vote-bulk``.
+
+    Applies one **absolute target** vote to every id in ``ids`` in a single
+    request, persisting the detector labelset once at the end.  Per-id
+    semantics match ``/api/medias/<id>/vote`` (idempotent, achievement-gated);
+    bulk votes are always image-level, so there is no ``region_box``.  Powers
+    the Browser's "Remove from Good" cull, which marks a hand-selected batch
+    of false-positives ``bad`` in one shot.
+
+    Unknown fields are silently dropped, matching :class:`MediaVoteRequestSchema`.
+    """
+
+    ids = fields.List(
+        fields.Integer(),
+        required=True,
+        metadata={"description": "Media ids to apply the target vote to."},
+    )
+    target = fields.String(
+        required=True,
+        validate=validate.OneOf(["good", "bad", "none"]),
+        metadata={
+            "description": "Absolute target state applied to every id: ``good``, ``bad``, or ``none``. Idempotent.",
+        },
+    )
+
+    class Meta:
+        unknown = "exclude"
+
+
+class MediaVoteBulkResponseSchema(Schema):
+    """Response for ``POST /api/medias/vote-bulk`` (success path)."""
+
+    ok = fields.Boolean(required=True)
+    changed = fields.Integer(
+        required=True,
+        metadata={
+            "description": "How many ids actually changed state (idempotent re-applies and missing ids excluded).",
+        },
+    )
+    missing = fields.List(
+        fields.Integer(),
+        required=True,
+        metadata={"description": "Requested ids that were not present in the loaded dataset."},
+    )
+
+
+# ---------------------------------------------------------------------------
 # /api/medias/<id>/paragraph and /api/medias/<id>/text
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 
 
 class LevelMetaSchema(Schema):
@@ -24,6 +24,17 @@ class ProjectionMetaSchema(Schema):
     levels = fields.List(fields.Nested(LevelMetaSchema), load_default=None)
     media_type = fields.String(load_default=None)
     method = fields.String(load_default=None)
+    content_version = fields.Integer(
+        load_default=0,
+        metadata={
+            "description": (
+                "Monotonic version of the projection's membership. Stays at 0 for "
+                "full-dataset projections; bumped when items are removed from a "
+                "subset browse in place. Combined with ``projection_id`` to bust "
+                "the immutable tile cache without re-framing the canvas."
+            ),
+        },
+    )
     # Build progress (when status == "building")
     job_id = fields.String(load_default=None)
     current = fields.Integer(load_default=None)
@@ -38,6 +49,22 @@ class ProjectionBuildResponseSchema(Schema):
     status = fields.String(required=True)
     job_id = fields.String(load_default=None)
     projection_id = fields.String(load_default=None)
+
+
+class SubsetRemoveRequestSchema(Schema):
+    """Body for ``POST /api/projection/subset/remove``."""
+
+    ids = fields.List(
+        fields.Integer(),
+        required=True,
+        validate=validate.Length(min=1),
+        metadata={"description": "Media ids to drop from the current subset browse."},
+    )
+    shape = fields.String(
+        load_default="hex",
+        validate=validate.OneOf(["hex", "square"]),
+        metadata={"description": "Bin shape whose updated meta to return (hex | square)."},
+    )
 
 
 class HexCellSchema(Schema):
@@ -68,5 +95,6 @@ __all__ = [
     "LevelMetaSchema",
     "ProjectionBuildResponseSchema",
     "ProjectionMetaSchema",
+    "SubsetRemoveRequestSchema",
     "TileResponseSchema",
 ]


### PR DESCRIPTION
## What & why

When you browse a Find run's positives, you can already hand-select items on the canvas. This PR lets you act on that selection: cull the false-positives and carry the correction back to Find.

### Remove from Good
A new **Remove from Good (N)** button in the browse selection panel (shown only when browsing Find positives). Clicking it:
1. asks for confirmation,
2. marks the selected items **Bad** in the detector's labels (one bulk request → one labelset write), and
3. drops them from the browse **in place** — the surviving items keep their exact 2-D positions and bins. **No UMAP re-fit.**

### Back to Find
A new **← Back to Find** button (top-left, subset mode only) returns to the originating Find view — previously there was no in-app way back. It **preserves the cull**: it flags the Find view to skip its automatic re-scoring on entry (which, with the unchanged model, would re-promote the just-removed items to Good) and instead just refreshes the now-updated Good/Bad lists.

> Design decision (confirmed with the user): returning to Find keeps the cull rather than retraining + re-running Find. This matches how manual votes in Find already behave (they don't trigger a re-score).

## The "don't re-UMAP" part (the important bit)

Removing items must **not** rebuild the 2-D layout. Bins are assigned by `hexbin_assign(coords, radius)` — independent of which other points exist — so we keep the frozen coordinates and just **re-bin the survivors onto the existing grid**:

- `vtscore.projection.remove_ids(projection, ids)` — drops points, keeps every survivor's exact coordinate, **preserves `projection_id`** (layout identity).
- `vtscore.projection.rebin_like(projection, template)` — rebuilds the pyramid reusing the template's `base_radius` / `tile_span` / `bounds` / level count, so each survivor stays in the same `(q, r)` cell; only counts, representatives, and now-empty cells change.

Because `projection_id` is preserved, the canvas keeps the user's pan/zoom (it only re-frames on a *new* projection id). Tiles are served `immutable` with no version in the URL, so an in-place edit needs a cache-bust: a new per-context `content_version` is bumped on each removal and combined with `projection_id` into the tile cache key + a `?v=` URL token. This also hardens a latent case where distinct projections shared a tile URL.

## Backend
- `POST /api/medias/vote-bulk` — applies one absolute vote target (`good`/`bad`/`none`) to many ids with the same idempotent semantics as the single-vote route, persisting the labelset once.
- `POST /api/projection/subset/remove` — re-bins the subset layout in place (via the helpers above) and returns the updated meta (same `projection_id`, bumped `content_version`).
- `content_version` added to the projection meta; OpenAPI snapshot regenerated. Both new routes are called from the frontend via plain `HttpClient` (same treatment as `add-to-pile`).

## Tests
- `tests/core/test_votes.py`: bulk-vote endpoint (move from Good, idempotent-not-counted, missing ids, empty 400, invalid-target 422).
- `tests/api/test_projection.py` `TestSubsetRemove`: drops ids + keeps survivor coords, bumps version per call, re-bins both shapes, 409 without a subset, 422 on empty ids.
- `tests_lib/projection/test_subset_edit.py`: pure-helper coverage — `remove_ids` preserves id/coords/order, `rebin_like` keeps every survivor in the same bin at every level and drops emptied cells.
- `./run-tests.sh core api projection` green (1241 tests), including the frontend build, OpenAPI snapshot, and linters.

## Notes
- Back-to-Find is the supported return path that preserves the cull; the browser's native Back would let Find re-score on entry.

https://claude.ai/code/session_015MUJiqhjTEFcTQzNvhCec4