### PR TITLE
Find verification workflow — Phase 2 (frontend)

### DIFF
--- a/docs/plans/find-verification-workflow.md
+++ b/docs/plans/find-verification-workflow.md
@@ -1,6 +1,6 @@
 # Find Verification Workflow
 
-**Status:** **Phase 1 (backend spine) shipped** — full `./run-tests.sh` green. Phase 2 (frontend) deferred to a session where the UI can be eyeballed (no browser in the build container). See **What shipped / Open follow-ups** at the bottom.
+**Status:** **Phase 1 (backend spine) + Phase 2 (frontend) shipped** — full `./run-tests.sh` green (4696 passed). Phase 2 was built without a browser in the container, so the UI passed `npm run build:prod` (no TS errors, no budget warnings) but was **not visually eyeballed**; a manual pass on a real screen is still owed. See **What shipped / Open follow-ups** at the bottom.
 
 ## The reframe (read this first)
 
@@ -140,9 +140,21 @@ All under `./run-tests.sh` (full suite green). Note one doc-vs-code correction d
 - **Verification state.** `DetectorContext.verified_ids` + `find_scores` (in-memory; cleared on pair change). Mark-verified on single-item find-mode votes (`set_vote`/`toggle_vote`), un-verify on un-vote.
 - **APIs.** `verified` array on `GET /api/votes`; `unverified`/`verified` `label_filter` on `/api/labels/export` (atomic via `VoteSnapshot.verified_ids`); new read-only `GET /api/find/stats` (adopted-label 2×2 confusion + the −10…10 FP/FN sweep, both over **all** items — unverified flood-filled like Export/Browse, with `verified_count` as context). `find-label` freezes `find_scores`.
 
+## What shipped (Phase 2 — frontend)
+
+All under `./run-tests.sh` (full suite + `npm run build:prod` green).
+
+- **No-retrain Inclusion slide.** `find-view.onInclusionChange` now calls `POST /api/inclusion` (no `runFindLabel`) and reconciles the server-returned cutoff + the re-split unverified votes on the cheap response — no scoring spinner. The backend `set_inclusion` now also re-thresholds the unverified Find items over the frozen `find_scores` (`rethreshold_unverified_find_items`), so export/Stats reflect the slider; `GET|POST /api/inclusion` returns the resolved `threshold`.
+- **Verified-id tracking.** `VoteStateService` exposes `verifiedIds$` (from the `/api/votes` `verified` array) with optimistic add/remove on a manual Find vote (merged over the server set so a racing poll doesn't flicker the left/right split).
+- **Right panel = the verified pile.** Find mode shows only `good/bad ∩ verified`, each bucket headed "Verified Good/Bad (V)" with a folded "[N] Unverified …" count; Browse / To Dataset / Export / Stats act on the **full** good set, a bad-bucket Export acts on the full bad set.
+- **Marginal-positive auto-advance.** After any vote (button or hover) the centre jumps to the lowest unverified item still above the cutoff; the seed reuses the same rule. Empty queue → a one-shot "All positives reviewed" toast (the done state).
+- **Unverified Export** button in the left work-queue header (`label_filter=unverified`), routed through a shared `vt-export-modal` that now takes an `initialFilter` and fetches the `unverified`/`verified` server partitions.
+- **`vt-find-stats-modal`** — the adopted-totals + verified count, the 2×2 confusion, agreement-rate / precision, and the FP/FN-vs-inclusion sweep drawn as a dependency-free inline SVG line chart (current inclusion marked).
+
 ## Open follow-ups
 
-- **Phase 2 — frontend (the whole UI).** Find slider → `POST /api/inclusion` (no retrain) with optimistic client-side re-threshold; 2 verified buckets + count-folding headers on the right; left work queue + Unverified Export button; marginal-positive auto-advance; big-button/hover verify wired through; `vt-find-stats-modal` rendering the 2×2 + FP/FN sweep as an inline SVG line chart.
+- **Left work queue does not hide verified items (deviation).** The plan called for the left panel to drop verified items (move them off-left). As built, the left keeps showing the **full scored ranking** (verified items stay, colored) while the right becomes verified-only. This was a deliberate trade: the stripe-overview maps click position → index into the full `sortOrder`, and filtering the media-list would desync stripe-click navigation (and add a per-CD filter cost). Auto-advance already drives the "walk the queue" workflow, so the left staying full is low-harm. If the off-left move is wanted, filter the media-list **and** the stripe together (keep their index spaces aligned) and recompute the header count from the unverified set.
+- **UI not visually verified.** Built headless; the right-panel folding headers, the SVG chart, and the Unverified Export button placement should be eyeballed on a real screen.
 - **Safe-threshold blend on Inclusion slide.** `recompute_detector_thresholds_for_inclusion` re-derives the *raw* cross-cal threshold from the fold orderings; it does not re-apply `calculate_safe_threshold` blending (which needs the haystack score distribution). When `safe_thresholds` is on, an Inclusion slide's threshold will differ slightly from a full retrain's. `find_scores` is available to blend if this matters; deferred (safe_thresholds is opt-in).
 - **Done-state polish.** The empty queue (no unverified item above the cutoff) is now well-defined; decide how rich the "all positives reviewed" rest state should be (plain message vs. a summary nudge toward Stats/Export).
 - **Under-threshold (false-negative) review surface.** Currently reachable only item-by-item via the left panel + big buttons. If demand appears, add a dedicated below-the-line work queue (the symmetric "find what the detector missed" flow).

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2933,6 +2933,10 @@
         "properties": {
           "inclusion": {
             "type": "integer"
+          },
+          "threshold": {
+            "nullable": true,
+            "type": "number"
           }
         },
         "required": [
@@ -10957,12 +10961,13 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Get the current Inclusion setting.",
+        "summary": "Get the current Inclusion setting and the cutoff it resolves to.",
         "tags": [
           "sorting"
         ]
       },
       "post": {
+        "description": "Inclusion is a pure cutoff knob: this re-derives the active detector's\nthreshold from its cached fold orderings (no MLP retrain) and, in Find\nmode, re-splits the unverified items over the frozen scores.  The new\ncutoff is returned so the Find slider can move the green/red line.",
         "operationId": "set_inclusion_route",
         "requestBody": {
           "content": {

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -28,6 +28,7 @@
       (mediaSelect)="onMediaSelect($event)"
       (mediaVote)="onHoverVote($event)"
       (inclusionChange)="onInclusionChange($event)"
+      (unverifiedExport)="onExportRequest('unverified')"
       (sortCancel)="onSortCancel()"
     />
   </div>
@@ -72,6 +73,20 @@
       (mediaVoted)="onHoverVote($event)"
       (browse)="onBrowse()"
       (toDataset)="onToDataset()"
+      (exportLabels)="onExportRequest($event)"
+      (stats)="onStats()"
     />
   </div>
 </div>
+
+@if (showExport) {
+  <vt-export-modal
+    [initialFilter]="exportFilter"
+    (closed)="showExport = false"
+    (exported)="showExport = false"
+  />
+}
+
+@if (showStats) {
+  <vt-find-stats-modal (closed)="showStats = false" />
+}

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -7,6 +7,9 @@ import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { ExportModalComponent } from '../modals/export-modal/export-modal.component';
+import { FindStatsModalComponent } from '../modals/find-stats-modal/find-stats-modal.component';
+import type { LabelFilter } from '../../services/sorting-api.service';
 import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
@@ -29,7 +32,15 @@ import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/gr
 @Component({
   selector: 'vt-find-view',
   standalone: true,
-  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent, ProgressBarComponent],
+  imports: [
+    CommonModule,
+    LeftPanelComponent,
+    CenterPanelComponent,
+    RightPanelComponent,
+    ProgressBarComponent,
+    ExportModalComponent,
+    FindStatsModalComponent,
+  ],
   templateUrl: './find-view.component.html',
   styleUrl: './find-view.component.scss',
 })
@@ -51,6 +62,14 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
+
+  /** Verified ids (Find mode): the right-panel confirmed pile. */
+  verifiedIds: Set<number> = new Set();
+  /** Export modal visibility + the label filter it opens on. */
+  showExport = false;
+  exportFilter: LabelFilter = 'good';
+  /** Detector-evaluation Stats modal visibility. */
+  showStats = false;
 
   private readonly LEFT_MIN = 180;
   private readonly RIGHT_MIN = 150;
@@ -89,6 +108,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
+    this.voteState.verifiedIds$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((ids) => (this.verifiedIds = ids));
     this.loadSettings();
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
       next: (status) => { this.datasetName = status.display_name || ''; },
@@ -233,20 +255,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.sortState.setLoadSortLabel(modelName);
           this.sortState.setSortStatus('');
           this.sortState.setSortProgress(0, 0);
-          // Select the item just above the threshold (last item with score >= threshold)
-          if (threshold != null && sorted.length > 0) {
-            let aboveId: number | null = null;
-            for (const item of sorted) {
-              if (item.score >= threshold) {
-                aboveId = item.id;
-              } else {
-                break;
-              }
-            }
-            if (aboveId != null) {
-              this.mediaState.selectMedia(aboveId);
-            }
-          }
+          // Seed the centre on the marginal positive (lowest item ≥ cutoff).
+          // With nothing verified yet this is the same rule auto-advance uses,
+          // so seed and advance unify.
+          this.queueEmptyNotified = false;
+          this.advanceToMarginalPositive();
           // Reload votes to reflect newly applied labels
           this.voteState.loadVotes();
         },
@@ -405,13 +418,14 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * Inclusion change in Find: persist to the active detector's context (the
-   * same per-detector value Train edits, via POST /api/inclusion), then
-   * re-score. set_inclusion invalidates the cached MLP, so runFindLabel
-   * retrains at the new inclusion — both the live and cold paths converge on
-   * a model trained at the value shown in the slider. The settings store only
-   * holds the default that seeds a fresh detector; this does not change the
-   * inclusion of any other detector's context.
+   * Inclusion change in Find: a pure cutoff slide, **no retrain**. Inclusion
+   * is the FP/FN cost weight in the labelset min-cost threshold search; the
+   * model and every item's frozen score are inclusion-independent, so the
+   * slider only moves the green/red line over the cached scores. POST
+   * /api/inclusion re-derives the cutoff from the cached fold orderings and
+   * re-splits the *unverified* items server-side (verified items hold). We
+   * reconcile the new threshold (moves the line) and the re-split votes on the
+   * cheap response — there is no scoring spinner.
    */
   onInclusionChange(value: number): void {
     if (this.sortState.sortBusy) return;
@@ -419,7 +433,16 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortingApi
       .setInclusion(value)
       .pipe(takeUntil(this.destroy$))
-      .subscribe({ next: () => this.runFindLabel() });
+      .subscribe({
+        next: (resp) => {
+          if (resp.threshold != null && this.sortState.sortOrder) {
+            this.sortState.setSortResults(this.sortState.sortOrder, resp.threshold);
+          }
+          // The server re-thresholded the unverified items over the frozen
+          // scores; pull the new good/bad split back for the left/right panes.
+          this.voteState.loadVotes();
+        },
+      });
   }
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
@@ -437,10 +460,61 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onMediaVoted(event: { id: number; vote: 'good' | 'bad' }): void {
-    // In find mode: re-fetch labelset counters but skip a re-sort. The local
-    // vote state has already been reconciled from the POST response inside
-    // submitToggleVote, so a follow-up GET /api/votes only refreshes counts.
+    // A single-item manual vote (big button or hover) verifies the item: it
+    // moves out of the left work queue into the right verified pile. Mirror
+    // the server's mark-verified optimistically so the move feels instant —
+    // the resulting local polarity (good/bad vs. un-voted) decides verified.
+    const verified =
+      this.voteState.goodVotes.has(event.id) || this.voteState.badVotes.has(event.id);
+    this.voteState.setOptimisticVerified(event.id, verified);
+    // Re-fetch labelset counters + the authoritative verified set.
     this.voteState.loadVotes();
+    // Auto-advance to the marginal positive (the lowest unverified item still
+    // above the cutoff), so "just sit and vote" walks the boundary upward.
+    this.advanceToMarginalPositive();
+  }
+
+  /**
+   * Select the next item to review: the lowest-scored unverified item still
+   * above the cutoff (the Unverified Good nearest the line). This is a cheap
+   * active-learning order — always the most marginal positive next. The queue
+   * is empty exactly when no unverified item remains above the cutoff; that is
+   * the done state.  Mirrors the initial seed in {@link runFindLabel}.
+   */
+  private advanceToMarginalPositive(): void {
+    const order = this.sortState.sortOrder;
+    const threshold = this.sortState.threshold;
+    if (!order || threshold == null) return;
+    const verified = this.voteState.verifiedIds;
+    let target: number | null = null;
+    for (const item of order) {
+      if (item.score < threshold) break; // below the cutoff: nothing left above
+      if (!verified.has(item.id)) target = item.id;
+    }
+    if (target != null) {
+      this.queueEmptyNotified = false;
+      this.mediaState.selectMedia(target);
+    } else if (!this.queueEmptyNotified) {
+      this.queueEmptyNotified = true;
+      this.toast.success({
+        message: 'All positives reviewed',
+        detail: 'Every item above the cutoff has been verified. Check Stats or Export your results.',
+        dedupKey: 'find-queue-empty',
+      });
+    }
+  }
+
+  private queueEmptyNotified = false;
+
+  /** Open the detector-evaluation Stats modal. */
+  onStats(): void {
+    this.showStats = true;
+  }
+
+  /** Open the export modal pre-set to a label filter (good / bad / unverified). */
+  onExportRequest(filter: LabelFilter): void {
+    this.exportFilter = filter;
+    this.showExport = true;
   }
 
   /**

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -14,6 +14,18 @@
         <h3 class="images-header-title">
           {{ mediaTypeName }}s ({{ medias.length | number }})
         </h3>
+        <button
+          class="goods-action-btn unverified-export-btn"
+          [disabled]="disabled"
+          (click)="unverifiedExport.emit()"
+          aria-label="Export unverified"
+          title="Export the untouched work queue (unverified labels) — e.g. to re-import as a dataset"
+        >
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="15 14 20 9 15 4"></polyline>
+            <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+          </svg>
+        </button>
         <vt-view-controls
           side="left"
           [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -122,7 +122,32 @@
 }
 
 .view-controls-slot {
+  margin-left: var(--space-xs);
+}
+
+// Find mode: compact icon button for "export the unverified work queue",
+// pushed to the right edge of the header next to the view controls.
+.unverified-export-btn {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xs, 4px);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--border-strong, var(--border-subtle));
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
 }
 
 .media-list-container {

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -97,6 +97,8 @@ export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Output() indicatorClick = new EventEmitter<string>();
   /** User clicked the Cancel button on the running sort progress bar. */
   @Output() sortCancel = new EventEmitter<void>();
+  /** Find mode: dump the untouched work queue (unverified labels) for re-import. */
+  @Output() unverifiedExport = new EventEmitter<void>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
   @Output() autopilotRefocus = new EventEmitter<void>();

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,4 +1,4 @@
-<vt-modal title="Export" [open]="true" (closed)="close()">
+<vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   <!-- Category Filter -->
   <div class="export-section">
     <h3 title="Filter which labeled items to include in the export">Categories</h3>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -15,6 +15,7 @@ import { DatasetStateService } from '../../../services/dataset-state.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
+import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ImporterField } from '../../../models/api.models';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
@@ -41,6 +42,13 @@ export interface ColumnDef {
 })
 export class ExportModalComponent implements OnInit, OnDestroy {
   @Input() detectorName = '';
+  /**
+   * The filter the modal opens on. ``unverified`` / ``verified`` are
+   * server-side partitions (by Find ``verified_ids``) that can't be derived
+   * client-side, so the modal fetches them with that ``label_filter``; the
+   * other values are client-side category filters over the full fetched set.
+   */
+  @Input() initialFilter: LabelFilter = 'good';
   @Output() closed = new EventEmitter<void>();
   @Output() exported = new EventEmitter<void>();
 
@@ -56,8 +64,15 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   /** Column definitions with selection state, built dynamically from API response. */
   columns: ColumnDef[] = [];
 
-  /** Filter which labels to show/export. Defaults to good-only. */
+  /** Client-side category filter over the fetched set (radio buttons). */
   labelFilter: 'good' | 'bad' | 'both' | 'corrections' = 'good';
+
+  /**
+   * Server-side partition the labels were fetched with. ``both`` fetches
+   * everything (the radios then slice it); ``unverified`` / ``verified`` fetch
+   * the Find work-queue / confirmed pile, which can't be sliced client-side.
+   */
+  serverFilter: 'both' | 'unverified' | 'verified' = 'both';
 
   /** Active export tab: 'clipboard' or an exporter name. */
   activeTab = 'clipboard';
@@ -105,6 +120,16 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    // Split the requested filter into a server-side partition (unverified /
+    // verified are fetched with that label_filter) and a client-side category.
+    if (this.initialFilter === 'unverified' || this.initialFilter === 'verified') {
+      this.serverFilter = this.initialFilter;
+      this.labelFilter = 'both';
+    } else {
+      this.serverFilter = 'both';
+      this.labelFilter = this.initialFilter;
+    }
+
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
       next: (status) => {
         this.datasetName = status.display_name || '';
@@ -122,7 +147,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       },
     });
 
-    this.sortingApi.exportLabels(false, { enrich: true }).pipe(takeUntil(this.destroy$)).subscribe({
+    const labelFilter = this.serverFilter === 'both' ? undefined : this.serverFilter;
+    this.sortingApi.exportLabels(false, { enrich: true, labelFilter }).pipe(takeUntil(this.destroy$)).subscribe({
       next: (data) => {
         this.labels = data.labels || [];
         this.labelsLoaded = true;
@@ -234,6 +260,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
    *  e.g. "Good-MyDetector-MyDataset.json" */
   private buildDefaultFilename(ext: string): string {
     const parts: string[] = [];
+    if (this.serverFilter === 'unverified') parts.push('Unverified');
+    else if (this.serverFilter === 'verified') parts.push('Verified');
     if (this.labelFilter === 'good') parts.push('Good');
     else if (this.labelFilter === 'bad') parts.push('Bad');
     else if (this.labelFilter === 'corrections') parts.push('Corrections');
@@ -405,6 +433,13 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     if (name.includes('webhook')) return 'webhook';
     if (name.includes('server') || name.includes('file')) return 'server';
     return 'upload';
+  }
+
+  /** Modal heading, noting the server-side partition when present. */
+  get modalTitle(): string {
+    if (this.serverFilter === 'unverified') return 'Export Unverified';
+    if (this.serverFilter === 'verified') return 'Export Verified';
+    return 'Export';
   }
 
   close(): void {

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -1,0 +1,96 @@
+<vt-modal [open]="true" title="Detector Stats" (closed)="close()">
+  @if (loading) {
+    <p class="loading-text">Loading stats…</p>
+  } @else if (error) {
+    <p class="error-text">{{ error }}</p>
+  } @else if (stats) {
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="Items the detector kept as positive (adopted, all items)">Good</td>
+          <td class="stat-value">{{ stats.total_good | number }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Items the detector dropped as negative (adopted, all items)">Bad</td>
+          <td class="stat-value">{{ stats.total_bad | number }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="How many items you actually reviewed by hand (the rest adopt the detector's call)">Verified by hand</td>
+          <td class="stat-value">{{ stats.verified_count | number }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="section-title">Adopted vs. detector's original call</h3>
+    <table class="stats-table confusion">
+      <thead>
+        <tr>
+          <th></th>
+          <th title="The detector's call at the default calibrated cutoff">Detector Good</th>
+          <th title="The detector's call at the default calibrated cutoff">Detector Bad</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th class="row-head">Kept Good</th>
+          <td class="cell agree" title="Confirmed positive (you and the detector agree)">{{ stats.confirmed_good | number }}</td>
+          <td class="cell correct" title="Rescued false negative (you promoted an item the detector dropped)">{{ stats.rescued_false_neg | number }}</td>
+        </tr>
+        <tr>
+          <th class="row-head">Marked Bad</th>
+          <td class="cell correct" title="Culled false positive (you dropped an item the detector kept)">{{ stats.culled_false_pos | number }}</td>
+          <td class="cell agree" title="Confirmed negative (you and the detector agree)">{{ stats.confirmed_bad | number }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="Items where the adopted label matches the detector's original call, over all items">Agreement rate</td>
+          <td class="stat-value">{{ agreementPct }} <span class="muted">({{ stats.agreements | number }} agree / {{ stats.corrections | number }} corrections)</span></td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Of everything the detector called good, how much the adopted set keeps (inflated by unverified items)">Precision</td>
+          <td class="stat-value">{{ precisionPct }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="section-title" title="As inclusion rises the cutoff drops: false positives climb, false negatives fall. Read off the inclusion that best balances the two on your data.">False pos / false neg vs. inclusion</h3>
+    <div class="chart-wrap">
+      <svg
+        class="fpfn-chart"
+        [attr.viewBox]="'0 0 ' + chartWidth + ' ' + chartHeight"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="False positive and false negative counts across inclusion -10 to 10"
+      >
+        <!-- axes -->
+        <line class="axis" [attr.x1]="axisLeft" [attr.y1]="axisTop" [attr.x2]="axisLeft" [attr.y2]="axisBottom" />
+        <line class="axis" [attr.x1]="axisLeft" [attr.y1]="axisBottom" [attr.x2]="axisRight" [attr.y2]="axisBottom" />
+        <!-- y-axis labels: 0 and max -->
+        <text class="tick" [attr.x]="axisLeft - 4" [attr.y]="axisBottom" text-anchor="end" dominant-baseline="middle">0</text>
+        <text class="tick" [attr.x]="axisLeft - 4" [attr.y]="axisTop + 4" text-anchor="end">{{ maxCount }}</text>
+        <!-- x-axis labels: -10, 0, 10 -->
+        <text class="tick" [attr.x]="axisLeft" [attr.y]="axisBottom + 12" text-anchor="middle">-10</text>
+        <text class="tick" [attr.x]="(axisLeft + axisRight) / 2" [attr.y]="axisBottom + 12" text-anchor="middle">0</text>
+        <text class="tick" [attr.x]="axisRight" [attr.y]="axisBottom + 12" text-anchor="middle">10</text>
+        <!-- current inclusion marker -->
+        <line class="current" [attr.x1]="currentX" [attr.y1]="axisTop" [attr.x2]="currentX" [attr.y2]="axisBottom" />
+        <!-- the two curves -->
+        <polyline class="line-fp" [attr.points]="fpPolyline" />
+        <polyline class="line-fn" [attr.points]="fnPolyline" />
+      </svg>
+      <div class="chart-legend">
+        <span class="legend-item"><span class="swatch swatch-fp"></span>False positives</span>
+        <span class="legend-item"><span class="swatch swatch-fn"></span>False negatives</span>
+        <span class="legend-item"><span class="swatch swatch-current"></span>Current (incl {{ stats.inclusion }})</span>
+      </div>
+    </div>
+  }
+
+  <div modal-footer>
+    <button class="btn btn--secondary" (click)="close()">Close</button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -1,0 +1,101 @@
+// `.loading-text`, `.error-text`, `.stats-table`, `.stat-label`,
+// `.stat-value`, and `.section-title` are shared utilities (see
+// dataset-stats-modal + _components.scss); only the find-specific confusion
+// grid and the inline chart are styled here.
+
+.confusion {
+  .row-head {
+    font-weight: var(--weight-medium);
+    color: var(--text-secondary);
+    text-align: left;
+  }
+
+  .cell {
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .agree {
+    color: var(--text-primary);
+  }
+
+  .correct {
+    color: var(--color-accent, var(--text-primary));
+    font-weight: var(--weight-semibold);
+  }
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}
+
+.chart-wrap {
+  margin-top: var(--space-sm);
+}
+
+.fpfn-chart {
+  width: 100%;
+  height: 150px;
+
+  .axis {
+    stroke: var(--border-subtle);
+    stroke-width: 1;
+  }
+
+  .tick {
+    fill: var(--text-muted);
+    font-size: 8px;
+  }
+
+  .current {
+    stroke: var(--text-muted);
+    stroke-width: 1;
+    stroke-dasharray: 3 2;
+  }
+
+  .line-fp {
+    fill: none;
+    stroke: var(--color-bad);
+    stroke-width: 1.5;
+  }
+
+  .line-fn {
+    fill: none;
+    stroke: var(--color-good);
+    stroke-width: 1.5;
+  }
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-top: var(--space-xs);
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs, 4px);
+}
+
+.swatch {
+  width: 12px;
+  height: 3px;
+  border-radius: 1px;
+}
+
+.swatch-fp {
+  background: var(--color-bad);
+}
+
+.swatch-fn {
+  background: var(--color-good);
+}
+
+.swatch-current {
+  background: var(--text-muted);
+}

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -1,0 +1,137 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+import { DetectorsFindApiService } from '../../../services/detectors-find-api.service';
+import type { FindStatsResponse } from '../../../generated/api-client/models/find-stats-response';
+
+/** A scaled point on the FP/FN-vs-inclusion chart. */
+interface ChartPoint {
+  inclusion: number;
+  x: number;
+  yFp: number;
+  yFn: number;
+}
+
+/**
+ * Detector-evaluation Stats for a Find run: the 2×2 confusion of the adopted
+ * label set against the detector's original call, the derived agreement /
+ * precision rates, and the headline FP/FN-vs-inclusion sweep rendered as a
+ * dependency-free inline SVG line chart (current inclusion marked).
+ * See docs/plans/find-verification-workflow.md.
+ */
+@Component({
+  selector: 'vt-find-stats-modal',
+  standalone: true,
+  imports: [CommonModule, ModalComponent],
+  templateUrl: './find-stats-modal.component.html',
+  styleUrl: './find-stats-modal.component.scss',
+})
+export class FindStatsModalComponent implements OnInit {
+  @Output() closed = new EventEmitter<void>();
+
+  loading = true;
+  error = '';
+  stats: FindStatsResponse | null = null;
+
+  // Chart geometry (SVG user units; the viewBox scales to the container width).
+  readonly chartWidth = 320;
+  readonly chartHeight = 150;
+  private readonly padLeft = 34;
+  private readonly padRight = 10;
+  private readonly padTop = 10;
+  private readonly padBottom = 22;
+
+  constructor(private findApi: DetectorsFindApiService) {}
+
+  ngOnInit(): void {
+    this.findApi.getFindStats().subscribe({
+      next: (data) => {
+        this.stats = data;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.error || err?.error?.message || 'Failed to load stats';
+        this.loading = false;
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  get agreementPct(): string {
+    return this.stats ? `${Math.round(this.stats.agreement_rate * 100)}%` : '-';
+  }
+
+  get precisionPct(): string {
+    return this.stats ? `${Math.round(this.stats.precision * 100)}%` : '-';
+  }
+
+  // --- FP/FN-vs-inclusion chart -------------------------------------------
+
+  private get plotW(): number {
+    return this.chartWidth - this.padLeft - this.padRight;
+  }
+
+  private get plotH(): number {
+    return this.chartHeight - this.padTop - this.padBottom;
+  }
+
+  /** Largest FP/FN count in the sweep; the chart's y-axis top (min 1). */
+  get maxCount(): number {
+    if (!this.stats) return 1;
+    let m = 1;
+    for (const p of this.stats.sweep) {
+      m = Math.max(m, p.false_pos, p.false_neg);
+    }
+    return m;
+  }
+
+  private xFor(inclusion: number): number {
+    return this.padLeft + ((inclusion + 10) / 20) * this.plotW;
+  }
+
+  private yFor(count: number): number {
+    return this.padTop + (1 - count / this.maxCount) * this.plotH;
+  }
+
+  get points(): ChartPoint[] {
+    if (!this.stats) return [];
+    return this.stats.sweep.map((p) => ({
+      inclusion: p.inclusion,
+      x: this.xFor(p.inclusion),
+      yFp: this.yFor(p.false_pos),
+      yFn: this.yFor(p.false_neg),
+    }));
+  }
+
+  get fpPolyline(): string {
+    return this.points.map((p) => `${p.x.toFixed(1)},${p.yFp.toFixed(1)}`).join(' ');
+  }
+
+  get fnPolyline(): string {
+    return this.points.map((p) => `${p.x.toFixed(1)},${p.yFn.toFixed(1)}`).join(' ');
+  }
+
+  /** X position of the current-inclusion marker line. */
+  get currentX(): number {
+    return this.stats ? this.xFor(this.stats.inclusion) : 0;
+  }
+
+  get axisTop(): number {
+    return this.padTop;
+  }
+
+  get axisBottom(): number {
+    return this.chartHeight - this.padBottom;
+  }
+
+  get axisLeft(): number {
+    return this.padLeft;
+  }
+
+  get axisRight(): number {
+    return this.chartWidth - this.padRight;
+  }
+}

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,8 +1,13 @@
 <div class="vote-section">
   <div class="vote-section-header">
-    <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
-      {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length | number }})
-    </h3>
+    <div class="vote-section-heading">
+      <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
+        {{ headingLabel ?? (label === 'good' ? 'Goods' : 'Bads') }} ({{ ids.length | number }})
+      </h3>
+      @if (foldedNote) {
+        <span class="folded-note" [title]="'These items live on the left work queue; the bucket actions still include them.'">{{ foldedNote }}</span>
+      }
+    </div>
     <ng-content select="[list-actions]"></ng-content>
   </div>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -30,6 +30,21 @@
   flex-shrink: 0;
 }
 
+// Find mode: heading word + count chip, with the "[N] Unverified …" folded
+// count stacked beneath it.
+.vote-section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.folded-note {
+  font-size: var(--font-xs, var(--font-sm));
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+
 h3 {
   font-size: var(--font-sm);
   letter-spacing: 0.05em;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -25,6 +25,17 @@ export interface LabelEntry {
 export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
+  /**
+   * Overrides the bucket heading word ("Goods"/"Bads"). Find mode passes
+   * "Verified Good" / "Verified Bad" so the bucket reads as the confirmed pile.
+   */
+  @Input() headingLabel: string | null = null;
+  /**
+   * Find mode: a small "[N] Unverified Good/Bad" line folded under the heading,
+   * counting the items still on the left work queue that the bucket's actions
+   * (Browse / Export / To Dataset) act on alongside the shown verified items.
+   */
+  @Input() foldedNote: string | null = null;
   @Input() medias: Media[] = [];
   @Input() clickTimes: Record<string, number> = {};
   @Input() learnedScores: Record<string, number> = {};

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -54,7 +54,9 @@
   } @else {
     <vt-label-list
       label="good"
-      [ids]="goodIds"
+      [ids]="goodDisplayIds"
+      [headingLabel]="mode === 'find' ? 'Verified Good' : null"
+      [foldedNote]="mode === 'find' ? ((unverifiedGoodCount | number) + ' Unverified Good') : null"
       [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
@@ -67,19 +69,26 @@
     >
       @if (mode === 'find') {
         <div list-actions class="goods-actions">
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse the positive results as their own 2-D UMAP projection (builds on click)">
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse the positive results (verified + unverified good) as their own 2-D UMAP projection (builds on click)">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
               <circle cx="12" cy="12" r="3"></circle>
             </svg>
           </button>
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the goods into their own dataset">
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the full good set (verified + unverified) into their own dataset">
             <vt-icon type="cubes" [size]="14"></vt-icon>
           </button>
-          <button class="goods-action-btn" [disabled]="disabled" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onExportGood()" aria-label="Export" title="Export the full good set (verified + unverified) to clipboard, file, email, or webhook">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="15 14 20 9 15 4"></polyline>
               <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+            </svg>
+          </button>
+          <button class="goods-action-btn" [disabled]="disabled" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="20" x2="18" y2="10"></line>
+              <line x1="12" y1="20" x2="12" y2="4"></line>
+              <line x1="6" y1="20" x2="6" y2="14"></line>
             </svg>
           </button>
         </div>
@@ -90,7 +99,9 @@
 
     <vt-label-list
       label="bad"
-      [ids]="badIds"
+      [ids]="badDisplayIds"
+      [headingLabel]="mode === 'find' ? 'Verified Bad' : null"
+      [foldedNote]="mode === 'find' ? ((unverifiedBadCount | number) + ' Unverified Bad') : null"
       [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
@@ -100,7 +111,18 @@
       [focusMode]="focusMode"
       (mediaSelected)="onMediaSelected($event)"
       (mediaVote)="onMediaVote($event)"
-    />
+    >
+      @if (mode === 'find') {
+        <div list-actions class="goods-actions">
+          <button class="goods-action-btn" [disabled]="disabled || badIds.length === 0" (click)="onExportBad()" aria-label="Export" title="Export the full bad set (verified + unverified) to clipboard, file, email, or webhook">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 14 20 9 15 4"></polyline>
+              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+            </svg>
+          </button>
+        </div>
+      }
+    </vt-label-list>
   }
 
   @if (mode !== 'find') {

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -62,9 +62,14 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Output() browse = new EventEmitter<void>();
   /** Find mode: promote the goods into their own dataset. */
   @Output() toDataset = new EventEmitter<void>();
+  /** Find mode: export a label partition (good / bad). */
+  @Output() exportLabels = new EventEmitter<'good' | 'bad'>();
+  /** Find mode: open the detector-evaluation Stats modal. */
+  @Output() stats = new EventEmitter<void>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
+  verifiedIds: Set<number> = new Set();
   clickTimes: Record<string, number> = {};
   learnedScores: Record<string, number> = {};
   goodElements: DetectorLabelView[] = [];
@@ -91,6 +96,32 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   /** True when the right pane should be sourced from the labelset (not /api/votes). */
   get useLabelset(): boolean {
     return this.mode === 'label' && !!this.trainableModelName;
+  }
+
+  /**
+   * Ids shown in the good bucket. In Find mode the right pane is the verified
+   * pile only (the unverified goods live on the left work queue), so it shows
+   * just ``good ∩ verified``. In Label mode it shows every good vote.
+   */
+  get goodDisplayIds(): number[] {
+    if (this.mode !== 'find') return this.goodIds;
+    return this.goodIds.filter((id) => this.verifiedIds.has(id));
+  }
+
+  /** Bad-bucket counterpart of {@link goodDisplayIds}. */
+  get badDisplayIds(): number[] {
+    if (this.mode !== 'find') return this.badIds;
+    return this.badIds.filter((id) => this.verifiedIds.has(id));
+  }
+
+  /** Find mode: count of unverified goods (the left work queue above the cutoff). */
+  get unverifiedGoodCount(): number {
+    return this.goodIds.length - this.goodDisplayIds.length;
+  }
+
+  /** Find mode: count of unverified bads (the left work queue below the cutoff). */
+  get unverifiedBadCount(): number {
+    return this.badIds.length - this.badDisplayIds.length;
   }
 
   ngOnInit(): void {
@@ -174,6 +205,18 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.toDataset.emit();
   }
 
+  onExportGood(): void {
+    this.exportLabels.emit('good');
+  }
+
+  onExportBad(): void {
+    this.exportLabels.emit('bad');
+  }
+
+  onStats(): void {
+    this.stats.emit();
+  }
+
   onDetectorRenamed(newName: string): void {
     if (!this.trainMode?.model?.registry_id) return;
     const registryId = this.trainMode.model.registry_id;
@@ -225,6 +268,11 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((votes) => {
         this.badIds = Array.from(votes);
+      });
+    this.voteState.verifiedIds$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((ids) => {
+        this.verifiedIds = ids;
       });
     this.voteState.clickTimes$
       .pipe(takeUntil(this.destroy$))

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -34,6 +34,9 @@ export type Media = MediaIdsListResponse &
 export interface VotesResponse {
   good: number[];
   bad: number[];
+  /** Find mode: ids the human has explicitly verified (acted on). Empty
+   *  outside Find mode. Drives the left work-queue vs. right verified split. */
+  verified?: number[];
   click_times: Record<string, number>;
   learned_scores: Record<string, number>;
   labelset_good_count?: number;

--- a/frontend/src/app/services/detectors-find-api.service.ts
+++ b/frontend/src/app/services/detectors-find-api.service.ts
@@ -11,9 +11,11 @@ import type { FindLabelRequest } from '../generated/api-client/models/find-label
 import type { FindLabelResponse } from '../generated/api-client/models/find-label-response';
 import type { FindRequest } from '../generated/api-client/models/find-request';
 import type { FindResponse } from '../generated/api-client/models/find-response';
+import type { FindStatsResponse } from '../generated/api-client/models/find-stats-response';
 import { cancelFind } from '../generated/api-client/fn/detector-find/cancel-find';
 import { findCheckLabels } from '../generated/api-client/fn/detector-find/find-check-labels';
 import { findLabel } from '../generated/api-client/fn/detector-scoring/find-label';
+import { findStats } from '../generated/api-client/fn/detector-scoring/find-stats';
 import { multiFind } from '../generated/api-client/fn/detector-find/multi-find';
 
 /** Multi-dataset Find, single-label Find, the check-labels precheck, and
@@ -42,5 +44,11 @@ export class DetectorsFindApiService {
   /** Cancel any in-flight find / find-label / auto-detect scoring. */
   cancelFind(): Observable<FindCancelResponse> {
     return cancelFind(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Detector-evaluation stats over the adopted Find label set (2x2 confusion
+   *  + the FP/FN-vs-inclusion sweep). Pure read. */
+  getFindStats(): Observable<FindStatsResponse> {
+    return findStats(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -53,6 +53,9 @@ import { exampleSortServer } from '../generated/api-client/fn/media-server/examp
 import { serverMediaFileFromMediaId } from '../generated/api-client/fn/media-server/server-media-file-from-media-id';
 import { listServerMediaFiles } from '../generated/api-client/fn/media-server/list-server-media-files';
 
+/** Server-side label partition for ``/api/labels/export``. */
+export type LabelFilter = 'good' | 'bad' | 'both' | 'corrections' | 'unverified' | 'verified';
+
 @Injectable({ providedIn: 'root' })
 export class SortingApiService {
   private http = inject(HttpClient);
@@ -111,10 +114,14 @@ export class SortingApiService {
     }).pipe(map((r) => r.body));
   }
 
-  exportLabels(goodsOnly?: boolean, options?: { enrich?: boolean }): Observable<LabelsExportResponse> {
+  exportLabels(
+    goodsOnly?: boolean,
+    options?: { enrich?: boolean; labelFilter?: LabelFilter },
+  ): Observable<LabelsExportResponse> {
     return exportLabels(this.http, this.config.rootUrl, {
       goods_only: goodsOnly || undefined,
       enrich: options?.enrich || undefined,
+      label_filter: options?.labelFilter || undefined,
     }).pipe(map((r) => r.body));
   }
 

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -31,6 +31,7 @@ const UNDO_STACK_MAX = 20;
 export class VoteStateService implements OnDestroy {
   private readonly goodVotesSubject = new BehaviorSubject<Set<number>>(new Set());
   private readonly badVotesSubject = new BehaviorSubject<Set<number>>(new Set());
+  private readonly verifiedIdsSubject = new BehaviorSubject<Set<number>>(new Set());
   private readonly clickTimesSubject = new BehaviorSubject<Record<string, number>>({});
   private readonly learnedScoresSubject = new BehaviorSubject<Record<string, number>>({});
   private readonly labelsetGoodCountSubject = new BehaviorSubject<number>(0);
@@ -48,6 +49,14 @@ export class VoteStateService implements OnDestroy {
    */
   private pendingOptimistic = new Map<number, { state: VoteState; clickTime: number | null }>();
 
+  /**
+   * Optimistic verified state per media (Find mode): ``true`` = just verified,
+   * ``false`` = just un-verified.  Merged over the server's ``verified`` array
+   * in {@link applyVotes} and cleared once the server confirms, so a 2s poll
+   * that raced ahead of the vote POST doesn't flicker the left/right split.
+   */
+  private pendingVerified = new Map<number, boolean>();
+
   /** Past votes available to undo, most-recent last.  Capped at UNDO_STACK_MAX. */
   private past: UndoEntry[] = [];
   /** Votes that have been undone and can be redone via Cmd/Ctrl-Shift-Z. */
@@ -56,6 +65,8 @@ export class VoteStateService implements OnDestroy {
 
   readonly goodVotes$ = this.goodVotesSubject.asObservable();
   readonly badVotes$ = this.badVotesSubject.asObservable();
+  /** Find mode: ids the human has explicitly verified (acted on). */
+  readonly verifiedIds$ = this.verifiedIdsSubject.asObservable();
   readonly clickTimes$ = this.clickTimesSubject.asObservable();
   readonly learnedScores$ = this.learnedScoresSubject.asObservable();
   readonly labelsetGoodCount$ = this.labelsetGoodCountSubject.asObservable();
@@ -81,6 +92,24 @@ export class VoteStateService implements OnDestroy {
 
   get badVotes(): Set<number> {
     return this.badVotesSubject.value;
+  }
+
+  get verifiedIds(): Set<number> {
+    return this.verifiedIdsSubject.value;
+  }
+
+  /**
+   * Optimistically record that *id* is now verified (good/bad vote landed in
+   * Find mode) or no longer verified (un-voted).  The server marks the same
+   * transition on the vote POST; this just makes the left→right move feel
+   * instant.  Reconciled by {@link applyVotes} on the next ``/api/votes`` read.
+   */
+  setOptimisticVerified(id: number, verified: boolean): void {
+    this.pendingVerified.set(id, verified);
+    const next = new Set(this.verifiedIdsSubject.value);
+    if (verified) next.add(id);
+    else next.delete(id);
+    this.verifiedIdsSubject.next(next);
   }
 
   get clickTimes(): Record<string, number> {
@@ -288,11 +317,13 @@ export class VoteStateService implements OnDestroy {
   clear(): void {
     this.goodVotesSubject.next(new Set());
     this.badVotesSubject.next(new Set());
+    this.verifiedIdsSubject.next(new Set());
     this.clickTimesSubject.next({});
     this.learnedScoresSubject.next({});
     this.labelsetGoodCountSubject.next(0);
     this.labelsetBadCountSubject.next(0);
     this.pendingOptimistic.clear();
+    this.pendingVerified.clear();
     this.past = [];
     this.future = [];
   }
@@ -391,8 +422,23 @@ export class VoteStateService implements OnDestroy {
       }
     }
 
+    // Verified ids: start from the server set, then apply pending optimistic
+    // overrides (clearing each once the server already agrees) so an in-flight
+    // verify/un-verify isn't clobbered by a poll that raced the vote POST.
+    const verified = new Set(votes.verified ?? []);
+    for (const [id, want] of this.pendingVerified) {
+      if (verified.has(id) === want) {
+        this.pendingVerified.delete(id);
+      } else if (want) {
+        verified.add(id);
+      } else {
+        verified.delete(id);
+      }
+    }
+
     this.goodVotesSubject.next(good);
     this.badVotesSubject.next(bad);
+    this.verifiedIdsSubject.next(verified);
     this.clickTimesSubject.next(times);
     this.learnedScoresSubject.next(votes.learned_scores);
     this.labelsetGoodCountSubject.next(votes.labelset_good_count ?? good.size);

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import app as app_module
 from vtscore.state.core import get_active_detector_context
+from vtscore.state.votes import rethreshold_unverified_find_items
 from vtsearch.state import set_find_initial_labels, set_find_scores, set_vote
 
 
@@ -94,6 +95,65 @@ class TestUnverifiedExport:
             app_module.medias[3]["md5"]: "good",
             app_module.medias[4]["md5"]: "bad",
         }
+
+
+class TestRethresholdUnverified:
+    """Sliding the cutoff re-splits unverified items only; verified items hold."""
+
+    def _setup(self):
+        ctx = get_active_detector_context()
+        ctx.find_mode = True
+        ctx.threshold = 0.5
+        set_find_scores({1: 0.9, 2: 0.8, 3: 0.2, 4: 0.1})
+        # Initial split at 0.5: 1,2 good; 3,4 bad.  Human verified id1 (good).
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        app_module.good_votes.update({1: None, 2: None})
+        app_module.bad_votes.update({3: None, 4: None})
+        ctx.verified_ids.clear()
+        ctx.verified_ids.update({1: None})
+        return ctx
+
+    def test_raise_cutoff_demotes_unverified(self):
+        ctx = self._setup()
+        ctx.threshold = 0.85  # now only id1 (0.9) clears it
+        rethreshold_unverified_find_items()
+        # id1 verified-good stays good even though... it still clears 0.85 anyway;
+        # id2 (0.8) is unverified and now below the line -> bad.
+        assert 1 in app_module.good_votes
+        assert 2 in app_module.bad_votes
+        assert 3 in app_module.bad_votes
+        assert 4 in app_module.bad_votes
+
+    def test_verified_item_holds_against_cutoff(self):
+        ctx = self._setup()
+        # Verify id2 as good, then raise the cutoff above its score.
+        ctx.verified_ids.update({2: None})
+        ctx.threshold = 0.85
+        rethreshold_unverified_find_items()
+        # id2 is verified-good; the cutoff must not demote it.
+        assert 2 in app_module.good_votes
+        assert 2 not in app_module.bad_votes
+
+    def test_lower_cutoff_promotes_unverified(self):
+        ctx = self._setup()
+        ctx.threshold = 0.05  # everything clears it
+        rethreshold_unverified_find_items()
+        for cid in (1, 2, 3, 4):
+            assert cid in app_module.good_votes
+
+    def test_noop_outside_find_mode(self):
+        ctx = self._setup()
+        ctx.find_mode = False
+        ctx.threshold = 0.85
+        rethreshold_unverified_find_items()
+        # No re-split: the initial 0.5 assignment stands.
+        assert 2 in app_module.good_votes
+
+    def test_inclusion_post_returns_threshold(self, client):
+        resp = client.post("/api/inclusion", json={"inclusion": 0})
+        assert resp.status_code == 200
+        assert "threshold" in resp.get_json()
 
 
 class TestFindStats:

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -69,6 +69,7 @@ from vtscore.state.votes import (  # noqa: F401
     get_find_scores,
     get_learned_scores,
     get_textsort_suggestions,
+    rethreshold_unverified_find_items,
     set_find_initial_labels,
     set_find_scores,
     set_vote,
@@ -224,6 +225,11 @@ def set_inclusion(value: int) -> None:
         # orderings instead of dropping the (inclusion-independent) MLP, so the
         # scores stay frozen across a slide.  See docs/plans/find-verification-workflow.md.
         _core.recompute_detector_thresholds_for_inclusion(value)
+        # In Find mode the unverified items' good/bad labels are derived from
+        # the cutoff, so the new threshold must re-split them over the frozen
+        # find_scores (no-op in Train mode / before a scoring pass).  Verified
+        # items keep their human vote.
+        rethreshold_unverified_find_items()
 
 
 def get_dataset_display_name() -> str | None:

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -145,6 +145,46 @@ def get_find_scores() -> dict[int, float]:
         return dict(get_active_detector_context().find_scores)
 
 
+def rethreshold_unverified_find_items() -> None:
+    """Re-split *unverified* Find items good/bad at the current cutoff.
+
+    Inclusion is a pure cutoff knob: sliding it moves
+    :attr:`DetectorContext.threshold` over the frozen ``find_scores`` with no
+    re-scoring.  Every scored item the human has not verified is re-assigned
+    good/bad purely by whether its frozen score clears the (already updated)
+    threshold; verified items keep their human vote wherever their score
+    lands, and ``find_initial_labels`` (the eval baseline at the default
+    cutoff) is left untouched.  Existing click-times are preserved so the
+    right-scroll ordering doesn't churn on a slide.
+
+    No-op outside Find mode or before a scoring pass has frozen ``find_scores``
+    (e.g. Train-mode inclusion changes).  Must run *after*
+    :func:`recompute_detector_thresholds_for_inclusion` has updated the
+    threshold.  See docs/plans/find-verification-workflow.md.
+    """
+    with _state_lock:
+        ctx = get_active_detector_context()
+        if not ctx.find_mode or not ctx.find_scores:
+            return
+        threshold = ctx.threshold
+        good_votes = ctx.good_votes
+        bad_votes = ctx.bad_votes
+        verified = ctx.verified_ids
+        for media_id, score in ctx.find_scores.items():
+            if media_id in verified:
+                continue
+            if score >= threshold:
+                if media_id in good_votes:
+                    continue
+                bad_votes.pop(media_id, None)
+                good_votes[media_id] = None
+            else:
+                if media_id in bad_votes:
+                    continue
+                good_votes.pop(media_id, None)
+                bad_votes[media_id] = None
+
+
 # ---------------------------------------------------------------------------
 # Compound operations (atomic vote toggle / label apply)
 # ---------------------------------------------------------------------------

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -164,7 +164,10 @@ def rethreshold_unverified_find_items() -> None:
     """
     with _state_lock:
         ctx = get_active_detector_context()
-        if not ctx.find_mode or not ctx.find_scores:
+        # The request-missing sentinel (no detector identified) exposes none of
+        # these fields; guard with getattr so an Inclusion/settings write with
+        # no detector context is a clean no-op rather than an AttributeError.
+        if not getattr(ctx, "find_mode", False) or not getattr(ctx, "find_scores", None):
             return
         threshold = ctx.threshold
         good_votes = ctx.good_votes

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -671,18 +671,34 @@ def add_textsort_suggestion_route(body: dict):
 @sorting_bp.route("/api/inclusion", methods=["GET"])
 @sorting_bp.response(200, InclusionResponseSchema)
 def get_inclusion_route():
-    """Get the current Inclusion setting."""
-    return {"inclusion": get_inclusion()}
+    """Get the current Inclusion setting and the cutoff it resolves to."""
+    return {"inclusion": get_inclusion(), "threshold": _active_detector_threshold()}
 
 
 @sorting_bp.route("/api/inclusion", methods=["POST"])
 @sorting_bp.arguments(InclusionRequestSchema)
 @sorting_bp.response(200, InclusionResponseSchema)
 def set_inclusion_route(body: dict):
-    """Set the Inclusion setting (clamped to ``[-10, 10]``)."""
+    """Set the Inclusion setting (clamped to ``[-10, 10]``).
+
+    Inclusion is a pure cutoff knob: this re-derives the active detector's
+    threshold from its cached fold orderings (no MLP retrain) and, in Find
+    mode, re-splits the unverified items over the frozen scores.  The new
+    cutoff is returned so the Find slider can move the green/red line.
+    """
     new_inclusion = int(max(-10, min(10, body["inclusion"])))
     set_inclusion(new_inclusion)
-    return {"inclusion": get_inclusion()}
+    return {"inclusion": get_inclusion(), "threshold": _active_detector_threshold()}
+
+
+def _active_detector_threshold() -> float | None:
+    """The active detector context's current cutoff, or ``None`` if unset."""
+    from vtscore.state.core import _empty_detector_context, get_active_detector_context
+
+    det_ctx = get_active_detector_context()
+    if det_ctx is _empty_detector_context:
+        return None
+    return det_ctx.threshold
 
 
 @sorting_bp.route("/api/safe-thresholds", methods=["GET"])

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -692,13 +692,17 @@ def set_inclusion_route(body: dict):
 
 
 def _active_detector_threshold() -> float | None:
-    """The active detector context's current cutoff, or ``None`` if unset."""
+    """The active detector context's current cutoff, or ``None`` if unset.
+
+    Returns ``None`` for the empty / request-missing sentinels (no detector
+    identified), which don't carry a meaningful threshold.
+    """
     from vtscore.state.core import _empty_detector_context, get_active_detector_context
 
     det_ctx = get_active_detector_context()
     if det_ctx is _empty_detector_context:
         return None
-    return det_ctx.threshold
+    return getattr(det_ctx, "threshold", None)
 
 
 @sorting_bp.route("/api/safe-thresholds", methods=["GET"])

--- a/vtsearch/schemas/sorting.py
+++ b/vtsearch/schemas/sorting.py
@@ -185,6 +185,11 @@ class InclusionResponseSchema(Schema):
     """Response for ``GET|POST /api/inclusion``."""
 
     inclusion = fields.Integer(required=True)
+    # The cutoff that this inclusion resolves to over the active detector's
+    # cached fold orderings.  Returned so the Find slider can move the
+    # green/red line over the frozen scores without re-scoring.  ``None`` when
+    # no detector context has computed a threshold yet.
+    threshold = fields.Float(required=False, allow_none=True)
 
 
 def _validate_numeric(value):


### PR DESCRIPTION
Builds the Find-verification UI on top of the Phase 1 backend spine (`docs/plans/find-verification-workflow.md`). Same Find screen, no new mode: a richer label vocabulary (unverified/verified × good/bad) layered onto the existing interface.

## What landed

- **No-retrain Inclusion slide.** The Find slider now calls `POST /api/inclusion` instead of re-scoring. Backend `set_inclusion` re-derives the cutoff from the cached fold orderings *and* re-splits the **unverified** Find items over the frozen `find_scores` (`rethreshold_unverified_find_items`) so export/Stats track the slider; verified items hold. `GET|POST /api/inclusion` now returns the resolved `threshold` so the frontend moves the green/red line with no scoring spinner.
- **Verified-id tracking.** `VoteStateService` exposes `verifiedIds$` (from the `/api/votes` `verified` array) with optimistic add/remove on a manual Find vote, merged over the server set so a racing poll doesn't flicker the split.
- **Right panel = the verified pile.** Find mode shows only `good/bad ∩ verified`, each bucket headed "Verified Good/Bad (V)" with a folded "[N] Unverified …" count. Browse / To Dataset / Export / Stats act on the **full** good set; a bad-bucket Export acts on the full bad set.
- **Marginal-positive auto-advance.** After any vote (button or hover) the centre jumps to the lowest unverified item still above the cutoff; seed reuses the same rule. Empty queue → a one-shot "All positives reviewed" toast.
- **Unverified Export** button in the left work-queue header (`label_filter=unverified`), via a shared `vt-export-modal` that now takes an `initialFilter` and fetches the `unverified`/`verified` server partitions.
- **`vt-find-stats-modal`** — adopted totals + verified count, the 2×2 confusion, agreement-rate / precision, and the FP/FN-vs-inclusion sweep as a dependency-free inline SVG line chart (current inclusion marked).

## Backwards-compat

No new break beyond Phase 1's (existing `inclusion` values already changed meaning there).

## Testing

`./run-tests.sh` green (4696 passed, 1 skipped) — includes ruff/codespell/deptry/pyright, OpenAPI snapshot, and `npm run build:prod` (no TS errors, no budget warnings). New backend tests cover the inclusion-slide re-threshold and the `threshold` field.

## Caveats / follow-ups (see plan doc)

- **Built headless — not visually eyeballed.** The folding headers, SVG chart, and button placements should get a manual pass on a real screen.
- **Left work queue keeps the full ranking** rather than dropping verified items off-left (a deliberate deviation: filtering the media-list would desync stripe-overview click→index navigation). Documented under Open follow-ups.

https://claude.ai/code/session_01EyyeXyqYkBPwaLuE1ZnW1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyyeXyqYkBPwaLuE1ZnW1q)_