### PR TITLE
Harden GET /api/settings against stale scalar in dict fields

### DIFF
--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -23,6 +23,29 @@ class TestSettingsAPI:
         assert "volume" in data
         assert "autorun_detectors" in data
 
+    def test_get_settings_tolerates_stale_scalar_dict_field(self, client, isolated_settings):
+        """A stale scalar where a per-media-type dict is expected must not 500.
+
+        Older settings files (or hand-edits) can carry e.g.
+        ``browse_bin_shape: "hex"`` from before the field became a
+        ``{media_type: shape}`` dict. Marshmallow's ``Dict`` field calls
+        ``.items()`` while dumping, so the bare string used to crash the
+        whole endpoint with ``AttributeError: 'str' object has no attribute
+        'items'`` → 500. The read path now coerces it to ``{}`` (equivalent
+        to "never set") instead.
+        """
+        import json as _json
+
+        from vtsearch import settings as settings_mod
+
+        isolated_settings._user.parent.mkdir(parents=True, exist_ok=True)
+        isolated_settings._user.write_text(_json.dumps({"browse_bin_shape": "hex"}) + "\n")
+        settings_mod.reset()  # force the in-memory cache to re-read the corrupt file
+
+        res = client.get("/api/settings")
+        assert res.status_code == 200
+        assert res.get_json()["browse_bin_shape"] == {}
+
     def test_update_volume(self, client):
         res = client.put(
             "/api/settings",

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from flask_smorest import Blueprint, abort
+from marshmallow import fields
 
 from vtsearch import settings
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
@@ -194,6 +195,33 @@ def _apply_dir(key: str, value: str, setter) -> None:
     setter(value.strip())
 
 
+#: Schema fields declared as dicts (``browse_*``, the per-media-type
+#: embedder maps, ``import_defaults_by_media_type`` …). A persisted or
+#: hand-edited settings file from an older build can carry a stale scalar
+#: where one of these is now expected (e.g. a pre-per-media-type
+#: ``browse_bin_shape: "hex"``). Marshmallow's ``Dict`` field calls
+#: ``.items()`` while dumping, so a bare string there would 500 the entire
+#: settings endpoint. Derived from the schema so it stays in sync as
+#: fields are added.
+_DICT_FIELD_NAMES = frozenset(
+    name for name, field in AppSettingsSchema().fields.items() if isinstance(field, fields.Dict)
+)
+
+
+def _coerce_dict_fields(data: dict) -> dict:
+    """Replace any non-dict value in a schema dict field with ``{}``.
+
+    Mirrors how the per-side getters (``view_mode`` etc.) already coerce a
+    junk persisted value back to its default on read: a stale scalar left
+    over from an older settings file resolves to "never set" rather than
+    crashing the serializer. Mutates and returns *data*.
+    """
+    for name in _DICT_FIELD_NAMES:
+        if name in data and not isinstance(data[name], dict):
+            data[name] = {}
+    return data
+
+
 def _with_effective(data: dict) -> dict:
     """Overlay the resolver-computed (read-only) views onto *data*.
 
@@ -205,7 +233,11 @@ def _with_effective(data: dict) -> dict:
     * ``hidden_plugins`` - the persisted server setting unioned with any
       ``--hide-plugin`` CLI flags, normalised to sorted lists so the
       "Server" settings tab can render what's actually in force.
+
+    Stale dict fields are coerced to ``{}`` first so a corrupt persisted
+    value can't 500 the endpoint (see :func:`_coerce_dict_fields`).
     """
+    _coerce_dict_fields(data)
     data["effective_solo_media_type"] = settings.get_effective_solo_media_type()
     data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
     data["hidden_plugins"] = {


### PR DESCRIPTION
## What

A persisted or hand-edited settings file from an older build can carry a bare string where a per-media-type dict is now expected (e.g. `browse_bin_shape: "hex"` from before that field became a `{media_type: shape}` map).

`GET /api/settings` (and the PUT response) merges the persisted JSON via `settings.get_all()` and serializes it through `AppSettingsSchema`. The schema's `Dict` fields call `.items()` while dumping, so a bare string there crashes the **entire** settings endpoint with:

```
AttributeError: 'str' object has no attribute 'items'  → 500
```

That bricks the whole settings modal over a single stale key, with an opaque error.

## Fix

Coerce any value the schema declares as a `Dict` field but that isn't a dict back to `{}` before serialization (equivalent to "the user never set it"). This mirrors how the per-side getters (`view_mode`, `grid_icon_size`, `focus_mode`, `panel_pct`) already coerce a non-dict persisted value back to defaults on read.

- The dict-field list is derived from `AppSettingsSchema` itself, so it stays in sync as fields are added.
- Applied in `_with_effective`, the shared response path for both GET and PUT; `/defaults` returns pure defaults and was never at risk.

## Why it only bit existing/upgraded installs

Every *write* path validates: per-side fields expand a scalar into a full per-type dict or reject it, and the other dict fields go through Pydantic `model_validate`, which rejects a string given to a `dict[...]` field. So the app never *persists* a bare string into these fields — only a file written by an older build (or a manual edit) can. New/fresh users were already unaffected; this hardens the read path so an upgraded install with a stale value degrades gracefully instead of 500ing.

## Tests

- New regression test writes a stale `browse_bin_shape: "hex"` into the on-disk user settings file, forces a cache re-read, and asserts `GET /api/settings` returns 200 with the field coerced to `{}`.
- `./run-tests.sh core api` — all 1198 pass (ruff / codespell / deptry / frontend build included).

https://claude.ai/code/session_01EULCj8g78Eaiw2xHMBSDfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EULCj8g78Eaiw2xHMBSDfq)_