### PR TITLE
Rename "Datasets Loaded" achievement to "Data: Set"

### DIFF
--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -35,7 +35,7 @@ TIER_NAMES: tuple[str, ...] = ("Bronze", "Silver", "Gold", "Platinum")
 ACHIEVEMENTS: list[dict[str, Any]] = [
     {
         "id": "datasets_loaded",
-        "name": "Datasets Loaded",
+        "name": "Data: Set",
         "description": "Load datasets you imported. Demos and synthetic don't count.",
         "icon": "cubes",
         "tiers": [1, 10, 100, 1000],


### PR DESCRIPTION
Renames the `datasets_loaded` achievement's display name from "Datasets Loaded" to "Data: Set".

The achievement `id` (`datasets_loaded`), description, icon, and tiers are unchanged — only the user-facing `name` is updated, so existing user progress is preserved.

## Testing
- `tests/core/test_achievements.py` — 73 passed
- `tests/api/test_dashboard.py` — 61 passed (after building the frontend bundle)

https://claude.ai/code/session_01VirJLkR1cEKDg9uttkpRHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VirJLkR1cEKDg9uttkpRHr)_