### PR TITLE
Show "< 5 sec left" instead of "~0 sec" on progress bars

### DIFF
--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -66,6 +66,9 @@ export function formatEta(seconds: number | null | undefined): string {
   // Sub-minute: round to a nice multiple of seconds (minimum 5s granularity).
   if (seconds < 60) {
     const s = snapEta(seconds, 5);
+    // A few seconds left snaps down to 0; claiming "~0 sec" reads as "done"
+    // even though work remains. Show "< 5 sec left" instead.
+    if (s <= 0) return '< 5 sec left';
     if (s < 60) return etaUnit(s, 'sec');
   }
   // Minutes: round to the nice fraction of a minute (minimum half-minute).


### PR DESCRIPTION
## Summary

When an ETA had only a few seconds remaining, `formatEta` snapped the value to the nearest 5-second step, which rounds anything under ~2.5s down to **0**, producing the misleading `~0 sec left` chip — it reads as "done" even though work remains.

Now any sub-minute estimate that snaps to 0 renders `< 5 sec left` instead, matching the bar's 5-second granularity without claiming completion.

## Changes

- `frontend/src/app/utils/format-progress.ts`: in the sub-minute branch of `formatEta`, return `< 5 sec left` when the snapped value is `<= 0`.

## Testing

- `npm run build:prod` — clean (no errors/warnings).

https://claude.ai/code/session_01Jxqaifwp55qZW2Hx8fhkN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxqaifwp55qZW2Hx8fhkN8)_