### PR TITLE
Browse: green success state with Back to Find when verification empties the canvas

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -28,6 +28,14 @@
         <button class="btn btn--secondary" (click)="onBuild()">Retry</button>
       </div>
     }
+    @case ('done') {
+      <div class="browse-status">
+        <p class="browse-status-message browse-status-success">
+          All items were verified. Go back to Find to see your results.
+        </p>
+        <button class="btn btn--primary" (click)="back()">Back to Find</button>
+      </div>
+    }
     @case ('ready') {
       <div class="browse-content" #content [style.--browse-panel-width]="panelWidth + 'px'">
         <div class="browse-main">

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -26,6 +26,10 @@
   color: var(--color-bad);
 }
 
+.browse-status-success {
+  color: var(--color-good);
+}
+
 .browse-status-count {
   font-size: var(--font-sm);
   color: var(--text-muted);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -72,7 +72,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * view, pushed up from the canvas. The legend labels the yellow end with it.
    */
   densityMax = 1;
-  status: 'loading' | 'building' | 'ready' | 'error' = 'loading';
+  status: 'loading' | 'building' | 'ready' | 'error' | 'done' = 'loading';
   errorMessage = '';
   buildProgress = 0;
   buildTotal = 0;
@@ -639,9 +639,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     });
     this.subsetIds = remaining;
     if (remaining.length === 0) {
-      // Nothing left to project; verifying emptied the browse.
-      this.status = 'error';
-      this.errorMessage = 'All items were verified. Go back to Find to see your results.';
+      // Nothing left to project; verifying emptied the browse. This is a
+      // success, not an error — render the ``done`` state (green, with a
+      // Back to Find button) rather than the red error state.
+      this.status = 'done';
       return;
     }
     this.projectionApi


### PR DESCRIPTION
## Problem

When you verify all the items on a Find-positives Browse canvas, the browse empties out — but the view reused the `'error'` state to say so. That meant:

1. The "All items were verified" message rendered **red** (`browse-status-error`), as if something had gone wrong — when it's actually a complete success.
2. The only button was **Retry**, which re-runs `onBuild()` and errors out (there's nothing left to build), instead of taking you back to Find where your results now live.

## Fix

Added a dedicated `'done'` status to `BrowseViewComponent`, distinct from `'error'`:

- `dropFromBrowse` now sets `status = 'done'` (instead of `'error'`) when verification leaves zero remaining items.
- New `@case ('done')` template branch renders the message in **green** (`.browse-status-success` → `--color-good`) with a primary **Back to Find** button wired to the existing `back()` method (which routes a subset browse back to the Find view, preserving the verifications).

The red `'error'` state and its Retry button are unchanged for genuine build failures.

https://claude.ai/code/session_01Jm3NceTRDyJisjgcFu32qv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm3NceTRDyJisjgcFu32qv)_