### PR TITLE
Contain-fit thumbnails in hovered browse bins; enlarge hover bump

### DIFF
--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -37,6 +37,13 @@ export interface BinGeometry {
    * inside a cell of the given `radius` — the hover hit-test predicate.
    */
   contains(ox: number, oy: number, radius: number): boolean;
+  /**
+   * Half-width / half-height of the cell's bounding box at the given screen
+   * `radius`. Used to contain-fit a thumbnail inside a cell: a hex is wider
+   * than tall (`√3·radius` × `2·radius`) while a square is `√3·radius` on a
+   * side, so the fit box differs by shape.
+   */
+  contentHalfExtent(radius: number): { hw: number; hh: number };
 }
 
 // Pointy-top hexagon: column spacing `radius·√3`, row spacing `radius·1.5`.
@@ -47,6 +54,7 @@ const HEX_GEOMETRY: BinGeometry = {
   dy: (radius) => radius * 1.5,
   traceCell: (ctx, cx, cy, radius, single) => traceHexCellPath(ctx, cx, cy, radius, single),
   contains: (ox, oy, radius) => ox * ox + oy * oy < radius * radius,
+  contentHalfExtent: (radius) => ({ hw: (radius * SQRT3) / 2, hh: radius }),
 };
 
 // Corner radius of a square-mode singleton, as a fraction of its half-side. A
@@ -75,6 +83,10 @@ const SQUARE_GEOMETRY: BinGeometry = {
   contains: (ox, oy, radius) => {
     const half = (radius * SQRT3) / 2;
     return Math.abs(ox) < half && Math.abs(oy) < half;
+  },
+  contentHalfExtent: (radius) => {
+    const half = (radius * SQRT3) / 2;
+    return { hw: half, hh: half };
   },
 };
 

--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -6,7 +6,13 @@
 // captures exactly those differences behind one `BinGeometry` interface so the
 // canvas and minimap stay shape-agnostic.
 
-import { SQRT3, traceCellPath as traceHexCellPath, densityColor, resolveColormap } from './hex-render.util';
+import {
+  SQRT3,
+  HEX_ANGLES,
+  traceCellPath as traceHexCellPath,
+  densityColor,
+  resolveColormap,
+} from './hex-render.util';
 import type { BinShape } from '../../models/projection.models';
 
 export { SQRT3, densityColor, resolveColormap };
@@ -44,6 +50,71 @@ export interface BinGeometry {
    * side, so the fit box differs by shape.
    */
   contentHalfExtent(radius: number): { hw: number; hh: number };
+  /**
+   * Trace the pile cell outline clipped to the centered axis-aligned rectangle
+   * of half-extents `(hw, hh)` as the current path. This is the cell shape with
+   * the corners that stick out past the rectangle lopped off — used to draw a
+   * hovered thumbnail tile trimmed to the thumbnail's contain-fit rectangle, so
+   * the enlarged tile doesn't paint background over its neighbours. The outer
+   * `radius` (and so the shape away from the cut) is unchanged.
+   */
+  traceTrimmedCell(
+    ctx: CanvasRenderingContext2D,
+    cx: number,
+    cy: number,
+    radius: number,
+    hw: number,
+    hh: number,
+  ): void;
+}
+
+// Sutherland–Hodgman clip of a convex polygon (local coords, centered on the
+// origin) against one axis-aligned half-plane, returning the clipped polygon.
+type Pt = { x: number; y: number };
+function clipHalfPlane(poly: Pt[], axis: 'x' | 'y', value: number, keepGreater: boolean): Pt[] {
+  if (poly.length === 0) return poly;
+  const inside = (p: Pt) => (keepGreater ? p[axis] >= value : p[axis] <= value);
+  const crossing = (a: Pt, b: Pt): Pt => {
+    const t = (value - a[axis]) / (b[axis] - a[axis]);
+    return axis === 'x'
+      ? { x: value, y: a.y + (b.y - a.y) * t }
+      : { x: a.x + (b.x - a.x) * t, y: value };
+  };
+  const out: Pt[] = [];
+  for (let i = 0; i < poly.length; i++) {
+    const cur = poly[i];
+    const prev = poly[(i + poly.length - 1) % poly.length];
+    const curIn = inside(cur);
+    if (curIn) {
+      if (!inside(prev)) out.push(crossing(prev, cur));
+      out.push(cur);
+    } else if (inside(prev)) {
+      out.push(crossing(prev, cur));
+    }
+  }
+  return out;
+}
+
+// Trace `verts` (local, origin-centered) clipped to the `±hw × ±hh` rectangle as
+// the current path at screen center `(cx, cy)`.
+function traceClippedPolygon(
+  ctx: CanvasRenderingContext2D,
+  verts: Pt[],
+  cx: number,
+  cy: number,
+  hw: number,
+  hh: number,
+): void {
+  let poly = clipHalfPlane(verts, 'x', -hw, true);
+  poly = clipHalfPlane(poly, 'x', hw, false);
+  poly = clipHalfPlane(poly, 'y', -hh, true);
+  poly = clipHalfPlane(poly, 'y', hh, false);
+  ctx.beginPath();
+  poly.forEach((p, i) => {
+    if (i === 0) ctx.moveTo(cx + p.x, cy + p.y);
+    else ctx.lineTo(cx + p.x, cy + p.y);
+  });
+  ctx.closePath();
 }
 
 // Pointy-top hexagon: column spacing `radius·√3`, row spacing `radius·1.5`.
@@ -55,6 +126,13 @@ const HEX_GEOMETRY: BinGeometry = {
   traceCell: (ctx, cx, cy, radius, single) => traceHexCellPath(ctx, cx, cy, radius, single),
   contains: (ox, oy, radius) => ox * ox + oy * oy < radius * radius,
   contentHalfExtent: (radius) => ({ hw: (radius * SQRT3) / 2, hh: radius }),
+  traceTrimmedCell: (ctx, cx, cy, radius, hw, hh) => {
+    const verts = HEX_ANGLES.map((a) => ({
+      x: radius * Math.cos(a),
+      y: radius * Math.sin(a),
+    }));
+    traceClippedPolygon(ctx, verts, cx, cy, hw, hh);
+  },
 };
 
 // Corner radius of a square-mode singleton, as a fraction of its half-side. A
@@ -87,6 +165,16 @@ const SQUARE_GEOMETRY: BinGeometry = {
   contentHalfExtent: (radius) => {
     const half = (radius * SQRT3) / 2;
     return { hw: half, hh: half };
+  },
+  traceTrimmedCell: (ctx, cx, cy, radius, hw, hh) => {
+    const half = (radius * SQRT3) / 2;
+    const verts: Pt[] = [
+      { x: -half, y: -half },
+      { x: half, y: -half },
+      { x: half, y: half },
+      { x: -half, y: half },
+    ];
+    traceClippedPolygon(ctx, verts, cx, cy, hw, hh);
   },
 };
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -51,7 +51,7 @@ export interface BrowseContextMenuEvent {
 /** How much larger the hovered cell is drawn relative to its neighbours so it
  *  lifts off the grid. The border is reserved for selection state, so hover is
  *  signalled by this size bump + a soft drop shadow instead of a ring. */
-const HOVER_RADIUS_SCALE = 1.18;
+const HOVER_RADIUS_SCALE = 1.38;
 
 @Component({
   selector: 'vt-browse-canvas',
@@ -813,6 +813,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     cell: HexCellPayload,
     cmap: ResolvedColormap,
     selectionActive: boolean,
+    fitMode: 'cover' | 'contain' = 'cover',
   ): void {
     // A cell with one item is drawn as a disc (slightly smaller than the cell);
     // multi-item cells keep their full shape so they tile the space.
@@ -821,12 +822,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
     // Image / video: paint the central item's thumbnail clipped to the cell.
     // Until it loads, fall back to the density shading below so the cell is
-    // never blank.
+    // never blank. Grid cells cover-fit (fill the bin, cropping the edges);
+    // the hovered cell contain-fits so a thumbnail clipped by its bin shows in
+    // full, scaled down to sit inside the enlarged view.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
     if (thumb) {
       ctx.save();
       ctx.clip();
-      this.drawImageCover(ctx, thumb, cx, cy, radius);
+      if (fitMode === 'contain') {
+        this.drawImageContain(ctx, thumb, cx, cy, radius);
+      } else {
+        this.drawImageCover(ctx, thumb, cx, cy, radius);
+      }
       ctx.restore();
     } else if (single) {
       // Singletons get the colormap's dedicated one-item colour, decoupled
@@ -901,7 +908,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.fill();
     ctx.restore();
 
-    this.drawHex(ctx, cx, cy, bumped, cell, cmap, selectionActive);
+    this.drawHex(ctx, cx, cy, bumped, cell, cmap, selectionActive, 'contain');
   }
 
   /** Cover-fit an image over the hex's 2*radius square (the path must be clipped). */
@@ -914,6 +921,25 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   ): void {
     const size = radius * 2;
     const scale = Math.max(size / img.naturalWidth, size / img.naturalHeight);
+    const dw = img.naturalWidth * scale;
+    const dh = img.naturalHeight * scale;
+    ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);
+  }
+
+  /** Contain-fit an image inside the cell's bounding box so the whole frame is
+   *  visible (letterboxed against the cell's base fill). Used for the hovered
+   *  cell, where a thumbnail clipped in the grid should show in full. The fit
+   *  box follows the shape (hex is wider than tall, square is even) so wide
+   *  thumbnails aren't re-cropped by the cell silhouette. */
+  private drawImageContain(
+    ctx: CanvasRenderingContext2D,
+    img: HTMLImageElement,
+    cx: number,
+    cy: number,
+    radius: number,
+  ): void {
+    const { hw, hh } = this.geom.contentHalfExtent(radius);
+    const scale = Math.min((hw * 2) / img.naturalWidth, (hh * 2) / img.naturalHeight);
     const dw = img.naturalWidth * scale;
     const dh = img.naturalHeight * scale;
     ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -813,24 +813,29 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     cell: HexCellPayload,
     cmap: ResolvedColormap,
     selectionActive: boolean,
-    fitMode: 'cover' | 'contain' = 'cover',
+    trim: { hw: number; hh: number } | null = null,
   ): void {
     // A cell with one item is drawn as a disc (slightly smaller than the cell);
-    // multi-item cells keep their full shape so they tile the space.
+    // multi-item cells keep their full shape so they tile the space. The hovered
+    // cell instead passes `trim`: its outline is the cell clipped to the
+    // thumbnail's contain-fit rectangle, so the enlarged tile is just the
+    // thumbnail with the protruding corners lopped off rather than background
+    // bars painted over the neighbours.
     const single = cell.count === 1;
-    this.geom.traceCell(ctx, cx, cy, radius, single);
+    if (trim) this.geom.traceTrimmedCell(ctx, cx, cy, radius, trim.hw, trim.hh);
+    else this.geom.traceCell(ctx, cx, cy, radius, single);
 
     // Image / video: paint the central item's thumbnail clipped to the cell.
     // Until it loads, fall back to the density shading below so the cell is
-    // never blank. Grid cells cover-fit (fill the bin, cropping the edges);
-    // the hovered cell contain-fits so a thumbnail clipped by its bin shows in
-    // full, scaled down to sit inside the enlarged view.
+    // never blank. Grid cells cover-fit (fill the bin, cropping the edges); the
+    // hovered cell instead draws the thumbnail contain-fit into `trim`, which
+    // its trimmed outline matches, so the whole frame shows with no letterbox.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
     if (thumb) {
       ctx.save();
       ctx.clip();
-      if (fitMode === 'contain') {
-        this.drawImageContain(ctx, thumb, cx, cy, radius);
+      if (trim) {
+        ctx.drawImage(thumb, cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
       } else {
         this.drawImageCover(ctx, thumb, cx, cy, radius);
       }
@@ -896,6 +901,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     selectionActive: boolean,
   ): void {
     const bumped = radius * HOVER_RADIUS_SCALE;
+    // With a thumbnail, trim the tile to the thumbnail's contain-fit rectangle
+    // so the enlarged cell is just the (whole) thumbnail — no background bars
+    // reaching over the neighbours. Without one (flat density), keep the full
+    // bumped cell.
+    const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
+    const trim = thumb ? this.containRect(thumb, bumped) : null;
+
     // Cast a single clean drop shadow from an opaque base shape first, then
     // paint the real (shadow-free) cell on top so the fill/border don't each
     // stack their own shadow.
@@ -903,12 +915,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
     ctx.shadowBlur = Math.max(4, radius * 0.3);
     ctx.shadowOffsetY = Math.max(1, radius * 0.1);
-    this.geom.traceCell(ctx, cx, cy, bumped, cell.count === 1);
+    if (trim) this.geom.traceTrimmedCell(ctx, cx, cy, bumped, trim.hw, trim.hh);
+    else this.geom.traceCell(ctx, cx, cy, bumped, cell.count === 1);
     ctx.fillStyle = this.themeColor('--bg-body');
     ctx.fill();
     ctx.restore();
 
-    this.drawHex(ctx, cx, cy, bumped, cell, cmap, selectionActive, 'contain');
+    this.drawHex(ctx, cx, cy, bumped, cell, cmap, selectionActive, trim);
   }
 
   /** Cover-fit an image over the hex's 2*radius square (the path must be clipped). */
@@ -926,23 +939,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);
   }
 
-  /** Contain-fit an image inside the cell's bounding box so the whole frame is
-   *  visible (letterboxed against the cell's base fill). Used for the hovered
-   *  cell, where a thumbnail clipped in the grid should show in full. The fit
-   *  box follows the shape (hex is wider than tall, square is even) so wide
-   *  thumbnails aren't re-cropped by the cell silhouette. */
-  private drawImageContain(
-    ctx: CanvasRenderingContext2D,
-    img: HTMLImageElement,
-    cx: number,
-    cy: number,
-    radius: number,
-  ): void {
+  /** Half-extents of an image contain-fit into the cell's bounding box at the
+   *  given `radius`. The fit box follows the shape (hex is wider than tall,
+   *  square is even) so wide thumbnails aren't re-cropped by the silhouette. */
+  private containRect(img: HTMLImageElement, radius: number): { hw: number; hh: number } {
     const { hw, hh } = this.geom.contentHalfExtent(radius);
     const scale = Math.min((hw * 2) / img.naturalWidth, (hh * 2) / img.naturalHeight);
-    const dw = img.naturalWidth * scale;
-    const dh = img.naturalHeight * scale;
-    ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);
+    return { hw: (img.naturalWidth * scale) / 2, hh: (img.naturalHeight * scale) / 2 };
   }
 
   /**


### PR DESCRIPTION
## Summary

In the browse canvas, thumbnails are **cover-fit** to fill their bin in the grid (cropping the edges). When you mouse over a bin and it expands, it kept cover-fitting, so a thumbnail clipped by its bin stayed clipped.

This change makes the **hovered (expanded) tile show the whole thumbnail**, and does it without wasting space:

- The enlarged tile's outline is **trimmed to the thumbnail's contain-fit rectangle** — the cell shape with the corners that stick out past the thumbnail lopped off. So the tile is just the (whole) thumbnail: **hex-ish in hex mode** (slanted sides kept, the top/bottom points cut to the thumbnail's height), the **rectangle itself in square mode**. No background bars are painted over the neighbouring thumbnails.
- The outer radius is unchanged; only the protruding corners that would block neighbours are cut.
- The thumbnail's fit box follows the bin shape (a hex is wider than tall, `√3·radius` × `2·radius`; a square is even), so wide thumbnails aren't re-cropped by the silhouette.
- The hover **enlarge bump** goes from `1.18×` to `1.38×` so the expanded tile reads more clearly.

Applies to both hex and square bin modes.

Note: a single-item bin (drawn as a disc / rounded square in the static grid) becomes the trimmed hex/square polygon while hovered, so all hovered thumbnails share one trim rule. The disc/rounded-square treatment is unchanged in the grid itself.

## Implementation

- `bin-geometry.ts`: add `contentHalfExtent(radius)` (per-shape fit box) and `traceTrimmedCell(ctx, cx, cy, radius, hw, hh)`, which clips the pile polygon to the centered rect via Sutherland–Hodgman and traces the result.
- `browse-canvas.component.ts`: bump `HOVER_RADIUS_SCALE`; `drawHex` takes an optional `trim` (the thumbnail's contain-fit half-extents) — when set it traces the trimmed outline and draws the thumbnail into it (the outline matches the rect, so no letterbox); `drawHoveredHex` computes the trim and casts the drop shadow / border from the trimmed shape.

Frontend `build:prod` passes clean (no errors/warnings). This is a canvas-rendering-only change (no Python touched).

https://claude.ai/code/session_01Jr7SSn2wbfR8ezh4p9DApu