### PR TITLE
Make Verify Good/Bad buttons symmetric green/red

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -17,19 +17,19 @@
     <div class="bsp-actions">
       <button
         type="button"
-        class="btn btn--primary btn--sm bsp-verify-good"
+        class="btn btn--sm bsp-verify-good"
         [disabled]="count === 0"
         (click)="onVerifyGood()"
         title="Mark the selected items Verified Good and remove them from this browse (they're no longer unverified)">
-        Verified Good ({{ count | number }})
+        Verified Good
       </button>
       <button
         type="button"
-        class="btn btn--danger btn--sm bsp-verify-bad"
+        class="btn btn--sm bsp-verify-bad"
         [disabled]="count === 0"
         (click)="onVerifyBad()"
         title="Mark the selected items Verified Bad and remove them from this browse (they're no longer unverified)">
-        Verified Bad ({{ count | number }})
+        Verified Bad
       </button>
     </div>
   }

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -62,9 +62,33 @@
   flex-shrink: 0;
 }
 
+// Verify Good / Bad are a symmetric pair: identical shape, distinguished only
+// by color (green = good, red = bad). Both are filled so neither reads as the
+// "primary" action over the other.
 .bsp-verify-good,
 .bsp-verify-bad {
   flex: 1;
+  color: var(--btn-filled-text);
+}
+
+.bsp-verify-good {
+  background: var(--color-good);
+  border-color: var(--color-good);
+
+  &:hover {
+    background: color-mix(in srgb, var(--color-good) 85%, var(--bg-body));
+    border-color: color-mix(in srgb, var(--color-good) 85%, var(--bg-body));
+  }
+}
+
+.bsp-verify-bad {
+  background: var(--color-bad);
+  border-color: var(--color-bad);
+
+  &:hover {
+    background: color-mix(in srgb, var(--color-bad) 85%, var(--bg-body));
+    border-color: color-mix(in srgb, var(--color-bad) 85%, var(--bg-body));
+  }
 }
 
 .bsp-toolbar {


### PR DESCRIPTION
## What changed

The "Verified Good" / "Verified Bad" buttons in the browse selection panel now read as a symmetric pair:

1. **Dropped the redundant count** from each button label. The panel header ("Selection (N)") already shows the selected count, so `Verified Good (N)` / `Verified Bad (N)` were repeating it. The labels are now just `Verified Good` and `Verified Bad`.
2. **Made the two buttons look like each other.** Previously Good used `btn--primary` (filled accent/blue) and Bad used `btn--danger` (red *outline*), so they looked nothing alike. Both are now filled buttons of identical shape, distinguished only by color: green (`--color-good`) for good, red (`--color-bad`) for bad, mirroring the established voting-overlay good/bad styling.

## Files

- `browse-selection-panel.component.html` — removed `({{ count | number }})` from both labels; dropped `btn--primary` / `btn--danger` variant classes.
- `browse-selection-panel.component.scss` — added symmetric green/red filled styling for `.bsp-verify-good` / `.bsp-verify-bad`.

Frontend `build:prod` passes with no warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXRcioggqvKu1XQtP4HGcG)_