### PR TITLE
Find: unverified-positives work-queue actions on the left panel

### DIFF
--- a/docs/plans/find-verification-workflow.md
+++ b/docs/plans/find-verification-workflow.md
@@ -1,6 +1,6 @@
 # Find Verification Workflow
 
-**Status:** **Phase 1 (backend spine) + Phase 2 (frontend) shipped; Phase 3 (verified-only colouring) shipped** — full `./run-tests.sh` green. Phase 2/3 were built without a browser in the container, so the UI passed `npm run build:prod` (no TS errors, no budget warnings) but was **not visually eyeballed**; a manual pass on a real screen is still owed. See **What shipped / Open follow-ups** at the bottom.
+**Status:** **Phase 1 (backend spine) + Phase 2 (frontend) + Phase 3 (verified-only colouring) + Phase 4 (left work-queue actions) shipped** — full `./run-tests.sh` green. The UI was built without a browser in the container, so it passes `npm run build:prod` (no TS errors, no budget warnings) but was **not visually eyeballed**; a manual pass on a real screen is still owed. See **What shipped / Open follow-ups** at the bottom.
 
 ## The reframe (read this first)
 
@@ -157,6 +157,14 @@ All under `./run-tests.sh` (full suite + `npm run build:prod` green). This close
 
 - **Items colour green/red only once verified.** The detector's threshold split is now a *presumption*, not a vote the UI paints. The left work queue is fed the ranking **minus verified items** (`find-view.unverifiedSortOrder`, recomputed only when the ranking or verified set changes), and the media-list + stripe receive **empty vote sets**, so nothing on the left is coloured. Verified items move to the right pile; the off-left move keeps the media-list and stripe on the same (filtered) index space, so stripe-click navigation stays aligned. The find header counts the unverified work-queue size.
 - **Big Good/Bad buttons verify instead of un-toggling.** `VoteStateService` gained a find-mode flag: `currentState()` reads an *unverified* item as `'none'` (its good/bad is the flood-filled presumption, not a human decision), and `effectiveGood`/`effectiveBad` expose that gated state to the centre buttons. So the buttons read neutral on an unverified item, and a click sets an absolute good/bad (verifying it) rather than toggling the detector's presumption off. The Find view sets the flag on enter and clears it on leave so Label/Train are untouched.
+
+## What shipped (Phase 4 — left work-queue actions)
+
+All under `./run-tests.sh` (full suite + `npm run build:prod` green).
+
+- **Left-panel work-queue actions.** Browse / To Dataset / Export now sit next to the Inclusion control in the Find left panel (`left-panel.component.html`, find mode), each scoped to the **unverified positives** — the above-cutoff slice of the work-queue ranking (which Phase 3 already feeds in verified-filtered), via `find-view.onBrowseUnverified` / `onToDatasetUnverified` and the `unverified_good` export filter. The button gating counts the above-threshold items of the (verified-filtered) `sortOrder`. These complement (do **not** replace) the right-panel trio, which still acts on the *full* good set (verified + unverified). The buttons disable when there are no unverified positives.
+- **`unverified_good` export filter.** A UI-only `LabelFilter` the export modal resolves to the server `unverified` partition sliced to the `good` category; never sent to the backend as a `label_filter` (typed out via `ServerLabelFilter`).
+- **Browse-canvas verify, replacing the cull.** The browse selection panel's single "Remove from Good" button became **"Verified Good" / "Verified Bad"** (`browse-selection-panel`, gated on `canVerify`). Both mark the selection good/bad and verify it (Find-mode `vote-bulk` already lands in `verified_ids`), then drop it from the canvas — so verifying a selection while browsing the unverified positives removes it (it's no longer unverified). The return-to-Find skip-rescore guard is unchanged.
 
 ## Open follow-ups
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11871,7 +11871,7 @@
     },
     "/api/medias/vote-bulk": {
       "post": {
-        "description": "Mirrors ``/api/medias/<id>/vote`` for a batch: each id is set to\n``target`` with the same idempotent semantics, then the detector\nlabelset is persisted **once** rather than per id.  Bulk votes are\nimage-level (no region boxes).  Powers the Browser's \"Remove from Good\"\ncull, which marks a hand-selected set of false-positives ``bad`` and\ndrops them from the browse.\n\nIds that aren't in the loaded dataset are skipped and reported back in\n``missing``; ``changed`` counts only the ids whose state actually moved\n(idempotent re-applies don't count).",
+        "description": "Mirrors ``/api/medias/<id>/vote`` for a batch: each id is set to\n``target`` with the same idempotent semantics (including Find-mode\nverification \u2014 a good/bad target marks the item verified), then the\ndetector labelset is persisted **once** rather than per id.  Bulk votes\nare image-level (no region boxes).  Powers the Browser's \"Verified Good\" /\n\"Verified Bad\" actions, which mark a hand-selected set good/bad, verify\nthem, and drop them from the browse.\n\nIds that aren't in the loaded dataset are skipped and reported back in\n``missing``; ``changed`` counts only the ids whose state actually moved\n(idempotent re-applies don't count).",
         "operationId": "vote_media_bulk",
         "requestBody": {
           "content": {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -13,15 +13,23 @@
     </button>
   </div>
 
-  @if (canRemoveGood) {
+  @if (canVerify) {
     <div class="bsp-actions">
       <button
         type="button"
-        class="btn btn--danger btn--sm bsp-remove-good"
+        class="btn btn--primary btn--sm bsp-verify-good"
         [disabled]="count === 0"
-        (click)="onRemoveGood()"
-        title="Mark the selected items Bad in the Find results and remove them from this browse">
-        Remove from Good ({{ count | number }})
+        (click)="onVerifyGood()"
+        title="Mark the selected items Verified Good and remove them from this browse (they're no longer unverified)">
+        Verified Good ({{ count | number }})
+      </button>
+      <button
+        type="button"
+        class="btn btn--danger btn--sm bsp-verify-bad"
+        [disabled]="count === 0"
+        (click)="onVerifyBad()"
+        title="Mark the selected items Verified Bad and remove them from this browse (they're no longer unverified)">
+        Verified Bad ({{ count | number }})
       </button>
     </div>
   }

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -56,12 +56,15 @@
 }
 
 .bsp-actions {
+  display: flex;
+  gap: var(--space-sm);
   padding: 0 var(--space-lg) var(--space-sm);
   flex-shrink: 0;
 }
 
-.bsp-remove-good {
-  width: 100%;
+.bsp-verify-good,
+.bsp-verify-bad {
+  flex: 1;
 }
 
 .bsp-toolbar {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -46,15 +46,19 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   @Input() mediaType = '';
 
   /**
-   * Whether to offer the "Remove from Good" cull action. Only meaningful when
-   * browsing a Find run's positives (subset mode): the action marks the
-   * selected items Bad in the detector's labels and drops them from the
-   * browse. The browse view owns the actual mutation + re-projection.
+   * Whether to offer the verify actions. Only meaningful when browsing a Find
+   * run's positives (subset mode): "Verified Good" / "Verified Bad" mark the
+   * selected items good/bad in the detector's labels *and* verify them, so they
+   * leave the unverified set and drop from the browse. The browse view owns the
+   * actual mutation + re-projection.
    */
-  @Input() canRemoveGood = false;
+  @Input() canVerify = false;
 
-  /** Emitted when the user confirms the "Remove from Good" cull. */
-  @Output() removeGood = new EventEmitter<void>();
+  /** Emitted when the user marks the selection Verified Good. */
+  @Output() verifyGood = new EventEmitter<void>();
+
+  /** Emitted when the user marks the selection Verified Bad. */
+  @Output() verifyBad = new EventEmitter<void>();
 
   count = 0;
   sortMode: SelectionSortMode = 'time-desc';
@@ -163,10 +167,16 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
     this.selection.clear();
   }
 
-  /** Ask the browse view to mark the selected items Bad and remove them. */
-  onRemoveGood(): void {
+  /** Ask the browse view to mark the selected items Verified Good and drop them. */
+  onVerifyGood(): void {
     if (this.count === 0) return;
-    this.removeGood.emit();
+    this.verifyGood.emit();
+  }
+
+  /** Ask the browse view to mark the selected items Verified Bad and drop them. */
+  onVerifyBad(): void {
+    if (this.count === 0) return;
+    this.verifyBad.emit();
   }
 
   /** Clicking a selected item drops it from the selection. */

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -181,8 +181,9 @@
           <vt-browse-selection-panel
             class="browse-side-selection"
             [mediaType]="mediaType"
-            [canRemoveGood]="subset"
-            (removeGood)="onRemoveGood()"
+            [canVerify]="subset"
+            (verifyGood)="onVerify('good')"
+            (verifyBad)="onVerify('bad')"
           />
           <div class="browse-side-meta">
             <div class="browse-side-minimap">

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -599,57 +599,49 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Cull the hand-selected items from a Find-positives browse: confirm, mark
-   * them Bad in the detector's labels (so they leave the Find view's Good
-   * list), then drop them from this browse by re-fitting the subset over the
-   * reduced id set. Subset mode only — wired up via the selection panel's
-   * ``canRemoveGood`` affordance, which is itself gated on ``subset``.
+   * Verify the hand-selected items in a Find-positives browse: mark them
+   * good/bad in the detector's labels *and* verify them (Find-mode bulk votes
+   * land in ``verified_ids``), so they leave the unverified set, then drop them
+   * from this browse by re-binning the layout over the reduced id set. Both
+   * "Verified Good" (*target* ``good``) and "Verified Bad" (*target* ``bad``)
+   * route here. Subset mode only — wired via the selection panel's ``canVerify``
+   * affordance, itself gated on ``subset``.
    */
-  onRemoveGood(): void {
+  onVerify(target: 'good' | 'bad'): void {
     const ids = this.selection.ids();
     if (ids.length === 0) return;
-    const n = ids.length;
-    this.dialog
-      .confirmDestructive(
-        `Remove ${n} item${n === 1 ? '' : 's'} from Good?`,
-        "(They'll be marked Bad in the Find results and removed from this browse. The underlying media is unaffected.)",
-        'Remove',
-      )
-      .then((ok) => {
-        if (!ok) return;
-        // 1) Mark them Bad in the detector's labels (one bulk request).
-        this.mediasApi
-          .voteBulk(ids, 'bad')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe({
-            next: () => this.dropFromBrowse(ids),
-            error: () =>
-              this.toast.error({ message: 'Failed to remove the selected items from Good.' }),
-          });
+    this.mediasApi
+      .voteBulk(ids, target)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.dropFromBrowse(ids, target),
+        error: () =>
+          this.toast.error({ message: 'Failed to verify the selected items.' }),
       });
   }
 
   /**
-   * Drop *removedIds* from the browse after they've been marked Bad. The
-   * remaining items keep their exact 2-D positions and bins — the server
-   * re-bins the frozen layout in place (no UMAP re-fit), returning the same
-   * ``projection_id`` with a bumped ``content_version`` so only the tile cache
-   * refreshes. The canvas then zooms to fit the survivors (via the one-shot
-   * fit request below), since the old framing leaves dead space wherever the
-   * culled items used to be.
+   * Drop *removedIds* from the browse after they've been verified as *target*
+   * (good/bad). The remaining items keep their exact 2-D positions and bins —
+   * the server re-bins the frozen layout in place (no UMAP re-fit), returning
+   * the same ``projection_id`` with a bumped ``content_version`` so only the
+   * tile cache refreshes. The canvas then zooms to fit the survivors (via the
+   * one-shot fit request below), since the old framing leaves dead space
+   * wherever the verified items used to be.
    */
-  private dropFromBrowse(removedIds: number[]): void {
+  private dropFromBrowse(removedIds: number[], target: 'good' | 'bad'): void {
     const removed = new Set(removedIds);
     const remaining = this.subsetIds.filter((id) => !removed.has(id));
     this.selection.clear();
+    const label = target === 'good' ? 'Verified Good' : 'Verified Bad';
     this.toast.success({
-      message: `Removed ${removedIds.length} item${removedIds.length === 1 ? '' : 's'} from Good.`,
+      message: `Marked ${removedIds.length} item${removedIds.length === 1 ? '' : 's'} ${label}.`,
     });
     this.subsetIds = remaining;
     if (remaining.length === 0) {
-      // Nothing left to project; the cull emptied the browse.
+      // Nothing left to project; verifying emptied the browse.
       this.status = 'error';
-      this.errorMessage = 'All positives were removed. Go back to Find to start over.';
+      this.errorMessage = 'All items were verified. Go back to Find to see your results.';
       return;
     }
     this.projectionApi
@@ -664,7 +656,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
         },
         error: () =>
           this.toast.error({
-            message: 'Items were removed from Good, but the browse view could not refresh.',
+            message: 'Items were verified, but the browse view could not refresh.',
           }),
       });
   }
@@ -684,8 +676,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /**
    * Return to the Find view this browse was launched from, preserving the
-   * cull: the flag tells the Find view to skip its automatic re-scoring (which
-   * would re-promote the removed items) and just show the updated labels.
+   * verifications: the flag tells the Find view to skip its automatic
+   * re-scoring (which would re-promote the items it re-scores) and just show
+   * the updated labels, with the verified items now in the right-panel pile.
    */
   private backToFind(): void {
     const datasetId = this.activeContext.datasetId;

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -28,7 +28,9 @@
       (mediaSelect)="onMediaSelect($event)"
       (mediaVote)="onHoverVote($event)"
       (inclusionChange)="onInclusionChange($event)"
-      (unverifiedExport)="onExportRequest('unverified')"
+      (browse)="onBrowseUnverified()"
+      (toDataset)="onToDatasetUnverified()"
+      (unverifiedExport)="onExportRequest('unverified_good')"
       (sortCancel)="onSortCancel()"
     />
   </div>

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -161,11 +161,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       });
 
     // Run find-label to score and label all medias — unless we're returning
-    // from the Browser after a "Remove from Good" cull. In that case the
-    // backend vote lists already reflect the removed items (now Bad), and the
-    // loadVotes() above refreshes them; re-running find here would re-score
-    // with the unchanged model and re-promote those items to Good, undoing
-    // the cull. Keep the cull instead (the user's decision).
+    // from the Browser after verifying a selection there. In that case the
+    // backend vote lists already reflect the verified items (now Verified
+    // Good/Bad), and the loadVotes() above refreshes them; re-running find here
+    // would re-score with the unchanged model and could re-promote those items,
+    // undoing the verification. Keep the verifications instead.
     // Seed the inclusion slider from the active detector's context value
     // (GET /api/inclusion resolves per-detector, falling back to the
     // user-settings default the first time it's read). This keeps Find's
@@ -546,36 +546,75 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * Browse the positive results of this Find run as their own UMAP projection.
-   * The positives are the current "good" list (the above-threshold items plus
-   * any manual corrections). We stash the ids for the browse view and navigate
-   * to `/browse/:datasetId?subset=1`, where they're UMAP'd on their own.
+   * Ids of the unverified positives: the above-threshold items (``goodVotes``)
+   * the human hasn't acted on yet (``goodVotes − verifiedIds``). The left
+   * work-queue actions (Browse / To Dataset / Export) all scope over exactly
+   * this set, as opposed to the right panel's full-good-set actions.
+   */
+  private unverifiedGoodIds(): number[] {
+    const verified = this.voteState.verifiedIds;
+    return Array.from(this.voteState.goodVotes).filter((id) => !verified.has(id));
+  }
+
+  /**
+   * Browse the full positive set of this Find run (verified + unverified good)
+   * as their own UMAP projection. Right-panel action; the left panel's Browse
+   * scopes to the unverified positives instead ({@link onBrowseUnverified}).
    */
   onBrowse(): void {
+    this.browseIds(Array.from(this.voteState.goodVotes), 'positives');
+  }
+
+  /**
+   * Browse only the unverified positives (above the cutoff, not yet acted on).
+   * Verifying a selection in the browse drops it from the canvas — it's no
+   * longer unverified. Left-panel work-queue action.
+   */
+  onBrowseUnverified(): void {
+    this.browseIds(this.unverifiedGoodIds(), 'unverified positives');
+  }
+
+  /**
+   * Stash *ids* for the browse view and navigate to
+   * `/browse/:datasetId?subset=1`, where they're UMAP'd on their own. *suffix*
+   * names the subset in the browse header (e.g. "<detector> — positives").
+   */
+  private browseIds(ids: number[], suffix: string): void {
     const datasetId = this.activeContext.datasetId;
-    if (!datasetId) return;
-    const ids = Array.from(this.voteState.goodVotes);
-    if (ids.length === 0) return;
+    if (!datasetId || ids.length === 0) return;
     const modelId = this.activeContext.modelId;
     const detectorName =
       this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
     this.browseSubset.set({
       datasetId,
       ids,
-      label: `${detectorName} — positives`,
+      label: `${detectorName} — ${suffix}`,
     });
     this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
   }
 
   /**
-   * Promote the current Goods pile into its own saved dataset. The
-   * promoted items keep their origins and embeddings; the new dataset
-   * gets a fresh created date but inherits this dataset's death date.
-   * We prompt for a name (prefilled "<dataset> <detector> Results"),
-   * then create + register it and confirm with a toast (staying in Find).
+   * Promote the full Goods pile (verified + unverified) into its own saved
+   * dataset. Right-panel action; the left panel promotes the unverified
+   * positives instead ({@link onToDatasetUnverified}).
    */
   onToDataset(): void {
-    const ids = Array.from(this.voteState.goodVotes);
+    this.toDatasetFromIds(Array.from(this.voteState.goodVotes));
+  }
+
+  /** Promote only the unverified positives into their own dataset. */
+  onToDatasetUnverified(): void {
+    this.toDatasetFromIds(this.unverifiedGoodIds());
+  }
+
+  /**
+   * Promote *ids* into their own saved dataset. The promoted items keep their
+   * origins and embeddings; the new dataset gets a fresh created date but
+   * inherits this dataset's death date. We prompt for a name (prefilled
+   * "<dataset> <detector> Results"), then create + register it and confirm
+   * with a toast (staying in Find).
+   */
+  private toDatasetFromIds(ids: number[]): void {
     if (ids.length === 0) return;
     const modelId = this.activeContext.modelId;
     const detectorName =

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -5,27 +5,56 @@
   @if (panelMode === 'find') {
     <!-- Find mode: simplified view (inclusion control, media list header, media items, and stripe). -->
     <div class="tab-panel-manual" role="region" aria-label="Find results">
-      <vt-inclusion-slider
-        [value]="inclusion"
-        (valueChange)="inclusionChange.emit($event)"
-      />
+      <!-- Inclusion cutoff plus the unverified-positives work-queue actions
+           (Browse / To Dataset / Export). All three scope over the unverified
+           items above the cutoff — the above-threshold items the human hasn't
+           acted on yet. -->
+      <div class="find-inclusion-row">
+        <vt-inclusion-slider
+          [value]="inclusion"
+          (valueChange)="inclusionChange.emit($event)"
+        />
+        <div class="goods-actions find-queue-actions">
+          <button
+            class="goods-action-btn"
+            [disabled]="disabled || unverifiedGoodCount === 0"
+            (click)="browse.emit()"
+            aria-label="Browse unverified positives"
+            title="Browse the unverified positives (above-threshold items you haven't acted on) as their own 2-D UMAP projection"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+              <circle cx="12" cy="12" r="3"></circle>
+            </svg>
+          </button>
+          <button
+            class="goods-action-btn"
+            [disabled]="disabled || unverifiedGoodCount === 0"
+            (click)="toDataset.emit()"
+            aria-label="Unverified positives to dataset"
+            title="Promote the unverified positives (above-threshold items you haven't acted on) into their own dataset"
+          >
+            <vt-icon type="cubes" [size]="14"></vt-icon>
+          </button>
+          <button
+            class="goods-action-btn"
+            [disabled]="disabled || unverifiedGoodCount === 0"
+            (click)="unverifiedExport.emit()"
+            aria-label="Export unverified positives"
+            title="Export the unverified positives (above-threshold items you haven't acted on) — e.g. to re-import as a dataset"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 14 20 9 15 4"></polyline>
+              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
 
       <div class="images-header">
         <h3 class="images-header-title">
           {{ mediaTypeName }}s ({{ (sortOrder?.length ?? medias.length) | number }})
         </h3>
-        <button
-          class="goods-action-btn unverified-export-btn"
-          [disabled]="disabled"
-          (click)="unverifiedExport.emit()"
-          aria-label="Export unverified"
-          title="Export the untouched work queue (unverified labels) — e.g. to re-import as a dataset"
-        >
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="15 14 20 9 15 4"></polyline>
-            <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
-          </svg>
-        </button>
         <vt-view-controls
           side="left"
           [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -125,28 +125,51 @@
   margin-left: var(--space-xs);
 }
 
-// Find mode: compact icon button for "export the unverified work queue",
-// pushed to the right edge of the header next to the view controls.
-.unverified-export-btn {
+// Find mode: the Inclusion cutoff and the unverified-positives work-queue
+// actions share one row, with the action cluster pushed to the right edge.
+.find-inclusion-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 0 var(--space-xs);
+  flex-shrink: 0;
+}
+
+// Icon-only action cluster (Browse / To Dataset / Export) sitting next to the
+// Inclusion control. Mirrors the right panel's ``.goods-actions``: compact,
+// borderless, tooltip-labelled.
+.find-queue-actions {
   margin-left: auto;
+}
+
+.goods-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.goods-action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-2xs, 4px);
-  background: transparent;
-  border: 1px solid var(--border-subtle);
+  padding: var(--space-xs);
+  border: none;
   border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
+  line-height: 0;
+  transition: color var(--transition-base), background var(--transition-base);
 
   &:hover:not(:disabled) {
+    background: var(--bg-hover);
     color: var(--text-primary);
-    border-color: var(--border-strong, var(--border-subtle));
   }
 
   &:disabled {
-    opacity: 0.5;
-    cursor: default;
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
   }
 }
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -20,6 +20,7 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { IconComponent } from '../icon/icon.component';
 import { Media, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsListingsApiService } from '../../services/datasets-listings-api.service';
@@ -40,6 +41,7 @@ export type { SortMode, SelectMode, SortedItem };
     StripeOverviewComponent,
     AutopilotPanelComponent,
     ViewControlsComponent,
+    IconComponent,
   ],
   templateUrl: './left-panel.component.html',
   styleUrl: './left-panel.component.scss',
@@ -97,7 +99,11 @@ export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Output() indicatorClick = new EventEmitter<string>();
   /** User clicked the Cancel button on the running sort progress bar. */
   @Output() sortCancel = new EventEmitter<void>();
-  /** Find mode: dump the untouched work queue (unverified labels) for re-import. */
+  /** Find mode: browse the unverified positives as their own UMAP projection. */
+  @Output() browse = new EventEmitter<void>();
+  /** Find mode: promote the unverified positives into their own dataset. */
+  @Output() toDataset = new EventEmitter<void>();
+  /** Find mode: export the unverified positives (above-threshold work queue). */
   @Output() unverifiedExport = new EventEmitter<void>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
@@ -190,6 +196,24 @@ export class LeftPanelComponent implements OnInit, OnChanges, OnDestroy {
     }
     const info = this.embedderInfos.find((e) => e.name === embedderName);
     this.textSortAvailable = info ? info.supports_text !== false : true;
+  }
+
+  /**
+   * Count of unverified positives: items above the cutoff in the work-queue
+   * ranking. In Find mode ``sortOrder`` is the *unverified* ranking (verified
+   * items are filtered out upstream), so the above-threshold slice is exactly
+   * the unverified positives. Gates the Find work-queue action buttons —
+   * Browse / To Dataset / Export all operate on exactly this set.
+   */
+  get unverifiedGoodCount(): number {
+    const order = this.sortOrder;
+    if (!order || this.threshold == null) return 0;
+    const cutoff = this.threshold;
+    let n = 0;
+    for (const item of order) {
+      if (item.score >= cutoff) n++;
+    }
+    return n;
   }
 
   onStripeClick(index: number): void {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -125,6 +125,11 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     if (this.initialFilter === 'unverified' || this.initialFilter === 'verified') {
       this.serverFilter = this.initialFilter;
       this.labelFilter = 'both';
+    } else if (this.initialFilter === 'unverified_good') {
+      // The left work-queue export: the unverified partition (server-side),
+      // sliced to the above-threshold good category (client-side).
+      this.serverFilter = 'unverified';
+      this.labelFilter = 'good';
     } else {
       this.serverFilter = 'both';
       this.labelFilter = this.initialFilter;

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -440,9 +440,12 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return 'upload';
   }
 
-  /** Modal heading, noting the server-side partition when present. */
+  /** Modal heading, noting the server-side partition (and category slice) when present. */
   get modalTitle(): string {
-    if (this.serverFilter === 'unverified') return 'Export Unverified';
+    if (this.serverFilter === 'unverified') {
+      // The left work-queue export opens on the above-threshold good slice.
+      return this.labelFilter === 'good' ? 'Export Unverified Good' : 'Export Unverified';
+    }
     if (this.serverFilter === 'verified') return 'Export Verified';
     return 'Export';
   }

--- a/frontend/src/app/services/browse-subset.service.ts
+++ b/frontend/src/app/services/browse-subset.service.ts
@@ -37,11 +37,11 @@ export class BrowseSubsetService {
 
   /**
    * Flag the reverse handoff: the user clicked "Back to Find" from the browse
-   * view after culling false-positives. The Find view consumes this on init
-   * to SKIP its automatic re-run of detector scoring — which would otherwise
-   * re-promote the just-removed items back to Good with the unchanged model —
-   * and instead just refresh the (already-updated) vote lists. Single-shot,
-   * like {@link take}.
+   * view after verifying a selection (Verified Good / Verified Bad). The Find
+   * view consumes this on init to SKIP its automatic re-run of detector
+   * scoring — which would otherwise re-promote the just-verified items with the
+   * unchanged model — and instead just refresh the (already-updated) vote
+   * lists. Single-shot, like {@link take}.
    */
   markReturningToFind(): void {
     this.returningToFind = true;

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -67,7 +67,7 @@ export class MediasApiService {
    *
    * Mirrors {@link vote} for a batch (idempotent, image-level — no region
    * boxes), persisting the detector labelset once server-side.  Used by the
-   * Browser's "Remove from Good" cull.  Stays on plain HttpClient (like
+   * Browser's "Verified Good" / "Verified Bad" actions.  Stays on plain HttpClient (like
    * {@link addToPile}) because the bulk route isn't modelled in the generated
    * client; the active-context interceptor still attaches the dataset /
    * detector headers the route requires.

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -53,8 +53,30 @@ import { exampleSortServer } from '../generated/api-client/fn/media-server/examp
 import { serverMediaFileFromMediaId } from '../generated/api-client/fn/media-server/server-media-file-from-media-id';
 import { listServerMediaFiles } from '../generated/api-client/fn/media-server/list-server-media-files';
 
-/** Server-side label partition for ``/api/labels/export``. */
-export type LabelFilter = 'good' | 'bad' | 'both' | 'corrections' | 'unverified' | 'verified';
+/**
+ * Label partition used to open the export modal. The first six map directly to
+ * the ``/api/labels/export`` ``label_filter`` query (server-side partitions or
+ * client-side category slices). ``unverified_good`` is a UI-only combination —
+ * the export modal fetches the server ``unverified`` partition and slices it to
+ * the ``good`` category (the above-threshold work queue); it is never sent to
+ * the backend as a ``label_filter`` value.
+ */
+export type LabelFilter =
+  | 'good'
+  | 'bad'
+  | 'both'
+  | 'corrections'
+  | 'unverified'
+  | 'verified'
+  | 'unverified_good';
+
+/**
+ * The subset of {@link LabelFilter} the backend ``/api/labels/export``
+ * ``label_filter`` query accepts. Excludes the UI-only ``unverified_good``,
+ * which the export modal resolves to a server ``unverified`` fetch plus a
+ * client-side ``good`` slice before any request is made.
+ */
+export type ServerLabelFilter = Exclude<LabelFilter, 'unverified_good'>;
 
 @Injectable({ providedIn: 'root' })
 export class SortingApiService {
@@ -116,7 +138,7 @@ export class SortingApiService {
 
   exportLabels(
     goodsOnly?: boolean,
-    options?: { enrich?: boolean; labelFilter?: LabelFilter },
+    options?: { enrich?: boolean; labelFilter?: ServerLabelFilter },
   ): Observable<LabelsExportResponse> {
     return exportLabels(this.http, this.config.rootUrl, {
       goods_only: goodsOnly || undefined,

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -648,11 +648,12 @@ def vote_media_bulk(body: dict):
     """Apply one absolute vote target to many medias in a single request.
 
     Mirrors ``/api/medias/<id>/vote`` for a batch: each id is set to
-    ``target`` with the same idempotent semantics, then the detector
-    labelset is persisted **once** rather than per id.  Bulk votes are
-    image-level (no region boxes).  Powers the Browser's "Remove from Good"
-    cull, which marks a hand-selected set of false-positives ``bad`` and
-    drops them from the browse.
+    ``target`` with the same idempotent semantics (including Find-mode
+    verification — a good/bad target marks the item verified), then the
+    detector labelset is persisted **once** rather than per id.  Bulk votes
+    are image-level (no region boxes).  Powers the Browser's "Verified Good" /
+    "Verified Bad" actions, which mark a hand-selected set good/bad, verify
+    them, and drop them from the browse.
 
     Ids that aren't in the loaded dataset are skipped and reported back in
     ``missing``; ``changed`` counts only the ids whose state actually moved


### PR DESCRIPTION
## What & why

The Find left panel was missing the verification action buttons. This adds **Browse**, **To Dataset**, and **Export** (in that order) next to the Inclusion control, each scoped to the **unverified positives** — the above-threshold items the human hasn't acted on yet (`goodVotes − verifiedIds`). And it makes the Browse canvas a verification surface: marking a selection **Verified Good** or **Verified Bad** removes it from the canvas, since it's no longer unverified.

These left-panel actions **complement** (don't replace) the existing right-panel trio, which still acts on the *full* good set (verified + unverified).

## Changes

**Left panel (Find mode)**
- New `Browse` / `To Dataset` / `Export` icon buttons sit on the Inclusion row, right-aligned (`left-panel.component.{html,ts,scss}`). All three disable when there are no unverified positives (`unverifiedGoodCount`). Replaces the lone "Unverified Export" button.
- `find-view` gains `onBrowseUnverified()` / `onToDatasetUnverified()` (scoped to `goodVotes − verifiedIds`) alongside the existing full-good-set handlers.

**Export scope**
- New UI-only `unverified_good` `LabelFilter`: the export modal resolves it to the server `unverified` partition sliced to the `good` category. It's never sent to the backend (`ServerLabelFilter` excludes it). Modal heading reads "Export Unverified Good".

**Browse canvas verify (replacing the cull)**
- The selection panel's single "Remove from Good" button becomes **"Verified Good" / "Verified Bad"** (`browse-selection-panel`, gated on `canVerify`). Both mark the selection good/bad and verify it — Find-mode `vote-bulk` already lands in `verified_ids` — then drop it from the canvas. The return-to-Find skip-rescore guard is unchanged.
- Docstrings/comments and the OpenAPI snapshot updated for the rename.

## Testing
- `./run-tests.sh` green: **ALL 4696 TESTS PASSED** (1 skipped).
- `npm run build:prod` clean: no TS errors, no budget warnings.
- Not visually eyeballed (no browser in container) — noted in the plan doc's open follow-ups.

## Notes
- Plan doc updated: `docs/plans/find-verification-workflow.md` (Phase 3 "What shipped").

https://claude.ai/code/session_019JDvG3UWkf1h8TpScxWvUb

---
_Generated by [Claude Code](https://claude.ai/code/session_019JDvG3UWkf1h8TpScxWvUb)_