### PR TITLE
Stop re-binning in the zoom-out rubber-band zone

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -673,7 +673,15 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   private updateActiveLevel(): void {
     if (!this.meta || this.meta.levels.length === 0) return;
-    this.activeLevel = this.levelForEffZoom(this.effZoom);
+    // Floor the level at the coarsest one reachable in "normal space" (the
+    // level the fit zoom lands on). Zooming out past the whole-projection fit
+    // only happens in the rubber-band overshoot zone, and that overshoot is
+    // always sprung back by the settle — so re-binning to a coarser level out
+    // there would shift the bins, then shift them straight back when the view
+    // snaps home. That double re-lay-out reads as a glitch. Holding the level
+    // at the floor keeps the bins put while the elastic edge does its bounce.
+    const floorLevel = this.levelForEffZoom(this.computeFitZoom());
+    this.activeLevel = Math.max(floorLevel, this.levelForEffZoom(this.effZoom));
   }
 
   private projToScreen(px: number, py: number): [number, number] {


### PR DESCRIPTION
## Problem

When zooming all the way out in VTSBrowse, the view enters a rubber-band overshoot below the whole-projection fit (the "bouncy ceiling") before the settle springs it back. The active pyramid level was selected straight from that overshoot zoom (`levelForEffZoom(effZoom)`), so if a level boundary happened to fall *inside* the elastic zone, the bins re-laid-out to a coarser level on the way out, then re-laid-out again when the view snapped home — a visible double shift that read as a glitch ("hanky and looks like a bug").

## Fix

Floor the active level at the level the **fit zoom** lands on (the coarsest level reachable in "normal space"). Zooming out past the whole-projection fit only ever happens in the rubber-band overshoot zone, and that overshoot is always sprung back — so there's no reason to re-bin out there. Holding the level at the floor keeps the bins put through the bounce.

This is a one-spot change in `updateActiveLevel()`:

```ts
const floorLevel = this.levelForEffZoom(this.computeFitZoom());
this.activeLevel = Math.max(floorLevel, this.levelForEffZoom(this.effZoom));
```

The clamp is a no-op while zoomed in (the live level is already ≥ the floor); it only bites in the overshoot zone.

### Bonus

`commitZoomChange()` keys its picture-in-picture transition off whether the level changed, so this also suppresses the spurious zoom animation that was firing on the same phantom level-cross.

## Behaviour preserved

- The bouncy ceiling / rubber-band itself is untouched — zooming too far out still gives and springs back.
- No change to zoom-in, panning, or any level selection within normal space.

## Testing

- `npm run build:prod` — clean, no errors or warnings.

https://claude.ai/code/session_01Gqe1H3URxTr5uDga1jHiUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqe1H3URxTr5uDga1jHiUZ)_