### PR TITLE
Browse: always show Back button (to Find or dashboard)

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -36,9 +36,17 @@
               <button
                 type="button"
                 class="btn btn--secondary btn--sm browse-back"
-                (click)="backToFind()"
+                (click)="back()"
                 title="Return to the Find view (keeps any items you removed from Good)">
                 &larr; Back to Find
+              </button>
+            } @else {
+              <button
+                type="button"
+                class="btn btn--secondary btn--sm browse-back"
+                (click)="back()"
+                title="Return to the dashboard">
+                &larr; Back to Dashboard
               </button>
             }
             <button

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -38,8 +38,9 @@
 }
 
 // Top-left overlay cluster, anchored to ``.browse-main`` like the other
-// overlays. Stacks the (subset-only) Back affordance above the Re-project
-// button so the two never overlap regardless of mode.
+// overlays. Stacks the Back affordance (to Find in subset mode, to the
+// dashboard in full-dataset mode) above the Re-project button so the two
+// never overlap regardless of mode.
 .browse-tools-left {
   position: absolute;
   top: var(--space-md);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -634,11 +634,24 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Return to wherever this browse was launched from: the Find view for a
+   * subset (Find-positives) browse, or the dashboard for a full-dataset
+   * browse.
+   */
+  back(): void {
+    if (this.subset) {
+      this.backToFind();
+      return;
+    }
+    this.router.navigate(['/dashboard']);
+  }
+
+  /**
    * Return to the Find view this browse was launched from, preserving the
    * cull: the flag tells the Find view to skip its automatic re-scoring (which
    * would re-promote the removed items) and just show the updated labels.
    */
-  backToFind(): void {
+  private backToFind(): void {
     const datasetId = this.activeContext.datasetId;
     const detectorId = this.activeContext.modelId;
     this.browseSubset.markReturningToFind();


### PR DESCRIPTION
## What

The upper-left Back button in the Browse view previously only rendered in subset mode (browsing a Find result set). When browsing an entire dataset there was no Back affordance at all.

This makes the Back button **always** appear and routes by mode:

- **Subset (Find-positives) browse** → "← Back to Find", returns to the Find view it was launched from, preserving any cull (unchanged behavior).
- **Full-dataset browse** → "← Back to Dashboard", returns to the dashboard.

## Changes

- `browse-view.component.html`: add an `@else` branch so a Back button shows in full-dataset mode; both buttons call the new `back()` handler.
- `browse-view.component.ts`: add `back()` that branches on `subset` (delegates to the existing Find return logic, else navigates to `/dashboard`); `backToFind()` is now `private`.
- `browse-view.component.scss`: update the stale "(subset-only)" comment on `.browse-tools-left`.

## Verification

`npm run build:prod` is clean (no errors, no budget warnings).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdkQLFxRfdu4LDaG784QVS)_