### PR TITLE
Promote a set of media items to its own dataset (Find "To Dataset")

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1135,6 +1135,53 @@
         ],
         "type": "object"
       },
+      "DatasetPromoteRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "media_ids": {
+            "description": "IDs of the media items (in the active dataset) to promote.",
+            "items": {
+              "type": "integer"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "description": "Display name for the new dataset.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "media_ids",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetPromoteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "num_items": {
+            "type": "integer"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "dataset_id",
+          "name",
+          "num_items",
+          "ok"
+        ],
+        "type": "object"
+      },
       "DatasetRegistryLoadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -8030,6 +8077,50 @@
         "summary": "Reload a dataset from a stored source origin dict.",
         "tags": [
           "datasets_load"
+        ]
+      }
+    },
+    "/api/dataset/promote": {
+      "post": {
+        "description": "Used by the Find interface's \"To Dataset\" button to turn the Goods\npile into its own dataset. The promoted items keep their original\norigins and in-memory embeddings (so preprocessing is preserved for\nfree; the new pickle is a self-contained snapshot). The new dataset\ngets a fresh ``created_at`` but inherits the source dataset's\n``expires_at`` (death date).",
+        "operationId": "promote_to_dataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetPromoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetPromoteResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "No dataset loaded or none of the items resolved."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "500": {
+            "description": "Failed to write or register the new dataset."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Promote a set of media items into a brand-new saved dataset.",
+        "tags": [
+          "datasets_staging"
         ]
       }
     },

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -70,6 +70,7 @@
       (mediaSelected)="onMediaSelect($event)"
       (mediaVoted)="onHoverVote($event)"
       (browse)="onBrowse()"
+      (toDataset)="onToDataset()"
     />
   </div>
 </div>

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -10,6 +10,9 @@ import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
+import { DatasetsCrudApiService } from '../../services/datasets-crud-api.service';
+import { ToastService } from '../../services/toast.service';
+import { VtDialogService } from '../../services/dialog.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
 import { MediaStateService } from '../../services/media-state.service';
@@ -64,6 +67,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private mediasApi: MediasApiService,
     private detectorsFindApi: DetectorsFindApiService,
     private datasetsRegistryApi: DatasetsRegistryApiService,
+    private datasetsCrudApi: DatasetsCrudApiService,
+    private toast: ToastService,
+    private dialog: VtDialogService,
     private ngZone: NgZone,
     private activeContext: ActiveContextService,
     private datasetState: DatasetStateService,
@@ -422,6 +428,38 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       label: `${detectorName} — positives`,
     });
     this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
+  }
+
+  /**
+   * Promote the current Goods pile into its own saved dataset. The
+   * promoted items keep their origins and embeddings; the new dataset
+   * gets a fresh created date but inherits this dataset's death date.
+   * We prompt for a name (prefilled "<dataset> <detector> Results"),
+   * then create + register it and confirm with a toast (staying in Find).
+   */
+  onToDataset(): void {
+    const ids = Array.from(this.voteState.goodVotes);
+    if (ids.length === 0) return;
+    const modelId = this.activeContext.modelId;
+    const detectorName =
+      this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
+    const base = [this.datasetName, detectorName, 'Results'].filter((s) => !!s).join(' ');
+
+    this.dialog.prompt('Name the new dataset', base).then((name) => {
+      const trimmed = (name ?? '').trim();
+      if (!trimmed) return;
+      this.datasetsCrudApi
+        .promote(trimmed, ids)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (res) => {
+            this.toast.success({
+              message: `Created dataset "${res.name}"`,
+              detail: `${res.num_items} item${res.num_items === 1 ? '' : 's'} promoted. Find it in the Datasets dashboard.`,
+            });
+          },
+        });
+    });
   }
 
   /** Cancel the find-label scoring run; the HTTP request will surface

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,7 +1,10 @@
 <div class="vote-section">
-  <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
-    {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length | number }})
-  </h3>
+  <div class="vote-section-header">
+    <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
+      {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length | number }})
+    </h3>
+    <ng-content select="[list-actions]"></ng-content>
+  </div>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>
     @for (entry of sortedEntries; track trackById($index, entry)) {
       <div

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -18,10 +18,22 @@
 // but are styled as compact uppercase chips, not as full section
 // headings. See the load-sort-modal comment about promoting a shared
 // `.subhead` class; same pattern, same eventual fix.
+// Header row: the "Goods (#)" / "Bads (#)" chip on the left, with an
+// optional projected action cluster (Browse / To Dataset / Export in the
+// Find right panel) pushed to the right.
+.vote-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+  flex-shrink: 0;
+}
+
 h3 {
   font-size: var(--font-sm);
   letter-spacing: 0.05em;
-  margin: 0 0 var(--space-md) 0;
+  margin: 0;
   flex-shrink: 0;
   display: flex;
   align-items: center;

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -64,7 +64,27 @@
       [focusMode]="focusMode"
       (mediaSelected)="onMediaSelected($event)"
       (mediaVote)="onMediaVote($event)"
-    />
+    >
+      @if (mode === 'find') {
+        <div list-actions class="goods-actions">
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse the positive results as their own 2-D UMAP projection (builds on click)">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+              <circle cx="12" cy="12" r="3"></circle>
+            </svg>
+          </button>
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the goods into their own dataset">
+            <vt-icon type="cubes" [size]="14"></vt-icon>
+          </button>
+          <button class="goods-action-btn" [disabled]="disabled" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 14 20 9 15 4"></polyline>
+              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+            </svg>
+          </button>
+        </div>
+      }
+    </vt-label-list>
 
     <div class="label-divider"></div>
 
@@ -83,12 +103,11 @@
     />
   }
 
-  <div class="export-row">
-    <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" title="Export labeled items to clipboard, file, email, or webhook">Export</button>
-    @if (mode === 'find') {
-      <button class="panel-btn browse-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" title="Browse the positive results as their own 2-D UMAP projection (builds on click)">Browse</button>
-    }
-  </div>
+  @if (mode !== 'find') {
+    <div class="export-row">
+      <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" title="Export labeled items to clipboard, file, email, or webhook">Export</button>
+    </div>
+  }
 </aside>
 
 @if (showLabelImport) {

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -80,6 +80,40 @@
   }
 }
 
+// Icon-only action cluster projected into the good label-list header in
+// Find mode (Browse / To Dataset / Export). Mirrors the dashboard card
+// action buttons: compact, borderless, tooltip-labelled.
+.goods-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.goods-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xs);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  line-height: 0;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover:not(:disabled) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+}
+
 .import-btn {
   flex: 1;
   text-align: center;

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -18,6 +18,7 @@ import { DetectorContextBarComponent } from './detector-context-bar/detector-con
 import { ExportModalComponent } from '../modals/export-modal/export-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { IconComponent } from '../icon/icon.component';
 
 export interface TrainModeContext {
   model: { name: string; registry_id?: string };
@@ -35,6 +36,7 @@ export interface TrainModeContext {
     ExportModalComponent,
     LabelImporterModalComponent,
     ViewControlsComponent,
+    IconComponent,
   ],
   templateUrl: './right-panel.component.html',
   styleUrl: './right-panel.component.scss',
@@ -58,6 +60,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
   /** Find mode: browse the positive results as their own UMAP projection. */
   @Output() browse = new EventEmitter<void>();
+  /** Find mode: promote the goods into their own dataset. */
+  @Output() toDataset = new EventEmitter<void>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
@@ -164,6 +168,10 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   onBrowse(): void {
     this.browse.emit();
+  }
+
+  onToDataset(): void {
+    this.toDataset.emit();
   }
 
   onDetectorRenamed(newName: string): void {

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -9,6 +9,7 @@ import type { DatasetAllImportersListResponse } from '../generated/api-client/mo
 import type { DatasetAvailableFilesResponse } from '../generated/api-client/models/dataset-available-files-response';
 import type { DatasetClearResponse } from '../generated/api-client/models/dataset-clear-response';
 import type { DatasetCombineRequest } from '../generated/api-client/models/dataset-combine-request';
+import type { DatasetPromoteResponse } from '../generated/api-client/models/dataset-promote-response';
 import type { DatasetImportersListResponse } from '../generated/api-client/models/dataset-importers-list-response';
 import type { DatasetLoadDemoRequest } from '../generated/api-client/models/dataset-load-demo-request';
 import type { DatasetLoadSourceRequest } from '../generated/api-client/models/dataset-load-source-request';
@@ -25,6 +26,7 @@ import { availableDatasetFiles } from '../generated/api-client/fn/datasets-stagi
 import { clearDatasetRoute } from '../generated/api-client/fn/datasets-load/clear-dataset-route';
 import { clearStaging } from '../generated/api-client/fn/datasets-staging/clear-staging';
 import { combineDatasetsRoute } from '../generated/api-client/fn/datasets-staging/combine-datasets-route';
+import { promoteToDataset } from '../generated/api-client/fn/datasets-staging/promote-to-dataset';
 import { datasetAllImporters } from '../generated/api-client/fn/datasets-listings/dataset-all-importers';
 import { datasetImporters } from '../generated/api-client/fn/datasets-listings/dataset-importers';
 import { detectMediaType } from '../generated/api-client/fn/datasets-ui/detect-media-type';
@@ -165,6 +167,14 @@ export class DatasetsCrudApiService {
 
   clearDataset(): Observable<DatasetClearResponse> {
     return clearDatasetRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Promote a set of media items (the Find Goods pile) into their own
+   *  saved dataset. Resolves with the new dataset's id / name / count. */
+  promote(name: string, mediaIds: number[]): Observable<DatasetPromoteResponse> {
+    return promoteToDataset(this.http, this.config.rootUrl, {
+      body: { name, media_ids: mediaIds },
+    }).pipe(map((r) => r.body));
   }
 
   /** Binary stream; stays on plain ``HttpClient`` so ``responseType: 'blob'``

--- a/tests/datasets/test_promote_dataset.py
+++ b/tests/datasets/test_promote_dataset.py
@@ -1,0 +1,146 @@
+"""Tests for ``POST /api/dataset/promote``.
+
+The promote endpoint turns a set of media items from the active dataset
+(the Find "Goods" pile) into a brand-new saved dataset. The promoted
+items keep their origins and embeddings; the new dataset gets a fresh
+``created_at`` but inherits the source dataset's ``expires_at``.
+"""
+
+from __future__ import annotations
+
+
+class TestPromoteToDataset:
+    def test_creates_registered_dataset_and_roundtrips(self, client, tmp_path):
+        from vtscore.datasets import registry as reg
+        from vtscore.datasets.loader import load_dataset_from_pickle
+        from vtsearch.state import snapshot_medias
+
+        snap = snapshot_medias()
+        ids = list(snap.keys())[:3]
+        assert len(ids) >= 1
+
+        before = len(reg.list_datasets())
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "My Promoted Set", "media_ids": ids},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["name"] == "My Promoted Set"
+        assert body["num_items"] == len(ids)
+
+        # Registry grew by exactly one, and the new entry is findable.
+        assert len(reg.list_datasets()) == before + 1
+        entry = reg.get_dataset(body["dataset_id"])
+        assert entry is not None
+        assert entry["name"] == "My Promoted Set"
+        assert entry["num_items"] == len(ids)
+        assert entry["origin"] == "promote"
+
+        # The pkl exists and round-trips back into a loadable dataset whose
+        # items preserve their original origins.
+        roundtrip: dict = {}
+        load_dataset_from_pickle(entry["pkl_path"], roundtrip)
+        assert len(roundtrip) == len(ids)
+        original_origins = {
+            (snap[cid].get("origin_name") or snap[cid].get("filename")) for cid in ids
+        }
+        promoted_origins = {
+            (m.get("origin_name") or m.get("filename")) for m in roundtrip.values()
+        }
+        assert promoted_origins == original_origins
+
+    def test_renumbers_ids_from_one(self, client):
+        from vtscore.datasets import registry as reg
+        from vtscore.datasets.loader import load_dataset_from_pickle
+        from vtsearch.state import snapshot_medias
+
+        ids = list(snapshot_medias().keys())[:2]
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "Renumbered", "media_ids": ids},
+        )
+        assert resp.status_code == 200
+        entry = reg.get_dataset(resp.get_json()["dataset_id"])
+        roundtrip: dict = {}
+        load_dataset_from_pickle(entry["pkl_path"], roundtrip)
+        assert sorted(roundtrip.keys()) == list(range(1, len(ids) + 1))
+
+    def test_inherits_expires_at_with_fresh_created_at(self, client):
+        from vtscore.datasets import registry as reg
+        from vtscore.state import core as state_core
+        from vtsearch.state import snapshot_medias
+
+        snap = snapshot_medias()
+        ids = list(snap.keys())[:2]
+
+        # Register a source dataset with an explicit death date and load its
+        # medias into a context whose id matches, so the active context (via
+        # the X-Dataset-Id header) resolves to a registered dataset.
+        src = reg.register_dataset(
+            name="Source DS",
+            media_type="audio",
+            num_items=len(ids),
+            pkl_path="/tmp/source-does-not-need-to-exist.pkl",
+            expires_at=99_999.0,
+        )
+        reg.add_loaded_id(src["id"])
+        ctx = state_core.DatasetContext(src["id"])
+        for cid in ids:
+            ctx.medias[cid] = snap[cid]
+        state_core.register_context(ctx)
+        try:
+            resp = client.post(
+                "/api/dataset/promote",
+                json={"name": "Inherited DS", "media_ids": ids},
+                headers={"X-Dataset-Id": src["id"]},
+            )
+            assert resp.status_code == 200, resp.get_json()
+            new_entry = reg.get_dataset(resp.get_json()["dataset_id"])
+            # Death date inherited; created date is fresh (not the source's).
+            assert new_entry["expires_at"] == 99_999.0
+            assert new_entry["created_at"] != src["created_at"]
+        finally:
+            state_core.unregister_context(src["id"])
+            reg.remove_loaded_id(src["id"])
+
+    def test_rejects_unknown_ids(self, client):
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "Nope", "media_ids": [999_999_999]},
+        )
+        assert resp.status_code == 400
+        assert "current dataset" in resp.get_json()["message"]
+
+    def test_requires_nonempty_name(self, client):
+        from vtsearch.state import snapshot_medias
+
+        ids = list(snapshot_medias().keys())[:1]
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "", "media_ids": ids},
+        )
+        assert resp.status_code == 422
+
+    def test_requires_media_ids(self, client):
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "No items", "media_ids": []},
+        )
+        assert resp.status_code == 422
+
+    def test_400_when_no_dataset_loaded(self, client):
+        from vtsearch.state import medias
+
+        saved = dict(medias)
+        medias.clear()
+        try:
+            resp = client.post(
+                "/api/dataset/promote",
+                json={"name": "Empty", "media_ids": [1, 2, 3]},
+            )
+            assert resp.status_code == 400
+            assert "No dataset loaded" in resp.get_json()["message"]
+        finally:
+            medias.update(saved)

--- a/tests/datasets/test_promote_dataset.py
+++ b/tests/datasets/test_promote_dataset.py
@@ -43,12 +43,8 @@ class TestPromoteToDataset:
         roundtrip: dict = {}
         load_dataset_from_pickle(entry["pkl_path"], roundtrip)
         assert len(roundtrip) == len(ids)
-        original_origins = {
-            (snap[cid].get("origin_name") or snap[cid].get("filename")) for cid in ids
-        }
-        promoted_origins = {
-            (m.get("origin_name") or m.get("filename")) for m in roundtrip.values()
-        }
+        original_origins = {(snap[cid].get("origin_name") or snap[cid].get("filename")) for cid in ids}
+        promoted_origins = {(m.get("origin_name") or m.get("filename")) for m in roundtrip.values()}
         assert promoted_origins == original_origins
 
     def test_renumbers_ids_from_one(self, client):
@@ -63,6 +59,7 @@ class TestPromoteToDataset:
         )
         assert resp.status_code == 200
         entry = reg.get_dataset(resp.get_json()["dataset_id"])
+        assert entry is not None
         roundtrip: dict = {}
         load_dataset_from_pickle(entry["pkl_path"], roundtrip)
         assert sorted(roundtrip.keys()) == list(range(1, len(ids) + 1))
@@ -98,6 +95,7 @@ class TestPromoteToDataset:
             )
             assert resp.status_code == 200, resp.get_json()
             new_entry = reg.get_dataset(resp.get_json()["dataset_id"])
+            assert new_entry is not None
             # Death date inherited; created date is fresh (not the source's).
             assert new_entry["expires_at"] == 99_999.0
             assert new_entry["created_at"] != src["created_at"]

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -17,6 +17,8 @@ in the plan doc.
 """
 
 import io
+import time
+from collections import Counter
 from pathlib import Path
 from uuid import uuid4
 
@@ -25,12 +27,18 @@ from flask_smorest import Blueprint, abort
 
 import vtscore.security.path_validation as _paths
 from vtscore.config import EMBEDDINGS_DIR
-from vtscore.datasets import DEMO_DATASETS, get_importer, list_importers
+from vtscore.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtscore.datasets.load_pipeline import (
     STAGING_DIR,
     _run_importer_in_background,
     _stage_importer_in_background,
 )
+from vtscore.datasets.registry import (
+    get_dataset as _reg_get,
+    get_saved_datasets_dir,
+    register_dataset as _reg_register,
+)
+from vtsearch.auth import get_current_user
 from vtsearch.routes._shared import get_plugin_or_404, register_plugin_typed_routes, validate_plugin_args
 from vtsearch.routes.datasets._helpers import _extract_clipper_params
 from vtsearch.schemas.datasets import (
@@ -38,12 +46,15 @@ from vtsearch.schemas.datasets import (
     DatasetAvailableFilesResponseSchema,
     DatasetCombineRequestSchema,
     DatasetLoadStartedResponseSchema,
+    DatasetPromoteRequestSchema,
+    DatasetPromoteResponseSchema,
     DatasetStageDemoRequestSchema,
     DatasetStageFileResponseSchema,
     DatasetStagingStartedResponseSchema,
     ImporterFieldOptionsRequestSchema,
     ImporterFieldOptionsResponseSchema,
 )
+from vtsearch.state import get_active_context, snapshot_medias
 from vtscore.security.pickle import peek_pickle_dataset_summary
 
 datasets_staging_bp = Blueprint(
@@ -95,6 +106,115 @@ def combine_datasets_route(body: dict):
 
     task_id = _run_importer_in_background(importer, {"datasets": dataset_paths, "name": name})
     return {"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""}
+
+
+@datasets_staging_bp.route("/api/dataset/promote", methods=["POST"])
+@datasets_staging_bp.arguments(DatasetPromoteRequestSchema)
+@datasets_staging_bp.response(200, DatasetPromoteResponseSchema)
+@datasets_staging_bp.alt_response(400, description="No dataset loaded or none of the items resolved.")
+@datasets_staging_bp.alt_response(500, description="Failed to write or register the new dataset.")
+def promote_to_dataset(body: dict):
+    """Promote a set of media items into a brand-new saved dataset.
+
+    Used by the Find interface's "To Dataset" button to turn the Goods
+    pile into its own dataset. The promoted items keep their original
+    origins and in-memory embeddings (so preprocessing is preserved for
+    free; the new pickle is a self-contained snapshot). The new dataset
+    gets a fresh ``created_at`` but inherits the source dataset's
+    ``expires_at`` (death date).
+    """
+    name = body["name"].strip()
+    media_ids = body["media_ids"]
+
+    snap = snapshot_medias()
+    if not snap:
+        abort(400, message="No dataset loaded")
+
+    # Build the subset, renumbering IDs from 1 and preserving each item's
+    # origin/embedding (a shallow copy is enough; we serialise immediately
+    # and never mutate the embedding array).
+    subset: dict[int, dict] = {}
+    new_id = 1
+    for mid in media_ids:
+        media = snap.get(mid)
+        if media is None:
+            continue
+        clone = dict(media)
+        clone["id"] = new_id
+        subset[new_id] = clone
+        new_id += 1
+
+    if not subset:
+        abort(400, message="None of the selected items are in the current dataset")
+
+    # Inherit embedder / clipper / media_type / death-date from the source
+    # dataset's registry entry when available; otherwise derive from the
+    # promoted items themselves.
+    ctx = get_active_context()
+    src_id = ctx.dataset_id or None
+    src_entry = _reg_get(src_id) if src_id else None
+
+    first = next(iter(subset.values()))
+    media_type = (src_entry or {}).get("media_type") or first.get("media_type", "audio")
+    embedder = (src_entry or {}).get("embedder") or first.get("embedder", "")
+    clipper = (src_entry or {}).get("clipper", "") if src_entry else ""
+    expires_at = (src_entry or {}).get("expires_at") if src_entry else None
+
+    ext_counter: Counter[str] = Counter()
+    for m in subset.values():
+        fn = m.get("filename", "")
+        if fn and "." in fn:
+            ext_counter[fn.rsplit(".", 1)[-1].lower()] += 1
+        else:
+            ext_counter["(no extension)"] += 1
+
+    now = time.time()
+    ds_dir = get_saved_datasets_dir()
+    ds_dir.mkdir(parents=True, exist_ok=True)
+    pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
+
+    try:
+        data_bytes = export_dataset_to_file(
+            subset,
+            embedder=embedder,
+            clipper=clipper,
+            media_type=media_type,
+            name=name,
+            created_at=now,
+            expires_at=expires_at,
+        )
+        Path(pkl_path).write_bytes(data_bytes)
+        del data_bytes
+    except Exception as exc:  # noqa: BLE001 (surface the failure to the caller)
+        Path(pkl_path).unlink(missing_ok=True)
+        abort(500, message=f"Failed to write dataset: {exc}")
+
+    source = {
+        "importer": "promote",
+        "params": {
+            "source_dataset_id": src_id or "",
+            "source_name": (src_entry or {}).get("name", "") if src_entry else "",
+        },
+    }
+    try:
+        entry = _reg_register(
+            name=name,
+            media_type=media_type,
+            num_items=len(subset),
+            pkl_path=pkl_path,
+            origin="promote",
+            source=source,
+            clipper=clipper,
+            embedder=embedder,
+            created_by=get_current_user(),
+            file_type_counts=dict(ext_counter.most_common()),
+            expires_at=expires_at,
+        )
+    except Exception as exc:  # noqa: BLE001
+        Path(pkl_path).unlink(missing_ok=True)
+        abort(500, message=f"Failed to register dataset: {exc}")
+
+    return {"ok": True, "dataset_id": entry["id"], "name": name, "num_items": len(subset)}
 
 
 @datasets_staging_bp.route("/api/dataset/stage-file", methods=["POST"])

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -423,6 +423,37 @@ class DatasetCombineRequestSchema(Schema):
     name = fields.String(load_default="")
 
 
+class DatasetPromoteRequestSchema(Schema):
+    """Body for ``POST /api/dataset/promote``.
+
+    Promotes a set of media items from the active dataset into a brand-new
+    saved dataset (e.g. the Find "Goods" pile). The items keep their
+    original origins and embeddings; the new dataset gets a fresh
+    ``created_at`` but inherits the source dataset's ``expires_at``.
+    """
+
+    name = fields.String(
+        required=True,
+        validate=validate.Length(min=1),
+        metadata={"description": "Display name for the new dataset."},
+    )
+    media_ids = fields.List(
+        fields.Integer(),
+        required=True,
+        validate=validate.Length(min=1),
+        metadata={"description": "IDs of the media items (in the active dataset) to promote."},
+    )
+
+
+class DatasetPromoteResponseSchema(Schema):
+    """Response for ``POST /api/dataset/promote``."""
+
+    ok = fields.Boolean(required=True)
+    dataset_id = fields.String(required=True)
+    name = fields.String(required=True)
+    num_items = fields.Integer(required=True)
+
+
 class DatasetStageFileResponseSchema(Schema):
     """Response for ``POST /api/dataset/stage-file`` (multipart upload).
 


### PR DESCRIPTION
## What this does

Adds the ability to promote a set of media items into a brand-new saved dataset, plus the Find right-panel UI to drive it.

### 1. Promote to dataset (backend)

New `POST /api/dataset/promote` (in `datasets_staging_bp`) takes a `name` and a list of `media_ids` from the active dataset and creates a self-contained saved dataset from them:

- **Origins + embeddings preserved for free.** The promoted items are copied straight out of the in-memory `medias` dict (which already carry their `origin`/`origin.params` and embeddings) and serialized via the existing `export_dataset_to_file`. Because the pickle is a snapshot of media + embeddings (the one sanctioned vector store), *preprocessing is preserved with zero extra work* — clipper config, clip boundaries, embedder, etc. all ride along in each item's `origin.params`. No re-embedding, no re-deriving.
- **Fresh created date, inherited death date.** The new registry entry gets a new `created_at` (set by `register_dataset`) but inherits the source dataset's `expires_at` (looked up from the source's registry entry via the active `X-Dataset-Id`), exactly as requested.
- IDs are renumbered from 1; `media_type` / `embedder` / `clipper` are inherited from the source registry entry (falling back to the promoted items themselves).
- The new dataset is registered (so it appears in the Datasets dashboard) but **not** loaded/switched-to — the user stays in their Find session.

### 2. Find right-panel UI

- New **"To Dataset"** action next to the **Goods (#)** title, using the same `cubes` icon as the Datasets section in the dashboard. It promotes the **Goods pile** (same set the Browse button already operates on).
- **Browse** and **Export** moved up from the bottom of the Find right panel to sit alongside **Goods (#)**. Order: **Browse → To Dataset → Export**.
- Buttons are icon-only with tooltips (matching the dashboard card action buttons): Browse reuses the dashboard Browser eye icon; Export reuses the Detectors-dashboard export icon.
- Clicking **To Dataset** prompts for a name, prefilled with `"<dataset> <detector> Results"`, then creates the dataset and confirms with a success toast. The bottom Export button is retained unchanged in Label mode.

The action cluster is projected into the good `vt-label-list` header via a content slot, so it only appears in Find mode and only on the Goods list.

## Tests

- `tests/datasets/test_promote_dataset.py`: registration + pkl round-trip (origins preserved), ID renumbering, `expires_at` inheritance with a fresh `created_at`, and the unknown-ids / empty-name / empty-ids / no-dataset rejections.
- OpenAPI snapshot + generated Angular client regenerated.
- Full suite green: `./run-tests.sh` → 4660 passed; frontend `build:prod` clean (no errors/warnings).

## Notes

- Backwards-compat: no breaks.
- The promoted dataset defaults to creator-only readers (consistent with other newly-created datasets), regardless of the source's sharing.

https://claude.ai/code/session_018z1pVoGZ22JMbooLBYswgi

---
_Generated by [Claude Code](https://claude.ai/code/session_018z1pVoGZ22JMbooLBYswgi)_