### PR TITLE
Redesign VTSBrowse right-click as a bin item popup

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -1,0 +1,58 @@
+<div
+  #panel
+  class="bin-popup"
+  [style.left.px]="left"
+  [style.top.px]="top"
+  role="dialog"
+  aria-label="Bin items">
+  <div class="bin-popup-header">
+    <span class="bin-popup-title" [title]="'Items in this bin (' + ids.length + ')'">
+      {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
+    </span>
+    <button
+      type="button"
+      class="bin-popup-close"
+      (click)="close()"
+      title="Close"
+      aria-label="Close">
+      &times;
+    </button>
+  </div>
+
+  <cdk-virtual-scroll-viewport
+    [itemSize]="itemHeight"
+    [style.height.px]="listHeight"
+    class="bin-popup-list"
+    (mouseleave)="onListLeave()">
+    <div
+      *cdkVirtualFor="let id of ids; trackBy: trackById"
+      class="bin-popup-entry"
+      [class.selected]="isSelected(id)"
+      role="button"
+      tabindex="0"
+      [attr.aria-pressed]="isSelected(id)"
+      [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
+      [title]="name(id)"
+      (click)="onEntryClick(id)"
+      (keydown)="onEntryKeydown($event, id)"
+      (mouseenter)="onEntryEnter(id)">
+      @if (hasThumbnailUrl(id)) {
+        <span class="bin-popup-thumb-wrap">
+          <img
+            class="bin-popup-thumb"
+            [src]="thumbnailUrl(id)"
+            [alt]="name(id)"
+            loading="lazy"
+            (error)="onThumbnailError(thumbnailUrl(id))" />
+        </span>
+      } @else {
+        <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+      }
+      <span class="bin-popup-name">{{ name(id) }}</span>
+    </div>
+  </cdk-virtual-scroll-viewport>
+
+  @if (mediaType === 'audio') {
+    <audio #audioEl class="sr-only" [src]="audioSrc"></audio>
+  }
+</div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -1,0 +1,134 @@
+// A small floating list of a bin's media items, opened by right-clicking a bin
+// on the VTSBrowse canvas. Rows mirror the selection panel's list entries.
+.bin-popup {
+  position: fixed;
+  z-index: var(--z-burger-menu);
+  width: 280px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.bin-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-sm) var(--space-xs) var(--space-md);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.bin-popup-title {
+  font-size: var(--font-xs);
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bin-popup-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--font-lg);
+  line-height: 1;
+  padding: var(--space-2xs) var(--space-xs);
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--text-primary);
+  }
+}
+
+.bin-popup-list {
+  // Concrete height is bound per render (rows, capped) so the virtual viewport
+  // scrolls; the cap is applied inline via [style.height.px].
+  overflow-x: hidden;
+}
+
+.bin-popup-entry {
+  height: 36px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: 0 var(--space-md);
+  font-size: var(--font-sm);
+  color: var(--text-vote);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  &.selected {
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    color: var(--text-primary);
+    box-shadow: inset 3px 0 0 var(--accent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+}
+
+.bin-popup-thumb-wrap {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.bin-popup-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  background: var(--bg-body);
+  display: block;
+}
+
+.bin-popup-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-body);
+  color: var(--text-muted);
+  font-size: var(--font-lg);
+  flex-shrink: 0;
+}
+
+.bin-popup-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,0 +1,276 @@
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { Subscription } from 'rxjs';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
+import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
+import { ActiveContextService } from '../../services/active-context.service';
+
+/** Row stride (px) for the virtualized list; must match ``.bin-popup-entry``. */
+const ITEM_HEIGHT = 36;
+/** Most rows shown before the popup caps its height and scrolls. */
+const MAX_VISIBLE_ROWS = 10;
+/** Extra rows of metadata prefetched beyond the visible window. */
+const PREFETCH_BUFFER = 50;
+/** Gap (px) kept between the popup and the viewport edge when clamping. */
+const EDGE_MARGIN = 8;
+
+/**
+ * The bin popup: a small floating, virtualized list of the media items in the
+ * bin the user right-clicked on the VTSBrowse canvas. It replaces the old
+ * right-click action menu — instead of menu commands, it shows the bin's
+ * members rendered like the right-panel selection list, so the user can scroll
+ * the bin, hear each item on hover (audio), and click to add/remove it from the
+ * canvas selection. This is how you reach the individual items folded into a
+ * dense bin without zooming all the way in.
+ *
+ * It shares the {@link BrowseSelectionService} instance provided by the browse
+ * view, so toggling an item here is the same selection the canvas rings and the
+ * selection panel reflect; selected members render highlighted and update live.
+ * Names/thumbnails resolve lazily through {@link MediaMetadataCacheService}
+ * (the browse view never loads the full media list), prefetched around the
+ * visible window so large bins stay responsive.
+ */
+@Component({
+  selector: 'vt-browse-bin-popup',
+  standalone: true,
+  imports: [CommonModule, ScrollingModule],
+  templateUrl: './browse-bin-popup.component.html',
+  styleUrl: './browse-bin-popup.component.scss',
+})
+export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDestroy {
+  /** Member media ids of the bin the popup was summoned over. */
+  @Input() memberIds: number[] = [];
+  /** Active dataset media type, used to decide hover-to-hear and placeholders. */
+  @Input() mediaType = '';
+  /** Viewport anchor (clientX/clientY) the popup opens at, then clamps inward. */
+  @Input() x = 0;
+  @Input() y = 0;
+
+  /** Emitted when the popup should close (outside click, Escape, or the X). */
+  @Output() dismissed = new EventEmitter<void>();
+
+  @ViewChild('panel') private panelRef?: ElementRef<HTMLElement>;
+  @ViewChild(CdkVirtualScrollViewport) private viewport?: CdkVirtualScrollViewport;
+  @ViewChild('audioEl') private audioRef?: ElementRef<HTMLAudioElement>;
+
+  /** Clamped on-screen position; starts at the anchor and is nudged inward. */
+  left = 0;
+  top = 0;
+
+  /** The bin's member ids, in bin order (the list's data source). */
+  ids: number[] = [];
+
+  readonly itemHeight = ITEM_HEIGHT;
+
+  /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
+  audioSrc = '';
+
+  private readonly failedThumbs = new Set<string>();
+  private readonly subs: Subscription[] = [];
+  private scrollSub: Subscription | null = null;
+
+  constructor(
+    private host: ElementRef<HTMLElement>,
+    private selection: BrowseSelectionService,
+    private metadataCache: MediaMetadataCacheService,
+    private activeContext: ActiveContextService,
+    private cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['memberIds']) {
+      this.ids = this.memberIds ?? [];
+      this.stopAudio();
+      // A fresh bin: jump the list back to the top and prefetch its first window.
+      this.viewport?.scrollToIndex(0);
+      this.prefetchVisible();
+    }
+    if (changes['x'] || changes['y'] || changes['memberIds']) {
+      this.left = this.x;
+      this.top = this.y;
+      // Measure + clamp after the new content lays out.
+      setTimeout(() => this.place());
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.subs.push(
+      // Names/thumbnails arrive asynchronously; repaint the visible rows.
+      this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
+      // A selection change anywhere (here, the canvas, the panel) re-highlights.
+      this.selection.changed$.subscribe(() => this.cdr.markForCheck()),
+    );
+    this.scrollSub =
+      this.viewport?.scrolledIndexChange.subscribe(() => this.prefetchVisible()) ?? null;
+    this.prefetchVisible();
+    setTimeout(() => this.place());
+  }
+
+  ngOnDestroy(): void {
+    for (const sub of this.subs) sub.unsubscribe();
+    this.scrollSub?.unsubscribe();
+    this.stopAudio();
+  }
+
+  /** Height (px) the list takes: just enough for its rows, capped then scrolled. */
+  get listHeight(): number {
+    return Math.min(Math.max(this.ids.length, 1), MAX_VISIBLE_ROWS) * this.itemHeight;
+  }
+
+  // --- Dismissal -----------------------------------------------------------
+
+  close(): void {
+    this.dismissed.emit();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.dismissed.emit();
+    }
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.dismissed.emit();
+  }
+
+  // --- Selection (click stays open so the user can scroll + multi-select) ---
+
+  isSelected(id: number): boolean {
+    return this.selection.has(id);
+  }
+
+  onEntryClick(id: number): void {
+    if (this.selection.has(id)) {
+      this.selection.remove(id);
+    } else {
+      this.selection.addAll([id]);
+    }
+  }
+
+  onEntryKeydown(event: KeyboardEvent, id: number): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onEntryClick(id);
+    }
+  }
+
+  // --- Hover-to-hear (audio only; other types just highlight, via CSS) ------
+
+  onEntryEnter(id: number): void {
+    if (this.mediaType !== 'audio') return;
+    const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
+    if (this.audioSrc === src) return;
+    this.audioSrc = src;
+    setTimeout(() => {
+      const el = this.audioRef?.nativeElement;
+      if (!el) return;
+      el.loop = true;
+      el.load();
+      el.play().catch(() => {});
+    });
+  }
+
+  onListLeave(): void {
+    this.stopAudio();
+  }
+
+  private stopAudio(): void {
+    const el = this.audioRef?.nativeElement;
+    if (el) {
+      el.pause();
+      el.currentTime = 0;
+    }
+    this.audioSrc = '';
+  }
+
+  // --- Names + thumbnails (mirrors the selection panel's treatment) ---------
+
+  name(id: number): string {
+    return this.metadataCache.get(id)?.filename || `Clip #${id}`;
+  }
+
+  hasThumbnailUrl(id: number): boolean {
+    const url = this.thumbnailUrl(id);
+    if (this.failedThumbs.has(url)) return false;
+    const media = this.metadataCache.get(id);
+    return (
+      !!media &&
+      (media.media_type === 'image' ||
+        media.media_type === 'video' ||
+        media.media_type === 'document' ||
+        media.media_type === 'audio')
+    );
+  }
+
+  thumbnailUrl(id: number): string {
+    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
+  }
+
+  onThumbnailError(url: string): void {
+    if (url) this.failedThumbs.add(url);
+  }
+
+  placeholderIcon(id: number): string {
+    if (this.hasThumbnailUrl(id)) return '';
+    const media = this.metadataCache.get(id);
+    if (!media) return '□';
+    if (media.media_type === 'audio') return '♫';
+    if (media.media_type === 'text') return '¶';
+    return '□';
+  }
+
+  trackById(_index: number, id: number): number {
+    return id;
+  }
+
+  // --- Positioning ---------------------------------------------------------
+
+  /** Clamp the popup inside the viewport so it never spills off an edge. */
+  private place(): void {
+    const panel = this.panelRef?.nativeElement;
+    if (!panel) return;
+    const rect = panel.getBoundingClientRect();
+    let l = this.x;
+    let t = this.y;
+    if (l + rect.width + EDGE_MARGIN > window.innerWidth) {
+      l = Math.max(EDGE_MARGIN, window.innerWidth - rect.width - EDGE_MARGIN);
+    }
+    if (t + rect.height + EDGE_MARGIN > window.innerHeight) {
+      t = Math.max(EDGE_MARGIN, window.innerHeight - rect.height - EDGE_MARGIN);
+    }
+    this.left = l;
+    this.top = t;
+    this.cdr.markForCheck();
+  }
+
+  /** Prefetch metadata for the rows around the visible window of the list. */
+  private prefetchVisible(): void {
+    if (this.ids.length === 0) return;
+    const vp = this.viewport;
+    if (!vp) {
+      this.metadataCache.ensureLoaded(this.ids.slice(0, MAX_VISIBLE_ROWS + PREFETCH_BUFFER));
+      return;
+    }
+    const start = Math.floor(vp.measureScrollOffset('top') / this.itemHeight);
+    const visible = Math.ceil((vp.elementRef.nativeElement.clientHeight || this.listHeight) / this.itemHeight);
+    const from = Math.max(0, start - PREFETCH_BUFFER);
+    const to = Math.min(this.ids.length, start + visible + PREFETCH_BUFFER);
+    this.metadataCache.ensureLoaded(this.ids.slice(from, to));
+  }
+}

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -38,15 +38,12 @@ export interface HexHoverEvent {
   screenY: number;
 }
 
-/** A right-click on the canvas, carrying everything the view needs to open a
- *  context menu and act on the spot under the cursor. */
+/** A right-click on the canvas, carrying what the view needs to open the bin
+ *  popup over the spot under the cursor. */
 export interface BrowseContextMenuEvent {
-  /** Viewport coords (clientX/clientY) the menu anchors to. */
+  /** Viewport coords (clientX/clientY) the popup anchors to. */
   clientX: number;
   clientY: number;
-  /** Canvas-relative coords — the anchor for the menu's "zoom in/out here". */
-  canvasX: number;
-  canvasY: number;
   /** Member media ids of the bin under the cursor; empty over blank space. */
   members: number[];
 }
@@ -101,7 +98,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input() marqueeMode = false;
   @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
-  /** A right-click on the canvas; the view opens a context menu in response. */
+  /** A right-click on the canvas; the view opens the bin popup in response. */
   @Output() contextMenu = new EventEmitter<BrowseContextMenuEvent>();
   /**
    * The densest visible cell's item count, emitted whenever it changes. Density
@@ -937,12 +934,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.zoomBy(BrowseCanvasComponent.DOUBLE_CLICK_ZOOM, mx, my);
   }
 
-  /** Right-click: suppress the native menu and ask the view to open ours,
-   *  carrying the cursor anchor and the bin (if any) under it. */
+  /** Right-click: suppress the native menu and ask the view to open the bin
+   *  popup, carrying the cursor anchor and the bin (if any) under it. */
   private onContextMenu(event: MouseEvent): void {
     event.preventDefault();
     const [mx, my] = this.canvasXY(event);
-    // Close any hover preview so it doesn't sit under the menu.
+    // Close any hover preview so it doesn't sit under the popup.
     this.clearHover();
     const cell = this.hitTest(mx, my);
     const members = cell ? this.cellMembers(cell) : [];
@@ -950,8 +947,6 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.contextMenu.emit({
         clientX: event.clientX,
         clientY: event.clientY,
-        canvasX: mx,
-        canvasY: my,
         members,
       }),
     );

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -56,11 +56,11 @@
             [mediaType]="mediaType"
           />
           @if (contextMenuOpen) {
-            <vt-media-context-menu
+            <vt-browse-bin-popup
               [x]="contextMenuX"
               [y]="contextMenuY"
-              [items]="contextMenuItems"
-              (actionSelected)="onContextMenuAction($event)"
+              [memberIds]="contextMembers"
+              [mediaType]="mediaType"
               (dismissed)="dismissContextMenu()"
             />
           }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -9,10 +9,7 @@ import {
   HexHoverEvent,
 } from '../browse-canvas/browse-canvas.component';
 import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
-import {
-  MediaContextMenuComponent,
-  MediaContextMenuItem,
-} from '../left-panel/media-item/media-context-menu.component';
+import { BrowseBinPopupComponent } from '../browse-bin-popup/browse-bin-popup.component';
 import { BrowseLegendComponent } from '../browse-legend/browse-legend.component';
 import { BrowseSelectionPanelComponent } from '../browse-selection-panel/browse-selection-panel.component';
 import { BrowseMinimapComponent } from '../browse-minimap/browse-minimap.component';
@@ -51,7 +48,7 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
     BrowseMinimapComponent,
     ProgressBarComponent,
     IconComponent,
-    MediaContextMenuComponent,
+    BrowseBinPopupComponent,
   ],
   // Scoped per browse view so the canvas, its minimap, and the selection panel
   // share one viewport channel and one selection set without leaking across
@@ -162,23 +159,14 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   private readonly ZOOM_BUTTON_FACTOR = 1.4;
 
-  /**
-   * Zoom step for the right-click menu's "Zoom in/out here". A decisive jump
-   * (mirrors the double-click factor) since it's a deliberate one-shot action,
-   * anchored at the spot the user right-clicked rather than the viewport centre.
-   */
-  private readonly CONTEXT_ZOOM_FACTOR = 2.0;
-
-  /** Right-click context-menu state. Open flag + viewport anchor for the menu,
-   *  the canvas-relative anchor for its zoom actions, and the bin (member ids)
-   *  the menu was summoned over. */
+  /** Bin-popup state: open flag, the viewport anchor it opens at, and the
+   *  member ids of the bin the user right-clicked. Right-clicking a bin pops a
+   *  scrollable list of its items (hear on hover, click to select) instead of an
+   *  action menu; right-clicking empty space closes it. */
   contextMenuOpen = false;
   contextMenuX = 0;
   contextMenuY = 0;
-  contextMenuItems: MediaContextMenuItem[] = [];
-  private ctxCanvasX = 0;
-  private ctxCanvasY = 0;
-  private ctxMembers: number[] = [];
+  contextMembers: number[] = [];
 
   private destroy$ = new Subject<void>();
   private polling = false;
@@ -483,57 +471,19 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.canvas?.zoomToFit();
   }
 
-  // --- Right-click context menu -------------------------------------------
+  // --- Right-click bin popup ----------------------------------------------
 
-  /** Open the canvas context menu at the cursor, with bin actions when the
-   *  right-click landed on a bin plus the always-available zoom/clear actions. */
+  /** Right-click on the canvas: pop the bin's item list at the cursor when it
+   *  landed on a bin; close any open popup when it hit empty space. */
   onCanvasContextMenu(event: BrowseContextMenuEvent): void {
-    this.ctxCanvasX = event.canvasX;
-    this.ctxCanvasY = event.canvasY;
-    this.ctxMembers = event.members;
+    if (event.members.length === 0) {
+      this.dismissContextMenu();
+      return;
+    }
+    this.contextMembers = event.members;
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
-    this.contextMenuItems = this.buildContextMenuItems(event.members);
     this.contextMenuOpen = true;
-  }
-
-  private buildContextMenuItems(members: number[]): MediaContextMenuItem[] {
-    const items: MediaContextMenuItem[] = [];
-    if (members.length > 0) {
-      const anySelected = this.selection.selectedCountIn(members) > 0;
-      items.push({
-        id: 'toggle-bin',
-        label: anySelected ? 'Deselect this bin' : 'Select this bin',
-      });
-    }
-    items.push(
-      { id: 'zoom-in', label: 'Zoom in here' },
-      { id: 'zoom-out', label: 'Zoom out here' },
-      { id: 'zoom-fit', label: 'Zoom to fit' },
-      { id: 'clear', label: 'Clear selection', disabled: this.selection.size === 0 },
-    );
-    return items;
-  }
-
-  onContextMenuAction(action: string): void {
-    this.dismissContextMenu();
-    switch (action) {
-      case 'toggle-bin':
-        if (this.ctxMembers.length > 0) this.selection.toggleBin(this.ctxMembers);
-        break;
-      case 'zoom-in':
-        this.canvas?.zoomBy(this.CONTEXT_ZOOM_FACTOR, this.ctxCanvasX, this.ctxCanvasY);
-        break;
-      case 'zoom-out':
-        this.canvas?.zoomBy(1 / this.CONTEXT_ZOOM_FACTOR, this.ctxCanvasX, this.ctxCanvasY);
-        break;
-      case 'zoom-fit':
-        this.canvas?.zoomToFit();
-        break;
-      case 'clear':
-        this.selection.clear();
-        break;
-    }
   }
 
   dismissContextMenu(): void {


### PR DESCRIPTION
## What

Replaces the VTSBrowse canvas right-click **action menu** (Select/Deselect this bin, Zoom in/out here, Zoom to fit, Clear selection) with a small floating **bin popup**: a scrollable, virtualized list of the media items in the bin you right-clicked, rendered like the right-panel selection list.

Right-clicking a bin now lets you reach the individual items folded into a dense bin without zooming all the way in: scroll the list, **hear each item on hover** (audio), and **click to add/remove it** from the canvas selection.

## Behavior

- **Right-click a bin** → opens the popup at the cursor (clamped to stay on-screen), listing that bin's members.
- **Click an item** → toggles it in the shared `BrowseSelectionService` (the same selection the canvas rings and the selection panel reflect). Selected items render highlighted and update live.
- **Popup stays open** on click so you can scroll and multi-select. It closes on outside-click, Escape, another right-click, or its **× button**.
- **Hover** → plays looping audio for audio datasets; other media types just highlight (matching the right panel; thumbnails already show inline).
- **Right-click empty space** → closes any open popup (no menu).
- **Large bins** → CDK virtual scroll with metadata prefetched around the visible window.

## Notes / scope

- The popup is a single-column **list view** (the requested "little list-view"), with each row styled like a right-panel list entry. It does not mirror the right panel's grid/list toggle — grid virtualization would be a large, separate machinery for a "little" popup, and the list reading is faithful to the request.
- **Breaking:** the old right-click actions are removed. Zoom stays on the scroll-wheel / on-screen +/-/fit buttons; whole-bin select stays on left-click; Clear lives in the selection panel — so no capability is lost.
- `BrowseContextMenuEvent` dropped its now-unused `canvasX`/`canvasY` (was only the anchor for "zoom here").
- The generic `vt-media-context-menu` component is untouched and still used by the label view.

## Testing

- `cd frontend && npm run build:prod` — clean (no errors, no budget warnings).
- `./run-tests.sh core` — all 721 passed (incl. ruff / codespell / deptry / frontend build check).

https://claude.ai/code/session_018Ka3jKVyLfEEipM6txDMdu

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ka3jKVyLfEEipM6txDMdu)_