### PR TITLE
Pin grayscale colormap for thumbnail (image/video) browse media

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -23,6 +23,7 @@ import {
   type BrowseColormapId,
   type CanvasTheme,
   type ResolvedColormap,
+  usesThumbnails,
 } from './hex-render.util';
 import { binGeometry, BinGeometry } from './bin-geometry';
 import type {
@@ -256,7 +257,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   /** True when cells should be painted with the central item's thumbnail. */
   private get thumbnailMode(): boolean {
-    return this.mediaType === 'image' || this.mediaType === 'video';
+    return usesThumbnails(this.mediaType);
   }
 
   /** Geometry (hex or square) for the active projection's bin shape. */

--- a/frontend/src/app/components/browse-canvas/hex-render.util.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.ts
@@ -32,6 +32,18 @@ export type BrowseColormapId = 'auto' | 'heat' | 'ocean' | 'gray';
 export const BROWSE_COLORMAP_IDS: readonly BrowseColormapId[] = ['auto', 'heat', 'ocean', 'gray'];
 
 /**
+ * Media types whose browse cells are painted with the central item's thumbnail
+ * (``image``, ``video``) rather than flat density shading. These are pinned to
+ * the grayscale colormap: the colourful presets are fun for the abstract
+ * density shading of non-thumbnail types, but under real thumbnails a neutral
+ * ground reads best and a coloured tint would fight the image content. Callers
+ * both force ``'gray'`` for these types and hide the colormap picker for them.
+ */
+export function usesThumbnails(mediaType: string): boolean {
+  return mediaType === 'image' || mediaType === 'video';
+}
+
+/**
  * Default width (CSS px) of the colormap-coloured border drawn around
  * multi-item ("pile") thumbnails, applied per media type when the user hasn't
  * set ``browse_thumbnail_border`` for that type. ``0`` would disable it.

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -30,6 +30,7 @@ import {
   BROWSE_COLORMAP_IDS,
   DEFAULT_THUMBNAIL_BORDER,
   MAX_THUMBNAIL_BORDER,
+  usesThumbnails,
   type BrowseColormapId,
 } from '../browse-canvas/hex-render.util';
 import type { BinShape, ProjectionMeta } from '../../models/projection.models';
@@ -315,11 +316,18 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (!s) return;
     const mt = this.mediaType;
 
-    const cmap = mt ? this.perMediaValue(s.browse_colormap, mt) : '';
-    this.colormap =
-      cmap && (BROWSE_COLORMAP_IDS as readonly string[]).includes(cmap)
-        ? (cmap as BrowseColormapId)
-        : 'auto';
+    // Thumbnail media (image/video) are pinned to grayscale so the colourful
+    // density presets never tint real thumbnails; the saved per-type value is
+    // ignored for them (the Settings UI hides the picker to match).
+    if (usesThumbnails(mt)) {
+      this.colormap = 'gray';
+    } else {
+      const cmap = mt ? this.perMediaValue(s.browse_colormap, mt) : '';
+      this.colormap =
+        cmap && (BROWSE_COLORMAP_IDS as readonly string[]).includes(cmap)
+          ? (cmap as BrowseColormapId)
+          : 'auto';
+    }
 
     const sizeLabel = mt ? this.perMediaValue(s.browse_icon_size, mt) : '';
     const sizeIdx = (BrowseViewComponent.ICON_SIZES as readonly string[]).indexOf(sizeLabel);

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -274,13 +274,20 @@
               </div>
               <div class="form-group">
                 <label class="form-label" title="Colors the density heatmap. Auto follows your theme: blue (Ocean) in light mode, red→yellow (Heat) in dark mode.">Colormap</label>
-                <select class="form-select" [ngModel]="getBrowseColormap(activeBrowseTab)" (ngModelChange)="onBrowseColormapChange(activeBrowseTab, $event)" aria-label="Browser colormap">
-                  <option value="auto">Auto (match theme)</option>
-                  <option value="heat">Heat (red → yellow)</option>
-                  <option value="ocean">Ocean (blue)</option>
-                  <option value="gray">Grayscale</option>
-                </select>
-                <p class="form-hint">Darker bins mean more items in light mode; brighter bins mean more in dark mode.</p>
+                @if (browseTabUsesThumbnails(activeBrowseTab)) {
+                  <select class="form-select" disabled aria-label="Browser colormap" title="Thumbnail datasets always use grayscale">
+                    <option value="gray" selected>Grayscale</option>
+                  </select>
+                  <p class="form-hint">Thumbnail datasets (image, video) always use grayscale, so the density shading never tints the thumbnails.</p>
+                } @else {
+                  <select class="form-select" [ngModel]="getBrowseColormap(activeBrowseTab)" (ngModelChange)="onBrowseColormapChange(activeBrowseTab, $event)" aria-label="Browser colormap">
+                    <option value="auto">Auto (match theme)</option>
+                    <option value="heat">Heat (red → yellow)</option>
+                    <option value="ocean">Ocean (blue)</option>
+                    <option value="gray">Grayscale</option>
+                  </select>
+                  <p class="form-hint">Darker bins mean more items in light mode; brighter bins mean more in dark mode.</p>
+                }
               </div>
               <div class="form-group">
                 <label class="form-label" title="On-screen size of the projection cells">Cell size</label>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -17,7 +17,11 @@ import { EmbedderInfo, MediaTypeInfo } from '../../../models/api.models';
 import { Theme, ThemeService } from '../../../services/theme.service';
 import { formatVersion } from '../../../utils/format-date';
 import { VtDialogService } from '../../../services/dialog.service';
-import { DEFAULT_THUMBNAIL_BORDER, MAX_THUMBNAIL_BORDER } from '../../browse-canvas/hex-render.util';
+import {
+  DEFAULT_THUMBNAIL_BORDER,
+  MAX_THUMBNAIL_BORDER,
+  usesThumbnails,
+} from '../../browse-canvas/hex-render.util';
 
 @Component({
   selector: 'vt-settings-modal',
@@ -317,6 +321,15 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
 
   onBrowseColormapChange(typeId: string, value: string): void {
     this.setBrowsePref('browse_colormap', typeId, value);
+  }
+
+  /**
+   * True when *typeId* paints cells with thumbnails (image/video). These types
+   * are pinned to grayscale, so the colormap picker is hidden for them and the
+   * UI shows a fixed read-only value instead.
+   */
+  browseTabUsesThumbnails(typeId: string): boolean {
+    return usesThumbnails(typeId);
   }
 
   getBrowseIconSize(typeId: string): string {


### PR DESCRIPTION
## What

When browsing without thumbnails, the colourful density colormaps (Auto / Heat / Ocean / Grayscale) are fun. But for thumbnail media types (image, video), cells are painted with the item's actual thumbnail, where a coloured density tint fights the image content. This pins those types to **grayscale** and stops the Settings UI from suggesting the colormap is changeable for them.

## Changes

- **`hex-render.util.ts`**: new shared `usesThumbnails(mediaType)` helper (`image` | `video`), so the canvas thumbnail check, the forced-gray rendering, and the Settings UI share one definition.
- **`browse-canvas.component.ts`**: `thumbnailMode` now delegates to `usesThumbnails()`.
- **`browse-view.component.ts`**: `applyBrowsePrefsForMediaType()` forces `colormap = 'gray'` for thumbnail media types, ignoring any saved per-type value (so the legend, minimap, and pile borders all render neutral).
- **`settings-modal`**: for a thumbnail media-type tab, the colormap `<select>` is replaced with a disabled control fixed to **Grayscale** plus an explanatory hint; non-thumbnail tabs keep the full picker.

## Notes

- No backend change: `browse_colormap` still accepts any value per type; the frontend simply pins/hides the choice for image/video, so there's no schema break.

https://claude.ai/code/session_0159tqFPs2BsgPHULVcdnr5a

---
_Generated by [Claude Code](https://claude.ai/code/session_0159tqFPs2BsgPHULVcdnr5a)_