### PR TITLE
VTSBrowser: re-project button (force UMAP re-fit of displayed items)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11992,7 +11992,7 @@
     },
     "/api/projection/build": {
       "post": {
-        "description": "Body: ``{\"shape\": \"hex\" | \"square\"}`` (defaults to hex).\n\nReturns immediately.  If the pyramid for this shape is already cached or\npersisted, returns ``\"ready\"``.  If the shared UMAP layout already exists\n(e.g. the other shape was built first), the new shape is re-binned inline\nand returned ready \u2014 no UMAP re-fit.  Only the first build of a dataset,\nwhere no layout exists yet, runs UMAP in the background and returns a\n``job_id`` for polling via ``GET /api/projection/meta``.",
+        "description": "Body: ``{\"shape\": \"hex\" | \"square\", \"ids\": [...]?, \"force\": bool?}``\n(``shape`` defaults to hex).\n\nReturns immediately.  If the pyramid for this shape is already cached or\npersisted, returns ``\"ready\"``.  If the shared UMAP layout already exists\n(e.g. the other shape was built first), the new shape is re-binned inline\nand returned ready \u2014 no UMAP re-fit.  Only the first build of a dataset,\nwhere no layout exists yet, runs UMAP in the background and returns a\n``job_id`` for polling via ``GET /api/projection/meta``.\n\n``force`` overrides every short-circuit: it discards the existing layout\n(cached + persisted for a full build, or the in-memory subset layout for an\n``ids`` build) and runs a fresh UMAP fit over the current items, returning a\nnew ``projection_id``.  This is the Browser's \"Re-project\" action.",
         "operationId": "build_projection",
         "responses": {
           "200": {

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -31,15 +31,27 @@
     @case ('ready') {
       <div class="browse-content" #content [style.--browse-panel-width]="panelWidth + 'px'">
         <div class="browse-main">
-          @if (subset) {
+          <div class="browse-tools-left">
+            @if (subset) {
+              <button
+                type="button"
+                class="btn btn--secondary btn--sm browse-back"
+                (click)="backToFind()"
+                title="Return to the Find view (keeps any items you removed from Good)">
+                &larr; Back to Find
+              </button>
+            }
             <button
               type="button"
-              class="btn btn--secondary btn--sm browse-back"
-              (click)="backToFind()"
-              title="Return to the Find view (keeps any items you removed from Good)">
-              &larr; Back to Find
+              class="btn btn--secondary btn--sm browse-reproject"
+              (click)="onReproject()"
+              [title]="subset
+                ? 'Re-project the displayed items into a fresh 2-D layout'
+                : 'Re-project all items into a fresh 2-D layout'">
+              <vt-icon type="shuffle" [size]="14"></vt-icon>
+              Re-project
             </button>
-          }
+          </div>
           <vt-browse-canvas
             [meta]="meta"
             [mediaType]="mediaType"

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -37,13 +37,30 @@
   color: var(--text-muted);
 }
 
-// Top-left affordance that returns to the Find view this browse came from
-// (subset mode only). Anchored to ``.browse-main`` like the other overlays.
-.browse-back {
+// Top-left overlay cluster, anchored to ``.browse-main`` like the other
+// overlays. Stacks the (subset-only) Back affordance above the Re-project
+// button so the two never overlap regardless of mode.
+.browse-tools-left {
   position: absolute;
   top: var(--space-md);
   left: var(--space-md);
   z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+
+// Re-fit UMAP over the displayed items into a fresh layout. The icon sits
+// inline with the label; mirrors the secondary-button look of ``.browse-back``.
+.browse-reproject {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+
+  vt-icon {
+    line-height: 0;
+  }
 }
 
 .browse-info {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -583,6 +583,43 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Re-fit UMAP over the items currently on screen and replace the layout with
+   * a fresh 2-D arrangement. Unlike the bin-shape toggle (which re-bins the
+   * frozen layout) or the Remove-from-Good cull (which re-bins minus points),
+   * this forces a new UMAP fit: useful after culling items from a subset (so
+   * the survivors re-spread) or just to reshuffle into a new arrangement. In
+   * full-dataset mode it re-projects every item and overwrites the persisted
+   * canonical layout; in subset mode it re-projects the current ``subsetIds``.
+   * The fit runs in the background, so the view shows build progress meanwhile.
+   */
+  onReproject(): void {
+    if (this.subset && this.subsetIds.length === 0) return;
+    this.selection.clear();
+    this.status = 'building';
+    this.buildProgress = 0;
+    this.buildTotal = 0;
+    this.buildMessage = '';
+    const request$ = this.subset
+      ? this.projectionApi.reprojectSubset(this.binShape, this.subsetIds)
+      : this.projectionApi.reproject(this.binShape);
+    request$.pipe(takeUntil(this.destroy$)).subscribe({
+      next: (resp) => {
+        if (resp.status === 'ready') {
+          // Defensive: a forced build always re-fits, but re-read meta anyway.
+          this.loadProjection();
+          return;
+        }
+        this.pollBuildStatus();
+      },
+      error: (err) => {
+        this.status = 'error';
+        this.errorMessage =
+          err?.error?.message || err?.error?.error || 'Failed to start re-projection';
+      },
+    });
+  }
+
+  /**
    * Cull the hand-selected items from a Find-positives browse: confirm, mark
    * them Bad in the detector's labels (so they leave the Find view's Good
    * list), then drop them from this browse by re-fitting the subset over the

--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -53,6 +53,26 @@ export class ProjectionApiService {
     return this.http.post<ProjectionMeta>('/api/projection/subset/remove', { shape, ids });
   }
 
+  /**
+   * Re-fit UMAP over the whole dataset and replace the frozen layout with a
+   * fresh arrangement (new ``projection_id``). Unlike {@link build}, ``force``
+   * overrides the cached/persisted layout. Runs in the background; poll
+   * `getMeta(shape)`.
+   */
+  reproject(shape: BinShape): Observable<ProjectionBuildResponse> {
+    return this.http.post<ProjectionBuildResponse>('/api/projection/build', { shape, force: true });
+  }
+
+  /**
+   * Re-fit UMAP over just `ids` (the items currently in a subset browse) and
+   * replace its layout with a fresh arrangement. Used to re-spread the
+   * survivors after a cull, or to reshuffle. Runs in the background; poll
+   * `getMeta(shape, true)`.
+   */
+  reprojectSubset(shape: BinShape, ids: number[]): Observable<ProjectionBuildResponse> {
+    return this.http.post<ProjectionBuildResponse>('/api/projection/build', { shape, ids, force: true });
+  }
+
   getTile(
     shape: BinShape,
     level: number,

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -566,3 +566,97 @@ class TestSubsetRemove:
     def test_remove_empty_ids_rejected(self, client):
         resp = client.post("/api/projection/subset/remove", json={"ids": []})
         assert resp.status_code == 422
+
+
+class TestForceReproject:
+    """``force`` re-fits UMAP over the displayed items into a fresh layout.
+
+    Powers the Browser's "Re-project" button: unlike a plain rebuild (which
+    short-circuits on the cached/persisted layout) it always runs a new fit and
+    returns a new ``projection_id``.
+    """
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_force_full_rebuild_makes_new_layout(self, _mock_fit, client):
+        ctx = get_active_context()
+        client.post("/api/projection/build")
+        _wait_projection()
+        first_id = ctx._pyramids["hex"].projection_id
+
+        # A plain rebuild short-circuits on the cached pyramid (same id)...
+        again = client.post("/api/projection/build").get_json()
+        assert again["status"] == "ready"
+        assert again["projection_id"] == first_id
+
+        # ...but force re-fits into a brand-new layout.
+        resp = client.post("/api/projection/build", json={"force": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] in ("building", "ready")
+        _wait_projection()
+        assert ctx._pyramids["hex"].projection_id != first_id
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_force_full_replaces_persisted(self, _mock_fit, client, tmp_path):
+        import pickle as _pickle
+
+        from vtscore.datasets.container import read_projection, write_container
+
+        fake_pkl = tmp_path / "reproject_persist.pkl"
+        write_container(fake_pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
+
+        with patch("vtsearch.routes.projection._pkl_path_for", return_value=str(fake_pkl)):
+            client.post("/api/projection/build")
+            _wait_projection()
+            first = read_projection(fake_pkl, "hex")
+            assert first is not None
+            first_id = first[0].projection_id
+
+            client.post("/api/projection/build", json={"force": True})
+            _wait_projection()
+            second = read_projection(fake_pkl, "hex")
+            assert second is not None
+            assert second[0].projection_id != first_id
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_force_full_drops_stale_other_shape(self, _mock_fit, client, tmp_path):
+        import pickle as _pickle
+
+        from vtscore.datasets.container import read_projection, write_container
+
+        fake_pkl = tmp_path / "reproject_shapes.pkl"
+        write_container(fake_pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
+
+        with patch("vtsearch.routes.projection._pkl_path_for", return_value=str(fake_pkl)):
+            client.post("/api/projection/build", json={"shape": "hex"})
+            _wait_projection()
+            client.post("/api/projection/build", json={"shape": "square"})
+            _wait_projection()
+            assert read_projection(fake_pkl, "square") is not None
+
+            # Force-rebuild hex: the stale square entry must be dropped so it
+            # can't resurrect the old (now-superseded) shared coordinates.
+            client.post("/api/projection/build", json={"shape": "hex", "force": True})
+            _wait_projection()
+            assert read_projection(fake_pkl, "square") is None
+            assert read_projection(fake_pkl, "hex") is not None
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_force_subset_refits_same_ids(self, _mock_fit, client):
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:5]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+        first_id = ctx._subset_projection.projection_id
+
+        # Same ids without force → cached, same layout id.
+        again = client.post("/api/projection/build", json={"ids": ids}).get_json()
+        assert again["status"] == "ready"
+        assert again["projection_id"] == first_id
+
+        # Same ids with force → fresh fit, new id, unchanged membership.
+        resp = client.post("/api/projection/build", json={"ids": ids, "force": True})
+        assert resp.status_code == 200
+        _wait_projection()
+        after = ctx._subset_projection
+        assert after.projection_id != first_id
+        assert after.ids == ids

--- a/tests_lib/projection/test_persistence.py
+++ b/tests_lib/projection/test_persistence.py
@@ -6,7 +6,9 @@ import numpy as np
 
 from vtscore.datasets.container import (
     append_projection,
+    read_container,
     read_projection,
+    remove_projections,
     write_container,
 )
 from vtscore.projection.pyramid import build_pyramid
@@ -160,3 +162,28 @@ def test_overwrite_existing(tmp_path):
     loaded = read_projection(path)
     assert loaded is not None
     assert loaded[0].projection_id == "second"
+
+
+def test_remove_projections_clears_all_shapes(tmp_path):
+    """``remove_projections`` drops every bin shape's entry (for a forced re-fit)."""
+    path = _make_container(tmp_path)
+    proj = _make_projection(pid="to-remove")
+    append_projection(path, proj, build_pyramid(proj, bin_shape="hex", n_levels=2))
+    append_projection(path, proj, build_pyramid(proj, bin_shape="square", n_levels=2))
+    assert read_projection(path, "hex") is not None
+    assert read_projection(path, "square") is not None
+
+    remove_projections(path)
+
+    assert read_projection(path, "hex") is None
+    assert read_projection(path, "square") is None
+    # The medias payload survives — only the projection entries are dropped.
+    _, meta = read_container(path)
+    assert meta["format_version"] == 1
+
+
+def test_remove_projections_no_entries_is_noop(tmp_path):
+    """Removing projections from a container that has none is a harmless no-op."""
+    path = _make_container(tmp_path)
+    remove_projections(path)  # must not raise
+    assert read_projection(path) is None

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -178,8 +178,9 @@ def remove_projections(path: str | Path) -> None:
     for entry in present:
         _rewrite_without(p, entry)
     if present:
-        logger.info("Removed %d projection entr%s from container: %s",
-                    len(present), "y" if len(present) == 1 else "ies", p)
+        logger.info(
+            "Removed %d projection entr%s from container: %s", len(present), "y" if len(present) == 1 else "ies", p
+        )
 
 
 def read_projection(path: str | Path, bin_shape: str = "hex") -> tuple[Any, Any] | None:

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -159,6 +159,29 @@ def append_projection(
     logger.info("Appended %s projection to container: %s", pyramid.bin_shape, p)
 
 
+def remove_projections(path: str | Path) -> None:
+    """Remove every stored projection entry (all bin shapes) from a container.
+
+    Used when a forced re-projection discards the frozen full-dataset layout:
+    the persisted hex/square entries must go too, or a later load — or the
+    not-yet-rebuilt other bin shape — would resurrect the stale coordinates
+    (which are shared across bin shapes).  A no-op if no entries are present.
+    """
+    p = Path(path)
+    entry_names = {_projection_entry_name(s) for s in ("hex", "square")}
+    try:
+        with zipfile.ZipFile(str(p), "r") as zf:
+            present = entry_names & set(zf.namelist())
+    except Exception:
+        logger.warning("Failed to read container %s while clearing projections", p, exc_info=True)
+        return
+    for entry in present:
+        _rewrite_without(p, entry)
+    if present:
+        logger.info("Removed %d projection entr%s from container: %s",
+                    len(present), "y" if len(present) == 1 else "ies", p)
+
+
 def read_projection(path: str | Path, bin_shape: str = "hex") -> tuple[Any, Any] | None:
     """Read the projection + pyramid for *bin_shape* from a container, or ``None``."""
     entry_name = _projection_entry_name(bin_shape)

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -12,6 +12,7 @@ frozen 2-D coordinates (fast), never re-fits UMAP.
 from __future__ import annotations
 
 import logging
+import uuid
 
 from flask import after_this_request, request
 from flask_smorest import Blueprint, abort
@@ -175,19 +176,49 @@ def _rebin_from_existing_layout(ctx, sorted_ids: list[int], bin_shape: str) -> d
     return {"status": "ready", "projection_id": pyr.projection_id}
 
 
-def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dict:
-    """Start (or reuse) the background UMAP fit + pyramid build for *bin_shape*."""
+def _reset_full_projection(ctx) -> None:
+    """Discard the cached + persisted full-dataset layout for a forced rebuild.
+
+    A re-projection must not be short-circuited by the frozen layout, so clear
+    the in-memory projection and every shape's cached pyramid, and drop the
+    persisted entries from the container — otherwise a later load, or the
+    not-yet-rebuilt other bin shape, would resurrect the stale coordinates
+    (which are shared across shapes).
+    """
+    ctx._projection = None
+    ctx._pyramids = {}
+    pkl_path = _pkl_path_for(ctx.dataset_id)
+    if pkl_path is None:
+        return
+    try:
+        from vtscore.datasets.container import remove_projections
+
+        remove_projections(pkl_path)
+    except Exception:
+        logger.warning("Failed to clear persisted projection for %s", ctx.dataset_id, exc_info=True)
+
+
+def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, force: bool = False) -> dict:
+    """Start (or reuse) the background UMAP fit + pyramid build for *bin_shape*.
+
+    With *force*, run a brand-new fit even when the ids are unchanged: the job
+    signature is namespaced with a nonce so the result cache can't hand back the
+    old frozen layout, yielding a fresh (differently-seeded) arrangement.
+    """
     from vtscore.concurrency.async_jobs import projection_jobs
     from vtscore.projection import build_pyramid, fit_projection
     from vtscore.state.core import thread_dataset_context
 
     sig = (ctx.dataset_id, bin_shape, tuple(sorted_ids))
-    job_cached = projection_jobs.cached_for(sig)
-    if job_cached is not None and job_cached.result is not None:
-        proj, pyr = job_cached.result
-        ctx._projection = proj
-        ctx._pyramids[bin_shape] = pyr
-        return {"status": "ready", "projection_id": pyr.projection_id}
+    if force:
+        sig = (*sig, uuid.uuid4().hex)
+    else:
+        job_cached = projection_jobs.cached_for(sig)
+        if job_cached is not None and job_cached.result is not None:
+            proj, pyr = job_cached.result
+            ctx._projection = proj
+            ctx._pyramids[bin_shape] = pyr
+            return {"status": "ready", "projection_id": pyr.projection_id}
 
     mat_copy = matrix.copy()
     ids_copy = list(sorted_ids)
@@ -214,7 +245,7 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dic
     return {"status": "building", "job_id": job.job_id}
 
 
-def _dispatch_subset_build(ctx, ids_raw, bin_shape: str) -> dict:
+def _dispatch_subset_build(ctx, ids_raw, bin_shape: str, *, force: bool = False) -> dict:
     """Validate the request body's ``ids`` and route to the subset build."""
     if not isinstance(ids_raw, list):
         abort(400, message="`ids` must be a list of media ids.")
@@ -227,12 +258,12 @@ def _dispatch_subset_build(ctx, ids_raw, bin_shape: str) -> dict:
     if not ctx.medias:
         abort(409, message="Dataset is empty — nothing to project.")
     try:
-        return _build_subset(ctx, requested, bin_shape)
+        return _build_subset(ctx, requested, bin_shape, force=force)
     except ValueError as exc:
         abort(409, message=str(exc))
 
 
-def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
+def _build_subset(ctx, requested_ids: list[int], bin_shape: str, *, force: bool = False) -> dict:
     """Build (or reuse) an ephemeral UMAP projection over just *requested_ids*.
 
     Unlike the full-dataset path, the subset projection is computed from only
@@ -248,7 +279,7 @@ def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
     if matrix.size == 0:
         abort(409, message="None of the selected items have embeddings — nothing to project.")
 
-    if ctx._subset_ids == sorted_ids:
+    if not force and ctx._subset_ids == sorted_ids:
         # Same subset: serve the cached pyramid, or re-bin the shared layout.
         pyr = ctx._subset_pyramids.get(bin_shape)
         if pyr is not None:
@@ -259,37 +290,46 @@ def _build_subset(ctx, requested_ids: list[int], bin_shape: str) -> dict:
             ctx._subset_pyramids[bin_shape] = pyr
             return {"status": "ready", "projection_id": pyr.projection_id}
     else:
-        # A different subset was requested: drop the stale layout before fitting.
+        # A different subset — or a forced re-projection — drops the stale layout
+        # before fitting.  ``force`` re-fits even when the ids are unchanged, so
+        # the survivors of a cull re-spread instead of keeping their old slots.
         ctx._subset_projection = None
         ctx._subset_pyramids = {}
         ctx._subset_ids = sorted_ids
         ctx._subset_job_id = None
         ctx._subset_content_version = 0  # fresh layout — reset the tile cache token
 
-    return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape)
+    return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape, force=force)
 
 
-def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str) -> dict:
-    """Start (or reuse) the background subset UMAP fit + pyramid build."""
+def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, force: bool = False) -> dict:
+    """Start (or reuse) the background subset UMAP fit + pyramid build.
+
+    With *force*, run a brand-new fit even for an unchanged id set (see
+    :func:`_start_umap_build`): the signature carries a nonce so neither the
+    result cache nor an in-flight job is reused.
+    """
     from vtscore.concurrency.async_jobs import projection_jobs
     from vtscore.projection import build_pyramid, fit_projection
     from vtscore.state.core import thread_dataset_context
 
     sig = (ctx.dataset_id, "subset", bin_shape, tuple(sorted_ids))
+    if force:
+        sig = (*sig, uuid.uuid4().hex)
+    else:
+        job_cached = projection_jobs.cached_for(sig)
+        if job_cached is not None and job_cached.result is not None:
+            proj, pyr = job_cached.result
+            ctx._subset_projection = proj
+            ctx._subset_pyramids[bin_shape] = pyr
+            return {"status": "ready", "projection_id": pyr.projection_id}
 
-    job_cached = projection_jobs.cached_for(sig)
-    if job_cached is not None and job_cached.result is not None:
-        proj, pyr = job_cached.result
-        ctx._subset_projection = proj
-        ctx._subset_pyramids[bin_shape] = pyr
-        return {"status": "ready", "projection_id": pyr.projection_id}
-
-    # Already building this exact subset + shape?  Reuse the in-flight job
-    # instead of queueing a duplicate fit.
-    if ctx._subset_job_id:
-        existing = projection_jobs.get(ctx._subset_job_id)
-        if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
-            return {"status": "building", "job_id": existing.job_id}
+        # Already building this exact subset + shape?  Reuse the in-flight job
+        # instead of queueing a duplicate fit.
+        if ctx._subset_job_id:
+            existing = projection_jobs.get(ctx._subset_job_id)
+            if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
+                return {"status": "building", "job_id": existing.job_id}
 
     mat_copy = matrix.copy()
     ids_copy = list(sorted_ids)
@@ -321,7 +361,8 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str)
 def build_projection():
     """Kick off (or short-circuit) a build of the requested bin shape.
 
-    Body: ``{"shape": "hex" | "square"}`` (defaults to hex).
+    Body: ``{"shape": "hex" | "square", "ids": [...]?, "force": bool?}``
+    (``shape`` defaults to hex).
 
     Returns immediately.  If the pyramid for this shape is already cached or
     persisted, returns ``"ready"``.  If the shared UMAP layout already exists
@@ -329,6 +370,11 @@ def build_projection():
     and returned ready — no UMAP re-fit.  Only the first build of a dataset,
     where no layout exists yet, runs UMAP in the background and returns a
     ``job_id`` for polling via ``GET /api/projection/meta``.
+
+    ``force`` overrides every short-circuit: it discards the existing layout
+    (cached + persisted for a full build, or the in-memory subset layout for an
+    ``ids`` build) and runs a fresh UMAP fit over the current items, returning a
+    new ``projection_id``.  This is the Browser's "Re-project" action.
     """
     from vtscore.embedding.matrix import get_embedding_matrix
     from vtscore.state.core import get_active_context
@@ -336,15 +382,21 @@ def build_projection():
     ctx = get_active_context()
     body = request.get_json(silent=True) or {}
     shape = _resolve_shape(body.get("shape"))
+    # ``force`` re-fits UMAP over the currently displayed items even when a
+    # layout already exists, replacing it with a fresh arrangement.  Powers the
+    # Browser's "Re-project" button (e.g. to re-spread the survivors after a
+    # cull, or just to reshuffle).
+    force = bool(body.get("force"))
 
     # Subset build: project only the supplied media ids (e.g. the positive
     # results of a Find run), fitting UMAP on just their high-d vectors.
     if body.get("ids") is not None:
-        return _dispatch_subset_build(ctx, body["ids"], shape)
+        return _dispatch_subset_build(ctx, body["ids"], shape, force=force)
 
-    cached = ctx._pyramids.get(shape)
-    if cached is not None:
-        return {"status": "ready", "projection_id": cached.projection_id}
+    if not force:
+        cached = ctx._pyramids.get(shape)
+        if cached is not None:
+            return {"status": "ready", "projection_id": cached.projection_id}
 
     if not ctx.medias:
         abort(409, message="Dataset is empty — nothing to project.")
@@ -357,11 +409,14 @@ def build_projection():
     if matrix.size == 0:
         abort(409, message="Dataset has no embeddings — nothing to project.")
 
-    ready = _rebin_from_existing_layout(ctx, sorted_ids, shape)
-    if ready is not None:
-        return ready
+    if force:
+        _reset_full_projection(ctx)
+    else:
+        ready = _rebin_from_existing_layout(ctx, sorted_ids, shape)
+        if ready is not None:
+            return ready
 
-    return _start_umap_build(ctx, sorted_ids, matrix, shape)
+    return _start_umap_build(ctx, sorted_ids, matrix, shape, force=force)
 
 
 @projection_bp.route("/api/projection/subset/remove", methods=["POST"])


### PR DESCRIPTION
## What

Adds a **Re-project** button to the VTSBrowser canvas (top-left, above the *Back to Find* affordance). It re-fits UMAP over the items **currently on screen** into a fresh 2-D layout.

Two motivating cases, both now covered:
- **After culling a subset** (Find positives → *Remove from Good*): until now the survivors kept their old positions because the cull only *re-bins* the frozen layout. Re-project re-fits over the reduced id set so they spread out properly.
- **Just reshuffling**: UMAP is unseeded, so a re-fit yields a new random arrangement of the same items.

Works in both browse modes (per the scope decision): subset mode re-projects the current `subsetIds`; full-dataset mode re-projects every item and overwrites the persisted canonical layout.

## How

**Backend** — `POST /api/projection/build` gains a `force` flag that overrides every short-circuit (cached pyramid, persisted layout, and the job result cache via a nonce-namespaced signature) and runs a fresh fit, returning a new `projection_id`:
- Full-dataset force: `_reset_full_projection()` clears the in-memory layout + every cached shape and drops **both** persisted bin-shape entries (new `remove_projections()` container helper), so the stale shared coordinates can't be resurrected by a later load or the other bin shape. The new fit re-persists.
- Subset force: re-fits the current ids even when unchanged (ephemeral, never persisted).

**Frontend** — `reproject()` / `reprojectSubset()` service calls; `onReproject()` drives the existing build-progress flow (the new `projection_id` busts the tile cache automatically). The Back-to-Find and Re-project buttons now share a stacked top-left `.browse-tools-left` cluster.

## Tests
- `tests/api/test_projection.py::TestForceReproject` — force makes a new full-dataset layout, replaces the persisted entry, drops the stale other-shape entry, and re-fits a subset over unchanged ids.
- `tests_lib/projection/test_persistence.py` — `remove_projections` clears all shapes and is a no-op when none exist.
- Full run: `./run-tests.sh api projection core` → all 1247 passed (incl. frontend build).

## Backwards compatibility
No breaks: `force` is an optional body field; existing build calls behave exactly as before.

https://claude.ai/code/session_01D7VLfcxTunxXG7w4Ew96cj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7VLfcxTunxXG7w4Ew96cj)_