### PR TITLE
Add region-select GUI toggle to the browse view

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.html
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.html
@@ -1,3 +1,3 @@
-<div class="canvas-container">
+<div class="canvas-container" [class.marquee-active]="marqueeMode">
   <canvas #canvas></canvas>
 </div>

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.scss
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.scss
@@ -18,4 +18,14 @@
       cursor: grabbing;
     }
   }
+
+  // Region-select toggle on: a plain drag paints a marquee rather than panning,
+  // so the cursor reads as "draw a box" instead of "grab to pan".
+  &.marquee-active canvas {
+    cursor: crosshair;
+
+    &:active {
+      cursor: crosshair;
+    }
+  }
 }

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -80,6 +80,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * in {@link thumbnailMode} (image/video); singletons never get the band.
    */
   @Input() thumbnailBorder = 0;
+  /**
+   * GUI parallel to the Shift modifier: when on, a plain left-drag rubber-bands
+   * a selection marquee instead of panning, so the region-select gesture is
+   * discoverable without knowing the Shift+drag hotkey. Shift+drag keeps working
+   * regardless. Toggled by the region-select button in the browse toolbar.
+   */
+  @Input() marqueeMode = false;
   @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
   /**
    * The densest visible cell's item count, emitted whenever it changes. Density
@@ -773,9 +780,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.panStartY = event.clientY;
     this.dragMoved = false;
 
-    if (event.shiftKey) {
-      // Shift+drag: rubber-band a region to add to the selection. Suppress any
-      // hover preview while marqueeing so it doesn't flicker over the rectangle.
+    if (event.shiftKey || this.marqueeMode) {
+      // Shift+drag (or the region-select toggle): rubber-band a region to add to
+      // the selection. Suppress any hover preview while marqueeing so it doesn't
+      // flicker over the rectangle.
       event.preventDefault();
       const [mx, my] = this.canvasXY(event);
       this.isMarquee = true;

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -274,6 +274,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.updateActiveLevel();
       this.requestRedraw();
     }
+    // Entering region-select mode: drop any hover preview/highlight that was
+    // showing, since hover is suppressed while the mode is on.
+    if (changes['marqueeMode'] && this.marqueeMode) {
+      this.clearHover();
+    }
     // A colormap change only affects flat (non-thumbnail) shading; repaint.
     if (changes['colormap'] && !changes['colormap'].firstChange) {
       this.requestRedraw();
@@ -938,7 +943,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private onCanvasMouseMove(event: MouseEvent): void {
-    if (this.isPanning || this.isMarquee) return;
+    // No hover while panning or marqueeing (mid-drag), and none at all in
+    // region-select mode: the cursor is a crosshair for drawing a box, so a
+    // hover preview/highlight popping up under it would just be noise.
+    if (this.isPanning || this.isMarquee || this.marqueeMode) return;
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
@@ -998,6 +1006,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private onCanvasMouseLeave(): void {
     this.pointerInside = false;
+    this.clearHover();
+  }
+
+  /** Drop any pending/active hover: cancel the debounce, clear the highlighted
+   *  cell, and tell the preview to close. Safe to call when nothing is hovered. */
+  private clearHover(): void {
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
     if (this.hoveredCell) {
       this.hoveredCell = null;

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -46,6 +46,7 @@
             [displayScale]="hexDisplayScale"
             [colormap]="colormap"
             [thumbnailBorder]="thumbnailBorder"
+            [marqueeMode]="marqueeMode"
             (hexHover)="onHexHover($event)"
             (densityMaxChanged)="onDensityMaxChanged($event)"
           />
@@ -54,6 +55,18 @@
             [mediaType]="mediaType"
           />
           <div class="browse-controls">
+            <div class="browse-select" role="group" aria-label="Region select">
+              <button
+                type="button"
+                class="browse-size-btn"
+                [class.browse-size-btn--active]="marqueeMode"
+                [attr.aria-pressed]="marqueeMode"
+                (click)="toggleMarqueeMode()"
+                title="Region select: drag to select a region (Shift+drag also works)"
+                aria-label="Region select: drag to select a region">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3 2.5" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5"/></svg>
+              </button>
+            </div>
             <div class="browse-zoom">
               <button
                 type="button"

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -158,6 +158,7 @@
 // Zoom (true span) control and on-screen hex size control. Both mirror the
 // grouped pill look of the Find view's grid-size buttons (.vc-btn); the hex
 // pill reuses the image icon at 11px / 18px, the zoom pill uses +/- glyphs.
+.browse-select,
 .browse-zoom,
 .browse-size,
 .browse-shape {
@@ -204,6 +205,12 @@
 
   vt-icon {
     line-height: 0;
+  }
+
+  // The region-select toggle carries an inline dashed-rectangle SVG rather than
+  // a vt-icon child; keep it from adding a baseline gap inside the flex button.
+  svg {
+    display: block;
   }
 }
 

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -113,6 +113,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   binShape: BinShape = 'hex';
 
   /**
+   * Region-select mode: the GUI parallel to the Shift+drag hotkey. When on, a
+   * plain left-drag on the canvas rubber-bands a selection marquee instead of
+   * panning. The toolbar button surfaces (and toggles) it so the gesture is
+   * discoverable; Shift+drag keeps working whether or not this is on. Not
+   * persisted — it's a transient interaction mode, reset on each visit.
+   */
+  marqueeMode = false;
+
+  /**
    * Subset mode: browse an ephemeral UMAP fit over just a handful of media
    * (the positives of a Find run) instead of the full dataset. Set from the
    * `?subset=1` query param plus a handoff from {@link BrowseSubsetService}.
@@ -425,6 +434,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             err?.error?.message || err?.error?.error || 'Failed to switch bin shape';
         },
       });
+  }
+
+  /** Toggle region-select mode (drag-to-marquee without holding Shift). */
+  toggleMarqueeMode(): void {
+    this.marqueeMode = !this.marqueeMode;
   }
 
   /** Zoom in one step (narrower span, cells keep their display size). */


### PR DESCRIPTION
## What

Adds a GUI parallel for the browse view's region-select gesture, mirroring the Train image-viewer's marquee button. Region select in the browser was only reachable via the Shift+drag hotkey — discoverable only if you already knew it. This adds a toolbar toggle that puts the canvas into region-select mode, so a plain left-drag rubber-bands a selection.

This is the same affordance we already give for region-voting in the Train interface: the hotkey still works, but a button surfaces it and hints at the gesture.

## How

- **`browse-canvas`**: new `marqueeMode` input. `onMouseDown` now starts a marquee on `event.shiftKey || this.marqueeMode`, so the toggle is a no-Shift path into the existing rubber-band logic. The canvas shows a `crosshair` cursor while the mode is on.
- **`browse-view`**: transient `marqueeMode` flag + `toggleMarqueeMode()`, a region-select button at the head of the `.browse-controls` cluster (dashed-rectangle icon matching the image-viewer's marquee button, reusing `.browse-size-btn` / `--active` styling and `aria-pressed`), and the input wired into the canvas.

The mode is intentionally **not persisted** — it's a transient interaction mode that resets on each visit. Shift+drag keeps working whether or not the toggle is on.

## Testing

- `npm run build:prod` — clean, no warnings.

https://claude.ai/code/session_015zkmCgCVRzBdEPh1smVMpd

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkmCgCVRzBdEPh1smVMpd)_