### PR TITLE
Fire achievement unlock toasts once; keep the dot until the panel is viewed

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -51,6 +51,14 @@
             "type": "array"
           },
           "pending_announcements": {
+            "description": "Milestones not yet seen in the panel; lights the notification dot.",
+            "items": {
+              "$ref": "#/components/schemas/_PendingAnnouncement"
+            },
+            "type": "array"
+          },
+          "pending_toasts": {
+            "description": "Milestones whose one-time unlock toast hasn't fired yet.",
             "items": {
               "$ref": "#/components/schemas/_PendingAnnouncement"
             },
@@ -69,6 +77,7 @@
           "hours",
           "media_types",
           "pending_announcements",
+          "pending_toasts",
           "tier_names"
         ],
         "type": "object"
@@ -6412,7 +6421,55 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Mark *category_id*'s tier as announced.",
+        "summary": "Mark *category_id*'s tier as announced (seen in the panel).",
+        "tags": [
+          "achievements"
+        ]
+      }
+    },
+    "/api/achievements/{category_id}/mark-toasted": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "category_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "mark_toasted",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcknowledgeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcknowledgeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Mark *category_id*'s tier's unlock toast as shown so it fires once.",
         "tags": [
           "achievements"
         ]

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -10,12 +10,14 @@ import type { PendingAnnouncement } from '../generated/api-client/models/pending
 import { acknowledgeAchievement } from '../generated/api-client/fn/achievements/acknowledge-achievement';
 import { checkPhrase } from '../generated/api-client/fn/achievements/check-phrase';
 import { getAchievements } from '../generated/api-client/fn/achievements/get-achievements';
+import { markToasted } from '../generated/api-client/fn/achievements/mark-toasted';
 import { SettingsStateService } from './settings-state.service';
 
 const EMPTY_STATE: AchievementState = {
   tier_names: [],
   achievements: [],
   pending_announcements: [],
+  pending_toasts: [],
   docs: [],
   media_types: [],
   hours: [],
@@ -27,8 +29,11 @@ const EMPTY_STATE: AchievementState = {
  * consumer (a global host component) can render dialogs sequentially.
  *
  * Trigger `refresh()` after any action that might unlock a tier (vote,
- * find, dataset load complete, label import).  Acknowledged announcements
- * are persisted server-side so they don't replay on reload.
+ * find, dataset load complete, label import).  Two server-side watermarks
+ * keep the toast and the dot independent: unlock toasts fire once
+ * (`pending_toasts`, marked shown via {@link markToasted}) and never replay
+ * on reload, while the notification dot stays lit (`pending_announcements`)
+ * until the user opens the panel, which ACKs via {@link acknowledge}.
  */
 @Injectable({ providedIn: 'root' })
 export class AchievementsService {
@@ -46,11 +51,12 @@ export class AchievementsService {
 
   /**
    * Milestones already pushed to {@link unlock$} this session, keyed by
-   * `categoryId:tierIdx`. The server keeps returning a milestone in
-   * `pending_announcements` until the user opens the panel (which ACKs it),
-   * so without this guard every `refresh()` — fired after votes, finds, and
-   * navigation — would re-pop a toast for an already-shown unlock. The toast
-   * fires once per real unlock; the notification dot stays server-driven.
+   * `categoryId:tierIdx`. The toast watermark lives server-side
+   * (`pending_toasts` shrinks once {@link markToasted} lands), but that
+   * round-trips asynchronously, so this set guards against a second
+   * `refresh()` re-popping the same toast before the mark is persisted.
+   * The persistent guard is the server; this is just the in-flight race
+   * fix. The notification dot stays driven by `pending_announcements`.
    */
   private readonly emittedUnlocks = new Set<string>();
 
@@ -103,13 +109,29 @@ export class AchievementsService {
       .subscribe((next) => {
         this.inFlight = false;
         this.state$.next(next);
-        for (const p of next.pending_announcements) {
+        for (const p of next.pending_toasts) {
           const key = `${p.id}:${p.tier_idx}`;
           if (this.emittedUnlocks.has(key)) continue;
           this.emittedUnlocks.add(key);
           this.unlock$.next(p);
+          this.markToasted(p.id, p.tier_idx);
         }
       });
+  }
+
+  /**
+   * Persist that a tier's unlock toast has been shown, so it stays out of
+   * future `pending_toasts` lists and never replays on app restart. Fire and
+   * forget — the toasted watermark drives only the toast, not the dot or the
+   * panel display, so there's nothing to refresh on success.
+   */
+  private markToasted(categoryId: string, tierIdx: number): void {
+    markToasted(this.http, this.config.rootUrl, {
+      category_id: categoryId,
+      body: { tier_idx: tierIdx },
+    })
+      .pipe(catchError(() => of(null)))
+      .subscribe();
   }
 
   /**

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -3,10 +3,11 @@
 Covers:
 - record_* helpers (vote, dataset load, detector import, find)
 - counter → tier index mapping
-- pending_announcements computation
-- acknowledge tracking
+- pending_announcements computation (notification dot)
+- pending_toasts computation (one-time unlock toast)
+- acknowledge / mark_toasted tracking (independent watermarks)
 - importer exclusion for datasets_loaded
-- /api/achievements and /api/achievements/<id>/acknowledge routes
+- /api/achievements and /api/achievements/<id>/{acknowledge,mark-toasted} routes
 """
 
 from __future__ import annotations
@@ -35,6 +36,10 @@ def _pending_for(state: dict, category: str) -> list[dict]:
     return [p for p in state["pending_announcements"] if p["id"] == category]
 
 
+def _toasts_for(state: dict, category: str) -> list[dict]:
+    return [p for p in state["pending_toasts"] if p["id"] == category]
+
+
 # ---------------------------------------------------------------------------
 # Empty / defaults
 # ---------------------------------------------------------------------------
@@ -45,6 +50,7 @@ class TestEmptyState:
         state = achievements.get_full_state()
         assert state["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
         assert state["pending_announcements"] == []
+        assert state["pending_toasts"] == []
         assert len(state["achievements"]) == 10
         for a in state["achievements"]:
             assert a["counter"] == 0
@@ -558,6 +564,65 @@ class TestTiers:
 
 
 # ---------------------------------------------------------------------------
+# One-time toast watermark (independent of the notification dot)
+# ---------------------------------------------------------------------------
+
+
+class TestToasts:
+    def test_new_unlock_pends_a_toast(self):
+        achievements.record_dataset_load("server_folder")  # Bronze
+        state = achievements.get_full_state()
+        toasts = _toasts_for(state, "datasets_loaded")
+        assert len(toasts) == 1
+        assert toasts[0]["tier_idx"] == 0
+        assert toasts[0]["tier_name"] == "Bronze"
+        assert toasts[0]["threshold"] == 1
+
+    def test_mark_toasted_clears_toast_but_keeps_dot(self):
+        # The whole point: toasting once must NOT clear the notification dot.
+        achievements.record_dataset_load("server_folder")
+        assert achievements.mark_toasted("datasets_loaded", 0) is True
+        state = achievements.get_full_state()
+        assert _toasts_for(state, "datasets_loaded") == []
+        # The dot (pending_announcements) stays lit until the panel is opened.
+        assert [p["tier_idx"] for p in _pending_for(state, "datasets_loaded")] == [0]
+
+    def test_acknowledge_does_not_clear_an_unseen_toast_after_marking(self):
+        # Marking toasted leaves the dot; opening the panel then clears it,
+        # and a re-toast never happens (toasted stays advanced).
+        achievements.record_dataset_load("server_folder")
+        achievements.mark_toasted("datasets_loaded", 0)
+        achievements.acknowledge("datasets_loaded", 0)
+        state = achievements.get_full_state()
+        assert _toasts_for(state, "datasets_loaded") == []
+        assert _pending_for(state, "datasets_loaded") == []
+
+    def test_acknowledge_also_advances_toasted(self):
+        # Opening the panel (acknowledge) implies the toast need not fire later.
+        achievements.record_dataset_load("server_folder")
+        achievements.acknowledge("datasets_loaded", 0)
+        state = achievements.get_full_state()
+        assert _toasts_for(state, "datasets_loaded") == []
+
+    def test_mark_toasted_lower_tier_is_noop(self):
+        achievements.record_dataset_load("server_folder")
+        assert achievements.mark_toasted("datasets_loaded", 0) is True
+        assert achievements.mark_toasted("datasets_loaded", 0) is False
+
+    def test_jumping_multiple_tiers_pends_each_toast(self):
+        achievements.record_find(2500)  # Bronze + Silver in one go
+        state = achievements.get_full_state()
+        assert [p["tier_idx"] for p in _toasts_for(state, "find_media")] == [0, 1]
+
+    def test_invalid_category_mark_toasted_returns_false(self):
+        assert achievements.mark_toasted("not_a_real_category", 0) is False
+
+    def test_invalid_tier_idx_mark_toasted_returns_false(self):
+        assert achievements.mark_toasted("datasets_loaded", 99) is False
+        assert achievements.mark_toasted("datasets_loaded", -1) is False
+
+
+# ---------------------------------------------------------------------------
 # Persistence in settings.json
 # ---------------------------------------------------------------------------
 
@@ -631,6 +696,27 @@ class TestAchievementsApi:
         resp = client.post("/api/achievements/votes_cast/acknowledge", json={})
         # Schema validation: missing required "tier_idx" → 422.
         assert resp.status_code == 422
+
+    def test_mark_toasted_endpoint(self, client):
+        achievements.record_dataset_load("server_folder")
+        resp = client.post(
+            "/api/achievements/datasets_loaded/mark-toasted",
+            json={"tier_idx": 0},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["changed"] is True
+
+        # The toast is gone, but the dot remains for the panel to clear.
+        body = client.get("/api/achievements").get_json()
+        assert _toasts_for(body, "datasets_loaded") == []
+        assert [p["tier_idx"] for p in _pending_for(body, "datasets_loaded")] == [0]
+
+        # Second call returns changed=False.
+        resp = client.post(
+            "/api/achievements/datasets_loaded/mark-toasted",
+            json={"tier_idx": 0},
+        )
+        assert resp.get_json()["changed"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -9,8 +9,23 @@ Categories and their tier thresholds are declared statically in
 :data:`ACHIEVEMENTS`.  Counters are incremented from hook points across the
 codebase (vote toggle, dataset load completion, label import, find).  The UI
 polls :func:`get_full_state` to render the Achievements tab and to discover
-newly-unlocked tiers (``pending_announcements``); the client ACKs each
-announcement via :func:`acknowledge` so the popup doesn't fire on refresh.
+newly-unlocked tiers.
+
+Two independent server-side watermarks track how far the user has been
+notified, so a one-time toast and a persistent notification dot don't have
+to share state:
+
+- ``toasted`` drives ``pending_toasts``: the milestones whose toast hasn't
+  fired yet.  The client pops a toast for each, then advances the watermark
+  via :func:`mark_toasted`, so the toast fires exactly once per real unlock
+  and never replays on the next app start.
+- ``announced`` drives ``pending_announcements``: the milestones the user
+  hasn't yet seen in the Achievements panel.  This is what lights the
+  notification dot.  It clears only when the user opens the panel, which ACKs
+  each announcement via :func:`acknowledge`.
+
+The dot therefore stays lit until the user actually looks at the panel, while
+the toast is a fire-once affair independent of whether they ever open it.
 """
 
 from __future__ import annotations
@@ -204,6 +219,7 @@ def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
         settings["achievement_state"] = state
     counters = state.setdefault("counters", {})
     announced = state.setdefault("announced", {})
+    toasted = state.setdefault("toasted", {})
     state.setdefault("trained_detector_ids", [])
     state.setdefault("imported_detector_ids", [])
     state.setdefault("days_seen", [])
@@ -220,6 +236,8 @@ def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
             counters[cid] = 0
         if cid not in announced or not isinstance(announced[cid], int):
             announced[cid] = -1
+        if cid not in toasted or not isinstance(toasted[cid], int):
+            toasted[cid] = -1
     return state
 
 
@@ -480,10 +498,17 @@ def get_full_state() -> dict[str, Any]:
                 },
                 ...
             ],
+            "pending_toasts": [ <same shape as pending_announcements>, ... ],
             "docs": [{"id", "name", "path", "read"}, ...],
             "media_types": [{"id", "name", "seen"}, ...],
             "hours": [{"hour": <0..23>, "seen": <bool>}, ...],
         }
+
+    ``pending_announcements`` lights the notification dot (it clears only when
+    the user opens the panel and ACKs via :func:`acknowledge`), while
+    ``pending_toasts`` drives the one-time unlock toast (the client pops each,
+    then advances the watermark via :func:`mark_toasted`).  The two are
+    independent so the toast fires once without forcing the dot to clear.
 
     The ``media_types`` and ``hours`` arrays back the "Multi Media" and
     "Around the Clock" expandable panels: each entry's ``seen`` flag says
@@ -508,6 +533,7 @@ def get_full_state() -> dict[str, Any]:
             "tier_names": list(TIER_NAMES),
             "achievements": zeroed,
             "pending_announcements": [],
+            "pending_toasts": [],
             "docs": [{"id": d["id"], "name": d["name"], "path": d["path"], "read": False} for d in DOCS],
             "media_types": [{"id": m["id"], "name": m["name"], "seen": False} for m in MEDIA_TYPES],
             "hours": [{"hour": h, "seen": False} for h in HOURS_OF_DAY],
@@ -524,11 +550,13 @@ def get_full_state() -> dict[str, Any]:
         state = _ensure_state(s)
         achievements: list[dict[str, Any]] = []
         pending: list[dict[str, Any]] = []
+        toasts: list[dict[str, Any]] = []
         for a in ACHIEVEMENTS:
             cid = a["id"]
             counter = int(state["counters"].get(cid, 0))
             tier_idx = _current_tier_idx(cid, counter)
             announced_idx = int(state["announced"].get(cid, -1))
+            toasted_idx = int(state["toasted"].get(cid, -1))
             next_threshold: int | None = a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
             achievements.append(
                 {
@@ -542,17 +570,19 @@ def get_full_state() -> dict[str, Any]:
                     "next_threshold": next_threshold,
                 }
             )
-            for i in range(announced_idx + 1, tier_idx + 1):
-                pending.append(
-                    {
-                        "id": cid,
-                        "name": a["name"],
-                        "icon": a["icon"],
-                        "tier_idx": i,
-                        "tier_name": TIER_NAMES[i],
-                        "threshold": a["tiers"][i],
-                    }
-                )
+
+            def _milestone(i: int, _a: dict[str, Any] = a, _cid: str = cid) -> dict[str, Any]:
+                return {
+                    "id": _cid,
+                    "name": _a["name"],
+                    "icon": _a["icon"],
+                    "tier_idx": i,
+                    "tier_name": TIER_NAMES[i],
+                    "threshold": _a["tiers"][i],
+                }
+
+            pending.extend(_milestone(i) for i in range(announced_idx + 1, tier_idx + 1))
+            toasts.extend(_milestone(i) for i in range(toasted_idx + 1, tier_idx + 1))
         read_ids = set(state.get("docs_read_ids", []))
         docs = [{"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids} for d in DOCS]
         seen_types = set(state.get("media_types_seen", []))
@@ -563,6 +593,7 @@ def get_full_state() -> dict[str, Any]:
             "tier_names": list(TIER_NAMES),
             "achievements": achievements,
             "pending_announcements": pending,
+            "pending_toasts": toasts,
             "docs": docs,
             "media_types": media_types,
             "hours": hours,
@@ -570,7 +601,11 @@ def get_full_state() -> dict[str, Any]:
 
 
 def acknowledge(category_id: str, tier_idx: int) -> bool:
-    """Mark a tier as announced so it isn't popped again.
+    """Mark a tier as announced (seen in the panel) so the dot clears.
+
+    Opening the panel also implies the toast need never fire, so this advances
+    the ``toasted`` watermark alongside ``announced`` (a tier the user has
+    already read about in the panel shouldn't pop a toast later).
 
     Returns True if the announced index advanced, False otherwise.
     """
@@ -584,10 +619,43 @@ def acknowledge(category_id: str, tier_idx: int) -> bool:
     def _apply(cache: dict[str, Any]) -> None:
         nonlocal advanced
         state = _ensure_state(cache)
+        if tier_idx > int(state["toasted"].get(category_id, -1)):
+            state["toasted"][category_id] = tier_idx
         prev = int(state["announced"].get(category_id, -1))
         if tier_idx <= prev:
             return
         state["announced"][category_id] = tier_idx
+        advanced = True
+
+    mutate_user(_apply)
+    return advanced
+
+
+def mark_toasted(category_id: str, tier_idx: int) -> bool:
+    """Mark a tier's unlock toast as shown so it isn't popped again.
+
+    The client calls this right after rendering the toast.  Advancing the
+    ``toasted`` watermark keeps the milestone out of future ``pending_toasts``
+    lists, so the toast fires exactly once and never replays on app restart.
+    Unlike :func:`acknowledge` it leaves ``announced`` untouched, so the
+    notification dot stays lit until the user opens the panel.
+
+    Returns True if the toasted index advanced, False otherwise.
+    """
+    if category_id not in _ACH_BY_ID:
+        return False
+    if tier_idx < 0 or tier_idx >= len(TIER_NAMES):
+        return False
+
+    advanced = False
+
+    def _apply(cache: dict[str, Any]) -> None:
+        nonlocal advanced
+        state = _ensure_state(cache)
+        prev = int(state["toasted"].get(category_id, -1))
+        if tier_idx <= prev:
+            return
+        state["toasted"][category_id] = tier_idx
         advanced = True
 
     mutate_user(_apply)

--- a/vtsearch/routes/achievements.py
+++ b/vtsearch/routes/achievements.py
@@ -6,7 +6,11 @@ GET  /api/achievements
     Return current achievement state for the UI.
 
 POST /api/achievements/<category_id>/acknowledge
-    Mark a tier as announced.  Body: ``{"tier_idx": <int>}``.
+    Mark a tier as announced (seen in the panel; clears the dot).
+    Body: ``{"tier_idx": <int>}``.
+
+POST /api/achievements/<category_id>/mark-toasted
+    Mark a tier's one-time unlock toast as shown.  Body: ``{"tier_idx": <int>}``.
 
 POST /api/achievements/check-phrase
     Match a user-submitted phrase against the Readme Reader doc set.
@@ -61,8 +65,17 @@ def get_achievements():
 @achievements_bp.arguments(AcknowledgeRequestSchema)
 @achievements_bp.response(200, AcknowledgeResponseSchema)
 def acknowledge_achievement(body: dict, category_id: str):
-    """Mark *category_id*'s tier as announced."""
+    """Mark *category_id*'s tier as announced (seen in the panel)."""
     changed = achievements.acknowledge(category_id, body["tier_idx"])
+    return {"ok": True, "changed": changed}
+
+
+@achievements_bp.route("/api/achievements/<category_id>/mark-toasted", methods=["POST"])
+@achievements_bp.arguments(AcknowledgeRequestSchema)
+@achievements_bp.response(200, AcknowledgeResponseSchema)
+def mark_toasted(body: dict, category_id: str):
+    """Mark *category_id*'s tier's unlock toast as shown so it fires once."""
+    changed = achievements.mark_toasted(category_id, body["tier_idx"])
     return {"ok": True, "changed": changed}
 
 

--- a/vtsearch/schemas/achievements.py
+++ b/vtsearch/schemas/achievements.py
@@ -58,7 +58,16 @@ class AchievementStateSchema(Schema):
 
     tier_names = fields.List(fields.String(), required=True)
     achievements = fields.List(fields.Nested(_AchievementEntrySchema), required=True)
-    pending_announcements = fields.List(fields.Nested(_PendingAnnouncementSchema), required=True)
+    pending_announcements = fields.List(
+        fields.Nested(_PendingAnnouncementSchema),
+        required=True,
+        metadata={"description": "Milestones not yet seen in the panel; lights the notification dot."},
+    )
+    pending_toasts = fields.List(
+        fields.Nested(_PendingAnnouncementSchema),
+        required=True,
+        metadata={"description": "Milestones whose one-time unlock toast hasn't fired yet."},
+    )
     docs = fields.List(fields.Nested(_DocEntrySchema), required=True)
     media_types = fields.List(fields.Nested(_MediaTypeEntrySchema), required=True)
     hours = fields.List(fields.Nested(_HourEntrySchema), required=True)


### PR DESCRIPTION
## Problem

Achievement unlock toasts re-fired on **every app start**. The toast was driven by the server's `pending_announcements` list, which only clears when the user opens the Achievements panel (which ACKs each milestone). The client-side `emittedUnlocks` guard that prevented re-toasting was session-scoped, so it reset on each load — meaning the only way to stop the toasts was to open the panel and acknowledge everything. That's too much friction for a "you unlocked something" nudge.

## Fix

Split the notification state into two **independent server-side watermarks** so the one-time toast and the persistent dot no longer share state:

- **`toasted`** drives a new `pending_toasts` list — the one-time unlock toast. The client pops each toast, then advances the watermark via the new `POST /api/achievements/<id>/mark-toasted`. The toast now fires exactly once per real unlock and never replays on restart.
- **`announced`** continues to drive `pending_announcements` — the notification dot. It still clears only when the user opens the panel (`acknowledge`).

Opening the panel (`acknowledge`) also advances `toasted`, so a milestone the user already read about in the panel never pops a toast later.

Net behavior, matching the request: **toast once, leave the dot on while there's something unseen, and that's it.**

## Changes

- `vtsearch/achievements.py`: add the `toasted` watermark, compute `pending_toasts` in `get_full_state`, add `mark_toasted()`, and couple `acknowledge` to also advance `toasted`.
- `vtsearch/schemas/achievements.py`: add `pending_toasts` to the state schema (reuses the pending-announcement entry shape).
- `vtsearch/routes/achievements.py`: add `POST /api/achievements/<id>/mark-toasted` (reuses the acknowledge request/response schemas).
- `frontend/openapi.json`: regenerated snapshot.
- `frontend/src/app/services/achievements.service.ts`: toast off `pending_toasts`, persist via `markToasted`; the dot stays driven by `pending_announcements`. The session `emittedUnlocks` set is now just an in-flight race guard, not the primary mechanism.
- `tests/core/test_achievements.py`: coverage for `pending_toasts`, `mark_toasted`, the toast/dot independence, and the new route.

## Testing

- `./run-tests.sh core` → all 749 pass (includes ruff/codespell/deptry/OpenAPI drift + frontend build).
- `npm run build:prod` → clean build; generated client now includes `markToasted`.

https://claude.ai/code/session_01UneD1yAqbWAEo6LDbubonL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UneD1yAqbWAEo6LDbubonL)_