### PR TITLE
Fix VTSBrowser QA findings: sidebar collapse, selection survival, copy

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,6 +18,7 @@ it can't drift far. (Point-in-time UI review/audit reports live in
 - [vtsbrowse-toponymy.md](vtsbrowse-toponymy.md): named-region "street signs" (design only)
 - [vtsbrowse-audit-fixes.md](vtsbrowse-audit-fixes.md): queued audit fixes (#1 shipped; #2–#3 open)
 - [vtsbrowser-hex-circle-radius.md](vtsbrowser-hex-circle-radius.md): singleton-circle radius investigation (needs visual verification)
+- [vtsbrowser-qa-followups.md](vtsbrowser-qa-followups.md): QA-drive follow-ups (deferred: startup wedge, tab crash; skipped: toolbar overlay)
 
 ## Scalability
 

--- a/docs/plans/vtsbrowser-qa-followups.md
+++ b/docs/plans/vtsbrowser-qa-followups.md
@@ -9,6 +9,34 @@ dashboard Train/Find hint copy, mailto-subject typo) live in that PR.
 
 ## Deferred
 
+### Server wedges during startup re-init; accept loop starves (grid, 2026-06-07)
+
+After a restart of `python app.py` on the grid (rack4n02, inside the SLURM
+allocation), the server became unreachable — port 5000 LISTENing with the
+accept backlog pegged at 129/128, connections timing out even from
+`localhost` on the node itself — and stayed that way for 30+ minutes. A
+py-spy dump showed the main thread parked in `select()` inside
+`serve_forever`, while the two startup load tasks were stuck, not slow
+(identical stacks across samples 5 s apart):
+
+- `ds-load-…`: `build_diversity_tree_for_context` → sklearn kmeans →
+  `threadpoolctl` → `posixpath.realpath` (frozen mid-`_joinrealpath`,
+  smells like a hung NFS `lstat`)
+- `det-load-…`: `train_from_labelset` → re-embedding label media → CLAP
+  `_np_extract_fbank_features` → `power_to_db` (frozen at the same line
+  across samples)
+
+Total process CPU ~1.6 %, RSS 2.1 GB. The previous app instance likely
+wedged the same way (it was restarted by hand right before this one).
+
+**Why deferred:** root cause is not yet clear — frozen stacks at low CPU
+point at the node's filesystem (NFS) rather than app logic, but the accept
+starvation while two registry `load_task` threads hang is an app-side
+fragility regardless. Worth: (a) a watchdog/timeout around the startup
+registry load tasks, (b) confirming whether the dev server should accept
+(and 503) while load tasks run, (c) checking grid NFS health when it
+recurs. Evidence above is the full diagnostic so far.
+
 ### Browser tab crash during rapid autopilot voting (unreproduced)
 
 Mid-drive, around the 16th vote of an autopilot labeling run with the audio

--- a/docs/plans/vtsbrowser-qa-followups.md
+++ b/docs/plans/vtsbrowser-qa-followups.md
@@ -1,0 +1,40 @@
+# VTSBrowser QA follow-ups (2026-06-07 drive)
+
+Findings from a full end-to-end QA drive of the browse flow (ESC-50 train →
+UrbanSound8K Find → browse positives → region-select wrong items → Remove from
+Good → back to Find) that were **not** fixed in the accompanying PR, with the
+reasoning. The fixed findings (sidebar flex collapse, selection cleared on
+Re-project, stale extent after a cull, autopilot boundary-phase copy,
+dashboard Train/Find hint copy, mailto-subject typo) live in that PR.
+
+## Deferred
+
+### Browser tab crash during rapid autopilot voting (unreproduced)
+
+Mid-drive, around the 16th vote of an autopilot labeling run with the audio
+player churning between items, the tab died ("Session closed. Most likely the
+page has been closed."). Backend state was intact — all 16 labels survived —
+and a fresh tab resumed cleanly. Not reproduced since; no console output was
+captured before the crash.
+
+**Why deferred:** one occurrence, no repro, no stack. Suspect the audio
+element churn (rapid create/play/destroy while voting quickly) but there is
+nothing actionable yet.
+
+**If it recurs:** drive the same flow with DevTools attached and
+`chrome://crashes` enabled; watch the media element count and JS heap while
+voting fast in audio mode.
+
+## Skipped (deliberate)
+
+### Top-left Back/Re-project overlay can sit over canvas bins
+
+The `.browse-tools-left` cluster floats over the canvas, so a bin can land
+under a button and a drag started there hits the button instead of the canvas.
+
+**Why skipped:** this is the standard map-UI overlay pattern, used consistently
+by this view (zoom/hex pills top-right, info chip bottom-left). The canvas is
+pannable, so any bin under a control can be moved out from under it in one
+drag. Reserving a non-canvas gutter for the controls would shrink the plot for
+every session to remove an occasional one-drag annoyance — a bad trade. Revisit
+only if real users report fighting the buttons.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12045,7 +12045,7 @@
     },
     "/api/projection/subset/remove": {
       "post": {
-        "description": "Re-bins the frozen subset layout onto its existing grid minus the removed\npoints: the remaining points keep their exact 2-D positions and bins, only\ncounts/representatives change.  The ``projection_id`` (layout identity) is\npreserved so the canvas keeps the user's pan/zoom; a bumped\n``content_version`` busts the otherwise-immutable tile cache.  Returns the\nupdated subset meta for *shape*.\n\nPowers the Browser's \"Remove from Good\" cull, which marks the items Bad via\n``/api/medias/vote-bulk`` and then calls this to make them disappear.",
+        "description": "Re-bins the frozen subset layout onto its existing grid minus the removed\npoints: the remaining points keep their exact 2-D positions and bins, only\ncounts/representatives change.  The ``projection_id`` (layout identity) is\npreserved and a bumped ``content_version`` busts the otherwise-immutable\ntile cache.  The served ``bounds`` shrink to the survivors' extent so the\nclient re-frames to what's left (zoom-to-fit, minimap) instead of keeping\ndead space where the culled points were \u2014 safe because bin assignment is\norigin-independent; bounds only drive client framing.  Returns the updated\nsubset meta for *shape*.\n\nPowers the Browser's \"Remove from Good\" cull, which marks the items Bad via\n``/api/medias/vote-bulk`` and then calls this to make them disappear.",
         "operationId": "remove_from_subset",
         "requestBody": {
           "content": {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -94,7 +94,7 @@
       }
     </div>
   </nav>
-  <a href="mailto:?subject=VTSearch%20Isssue%3A" title="Email us with any comments, concerns, or suggestions!">
+  <a href="mailto:?subject=VTSearch%20Issue%3A" title="Email us with any comments, concerns, or suggestions!">
     <img src="logo.png" alt="VTSearch logo" class="header-logo">
   </a>
   <button

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -286,8 +286,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
         // A new projection (media-type switch / rebuild) re-lays-out every item,
         // so the old selection no longer maps to what's on screen — drop it. A
         // bin-shape toggle keeps the same projection id and selection, since the
-        // ids are shape-independent.
-        this.selection.clear();
+        // ids are shape-independent. A Re-project of the items already on screen
+        // arms the survive mark instead: the ids are unchanged (only positions
+        // move), so the id-based selection stays coherent and is kept.
+        if (!this.selection.consumeSurviveProjectionChange()) {
+          this.selection.clear();
+        }
+        this.fitToData();
+      } else if (this.viewport.consumeFitOnNextMeta()) {
+        // Same projection id, but the view asked for a re-frame (e.g. a
+        // Remove-from-Good cull shrank the bounds): fit to what remains.
         this.fitToData();
       } else {
         this.updateActiveLevel();

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.scss
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.scss
@@ -21,6 +21,14 @@
   height: 100%;
   box-shadow: none;
   border-radius: var(--radius-sm);
+
+  // Out of flow so the explicit pixel size the ResizeObserver writes onto the
+  // canvas can never feed back into the host's (and the side panel's) layout —
+  // the panel cell drives the canvas size, never the reverse.
+  canvas {
+    position: absolute;
+    inset: 0;
+  }
 }
 
 canvas {

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -147,8 +147,12 @@
   overflow: hidden;
 }
 
+// ``flex-basis: 0`` (not ``auto``) is load-bearing: the docked minimap sets an
+// explicit pixel height on its canvas from a ResizeObserver, so a content-sized
+// basis would feed that height back into this row and ratchet it until it
+// swallows the whole panel, crushing the selection list above to nothing.
 .browse-side-meta {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 180px;
   display: flex;
   align-items: stretch;

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -184,6 +184,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private router: Router,
     private browseSubset: BrowseSubsetService,
     private selection: BrowseSelectionService,
+    private browseViewport: BrowseViewportService,
     private mediasApi: MediasApiService,
     private dialog: VtDialogService,
     private toast: ToastService,
@@ -544,7 +545,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   onReproject(): void {
     if (this.subset && this.subsetIds.length === 0) return;
-    this.selection.clear();
+    // The same items come back in new positions, and selection is id-based —
+    // arm the one-shot survive mark so the canvas keeps it when the fresh
+    // projection id lands, instead of treating the re-fit as a new projection.
+    this.selection.markSurviveProjectionChange();
     this.status = 'building';
     this.buildProgress = 0;
     this.buildTotal = 0;
@@ -562,6 +566,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
         this.pollBuildStatus();
       },
       error: (err) => {
+        // Disarm: no new projection is coming, so the mark would otherwise
+        // linger and wrongly exempt the next genuine projection change.
+        this.selection.consumeSurviveProjectionChange();
         this.status = 'error';
         this.errorMessage =
           err?.error?.message || err?.error?.error || 'Failed to start re-projection';
@@ -605,7 +612,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * remaining items keep their exact 2-D positions and bins — the server
    * re-bins the frozen layout in place (no UMAP re-fit), returning the same
    * ``projection_id`` with a bumped ``content_version`` so only the tile cache
-   * refreshes while the canvas holds the user's pan/zoom.
+   * refreshes. The canvas then zooms to fit the survivors (via the one-shot
+   * fit request below), since the old framing leaves dead space wherever the
+   * culled items used to be.
    */
   private dropFromBrowse(removedIds: number[]): void {
     const removed = new Set(removedIds);
@@ -625,7 +634,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       .subsetRemove(this.binShape, removedIds)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (meta) => this.applyMeta(meta),
+        next: (meta) => {
+          // The survivors' bounds shrank; re-frame to them rather than leaving
+          // dead space where the culled cluster was.
+          this.browseViewport.requestFitOnNextMeta();
+          this.applyMeta(meta);
+        },
         error: () =>
           this.toast.error({
             message: 'Items were removed from Good, but the browse view could not refresh.',

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1061,9 +1061,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get findHint(): string {
     const nDatasets = this.resolvedSelectedDatasets.length;
     const nModels = this.resolvedSelectedModels.length;
-    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and a detector';
-    if (nDatasets === 0) return 'Select a dataset';
-    if (nModels === 0) return 'Select a detector';
+    // "row above": selection means checking a table row — a dataset can be
+    // loaded (named in the top bar) while its row is unchecked, so a bare
+    // "select a dataset" reads as already satisfied.
+    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and a detector row above';
+    if (nDatasets === 0) return 'Select a dataset row in the table above';
+    if (nModels === 0) return 'Select a detector row in the table above';
     if (!this.findMediaTypesMatch()) return 'Media type mismatch';
     if (this.hasUntrainedModel()) return 'Selected detector has no training labels';
     return 'Score selected datasets with selected detectors';
@@ -1072,7 +1075,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get labelHint(): string {
     const nDatasets = this.resolvedSelectedDatasets.length;
     const nModels = this.resolvedSelectedModels.length;
-    if (nDatasets === 0) return 'Select a dataset';
+    if (nDatasets === 0) return 'Select a dataset row in the table above';
     if (nDatasets > 1) return 'Select exactly 1 dataset';
     if (nModels === 0) return 'Create a new detector and start training';
     if (nModels > 1) return 'Select exactly 1 detector';

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -221,8 +221,11 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       case 'bad':
         return `${this.badVotes.size}/${st.badToStart} bad labels`;
       case 'hard': {
+        // No count target here — the phase ends when the smart and stable
+        // indicators (the dots rendered right after this text) both go green,
+        // so say that instead of an open-ended bare count.
         const total = this.goodVotes.size + this.badVotes.size;
-        return `${total} labels`;
+        return `${total} labels · ends when both turn green`;
       }
       case 'new':
         return `Diversity: ${Math.round(st.fracDiversity)}`;

--- a/frontend/src/app/services/browse-selection.service.ts
+++ b/frontend/src/app/services/browse-selection.service.ts
@@ -94,6 +94,30 @@ export class BrowseSelectionService {
     if (changed) this.bump();
   }
 
+  /**
+   * Arm a one-shot exemption from the canvas's clear-on-new-projection rule.
+   *
+   * Selection is id-based, so it survives any relayout of the *same* items —
+   * a Re-project re-fits UMAP over what's already on screen and only moves
+   * points around. The view marks the selection before kicking off such a
+   * build; the canvas consumes the mark when the new projection arrives and
+   * keeps the selection instead of dropping it. Genuine new projections
+   * (media-type switch, rebuild over different items) never set the mark, so
+   * they still clear.
+   */
+  markSurviveProjectionChange(): void {
+    this.surviveProjectionChange = true;
+  }
+
+  /** Consume the one-shot survive mark, returning whether it was set. */
+  consumeSurviveProjectionChange(): boolean {
+    const survive = this.surviveProjectionChange;
+    this.surviveProjectionChange = false;
+    return survive;
+  }
+
+  private surviveProjectionChange = false;
+
   /** Drop the whole selection. */
   clear(): void {
     if (this.selected.size === 0) return;

--- a/frontend/src/app/services/browse-viewport.service.ts
+++ b/frontend/src/app/services/browse-viewport.service.ts
@@ -29,4 +29,24 @@ export class BrowseViewportService {
   requestRecenter(x: number, y: number): void {
     this.recenter$.next({ x, y });
   }
+
+  /**
+   * Arm a one-shot zoom-to-fit for the next meta the canvas receives. Used by
+   * the Remove-from-Good cull: the same projection id comes back (so the
+   * canvas would normally hold the user's pan/zoom), but the survivors'
+   * bounds have shrunk and the old framing leaves dead space where the culled
+   * cluster was — re-frame to what's left instead.
+   */
+  requestFitOnNextMeta(): void {
+    this.pendingFit = true;
+  }
+
+  /** Consume the one-shot fit request, returning whether it was set. */
+  consumeFitOnNextMeta(): boolean {
+    const fit = this.pendingFit;
+    this.pendingFit = false;
+    return fit;
+  }
+
+  private pendingFit = false;
 }

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -531,6 +531,37 @@ class TestSubsetRemove:
         np.testing.assert_array_equal(after.coords[after.ids.index(keep_id)], keep_coord)
 
     @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_remove_shrinks_bounds_to_survivors(self, _mock_fit, client):
+        """Served bounds track the surviving points so the client re-frames.
+
+        ``rebin_like`` keeps the template's bounds (grid identity), but the
+        route stamps the reduced projection's extent over them — otherwise the
+        browse canvas's post-cull zoom-to-fit and the minimap keep framing
+        dead space where the culled points used to be.
+        """
+        ctx = get_active_context()
+        ids = sorted(ctx.medias.keys())[:6]
+        client.post("/api/projection/build", json={"ids": ids})
+        _wait_projection()
+
+        proj = ctx._subset_projection
+        bounds_before = ctx._subset_pyramids["hex"].bounds
+        # Remove the point at the extreme right of the layout so the surviving
+        # extent provably shrinks along x.
+        xmax_idx = int(np.argmax(proj.coords[:, 0]))
+        removed = [proj.ids[xmax_idx]]
+
+        meta = client.post("/api/projection/subset/remove", json={"ids": removed}).get_json()
+
+        survivors = ctx._subset_projection
+        assert tuple(meta["bounds"]) == survivors.bounds
+        assert tuple(meta["bounds"]) != tuple(bounds_before)
+        assert meta["bounds"][2] < bounds_before[2]  # xmax shrank
+        # The stored pyramid serves the same shrunken bounds on later meta GETs.
+        again = client.get("/api/projection/meta", query_string={"subset": "1"}).get_json()
+        assert tuple(again["bounds"]) == survivors.bounds
+
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_remove_bumps_version_each_call(self, _mock_fit, client):
         ctx = get_active_context()
         ids = sorted(ctx.medias.keys())[:6]

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -429,13 +429,18 @@ def remove_from_subset(body: dict):
     Re-bins the frozen subset layout onto its existing grid minus the removed
     points: the remaining points keep their exact 2-D positions and bins, only
     counts/representatives change.  The ``projection_id`` (layout identity) is
-    preserved so the canvas keeps the user's pan/zoom; a bumped
-    ``content_version`` busts the otherwise-immutable tile cache.  Returns the
-    updated subset meta for *shape*.
+    preserved and a bumped ``content_version`` busts the otherwise-immutable
+    tile cache.  The served ``bounds`` shrink to the survivors' extent so the
+    client re-frames to what's left (zoom-to-fit, minimap) instead of keeping
+    dead space where the culled points were — safe because bin assignment is
+    origin-independent; bounds only drive client framing.  Returns the updated
+    subset meta for *shape*.
 
     Powers the Browser's "Remove from Good" cull, which marks the items Bad via
     ``/api/medias/vote-bulk`` and then calls this to make them disappear.
     """
+    from dataclasses import replace
+
     from vtscore.projection import rebin_like
     from vtscore.projection import remove_ids as _remove_ids
     from vtscore.state.core import get_active_context
@@ -453,8 +458,11 @@ def remove_from_subset(body: dict):
     ctx._subset_ids = list(new_proj.ids)
     ctx._subset_job_id = None
     ctx._subset_content_version = getattr(ctx, "_subset_content_version", 0) + 1
-    # Re-bin every shape that was already built, each on its own preserved grid.
-    ctx._subset_pyramids = {s: rebin_like(new_proj, pyr) for s, pyr in ctx._subset_pyramids.items()}
+    # Re-bin every shape that was already built, each on its own preserved grid,
+    # then stamp the survivors' extent over rebin_like's kept template bounds.
+    ctx._subset_pyramids = {
+        s: replace(rebin_like(new_proj, pyr), bounds=new_proj.bounds) for s, pyr in ctx._subset_pyramids.items()
+    }
 
     return _subset_meta(ctx, shape)
 


### PR DESCRIPTION
## Summary

Fixes from a full end-to-end QA drive of the browse flow (train a detector on ESC-50 → Find on UrbanSound8K → browse positives → region-select wrong items → Remove from Good → back to Find), driven live against the grid instance.

- **Browse side panel collapse (major):** the docked minimap's ResizeObserver writes an explicit pixel height onto its canvas; with the meta-row at `flex-basis: auto` that height fed back into the row's content size and ratcheted it until the selection panel above collapsed to ~1px — its Clear / Remove-from-Good controls painted under (and click-blocked by) the minimap canvas. Fixed with two independently sufficient loop-breakers: `flex: 1 1 0` on `.browse-side-meta`, and the dock-mode canvas taken out of flow (`position: absolute`) so its written size can never feed layout.
- **Selection now survives Re-project:** a re-fit mints a new projection id, which the canvas treated as new-projection → clear selection. Selection is id-based and re-projection only moves points, so the view arms a one-shot survive mark the canvas consumes (same idiom as `markReturningToFind`). Disarmed on build error. Media-type switches / genuine rebuilds still clear.
- **Remove from Good zooms to fit the survivors:** the cull keeps the projection id (so the canvas held its old framing) while bounds shrink, leaving dead space where the culled cluster was. One-shot fit request through the viewport service.
- **Autopilot Refine Boundary copy:** showed an open-ended bare count ("16 labels") with no target; the phase actually ends when the smart + stable indicators go green, so the detail now says so.
- **Dashboard Train/Find disabled hints** point at the table rows — a loaded dataset shows in the top bar while its row is unchecked, so a bare "Select a dataset" read as already satisfied.
- **Typo:** mailto subject "Isssue" → "Issue".

Deferred/skipped findings (tab crash during rapid voting, top-left toolbar overlay, grid server startup wedge diagnosis) recorded in `docs/plans/vtsbrowser-qa-followups.md`.

Includes a drive-by `ruff format` of the two single-instance-lock files that were blocking `run-tests.sh` on dev.

## Testing

- `npm run build:prod`: clean, zero warnings
- `./run-tests.sh`: ALL 4618 TESTS PASSED (4 skipped, total: 4622) — includes the new subset-remove bounds test
- Live drive against the grid instance verified the sidebar fix, selection-survives-Re-project, and surfaced that the post-cull zoom-to-fit framed the old extent — fixed by shrinking served bounds to the survivors (`/api/projection/subset/remove`); in-browser re-check of that last fix pending a grid app restart with this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
