### PR TITLE
Probe port preflight with SO_REUSEADDR to ignore orphaned TIME_WAIT sockets

### DIFF
--- a/app.py
+++ b/app.py
@@ -602,12 +602,17 @@ if os.environ.get("VTSEARCH_SERVER_INIT") == "1":
 def _port_is_free(port: int) -> bool:
     """Return True if nothing is bound to ``0.0.0.0:port``.
 
-    Probes by attempting a plain bind (no ``SO_REUSEADDR``), so an existing
-    LISTEN socket surfaces as ``EADDRINUSE``.
+    Probes with ``SO_REUSEADDR``, matching how werkzeug actually binds.  On
+    Linux an active LISTEN socket still surfaces as ``EADDRINUSE`` (only
+    ``SO_REUSEPORT`` would mask it), but orphaned ``TIME_WAIT`` remnants - the
+    parent-less sockets a ``kill -9``'d server leaves behind for ~60s - do
+    not.  Without the flag those remnants made the preflight refuse a restart
+    that werkzeug's own bind would have happily performed.
     """
     import socket
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind(("0.0.0.0", port))
         except OSError:

--- a/tests/core/test_startup_port_preflight.py
+++ b/tests/core/test_startup_port_preflight.py
@@ -44,6 +44,30 @@ def test_port_is_free_reflects_binding():
     assert app_module._port_is_free(port) is True
 
 
+def test_port_is_free_ignores_orphaned_time_wait():
+    """Sockets a dead server leaves in TIME_WAIT must not read as "in use".
+
+    A ``kill -9``'d server's accepted connections linger in TIME_WAIT (local
+    port == the listen port, owned by no process) for ~60s. werkzeug binds
+    with ``SO_REUSEADDR`` and would start fine, so the probe - which matches
+    that bind - must report the port free rather than block the restart.
+    Closing the server side of the connection first parks its socket in
+    TIME_WAIT, surviving all three ``close()`` calls below.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("127.0.0.1", port))
+    conn, _ = server.accept()
+    conn.close()  # server closes first -> this socket heads to TIME_WAIT
+    client.close()
+    server.close()
+    assert app_module._port_is_free(port) is True
+
+
 def test_find_listener_pids_identifies_self():
     sock, port = _listening_socket()
     try:


### PR DESCRIPTION
## Problem

After force-killing a deadlocked `app.py` (the #1855 freeze), restart attempts within ~60s were spuriously blocked:

```
⚠️  Port 5000 is already in use (could not identify the owning process).
```

The killed server's accepted connections linger in **TIME_WAIT** (local port 5000, owned by no process — hence the unidentifiable owner). The preflight probed with a plain `bind()` (no `SO_REUSEADDR`), which fails on those remnants — yet werkzeug itself binds **with** `SO_REUSEADDR` and would have started fine. The probe was stricter than the bind it protects.

## Fix

Set `SO_REUSEADDR` on the probe socket, matching the real bind. On Linux a genuine LISTEN conflict still surfaces as `EADDRINUSE` (only `SO_REUSEPORT` would mask it), so real-listener detection is unchanged — verified by the existing `test_port_is_free_reflects_binding` / preflight-bail tests.

Adds `test_port_is_free_ignores_orphaned_time_wait`, which reproduces the exact scenario (server-side-first close → TIME_WAIT on the listen port) and fails against the old probe.

## Testing

Full `./run-tests.sh` on the grid (CPU mode): **ALL 4622 TESTS PASSED** (1 skipped, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)