### PR TITLE
Refuse a second app.py launch via an early single-instance lock

### DIFF
--- a/app.py
+++ b/app.py
@@ -709,6 +709,31 @@ def _terminate_listeners(pids: "list[int]", port: int) -> bool:
     return _wait_for_free(port)
 
 
+def _acquire_single_instance_lock(port: int):
+    """Fail fast if another ``python app.py`` is already running on ``port``.
+
+    Closes the gap :func:`_preflight_port` cannot: during the first instance's
+    minute-long model load the port is not bound yet, so a second launch in
+    that window slips past the port check and loads the model stack (~17 GB) a
+    second time, OOM-killing the job. The lock here is taken before any model
+    load, so the duplicate dies in milliseconds. Returns a handle the caller
+    must hold for the process lifetime.
+    """
+    from vtscore.single_instance import AlreadyRunningError, acquire
+
+    try:
+        return acquire(port)
+    except AlreadyRunningError as exc:
+        print(
+            f"\u26d4 {exc}. Refusing to start a second copy, which would reload "
+            f"the model stack and risk OOM-killing the job. Stop the first "
+            f"instance (e.g. `fuser -k {port}/tcp`), or set VTSEARCH_RUNDIR to "
+            f"isolate this one.",
+            flush=True,
+        )
+        sys.exit(1)
+
+
 def _preflight_port(port: int) -> None:
     """Warn-and-prompt if ``port`` is already bound before we try to bind it.
 
@@ -1310,6 +1335,12 @@ if __name__ == "__main__":
                 flush=True,
             )
 
+        # Single-instance lock FIRST -- before the model load -- so a
+        # duplicate launch fails in milliseconds. _preflight_port only
+        # catches an already-*listening* instance; this also covers the
+        # model-loading window when the port is briefly still free. Held
+        # for the process lifetime (released on exit).
+        _instance_lock = _acquire_single_instance_lock(5000)  # noqa: F841
         # Catch a leftover instance before the expensive model load, so the
         # user is prompted up front instead of after a long startup.
         _preflight_port(5000)

--- a/tests/integration/test_single_instance.py
+++ b/tests/integration/test_single_instance.py
@@ -1,0 +1,49 @@
+"""Single-instance lock: a second acquire for the same port is refused,
+and the lock is released once the holder exits (no stale lock)."""
+import os
+import subprocess
+import sys
+import textwrap
+
+from vtscore import single_instance
+
+
+def test_second_acquire_same_port_raises(tmp_path, monkeypatch):
+    # Set the rundir in our OWN env so both this process and the child below
+    # resolve the same lockfile (the child inherits this env).
+    monkeypatch.setenv("VTSEARCH_RUNDIR", str(tmp_path))
+    handle = single_instance.acquire(5099)
+    try:
+        # flock is per-open-file-description, so a true second *process* is
+        # needed to observe the conflict.
+        code = textwrap.dedent(
+            """
+            import sys
+            from vtscore import single_instance
+            try:
+                single_instance.acquire(5099)
+            except single_instance.AlreadyRunningError as exc:
+                print("HOLDER", exc.holder_pid)
+                sys.exit(7)
+            sys.exit(0)
+            """
+        )
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 7, result.stderr
+        assert str(os.getpid()) in result.stdout
+    finally:
+        handle.close()
+
+
+def test_lock_released_after_holder_exits(tmp_path, monkeypatch):
+    monkeypatch.setenv("VTSEARCH_RUNDIR", str(tmp_path))
+    # A short-lived process takes the lock and exits without explicit release.
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", "from vtscore import single_instance; single_instance.acquire(5098)"],
+        check=True,
+    )
+    # No stale lock left behind: we can acquire the same port now.
+    handle = single_instance.acquire(5098)
+    handle.close()

--- a/vtscore/single_instance.py
+++ b/vtscore/single_instance.py
@@ -1,0 +1,58 @@
+"""Process-level single-instance lock.
+
+Used by the VTSearch server (``app.py``) to refuse a second ``python app.py``
+on the same port. Running the server twice in one allocation reloads the model
+stack (~17 GB) and OOM-kills the SLURM job. Uses ``flock``, so the lock
+releases automatically when the holding process exits -- a crash never leaves a
+stale lock behind.
+
+Linux/POSIX only (``fcntl``), consistent with the rest of the server, which
+already relies on ``/proc`` and POSIX semantics.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+import tempfile
+from typing import IO
+
+
+class AlreadyRunningError(RuntimeError):
+    """Raised when another live process already holds the lock for this port."""
+
+    def __init__(self, port: int, holder_pid: str) -> None:
+        self.port = port
+        self.holder_pid = holder_pid
+        super().__init__(f"VTSearch already running (PID {holder_pid}) on port {port}")
+
+
+def lock_path_for(port: int) -> str:
+    """Path of the lockfile for ``port`` (override the dir via ``VTSEARCH_RUNDIR``)."""
+    rundir = os.environ.get("VTSEARCH_RUNDIR") or tempfile.gettempdir()
+    return os.path.join(rundir, f"vtsearch-{port}.lock")
+
+
+def acquire(port: int) -> "IO[str]":
+    """Take an exclusive lock for ``port`` and return the open handle to hold.
+
+    The caller must keep the returned handle open for the process lifetime
+    (``flock`` is released when it closes, or when the process exits). Raises
+    :class:`AlreadyRunningError` if another live process already holds it.
+    """
+    handle = open(lock_path_for(port), "a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno not in (errno.EACCES, errno.EAGAIN):
+            handle.close()
+            raise
+        handle.seek(0)
+        holder = handle.read().strip() or "unknown"
+        handle.close()
+        raise AlreadyRunningError(port, holder) from None
+    handle.seek(0)
+    handle.truncate()
+    handle.write(str(os.getpid()))
+    handle.flush()
+    return handle


### PR DESCRIPTION
## Problem

Running `python app.py` twice in one allocation loads the model stack (~17 GB) a second time and OOM-kills the SLURM job — exactly what happened on the grid today (job died, `sacct` showed two model-loading steps under one 32 GB cgroup).

`_preflight_port` already guards the port, but only catches a duplicate once the first instance is **already listening**. During the first instance's ~minute-long model load the port is still free, so a second launch in that window slips past the check and both balloon in memory.

## Fix

- New `vtscore/single_instance.py`: a stdlib-only, `flock`-based per-port lock. Because it uses `flock`, the lock releases automatically when the holding process exits — a crash never leaves a stale lock behind.
- `app.py` takes the lock as the **first** step of `__main__`, before the model load, so a duplicate fails in milliseconds with a message naming the holder PID (instead of OOM-ing after a long startup).
- `VTSEARCH_RUNDIR` overrides the lock dir to run isolated copies on purpose.

## Tests

`tests/integration/test_single_instance.py`:
- a second *process* acquiring the same port raises `AlreadyRunningError` (names the holder PID)
- the lock is released after the holder exits (no stale lock)

Both pass; ruff + pyright clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)