### PR TITLE
Precompute image thumbnails at ingest for responsive browse zoom

### DIFF
--- a/docs/plans/image-thumbnail-tiles.md
+++ b/docs/plans/image-thumbnail-tiles.md
@@ -1,9 +1,9 @@
 # Downscaled thumbnails for grid/list tiles
 
-**Status:** Shipped app-wide. The media-list grid/list (the reported crash
-path) plus every other image-thumbnail consumer (Find/Train right panels,
-browse views) now serve downscaled thumbnails, and all "thumbnail" routes
-finally downscale images.
+**Status:** Shipped app-wide, then extended to **precompute at ingest** (see
+"Precompute at ingest" below). Image thumbnails are now generated once when
+media is loaded and served verbatim, so a fresh browse-canvas zoom no longer
+waits on per-tile full-resolution decodes.
 
 ## What shipped
 
@@ -53,10 +53,57 @@ produce real image thumbnails:
   (detail view) and `label-view`'s crop overlay — the crop maps coordinates
   onto the real pixels, so it needs the original resolution.
 
+## Precompute at ingest (shipped)
+
+The whole-app rollout above downscaled images but still regenerated the
+thumbnail from the full-resolution original on every *cold* `/thumbnail`
+request (no server-side cache). On the browse canvas this was the dominant
+cost behind "zoom into a fresh region and wait for the bin tiles to appear":
+each newly visible bin fans out a request that does a full-res PIL decode +
+LANCZOS resize, throttled by the browser's ~6-connection-per-origin cap and
+the server's thread pool. The delivered 384 px tile is tiny to decode
+client-side, so the lag was almost entirely server-side generation + fan-out,
+not browser "reformatting".
+
+Audio and video already avoided this: they generate `thumbnail_bytes` at
+ingest and serve the stored bytes via `image_response`. Images were the gap.
+What shipped brings images to parity:
+
+- **Generate at ingest.** `ImageMediaType.load_media_data` now precomputes
+  `thumbnail_bytes` (via `make_image_thumbnail`), and the add-to-pile upload
+  route (`routes/media/list.py`) does the same for image uploads. Undecodable
+  sources (SVG, corrupt) yield `None` and fall back to request-time generation.
+- **Persist it.** `ImageMediaType.pickle_extra_fields` now lists
+  `thumbnail_bytes`, and `export_dataset_to_file` was fixed to write *every*
+  media type's `pickle_extra_fields` instead of a hardcoded key list. That
+  hardcoded list silently dropped `thumbnail_bytes` on export, so even
+  audio/video thumbnails were not surviving a pickle round-trip before this
+  change — they do now.
+- **Serve it directly.** `GET /api/medias/<id>/thumbnail` checks
+  `media["thumbnail_bytes"]` first and streams it with no decode/resize
+  (`_shared.cached_thumbnail_response`, mimetype sniffed from magic bytes).
+  Media without a stored thumbnail (old pickles, thin loads, demo images,
+  undecodable sources) fall back to the existing on-demand generation.
+
+**Backwards compatibility:** exported dataset pickles now embed image/audio/
+video thumbnails, so they grow by roughly one ~20-40 KB thumbnail per visual
+item (marginal next to the full media bytes already stored). Old pickles
+without `thumbnail_bytes` still load and simply regenerate thumbnails on
+demand. The image `/thumbnail` `ETag` now fingerprints the thumbnail bytes
+rather than the source bytes, so caches revalidate once after deploy.
+
 ## Open follow-ups
 
-- **Optional server-side thumbnail cache.** Currently each thumbnail is
-  generated on demand (PIL decode + resize) and cached only in the browser via
-  `ETag`/`Cache-Control`. If first-paint CPU on very large datasets becomes a
-  concern, add a process-scoped LRU keyed by media id + content hash. Not
-  needed for the reported workload.
+- **Document thumbnails.** The `document` media type has no `image_response`
+  and no `thumbnail_bytes`; document tiles get no real thumbnail. Out of scope
+  for the image/video responsiveness work; render a first-page image at ingest
+  if document tiles ever need a preview.
+- **Demo image datasets.** Demo image loaders (`vtscore/media/image/_demo_*`,
+  `loader_demo`) build media dicts without routing through
+  `load_media_data`, so demo images fall back to request-time thumbnail
+  generation. The main folder/server/upload import flows (what populates real
+  browse datasets) precompute. Add precompute to the demo path if demo-set
+  browse responsiveness matters.
+- **Thin loads stay lazy by design.** Thin-mode imports/pickles deliberately
+  skip reading bytes, so they carry no `thumbnail_bytes` and regenerate on
+  demand — generating thumbnails eagerly there would defeat thin mode.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11853,7 +11853,7 @@
     },
     "/api/medias/{media_id}/thumbnail": {
       "get": {
-        "description": "Grid and list tiles use this instead of ``/image`` so a gallery of many\nhigh-resolution items doesn't force the browser to decode every full-size\nbitmap at once.  The thumbnail is bounded to a fixed longest-side length\n(see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the\nsame regardless of zoom level, so an ``ETag`` lets the browser reuse it\nacross scrolls and zoom changes.  Undecodable sources (e.g. SVG) fall\nback to the original bytes.",
+        "description": "Grid and list tiles use this instead of ``/image`` so a gallery of many\nhigh-resolution items doesn't force the browser to decode every full-size\nbitmap at once.  The thumbnail is bounded to a fixed longest-side length\n(see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the\nsame regardless of zoom level, so an ``ETag`` lets the browser reuse it\nacross scrolls and zoom changes.\n\nWhen the media carries a precomputed ``thumbnail_bytes`` (generated at\ningest for image/audio/video), the bytes are streamed directly with no\nrequest-time decode/resize -- the path that keeps a fresh browse-canvas\nzoom responsive.  Media without one (old pickles, thin loads, undecodable\nSVGs) fall back to generating the thumbnail from the display image.",
         "operationId": "media_thumbnail",
         "responses": {
           "400": {

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -496,6 +496,7 @@ class TestMediaThumbnail:
 
         sentinel = b"\x89PNG\r\n\x1a\n" + b"precomputed-thumbnail-payload"
         media = get_media(1)
+        assert media is not None
         original = media.get("thumbnail_bytes")
         media["thumbnail_bytes"] = sentinel
         try:

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -489,6 +489,26 @@ class TestMediaThumbnail:
         resp2 = client.get("/api/medias/1/thumbnail")
         assert resp1.data == resp2.data
 
+    def test_serves_precomputed_thumbnail_directly(self, client):
+        # A media carrying ``thumbnail_bytes`` (precomputed at ingest) is
+        # streamed verbatim, with no request-time decode/resize.
+        from vtsearch.state import get_media  # noqa: PLC0415
+
+        sentinel = b"\x89PNG\r\n\x1a\n" + b"precomputed-thumbnail-payload"
+        media = get_media(1)
+        original = media.get("thumbnail_bytes")
+        media["thumbnail_bytes"] = sentinel
+        try:
+            resp = client.get("/api/medias/1/thumbnail")
+            assert resp.status_code == 200
+            assert resp.content_type == "image/png"
+            assert resp.data == sentinel
+        finally:
+            if original is None:
+                media.pop("thumbnail_bytes", None)
+            else:
+                media["thumbnail_bytes"] = original
+
 
 class TestMediaAudio:
     def test_returns_wav_for_valid_id(self, client):

--- a/tests_lib/datasets/test_thumbnail_persistence.py
+++ b/tests_lib/datasets/test_thumbnail_persistence.py
@@ -1,0 +1,89 @@
+"""Library-tier tests for precomputed thumbnails through ingest and pickle.
+
+Images precompute their grid/list thumbnail at ingest (matching the existing
+audio/video behavior) so the request path never re-decodes the full-resolution
+original on a cold tile fetch.  These tests lock two things:
+
+1. ``ImageMediaType.load_media_data`` produces ``thumbnail_bytes`` and declares
+   it in ``pickle_extra_fields``.
+2. ``export_dataset_to_file`` writes every media type's ``pickle_extra_fields``
+   (not just a hardcoded list), so ``thumbnail_bytes`` survives a pickle
+   round-trip.  This previously silently dropped for audio/video too.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader_pickle import load_dataset_from_pickle
+from vtscore.media.image.media_type import ImageMediaType
+
+
+def _png_bytes(size: tuple[int, int] = (1200, 800), color: tuple[int, int, int] = (10, 120, 200)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestImageLoadMediaDataThumbnail:
+    def test_load_media_data_includes_thumbnail_bytes(self, tmp_path: Path):
+        src = _png_bytes()
+        path = tmp_path / "img.png"
+        path.write_bytes(src)
+
+        data = ImageMediaType().load_media_data(path, media_bytes=src)
+
+        assert data["thumbnail_bytes"] is not None
+        with Image.open(io.BytesIO(data["thumbnail_bytes"])) as thumb:
+            assert max(thumb.size) <= 384
+        # The precomputed thumbnail is smaller than the source it was bounded from.
+        assert len(data["thumbnail_bytes"]) < len(src)
+
+    def test_thumbnail_bytes_is_declared_for_pickling(self):
+        assert "thumbnail_bytes" in ImageMediaType().pickle_extra_fields
+
+    def test_undecodable_source_yields_no_thumbnail(self, tmp_path: Path):
+        path = tmp_path / "bad.png"
+        path.write_bytes(b"not an image")
+        data = ImageMediaType().load_media_data(path, media_bytes=b"not an image")
+        assert data["thumbnail_bytes"] is None
+
+
+class TestThumbnailSurvivesPickleRoundTrip:
+    def test_image_thumbnail_persists(self, tmp_path: Path):
+        src = _png_bytes()
+        thumb = ImageMediaType().load_media_data(tmp_path / "i.png", media_bytes=src)["thumbnail_bytes"]
+        assert thumb is not None
+
+        rng = np.random.default_rng(7)
+        medias = {
+            1: {
+                "id": 1,
+                "media_type": "image",
+                "duration": 0,
+                "file_size": len(src),
+                "md5": "abc",
+                "embedder": "siglip",
+                "embedding": rng.standard_normal(512).astype(np.float32),
+                "filename": "i.png",
+                "category": "test",
+                "media_bytes": src,
+                "width": 1200,
+                "height": 800,
+                "thumbnail_bytes": thumb,
+            }
+        }
+
+        container = export_dataset_to_file(medias, embedder="siglip", media_type="image")
+        pkl = tmp_path / "ds.pkl"
+        pkl.write_bytes(container)
+
+        loaded: dict = {}
+        load_dataset_from_pickle(pkl, loaded)
+
+        assert loaded[1]["thumbnail_bytes"] == thumb

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -198,32 +198,43 @@ def export_dataset_to_file(
 
     if on_stage:
         on_stage("Serializing dataset…")
-    data: dict[str, Any] = {
-        "medias": {
-            cid: {
-                "id": media["id"],
-                "media_type": media.get("media_type", "audio"),
-                "duration": media["duration"],
-                "file_size": media["file_size"],
-                "md5": media["md5"],
-                "embedder": media.get("embedder", ""),
-                "embedding": _embedding_for_pickle(media["embedding"]),
-                "filename": media.get("filename", f"media_{cid}.wav"),
-                "category": media.get("category", "unknown"),
-                "origin": media.get("origin"),
-                "origin_name": media.get("origin_name", media.get("filename", "")),
-                "media_bytes": media.get("media_bytes"),
-                "media_string": media.get("media_string"),
-                "media_path": media.get("media_path"),
-                "word_count": media.get("word_count"),
-                "character_count": media.get("character_count"),
-                "width": media.get("width"),
-                "height": media.get("height"),
-                "custom_metadata": media.get("custom_metadata"),
-            }
-            for cid, media in medias.items()
+
+    # Per-type extra fields (e.g. the image/audio/video ``thumbnail_bytes``)
+    # are declared by each media type's ``pickle_extra_fields`` and copied back
+    # on load; the export side must write them too or they silently drop out of
+    # the round-trip.  Build the type→fields map once and merge each media's
+    # extra fields into its serialized entry below.
+    from vtscore.media import all_types  # noqa: PLC0415
+
+    extra_fields_by_type: dict[str, list[str]] = {mt.type_id: mt.pickle_extra_fields for mt in all_types()}
+
+    def _serialize_media(cid: int, media: dict[str, Any]) -> dict[str, Any]:
+        entry = {
+            "id": media["id"],
+            "media_type": media.get("media_type", "audio"),
+            "duration": media["duration"],
+            "file_size": media["file_size"],
+            "md5": media["md5"],
+            "embedder": media.get("embedder", ""),
+            "embedding": _embedding_for_pickle(media["embedding"]),
+            "filename": media.get("filename", f"media_{cid}.wav"),
+            "category": media.get("category", "unknown"),
+            "origin": media.get("origin"),
+            "origin_name": media.get("origin_name", media.get("filename", "")),
+            "media_bytes": media.get("media_bytes"),
+            "media_string": media.get("media_string"),
+            "media_path": media.get("media_path"),
+            "word_count": media.get("word_count"),
+            "character_count": media.get("character_count"),
+            "width": media.get("width"),
+            "height": media.get("height"),
+            "custom_metadata": media.get("custom_metadata"),
         }
-    }
+        for field in extra_fields_by_type.get(media.get("media_type", ""), ()):
+            entry[field] = media.get(field)
+        return entry
+
+    data: dict[str, Any] = {"medias": {cid: _serialize_media(cid, media) for cid, media in medias.items()}}
 
     pkl_buf = io.BytesIO()
     pickle.dump(data, pkl_buf, protocol=_PICKLE_PROTOCOL)

--- a/vtscore/media/image/media_type.py
+++ b/vtscore/media/image/media_type.py
@@ -65,7 +65,7 @@ class ImageMediaType(MediaType):
 
     @property
     def pickle_extra_fields(self) -> list[str]:
-        return ["width", "height"]
+        return ["width", "height", "thumbnail_bytes"]
 
     # ------------------------------------------------------------------
     # Display metadata
@@ -136,6 +136,8 @@ class ImageMediaType(MediaType):
 
         from PIL import Image  # noqa: PLC0415
 
+        from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
+
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
@@ -144,11 +146,18 @@ class ImageMediaType(MediaType):
                 width, height = img.width, img.height
         except Exception:
             width, height = None, None
+        # Precompute the grid/list thumbnail at ingest so the request path
+        # streams it without re-decoding the full-resolution original on every
+        # cold fetch (e.g. each fresh browse-canvas zoom).  Undecodable sources
+        # (SVG, corrupt files) yield None and fall back to request-time
+        # generation in the thumbnail route.
+        thumb = make_image_thumbnail(media_bytes)
         return {
             "media_bytes": media_bytes,
             "duration": 0,
             "width": width,
             "height": height,
+            "thumbnail_bytes": thumb[0] if thumb is not None else None,
         }
 
     # ------------------------------------------------------------------

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -18,6 +18,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sniff_image_mimetype(data: bytes) -> str:
+    """Best-effort image mimetype from magic bytes (PNG vs JPEG).
+
+    Precomputed thumbnails are always either PNG (alpha / waveform / video
+    frame) or JPEG (opaque image), so a two-way sniff is enough; anything
+    unrecognised defaults to JPEG.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    return "image/jpeg"
+
+
+def cached_thumbnail_response(thumb_bytes: bytes, download_name: str):
+    """Serve already-final thumbnail bytes with an ``ETag`` and cache headers.
+
+    Unlike :func:`image_thumbnail_response`, this does **no** decode/resize:
+    the bytes are a thumbnail that was precomputed at ingest (the media dict's
+    ``thumbnail_bytes``), so the request path just streams them.  The ``ETag``
+    fingerprints the thumbnail bytes so the browser reuses one tile per item
+    across scrolls and zoom levels, short-circuiting to a 304.
+    """
+    etag = hashlib.md5(thumb_bytes).hexdigest()
+    if etag in request.if_none_match:
+        resp = make_response("", 304)
+        resp.set_etag(etag)
+        resp.headers["Cache-Control"] = "private, max-age=86400"
+        return resp
+
+    resp = make_response(
+        send_file(io.BytesIO(thumb_bytes), mimetype=_sniff_image_mimetype(thumb_bytes), download_name=download_name)
+    )
+    resp.set_etag(etag)
+    resp.headers["Cache-Control"] = "private, max-age=86400"
+    return resp
+
+
 def image_thumbnail_response(image_bytes: bytes, fallback_mimetype: str, download_name: str):
     """Build a cached, downscaled-image thumbnail response from ``image_bytes``.
 

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -38,6 +38,7 @@ from vtsearch.schemas.media import (
     MediaVoteResponseSchema,
 )
 from vtsearch.routes._shared import (
+    cached_thumbnail_response,
     image_thumbnail_response,
     require_dataset_header,
     require_detector_header,
@@ -489,9 +490,20 @@ def media_thumbnail(media_id: int):
     bitmap at once.  The thumbnail is bounded to a fixed longest-side length
     (see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the
     same regardless of zoom level, so an ``ETag`` lets the browser reuse it
-    across scrolls and zoom changes.  Undecodable sources (e.g. SVG) fall
-    back to the original bytes.
+    across scrolls and zoom changes.
+
+    When the media carries a precomputed ``thumbnail_bytes`` (generated at
+    ingest for image/audio/video), the bytes are streamed directly with no
+    request-time decode/resize -- the path that keeps a fresh browse-canvas
+    zoom responsive.  Media without one (old pickles, thin loads, undecodable
+    SVGs) fall back to generating the thumbnail from the display image.
     """
+    c = get_media(media_id)
+    if not c:
+        abort(404, message="not found")
+    thumb = c.get("thumbnail_bytes")
+    if thumb:
+        return cached_thumbnail_response(thumb, f"thumb_{media_id}")
     data, src_mimetype, _ = _resolve_display_image(media_id)
     return image_thumbnail_response(data, src_mimetype, f"thumb_{media_id}")
 
@@ -784,7 +796,8 @@ def add_media_to_pile():  # noqa: C901
     if embedding is None:
         abort(400, message="Failed to embed the uploaded file.")
 
-    # Generate thumbnail for non-image media
+    # Precompute the grid/list thumbnail so the request path never decodes the
+    # full-resolution upload on a cold tile fetch (matches the ingest path).
     thumb = None
     if dataset_media_type == "audio":
         from vtscore.media.audio.media_type import generate_waveform_thumbnail  # noqa: PLC0415
@@ -794,6 +807,11 @@ def add_media_to_pile():  # noqa: C901
         from vtscore.media.video.media_type import generate_video_thumbnail  # noqa: PLC0415
 
         thumb = generate_video_thumbnail(file_bytes)
+    elif dataset_media_type == "image":
+        from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
+
+        result = make_image_thumbnail(file_bytes)
+        thumb = result[0] if result is not None else None
 
     new_media: dict[str, Any] = {
         "media_type": dataset_media_type,


### PR DESCRIPTION
## Problem

Zooming into a fresh region of the browse canvas trickled in bin thumbnails instead of painting instantly. Tracing the hot path showed the cost is **server-side generation + request fan-out**, not client-side "reformatting on arrival":

- Image `/thumbnail` requests regenerated a 384 px thumbnail from the **full-resolution original on every cold request** (PIL decode + LANCZOS resize), with no server-side cache.
- A fresh zoom fans out N such requests, throttled by the browser's ~6-connection-per-origin cap and the server thread pool.
- The delivered 384 px JPEG decodes in ~1 ms off-thread, and revisiting a cached region paints instantly — so the lag was the per-item server generation, not the browser.

Audio and video already avoided this by generating `thumbnail_bytes` at ingest and serving the stored bytes. Images were the gap.

## Change

Bring images to parity with the existing audio/video pattern:

- **Generate at ingest.** `ImageMediaType.load_media_data` precomputes `thumbnail_bytes` via `make_image_thumbnail`; the add-to-pile upload route does the same for image uploads. Undecodable sources (SVG, corrupt) yield `None` and fall back to request-time generation.
- **Persist it.** `ImageMediaType.pickle_extra_fields` now declares `thumbnail_bytes`, and `export_dataset_to_file` now writes **every** media type's `pickle_extra_fields` instead of a hardcoded key list. That hardcoded list silently dropped `thumbnail_bytes` on export, so even audio/video thumbnails were not surviving a pickle round-trip before this fix.
- **Serve it directly.** `GET /api/medias/<id>/thumbnail` checks `media["thumbnail_bytes"]` first and streams it with no decode/resize (`_shared.cached_thumbnail_response`, mimetype sniffed from magic bytes). Media without a stored thumbnail (old pickles, thin loads, demo images, undecodable sources) fall back to the existing on-demand path.

## Backwards compatibility

- Exported dataset pickles now embed image/audio/video thumbnails, growing by ~one 20-40 KB thumbnail per visual item (marginal next to the media bytes already stored). Old pickles without `thumbnail_bytes` still load and regenerate on demand.
- The image `/thumbnail` `ETag` now fingerprints the thumbnail bytes rather than the source bytes, so browser caches revalidate once after deploy.

## Tests

- `tests_lib/datasets/test_thumbnail_persistence.py`: `load_media_data` produces `thumbnail_bytes`, declares it for pickling, and it survives an export → load round-trip.
- `tests/core/test_medias.py`: the route serves a precomputed thumbnail verbatim.
- Full suite green (4652 passed, 1 skipped).

## Follow-ups (tracked in `docs/plans/image-thumbnail-tiles.md`)

Document thumbnails, demo image datasets, and thin-load behavior — see the plan's "Open follow-ups".

https://claude.ai/code/session_016A1x6jEsPZoNDmtx8xEPjp

---
_Generated by [Claude Code](https://claude.ai/code/session_016A1x6jEsPZoNDmtx8xEPjp)_