### PR TITLE
Raise panel-width cap so wide panels persist instead of returning 400

### DIFF
--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -489,11 +489,16 @@ class TestSettingsModule:
         with pytest.raises(ValueError):
             settings_mod.set_panel_pct_left({"audio": 100})
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left({"audio": 600})
+            settings_mod.set_panel_pct_left({"audio": 20000})
         with pytest.raises(ValueError):
             settings_mod.set_panel_pct_left(100)
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left(600)
+            settings_mod.set_panel_pct_left(20000)
+
+    def test_panel_pct_wide_panel_allowed(self, isolated_settings):
+        """Widths above the old 500px cap are accepted (no upper-bound clip)."""
+        settings_mod.set_panel_pct_left({"audio": 520})
+        assert settings_mod.get_panel_pct_left()["audio"] == 520
 
     def test_panel_pct_invalid_media_type(self):
         with pytest.raises(ValueError):
@@ -508,11 +513,11 @@ class TestSettingsModule:
         settings_mod.set_panel_pct_left({"audio": 300})
         # Manually write an out-of-range value to disk
         raw = json.loads(isolated_settings.read_text())
-        raw["panel_pct_left"]["audio"] = 700
+        raw["panel_pct_left"]["audio"] = 20000
         isolated_settings.write_text(json.dumps(raw))
         settings_mod.reset()
         result = settings_mod.get_panel_pct_left()
-        assert result["audio"] == 500
+        assert result["audio"] == 10000
 
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -463,8 +463,14 @@ class TestSettingsAPI:
     def test_update_panel_pct_left_out_of_range(self, client):
         res = client.put("/api/settings", json={"panel_pct_left": 100})
         assert res.status_code == 400
-        res = client.put("/api/settings", json={"panel_pct_left": 600})
+        res = client.put("/api/settings", json={"panel_pct_left": 20000})
         assert res.status_code == 400
+
+    def test_update_panel_pct_left_wide_panel(self, client):
+        """Widths above the old 500px cap persist (frontend resize allows them)."""
+        res = client.put("/api/settings", json={"panel_pct_left": {"image": 520}})
+        assert res.status_code == 200
+        assert res.get_json()["panel_pct_left"]["image"] == 520
 
     def test_get_settings_includes_panel_pct(self, client):
         res = client.get("/api/settings")

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -68,7 +68,13 @@ VALID_FOCUS_MODES: tuple[str, ...] = ("click", "hover")
 VALID_BIN_SHAPES: tuple[str, ...] = ("hex", "square")
 VALID_BROWSE_COLORMAPS: tuple[str, ...] = ("auto", "heat", "ocean", "gray")
 VALID_BROWSE_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL")
-VALID_PANEL_PX: tuple[int, int] = (150, 500)
+# Allowed range (CSS px) for the saved left/right panel widths. The floor keeps
+# a panel usable; the ceiling is a sanity bound only. The frontend resize logic
+# already constrains a panel to the available layout space (viewport minus the
+# dividers, the center column, and the opposite panel), so legitimate widths
+# never approach this ceiling even on very large displays. Out-of-range values
+# raise on write and clamp on read.
+VALID_PANEL_PX: tuple[int, int] = (150, 10000)
 # Allowed range (CSS px) for the VTSBrowse pile-thumbnail border width. ``0``
 # disables the border; values are clamped into this range on read/write.
 BROWSE_THUMBNAIL_BORDER_PX: tuple[int, int] = (0, 8)


### PR DESCRIPTION
## Problem

A user hit `400 Bad Request` on `PUT /api/settings`:

> Invalid panel_pct_left value for image: 520 (must be between 150 and 500)

This is **not** stale settings data. The error is on a *write*: reads silently clamp `panel_pct_*` into range (`settings.py`), so an old `settings.json` could never produce a 400 — only a live PUT can.

The `520` came from the frontend. The panel-resize logic (`label-view.component.ts`, `find-view.component.ts`) clamps a dragged panel only against **available layout space** (`leftMax = layoutWidth − dividers − center − otherPanel`), with no 500px ceiling. On a wide enough display the user can drag a panel past 500px; the frontend then PUTs that width, and the backend's `VALID_PANEL_PX = (150, 500)` rejects it with a hard 400. The drag looks applied on screen but silently fails to persist, and the user gets an error toast. It reproduces for anyone on a large monitor who widens a panel.

## Fix

Relax the backend cap. The frontend's resize is already viewport-bounded, so the backend cap's only job is to reject garbage. Raise the ceiling to a generous sanity bound (`10000px`) that a real viewport never approaches, keeping the `150px` floor. Out-of-range values still raise on write and clamp on read, as before. `VALID_PANEL_PX` is the single source of truth for both paths, so this is a one-line constant change plus a clarifying comment.

No frontend change needed — it already sends what the resize allows, which the relaxed backend now accepts.

## Tests

- Updated the out-of-range assertions (old `600` is now valid) to use a value above the new ceiling.
- Updated the read-clamp test to clamp to the new max.
- Added coverage that a `520px` panel now persists end-to-end (API + settings layer).
- `./run-tests.sh core` green (740 passed), including ruff/codespell/deptry and the frontend build check.

https://claude.ai/code/session_01PXg4GHwGLBoCnKZq3yV3kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXg4GHwGLBoCnKZq3yV3kg)_