### PR TITLE
Store dataset containers uncompressed to kill the save-stage load stall

### DIFF
--- a/tests_lib/datasets/test_container.py
+++ b/tests_lib/datasets/test_container.py
@@ -66,6 +66,38 @@ class TestContainerFormat:
         assert meta["clipper"] == "test_clipper"
         assert meta["name"] == "Test Dataset"
 
+    def test_payload_stored_uncompressed(self, tmp_path):
+        """medias.pkl must be stored (ZIP_STORED), not DEFLATE-compressed.
+
+        The payload is float32 embeddings + already-compressed media_bytes,
+        both incompressible: DEFLATE burned seconds scanning every byte for
+        zero gain, the bulk of the post-diversity "Saving to registry…"
+        stall.  Pin STORED so the latency fix can't silently regress.
+        """
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(), _meta())
+        with zipfile.ZipFile(str(path), "r") as zf:
+            for info in zf.infolist():
+                assert info.compress_type == zipfile.ZIP_STORED, (
+                    f"{info.filename} is compressed ({info.compress_type}); expected ZIP_STORED"
+                )
+
+    def test_reads_legacy_deflate_container(self, tmp_path):
+        """Pre-existing DEFLATE-compressed containers must still load.
+
+        Switching writes to STORED must not orphan datasets written by an
+        older build; zipfile decompresses any method on read.
+        """
+        path = tmp_path / "legacy.pkl"
+        with zipfile.ZipFile(str(path), "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("medias.pkl", _medias_pkl_bytes())
+            import json
+
+            zf.writestr("meta.json", json.dumps(_meta()))
+        data, meta = read_container(path)
+        assert len(data["medias"]) == 5
+        assert meta["embedder"] == "test_embedder"
+
     def test_read_meta_only(self, tmp_path):
         path = tmp_path / "dataset.pkl"
         write_container(path, _medias_pkl_bytes(), _meta())

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -61,8 +61,15 @@ def write_container(
         pickle.dump(data, buf, protocol=5)
         medias_pickle_bytes = buf.getvalue()
 
+    # Store the payload uncompressed (ZIP_STORED).  The pickle is dominated
+    # by float32 embeddings and already-compressed media_bytes (JPEG/PNG/
+    # audio), both of which DEFLATE cannot shrink — on an image dataset it
+    # burned ~9s scanning every byte to save zero space, the bulk of the
+    # post-diversity "Saving to registry…" stall.  Reads are unaffected:
+    # zipfile decompresses any method, so legacy DEFLATE containers still
+    # load.
     if isinstance(dest, io.BytesIO):
-        with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_STORED) as zf:
             zf.writestr("medias.pkl", medias_pickle_bytes)
             zf.writestr("meta.json", json.dumps(meta, indent=2))
         return
@@ -72,7 +79,7 @@ def write_container(
     fd, tmp = tempfile.mkstemp(dir=p.parent, suffix=".tmp")
     try:
         with os.fdopen(fd, "wb") as raw:
-            with zipfile.ZipFile(raw, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            with zipfile.ZipFile(raw, "w", compression=zipfile.ZIP_STORED) as zf:
                 zf.writestr("medias.pkl", medias_pickle_bytes)
                 zf.writestr("meta.json", json.dumps(meta, indent=2))
         os.replace(tmp, str(p))

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -591,6 +591,7 @@ def _auto_register_dataset(
     created_by: str = "",
     display_name: str | None = None,
     ingest_started_at: float | None = None,
+    on_stage: Callable[[str], None] | None = None,
 ) -> dict | None:
     """Save *media_dict* as a pkl and register in the dataset registry.
 
@@ -601,6 +602,8 @@ def _auto_register_dataset(
     """
     if not media_dict:
         return None
+
+    _stage = on_stage or (lambda _msg: None)
 
     first = next(iter(media_dict.values()))
     media_type = first.get("media_type", "audio")
@@ -657,13 +660,16 @@ def _auto_register_dataset(
             name=name,
             created_at=now,
             expires_at=expires_at,
+            on_stage=on_stage,
         )
+        _stage("Writing to disk…")
         Path(pkl_path).write_bytes(data_bytes)
         del data_bytes
     except Exception:
         traceback.print_exc()
         return None
 
+    _stage("Registering dataset…")
     try:
         entry = _reg_register(
             name=name,
@@ -1135,7 +1141,13 @@ def _register_and_migrate(
     in-memory migration steps raise, the entry is rolled back before the
     exception propagates so we never leave an orphan on disk.
     """
-    tracker.update("loading", "Saving to registry…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
+
+    def _on_stage(message: str) -> None:
+        # Keep the dashboard row alive through the otherwise-silent
+        # serialize → write → register window (the old "frozen bar" gap).
+        tracker.update("loading", message, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
+
+    _on_stage("Saving to registry…")
     entry = _auto_register_dataset(
         ctx.medias,
         name=name,
@@ -1146,6 +1158,7 @@ def _register_and_migrate(
         created_by=created_by,
         display_name=name,
         ingest_started_at=ingest_started_at,
+        on_stage=_on_stage,
     )
     if entry is None:
         return task_id, None

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -166,6 +166,7 @@ def export_dataset_to_file(
     created_at: float | None = None,
     expires_at: float | None = None,
     extra_pickle_keys: dict[str, Any] | None = None,
+    on_stage: Callable[[str], None] | None = None,
 ) -> bytes:
     """Serialise the current media dataset to a ZIP container byte string.
 
@@ -184,6 +185,9 @@ def export_dataset_to_file(
         expires_at: Unix timestamp when the dataset expires (``None`` = never).
         extra_pickle_keys: Additional top-level keys for the pickle dict
             (e.g. ``audio_dir``, ``video_dir``).
+        on_stage: Optional callback fired with a human-readable message
+            before each internal stage (build dict / pickle / package), so
+            a caller can keep a progress bar moving during serialisation.
 
     Returns:
         Raw bytes of the ZIP container.
@@ -192,6 +196,8 @@ def export_dataset_to_file(
 
     from vtscore.datasets.container import write_container
 
+    if on_stage:
+        on_stage("Serializing dataset…")
     data: dict[str, Any] = {
         "medias": {
             cid: {
@@ -233,6 +239,8 @@ def export_dataset_to_file(
         "expires_at": expires_at,
     }
 
+    if on_stage:
+        on_stage("Packaging dataset…")
     out_buf = io.BytesIO()
     write_container(
         out_buf,


### PR DESCRIPTION
## What

Fixes the ~6-second freeze at the end of a dataset load — the gap *after* the diversity index finishes but *before* the load reports done, where the progress bar sat silently on "Saving to registry…".

## Root cause

After diversity, the load enters `_register_and_migrate` → `_auto_register_dataset` → `export_dataset_to_file`, which pickles the whole dataset and **ZIP-compresses it with DEFLATE** before writing to disk (`vtscore/datasets/container.py`). That stage emitted one "Saving to registry…" message and then ran silently.

The payload is **fundamentally incompressible**: embeddings are float32 noise and `media_bytes` holds already-compressed JPEG/PNG/audio. DEFLATE spent the entire window scanning every byte for essentially zero gain.

Benchmark on synthetic-but-realistic data:

| Dataset | DEFLATE (before) | STORED (after) | Size change |
|---|---|---|---|
| 5k items, 512-dim emb, ~40KB media_bytes each (images) | **9.0 s** | **0.17 s** | 210.7→210.6 MB (smaller) |
| 20k items, embeddings only | 1.75 s | 0.07 s | +0.1 MB |
| 5k items, embeddings only | 0.46 s | 0.01 s | +1 MB |

## Change

- Switch the container ZIP from `ZIP_DEFLATED` to `ZIP_STORED`. Reads are unaffected — `zipfile` decompresses any method transparently, so **existing DEFLATE containers still load** (regression-tested).
- Thread per-stage progress messages (Serializing → Packaging → Writing to disk → Registering) through the save path so the dashboard row keeps moving instead of freezing.
- Add container tests pinning the STORED format and verifying legacy DEFLATE containers still read.

## Backwards compatibility

New dataset `.pkl` containers are written uncompressed. Old DEFLATE-compressed containers continue to load unchanged. Uncompressed containers are slightly larger only for text-heavy datasets (where `media_string` prose would have compressed); media datasets are the same size or smaller.

## Testing

Full suite green: `ALL 4645 TESTS PASSED`.

https://claude.ai/code/session_01TDpLjbT7wLrfD4WRVTaCtW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDpLjbT7wLrfD4WRVTaCtW)_