### PR TITLE
Hover thumbnails break out of the bin as a full rectangle

### DIFF
--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -8,7 +8,6 @@
 
 import {
   SQRT3,
-  HEX_ANGLES,
   traceCellPath as traceHexCellPath,
   densityColor,
   resolveColormap,
@@ -17,6 +16,12 @@ import type { BinShape } from '../../models/projection.models';
 
 export { SQRT3, densityColor, resolveColormap };
 export type { BinShape };
+
+/** Offset from a cell centre to a neighbour centre, in units of `radius`. */
+export interface NeighborOffset {
+  dx: number;
+  dy: number;
+}
 
 export interface BinGeometry {
   readonly shape: BinShape;
@@ -44,78 +49,36 @@ export interface BinGeometry {
    */
   contains(ox: number, oy: number, radius: number): boolean;
   /**
-   * Half-width / half-height of the cell's bounding box at the given screen
-   * `radius`. Used to contain-fit a thumbnail inside a cell: a hex is wider
-   * than tall (`√3·radius` × `2·radius`) while a square is `√3·radius` on a
-   * side, so the fit box differs by shape.
+   * Offsets, in units of `radius`, from a cell centre to each immediately
+   * adjacent cell centre — six for a hex, four for a square. Multiply by a
+   * screen `radius` to get neighbour-centre offsets in screen px. Used to size
+   * a hovered thumbnail so it grows until its edge just reaches the nearest
+   * neighbour centre, never covering one.
    */
-  contentHalfExtent(radius: number): { hw: number; hh: number };
-  /**
-   * Trace the pile cell outline clipped to the centered axis-aligned rectangle
-   * of half-extents `(hw, hh)` as the current path. This is the cell shape with
-   * the corners that stick out past the rectangle lopped off — used to draw a
-   * hovered thumbnail tile trimmed to the thumbnail's contain-fit rectangle, so
-   * the enlarged tile doesn't paint background over its neighbours. The outer
-   * `radius` (and so the shape away from the cut) is unchanged.
-   */
-  traceTrimmedCell(
-    ctx: CanvasRenderingContext2D,
-    cx: number,
-    cy: number,
-    radius: number,
-    hw: number,
-    hh: number,
-  ): void;
+  neighborOffsets(): readonly NeighborOffset[];
 }
 
-// Sutherland–Hodgman clip of a convex polygon (local coords, centered on the
-// origin) against one axis-aligned half-plane, returning the clipped polygon.
-type Pt = { x: number; y: number };
-function clipHalfPlane(poly: Pt[], axis: 'x' | 'y', value: number, keepGreater: boolean): Pt[] {
-  if (poly.length === 0) return poly;
-  const inside = (p: Pt) => (keepGreater ? p[axis] >= value : p[axis] <= value);
-  const crossing = (a: Pt, b: Pt): Pt => {
-    const t = (value - a[axis]) / (b[axis] - a[axis]);
-    return axis === 'x'
-      ? { x: value, y: a.y + (b.y - a.y) * t }
-      : { x: a.x + (b.x - a.x) * t, y: value };
-  };
-  const out: Pt[] = [];
-  for (let i = 0; i < poly.length; i++) {
-    const cur = poly[i];
-    const prev = poly[(i + poly.length - 1) % poly.length];
-    const curIn = inside(cur);
-    if (curIn) {
-      if (!inside(prev)) out.push(crossing(prev, cur));
-      out.push(cur);
-    } else if (inside(prev)) {
-      out.push(crossing(prev, cur));
-    }
-  }
-  return out;
-}
+// Pointy-top hex neighbours: two along the row at ±√3·radius, and four in the
+// rows above/below offset half a column (±√3/2·radius) and ±1.5·radius — the
+// same spacing as `dx`/`dy`. All six sit one centre-distance (√3·radius) away.
+const HEX_NEIGHBORS: readonly NeighborOffset[] = [
+  { dx: SQRT3, dy: 0 },
+  { dx: -SQRT3, dy: 0 },
+  { dx: SQRT3 / 2, dy: 1.5 },
+  { dx: SQRT3 / 2, dy: -1.5 },
+  { dx: -SQRT3 / 2, dy: 1.5 },
+  { dx: -SQRT3 / 2, dy: -1.5 },
+];
 
-// Trace `verts` (local, origin-centered) clipped to the `±hw × ±hh` rectangle as
-// the current path at screen center `(cx, cy)`.
-function traceClippedPolygon(
-  ctx: CanvasRenderingContext2D,
-  verts: Pt[],
-  cx: number,
-  cy: number,
-  hw: number,
-  hh: number,
-): void {
-  let poly = clipHalfPlane(verts, 'x', -hw, true);
-  poly = clipHalfPlane(poly, 'x', hw, false);
-  poly = clipHalfPlane(poly, 'y', -hh, true);
-  poly = clipHalfPlane(poly, 'y', hh, false);
-  ctx.beginPath();
-  poly.forEach((p, i) => {
-    if (i === 0) ctx.moveTo(cx + p.x, cy + p.y);
-    else ctx.lineTo(cx + p.x, cy + p.y);
-  });
-  ctx.closePath();
-}
+// Square neighbours: the four edge-adjacent cells at ±√3·radius (the diagonal
+// corners are deliberately excluded — the thumbnail may grow past a corner so
+// long as it doesn't reach an edge neighbour's centre).
+const SQUARE_NEIGHBORS: readonly NeighborOffset[] = [
+  { dx: SQRT3, dy: 0 },
+  { dx: -SQRT3, dy: 0 },
+  { dx: 0, dy: SQRT3 },
+  { dx: 0, dy: -SQRT3 },
+];
 
 // Pointy-top hexagon: column spacing `radius·√3`, row spacing `radius·1.5`.
 // Hit-tested against the circumscribed circle (matching the original canvas).
@@ -125,14 +88,7 @@ const HEX_GEOMETRY: BinGeometry = {
   dy: (radius) => radius * 1.5,
   traceCell: (ctx, cx, cy, radius, single) => traceHexCellPath(ctx, cx, cy, radius, single),
   contains: (ox, oy, radius) => ox * ox + oy * oy < radius * radius,
-  contentHalfExtent: (radius) => ({ hw: (radius * SQRT3) / 2, hh: radius }),
-  traceTrimmedCell: (ctx, cx, cy, radius, hw, hh) => {
-    const verts = HEX_ANGLES.map((a) => ({
-      x: radius * Math.cos(a),
-      y: radius * Math.sin(a),
-    }));
-    traceClippedPolygon(ctx, verts, cx, cy, hw, hh);
-  },
+  neighborOffsets: () => HEX_NEIGHBORS,
 };
 
 // Corner radius of a square-mode singleton, as a fraction of its half-side. A
@@ -162,20 +118,7 @@ const SQUARE_GEOMETRY: BinGeometry = {
     const half = (radius * SQRT3) / 2;
     return Math.abs(ox) < half && Math.abs(oy) < half;
   },
-  contentHalfExtent: (radius) => {
-    const half = (radius * SQRT3) / 2;
-    return { hw: half, hh: half };
-  },
-  traceTrimmedCell: (ctx, cx, cy, radius, hw, hh) => {
-    const half = (radius * SQRT3) / 2;
-    const verts: Pt[] = [
-      { x: -half, y: -half },
-      { x: half, y: -half },
-      { x: half, y: half },
-      { x: -half, y: half },
-    ];
-    traceClippedPolygon(ctx, verts, cx, cy, hw, hh);
-  },
+  neighborOffsets: () => SQUARE_NEIGHBORS,
 };
 
 /** The geometry for a bin shape; defaults to hex for an unset/unknown shape. */

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -52,9 +52,11 @@ export interface BrowseContextMenuEvent {
   bounds: DOMRect;
 }
 
-/** How much larger the hovered cell is drawn relative to its neighbours so it
- *  lifts off the grid. The border is reserved for selection state, so hover is
- *  signalled by this size bump + a soft drop shadow instead of a ring. */
+/** How much larger a hovered *flat-density* cell (audio/text — no thumbnail) is
+ *  drawn relative to its neighbours so it lifts off the grid. The border is
+ *  reserved for selection state, so hover is signalled by this size bump + a
+ *  soft drop shadow instead of a ring. Thumbnail cells ignore this and size
+ *  their break-out rectangle by the neighbour-centre rule (`hoverThumbRect`). */
 const HOVER_RADIUS_SCALE = 1.38;
 
 @Component({
@@ -1123,19 +1125,24 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   ): void {
     // A cell with one item is drawn as a disc (slightly smaller than the cell);
     // multi-item cells keep their full shape so they tile the space. The hovered
-    // cell instead passes `trim`: its outline is the cell clipped to the
-    // thumbnail's contain-fit rectangle, so the enlarged tile is just the
-    // thumbnail with the protruding corners lopped off rather than background
-    // bars painted over the neighbours.
+    // cell instead passes `trim`: a plain rectangle of the thumbnail's native
+    // aspect ratio, so the enlarged tile breaks out of the bin silhouette and
+    // shows the whole frame (no hex/square clip, no background bars).
     const single = cell.count === 1;
-    if (trim) this.geom.traceTrimmedCell(ctx, cx, cy, radius, trim.hw, trim.hh);
-    else this.geom.traceCell(ctx, cx, cy, radius, single);
+    if (trim) {
+      ctx.beginPath();
+      ctx.rect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
+      ctx.closePath();
+    } else {
+      this.geom.traceCell(ctx, cx, cy, radius, single);
+    }
 
     // Image / video: paint the central item's thumbnail clipped to the cell.
     // Until it loads, fall back to the density shading below so the cell is
     // never blank. Grid cells cover-fit (fill the bin, cropping the edges); the
-    // hovered cell instead draws the thumbnail contain-fit into `trim`, which
-    // its trimmed outline matches, so the whole frame shows with no letterbox.
+    // hovered cell instead draws the whole thumbnail to fill `trim`, whose
+    // rectangle already carries the image's aspect ratio, so it shows undistorted
+    // and uncropped.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
     if (thumb) {
       ctx.save();
@@ -1206,13 +1213,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     cmap: ResolvedColormap,
     selectionActive: boolean,
   ): void {
-    const bumped = radius * HOVER_RADIUS_SCALE;
-    // With a thumbnail, trim the tile to the thumbnail's contain-fit rectangle
-    // so the enlarged cell is just the (whole) thumbnail — no background bars
-    // reaching over the neighbours. Without one (flat density), keep the full
-    // bumped cell.
+    // A hovered thumbnail breaks out of its bin: it's shown whole at its native
+    // aspect ratio as a plain rectangle (no silhouette), sized to grow until its
+    // edge just reaches the nearest neighbour cell's centre (`hoverThumbRect`).
+    // A non-thumbnail (flat density) cell has no such rectangle, so it keeps its
+    // silhouette and simply lifts off with a fixed size bump.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
-    const trim = thumb ? this.containRect(thumb, bumped) : null;
+    const trim = thumb ? this.hoverThumbRect(thumb, radius) : null;
+    const bumped = radius * HOVER_RADIUS_SCALE;
 
     // Cast a single clean drop shadow from an opaque base shape first, then
     // paint the real (shadow-free) cell on top so the fill/border don't each
@@ -1221,13 +1229,20 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
     ctx.shadowBlur = Math.max(4, radius * 0.3);
     ctx.shadowOffsetY = Math.max(1, radius * 0.1);
-    if (trim) this.geom.traceTrimmedCell(ctx, cx, cy, bumped, trim.hw, trim.hh);
-    else this.geom.traceCell(ctx, cx, cy, bumped, cell.count === 1);
+    if (trim) {
+      ctx.beginPath();
+      ctx.rect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
+      ctx.closePath();
+    } else {
+      this.geom.traceCell(ctx, cx, cy, bumped, cell.count === 1);
+    }
     ctx.fillStyle = this.themeColor('--bg-body');
     ctx.fill();
     ctx.restore();
 
-    this.drawHex(ctx, cx, cy, bumped, cell, cmap, selectionActive, trim);
+    // `radius` is unused for the shape when `trim` is set (the rectangle drives
+    // it), so the un-bumped radius is fine there; flat-density cells use the bump.
+    this.drawHex(ctx, cx, cy, trim ? radius : bumped, cell, cmap, selectionActive, trim);
   }
 
   /** Cover-fit an image over the hex's 2*radius square (the path must be clipped). */
@@ -1245,13 +1260,25 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);
   }
 
-  /** Half-extents of an image contain-fit into the cell's bounding box at the
-   *  given `radius`. The fit box follows the shape (hex is wider than tall,
-   *  square is even) so wide thumbnails aren't re-cropped by the silhouette. */
-  private containRect(img: HTMLImageElement, radius: number): { hw: number; hh: number } {
-    const { hw, hh } = this.geom.contentHalfExtent(radius);
-    const scale = Math.min((hw * 2) / img.naturalWidth, (hh * 2) / img.naturalHeight);
-    return { hw: (img.naturalWidth * scale) / 2, hh: (img.naturalHeight * scale) / 2 };
+  /**
+   * Half-extents of a hovered thumbnail. On hover the thumbnail breaks out of
+   * its bin and is shown whole at its native aspect ratio, grown as large as
+   * possible under one rule: no neighbouring cell's centre may be covered. The
+   * rectangle (aspect = image width / height) is centred on the cell, so a
+   * neighbour at screen offset `(ox, oy)` stays uncovered while the half-height
+   * `H` satisfies `H ≤ max(|ox| / aspect, |oy|)`; the binding neighbour is the
+   * tightest of those (four for a square, six for a hex), and the rectangle's
+   * edge then just touches that centre. Wide images grow until they reach the
+   * side neighbours, tall ones until they reach the top/bottom — each axis
+   * limited by whichever neighbour it would otherwise overrun.
+   */
+  private hoverThumbRect(img: HTMLImageElement, radius: number): { hw: number; hh: number } {
+    const aspect = img.naturalWidth / img.naturalHeight;
+    let hh = Infinity;
+    for (const { dx, dy } of this.geom.neighborOffsets()) {
+      hh = Math.min(hh, Math.max((Math.abs(dx) * radius) / aspect, Math.abs(dy) * radius));
+    }
+    return { hw: aspect * hh, hh };
   }
 
   /**


### PR DESCRIPTION
## What

When hovering an image/video bin in the browse projection, the thumbnail now **breaks out of its bin and shows the whole frame** at its native aspect ratio as a plain rectangle — for both the hex grid and the square grid.

Previously both grids used a fixed `HOVER_RADIUS_SCALE = 1.38` bump and traced the *bin silhouette clipped to the thumbnail's contain box* (`traceTrimmedCell`). For the square that produced a plain rectangle, but for the hex it left a "slightly-hex" clipped shape. That trimming is gone; on hover the cell is just the thumbnail.

## Resting vs hover (unchanged resting behavior)

- **Resting:** thumbnail is cover-fit and clipped to the bin shape (hex/square) — truncated, fills the bin. (unchanged)
- **Hover:** whole thumbnail, native aspect ratio, drawn as a plain rectangle with no silhouette clip.

## Size rule (shared by both grids)

The break-out rectangle grows as large as possible under one constraint: **no neighbouring cell's centre may be covered** — four neighbours for the square, six for the hex. With the rectangle centred on the cell and carrying the image's aspect ratio `a = w/h`, a neighbour at screen offset `(ox, oy)` stays uncovered while the half-height `H ≤ max(|ox|/a, |oy|)`; the binding neighbour is the tightest of those, and the edge then just touches that centre. Wide images grow until they reach the side neighbours, tall ones until they reach the top/bottom.

Flat-density cells (audio/text — no thumbnail) keep the fixed `1.38×` size bump + drop shadow.

## Implementation

- `bin-geometry.ts`: dropped `contentHalfExtent` / `traceTrimmedCell` (and the Sutherland–Hodgman polygon clipper they needed); added `neighborOffsets()` returning the per-shape neighbour-centre offsets (6 hex / 4 square).
- `browse-canvas.component.ts`: replaced `containRect` (contain-fit into the bin's content box) with `hoverThumbRect` (the neighbour-centre size calc); the hovered tile and its shadow base now trace a plain rectangle.

## Notes

- This **changes the square grid's hover size**: a square image's half-size goes from ~1.2·r to 1.5·r, since the neighbour-centre rule now drives both grids (confirmed intent: unify, so hex truly matches square).

## Testing

`./run-tests.sh core` — all 738 tests pass; ruff/codespell/deptry clean; `npm run build:prod` clean (no errors or budget warnings).

https://claude.ai/code/session_01NzCMytCiV1N88kvDfnG6iZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzCMytCiV1N88kvDfnG6iZ)_