### PR TITLE
Keep the browse bin popup on the canvas

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -25,7 +25,7 @@ const ITEM_HEIGHT = 36;
 const MAX_VISIBLE_ROWS = 10;
 /** Extra rows of metadata prefetched beyond the visible window. */
 const PREFETCH_BUFFER = 50;
-/** Gap (px) kept between the popup and the viewport edge when clamping. */
+/** Gap (px) kept between the popup and the canvas edge when clamping. */
 const EDGE_MARGIN = 8;
 
 /**
@@ -59,6 +59,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Viewport anchor (clientX/clientY) the popup opens at, then clamps inward. */
   @Input() x = 0;
   @Input() y = 0;
+  /** The canvas's bounding rect (viewport coords); the popup is clamped inside
+   *  it so it stays on the canvas. Null falls back to the full viewport. */
+  @Input() bounds: DOMRect | null = null;
 
   /** Emitted when the popup should close (outside click, Escape, or the X). */
   @Output() dismissed = new EventEmitter<void>();
@@ -99,7 +102,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       this.viewport?.scrollToIndex(0);
       this.prefetchVisible();
     }
-    if (changes['x'] || changes['y'] || changes['memberIds']) {
+    if (changes['x'] || changes['y'] || changes['bounds'] || changes['memberIds']) {
       this.left = this.x;
       this.top = this.y;
       // Measure + clamp after the new content lays out.
@@ -241,21 +244,28 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
 
   // --- Positioning ---------------------------------------------------------
 
-  /** Clamp the popup inside the viewport so it never spills off an edge. */
+  /** Clamp the popup inside the canvas (or the viewport, when no bounds are
+   *  given) so it never spills off an edge or onto the side panel. */
   private place(): void {
     const panel = this.panelRef?.nativeElement;
     if (!panel) return;
     const rect = panel.getBoundingClientRect();
+    const b = this.bounds;
+    const minLeft = b ? b.left + EDGE_MARGIN : EDGE_MARGIN;
+    const minTop = b ? b.top + EDGE_MARGIN : EDGE_MARGIN;
+    const maxRight = b ? b.right : window.innerWidth;
+    const maxBottom = b ? b.bottom : window.innerHeight;
     let l = this.x;
     let t = this.y;
-    if (l + rect.width + EDGE_MARGIN > window.innerWidth) {
-      l = Math.max(EDGE_MARGIN, window.innerWidth - rect.width - EDGE_MARGIN);
+    if (l + rect.width + EDGE_MARGIN > maxRight) {
+      l = maxRight - rect.width - EDGE_MARGIN;
     }
-    if (t + rect.height + EDGE_MARGIN > window.innerHeight) {
-      t = Math.max(EDGE_MARGIN, window.innerHeight - rect.height - EDGE_MARGIN);
+    if (t + rect.height + EDGE_MARGIN > maxBottom) {
+      t = maxBottom - rect.height - EDGE_MARGIN;
     }
-    this.left = l;
-    this.top = t;
+    // Never push the top-left off the opposite edge (popup larger than canvas).
+    this.left = Math.max(minLeft, l);
+    this.top = Math.max(minTop, t);
     this.cdr.markForCheck();
   }
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -47,6 +47,9 @@ export interface BrowseContextMenuEvent {
   clientY: number;
   /** Member media ids of the bin under the cursor; empty over blank space. */
   members: number[];
+  /** The canvas's bounding rect (viewport coords); the popup clamps inside it
+   *  so it never spills onto the side panel or past the canvas edges. */
+  bounds: DOMRect;
 }
 
 /** How much larger the hovered cell is drawn relative to its neighbours so it
@@ -1240,7 +1243,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    *  popup, carrying the cursor anchor and the bin (if any) under it. */
   private onContextMenu(event: MouseEvent): void {
     event.preventDefault();
-    const [mx, my] = this.canvasXY(event);
+    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const mx = event.clientX - rect.left;
+    const my = event.clientY - rect.top;
     // Close any hover preview so it doesn't sit under the popup.
     this.clearHover();
     const cell = this.hitTest(mx, my);
@@ -1250,6 +1255,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
         clientX: event.clientX,
         clientY: event.clientY,
         members,
+        bounds: rect,
       }),
     );
   }

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -78,6 +78,7 @@
             <vt-browse-bin-popup
               [x]="contextMenuX"
               [y]="contextMenuY"
+              [bounds]="contextBounds"
               [memberIds]="contextMembers"
               [mediaType]="mediaType"
               (dismissed)="dismissContextMenu()"

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -170,6 +170,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   contextMenuX = 0;
   contextMenuY = 0;
   contextMembers: number[] = [];
+  /** Canvas bounds the popup clamps inside, so it stays on the canvas rather
+   *  than spilling onto the side panel or past the canvas edges. */
+  contextBounds: DOMRect | null = null;
 
   private destroy$ = new Subject<void>();
   private polling = false;
@@ -502,6 +505,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.contextMembers = event.members;
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
+    this.contextBounds = event.bounds;
     this.contextMenuOpen = true;
   }
 


### PR DESCRIPTION
## Problem

Right-clicking a bin near the canvas's right or bottom edge let the 280px bin popup spill **off the canvas** — across the divider onto the side panel, or past the canvas's bottom edge. The popup clamped to the browser **viewport** (`window.innerWidth`/`innerHeight`), which is larger than the canvas, so the canvas edges weren't respected.

## Fix

The popup now clamps to the **canvas** rectangle instead of the viewport:

- `BrowseContextMenuEvent` carries the canvas's `getBoundingClientRect()` (`bounds`).
- `BrowseViewComponent` stores it and passes it to `vt-browse-bin-popup` as a new `[bounds]` input.
- The popup's `place()` clamps `left`/`top` inside `bounds` (with the existing 8px edge margin), falling back to the viewport when no bounds are supplied.

The right-click anchor is always inside the canvas, so the popup opens at the cursor and only nudges inward when it would otherwise overrun a canvas edge.

## Testing

- `npm run build:prod` — clean build, no errors or warnings.

No backend changes; no Python tests affected. There are no spec files for these components.

https://claude.ai/code/session_01QfEuCLF5ZDT4ums8xha8e3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfEuCLF5ZDT4ums8xha8e3)_