### PR TITLE
Fix image-set browsing freeze: serve downscaled thumbnails + harden grid measurement

### DIFF
--- a/docs/plans/image-thumbnail-tiles.md
+++ b/docs/plans/image-thumbnail-tiles.md
@@ -1,0 +1,53 @@
+# Downscaled thumbnails for grid/list tiles
+
+**Status:** Shipped for the media-list grid/list tiles (the reported crash
+path). Open follow-up: the other small-thumbnail consumers still request the
+full-resolution `/image` route.
+
+## What shipped
+
+Browsing a large image result set (e.g. the "Good" results of a Find with ~209
+positives) and zooming the grid up and down repeatedly could exhaust browser
+memory and hang the whole machine (Chrome "not responding", OS unresponsive
+from swap thrashing). Two compounding causes, both fixed:
+
+1. **Full-resolution tiles.** Grid and list tiles loaded
+   `/api/medias/<id>/image`, which streams the *original* source bytes. A
+   gallery of many high-res photos forced the browser to download and decode
+   every full-size bitmap at once (tens of MB of decoded pixels each).
+
+   Fix: new `GET /api/medias/<id>/thumbnail` route serving a downscaled image
+   (longest side ≤ `vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`, currently
+   384 px), with an `ETag` + `Cache-Control` so the browser reuses one
+   thumbnail per media across scrolls and every zoom level. The full-res
+   `/image` route is unchanged and still backs the detail viewer.
+   `MediaItemComponent.thumbnailUrl` now points at `/thumbnail`.
+
+2. **Virtualization collapse on zoom.** The grid's CDK virtual scroll uses a
+   fixed `itemSize` measured live from the first rendered card. During a zoom
+   relayout a card can momentarily report a near-zero height; that value was
+   locked in as `itemSize`, making the viewport think each row was a few pixels
+   tall and mount nearly every tile at once.
+
+   Fix: `MIN_GRID_ROW_HEIGHT` floor in
+   `media-list.component.ts#measureGridLayout` — heights below the floor are
+   treated as "not yet laid out" and ignored until a real card measures, so
+   `gridHeightMeasured` stays false and the next pass re-measures.
+
+## Open follow-ups
+
+- **Wire the other thumbnail consumers to `/thumbnail`.** Several views still
+  load full-res `/image` for small thumbnails. Lower risk than the grid (they
+  render far fewer items), but they'd benefit from the same bounded decode:
+  - `right-panel/label-list/label-list.component.ts`
+  - `browse-selection-panel/browse-selection-panel.component.ts`
+  - `browse-bin-popup/browse-bin-popup.component.ts`
+  - `browse-canvas/browse-canvas.component.ts`
+  - `label-view/label-view.component.ts`
+
+  Each has spec tests asserting the `/image` URL that would need updating.
+- **Optional server-side thumbnail cache.** Currently each thumbnail is
+  generated on demand (PIL decode + resize) and cached only in the browser via
+  `ETag`/`Cache-Control`. If first-paint CPU on very large datasets becomes a
+  concern, add a process-scoped LRU keyed by media id + content hash. Not
+  needed for the reported workload.

--- a/docs/plans/image-thumbnail-tiles.md
+++ b/docs/plans/image-thumbnail-tiles.md
@@ -1,8 +1,9 @@
 # Downscaled thumbnails for grid/list tiles
 
-**Status:** Shipped for the media-list grid/list tiles (the reported crash
-path). Open follow-up: the other small-thumbnail consumers still request the
-full-resolution `/image` route.
+**Status:** Shipped app-wide. The media-list grid/list (the reported crash
+path) plus every other image-thumbnail consumer (Find/Train right panels,
+browse views) now serve downscaled thumbnails, and all "thumbnail" routes
+finally downscale images.
 
 ## What shipped
 
@@ -34,18 +35,26 @@ from swap thrashing). Two compounding causes, both fixed:
    treated as "not yet laid out" and ignored until a real card measures, so
    `gridHeightMeasured` stays false and the next pass re-measures.
 
+## Whole-app rollout (shipped)
+
+A shared `vtsearch.routes._shared.image_thumbnail_response` helper (ETag +
+`Cache-Control` + downscale via `make_image_thumbnail`) now backs every
+small-image route, and the previously-full-res "thumbnail" routes finally
+produce real image thumbnails:
+
+- **Backend routes that now downscale images:** `/api/medias/<id>/thumbnail`,
+  `/api/detectors/<name>/labels/<id>/thumbnail` (in-memory + origin paths,
+  backing the right-panel `labelset-list`), and
+  `/api/server-media-files/<file>/thumbnail`.
+- **Frontend consumers switched from `/image` to `/thumbnail`:** right-panel
+  `label-list` (current votes), `browse-selection-panel`, `browse-bin-popup`,
+  `browse-canvas`.
+- **Intentionally left on full-res `/image`:** the center `image-viewer`
+  (detail view) and `label-view`'s crop overlay — the crop maps coordinates
+  onto the real pixels, so it needs the original resolution.
+
 ## Open follow-ups
 
-- **Wire the other thumbnail consumers to `/thumbnail`.** Several views still
-  load full-res `/image` for small thumbnails. Lower risk than the grid (they
-  render far fewer items), but they'd benefit from the same bounded decode:
-  - `right-panel/label-list/label-list.component.ts`
-  - `browse-selection-panel/browse-selection-panel.component.ts`
-  - `browse-bin-popup/browse-bin-popup.component.ts`
-  - `browse-canvas/browse-canvas.component.ts`
-  - `label-view/label-view.component.ts`
-
-  Each has spec tests asserting the `/image` URL that would need updating.
 - **Optional server-side thumbnail cache.** Currently each thumbnail is
   generated on demand (PIL decode + resize) and cached only in the browser via
   `ETag`/`Cache-Control`. If first-paint CPU on very large datasets becomes a

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11851,6 +11851,38 @@
         }
       ]
     },
+    "/api/medias/{media_id}/thumbnail": {
+      "get": {
+        "description": "Grid and list tiles use this instead of ``/image`` so a gallery of many\nhigh-resolution items doesn't force the browser to decode every full-size\nbitmap at once.  The thumbnail is bounded to a fixed longest-side length\n(see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the\nsame regardless of zoom level, so an ``ETag`` lets the browser reuse it\nacross scrolls and zoom changes.  Undecodable sources (e.g. SVG) fall\nback to the original bytes.",
+        "operationId": "media_thumbnail",
+        "responses": {
+          "400": {
+            "description": "Media is not an image and has no image_response delegate."
+          },
+          "404": {
+            "description": "Media not found, or media bytes unavailable."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Stream a downscaled thumbnail of a media item's image.",
+        "tags": [
+          "medias"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "media_id",
+          "required": true,
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        }
+      ]
+    },
     "/api/medias/{media_id}/video": {
       "get": {
         "description": "Determines the MIME type from the media's filename extension, defaulting\nto ``video/mp4`` for unrecognised extensions.",

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -219,7 +219,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   }
 
   thumbnailUrl(id: number): string {
-    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
+    return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
   }
 
   onThumbnailError(url: string): void {

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -746,8 +746,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.thumbCache.delete(representativeId);
       this.thumbFailed.add(representativeId);
     };
-    // The /image route serves the frame for video via its image_response hook.
-    img.src = this.activeContext.mediaUrl(`/api/medias/${representativeId}/image`);
+    // Downscaled tile, not full-res /image: a browse projection can hold
+    // thousands of points, so painting full-size bitmaps onto the hexes would
+    // exhaust memory. The /thumbnail route serves the frame for video via the
+    // same image_response hook, then downscales it.
+    img.src = this.activeContext.mediaUrl(`/api/medias/${representativeId}/thumbnail`);
     this.thumbCache.set(representativeId, img);
     return null;
   }

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -197,7 +197,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   }
 
   thumbnailUrl(id: number): string {
-    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
+    return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
   }
 
   onThumbnailError(url: string): void {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -70,12 +70,12 @@ describe('MediaItemComponent', () => {
   });
 
   it('should show thumbnail for audio type', () => {
-    expect(component.thumbnailUrl).toBe('/api/medias/1/image');
+    expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
   });
 
   it('should show thumbnail for image type', () => {
     component.media = { ...mockMedia, media_type: 'image' };
-    expect(component.thumbnailUrl).toBe('/api/medias/1/image');
+    expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
   });
 
   it('should not show thumbnail for text type', () => {
@@ -85,7 +85,7 @@ describe('MediaItemComponent', () => {
 
   it('should fall back to placeholder when thumbnail fails to load', () => {
     component.viewMode = 'grid';
-    expect(component.thumbnailUrl).toBe('/api/medias/1/image');
+    expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
     component.onThumbnailError();
     expect(component.thumbnailUrl).toBeNull();
     expect(component.placeholderIcon).toBe('\u266B');
@@ -96,7 +96,7 @@ describe('MediaItemComponent', () => {
     expect(component.thumbnailUrl).toBeNull();
     component.media = { ...mockMedia, id: 2 };
     component.ngOnChanges({ media: {} as any });
-    expect(component.thumbnailUrl).toBe('/api/medias/2/image');
+    expect(component.thumbnailUrl).toBe('/api/medias/2/thumbnail');
   });
 
   it('should show score when provided', () => {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -44,7 +44,11 @@ export class MediaItemComponent implements OnChanges {
   get thumbnailUrl(): string | null {
     if (this.thumbnailFailed) return null;
     if (this.media.media_type === 'image' || this.media.media_type === 'video' || this.media.media_type === 'document' || this.media.media_type === 'audio') {
-      return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
+      // Use the downscaled thumbnail endpoint, not the full-resolution
+      // ``/image`` route: a grid of hundreds of high-res items would otherwise
+      // force the browser to decode every full-size bitmap at once and exhaust
+      // memory. The same thumbnail is reused at every zoom level.
+      return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/thumbnail`);
     }
     return null;
   }

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -45,6 +45,16 @@ const LIST_ITEM_HEIGHT = 28;
 const GRID_GAP_PX = 4;
 /** Fallback grid-row stride before the first real card is measured (px). */
 const GRID_ROW_HEIGHT_FALLBACK = 100;
+/**
+ * Smallest plausible measured grid-row stride (px).  A card mid-relayout
+ * (its ``<img>`` still loading after a zoom) can momentarily report a
+ * near-zero ``getBoundingClientRect().height``.  Accepting that as the CDK
+ * ``itemSize`` would make the viewport think each row is a few pixels tall and
+ * mount nearly every item at once — defeating virtualization and decoding
+ * hundreds of images simultaneously.  Heights below this floor are treated as
+ * "not yet laid out" and ignored until a real card measures.
+ */
+const MIN_GRID_ROW_HEIGHT = 24;
 /** Extra items to prefetch beyond the visible viewport edges. */
 const PREFETCH_BUFFER = 50;
 
@@ -381,7 +391,12 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     const card = vp?.querySelector('vt-media-item .media-item') as HTMLElement | null;
     if (card) {
       const measured = Math.round(card.getBoundingClientRect().height + GRID_GAP_PX);
-      if (measured > 0) {
+      // Only trust a measurement once the card has actually laid out: a
+      // transient near-zero height (image still loading after a zoom) would
+      // otherwise be locked in as a tiny ``itemSize`` and collapse
+      // virtualization.  Leave ``gridHeightMeasured`` false so the next
+      // change-detection / resize pass re-measures against a real card.
+      if (measured >= MIN_GRID_ROW_HEIGHT) {
         this.gridHeightMeasured = true;
         if (Math.abs(measured - this.gridRowHeight) > 1) {
           this.gridRowHeight = measured;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -157,9 +157,9 @@ describe('LabelListComponent', () => {
     });
 
     it('should generate correct thumbnail URLs', () => {
-      expect(component.thumbnailUrl(1)).toBe('/api/medias/1/image');
-      expect(component.thumbnailUrl(2)).toBe('/api/medias/2/image');
-      expect(component.thumbnailUrl(3)).toBe('/api/medias/3/image');
+      expect(component.thumbnailUrl(1)).toBe('/api/medias/1/thumbnail');
+      expect(component.thumbnailUrl(2)).toBe('/api/medias/2/thumbnail');
+      expect(component.thumbnailUrl(3)).toBe('/api/medias/3/thumbnail');
     });
 
     it('should be in grid mode when viewMode is grid', () => {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -156,7 +156,10 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   thumbnailUrl(id: number): string {
     const media = this.lookup(id);
     if (!media) return '';
-    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
+    // Downscaled tile, not the full-resolution ``/image``: the labeled set can
+    // hold hundreds of items, and decoding every full-size bitmap at once
+    // exhausts browser memory.
+    return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
   }
 
   onThumbnailError(url: string): void {

--- a/tests/cli/test_load_sort_window.py
+++ b/tests/cli/test_load_sort_window.py
@@ -182,16 +182,23 @@ class TestServerMediaFileThumbnail:
             wf.writeframes(struct.pack(f"<{num_samples}h", *samples))
         return path
 
-    def test_image_returns_file_bytes(self, client):
+    def test_image_returns_thumbnail(self, client):
+        import io
+
         from PIL import Image
 
+        from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM
+
         path = self._media_dir / "example.png"
-        Image.new("RGB", (16, 16), color=(123, 45, 67)).save(path)
+        # Larger than the thumbnail cap so we can confirm it gets downscaled.
+        Image.new("RGB", (1000, 800), color=(123, 45, 67)).save(path)
 
         resp = client.get("/api/server-media-files/example.png/thumbnail")
         assert resp.status_code == 200
-        assert resp.mimetype == "image/png"
-        assert resp.data[:8] == b"\x89PNG\r\n\x1a\n"
+        # Opaque images are re-encoded as JPEG and bounded to the thumbnail cap.
+        assert resp.mimetype in ("image/jpeg", "image/png")
+        with Image.open(io.BytesIO(resp.data)) as img:
+            assert max(img.size) <= DEFAULT_MAX_DIM
 
     def test_audio_returns_waveform_png(self, client):
         self._make_wav("example.wav")

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -447,6 +447,49 @@ class TestMediaImage:
                 media["thumbnail_bytes"] = saved_thumb
 
 
+class TestMediaThumbnail:
+    """Tests for GET /api/medias/<id>/thumbnail (downscaled grid/list tiles)."""
+
+    def test_returns_image_for_audio_media(self, client):
+        # The default test dataset is audio; /image yields a waveform PNG, which
+        # the thumbnail route downscales (and re-encodes, here keeping PNG).
+        resp = client.get("/api/medias/1/thumbnail")
+        assert resp.status_code == 200
+        assert resp.content_type in ("image/jpeg", "image/png")
+
+    def test_thumbnail_is_bounded(self, client):
+        from PIL import Image  # noqa: PLC0415
+
+        from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM  # noqa: PLC0415
+
+        resp = client.get("/api/medias/1/thumbnail")
+        assert resp.status_code == 200
+        with Image.open(io.BytesIO(resp.data)) as img:
+            assert max(img.size) <= DEFAULT_MAX_DIM
+
+    def test_returns_404_for_invalid_id(self, client):
+        resp = client.get("/api/medias/9999/thumbnail")
+        assert resp.status_code == 404
+
+    def test_sets_cache_headers_and_etag(self, client):
+        resp = client.get("/api/medias/1/thumbnail")
+        assert resp.status_code == 200
+        assert "max-age" in resp.headers.get("Cache-Control", "")
+        assert resp.headers.get("ETag")
+
+    def test_conditional_request_returns_304(self, client):
+        first = client.get("/api/medias/1/thumbnail")
+        etag = first.headers["ETag"]
+        second = client.get("/api/medias/1/thumbnail", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        assert second.data == b""
+
+    def test_consistent_responses(self, client):
+        resp1 = client.get("/api/medias/1/thumbnail")
+        resp2 = client.get("/api/medias/1/thumbnail")
+        assert resp1.data == resp2.data
+
+
 class TestMediaAudio:
     def test_returns_wav_for_valid_id(self, client):
         resp = client.get("/api/medias/1/audio")

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -298,8 +298,18 @@ class TestLabelElementThumbnail:
         try:
             res = client.get(f"/api/detectors/{name}/labels/{element_id}/thumbnail")
             assert res.status_code == 200, res.get_json()
-            assert res.mimetype == "image/png"
-            assert res.data == png
+            # The thumbnail route downscales/re-encodes the image (so a labelset
+            # of many high-res items doesn't decode every full-size bitmap at
+            # once), so assert a valid bounded image rather than byte-equality.
+            import io  # noqa: PLC0415
+
+            from PIL import Image  # noqa: PLC0415
+
+            from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM  # noqa: PLC0415
+
+            assert res.mimetype in ("image/jpeg", "image/png")
+            with Image.open(io.BytesIO(res.data)) as thumb_img:
+                assert max(thumb_img.size) <= DEFAULT_MAX_DIM
         finally:
             medias.clear()
             medias.update(saved)

--- a/tests_lib/core/test_image_thumbnail.py
+++ b/tests_lib/core/test_image_thumbnail.py
@@ -1,0 +1,87 @@
+"""Library-tier tests for :func:`vtscore.media.image.thumbnail.make_image_thumbnail`.
+
+The thumbnail helper bounds the decoded size of grid/list tiles so a gallery
+of many high-resolution items can't force the browser to decode every
+full-size bitmap at once (the cause of the image-set browsing freeze).
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM, make_image_thumbnail
+
+
+def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestMakeImageThumbnail:
+    def test_downscales_large_image_within_max_dim(self):
+        big = Image.new("RGB", (2000, 1200), color=(120, 30, 200))
+        result = make_image_thumbnail(_encode(big, "JPEG"))
+        assert result is not None
+        thumb_bytes, mimetype = result
+        assert mimetype == "image/jpeg"
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert max(out.size) <= DEFAULT_MAX_DIM
+            # Aspect ratio preserved: longest side hits the cap.
+            assert max(out.size) == DEFAULT_MAX_DIM
+            assert out.size == (DEFAULT_MAX_DIM, round(DEFAULT_MAX_DIM * 1200 / 2000))
+
+    def test_respects_custom_max_dim(self):
+        big = Image.new("RGB", (1000, 1000), color=(10, 10, 10))
+        result = make_image_thumbnail(_encode(big, "JPEG"), max_dim=64)
+        assert result is not None
+        thumb_bytes, _ = result
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert max(out.size) == 64
+
+    def test_does_not_upscale_small_image(self):
+        small = Image.new("RGB", (40, 30), color=(1, 2, 3))
+        result = make_image_thumbnail(_encode(small, "PNG"))
+        assert result is not None
+        thumb_bytes, _ = result
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert out.size == (40, 30)
+
+    def test_preserves_alpha_as_png(self):
+        rgba = Image.new("RGBA", (800, 800), color=(0, 0, 0, 0))
+        result = make_image_thumbnail(_encode(rgba, "PNG"))
+        assert result is not None
+        thumb_bytes, mimetype = result
+        assert mimetype == "image/png"
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert out.mode == "RGBA"
+            assert max(out.size) <= DEFAULT_MAX_DIM
+
+    def test_thumbnail_is_smaller_than_source(self):
+        big = Image.new("RGB", (3000, 3000), color=(200, 100, 50))
+        source = _encode(big, "JPEG")
+        result = make_image_thumbnail(source)
+        assert result is not None
+        thumb_bytes, _ = result
+        assert len(thumb_bytes) < len(source)
+
+    def test_returns_none_for_undecodable_bytes(self):
+        assert make_image_thumbnail(b"<svg></svg>") is None
+        assert make_image_thumbnail(b"not an image at all") is None
+
+    def test_applies_exif_orientation(self):
+        # A landscape image tagged "rotate 90°" (orientation 6) should come back
+        # portrait once the orientation is baked in.
+        landscape = Image.new("RGB", (400, 200), color=(50, 50, 50))
+        exif = landscape.getexif()
+        exif[274] = 6  # 274 = Orientation tag; 6 = rotate 90° CW
+        buf = io.BytesIO()
+        landscape.save(buf, format="JPEG", exif=exif)
+        result = make_image_thumbnail(buf.getvalue())
+        assert result is not None
+        thumb_bytes, _ = result
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            # Width/height swapped relative to the stored 400×200.
+            assert out.size[1] > out.size[0]

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -42,7 +42,7 @@ def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> 
         with Image.open(io.BytesIO(media_bytes)) as src:
             img = ImageOps.exif_transpose(src) or src
             has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
-            img.thumbnail((max_dim, max_dim), Image.LANCZOS)
+            img.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
             out = io.BytesIO()
             if has_alpha:
                 img.convert("RGBA").save(out, format="PNG", optimize=True)

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -1,0 +1,55 @@
+"""Downscale image bytes to a bounded thumbnail for grid/list display.
+
+Grid and list tiles render a media item at a few dozen to a couple hundred
+pixels, but the ``/api/medias/<id>/image`` route streams the *original*
+source bytes.  A gallery of a few hundred high-resolution photos therefore
+forces the browser to download and decode every full-size bitmap at once
+(tens of megabytes of decoded pixels each), which exhausts memory and can
+hang the machine.  Serving a small thumbnail instead caps the per-tile
+decode cost to a fixed budget regardless of the source resolution.
+
+The full-resolution route is unchanged and still backs the detail viewer,
+where a crisp original is wanted.
+"""
+
+from __future__ import annotations
+
+import io
+
+#: Longest-side length (px) of a generated thumbnail.  Comfortably covers the
+#: largest grid tile (XL ≈ 200 px CSS, ≈ 400 px on a 2× display) while keeping
+#: the decoded bitmap small (≈ ``MAX_DIM`` × ``MAX_DIM`` × 4 bytes).  The same
+#: thumbnail is reused at every zoom level, so the browser never re-fetches
+#: when the user zooms in or out.
+DEFAULT_MAX_DIM = 384
+
+
+def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> tuple[bytes, str] | None:
+    """Return ``(thumbnail_bytes, mimetype)`` downscaled to ``max_dim`` px.
+
+    The longest side of the result is at most ``max_dim``; images already
+    within that bound are re-encoded (never upscaled) so callers still get a
+    compact, decode-cheap artifact.  Opaque images become JPEG; images that
+    carry an alpha channel become PNG so transparency survives.  Camera EXIF
+    orientation is applied so portrait photos aren't shown sideways.
+
+    Returns ``None`` when the bytes can't be decoded as an image (e.g. SVG or
+    a corrupt file), letting the caller fall back to the original bytes.
+    """
+    from PIL import Image, ImageOps  # noqa: PLC0415
+
+    try:
+        with Image.open(io.BytesIO(media_bytes)) as src:
+            img = ImageOps.exif_transpose(src) or src
+            has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
+            img.thumbnail((max_dim, max_dim), Image.LANCZOS)
+            out = io.BytesIO()
+            if has_alpha:
+                img.convert("RGBA").save(out, format="PNG", optimize=True)
+                mimetype = "image/png"
+            else:
+                img.convert("RGB").save(out, format="JPEG", quality=82, optimize=True)
+                mimetype = "image/jpeg"
+            return out.getvalue(), mimetype
+    except Exception:
+        return None

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
 import logging
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
-from flask import g, jsonify, request
+from flask import g, jsonify, make_response, request, send_file
 from flask_smorest import abort
 from marshmallow import ValidationError
 
@@ -14,6 +16,36 @@ if TYPE_CHECKING:
     from vtscore.plugins import PluginBase
 
 logger = logging.getLogger(__name__)
+
+
+def image_thumbnail_response(image_bytes: bytes, fallback_mimetype: str, download_name: str):
+    """Build a cached, downscaled-image thumbnail response from ``image_bytes``.
+
+    Shared by every route that serves a small image tile (the media grid/list,
+    saved detector labels, server-media examples).  The bytes are run through
+    :func:`vtscore.media.image.thumbnail.make_image_thumbnail` so a gallery of
+    many high-resolution items never forces the browser to decode every
+    full-size bitmap at once; undecodable sources fall back to the original
+    bytes.  An ``ETag`` fingerprints the *source* bytes so the browser reuses
+    one thumbnail per item across scrolls and zoom levels, and conditional
+    requests short-circuit to a 304 without regenerating the thumbnail.
+    """
+    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
+
+    etag = hashlib.md5(image_bytes).hexdigest()
+    if etag in request.if_none_match:
+        resp = make_response("", 304)
+        resp.set_etag(etag)
+        resp.headers["Cache-Control"] = "private, max-age=86400"
+        return resp
+
+    result = make_image_thumbnail(image_bytes)
+    thumb, mimetype = result if result is not None else (image_bytes, fallback_mimetype)
+
+    resp = make_response(send_file(io.BytesIO(thumb), mimetype=mimetype, download_name=download_name))
+    resp.set_etag(etag)
+    resp.headers["Cache-Control"] = "private, max-age=86400"
+    return resp
 
 
 def _has_context_id(header_name: str, query_param: str) -> bool:

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -54,6 +54,7 @@ from vtscore.detectors.store import (
     _write_detector,
 )
 from vtscore.detectors.workflow import apply_and_retrain as _apply_and_retrain
+from vtsearch.routes._shared import image_thumbnail_response
 from vtsearch.schemas.detectors import (
     DetectorLabelsDetailResponseSchema,
     DetectorLabelVoteRequestSchema,
@@ -428,11 +429,7 @@ def _in_memory_thumbnail_response(media: dict, media_type: str):
         resp = mt.media_response(media)
         if not isinstance(resp.data, (bytes, bytearray)) or not resp.data:
             return None
-        return send_file(
-            io.BytesIO(resp.data),
-            mimetype=resp.mimetype,
-            download_name=resp.download_name,
-        )
+        return image_thumbnail_response(bytes(resp.data), resp.mimetype, resp.download_name)
 
     image_response_fn = getattr(mt, "image_response", None)
     if image_response_fn is None:
@@ -453,13 +450,11 @@ def _origin_thumbnail_response(file_path: Path, media_type: str, elem):
         suffix = file_path.suffix.lower()
         mimetype = _MIMETYPE_BY_SUFFIX.get(suffix) or "image/jpeg"
         try:
-            return send_file(
-                io.BytesIO(file_path.read_bytes()),
-                mimetype=mimetype,
-                download_name=elem.origin_name or elem.filename or f"label{suffix}",
-            )
+            image_bytes = file_path.read_bytes()
         except OSError:
             abort(404, message="Element media file unreadable")
+        download_name = elem.origin_name or elem.filename or f"label{suffix}"
+        return image_thumbnail_response(image_bytes, mimetype, download_name)
 
     if media_type == "audio":
         from vtscore.media.audio.media_type import generate_waveform_thumbnail_from_file  # noqa: PLC0415

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -37,7 +37,11 @@ from vtsearch.schemas.media import (
     MediaVoteRequestSchema,
     MediaVoteResponseSchema,
 )
-from vtsearch.routes._shared import require_dataset_header, require_detector_header
+from vtsearch.routes._shared import (
+    image_thumbnail_response,
+    require_dataset_header,
+    require_detector_header,
+)
 from vtsearch.state import (
     _state_lock,
     apply_label,
@@ -488,26 +492,8 @@ def media_thumbnail(media_id: int):
     across scrolls and zoom changes.  Undecodable sources (e.g. SVG) fall
     back to the original bytes.
     """
-    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
-
     data, src_mimetype, _ = _resolve_display_image(media_id)
-
-    # ETag fingerprints the source bytes so the browser can revalidate cheaply
-    # without us regenerating the thumbnail on every conditional request.
-    etag = hashlib.md5(data).hexdigest()
-    if etag in request.if_none_match:
-        resp = make_response("", 304)
-        resp.set_etag(etag)
-        resp.headers["Cache-Control"] = "private, max-age=86400"
-        return resp
-
-    result = make_image_thumbnail(data)
-    thumb, mimetype = result if result is not None else (data, src_mimetype)
-
-    resp = make_response(send_file(io.BytesIO(thumb), mimetype=mimetype, download_name=f"thumb_{media_id}"))
-    resp.set_etag(etag)
-    resp.headers["Cache-Control"] = "private, max-age=86400"
-    return resp
+    return image_thumbnail_response(data, src_mimetype, f"thumb_{media_id}")
 
 
 @medias_bp.route("/api/medias/<int:media_id>/paragraph")

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -407,16 +407,15 @@ def media_video(media_id: int):
     return _send_video_bytes(media_bytes, mimetype, f"media_{media_id}{ext}")
 
 
-@medias_bp.route("/api/medias/<int:media_id>/image")
-@medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
-@medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
-def media_image(media_id: int):  # noqa: C901
-    """Stream the image bytes for a single image media item.
+def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
+    """Resolve the displayable image for a media item.
 
-    Determines the MIME type from the media's filename extension, defaulting
-    to ``image/jpeg`` for unrecognised extensions. For non-image media types
-    that declare an ``image_response`` hook (audio waveforms, video frames),
-    the route delegates to that hook.
+    Returns ``(image_bytes, mimetype, download_name)`` for the bytes the
+    ``/image`` route would serve, ``abort``-ing with the matching error when
+    no image is available.  For non-image types it delegates to the media
+    type's ``image_response`` hook (audio waveforms, video frames); for image
+    types it streams the source bytes with a mimetype derived from the
+    filename extension.  Shared by the full-image and thumbnail routes.
     """
     c = get_media(media_id)
     if not c:
@@ -436,11 +435,7 @@ def media_image(media_id: int):  # noqa: C901
         if image_response_fn is not None:
             resp = image_response_fn(c)
             if resp is not None:
-                return send_file(
-                    io.BytesIO(resp.data),
-                    mimetype=resp.mimetype,
-                    download_name=resp.download_name,
-                )
+                return resp.data, resp.mimetype, resp.download_name
         abort(400, message="no image available")
 
     media_bytes = _resolve_bytes(c)
@@ -460,11 +455,59 @@ def media_image(media_id: int):  # noqa: C901
     else:
         mimetype = "image/jpeg"
 
-    return send_file(
-        io.BytesIO(media_bytes),
-        mimetype=mimetype,
-        download_name=f"media_{media_id}{Path(filename).suffix if filename and Path(filename).suffix else '.jpg'}",
-    )
+    suffix = Path(filename).suffix if filename and Path(filename).suffix else ".jpg"
+    return media_bytes, mimetype, f"media_{media_id}{suffix}"
+
+
+@medias_bp.route("/api/medias/<int:media_id>/image")
+@medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
+@medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
+def media_image(media_id: int):
+    """Stream the image bytes for a single image media item.
+
+    Determines the MIME type from the media's filename extension, defaulting
+    to ``image/jpeg`` for unrecognised extensions. For non-image media types
+    that declare an ``image_response`` hook (audio waveforms, video frames),
+    the route delegates to that hook.
+    """
+    data, mimetype, download_name = _resolve_display_image(media_id)
+    return send_file(io.BytesIO(data), mimetype=mimetype, download_name=download_name)
+
+
+@medias_bp.route("/api/medias/<int:media_id>/thumbnail")
+@medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
+@medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
+def media_thumbnail(media_id: int):
+    """Stream a downscaled thumbnail of a media item's image.
+
+    Grid and list tiles use this instead of ``/image`` so a gallery of many
+    high-resolution items doesn't force the browser to decode every full-size
+    bitmap at once.  The thumbnail is bounded to a fixed longest-side length
+    (see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the
+    same regardless of zoom level, so an ``ETag`` lets the browser reuse it
+    across scrolls and zoom changes.  Undecodable sources (e.g. SVG) fall
+    back to the original bytes.
+    """
+    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
+
+    data, src_mimetype, _ = _resolve_display_image(media_id)
+
+    # ETag fingerprints the source bytes so the browser can revalidate cheaply
+    # without us regenerating the thumbnail on every conditional request.
+    etag = hashlib.md5(data).hexdigest()
+    if etag in request.if_none_match:
+        resp = make_response("", 304)
+        resp.set_etag(etag)
+        resp.headers["Cache-Control"] = "private, max-age=86400"
+        return resp
+
+    result = make_image_thumbnail(data)
+    thumb, mimetype = result if result is not None else (data, src_mimetype)
+
+    resp = make_response(send_file(io.BytesIO(thumb), mimetype=mimetype, download_name=f"thumb_{media_id}"))
+    resp.set_etag(etag)
+    resp.headers["Cache-Control"] = "private, max-age=86400"
+    return resp
 
 
 @medias_bp.route("/api/medias/<int:media_id>/paragraph")

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -407,7 +407,7 @@ def media_video(media_id: int):
     return _send_video_bytes(media_bytes, mimetype, f"media_{media_id}{ext}")
 
 
-def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
+def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:  # noqa: C901
     """Resolve the displayable image for a media item.
 
     Returns ``(image_bytes, mimetype, download_name)`` for the bytes the

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -18,7 +18,7 @@ from flask_smorest import Blueprint, abort
 from werkzeug.exceptions import HTTPException
 
 from vtscore.config import DATA_DIR
-from vtsearch.routes._shared import format_exception_detail
+from vtsearch.routes._shared import format_exception_detail, image_thumbnail_response
 from vtsearch.schemas.media import (
     ExampleSortByIdRequestSchema,
     ExampleSortOriginRequestSchema,
@@ -162,11 +162,7 @@ def server_media_file_thumbnail(filename: str):
 
     if media_type == "image":
         mimetype = _IMAGE_MIMETYPES.get(suffix, "image/jpeg")
-        return send_file(
-            io.BytesIO(file_path.read_bytes()),
-            mimetype=mimetype,
-            download_name=file_path.name,
-        )
+        return image_thumbnail_response(file_path.read_bytes(), mimetype, file_path.name)
 
     if media_type == "audio":
         from vtscore.media.audio.media_type import generate_waveform_thumbnail_from_file


### PR DESCRIPTION
## Problem

Browsing the "Good" results of a Find on an image set with ~209 positives and zooming the grid up and down repeatedly could exhaust browser memory and hang the whole machine (Chrome "not responding"; OS unresponsive from swap thrashing — a pure JS loop pegs one core but leaves the OS alive, so the signature was memory exhaustion).

Two compounding causes:

1. **Tiles loaded full-resolution images.** Grid/list/right-panel/browse tiles pointed at `/api/medias/<id>/image`, which streams the *original* source bytes with no downscaling. The app's existing "thumbnail" routes (`/server-media-files/.../thumbnail`, `/detectors/.../labels/.../thumbnail`) only produced small images for audio/video — for **images they also served full-res bytes**, so nothing actually downscaled images. A gallery of many high-res photos forced the browser to decode every full-size bitmap at once (tens of MB each → multi-GB).

2. **Virtualization collapsed during zoom.** The grid's CDK virtual scroll uses a fixed `itemSize` measured live from the first rendered card. During a zoom relayout a card can momentarily report a near-zero height; that got locked in as `itemSize`, so the viewport mounted nearly every tile at once — multiplying the decode bomb.

## Fix

**New real image downscaler** — `vtscore.media.image.thumbnail.make_image_thumbnail` (longest side ≤ 384 px; JPEG for opaque, PNG to preserve alpha; EXIF orientation applied). A shared `vtsearch.routes._shared.image_thumbnail_response` helper wraps it with an `ETag` + `Cache-Control` so the browser reuses one thumbnail per item across scrolls and every zoom level.

**Every small-image route now downscales images:**
- new `GET /api/medias/<id>/thumbnail`
- `/api/detectors/<name>/labels/<id>/thumbnail` (in-memory + origin paths → right-panel `labelset-list`)
- `/api/server-media-files/<file>/thumbnail`

**Frontend tiles switched from `/image` to `/thumbnail`:** left-panel `media-item` grid/list (the crash path), right-panel `label-list`, `browse-selection-panel`, `browse-bin-popup`, `browse-canvas`. The center `image-viewer` and `label-view`'s crop overlay intentionally stay full-res (the crop maps coordinates onto real pixels).

**Virtualization hardening** — a `MIN_GRID_ROW_HEIGHT` floor in `media-list.component.ts#measureGridLayout` so a not-yet-laid-out card height can't be locked in as a tiny `itemSize` and collapse virtualization.

The full-resolution `/image` route is unchanged and still backs the detail viewer.

## Tests

- `tests_lib/core/test_image_thumbnail.py` — helper coverage (downscale, max-dim cap, no upscale, alpha→PNG, EXIF orientation, undecodable→None).
- `tests/core/test_medias.py::TestMediaThumbnail` — route coverage (bounded dims, 404, ETag + `Cache-Control`, 304).
- Updated existing thumbnail-route tests (labelset + server-media-files) to assert a bounded re-encoded image instead of raw byte-equality; updated frontend spec URL expectations; regenerated `frontend/openapi.json`.
- Full suite green: **4645 passed, 1 skipped.**

## Notes / follow-ups

- **Breaking change:** thumbnail consumers now hit `/thumbnail` and image thumbnail routes return downscaled (often JPEG-re-encoded) bytes, not the original file. Recorded in `docs/plans/image-thumbnail-tiles.md`, along with an optional future server-side thumbnail LRU.

https://claude.ai/code/session_01FwbaLGnyR1SKcFy7eBxeNp