### PR TITLE
Honor HF_TOKEN for Hub downloads and surface metadata-resolution waits

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,10 +21,14 @@ from vtsearch.logging_config import new_request_id, setup_logging  # noqa: E402
 
 setup_logging()
 
-# All HF models we use are public, so no token is needed.  Each from_pretrained()
-# call passes token=False to signal this explicitly.  The env var + warnings
-# filter below are belt-and-suspenders in case any transitive HF code still
-# warns about missing tokens.
+# All HF models we use are public, so no token is *required*.  Each
+# from_pretrained() call passes token=hf_token(): the HF_TOKEN env var when
+# set (authenticated requests sidestep the Hub's per-IP anonymous rate limits,
+# which matter behind shared egress IPs like cluster NATs), else False to
+# signal "anonymous on purpose" and suppress missing-token warnings.  The env
+# var below disables *implicit* token pickup so the explicit pass in
+# hf_token() stays the single path; the warnings filters are
+# belt-and-suspenders in case any transitive HF code still warns.
 os.environ["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 warnings.filterwarnings("ignore", message=".*unauthenticated requests.*")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "threadpoolctl",
     "umap-learn",
     "transformers",
+    # Imported directly by vtscore.media.embedder for the Hub metadata
+    # preflight (also a transformers dependency).
+    "huggingface_hub",
     "pandas",
     "pyyaml",
     "matplotlib",

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -769,7 +769,7 @@ class TestHubMetadataPreflight:
     def test_fetches_config_json_with_cache_and_token(self):
         with patch("huggingface_hub.hf_hub_download") as dl:
             _hub_metadata_preflight(("org/repo",), {"cache_dir": "/tmp/c", "token": "tok"})
-        dl.assert_called_once_with("org/repo", "config.json", cache_dir="/tmp/c", token="tok")
+        dl.assert_called_once_with("org/repo", "config.json", cache_dir="/tmp/c", token="tok")  # noqa: S106  # dummy token
 
     def test_supports_cache_folder_alias(self):
         """SentenceTransformer call sites pass cache_folder instead of cache_dir."""

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -17,7 +17,13 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
 
-from vtscore.media.embedder import intercept_weight_loading_progress, load_pretrained_local_first, timed_progress
+from vtscore.media.embedder import (
+    _hub_metadata_preflight,
+    hf_token,
+    intercept_weight_loading_progress,
+    load_pretrained_local_first,
+    timed_progress,
+)
 from vtscore.embedding.loader import _make_console_progress, predict_embedders_to_preload, preload_predicted_embedders
 
 
@@ -709,6 +715,93 @@ class TestLoadPretrainedLocalFirst:
         result = load_pretrained_local_first(fake_load, "model-id")
         assert result is sentinel
         assert mock_sleep.call_count == 2
+
+    @patch("vtscore.media.embedder._hub_metadata_preflight")
+    def test_on_progress_consumed_and_preflight_runs(self, mock_preflight):
+        """on_progress triggers the Hub preflight + ticker and is never forwarded to load_fn."""
+        events = []
+        forwarded = {}
+
+        def fake_load(*args, **kwargs):
+            if kwargs.get("local_files_only"):
+                raise OSError("not cached")
+            forwarded.update(kwargs)
+            return "ok"
+
+        result = load_pretrained_local_first(
+            fake_load, "model-id", cache_dir="/tmp", on_progress=lambda *a: events.append(a)
+        )
+        assert result == "ok"
+        assert "on_progress" not in forwarded
+        mock_preflight.assert_called_once_with(("model-id",), {"cache_dir": "/tmp"})
+        assert any("Contacting HuggingFace Hub" in e[1] for e in events)
+
+    @patch("vtscore.media.embedder._hub_metadata_preflight")
+    def test_no_preflight_when_cached(self, mock_preflight):
+        """A successful local_files_only load must not touch the network preflight."""
+        events = []
+
+        def fake_load(*args, **kwargs):
+            assert kwargs.get("local_files_only") is True
+            return "cached"
+
+        result = load_pretrained_local_first(fake_load, "model-id", on_progress=lambda *a: events.append(a))
+        assert result == "cached"
+        mock_preflight.assert_not_called()
+        assert events == []
+
+    @patch("vtscore.media.embedder._hub_metadata_preflight")
+    def test_no_preflight_without_on_progress(self, mock_preflight):
+        """Without on_progress there is no ticker, so the preflight is skipped."""
+
+        def fake_load(*args, **kwargs):
+            if kwargs.get("local_files_only"):
+                raise OSError("not cached")
+            return "ok"
+
+        assert load_pretrained_local_first(fake_load, "model-id") == "ok"
+        mock_preflight.assert_not_called()
+
+
+class TestHubMetadataPreflight:
+    """Tests for the best-effort config.json preflight."""
+
+    def test_fetches_config_json_with_cache_and_token(self):
+        with patch("huggingface_hub.hf_hub_download") as dl:
+            _hub_metadata_preflight(("org/repo",), {"cache_dir": "/tmp/c", "token": "tok"})
+        dl.assert_called_once_with("org/repo", "config.json", cache_dir="/tmp/c", token="tok")
+
+    def test_supports_cache_folder_alias(self):
+        """SentenceTransformer call sites pass cache_folder instead of cache_dir."""
+        with patch("huggingface_hub.hf_hub_download") as dl:
+            _hub_metadata_preflight(("org/repo",), {"cache_folder": "/tmp/c"})
+        dl.assert_called_once_with("org/repo", "config.json", cache_dir="/tmp/c", token=None)
+
+    def test_swallows_download_errors(self):
+        with patch("huggingface_hub.hf_hub_download", side_effect=RuntimeError("hub down")):
+            _hub_metadata_preflight(("org/repo",), {})  # must not raise
+
+    def test_skips_without_string_repo_id(self):
+        with patch("huggingface_hub.hf_hub_download") as dl:
+            _hub_metadata_preflight((), {})
+            _hub_metadata_preflight((object(),), {})
+        dl.assert_not_called()
+
+
+class TestHfToken:
+    """Tests for the HF_TOKEN env passthrough."""
+
+    def test_false_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        assert hf_token() is False
+
+    def test_returns_env_token(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "hf_secret")
+        assert hf_token() == "hf_secret"
+
+    def test_empty_env_is_false(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "")
+        assert hf_token() is False
 
 
 class TestTimedProgress:

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -18,6 +18,7 @@ from vtscore.config import AST_MODEL_ID, AST_SAMPLE_RATE
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
@@ -80,14 +81,15 @@ class AudioASTEmbedder(MediaEmbedder):
                 AST_MODEL_ID,
                 low_cpu_mem_usage=True,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._model.eval()
         self._on_progress("loading", "Loading AST feature extractor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                ASTFeatureExtractor.from_pretrained, AST_MODEL_ID, cache_dir=cache_dir, token=False
+                ASTFeatureExtractor.from_pretrained, AST_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
         # Warmup: run a dummy forward pass so the first real embed_media

--- a/vtscore/media/audio/embedder_clap.py
+++ b/vtscore/media/audio/embedder_clap.py
@@ -12,6 +12,7 @@ from vtscore.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
@@ -75,14 +76,19 @@ class AudioClapEmbedder(MediaEmbedder):
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP model weights…")
         with intercept_tqdm_progress(self._on_progress):
             self._model = load_pretrained_local_first(
-                ClapModel.from_pretrained, CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                ClapModel.from_pretrained,
+                CLAP_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         # Materialize any tensors left on the ``meta`` device.
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                ClapProcessor.from_pretrained, CLAP_MODEL_ID, cache_dir=cache_dir, token=False
+                ClapProcessor.from_pretrained, CLAP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
         # Warmup: trigger the numba JIT for audio resampling, and run a

--- a/vtscore/media/audio/embedder_clap_general.py
+++ b/vtscore/media/audio/embedder_clap_general.py
@@ -12,6 +12,7 @@ from vtscore.config import CLAP_GENERAL_MODEL_ID, CLAP_SAMPLE_RATE
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
@@ -76,13 +77,14 @@ class AudioClapGeneralEmbedder(MediaEmbedder):
                 CLAP_GENERAL_MODEL_ID,
                 low_cpu_mem_usage=True,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP General processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                ClapProcessor.from_pretrained, CLAP_GENERAL_MODEL_ID, cache_dir=cache_dir, token=False
+                ClapProcessor.from_pretrained, CLAP_GENERAL_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
         # Warmup: run a dummy forward pass

--- a/vtscore/media/audio/embedder_clap_music.py
+++ b/vtscore/media/audio/embedder_clap_music.py
@@ -12,6 +12,7 @@ from vtscore.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
@@ -72,13 +73,18 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP Music model weights…")
         with intercept_tqdm_progress(self._on_progress):
             self._model = load_pretrained_local_first(
-                ClapModel.from_pretrained, CLAP_MUSIC_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                ClapModel.from_pretrained,
+                CLAP_MUSIC_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP Music processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                ClapProcessor.from_pretrained, CLAP_MUSIC_MODEL_ID, cache_dir=cache_dir, token=False
+                ClapProcessor.from_pretrained, CLAP_MUSIC_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
         # Warmup: run a dummy forward pass

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -25,6 +25,7 @@ from vtscore.config import WHISPER_MODEL_ID, WHISPER_SAMPLE_RATE
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
@@ -87,7 +88,8 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
                 WHISPER_MODEL_ID,
                 low_cpu_mem_usage=True,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         # Encoder only - drop the decoder so we don't keep ~half the
         # weights in RSS for no benefit (we never invoke it).
@@ -98,7 +100,7 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
         self._on_progress("loading", "Loading Whisper feature extractor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                WhisperFeatureExtractor.from_pretrained, WHISPER_MODEL_ID, cache_dir=cache_dir, token=False
+                WhisperFeatureExtractor.from_pretrained, WHISPER_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
         # Warmup: run a dummy forward pass.

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -168,6 +168,20 @@ _HF_RETRY_COUNT = 3
 _HF_RETRY_BACKOFF_BASE = 2  # seconds; delays will be 2, 4, 8, …
 
 
+def hf_token() -> str | bool:
+    """Token for HuggingFace Hub requests: ``HF_TOKEN`` env var when set, else ``False``.
+
+    All bundled models are public, so no token is *required*; ``False``
+    explicitly tells the HF libraries not to look for (or warn about) a
+    missing one.  Setting ``HF_TOKEN`` opts into authenticated requests,
+    which matters behind shared egress IPs (e.g. clusters where many users
+    NAT through one address): the Hub rate-limits anonymous requests per IP
+    and can silently delay the first metadata call by minutes, while
+    authenticated requests are limited per account.
+    """
+    return os.environ.get("HF_TOKEN") or False
+
+
 def _is_transient_hf_error(exc: Exception) -> bool:
     """Return True if *exc* looks like a retryable HuggingFace Hub HTTP error."""
     cls_names = {type(exc).__name__} | {c.__name__ for c in type(exc).__mro__}
@@ -183,7 +197,12 @@ def _is_transient_hf_error(exc: Exception) -> bool:
     return False
 
 
-def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+def load_pretrained_local_first(
+    load_fn: Callable[..., Any],
+    *args: Any,
+    on_progress: Optional[ProgressCallback] = None,
+    **kwargs: Any,
+) -> Any:
     """Call *load_fn* preferring cached model files, falling back to download.
 
     HuggingFace ``from_pretrained`` (and ``SentenceTransformer()``) contact the
@@ -196,10 +215,23 @@ def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwarg
     model can be downloaded normally.  Transient HTTP errors from the
     HuggingFace Hub (5xx, timeouts) are retried up to ``_HF_RETRY_COUNT``
     times with exponential backoff.
+
+    When *on_progress* is given, the network fallback is preceded by a
+    metadata preflight (one tiny ``config.json`` fetch) under a
+    :func:`timed_progress` ticker labelled "Contacting HuggingFace Hub…".
+    The Hub's first metadata request is where pre-download stalls land (DNS
+    trouble, Hub latency, anonymous per-IP rate-limit waits — observed at
+    minutes on shared egress IPs), and previously they masqueraded as model
+    loading.  The preflight absorbs that wait under an honest, ticking label
+    while the subsequent real download keeps its clean tqdm progress.
+    *on_progress* is consumed here and never forwarded to *load_fn*.
     """
     try:
         return load_fn(*args, local_files_only=True, **kwargs)
     except (OSError, TypeError, ValueError):
+        if on_progress is not None:
+            with timed_progress(on_progress, "loading", "Contacting HuggingFace Hub…"):
+                _hub_metadata_preflight(args, kwargs)
         last_exc: Exception | None = None
         for attempt in range(_HF_RETRY_COUNT):
             try:
@@ -218,6 +250,33 @@ def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwarg
                 )
                 time.sleep(delay)
         raise last_exc  # type: ignore[misc]
+
+
+def _hub_metadata_preflight(args: tuple, kwargs: dict) -> None:
+    """Best-effort fetch of the repo's ``config.json`` to absorb Hub waits.
+
+    Downloads (and thereby caches) the smallest standard file of the model
+    repo so that any per-IP anonymous rate-limit sleep or slow first
+    connection happens here, inside the caller's "Contacting HuggingFace
+    Hub…" ticker, rather than silently inside ``from_pretrained``.  All
+    failures are swallowed: the real ``load_fn`` call that follows performs
+    its own requests and produces the user-facing error if the Hub is
+    genuinely unreachable.
+    """
+    repo_id = args[0] if args and isinstance(args[0], str) else None
+    if repo_id is None:
+        return
+    try:
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
+
+        hf_hub_download(
+            repo_id,
+            "config.json",
+            cache_dir=kwargs.get("cache_dir") or kwargs.get("cache_folder"),
+            token=kwargs.get("token"),
+        )
+    except Exception:
+        pass
 
 
 @contextlib.contextmanager

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -25,6 +25,7 @@ from vtscore.config import DINOV2_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -74,14 +75,19 @@ class _Dinov2Base(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading DINOv2 model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                AutoModel.from_pretrained, DINOV2_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                AutoModel.from_pretrained,
+                DINOV2_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._model.eval()
         self._on_progress("loading", "Loading DINOv2 image processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                AutoImageProcessor.from_pretrained, DINOV2_MODEL_ID, cache_dir=cache_dir, token=False
+                AutoImageProcessor.from_pretrained, DINOV2_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
     def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -26,6 +26,7 @@ from vtscore.config import DINOV3_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -85,14 +86,19 @@ class _Dinov3Base(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading DINOv3 model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                AutoModel.from_pretrained, DINOV3_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                AutoModel.from_pretrained,
+                DINOV3_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._model.eval()
         self._on_progress("loading", "Loading DINOv3 image processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                AutoImageProcessor.from_pretrained, DINOV3_MODEL_ID, cache_dir=cache_dir, token=False
+                AutoImageProcessor.from_pretrained, DINOV3_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
     def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -12,6 +12,7 @@ from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -65,13 +66,18 @@ class ImageClipEmbedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading CLIP model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                CLIPModel.from_pretrained, CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                CLIPModel.from_pretrained,
+                CLIP_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                CLIPProcessor.from_pretrained, CLIP_MODEL_ID, cache_dir=cache_dir, token=False
+                CLIPProcessor.from_pretrained, CLIP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
     @property

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -12,6 +12,7 @@ from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -79,7 +80,12 @@ class ImageSiglipEmbedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading SigLIP model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                SiglipModel.from_pretrained, SIGLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                SiglipModel.from_pretrained,
+                SIGLIP_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading SigLIP processor…", 0, 0)
@@ -87,10 +93,10 @@ class ImageSiglipEmbedder(MediaEmbedder):
             from transformers import SiglipImageProcessor, SiglipTokenizer  # noqa: PLC0415
 
             image_processor = load_pretrained_local_first(
-                SiglipImageProcessor.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
+                SiglipImageProcessor.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
             tokenizer = load_pretrained_local_first(
-                SiglipTokenizer.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
+                SiglipTokenizer.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
             self._processor = SiglipProcessor(image_processor=image_processor, tokenizer=tokenizer)
 

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -17,6 +17,7 @@ from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -71,13 +72,18 @@ class ImageSiglip2Embedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading SigLIP 2 model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                AutoModel.from_pretrained, SIGLIP2_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                AutoModel.from_pretrained,
+                SIGLIP2_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading SigLIP 2 processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                AutoProcessor.from_pretrained, SIGLIP2_MODEL_ID, cache_dir=cache_dir, token=False
+                AutoProcessor.from_pretrained, SIGLIP2_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
 
     @property

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -12,6 +12,7 @@ from vtscore.config import BGE_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -95,7 +96,11 @@ class TextBGEEmbedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading BGE model…"),
         ):
             self._model = load_pretrained_local_first(
-                SentenceTransformer, BGE_MODEL_ID, cache_folder=cache_dir, token=False
+                SentenceTransformer,
+                BGE_MODEL_ID,
+                cache_folder=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
 
     # ------------------------------------------------------------------

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -12,6 +12,7 @@ from vtscore.config import E5_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -99,7 +100,11 @@ class TextE5Embedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading E5 model…"),
         ):
             self._model = load_pretrained_local_first(
-                SentenceTransformer, E5_MODEL_ID, cache_folder=cache_dir, token=False
+                SentenceTransformer,
+                E5_MODEL_ID,
+                cache_folder=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
 
     # ------------------------------------------------------------------

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -11,6 +11,7 @@ from vtscore.config import LANGUAGEBIND_VIDEO_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -114,8 +115,9 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
                 LANGUAGEBIND_VIDEO_MODEL_ID,
                 low_cpu_mem_usage=True,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
                 trust_remote_code=True,
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading LanguageBind tokenizer...", 0, 0)
@@ -124,7 +126,7 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
                 AutoTokenizer.from_pretrained,
                 LANGUAGEBIND_VIDEO_MODEL_ID,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
                 trust_remote_code=True,
             )
 

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -21,6 +21,7 @@ from vtscore.config import VIDEOMAE_MODEL_ID
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -153,8 +154,9 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
                 VIDEOMAE_MODEL_ID,
                 low_cpu_mem_usage=True,
                 cache_dir=cache_dir,
-                token=False,
+                token=hf_token(),
                 trust_remote_code=True,
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._model.eval()

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -12,6 +12,7 @@ from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
+    hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
@@ -77,13 +78,18 @@ class VideoXClipEmbedder(MediaEmbedder):
             intercept_weight_loading_progress(self._on_progress, "Loading X-CLIP model weights…"),
         ):
             self._model = load_pretrained_local_first(
-                XCLIPModel.from_pretrained, XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+                XCLIPModel.from_pretrained,
+                XCLIP_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(
-                XCLIPProcessor.from_pretrained, XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False
+                XCLIPProcessor.from_pretrained, XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=hf_token()
             )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A DemoDataset image add appeared frozen for 2 minutes on "Loading SigLIP model weights…". Forensics (HF cache lock timestamps + xet logs) showed the actual download took 12s at 85MB/s — the stall was the Hub's *first metadata request*, which preceded all visible activity. Root cause: every `from_pretrained` passes `token=False` (added in 08efce08 purely to silence the unauthenticated-requests warning), forcing anonymous requests; on a shared egress IP (a cluster's NAT, a workshop's worth of users) the Hub's per-IP anonymous rate limits can silently sleep the request for minutes.

## Changes

1. **`hf_token()` helper** (`vtscore/media/embedder.py`): returns the `HF_TOKEN` env var when set — authenticated requests are limited per account, not per IP — else `False` (anonymous on purpose, warning still suppressed). All 29 `token=False` call sites switched; `app.py`'s `HF_HUB_DISABLE_IMPLICIT_TOKEN` stays so the explicit pass is the single path.

2. **Honest progress during Hub resolution**: `load_pretrained_local_first` gains an optional `on_progress` (consumed, never forwarded). Before the network fallback it runs a best-effort `config.json` preflight under a `timed_progress` ticker — "Contacting HuggingFace Hub… (61s)" — so resolution stalls are visibly a live network wait instead of masquerading as model loading. The real download keeps its clean tqdm progress (the preflight design avoids ticker/tqdm interleave). All 15 model-load call sites pass their callback.

3. **deptry**: `huggingface_hub` declared as a direct dependency (already installed via transformers).

## Testing

10 new tests (`TestLoadPretrainedLocalFirst` additions, `TestHubMetadataPreflight`, `TestHfToken`). Full `./run-tests.sh` on the grid (CPU mode): **ALL 4632 TESTS PASSED** (1 skipped, 1 xfailed).

## Usage on the grid

`export HF_TOKEN=hf_…` (e.g. in `~/.bashrc` or the vtsearch launcher) to opt into authenticated downloads; without it behavior is unchanged except the new progress message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)