### PR TITLE
Add double-click zoom and right-click context menu to VTSBrowser

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -862,6 +862,24 @@ and available to any future consumer of `vtscore`.
       plain `Set<number>` ready to hand off.
     - **Minimap selection overlay.** The minimap does not yet show which region is
       selected; a faint accent wash over selected cells there would aid orientation.
+- **Double-click + right-click on the canvas.** Two map-idiom gestures on top of
+  the existing pan / wheel-zoom / click-to-select model
+  (`browse-canvas.component.ts`). A **double-click** zooms in about the cursor
+  (`DOUBLE_CLICK_ZOOM`, via the shared `zoomBy(factor, anchor)`); a plain
+  **single click** still toggles the bin, but the toggle is now *deferred by the
+  double-click window* (`DBLCLICK_MS`, 250 ms) so a double-click zooms without
+  also flipping the bin's selection — a fresh press commits any pending toggle so
+  quick clicks on different bins each register. A **right-click** suppresses the
+  native menu and emits `contextMenu` with the cursor anchor + the bin's member
+  ids; the view (`browse-view.component.ts`) renders the shared
+  `vt-media-context-menu` with *Select/Deselect this bin* (when over a bin),
+  *Zoom in/out here* (anchored at the click), *Zoom to fit*, and *Clear
+  selection* (disabled when the set is empty). Shift / region-select mode are
+  reserved for the marquee, so neither double-click nor its zoom fire there.
+  - *Open follow-ups:* the context menu is the natural home for the deferred
+    selection *actions* (export the subset, seed a detector, build a subset
+    projection) once those land — add them as items rather than new toolbar
+    buttons.
 - **Load + project on the dashboard before entering Browse.** The dashboard's
   per-row `Browse` button no longer navigates straight to `/browse/:id` and
   lets the browse view discover a missing load/projection. It now mirrors the

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -38,6 +38,19 @@ export interface HexHoverEvent {
   screenY: number;
 }
 
+/** A right-click on the canvas, carrying everything the view needs to open a
+ *  context menu and act on the spot under the cursor. */
+export interface BrowseContextMenuEvent {
+  /** Viewport coords (clientX/clientY) the menu anchors to. */
+  clientX: number;
+  clientY: number;
+  /** Canvas-relative coords — the anchor for the menu's "zoom in/out here". */
+  canvasX: number;
+  canvasY: number;
+  /** Member media ids of the bin under the cursor; empty over blank space. */
+  members: number[];
+}
+
 /** How much larger the hovered cell is drawn relative to its neighbours so it
  *  lifts off the grid. The border is reserved for selection state, so hover is
  *  signalled by this size bump + a soft drop shadow instead of a ring. */
@@ -88,6 +101,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input() marqueeMode = false;
   @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
+  /** A right-click on the canvas; the view opens a context menu in response. */
+  @Output() contextMenu = new EventEmitter<BrowseContextMenuEvent>();
   /**
    * The densest visible cell's item count, emitted whenever it changes. Density
    * shading is renormalized to this per frame (yellow = this many items, the
@@ -136,6 +151,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private dragMoved = false;
   private static readonly CLICK_MOVE_THRESHOLD = 4;
 
+  // A single click toggles the bin under the cursor, but a double-click zooms in
+  // there — so the toggle is deferred by the double-click window and dropped if a
+  // second click lands. Without the defer, every double-click would also flip the
+  // bin's selection on its way to zooming.
+  private clickTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingToggleX = 0;
+  private pendingToggleY = 0;
+  private static readonly DBLCLICK_MS = 250;
+  // How hard a double-click zooms in about the cursor. Larger than the wheel's
+  // 1.15/tick so the gesture lands a decisive jump, matching the map idiom.
+  private static readonly DOUBLE_CLICK_ZOOM = 2.0;
+
   // Shift+drag draws a marquee rectangle (canvas-relative screen coords) that
   // adds every bin whose centre falls inside it to the selection — the fast path
   // for grabbing a region, since plain drag is reserved for panning.
@@ -176,6 +203,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private boundWheel = this.onWheel.bind(this);
   private boundCanvasMouseMove = this.onCanvasMouseMove.bind(this);
   private boundCanvasMouseLeave = this.onCanvasMouseLeave.bind(this);
+  private boundDblClick = this.onDblClick.bind(this);
+  private boundContextMenu = this.onContextMenu.bind(this);
 
   private recenterSub: Subscription | null = null;
   private selectionSub: Subscription | null = null;
@@ -241,6 +270,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       el.addEventListener('wheel', this.boundWheel, { passive: false });
       el.addEventListener('mousemove', this.boundCanvasMouseMove);
       el.addEventListener('mouseleave', this.boundCanvasMouseLeave);
+      el.addEventListener('dblclick', this.boundDblClick);
+      el.addEventListener('contextmenu', this.boundContextMenu);
     });
   }
 
@@ -299,11 +330,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.themeObserver?.disconnect();
     if (this.rafId) cancelAnimationFrame(this.rafId);
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
+    if (this.clickTimer) clearTimeout(this.clickTimer);
     const el = this.canvasRef.nativeElement;
     el.removeEventListener('mousedown', this.boundMouseDown);
     el.removeEventListener('wheel', this.boundWheel);
     el.removeEventListener('mousemove', this.boundCanvasMouseMove);
     el.removeEventListener('mouseleave', this.boundCanvasMouseLeave);
+    el.removeEventListener('dblclick', this.boundDblClick);
+    el.removeEventListener('contextmenu', this.boundContextMenu);
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
     this.thumbCache.clear();
@@ -781,6 +815,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private onMouseDown(event: MouseEvent): void {
     if (event.button !== 0) return;
+    // A fresh press settles any single-click toggle still waiting out the
+    // double-click window (so quick clicks on different bins each register). The
+    // second press of a double-click (detail >= 2) is exempt: flushing there
+    // would commit the very toggle the double-click means to drop.
+    if (event.detail < 2) this.flushPendingToggle();
     this.panStartX = event.clientX;
     this.panStartY = event.clientY;
     this.dragMoved = false;
@@ -844,11 +883,78 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const wasPanning = this.isPanning;
     this.isPanning = false;
     // A press that never crossed the move threshold is a click: toggle the bin
-    // under the cursor (no modifier — Shift is reserved for the marquee).
+    // under the cursor (no modifier — Shift is reserved for the marquee). The
+    // toggle is deferred so a double-click (which zooms) doesn't also select.
     if (wasPanning && !this.dragMoved && !event.shiftKey) {
-      const [mx, my] = this.canvasXY(event);
-      this.toggleCellAt(mx, my);
+      if (event.detail >= 2) {
+        // Second release of a double-click: the dblclick handler zooms, so drop
+        // the pending single-click toggle rather than flipping the bin.
+        this.cancelPendingToggle();
+      } else {
+        const [mx, my] = this.canvasXY(event);
+        this.scheduleToggle(mx, my);
+      }
     }
+  }
+
+  /**
+   * Schedule a single-click bin toggle, deferred by the double-click window so a
+   * double-click (which zooms in) doesn't also flip the bin's selection. Any
+   * pending toggle is committed first, so two quick clicks on *different* bins
+   * each register rather than the second cancelling the first.
+   */
+  private scheduleToggle(mx: number, my: number): void {
+    this.flushPendingToggle();
+    this.pendingToggleX = mx;
+    this.pendingToggleY = my;
+    this.clickTimer = setTimeout(() => {
+      this.clickTimer = null;
+      this.toggleCellAt(mx, my);
+    }, BrowseCanvasComponent.DBLCLICK_MS);
+  }
+
+  /** Run a pending single-click toggle now (if any) and clear the timer. */
+  private flushPendingToggle(): void {
+    if (this.clickTimer === null) return;
+    clearTimeout(this.clickTimer);
+    this.clickTimer = null;
+    this.toggleCellAt(this.pendingToggleX, this.pendingToggleY);
+  }
+
+  /** Drop a pending single-click toggle without running it (double-click path). */
+  private cancelPendingToggle(): void {
+    if (this.clickTimer === null) return;
+    clearTimeout(this.clickTimer);
+    this.clickTimer = null;
+  }
+
+  /** Double-click zooms in about the cursor (map idiom). Shift/region-select are
+   *  reserved for the marquee, so they don't zoom. */
+  private onDblClick(event: MouseEvent): void {
+    if (event.shiftKey || this.marqueeMode) return;
+    this.cancelPendingToggle();
+    const [mx, my] = this.canvasXY(event);
+    this.zoomBy(BrowseCanvasComponent.DOUBLE_CLICK_ZOOM, mx, my);
+  }
+
+  /** Right-click: suppress the native menu and ask the view to open ours,
+   *  carrying the cursor anchor and the bin (if any) under it. */
+  private onContextMenu(event: MouseEvent): void {
+    event.preventDefault();
+    const [mx, my] = this.canvasXY(event);
+    // Close any hover preview so it doesn't sit under the menu.
+    this.clearHover();
+    const cell = this.hitTest(mx, my);
+    const members = cell ? this.cellMembers(cell) : [];
+    this.ngZone.run(() =>
+      this.contextMenu.emit({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        canvasX: mx,
+        canvasY: my,
+        members,
+      }),
+    );
   }
 
   /** Canvas-relative ``[x, y]`` for a mouse event. */

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -49,11 +49,21 @@
             [marqueeMode]="marqueeMode"
             (hexHover)="onHexHover($event)"
             (densityMaxChanged)="onDensityMaxChanged($event)"
+            (contextMenu)="onCanvasContextMenu($event)"
           />
           <vt-browse-hover-preview
             [hover]="hoverEvent"
             [mediaType]="mediaType"
           />
+          @if (contextMenuOpen) {
+            <vt-media-context-menu
+              [x]="contextMenuX"
+              [y]="contextMenuY"
+              [items]="contextMenuItems"
+              (actionSelected)="onContextMenuAction($event)"
+              (dismissed)="dismissContextMenu()"
+            />
+          }
           <div class="browse-controls">
             <div class="browse-select" role="group" aria-label="Region select">
               <button

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -3,8 +3,16 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { BrowseCanvasComponent, HexHoverEvent } from '../browse-canvas/browse-canvas.component';
+import {
+  BrowseCanvasComponent,
+  BrowseContextMenuEvent,
+  HexHoverEvent,
+} from '../browse-canvas/browse-canvas.component';
 import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
+import {
+  MediaContextMenuComponent,
+  MediaContextMenuItem,
+} from '../left-panel/media-item/media-context-menu.component';
 import { BrowseLegendComponent } from '../browse-legend/browse-legend.component';
 import { BrowseSelectionPanelComponent } from '../browse-selection-panel/browse-selection-panel.component';
 import { BrowseMinimapComponent } from '../browse-minimap/browse-minimap.component';
@@ -43,6 +51,7 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
     BrowseMinimapComponent,
     ProgressBarComponent,
     IconComponent,
+    MediaContextMenuComponent,
   ],
   // Scoped per browse view so the canvas, its minimap, and the selection panel
   // share one viewport channel and one selection set without leaking across
@@ -152,6 +161,24 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * zoom anchors at the viewport centre (no cursor to zoom toward).
    */
   private readonly ZOOM_BUTTON_FACTOR = 1.4;
+
+  /**
+   * Zoom step for the right-click menu's "Zoom in/out here". A decisive jump
+   * (mirrors the double-click factor) since it's a deliberate one-shot action,
+   * anchored at the spot the user right-clicked rather than the viewport centre.
+   */
+  private readonly CONTEXT_ZOOM_FACTOR = 2.0;
+
+  /** Right-click context-menu state. Open flag + viewport anchor for the menu,
+   *  the canvas-relative anchor for its zoom actions, and the bin (member ids)
+   *  the menu was summoned over. */
+  contextMenuOpen = false;
+  contextMenuX = 0;
+  contextMenuY = 0;
+  contextMenuItems: MediaContextMenuItem[] = [];
+  private ctxCanvasX = 0;
+  private ctxCanvasY = 0;
+  private ctxMembers: number[] = [];
 
   private destroy$ = new Subject<void>();
   private polling = false;
@@ -454,6 +481,63 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   /** Choose a zoom and pan so the current data just fits in view. */
   zoomToFit(): void {
     this.canvas?.zoomToFit();
+  }
+
+  // --- Right-click context menu -------------------------------------------
+
+  /** Open the canvas context menu at the cursor, with bin actions when the
+   *  right-click landed on a bin plus the always-available zoom/clear actions. */
+  onCanvasContextMenu(event: BrowseContextMenuEvent): void {
+    this.ctxCanvasX = event.canvasX;
+    this.ctxCanvasY = event.canvasY;
+    this.ctxMembers = event.members;
+    this.contextMenuX = event.clientX;
+    this.contextMenuY = event.clientY;
+    this.contextMenuItems = this.buildContextMenuItems(event.members);
+    this.contextMenuOpen = true;
+  }
+
+  private buildContextMenuItems(members: number[]): MediaContextMenuItem[] {
+    const items: MediaContextMenuItem[] = [];
+    if (members.length > 0) {
+      const anySelected = this.selection.selectedCountIn(members) > 0;
+      items.push({
+        id: 'toggle-bin',
+        label: anySelected ? 'Deselect this bin' : 'Select this bin',
+      });
+    }
+    items.push(
+      { id: 'zoom-in', label: 'Zoom in here' },
+      { id: 'zoom-out', label: 'Zoom out here' },
+      { id: 'zoom-fit', label: 'Zoom to fit' },
+      { id: 'clear', label: 'Clear selection', disabled: this.selection.size === 0 },
+    );
+    return items;
+  }
+
+  onContextMenuAction(action: string): void {
+    this.dismissContextMenu();
+    switch (action) {
+      case 'toggle-bin':
+        if (this.ctxMembers.length > 0) this.selection.toggleBin(this.ctxMembers);
+        break;
+      case 'zoom-in':
+        this.canvas?.zoomBy(this.CONTEXT_ZOOM_FACTOR, this.ctxCanvasX, this.ctxCanvasY);
+        break;
+      case 'zoom-out':
+        this.canvas?.zoomBy(1 / this.CONTEXT_ZOOM_FACTOR, this.ctxCanvasX, this.ctxCanvasY);
+        break;
+      case 'zoom-fit':
+        this.canvas?.zoomToFit();
+        break;
+      case 'clear':
+        this.selection.clear();
+        break;
+    }
+  }
+
+  dismissContextMenu(): void {
+    this.contextMenuOpen = false;
   }
 
   /**


### PR DESCRIPTION
## What

Adds two map-idiom mouse gestures to the VTSBrowse canvas, on top of the existing pan / wheel-zoom / click-to-select / Shift-drag-marquee model.

- **Double-click → zoom in about the cursor.** Reuses the canvas's existing `zoomBy(factor, anchor)` so the point under the cursor stays fixed, just like the wheel.
- **Right-click → context menu** at the cursor (reuses the existing `vt-media-context-menu` component), with:
  - **Select / Deselect this bin** — only when the right-click landed on a bin; label tracks the bin's current selection state.
  - **Zoom in here / Zoom out here** — anchored at the exact spot clicked.
  - **Zoom to fit.**
  - **Clear selection** — disabled when nothing is selected.

## How / notable details

- **Single-click selection is now deferred** by the double-click window (250 ms) so a double-click zooms *without* also toggling the bin's selection on its way. A fresh press commits any pending toggle, so quick clicks on different bins each still register; the second release of a double-click (`event.detail >= 2`) drops the pending toggle instead. Hover feedback stays immediate, so the click still feels acknowledged. Trade-off: a genuine single-click's selection ring appears ~250 ms later.
- The canvas emits a new `contextMenu` output (`BrowseContextMenuEvent`: viewport anchor for the menu, canvas-relative anchor for the zoom actions, and the bin's member ids). The view owns the menu rendering and dispatch, calling back into the canvas (`zoomBy` / `zoomToFit`) and `BrowseSelectionService` (`toggleBin` / `clear`).
- Right-click closes any open hover preview so it doesn't sit under the menu, and suppresses the native browser menu.
- **Shift / region-select mode are left untouched** — they remain the marquee modifier, so neither double-click nor its zoom fire there.
- No new persisted state; everything rides existing in-memory selection + transform.

Right-click was deliberately spent on a context menu rather than a "double-right-click to zoom out" gesture: it's the natural future home for the deferred selection *actions* (export subset, seed a detector, build a subset projection) — noted as an open follow-up in `docs/plans/vtsbrowse.md`.

## Testing

`./run-tests.sh core` (includes ruff / codespell / deptry / the Angular `build:prod` check) — all 721 tests pass, frontend build clean.

https://claude.ai/code/session_013SyixSgEg7wRqV2XXb46yh

---
_Generated by [Claude Code](https://claude.ai/code/session_013SyixSgEg7wRqV2XXb46yh)_