### PR TITLE
Order VTBrowse bin-popup members by a Hilbert traversal of the layout

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -636,6 +636,19 @@ in git history and the cited source files.
   button UMAPs only the positive ids into an ephemeral, never-persisted `_subset_*`
   projection (`?subset=1`). *Known limitation:* in-memory id handoff, so a hard
   reload of the subset URL loses it.
+- ~~**Bin-popup member ordering**~~ — a bin's `member_ids` are served in a
+  locality-preserving 1-D order (a Hilbert space-filling-curve traversal of the
+  frozen 2-D layout, `_hilbert_order` in `pyramid.py`) rather than by media id,
+  so a dense bin lists similar items together (cats with cats, dogs with dogs)
+  and hiding items keeps the survivors' relative order. Derived from the 2-D
+  coords with no second UMAP fit, and recomputed wherever the `_member_index`
+  cache is (re)built, so it rebuilds/caches/trashes exactly like the coords. The
+  earlier idea — a *separate* 1-D UMAP fit, persisted alongside the 2-D coords —
+  was dropped because it would roughly double the projection build time for a
+  marginal gain over the curve, which already linearizes the layout UMAP
+  produced. *Open follow-up:* if a future ordering wants true 1-D-UMAP semantics
+  (not just a space-filling linearization of the 2-D layout), it would need that
+  second fit and a persisted `order` field on `Projection`.
 
 **Active:**
 - **Dataset pickle size — drop inline `media_bytes` when the media is reachable

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -74,7 +74,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   left = 0;
   top = 0;
 
-  /** The bin's member ids, in bin order (the list's data source). */
+  /** The bin's member ids, in bin order — a locality-preserving 1-D (Hilbert)
+   *  traversal of the layout, so spatially/semantically similar items sit
+   *  together in the list (the server orders them; see ``tile_member_ids``). */
   ids: number[] = [];
 
   readonly itemHeight = ITEM_HEIGHT;

--- a/tests_lib/projection/test_member_order.py
+++ b/tests_lib/projection/test_member_order.py
@@ -1,0 +1,106 @@
+"""Tests for bin-popup member ordering (the 1-D Hilbert traversal).
+
+A bin's member ids are served in a locality-preserving 1-D order derived from
+the frozen 2-D layout (``_hilbert_order``), not by media id, so a dense bin's
+contents group by region — and hiding items leaves the survivors' order intact.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.projection import build_pyramid, rebin_like, remove_ids, tile_member_ids
+from vtscore.projection.pyramid import _hilbert_order
+from vtscore.projection.umap_projection import Projection
+
+
+def _single_bin_members(pyr, proj) -> list[int]:
+    """The member list of the one cell in a single-bin pyramid (all points)."""
+    members: list[int] = []
+    for lvl, tx, ty in pyr.tiles:
+        for mem in tile_member_ids(pyr, proj, lvl, tx, ty).values():
+            members.extend(mem)
+    return members
+
+
+def _interleaved_clusters(seed: int = 7):
+    """Three far-apart, tight blobs with ids assigned independently of cluster.
+
+    Row order (== id order, ids are ``range(N)``) interleaves the clusters, so a
+    spatial regrouping is observable: id order scatters the clusters, the Hilbert
+    order must put each back together.
+    """
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.0], [100.0, 0.0], [50.0, 80.0]])
+    blocks = [c + rng.standard_normal((100, 2)) * 0.3 for c in centers]
+    coords = np.concatenate(blocks).astype(np.float32)
+    cluster_of_row = np.repeat([0, 1, 2], 100)
+    perm = rng.permutation(coords.shape[0])  # interleave the rows
+    coords = np.ascontiguousarray(coords[perm])
+    cluster_of_row = cluster_of_row[perm]
+    proj = Projection("hilbert-test", list(range(coords.shape[0])), coords, "test")
+    return proj, cluster_of_row
+
+
+def _transitions(labels: list[int]) -> int:
+    return sum(1 for a, b in zip(labels, labels[1:]) if a != b)
+
+
+def test_dense_bin_groups_clusters():
+    """A bin holding three interleaved clusters lists each cluster contiguously."""
+    proj, cluster_of_row = _interleaved_clusters()
+    # base_radius huge -> every point lands in one cell.
+    pyr = build_pyramid(proj, n_levels=1, base_radius=1000.0)
+    members = _single_bin_members(pyr, proj)
+    assert len(members) == len(proj.ids)
+
+    # ids are row indices, so cluster_of_row indexes directly by member id.
+    hilbert_labels = [int(cluster_of_row[m]) for m in members]
+    # Ideal grouping of 3 clusters is 2 transitions; allow a couple for curve
+    # seams. The point is it's *nothing like* the interleaved id order below.
+    assert _transitions(hilbert_labels) <= 4
+
+    id_labels = [int(cluster_of_row[m]) for m in sorted(members)]
+    assert _transitions(id_labels) > 50  # id order scatters the clusters
+
+
+def test_members_follow_global_hilbert_order():
+    """Within every cell at every level, members are in global Hilbert order."""
+    rng = np.random.default_rng(3)
+    centers = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 8.0]])
+    coords = np.concatenate([c + rng.standard_normal((100, 2)) * 0.5 for c in centers]).astype(np.float32)
+    proj = Projection("rank-test", list(range(coords.shape[0])), coords, "test")
+    pyr = build_pyramid(proj, n_levels=4)
+
+    # Same coords the membership pass sees (float64), so the curve matches.
+    perm = _hilbert_order(np.ascontiguousarray(coords, dtype=np.float64))
+    rank = np.empty(perm.shape[0], dtype=np.int64)
+    rank[perm] = np.arange(perm.shape[0])  # rank[id] = position in the order
+
+    for lvl, tx, ty in pyr.tiles:
+        for mem in tile_member_ids(pyr, proj, lvl, tx, ty).values():
+            ranks = [int(rank[m]) for m in mem]
+            assert ranks == sorted(ranks)
+
+
+def test_hiding_items_preserves_relative_order():
+    """Removing ids leaves the survivors in the same relative order (subsequence)."""
+    proj, _ = _interleaved_clusters(seed=5)
+    pyr = build_pyramid(proj, n_levels=1, base_radius=1000.0)
+    full_order = _single_bin_members(pyr, proj)
+
+    removed = set(proj.ids[::3])  # cull every third item
+    reduced = remove_ids(proj, removed)
+    reduced_pyr = rebin_like(reduced, pyr)
+    reduced_order = _single_bin_members(reduced_pyr, reduced)
+
+    survivors = [i for i in full_order if i not in removed]
+    assert reduced_order == survivors
+
+
+def test_hilbert_order_handles_degenerate_inputs():
+    """Empty and all-coincident layouts order deterministically without error."""
+    assert _hilbert_order(np.empty((0, 2), dtype=np.float64)).tolist() == []
+    coincident = np.zeros((5, 2), dtype=np.float64)
+    # All on one point: ties break by row index (stable), so order is identity.
+    assert _hilbert_order(coincident).tolist() == [0, 1, 2, 3, 4]

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -351,6 +351,52 @@ def rebin_like(projection: Projection, template: Pyramid) -> Pyramid:
     return replace(pyr, bounds=template.bounds)
 
 
+def _hilbert_order(coords: np.ndarray, bits: int = 16) -> np.ndarray:
+    """Indices that walk *coords* along a 2-D Hilbert space-filling curve.
+
+    Returns a permutation ``perm`` such that ``coords[perm]`` traverses the frozen
+    layout in a locality-preserving 1-D order: points adjacent in ``perm`` are
+    adjacent in the plane, so a contiguous slice of the order is a contiguous
+    region of the projection.  This is the cheap "derive a 1-D ordering from the
+    2-D coords" (one quantize + bit-twiddle + stable argsort, no second UMAP fit)
+    that orders bin-popup contents — because UMAP already places semantically
+    similar items near each other, the curve keeps them grouped in the list
+    (cats with cats, dogs with dogs) instead of scattering by media id, and the
+    order of any subset is just the order with the hidden points dropped.
+
+    The integer Hilbert distance is computed by the standard quadrant-rotation
+    walk (Wikipedia's ``xy2d``/``rot``), vectorized over all points.  Ties
+    (co-located points map to the same curve cell) break by ascending row index
+    via a stable sort — ascending id, since ids are sorted — so the order is
+    deterministic.
+    """
+    n = coords.shape[0]
+    if n == 0:
+        return np.empty(0, dtype=np.int64)
+    side = 1 << bits  # curve resolution: side x side cells
+    mins = coords.min(axis=0)
+    span = np.maximum(coords.max(axis=0) - mins, 1e-12)  # guard all-coincident axes
+    grid = np.clip(((coords - mins) / span * (side - 1)).astype(np.int64), 0, side - 1)
+    x = grid[:, 0].copy()
+    y = grid[:, 1].copy()
+    d = np.zeros(n, dtype=np.int64)
+    s = side >> 1
+    while s > 0:
+        rx = ((x & s) > 0).astype(np.int64)
+        ry = ((y & s) > 0).astype(np.int64)
+        d += s * s * ((3 * rx) ^ ry)
+        # rot(): in the ry == 0 quadrant, flip both axes when rx == 1, then swap.
+        flip = (ry == 0) & (rx == 1)
+        x[flip] = (side - 1) - x[flip]
+        y[flip] = (side - 1) - y[flip]
+        swap = ry == 0
+        x_swap = x[swap]
+        x[swap] = y[swap]
+        y[swap] = x_swap
+        s >>= 1
+    return np.argsort(d, kind="stable")
+
+
 def _level_membership(
     pyr: Pyramid,
     projection: Projection,
@@ -371,6 +417,11 @@ def _level_membership(
     then a dict lookup — turning a per-tile O(N) scan into one O(N) pass per
     level.  The cache is process-scoped and never persisted; the frozen layout
     re-derives it on the next load.
+
+    Within each cell, members come out in :func:`_hilbert_order` (a 1-D Hilbert
+    traversal of the frozen layout) rather than by id, so a dense bin's contents
+    group by region — the popup shows similar items together and a subset keeps
+    that order when items are hidden.
     """
     cached = pyr._member_index.get(level)
     if cached is not None:
@@ -388,7 +439,13 @@ def _level_membership(
     q, r = geom.assign(coords, radius)
     tx_all, ty_all = geom.tile_index(q, r, pyr.tile_span)
 
-    for txx, tyy, qq, rr, mid in zip(tx_all.tolist(), ty_all.tolist(), q.tolist(), r.tolist(), ids.tolist()):
+    # Visit points along the Hilbert curve so each cell's member list lands in a
+    # locality-preserving 1-D order (shared across this level's tiles; the whole
+    # index is memoized, so the curve is computed at most once per level).
+    perm = _hilbert_order(coords)
+    for txx, tyy, qq, rr, mid in zip(
+        tx_all[perm].tolist(), ty_all[perm].tolist(), q[perm].tolist(), r[perm].tolist(), ids[perm].tolist()
+    ):
         tile_cells = index.setdefault((int(txx), int(tyy)), {})
         tile_cells.setdefault((int(qq), int(rr)), []).append(int(mid))
 
@@ -408,9 +465,11 @@ def tile_member_ids(
     The browse canvas needs each cell's full membership to render per-cell
     selection state (none / partial / full) and to toggle a whole bin's
     contents.  Returned keyed by ``(q, r)`` so the tile endpoint can hand each
-    cell its members.  Backed by the per-level cache in :func:`_level_membership`
-    (computed once per level, shared across that level's tiles); the result is
-    also immutable for the dataset's life, so the tile endpoint HTTP-caches it.
+    cell its members, each list ordered by a 1-D Hilbert traversal of the layout
+    (see :func:`_level_membership`) so the popup groups similar items.  Backed by
+    the per-level cache in :func:`_level_membership` (computed once per level,
+    shared across that level's tiles); the result is also immutable for the
+    dataset's life, so the tile endpoint HTTP-caches it.
     """
     return _level_membership(pyr, projection, level).get((tx, ty), {})
 


### PR DESCRIPTION
## What & why

Bin popups in VTBrowse listed their contents by **media id**, so right-clicking a dense bin (e.g. "all animals") scattered semantically-similar clips — dogs, cats, and goats interleaved arbitrarily.

This serves each cell's `member_ids` in a **locality-preserving 1-D order** instead: a Hilbert space-filling-curve traversal of the frozen 2-D UMAP layout. Because a contiguous slice of the curve is a contiguous region of the plane, and UMAP already clusters similar items spatially, a bin's contents now group by region (cats with cats, dogs with dogs). And because it's a *global* order, hiding items leaves the survivors' relative order intact.

## Approach

Following a discussion of the cost tradeoff, the ordering is **derived from the existing 2-D coords** rather than a second `n_components=1` UMAP fit (which would roughly double projection build time). A Hilbert curve is the same cost as PCA-1 (one quantize + bit-twiddle + stable argsort) but far better preserves the clustering UMAP produced — PCA-1 collapses the minor axis and interleaves clusters stacked perpendicular to the principal axis.

The order is a pure function of the frozen coords, computed right where the per-cell member lists are built and memoized (`_level_membership`). So it "rebuilds/caches/trashes" exactly with the coords — **zero changes** to `Projection`, the `.npz` container persistence, the routes, or any existing constructor.

## Changes

- `vtscore/projection/pyramid.py`: new `_hilbert_order` helper (vectorized `xy2d`); `_level_membership` now visits points along the curve so each cell's list comes out spatially ordered.
- `tests_lib/projection/test_member_order.py`: new tests — dense bins group interleaved clusters, members follow the global Hilbert order at every level, hiding items preserves relative order (subsequence), and degenerate (empty / all-coincident) inputs are deterministic.
- `frontend/.../browse-bin-popup.component.ts`: comment update noting the list is spatially ordered server-side.
- `docs/plans/vtsbrowse.md`: shipped note + open follow-up (true 1-D-UMAP semantics would need the second fit and a persisted `order` field).

## Testing

`./run-tests.sh` — **ALL 4702 TESTS PASSED (1 skipped)**, including ruff/codespell/deptry and the frontend build.

https://claude.ai/code/session_017Yot3EUAbYQGAgqHjTMFpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Yot3EUAbYQGAgqHjTMFpJ)_