### PR TITLE
Don't zoom-to-fit after verifying items in browse

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -382,10 +382,6 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
           this.selection.clear();
         }
         this.fitToData();
-      } else if (this.viewport.consumeFitOnNextMeta()) {
-        // Same projection id, but the view asked for a re-frame (e.g. a
-        // Remove-from-Good cull shrank the bounds): fit to what remains.
-        this.fitToData();
       } else {
         this.updateActiveLevel();
       }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -190,7 +190,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private router: Router,
     private browseSubset: BrowseSubsetService,
     private selection: BrowseSelectionService,
-    private browseViewport: BrowseViewportService,
     private mediasApi: MediasApiService,
     private dialog: VtDialogService,
     private toast: ToastService,
@@ -625,9 +624,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * (good/bad). The remaining items keep their exact 2-D positions and bins —
    * the server re-bins the frozen layout in place (no UMAP re-fit), returning
    * the same ``projection_id`` with a bumped ``content_version`` so only the
-   * tile cache refreshes. The canvas then zooms to fit the survivors (via the
-   * one-shot fit request below), since the old framing leaves dead space
-   * wherever the verified items used to be.
+   * tile cache refreshes. The viewport is left exactly where the user had it:
+   * verifying may leave dead space where the culled items used to be, but a
+   * surprise zoom-to-fit jump is more disruptive than that dead space. The
+   * user can hit Zoom Fit themselves if they want to re-frame.
    */
   private dropFromBrowse(removedIds: number[], target: 'good' | 'bad'): void {
     const removed = new Set(removedIds);
@@ -649,9 +649,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (meta) => {
-          // The survivors' bounds shrank; re-frame to them rather than leaving
-          // dead space where the culled cluster was.
-          this.browseViewport.requestFitOnNextMeta();
+          // Leave the viewport where the user had it; don't yank the camera to
+          // re-fit the survivors. They can hit Zoom Fit if they want that.
           this.applyMeta(meta);
         },
         error: () =>

--- a/frontend/src/app/services/browse-viewport.service.ts
+++ b/frontend/src/app/services/browse-viewport.service.ts
@@ -29,24 +29,4 @@ export class BrowseViewportService {
   requestRecenter(x: number, y: number): void {
     this.recenter$.next({ x, y });
   }
-
-  /**
-   * Arm a one-shot zoom-to-fit for the next meta the canvas receives. Used by
-   * the Remove-from-Good cull: the same projection id comes back (so the
-   * canvas would normally hold the user's pan/zoom), but the survivors'
-   * bounds have shrunk and the old framing leaves dead space where the culled
-   * cluster was — re-frame to what's left instead.
-   */
-  requestFitOnNextMeta(): void {
-    this.pendingFit = true;
-  }
-
-  /** Consume the one-shot fit request, returning whether it was set. */
-  consumeFitOnNextMeta(): boolean {
-    const fit = this.pendingFit;
-    this.pendingFit = false;
-    return fit;
-  }
-
-  private pendingFit = false;
 }


### PR DESCRIPTION
## What

Marking items **Verified Good** / **Verified Bad** in the browse view re-bins the frozen layout in place and then was yanking the camera to re-fit the survivors. That auto-reframe is a jarring jump. This change leaves the viewport exactly where the user had it after a verify; they can hit **Zoom Fit** themselves if they want to re-frame.

## How

- `browse-view.component.ts` — `dropFromBrowse()` no longer arms a one-shot fit before `applyMeta()`. The viewport stays put.
- Removed the now-dead one-shot fit machinery: `requestFitOnNextMeta` / `consumeFitOnNextMeta` / `pendingFit` in `BrowseViewportService`, and the consume branch in `browse-canvas.component.ts`. (A genuinely new projection still auto-fits as before — only the same-projection cull path changed.)
- Dropped the unused `BrowseViewportService` constructor injection from `browse-view`; the `providers` entry that scopes it for the canvas/minimap stays.

A new projection (media-type switch, rebuild) still auto-fits on first frame as before — only the verify cull (same `projection_id`) stops reframing.

## Test

`npm run build:prod` is clean (no errors, no budget warnings).

https://claude.ai/code/session_01QCn6GDFMDfPkHoq6j2YeTd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCn6GDFMDfPkHoq6j2YeTd)_