### PR TITLE
VTSBrowser: bottom-pinned legend, larger thumbnails, fit-on-open, minimap fit

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -149,6 +149,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // `resize()`; this flag stops later window resizes from clobbering the user's
   // pan/zoom.
   private fittedAgainstRealSize = false;
+  // Whether the user has taken over the framing (panned, zoomed, or resized a
+  // thumbnail). Until then the view stays auto-fit: applying a saved cell size
+  // (which changes the bin radius and thus how far edge bins reach) re-fits so
+  // the projection opens fully in view, rather than leaving the initial fit —
+  // computed for the default radius — clipping the now-larger edge bins.
+  private framedByUser = false;
 
   private isPanning = false;
   private panStartX = 0;
@@ -322,6 +328,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       // re-frames to data and drops stale representative thumbnails.
       if (this.meta.projection_id !== this.lastProjectionId) {
         this.lastProjectionId = this.meta.projection_id;
+        // A brand-new projection opens auto-fit: clear the user-framed flag so a
+        // saved cell size applied right after load re-fits to keep it all in view.
+        this.framedByUser = false;
         this.thumbCache.clear();
         this.thumbFailed.clear();
         // A new projection (media-type switch / rebuild) re-lays-out every item,
@@ -1057,6 +1066,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       Math.abs(dy) > BrowseCanvasComponent.CLICK_MOVE_THRESHOLD
     ) {
       this.dragMoved = true;
+      this.framedByUser = true;
     }
     const z = this.effZoom;
     this.transform.centerX = this.panStartCenterX - dx / z;
@@ -1219,6 +1229,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   zoomBy(factor: number, anchorX = this.width / 2, anchorY = this.height / 2): void {
+    this.framedByUser = true;
     const prevLevel = this.activeLevel;
     const [projX, projY] = this.screenToProj(anchorX, anchorY);
     const newZoom = Math.max(0.01, Math.min(100000, this.transform.zoom * factor));
@@ -1253,10 +1264,20 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   setThumbnailRadius(radius: number, reframe: boolean): void {
     if (radius <= 0 || radius === this.targetRadius) return;
     if (reframe && this.meta && this.fittedAgainstRealSize) {
+      this.framedByUser = true;
       this.transform.zoom *= radius / this.targetRadius;
     }
     this.targetRadius = radius;
-    this.updateActiveLevel();
+    // On initial load (the user hasn't framed yet) a saved cell size changes the
+    // bin radius, so re-fit to keep the whole projection in view rather than
+    // letting the now-larger edge bins spill past the default-radius framing.
+    // Once the user has panned/zoomed, only re-select the level so their view is
+    // preserved.
+    if (!reframe && !this.framedByUser && this.meta && this.fittedAgainstRealSize) {
+      this.fitToData();
+    } else {
+      this.updateActiveLevel();
+    }
     this.requestRedraw();
     if (reframe) this.refreshHoverAfterZoom();
   }

--- a/frontend/src/app/components/browse-legend/browse-legend.component.scss
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.scss
@@ -1,14 +1,13 @@
-// Vertical color key for the density shading. Docked in the browse side
-// panel's bottom meta-row beside the overview minimap. Purely informational.
+// Horizontal color key for the density shading. Docked along the bottom of the
+// browse side panel, beneath the overview minimap. Purely informational.
 .browse-legend {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--space-sm);
+  gap: var(--space-2xs);
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  padding: var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
   pointer-events: none;
 }
 
@@ -19,33 +18,43 @@
   white-space: nowrap;
 }
 
-// The swatch and its tick labels share one height so the labels line up with
-// the gradient they annotate.
-.browse-legend-body {
+// The single-item swatch and the density ramp sit side by side in one row.
+.browse-legend-row {
   display: flex;
-  align-items: stretch;
-  gap: var(--space-xs);
-  height: 140px;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
-// The swatch itself: a tall, narrow stripe carrying the density ramp (dense at
-// the top).
+// The swatch and its tick labels stack so the labels sit under the gradient
+// they annotate. Grows to fill the row width to the right of the single dot.
+.browse-legend-body {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+// The swatch itself: a wide, short stripe carrying the density ramp (dense at
+// the right).
 .browse-legend-bar {
-  width: 10px;
+  height: 10px;
+  width: 100%;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
 }
 
-// Ramp tick labels are absolutely placed at their fractional height up the bar
-// and centered on that mark, so each number sits beside the color it denotes.
+// Ramp tick labels are absolutely placed at their fractional position along the
+// bar and centered on that mark, so each number sits beneath the color it
+// denotes.
 .browse-legend-ticks {
   position: relative;
-  min-width: 2.5ch;
+  height: 1em;
 
   .browse-legend-tick {
     position: absolute;
-    left: 0;
-    transform: translateY(50%);
+    top: 0;
+    transform: translateX(-50%);
   }
 }
 
@@ -62,7 +71,8 @@
 .browse-legend-single {
   display: flex;
   align-items: center;
-  gap: var(--space-xs);
+  gap: var(--space-2xs);
+  flex: none;
 }
 
 .browse-legend-dot {

--- a/frontend/src/app/components/browse-legend/browse-legend.component.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.ts
@@ -15,7 +15,7 @@ interface LegendTick {
 }
 
 /**
- * Vertical color key for the browse canvas. The canvas shades each cell by its
+ * Horizontal color key for the browse canvas. The canvas shades each cell by its
  * item count: a one-item cell gets the colormap's dedicated ``single`` colour
  * (drawn as a dot), and multi-item cells use the density ``ramp``, renormalized
  * to the densest cell currently in view — so the ramp's top is {@link maxCount}
@@ -33,21 +33,23 @@ interface LegendTick {
   template: `
     <div class="browse-legend" role="img" [attr.aria-label]="ariaLabel">
       <span class="browse-legend-title">{{ title }}</span>
-      @if (ticks.length > 0) {
-        <div class="browse-legend-body">
-          <div class="browse-legend-bar" [style.background]="barGradient"></div>
-          <div class="browse-legend-ticks">
-            @for (tick of ticks; track tick.t) {
-              <span class="browse-legend-tick" [style.bottom.%]="tick.t * 100">{{
-                tick.label
-              }}</span>
-            }
-          </div>
+      <div class="browse-legend-row">
+        <div class="browse-legend-single">
+          <span class="browse-legend-dot" [style.background]="singleColor"></span>
+          <span class="browse-legend-tick">1</span>
         </div>
-      }
-      <div class="browse-legend-single">
-        <span class="browse-legend-dot" [style.background]="singleColor"></span>
-        <span class="browse-legend-tick">1</span>
+        @if (ticks.length > 0) {
+          <div class="browse-legend-body">
+            <div class="browse-legend-bar" [style.background]="barGradient"></div>
+            <div class="browse-legend-ticks">
+              @for (tick of ticks; track tick.t) {
+                <span class="browse-legend-tick" [style.left.%]="tick.t * 100">{{
+                  tick.label
+                }}</span>
+              }
+            </div>
+          </div>
+        }
       </div>
     </div>
   `,
@@ -90,9 +92,9 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
     return resolveColormap(this.colormap, this.theme);
   }
 
-  /** Vertical gradient with the dense (last ramp stop) end at the top. */
+  /** Horizontal gradient with the dense (last ramp stop) end at the right. */
   get barGradient(): string {
-    return `linear-gradient(to top, ${gradientStops(this.resolved.ramp)})`;
+    return `linear-gradient(to right, ${gradientStops(this.resolved.ramp)})`;
   }
 
   /** The one-item cell colour, shown as a dot. */
@@ -104,8 +106,9 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
    * Tick labels for the ramp (multi-item cells, count ≥ 2). The canvas maps a
    * count to a height via `t = ln(count) / ln(maxCount)`, so a height `t` reads
    * back as `count = maxCount^t` and each label sits exactly at the color that
-   * count is painted with. Sampled top→bottom, deduped, and dropping anything
-   * that rounds below 2 (those are singletons, shown by the dot instead).
+   * count is painted with (placed left→right along the bar). Sampled high→low,
+   * deduped, and dropping anything that rounds below 2 (those are singletons,
+   * shown by the dot instead).
    */
   get ticks(): LegendTick[] {
     const max = Math.max(Math.round(this.maxCount), 1);

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -253,6 +253,14 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Projection→minimap scale (fits the whole extent inside an inset margin)
    * and the data centre, or ``null`` when there's nothing to map.
+   *
+   * ``bounds`` is the extent of the bin *centres*, but each edge bin is drawn
+   * out to its circumradius beyond its centre, so scaling on the centres alone
+   * clips the edge bins off the minimap. We add the overview-level bin radius
+   * (in projection units) as margin on every side. That radius depends on the
+   * scale we're solving for (the overview level is chosen from it), so iterate
+   * from the no-margin fit to a fixed point — the level is quantised, so this
+   * settles immediately.
    */
   private fit(): { scale: number; cx: number; cy: number; margin: number } | null {
     if (!this.meta || this.meta.point_count === 0) return null;
@@ -260,10 +268,14 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     const dataW = xmax - xmin || 1;
     const dataH = ymax - ymin || 1;
     const margin = 4;
-    const scale = Math.min(
-      (this.width - margin * 2) / dataW,
-      (this.height - margin * 2) / dataH,
-    );
+    const availW = this.width - margin * 2;
+    const availH = this.height - margin * 2;
+    let scale = Math.min(availW / dataW, availH / dataH);
+    for (let i = 0; i < 3; i++) {
+      const level = this.overviewLevel({ scale });
+      const r = this.meta.base_radius / Math.pow(2, level);
+      scale = Math.min(availW / (dataW + 2 * r), availH / (dataH + 2 * r));
+    }
     return { scale, cx: (xmin + xmax) / 2, cy: (ymin + ymax) / 2, margin };
   }
 

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -101,7 +101,7 @@
                 type="button"
                 class="browse-size-btn"
                 (click)="zoomIn()"
-                title="Zoom in — view a smaller region, re-binned finer (thumbnails stay the same size)"
+                title="Zoom In"
                 aria-label="Zoom in">
                 <vt-icon type="zoom-in" [size]="16"></vt-icon>
               </button>
@@ -117,7 +117,7 @@
                 type="button"
                 class="browse-size-btn"
                 (click)="zoomOut()"
-                title="Zoom out — view a larger region, re-binned coarser (thumbnails stay the same size)"
+                title="Zoom out"
                 aria-label="Zoom out">
                 <vt-icon type="zoom-out" [size]="16"></vt-icon>
               </button>
@@ -128,7 +128,7 @@
                 class="browse-size-btn"
                 [disabled]="atMinHexSize"
                 (click)="bumpHexSize(-1)"
-                title="Smaller thumbnails — same bins, fewer pixels each (shows more of the canvas)"
+                title="Smaller thumbnails"
                 aria-label="Smaller thumbnails">
                 <vt-icon type="image" [size]="11"></vt-icon>
               </button>
@@ -137,7 +137,7 @@
                 class="browse-size-btn"
                 [disabled]="atMaxHexSize"
                 (click)="bumpHexSize(1)"
-                title="Bigger thumbnails — same bins, more pixels each (shows less of the canvas)"
+                title="Bigger thumbnails"
                 aria-label="Bigger thumbnails">
                 <vt-icon type="image" [size]="18"></vt-icon>
               </button>
@@ -155,7 +155,7 @@
               </button>
               <button
                 type="button"
-                class="browse-size-btn browse-size-btn--glyph"
+                class="browse-size-btn browse-size-btn--glyph browse-size-btn--square-glyph"
                 [class.browse-size-btn--active]="binShape === 'square'"
                 [attr.aria-pressed]="binShape === 'square'"
                 (click)="setBinShape('square')"
@@ -184,7 +184,6 @@
             (removeGood)="onRemoveGood()"
           />
           <div class="browse-side-meta">
-            <vt-browse-legend [maxCount]="densityMax" [colormap]="colormap" />
             <div class="browse-side-minimap">
               <vt-browse-minimap
                 [meta]="meta"
@@ -192,6 +191,11 @@
                 [dock]="true"
               />
             </div>
+            <vt-browse-legend
+              class="browse-side-legend"
+              [maxCount]="densityMax"
+              [colormap]="colormap"
+            />
           </div>
         </aside>
       </div>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -91,7 +91,7 @@
 // property the divider drag updates (persisted as ``browse_panel_width``).
 .browse-content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 8px var(--browse-panel-width, 360px);
+  grid-template-columns: minmax(0, 1fr) 8px var(--browse-panel-width, 300px);
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -129,8 +129,8 @@
   }
 }
 
-// The docked side panel: selection list on top, legend + overview minimap in a
-// meta-row below (roughly a 2:1 split).
+// The docked side panel: selection list on top, then the overview minimap with
+// the density legend pinned beneath it (roughly a 2:1 split).
 .browse-side {
   display: flex;
   flex-direction: column;
@@ -151,11 +151,15 @@
 // explicit pixel height on its canvas from a ResizeObserver, so a content-sized
 // basis would feed that height back into this row and ratchet it until it
 // swallows the whole panel, crushing the selection list above to nothing.
+//
+// Stacks the overview minimap above the legend so the legend sits flush at the
+// bottom of the panel with no dead space beneath it; the minimap takes the rest
+// of the meta height (a short, wide rectangle).
 .browse-side-meta {
   flex: 1 1 0;
   min-height: 180px;
   display: flex;
-  align-items: stretch;
+  flex-direction: column;
   gap: var(--space-md);
   padding: var(--space-md) var(--space-lg);
   border-top: 1px solid var(--border);
@@ -166,6 +170,12 @@
   flex: 1 1 0;
   min-width: 0;
   min-height: 0;
+}
+
+// The density legend, pinned to the very bottom of the panel under the minimap.
+.browse-side-legend {
+  flex: none;
+  display: block;
 }
 
 // Top-right control cluster: the zoom +/- pill sits beside the hex-size pill.
@@ -240,6 +250,13 @@
 .browse-size-btn--glyph {
   font-size: var(--font-md);
   line-height: 1;
+}
+
+// The filled-square glyph (U+25A0) is drawn smaller than the filled-hexagon
+// glyph (U+2B22) at the same font size, so bump it up until the two read as
+// roughly equal-area lattice swatches.
+.browse-size-btn--square-glyph {
+  font-size: calc(var(--font-md) * 1.3);
 }
 
 // The selected bin shape reads as pressed: filled accent surface that stays

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -88,9 +88,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * instead re-bins a smaller region more finely. The persisted per-media value
    * is the size *label* (see {@link ICON_SIZES}), not the multiplier.
    */
-  private readonly HEX_SCALES = [0.5, 0.75, 1, 1.6, 2.5];
+  private readonly HEX_SCALES = [0.5, 0.75, 1, 1.6, 2.5, 4, 6.25];
   /** Named icon sizes, index-aligned with {@link HEX_SCALES}. */
-  static readonly ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL'] as const;
+  static readonly ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'] as const;
   hexScaleIndex = 2;
 
   /**
@@ -144,7 +144,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * overview minimap), mirrored from the ``browse_panel_width`` setting and
    * driven by the draggable divider between the canvas and the panel.
    */
-  panelWidth = 360;
+  panelWidth = 300;
   /** Clamp + divider geometry, mirroring the Find view's panel dividers. */
   private static readonly PANEL_MIN = 260;
   private static readonly PANEL_MAX = 800;

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -290,6 +290,8 @@
                   <option value="M">M</option>
                   <option value="L">L</option>
                   <option value="XL">XL</option>
+                  <option value="XXL">XXL</option>
+                  <option value="XXXL">XXXL</option>
                 </select>
               </div>
               <div class="form-group">


### PR DESCRIPTION
Addresses a batch of VTSBrowser right-panel and canvas tweaks.

## What landed

**Right-panel layout**
- The side panel's bottom meta region now **stacks the overview minimap above the density legend**, with the legend converted to a **horizontal strip pinned to the bottom** of the panel (no dead space beneath it). This squishes the minimap into a short, wide rectangle.
- The **default right-panel width is narrower** (360px → 300px) and the `Sort:` / thumbnail / view controls in the selection-panel toolbar are packed together with no wasted gap (dropped the `margin-left: auto`). Dragging the divider still gives more room.

**Thumbnail sizes**
- Added **two larger steps** (`XXL` = 4×, `XXXL` = 6.25×) to the browse cell-size scale and to the Settings → Browser **Cell size** dropdown.

**Tooltips**
- Trimmed the verbose button mouse-overs to `Bigger thumbnails`, `Smaller thumbnails`, `Zoom In`, `Zoom out`.

**Square-bins glyph**
- Enlarged the `Square bins` glyph (U+25A0 renders smaller than the hex glyph U+2B22) so the two read as roughly equal-area lattice swatches.

**Open zoomed-to-fit**
- The browse view now opens **already zoomed to fit** even when a saved cell size is applied after the initial fit: the canvas re-fits while the view is still auto-framed (tracked by a new `framedByUser` flag), so larger edge bins no longer spill past the edge on open.

**Minimap fit**
- The minimap now scales to keep **whole edge bins** in view (adds the overview-level bin circumradius as margin, iterating to a fixed point), not just bin centres.

## Note on interpretation
For the legend task ("divider above the legend push the legend to the bottom of the screen … squish the minimap to a shorter rectangle"), I read the desired end-state as a vertical stack — minimap on top, a compact horizontal legend flush at the bottom — since that's the only arrangement where pushing the legend down squishes the minimap. Happy to adjust the legend orientation if you had something else in mind.

## Testing
- `./run-tests.sh core` → all 735 tests pass (includes the production frontend build check; no budget warnings).

https://claude.ai/code/session_01P3PMt7cNPxp2kh5LrFwm7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3PMt7cNPxp2kh5LrFwm7p)_