### PR TITLE
Fix votes not syncing to labelset due to stuck process-global find mode

### DIFF
--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -136,6 +136,7 @@ class TestFindModeIsPerDetector:
         # A's find mode leaked through the global flag and the sync was skipped,
         # leaving B's labelset (and the Good/Bad panels) empty.
         data = _read_detector(_detector_path("find-leak-B"))
+        assert data is not None
         good_md5s = {el["md5"] for el in data["labelset"]["labels"] if el["label"] == "good"}
         assert medias[target_id]["md5"] in good_md5s
 

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -83,6 +83,62 @@ class TestFindLabel:
         assert "dataset_id" in resp.get_json()["errors"]["json"]
 
 
+class TestFindModeIsPerDetector:
+    """Find mode is per-detector state, not a process-wide global.
+
+    Running ``/api/find-label`` on detector A used to flip a process-global
+    ``_find_mode`` flag that was only ever cleared by explicitly *unloading* a
+    detector.  Loading detector B to train it (or creating a new detector)
+    left the flag stuck True, so ``sync_labels_to_loaded_detector`` silently
+    dropped every vote on B: the right-pane Good/Bad panels stayed empty and
+    Learned sort stayed greyed out even though the stripe still showed the
+    in-memory votes.  Find mode now lives on each ``DetectorContext``, so a
+    find pass on A never blocks vote syncing on B.
+    """
+
+    def test_find_label_on_one_detector_does_not_block_sync_on_another(self, client):
+        from tests import load_detector_and_wait
+        from vtscore.detectors.store import _detector_path, _read_detector
+        from vtsearch.state import medias
+
+        if len(medias) < 5:
+            pytest.skip("Need at least 5 medias")
+        ids = list(medias.keys())
+        snap = snapshot_medias()
+
+        mid_a = setup_trainable_model_in_registry(
+            "find-leak-A",
+            good_ids=[ids[0], ids[1]],
+            bad_ids=[ids[2], ids[3]],
+            snap=snap,
+        )
+        mid_b = setup_trainable_model_in_registry(
+            "find-leak-B",
+            good_ids=[ids[0]],
+            bad_ids=[ids[1]],
+            snap=snap,
+        )
+
+        # Use detector A to score the whole dataset: A enters find mode so its
+        # scoring labels are NOT synced back over its training labelset.
+        load_detector_and_wait(client, mid_a)
+        resp = client.post("/api/find-label", json={"detector_id": mid_a})
+        assert resp.status_code == 200, resp.get_json()
+
+        # Switch to detector B and cast a genuine training vote.
+        load_detector_and_wait(client, mid_b)
+        target_id = ids[4]
+        resp = client.post(f"/api/medias/{target_id}/vote", json={"target": "good"})
+        assert resp.status_code == 200, resp.get_json()
+
+        # B's on-disk labelset must have recorded the vote.  Before the fix,
+        # A's find mode leaked through the global flag and the sync was skipped,
+        # leaving B's labelset (and the Good/Bad panels) empty.
+        data = _read_detector(_detector_path("find-leak-B"))
+        good_md5s = {el["md5"] for el in data["labelset"]["labels"] if el["label"] == "good"}
+        assert medias[target_id]["md5"] in good_md5s
+
+
 class TestAutoDetect:
     """``POST /api/auto-detect`` iterates detectors flagged for autorun."""
 

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -8,6 +8,7 @@ labelset stored on disk.
 from __future__ import annotations
 
 import app as app_module
+import pytest
 from helpers import setup_trainable_model_in_registry
 from vtsearch.state import snapshot_medias
 

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -103,6 +103,9 @@ def ensure_votes_match_active_dataset() -> None:
             det_ctx.last_learned_scores.clear()
             det_ctx.find_initial_labels.clear()
             det_ctx.training_medias.clear()
+            # The detector now has no votes for the active dataset, so they
+            # can't be find/scoring output; let the next vote sync normally.
+            det_ctx.find_mode = False
             det_ctx.votes_dataset_id = ds_ctx.dataset_id
             det_ctx.cached_labelset = None
             det_ctx.cached_labelset_mtime = 0.0
@@ -132,6 +135,9 @@ def ensure_votes_match_active_dataset() -> None:
         det_ctx.last_learned_scores.clear()
         det_ctx.find_initial_labels.clear()
         det_ctx.training_medias.clear()
+        # Votes are about to be re-derived from the on-disk labelset (the
+        # canonical training labels), so any prior find/scoring state is stale.
+        det_ctx.find_mode = False
         restore_labels_from_detector(data)
         det_ctx.votes_dataset_id = ds_ctx.dataset_id
         det_ctx.cached_labelset = LabelSet.from_dict(data.get("labelset") or {})

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -34,10 +34,6 @@ _entries: list[dict[str, Any]] | None = None
 # Set of detector IDs currently loaded in memory (each has a DetectorContext).
 _loaded_ids: set[str] = set()
 
-# When ``True`` the detector most recently used for scoring is in "find mode"
-# - its labels should NOT be synced back to the detector's saved labelset.
-_find_mode: bool = False
-
 
 # ---------------------------------------------------------------------------
 # Persistence
@@ -241,22 +237,36 @@ def get_loaded_detector_ids() -> set[str]:
 
 
 def is_find_mode() -> bool:
-    """Return ``True`` if the active detector is in find/scoring mode."""
-    with _lock:
-        return _find_mode
+    """Return ``True`` if the active detector's votes are find/scoring output.
+
+    Find mode is per-detector state (``DetectorContext.find_mode``), not a
+    process global: a scoring pass on one detector must never block vote
+    syncing on another, and switching to a different detector must not inherit
+    the previous detector's find state.
+    """
+    from vtscore.state.core import _state_lock, get_active_detector_context
+
+    with _state_lock:
+        return get_active_detector_context().find_mode
 
 
 def set_find_mode(enabled: bool = True) -> None:
-    """Set or clear find mode for the active detector."""
-    global _find_mode
-    with _lock:
-        _find_mode = enabled
+    """Set or clear find mode on the active detector context.
+
+    No-op when no real detector is active (the empty / request-missing
+    sentinel contexts have no labelset to protect).
+    """
+    from vtscore.state.core import _state_lock, get_active_detector_context
+
+    with _state_lock:
+        det_ctx = get_active_detector_context()
+        if det_ctx.detector_id:
+            det_ctx.find_mode = enabled
 
 
 def reset_for_tests() -> None:
     """Reset the in-memory cache (for test isolation)."""
-    global _entries, _find_mode
+    global _entries
     with _lock:
         _entries = None
         _loaded_ids.clear()
-        _find_mode = False

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -339,6 +339,14 @@ class DetectorContext:
         "vote_click_times",
         "vote_region_boxes",
         "click_counter",
+        # True when this detector's in-memory votes are find/scoring output
+        # (set by /api/find-label) rather than genuine training labels.  While
+        # set, ``sync_labels_to_loaded_detector`` refuses to persist the votes
+        # so a scoring pass can't overwrite the detector's saved labelset.
+        # Per-detector (not a process global) so a find pass on one detector
+        # never blocks vote syncing on another.  Cleared whenever the votes are
+        # re-derived from the on-disk labelset (detector load / dataset switch).
+        "find_mode",
         # Training artifacts
         "last_learned_scores",
         "textsort_suggestions",
@@ -406,6 +414,8 @@ class DetectorContext:
         # yes-votes and for every no-vote.  Patch-embedder v2.
         self.vote_region_boxes: dict[int, tuple[float, float, float, float]] = {}
         self.click_counter: int = 0
+        # See the slot comment: True while these votes are find/scoring output.
+        self.find_mode: bool = False
         # Training artifacts
         self.last_learned_scores: dict[int, float] = {}
         self.textsort_suggestions: list[str] = []

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -427,16 +427,17 @@ def load_detector_route(body: dict):  # noqa: C901
         sync_labels_to_loaded_detector()
 
     if detector_id is None:
-        from vtscore.detectors.registry import remove_loaded_detector_id, set_find_mode
+        from vtscore.detectors.registry import remove_loaded_detector_id
 
         det_ctx = get_active_detector_context()
         prev_id = det_ctx.detector_id if det_ctx.detector_id else None
         if prev_id:
             from vtsearch.state import unregister_detector_context
 
+            # Find mode lived on this detector's context (per-detector), so
+            # tearing the context down clears it; no separate global to reset.
             unregister_detector_context(prev_id)
             remove_loaded_detector_id(prev_id)
-        set_find_mode(False)
         return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
 
     if is_detector_loaded(detector_id):


### PR DESCRIPTION
## Problem

When training a detector, votes weren't being recorded in the detector's LabelSet: the Good/Bad panels stayed empty and Learned sort was greyed out, even though the stripe (and the Manual view) showed the red/green vote notches. Switching sort modes didn't help: with no labels persisted there was no MLP to train, so Learned stayed disabled.

## Root cause

The two halves of the UI read from different sources:

- **Stripe / Manual view** read the **in-memory** `good_votes`/`bad_votes` on the active `DetectorContext` (`/api/votes`). These always populate, which is why the notches showed up.
- **Good/Bad panels** and the **Learned-mode gating** (`labelset_good_count`/`labelset_bad_count`) read the **on-disk labelset** written by `sync_labels_to_loaded_detector()` (`/api/detectors/<name>/labels-detail`).

`sync_labels_to_loaded_detector()` bails at its first guard when `is_find_mode()` is true. Find mode was a **process-wide global** (`_find_mode` in `vtscore/detectors/registry.py`): set `True` by `/api/find-label`, and cleared `False` in exactly one place: the detector **unload** branch (`detector_id is None`). Loading a detector to train, creating a new detector, casting a vote, and switching datasets never cleared it. So once any find/score pass had run in a server session, every subsequent training vote was silently dropped from the labelset. This also matches the intermittency ("happens a few times now" = whenever a find/score happened earlier in the same session).

The flag was global, but the vote state it guards is **per-detector** (`DetectorContext`), so find mode for detector A leaked into a training session on detector B.

## Fix

Move find mode onto `DetectorContext` (`find_mode`), matching the per-detector scope of the vote state it protects:

- `is_find_mode()` / `set_find_mode()` now read/write the **active** detector context (no-op when no real detector is active).
- Find mode is cleared whenever votes are re-derived from the on-disk labelset, i.e. in both clearing paths of `ensure_votes_match_active_dataset` (detector load and dataset switch). A freshly-loaded detector starts with `find_mode = False`.
- The obsolete global-clear on the unload path was removed: tearing down the detector's context disposes of its `find_mode`.

A find pass on one detector can no longer block vote syncing on another, and a find-scored detector keeps its own flag so its scoring votes still aren't written over its training labelset.

## Tests

- New regression test `TestFindModeIsPerDetector.test_find_label_on_one_detector_does_not_block_sync_on_another`: runs `/api/find-label` on detector A, then loads detector B and casts a vote, and asserts B's on-disk labelset records it.
- Full suite green: 4653 passed, 1 skipped, 2 xpassed (ruff/format/codespell/deptry/pip-audit/pyright + frontend TS build all clean).

## Backwards compatibility

`_find_mode` (module global) and its `reset_for_tests` reset were removed; `DetectorContext` gains a `find_mode` slot/field. No external callers reference the removed global.

https://claude.ai/code/session_01C1F6DvweYscrytfYmq82By

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1F6DvweYscrytfYmq82By)_