### PR TITLE
Decouple Browse thumbnail-size from zoom

### DIFF
--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -81,7 +81,7 @@ resolution rather than relying on a closed-form estimate.
 
 | Knob | Current value | Location |
 |------|---------------|----------|
-| Target on-screen hex radius (level picker) | `28` px | `updateActiveLevel`, `:163` |
+| Target on-screen hex radius (level picker) | `28` px default (`DEFAULT_TARGET_RADIUS`), scaled by the thumbnail-size buttons (XS–XL → ×0.5–×2.5) into `targetRadius` | `levelForEffZoom` / `setThumbnailRadius` |
 | Density scale | log (`log(count)/log(maxCount)`) | `drawHex`, `:284` |
 | Colormap | darkred→yellow, 8-stop LUT (black left free for "None"/empty space) | `HEATMAP`, `hex-render.util.ts` |
 | Singleton cell shape | inscribed disc (`HEX_INRADIUS_RATIO`), hex otherwise | `traceCellPath`, `hex-render.util.ts` |

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -69,12 +69,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input() mediaType = '';
   /**
-   * User-controlled on-screen size multiplier for hexes. ``1`` is the default
-   * fit. This scales rendering (positions + hex radius) only; it deliberately
-   * does NOT feed level selection, so growing/shrinking the display never
-   * changes the binning, i.e. which vectors land in a given hex.
+   * Target on-screen bin radius in CSS px: the size each bin/thumbnail aims to
+   * render at. Level selection picks the pyramid level whose bins land closest
+   * to this, so it is the "thumbnail size" knob — bigger value ⇒ bigger, coarser
+   * bins. It is set, not bound: {@link setThumbnailRadius} updates it (and, for
+   * the +/- buttons, scales the view in lock-step so the *same* bins simply use
+   * more pixels rather than re-binning). Default 28 = the "M" thumbnail size.
    */
-  @Input() displayScale = 1;
+  private targetRadius = BrowseCanvasComponent.DEFAULT_TARGET_RADIUS;
   /**
    * Density colormap preset for the flat (non-thumbnail) shading. ``auto``
    * follows the theme (Ocean in light mode, Heat in dark); the others lock to
@@ -160,6 +162,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // 1.15/tick so the gesture lands a decisive jump, matching the map idiom.
   private static readonly DOUBLE_CLICK_ZOOM = 2.0;
 
+  // On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
+  // default before any saved size is applied. See {@link targetRadius}.
+  static readonly DEFAULT_TARGET_RADIUS = 28;
+
   // Shift+drag draws a marquee rectangle (canvas-relative screen coords) that
   // adds every bin whose centre falls inside it to the selection — the fast path
   // for grabbing a region, since plain drag is reserved for panning.
@@ -224,10 +230,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     return binGeometry(this.meta?.bin_shape);
   }
 
-  /** On-screen scale: base zoom × display-size multiplier. Used for all
-   * projection↔screen conversions, rendered hex radius, and level selection. */
+  /** On-screen scale (projection units → CSS px). Used for all projection↔screen
+   * conversions and the rendered bin radius. Thumbnail size no longer folds in
+   * here: it lives in {@link targetRadius} (level selection) and, for the +/-
+   * buttons, in a matching {@link transform}.zoom change, so "Zoom" and
+   * "thumbnail size" are now distinct operations rather than the same multiply. */
   private get effZoom(): number {
-    return this.transform.zoom * this.displayScale;
+    return this.transform.zoom;
   }
 
   ngOnInit(): void {
@@ -300,14 +309,6 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       } else {
         this.updateActiveLevel();
       }
-      this.requestRedraw();
-    }
-    // Display-size changes rescale rendering and require a level re-selection:
-    // effZoom = transform.zoom * displayScale, so a larger displayScale raises
-    // the effective zoom and should switch to a finer pyramid level to keep
-    // hexes near the 28px target, not blow them up.
-    if (changes['displayScale'] && !changes['displayScale'].firstChange) {
-      this.updateActiveLevel();
       this.requestRedraw();
     }
     // Entering region-select mode: drop any hover preview/highlight that was
@@ -393,17 +394,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // active level — and therefore the radius — depends on the zoom we're solving
     // for, so iterate a few times from the no-margin fit to a fixed point (the
     // level is quantised and clamps at 0, so this settles immediately).
-    let zoom =
-      Math.min(w / (dataW * (1 + padding * 2)), h / (dataH * (1 + padding * 2))) /
-      this.displayScale;
+    let zoom = Math.min(
+      w / (dataW * (1 + padding * 2)),
+      h / (dataH * (1 + padding * 2)),
+    );
     for (let i = 0; i < 3; i++) {
-      const level = this.levelForEffZoom(zoom * this.displayScale);
+      const level = this.levelForEffZoom(zoom);
       const r = this.meta.base_radius / Math.pow(2, level);
       const padW = dataW + 2 * (r + dataW * padding);
       const padH = dataH + 2 * (r + dataH * padding);
-      // Fit so the *effective* zoom fills the viewport: divide out displayScale so
-      // a non-default display size still frames the whole projection on load.
-      zoom = Math.min(w / padW, h / padH) / this.displayScale;
+      zoom = Math.min(w / padW, h / padH);
     }
     this.transform.zoom = zoom;
     this.transform.centerX = (xmin + xmax) / 2;
@@ -414,13 +414,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.updateActiveLevel();
   }
 
-  /** Pyramid level whose bins render closest to the target on-screen radius at
-   * the given effective zoom. Shared by live level selection and fit framing. */
+  /** Pyramid level whose bins render closest to the current thumbnail size
+   * ({@link targetRadius}) at the given on-screen zoom. Shared by live level
+   * selection and fit framing. */
   private levelForEffZoom(effZoom: number): number {
     if (!this.meta || this.meta.levels.length === 0) return 0;
-    const targetScreenRadius = 28;
     const idealLevel = Math.log2(
-      (this.meta.base_radius * effZoom) / targetScreenRadius,
+      (this.meta.base_radius * effZoom) / this.targetRadius,
     );
     return Math.max(
       0,
@@ -1029,17 +1029,41 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   zoomBy(factor: number, anchorX = this.width / 2, anchorY = this.height / 2): void {
     const [projX, projY] = this.screenToProj(anchorX, anchorY);
     const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));
-    // Anchor the point under the cursor using the new *effective* zoom so the
-    // display-size multiplier keeps that pixel fixed while zooming.
-    const newEffZoom = newZoom * this.displayScale;
-
-    this.transform.centerX = projX - (anchorX - this.width / 2) / newEffZoom;
-    this.transform.centerY = projY - (anchorY - this.height / 2) / newEffZoom;
+    // Keep the point under the cursor fixed while zooming.
+    this.transform.centerX = projX - (anchorX - this.width / 2) / newZoom;
+    this.transform.centerY = projY - (anchorY - this.height / 2) / newZoom;
     this.transform.zoom = newZoom;
 
+    // Zoom holds the thumbnail size (targetRadius) and re-selects the level, so
+    // a smaller region is re-binned more finely while bins stay ~the same size.
     this.updateActiveLevel();
     this.requestRedraw();
     this.refreshHoverAfterZoom();
+  }
+
+  /**
+   * Set the thumbnail size — the on-screen radius each bin aims to render at.
+   *
+   * `reframe` picks between the two callers:
+   *  - `true` (the +/- thumbnail buttons): scale the view by the same factor as
+   *    the size change so the level is held (level selection divides
+   *    `base_radius * zoom` by `targetRadius`, and scaling both by the same
+   *    factor leaves the quotient — hence the chosen level — unchanged). The
+   *    *same bins* therefore just use more/fewer pixels and the visible region
+   *    shrinks/grows. This is "make the thumbnails bigger", never a re-bin.
+   *  - `false` (initial load / settings sync): only record the size and
+   *    re-select the level at the current framing, so a saved size sets the
+   *    overview granularity without yanking the viewport.
+   */
+  setThumbnailRadius(radius: number, reframe: boolean): void {
+    if (radius <= 0 || radius === this.targetRadius) return;
+    if (reframe && this.meta && this.fittedAgainstRealSize) {
+      this.transform.zoom *= radius / this.targetRadius;
+    }
+    this.targetRadius = radius;
+    this.updateActiveLevel();
+    this.requestRedraw();
+    if (reframe) this.refreshHoverAfterZoom();
   }
 
   private onWheel(event: WheelEvent): void {

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -68,6 +68,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * flat density (darkred→yellow) shading.
    */
   @Input() mediaType = '';
+  /** On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
+   * default before any saved size is applied. See {@link targetRadius}. */
+  static readonly DEFAULT_TARGET_RADIUS = 28;
   /**
    * Target on-screen bin radius in CSS px: the size each bin/thumbnail aims to
    * render at. Level selection picks the pyramid level whose bins land closest
@@ -161,10 +164,6 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // How hard a double-click zooms in about the cursor. Larger than the wheel's
   // 1.15/tick so the gesture lands a decisive jump, matching the map idiom.
   private static readonly DOUBLE_CLICK_ZOOM = 2.0;
-
-  // On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
-  // default before any saved size is applied. See {@link targetRadius}.
-  static readonly DEFAULT_TARGET_RADIUS = 28;
 
   // Shift+drag draws a marquee rectangle (canvas-relative screen coords) that
   // adds every bin whose centre falls inside it to the selection — the fast path

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -63,7 +63,6 @@
           <vt-browse-canvas
             [meta]="meta"
             [mediaType]="mediaType"
-            [displayScale]="hexDisplayScale"
             [colormap]="colormap"
             [thumbnailBorder]="thumbnailBorder"
             [marqueeMode]="marqueeMode"
@@ -102,7 +101,7 @@
                 type="button"
                 class="browse-size-btn"
                 (click)="zoomIn()"
-                title="Zoom in"
+                title="Zoom in — view a smaller region, re-binned finer (thumbnails stay the same size)"
                 aria-label="Zoom in">
                 <vt-icon type="zoom-in" [size]="16"></vt-icon>
               </button>
@@ -118,7 +117,7 @@
                 type="button"
                 class="browse-size-btn"
                 (click)="zoomOut()"
-                title="Zoom out"
+                title="Zoom out — view a larger region, re-binned coarser (thumbnails stay the same size)"
                 aria-label="Zoom out">
                 <vt-icon type="zoom-out" [size]="16"></vt-icon>
               </button>
@@ -129,8 +128,8 @@
                 class="browse-size-btn"
                 [disabled]="atMinHexSize"
                 (click)="bumpHexSize(-1)"
-                title="Smaller cells"
-                aria-label="Smaller cells">
+                title="Smaller thumbnails — same bins, fewer pixels each (shows more of the canvas)"
+                aria-label="Smaller thumbnails">
                 <vt-icon type="image" [size]="11"></vt-icon>
               </button>
               <button
@@ -138,8 +137,8 @@
                 class="browse-size-btn"
                 [disabled]="atMaxHexSize"
                 (click)="bumpHexSize(1)"
-                title="Bigger cells"
-                aria-label="Bigger cells">
+                title="Bigger thumbnails — same bins, more pixels each (shows less of the canvas)"
+                aria-label="Bigger thumbnails">
                 <vt-icon type="image" [size]="18"></vt-icon>
               </button>
             </div>

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -79,12 +79,14 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   datasetName = '';
 
   /**
-   * Discrete on-screen size multipliers for the hexes, one per named icon
-   * size (XS…XL). ``M`` (index 2, scale 1) is the default fit; the
-   * bigger/smaller buttons step through these and the Settings → Browser tab
-   * picks one by name. This only rescales the rendering — it never changes
-   * which vectors land in a hex. The persisted per-media value is the size
-   * *label* (see {@link ICON_SIZES}), not the multiplier.
+   * Discrete thumbnail-size multipliers, one per named icon size (XS…XL),
+   * applied to the canvas's default target bin radius. ``M`` (index 2, scale 1)
+   * is the default. The bigger/smaller buttons step through these and the
+   * Settings → Browser tab picks one by name. Growing the size makes the *same
+   * bins* use more pixels (the view zooms in lock-step, so the binning — which
+   * vectors land in a hex — is unchanged); it is not the "Zoom" control, which
+   * instead re-bins a smaller region more finely. The persisted per-media value
+   * is the size *label* (see {@link ICON_SIZES}), not the multiplier.
    */
   private readonly HEX_SCALES = [0.5, 0.75, 1, 1.6, 2.5];
   /** Named icon sizes, index-aligned with {@link HEX_SCALES}. */
@@ -268,10 +270,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.densityMax = max;
   }
 
-  get hexDisplayScale(): number {
-    return this.HEX_SCALES[this.hexScaleIndex];
-  }
-
   /** Noun for the item-count chip — "positives" for a Find-subset browse. */
   get countNoun(): string {
     return this.subset ? 'positives' : 'items';
@@ -285,8 +283,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     return this.hexScaleIndex === this.HEX_SCALES.length - 1;
   }
 
-  /** Grow (+1) or shrink (-1) the on-screen hex size, clamped to the range,
-   *  and persist the new size as the per-media ``browse_icon_size``. */
+  /** Target bin radius (CSS px) for the current named thumbnail size. */
+  private get thumbnailRadius(): number {
+    return BrowseCanvasComponent.DEFAULT_TARGET_RADIUS * this.HEX_SCALES[this.hexScaleIndex];
+  }
+
+  /** Grow (+1) or shrink (-1) the on-screen thumbnail size, clamped to the
+   *  range, and persist the new size as the per-media ``browse_icon_size``.
+   *  Reframes the canvas so the same bins render bigger/smaller (the region
+   *  shrinks/grows) without changing the binning. */
   bumpHexSize(delta: 1 | -1): void {
     const next = Math.max(
       0,
@@ -294,6 +299,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     );
     if (next === this.hexScaleIndex) return;
     this.hexScaleIndex = next;
+    this.canvas?.setThumbnailRadius(this.thumbnailRadius, true);
     this.persistBrowsePref('browse_icon_size', BrowseViewComponent.ICON_SIZES[next]);
   }
 
@@ -318,6 +324,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     const sizeLabel = mt ? this.perMediaValue(s.browse_icon_size, mt) : '';
     const sizeIdx = (BrowseViewComponent.ICON_SIZES as readonly string[]).indexOf(sizeLabel);
     this.hexScaleIndex = sizeIdx >= 0 ? sizeIdx : 2;
+    // Seed the saved size as the overview granularity (no reframe): a settings
+    // change re-bins at the current framing rather than zooming the viewport,
+    // and on first load the initial fit picks the matching level.
+    this.canvas?.setThumbnailRadius(this.thumbnailRadius, false);
 
     const shape: BinShape = this.perMediaValue(s.browse_bin_shape, mt) === 'square' ? 'square' : 'hex';
     if (shape !== this.binShape) this.switchBinShape(shape, false);


### PR DESCRIPTION
## Problem

In the Browser canvas, the **Zoom** buttons and the **IconSize** (thumbnail-size) buttons were secretly the *same* operation. Both funneled through a single quantity:

```
effZoom = transform.zoom × displayScale
level   = round(log2(base_radius × effZoom / 28))
binPixelRadius = (base_radius / 2^level) × effZoom
```

`effZoom` was the **only** input to *both* the rendered bin pixel size *and* the pyramid level. Zoom scaled `transform.zoom`; IconSize scaled `displayScale` — but multiplied together they were interchangeable. Because the level uses `round(...)`, bins grew continuously within a level, then snapped to half-size-but-finer at each rounding boundary. Whether a given nudge *grew the bins* or *flipped to finer* depended only on where you sat relative to that boundary, identically for both controls — so neither was predictable. (A stale comment even claimed IconSize "never changes which vectors land in a hex" while the code re-ran level selection on every IconSize change.)

## Fix

Split the two real degrees of freedom — **bin pixel size** and **granularity** — so each control moves one and holds the other:

- **Zoom / scroll-wheel** changes `transform.zoom` only, holding the thumbnail size (`targetRadius`) and re-selecting the level. A smaller region is re-binned **finer** while bins stay ~the same size. This is the only control that changes granularity.
- **Thumbnail-size buttons** scale the view in lock-step with `targetRadius` (the level is held by construction, since level selection divides `base_radius × zoom` by `targetRadius` and both scale by the same factor). The **same bins** simply render with more/fewer pixels and the visible region shrinks/grows — never a re-bin.

### Changes
- Drop `displayScale` from `effZoom`; `effZoom` is now just `transform.zoom`.
- `targetRadius` (default `28`, scaled XS–XL → ×0.5–×2.5) feeds level selection.
- New `setThumbnailRadius(radius, reframe)` on the canvas: the +/- buttons call it with `reframe: true` (scale the view, hold the level); settings-sync / initial load call it with `reframe: false` (seed the size as the overview granularity without yanking the viewport).
- Tooltips now spell out exactly what each control does.

Scroll-wheel stays Zoom only (no ctrl+scroll thumbnail gesture — browsers grab ctrl+wheel for page zoom).

## Note
The Settings → Browser **size dropdown** changes the size with `reframe: false` (re-bins at the current framing) rather than zooming the viewport like the live +/- buttons; it reads as a "default overview size" preference. The minimap viewport rect now tracks `transform.zoom`, so it correctly shrinks when thumbnails grow.

## Testing
- `./run-tests.sh core` — ALL 722 tests passed (ruff / codespell / deptry / frontend `build:prod` all clean, no warnings).

https://claude.ai/code/session_01Tiw4Ajf9jVFiWhQMPNBpbd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tiw4Ajf9jVFiWhQMPNBpbd)_