### PR TITLE
VTSBrowse: bin popup gets full List/Grid + size view, persisted per mediaType

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -255,6 +255,12 @@
             },
             "type": "object"
           },
+          "grid_icon_size_popup": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "grid_icon_size_right": {
             "additionalProperties": {
               "type": "string"
@@ -346,6 +352,12 @@
             "type": "string"
           },
           "view_mode_left": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "view_mode_popup": {
             "additionalProperties": {
               "type": "string"
             },
@@ -4299,6 +4311,7 @@
           "focus_mode_left": {},
           "focus_mode_right": {},
           "grid_icon_size_left": {},
+          "grid_icon_size_popup": {},
           "grid_icon_size_right": {},
           "hide_autopilot": {
             "type": "boolean"
@@ -4342,6 +4355,7 @@
             "type": "string"
           },
           "view_mode_left": {},
+          "view_mode_popup": {},
           "view_mode_right": {},
           "volume": {
             "type": "number"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -9,6 +9,11 @@
     <span class="bin-popup-title" [title]="'Items in this bin (' + ids.length + ')'">
       {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
     </span>
+    <vt-view-controls
+      side="popup"
+      [currentMediaType]="mediaType"
+      [showFocus]="false"
+      class="bin-popup-view-controls" />
     <button
       type="button"
       class="bin-popup-close"
@@ -20,35 +25,47 @@
   </div>
 
   <cdk-virtual-scroll-viewport
-    [itemSize]="itemHeight"
-    [style.height.px]="listHeight"
-    class="bin-popup-list"
+    [itemSize]="rowSize"
+    [style.height.px]="bodyHeight"
+    [style.width.px]="isGrid ? 280 : null"
+    class="bin-popup-body"
+    [class.grid]="isGrid"
     (mouseleave)="onListLeave()">
     <div
-      *cdkVirtualFor="let id of ids; trackBy: trackById"
-      class="bin-popup-entry"
-      [class.selected]="isSelected(id)"
-      role="button"
-      tabindex="0"
-      [attr.aria-pressed]="isSelected(id)"
-      [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
-      [title]="name(id)"
-      (click)="onEntryClick(id)"
-      (keydown)="onEntryKeydown($event, id)"
-      (mouseenter)="onEntryEnter(id)">
-      @if (hasThumbnailUrl(id)) {
-        <span class="bin-popup-thumb-wrap">
-          <img
-            class="bin-popup-thumb"
-            [src]="thumbnailUrl(id)"
-            [alt]="name(id)"
-            loading="lazy"
-            (error)="onThumbnailError(thumbnailUrl(id))" />
-        </span>
-      } @else {
-        <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+      *cdkVirtualFor="let row of rows; trackBy: trackByRow"
+      class="bin-popup-row"
+      [class.grid]="isGrid"
+      [style.height.px]="rowSize"
+      [style.--popup-cols]="columns"
+      [style.--popup-cell.px]="gridGoalWidth">
+      @for (id of row; track trackById($index, id)) {
+        <div
+          class="bin-popup-entry"
+          [class.grid]="isGrid"
+          [class.selected]="isSelected(id)"
+          role="button"
+          tabindex="0"
+          [attr.aria-pressed]="isSelected(id)"
+          [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
+          [title]="name(id)"
+          (click)="onEntryClick(id)"
+          (keydown)="onEntryKeydown($event, id)"
+          (mouseenter)="onEntryEnter(id)">
+          @if (hasThumbnailUrl(id)) {
+            <span class="bin-popup-thumb-wrap">
+              <img
+                class="bin-popup-thumb"
+                [src]="thumbnailUrl(id)"
+                [alt]="name(id)"
+                loading="lazy"
+                (error)="onThumbnailError(thumbnailUrl(id))" />
+            </span>
+          } @else {
+            <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+          }
+          <span class="bin-popup-name">{{ name(id) }}</span>
+        </div>
       }
-      <span class="bin-popup-name">{{ name(id) }}</span>
     </div>
   </cdk-virtual-scroll-viewport>
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -27,7 +27,6 @@
   <cdk-virtual-scroll-viewport
     [itemSize]="rowSize"
     [style.height.px]="bodyHeight"
-    [style.width.px]="isGrid ? 280 : null"
     class="bin-popup-body"
     [class.grid]="isGrid"
     (mouseleave)="onListLeave()">
@@ -37,7 +36,7 @@
       [class.grid]="isGrid"
       [style.height.px]="rowSize"
       [style.--popup-cols]="columns"
-      [style.--popup-cell.px]="gridGoalWidth">
+      [style.--popup-cell]="gridGoalWidth + 'px'">
       @for (id of row; track trackById($index, id)) {
         <div
           class="bin-popup-entry"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -1,5 +1,7 @@
-// A small floating list of a bin's media items, opened by right-clicking a bin
-// on the VTSBrowse canvas. Rows mirror the selection panel's list entries.
+// A small floating panel of a bin's media items, opened by right-clicking a bin
+// on the VTSBrowse canvas. A mini knock-off of the Find right panel: its header
+// carries the shared List/Grid + size controls and the body renders the bin's
+// members as a virtualized list or thumbnail grid.
 .bin-popup {
   position: fixed;
   z-index: var(--z-burger-menu);
@@ -31,6 +33,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex-shrink: 0;
+}
+
+.bin-popup-view-controls {
+  margin-left: auto;
 }
 
 .bin-popup-close {
@@ -48,22 +55,40 @@
   }
 }
 
-.bin-popup-list {
+.bin-popup-body {
   // Concrete height is bound per render (rows, capped) so the virtual viewport
   // scrolls; the cap is applied inline via [style.height.px].
   overflow-x: hidden;
 }
 
-.bin-popup-entry {
-  height: 36px;
+// --- Rows ------------------------------------------------------------------
+// One virtual item == one row. In list mode a row holds a single full-width
+// entry; in grid mode it is a CSS grid of fixed-size thumbnail cells.
+.bin-popup-row {
   box-sizing: border-box;
+
+  &.grid {
+    display: grid;
+    grid-template-columns: repeat(var(--popup-cols, 1), 1fr);
+    align-content: start;
+    justify-items: center;
+    column-gap: var(--space-2xs);
+    padding: 0 var(--space-sm);
+  }
+}
+
+.bin-popup-entry {
+  box-sizing: border-box;
+  cursor: pointer;
+  color: var(--text-vote);
+
+  // --- List mode: a horizontal row (thumbnail + name) --------------------
+  height: 36px;
   display: flex;
   align-items: center;
   gap: var(--space-md);
   padding: 0 var(--space-md);
   font-size: var(--font-sm);
-  color: var(--text-vote);
-  cursor: pointer;
 
   &:hover {
     background: var(--bg-hover);
@@ -80,8 +105,26 @@
     outline: 2px solid var(--accent);
     outline-offset: -2px;
   }
+
+  // --- Grid mode: a vertical cell (thumbnail above its name) -------------
+  &.grid {
+    height: auto;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    width: var(--popup-cell, 80px);
+
+    &.selected {
+      // The list's inset accent bar reads oddly under a square thumbnail; use
+      // a ring instead so the whole cell shows as selected.
+      box-shadow: 0 0 0 2px var(--accent);
+    }
+  }
 }
 
+// List-mode thumbnail/placeholder: fixed 28px square.
 .bin-popup-thumb-wrap {
   display: block;
   width: 28px;
@@ -116,9 +159,29 @@
   flex: 1;
   min-width: 0;
   font-weight: var(--weight-medium);
+  font-size: var(--font-sm);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+// Grid mode resizes the thumbnail to the chosen cell size and stacks the name
+// underneath it, truncated to the cell width.
+.bin-popup-entry.grid {
+  .bin-popup-thumb-wrap,
+  .bin-popup-placeholder {
+    width: var(--popup-cell, 80px);
+    height: var(--popup-cell, 80px);
+  }
+
+  .bin-popup-name {
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: var(--popup-cell, 80px);
+    text-align: center;
+    font-size: var(--font-xs);
+    font-weight: var(--weight-normal);
+  }
 }
 
 .sr-only {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -18,49 +18,66 @@ import { Subscription } from 'rxjs';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
+import { SettingsStateService } from '../../services/settings-state.service';
+import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 
-/** Row stride (px) for the virtualized list; must match ``.bin-popup-entry``. */
-const ITEM_HEIGHT = 36;
-/** Most rows shown before the popup caps its height and scrolls. */
-const MAX_VISIBLE_ROWS = 10;
+/** Row stride (px) for the virtualized list mode; matches ``.bin-popup-entry``. */
+const LIST_ROW_HEIGHT = 36;
+/** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
+const GRID_LABEL_HEIGHT = 18;
+/** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
+const GRID_GAP = 4;
+/** Width (px) available to lay out cells inside the popup body (≈ popup width
+ *  minus padding and the scrollbar). Columns are derived from this. */
+const GRID_CONTENT_WIDTH = 256;
+/** Tallest the scrolling body grows before it caps and scrolls internally. */
+const MAX_BODY_PX = 400;
 /** Extra rows of metadata prefetched beyond the visible window. */
 const PREFETCH_BUFFER = 50;
-/** Gap (px) kept between the popup and the canvas edge when clamping. */
+/** Gap (px) kept between the popup and the visible edge when clamping. */
 const EDGE_MARGIN = 8;
 
 /**
- * The bin popup: a small floating, virtualized list of the media items in the
- * bin the user right-clicked on the VTSBrowse canvas. It replaces the old
- * right-click action menu — instead of menu commands, it shows the bin's
- * members rendered like the right-panel selection list, so the user can scroll
- * the bin, hear each item on hover (audio), and click to add/remove it from the
- * canvas selection. This is how you reach the individual items folded into a
- * dense bin without zooming all the way in.
+ * The bin popup: a small floating panel showing the media items in the bin the
+ * user right-clicked on the VTSBrowse canvas. It is a miniature knock-off of
+ * the Find right panel — the same List/Grid + thumbnail-size controls (via
+ * {@link ViewControlsComponent}) sit in its header, and the body renders the
+ * bin's members in whichever mode is chosen. This is how you reach the
+ * individual items folded into a dense bin without zooming all the way in.
+ *
+ * The view-mode + size choice is remembered per media type under the
+ * ``view_mode_popup`` / ``grid_icon_size_popup`` settings (independent of the
+ * left/right panels), so tuning the popup while browsing one bin becomes the
+ * default for every future popup of that media type. The controls write those
+ * settings and this component re-reads them from {@link SettingsStateService},
+ * keyed by the active dataset's media type.
  *
  * It shares the {@link BrowseSelectionService} instance provided by the browse
  * view, so toggling an item here is the same selection the canvas rings and the
  * selection panel reflect; selected members render highlighted and update live.
  * Names/thumbnails resolve lazily through {@link MediaMetadataCacheService}
  * (the browse view never loads the full media list), prefetched around the
- * visible window so large bins stay responsive.
+ * visible window so large bins stay responsive in either mode.
  */
 @Component({
   selector: 'vt-browse-bin-popup',
   standalone: true,
-  imports: [CommonModule, ScrollingModule],
+  imports: [CommonModule, ScrollingModule, ViewControlsComponent],
   templateUrl: './browse-bin-popup.component.html',
   styleUrl: './browse-bin-popup.component.scss',
 })
 export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDestroy {
   /** Member media ids of the bin the popup was summoned over. */
   @Input() memberIds: number[] = [];
-  /** Active dataset media type, used to decide hover-to-hear and placeholders. */
+  /** Active dataset media type, used for the view prefs, hover-to-hear, and placeholders. */
   @Input() mediaType = '';
   /** Viewport anchor (clientX/clientY) the popup opens at, then clamps inward. */
   @Input() x = 0;
   @Input() y = 0;
-  /** The canvas's bounding rect (viewport coords); the popup is clamped inside
-   *  it so it stays on the canvas. Null falls back to the full viewport. */
+  /** The canvas's bounding rect (viewport coords); the popup is clamped to the
+   *  on-screen part of it so it stays fully visible. Null falls back to the
+   *  full viewport. */
   @Input() bounds: DOMRect | null = null;
 
   /** Emitted when the popup should close (outside click, Escape, or the X). */
@@ -79,7 +96,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  together in the list (the server orders them; see ``tile_member_ids``). */
   ids: number[] = [];
 
-  readonly itemHeight = ITEM_HEIGHT;
+  /** Per-media-type view prefs, mirrored from settings. */
+  viewMode: 'grid' | 'list' = 'grid';
+  gridGoalWidth = 80;
+
+  /** Number of columns the grid lays out; always 1 in list mode. */
+  columns = 1;
+  /** Member ids chunked into rows of {@link columns}; the virtual list's data. */
+  rows: number[][] = [];
 
   /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
   audioSrc = '';
@@ -93,6 +117,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     private selection: BrowseSelectionService,
     private metadataCache: MediaMetadataCacheService,
     private activeContext: ActiveContextService,
+    private settingsState: SettingsStateService,
     private cdr: ChangeDetectorRef,
   ) {}
 
@@ -100,9 +125,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     if (changes['memberIds']) {
       this.ids = this.memberIds ?? [];
       this.stopAudio();
+      this.rebuildRows();
       // A fresh bin: jump the list back to the top and prefetch its first window.
       this.viewport?.scrollToIndex(0);
       this.prefetchVisible();
+    }
+    if (changes['mediaType']) {
+      // A new media type may carry a different remembered view mode/size.
+      this.applyViewPrefs();
     }
     if (changes['x'] || changes['y'] || changes['bounds'] || changes['memberIds']) {
       this.left = this.x;
@@ -118,7 +148,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
       // A selection change anywhere (here, the canvas, the panel) re-highlights.
       this.selection.changed$.subscribe(() => this.cdr.markForCheck()),
+      // Re-read the popup's view mode + size whenever settings change (this is
+      // how the in-header controls take effect, and how a change on one popup
+      // becomes the default for every future popup of this media type).
+      this.settingsState.settings$.subscribe((settings) => {
+        if (!settings) return;
+        this.viewModeDict = (settings.view_mode_popup as Record<string, 'grid' | 'list'>) ?? {};
+        this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
+        this.applyViewPrefs();
+      }),
     );
+    this.settingsState.load();
     this.scrollSub =
       this.viewport?.scrolledIndexChange.subscribe(() => this.prefetchVisible()) ?? null;
     this.prefetchVisible();
@@ -131,9 +171,57 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.stopAudio();
   }
 
-  /** Height (px) the list takes: just enough for its rows, capped then scrolled. */
-  get listHeight(): number {
-    return Math.min(Math.max(this.ids.length, 1), MAX_VISIBLE_ROWS) * this.itemHeight;
+  private viewModeDict: Record<string, 'grid' | 'list'> = {};
+  private gridSizeDict: Record<string, string> = {};
+
+  /** Pull the remembered view mode + thumbnail size for the active media type,
+   *  rechunk the rows, and re-clamp (the body height may have changed). */
+  private applyViewPrefs(): void {
+    const prevMode = this.viewMode;
+    const prevGoal = this.gridGoalWidth;
+    this.viewMode = this.mediaType ? (this.viewModeDict[this.mediaType] ?? 'grid') : 'grid';
+    this.gridGoalWidth = iconSizeToGoalWidth(
+      (this.mediaType && this.gridSizeDict[this.mediaType]) || 'M',
+    );
+    if (this.viewMode !== prevMode || this.gridGoalWidth !== prevGoal) {
+      this.rebuildRows();
+      // The row stride changed; let the virtual viewport remeasure, then clamp.
+      setTimeout(() => {
+        this.viewport?.checkViewportSize();
+        this.place();
+      });
+    }
+    this.cdr.markForCheck();
+  }
+
+  /** Recompute the column count + row chunking for the current mode/size. */
+  private rebuildRows(): void {
+    this.columns =
+      this.viewMode === 'grid'
+        ? Math.max(1, Math.floor((GRID_CONTENT_WIDTH + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)))
+        : 1;
+    const cols = this.columns;
+    const rows: number[][] = [];
+    for (let i = 0; i < this.ids.length; i += cols) {
+      rows.push(this.ids.slice(i, i + cols));
+    }
+    this.rows = rows;
+  }
+
+  /** Pixel stride of one virtual row (a list entry, or a grid row of cells). */
+  get rowSize(): number {
+    return this.viewMode === 'grid'
+      ? this.gridGoalWidth + GRID_LABEL_HEIGHT + GRID_GAP
+      : LIST_ROW_HEIGHT;
+  }
+
+  /** Height (px) the body takes: just enough for its rows, capped then scrolled. */
+  get bodyHeight(): number {
+    return Math.min(Math.max(this.rows.length, 1) * this.rowSize, MAX_BODY_PX);
+  }
+
+  get isGrid(): boolean {
+    return this.viewMode === 'grid';
   }
 
   // --- Dismissal -----------------------------------------------------------
@@ -244,45 +332,57 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return id;
   }
 
+  trackByRow(index: number): number {
+    return index;
+  }
+
   // --- Positioning ---------------------------------------------------------
 
-  /** Clamp the popup inside the canvas (or the viewport, when no bounds are
-   *  given) so it never spills off an edge or onto the side panel. */
+  /** Clamp the popup inside the *visible* part of the canvas — the canvas rect
+   *  intersected with the viewport — so it never spills off an edge, onto the
+   *  side panel, or below the bottom of the window. */
   private place(): void {
     const panel = this.panelRef?.nativeElement;
     if (!panel) return;
     const rect = panel.getBoundingClientRect();
     const b = this.bounds;
-    const minLeft = b ? b.left + EDGE_MARGIN : EDGE_MARGIN;
-    const minTop = b ? b.top + EDGE_MARGIN : EDGE_MARGIN;
-    const maxRight = b ? b.right : window.innerWidth;
-    const maxBottom = b ? b.bottom : window.innerHeight;
+    // Visible region = canvas rect clipped to the viewport. Clipping to the
+    // window is what keeps the popup fully on-screen when the canvas extends
+    // past the bottom/right edges of the window.
+    const regionLeft = Math.max(b ? b.left : 0, 0);
+    const regionTop = Math.max(b ? b.top : 0, 0);
+    const regionRight = Math.min(b ? b.right : window.innerWidth, window.innerWidth);
+    const regionBottom = Math.min(b ? b.bottom : window.innerHeight, window.innerHeight);
     let l = this.x;
     let t = this.y;
-    if (l + rect.width + EDGE_MARGIN > maxRight) {
-      l = maxRight - rect.width - EDGE_MARGIN;
+    if (l + rect.width + EDGE_MARGIN > regionRight) {
+      l = regionRight - rect.width - EDGE_MARGIN;
     }
-    if (t + rect.height + EDGE_MARGIN > maxBottom) {
-      t = maxBottom - rect.height - EDGE_MARGIN;
+    if (t + rect.height + EDGE_MARGIN > regionBottom) {
+      t = regionBottom - rect.height - EDGE_MARGIN;
     }
-    // Never push the top-left off the opposite edge (popup larger than canvas).
-    this.left = Math.max(minLeft, l);
-    this.top = Math.max(minTop, t);
+    // Never push the top-left off the opposite edge (popup larger than region).
+    this.left = Math.max(regionLeft + EDGE_MARGIN, l);
+    this.top = Math.max(regionTop + EDGE_MARGIN, t);
     this.cdr.markForCheck();
   }
 
-  /** Prefetch metadata for the rows around the visible window of the list. */
+  /** Prefetch metadata for the items around the visible window of the body. */
   private prefetchVisible(): void {
     if (this.ids.length === 0) return;
+    const cols = this.columns;
     const vp = this.viewport;
     if (!vp) {
-      this.metadataCache.ensureLoaded(this.ids.slice(0, MAX_VISIBLE_ROWS + PREFETCH_BUFFER));
+      const window = Math.ceil(MAX_BODY_PX / this.rowSize) * cols + PREFETCH_BUFFER;
+      this.metadataCache.ensureLoaded(this.ids.slice(0, window));
       return;
     }
-    const start = Math.floor(vp.measureScrollOffset('top') / this.itemHeight);
-    const visible = Math.ceil((vp.elementRef.nativeElement.clientHeight || this.listHeight) / this.itemHeight);
-    const from = Math.max(0, start - PREFETCH_BUFFER);
-    const to = Math.min(this.ids.length, start + visible + PREFETCH_BUFFER);
+    const startRow = Math.floor(vp.measureScrollOffset('top') / this.rowSize);
+    const visibleRows = Math.ceil(
+      (vp.elementRef.nativeElement.clientHeight || this.bodyHeight) / this.rowSize,
+    );
+    const from = Math.max(0, (startRow - Math.ceil(PREFETCH_BUFFER / cols)) * cols);
+    const to = Math.min(this.ids.length, (startRow + visibleRows) * cols + PREFETCH_BUFFER);
     this.metadataCache.ensureLoaded(this.ids.slice(from, to));
   }
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -326,6 +326,28 @@
                   aria-label="Browser thumbnail border width" />
                 <p class="form-hint">Only affects datasets that show thumbnails (image, video). Draws a colored band around each stacked tile; its color shows how many items are piled there. Set to 0 to hide it.</p>
               </div>
+              <div class="form-group">
+                <label class="form-label" title="How a right-clicked bin's items are shown in the popup">Bin popup</label>
+                <div class="toggle-group">
+                  <button class="toggle-btn" [class.toggle-btn--active]="getPopupViewMode(activeBrowseTab) === 'grid'" (click)="onPopupViewModeChange(activeBrowseTab, 'grid')" title="Show a right-clicked bin's items as a thumbnail grid">
+                    Grid
+                  </button>
+                  <button class="toggle-btn" [class.toggle-btn--active]="getPopupViewMode(activeBrowseTab) === 'list'" (click)="onPopupViewModeChange(activeBrowseTab, 'list')" title="Show a right-clicked bin's items as a list">
+                    List
+                  </button>
+                </div>
+                <p class="form-hint">How the right-click bin popup shows a bin&rsquo;s items. Changing it on a popup while browsing remembers the choice here for this media type.</p>
+              </div>
+              <div class="form-group">
+                <label class="form-label" title="Thumbnail size in the bin popup's grid">Popup thumbnail size</label>
+                <select class="form-select" [ngModel]="getPopupGridIconSize(activeBrowseTab)" (ngModelChange)="onPopupGridIconSizeChange(activeBrowseTab, $event)" [disabled]="getPopupViewMode(activeBrowseTab) === 'list'" aria-label="Bin popup thumbnail size">
+                  <option value="XS">XS</option>
+                  <option value="S">S</option>
+                  <option value="M">M</option>
+                  <option value="L">L</option>
+                  <option value="XL">XL</option>
+                </select>
+              </div>
             </div>
           } @else {
             <p class="empty-state">No media types registered.</p>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -380,6 +380,36 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     this.save();
   }
 
+  // --- Browser tab: right-click bin-popup view prefs ---
+  // The bin popup keeps its own per-media-type view mode + thumbnail size
+  // (``view_mode_popup`` / ``grid_icon_size_popup``), independent of the
+  // left/right panels. The popup's in-header controls write the same maps, so
+  // these widgets and the live popup stay in step.
+
+  getPopupViewMode(typeId: string): string {
+    const dict = this.settings.view_mode_popup as Record<string, string> | undefined;
+    return (dict && dict[typeId]) || 'grid';
+  }
+
+  onPopupViewModeChange(typeId: string, value: string): void {
+    const dict = { ...((this.settings.view_mode_popup as Record<string, string> | undefined) || {}) };
+    dict[typeId] = value;
+    (this.settings as Record<string, unknown>)['view_mode_popup'] = dict;
+    this.save();
+  }
+
+  getPopupGridIconSize(typeId: string): string {
+    const dict = this.settings.grid_icon_size_popup as Record<string, string> | undefined;
+    return (dict && dict[typeId]) || 'M';
+  }
+
+  onPopupGridIconSizeChange(typeId: string, value: string): void {
+    const dict = { ...((this.settings.grid_icon_size_popup as Record<string, string> | undefined) || {}) };
+    dict[typeId] = value;
+    (this.settings as Record<string, unknown>)['grid_icon_size_popup'] = dict;
+    this.save();
+  }
+
   onNumberChange(key: string, value: number): void {
     (this.settings as Record<string, unknown>)[key] = value;
     this.save();

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -18,7 +18,7 @@ type IconSize = (typeof ICON_SIZES)[number];
   styleUrl: './view-controls.component.scss',
 })
 export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() side: 'left' | 'right' = 'left';
+  @Input() side: 'left' | 'right' | 'popup' = 'left';
   @Input() currentMediaType = '';
   /**
    * Whether to show the click/hover focus toggle. The VTSBrowse selection
@@ -67,6 +67,8 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private defaultViewMode(): 'grid' | 'list' {
+    // Left panel reads as a list by default; the right panel and the
+    // VTSBrowse bin popup default to a thumbnail grid.
     return this.side === 'left' ? 'list' : 'grid';
   }
 

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -97,6 +97,10 @@ class AppSettingsSchema(Schema):
     focus_mode_right = _PerMediaTypeStringDict()
     panel_pct_left = _PerMediaTypeNumberDict()
     panel_pct_right = _PerMediaTypeNumberDict()
+    # VTSBrowse bin-popup view mode + thumbnail size, per media type. Driven by
+    # the popup's own view controls and the Settings → Browser tab.
+    view_mode_popup = _PerMediaTypeStringDict()
+    grid_icon_size_popup = _PerMediaTypeStringDict()
 
     # Server-tier. These are fixed at server start (config file /
     # environment / CLI flags) and shared across all users; the frontend
@@ -184,6 +188,8 @@ class SettingsUpdateSchema(Schema):
     focus_mode_right = fields.Raw()
     panel_pct_left = fields.Raw()
     panel_pct_right = fields.Raw()
+    view_mode_popup = fields.Raw()
+    grid_icon_size_popup = fields.Raw()
 
     autopilot_enabled = fields.Boolean()
     hide_autopilot = fields.Boolean()

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -247,6 +247,19 @@ class UserSettings(BaseModel):
     grid_icon_size_right: dict[str, Annotated[GridIconSize, BeforeValidator(_upper)]] = Field(default_factory=dict)
     focus_mode_left: dict[str, FocusMode] = Field(default_factory=dict)
     focus_mode_right: dict[str, FocusMode] = Field(default_factory=dict)
+
+    # VTSBrowse bin-popup display prefs, per media type. The right-click bin
+    # popup renders the bin's members like a mini Find panel with its own
+    # List/Grid + thumbnail-size controls, independent of the left/right
+    # panels. Empty entries fall back on the frontend to grid + ``M``.
+    # Driven by the popup's own view-controls AND the Settings → Browser tab;
+    # both write the same maps keyed by the active dataset's media type, so
+    # tuning the popup while browsing one bin becomes the default for every
+    # future popup of that media type. Unlike ``view_mode_{left,right}`` these
+    # are plain per-media-type dicts (no per-side machinery): the popup is a
+    # single, third context, so it uses the generic Pydantic-driven accessors.
+    view_mode_popup: dict[str, ViewMode] = Field(default_factory=dict)
+    grid_icon_size_popup: dict[str, Annotated[GridIconSize, BeforeValidator(_upper)]] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)
 


### PR DESCRIPTION
## What & why

Right-clicking a bin on the VTSBrowse canvas used to open a fixed list-only popup. This turns it into a miniature knock-off of the Find right panel, and fixes the popup spilling off the bottom of the screen.

### Bin popup becomes a real view
- The shared **List/Grid + thumbnail-size** controls (`vt-view-controls`) now live in the popup header. The body renders the bin's members in whichever mode is chosen — a virtualized list (as before) or a virtualized thumbnail grid.
- Both modes stay virtualized (row-based for the grid) so dense bins remain responsive.

### Per-mediaType persistence (a new settings object)
- New per-mediaType maps `view_mode_popup` / `grid_icon_size_popup`, independent of the left/right panels.
- Exposed in **Settings → Browser** (a "Bin popup" toggle + "Popup thumbnail size" picker per media type).
- Changing the controls on a live popup writes those same maps, so tuning the popup while browsing one bin of media type *M* becomes the default for every future popup of *M*. Fresh popups default to **Grid / M**.

### Bottom-edge clamping fix
- The popup is now clamped to the **on-screen** part of the canvas (canvas rect ∩ viewport) rather than the raw canvas rect, so right-clicking near the bottom (where the canvas extends past the window) keeps the popup fully visible.

## Implementation notes
- Backend: two new per-mediaType dict fields on `UserSettings` (plain Pydantic-driven accessors, not the left/right per-side machinery), added to `AppSettingsSchema` / `SettingsUpdateSchema`; OpenAPI snapshot regenerated.
- Frontend: `view-controls` gains a `popup` side; `browse-bin-popup` reads the prefs from `SettingsStateService` and rebuilds its row chunking on mode/size change; Settings modal gains the Browser-tab widgets.

## Compatibility
No breaking changes. Existing settings round-trip unchanged; the new keys default to empty (frontend falls back to grid + M).

## Testing
- `./run-tests.sh` — ALL 4698 passed (1 skipped). Includes ruff/codespell/deptry, OpenAPI snapshot check, and the frontend build/typecheck.
- `npm run build:prod` — clean, no errors or budget warnings.

https://claude.ai/code/session_018LqBR5NLZND9x6KFwYT9kR

---
_Generated by [Claude Code](https://claude.ai/code/session_018LqBR5NLZND9x6KFwYT9kR)_