### PR TITLE
Spread the button micro-animations: waggle (slow jobs) + tilt-while-open (modals)

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -113,7 +113,9 @@
     aria-label="Achievements"
     title="Achievements: usage milestones and tier progress"
     (click)="onAchievements()"
-  ><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+  ><svg aria-hidden="true" [class.trophy-open]="showAchievements" [class.trophy-close]="achievementsClosing"
+       (animationend)="onTrophyAnimationEnd()"
+       viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M6 4h12v4a6 6 0 0 1-12 0z"/>
       <path d="M6 6H3a2 2 0 0 0 0 4h3"/>
@@ -130,8 +132,10 @@
     class="help-btn"
     aria-label="Help"
     title="Help (?)"
-    (click)="showKeyboardHelp = true"
-  ><svg aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    (click)="onHelp()"
+  ><svg aria-hidden="true" [class.help-open]="showKeyboardHelp" [class.help-close]="helpClosing"
+       (animationend)="onHelpAnimationEnd()"
+       viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.2"/>
       <path d="M5.8 6.2a2.2 2.2 0 014.4 0c0 1.1-.8 1.5-1.5 2-.5.3-.7.7-.7 1.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/>
       <circle cx="8" cy="12" r="0.7" fill="currentColor"/>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -207,6 +207,19 @@ header {
     width: 20px;
     height: 20px;
     color: var(--header-text-dim);
+
+    // Tilt-and-hold while the button's modal is open, mirroring the Settings
+    // gear. trophy-* lives on the Achievements icon, help-* on the Help icon;
+    // both reuse the shared header tilt keyframes.
+    &.trophy-open,
+    &.help-open {
+      animation: header-icon-tilt-open 0.3s ease-in-out forwards;
+    }
+
+    &.trophy-close,
+    &.help-close {
+      animation: header-icon-tilt-close 0.3s ease-in-out forwards;
+    }
   }
 
   &:hover {
@@ -253,11 +266,11 @@ header {
     color: var(--header-text-dim);
 
     &.gear-open {
-      animation: gear-spin-open 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-open 0.3s ease-in-out forwards;
     }
 
     &.gear-close {
-      animation: gear-spin-close 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-close 0.3s ease-in-out forwards;
     }
   }
 
@@ -304,13 +317,13 @@ header {
   font-style: italic;
 }
 
-@keyframes gear-spin-open {
+@keyframes header-icon-tilt-open {
   0% { transform: rotate(0deg); }
   50% { transform: rotate(15deg); }
   100% { transform: rotate(30deg); }
 }
 
-@keyframes gear-spin-close {
+@keyframes header-icon-tilt-close {
   0% { transform: rotate(30deg); }
   50% { transform: rotate(15deg); }
   100% { transform: rotate(0deg); }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -65,6 +65,8 @@ export class AppComponent {
   achievementsDisabled = false;
   showKeyboardHelp = false;
   gearClosing = false;
+  achievementsClosing = false;
+  helpClosing = false;
   isOnLabelView = false;
   private isOnBrowseView = false;
   settingsViewTab = '';
@@ -175,7 +177,11 @@ export class AppComponent {
     if (event.ctrlKey || event.metaKey || event.altKey) return;
     if (this.isTypingTarget(event.target)) return;
     event.preventDefault();
-    this.showKeyboardHelp = !this.showKeyboardHelp;
+    if (this.showKeyboardHelp) {
+      this.onKeyboardHelpClosed();
+    } else {
+      this.onHelp();
+    }
   }
 
   private isTypingTarget(target: EventTarget | null): boolean {
@@ -193,10 +199,12 @@ export class AppComponent {
 
   onKeyboardHelpClosed(): void {
     this.showKeyboardHelp = false;
+    this.helpClosing = true;
   }
 
   onHelp(): void {
     this.menuOpen = false;
+    this.helpClosing = false;
     this.showKeyboardHelp = true;
   }
 
@@ -274,16 +282,26 @@ export class AppComponent {
 
   onAchievements(): void {
     this.menuOpen = false;
+    this.achievementsClosing = false;
     this.showAchievements = true;
     this.achievements.acknowledgeAll();
   }
 
   onAchievementsClosed(): void {
     this.showAchievements = false;
+    this.achievementsClosing = true;
   }
 
   onGearAnimationEnd(): void {
     this.gearClosing = false;
+  }
+
+  onTrophyAnimationEnd(): void {
+    this.achievementsClosing = false;
+  }
+
+  onHelpAnimationEnd(): void {
+    this.helpClosing = false;
   }
 
   // --- Hoisted new-thing modal handlers (delegate to NewThingFlowsService) ---

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -269,6 +269,7 @@
                 [loadingTask]="loadingTasksSvc.getInlineDetectorTask(detector.id)"
                 [deleteConfirmOpen]="deletingDetectorId === detector.id"
                 [addLabelsOpen]="modals.addLabels.open && modals.addLabels.detectorId === detector.id"
+                [exportOpen]="modals.export.open && modals.export.detectorName === detector.name"
                 (rowClick)="!isLoading && toggleDetectorSelection(detector.id, $event)"
                 (checkboxToggle)="!isLoading && toggleDetectorCheckbox(detector.id)"
                 (rename)="renameDetector(detector, $event)"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -290,10 +290,6 @@
 
     svg {
       flex-shrink: 0;
-
-      &.icon-waggle {
-        animation: icon-waggle 2s ease-in-out infinite;
-      }
     }
   }
 }
@@ -319,11 +315,4 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
-}
-
-// Waggle for Train/Find icons while loading: rotate to 90° (0.3s), hold,
-// rotate back (0.3s), hold. 2s cycle.
-@keyframes icon-waggle {
-  0%, 65%, 100% { transform: rotate(0deg); }
-  15%, 50% { transform: rotate(90deg); }
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -32,8 +32,12 @@
   }
 </td>
 @if (loadingTask && !loadingTask.error) {
-  <!-- Inline progress: replace remaining columns (middle + actions) with a progress bar -->
-  <td [attr.colspan]="columnOrder.length + 1">
+  <!-- Inline progress: replace the middle columns with a progress bar. For a
+       projection build (the Browse button's pre-build) we keep the actions
+       column so the Browse eye stays put and waggles, mirroring how Find/Train
+       waggle while their job runs; a plain dataset load replaces the actions
+       column too. -->
+  <td [attr.colspan]="taskKind === 'projection' ? columnOrder.length : columnOrder.length + 1">
     <div class="inline-loading-progress">
       <div class="progress-context">
         <div class="progress-header">{{ taskProgressInfo.header }}</div>
@@ -57,6 +61,18 @@
       </div>
     </div>
   </td>
+  @if (taskKind === 'projection') {
+    <td class="actions-col">
+      <div class="actions-cell">
+        <button class="browse-btn" type="button" disabled aria-label="Building projection for browse" title="Building projection…">
+          <svg class="icon-waggle" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+            <circle cx="12" cy="12" r="3"></circle>
+          </svg>
+        </button>
+      </div>
+    </td>
+  }
 } @else if (loadingTask && loadingTask.error) {
   <!-- Inline error: replace remaining columns (middle + actions) with error message -->
   <td [attr.colspan]="columnOrder.length + 1">

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -147,7 +147,7 @@
       <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
     </button>
     <button class="export-btn" (click)="onExport($event)" aria-label="Export detector" title="Export">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.export-active]="exportOpen" [class.export-inactive]="!exportOpen && wasExportOpen" (animationend)="onExportAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="15 14 20 9 15 4"></polyline>
         <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
       </svg>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -247,6 +247,14 @@ td.actions-col {
   &:hover {
     background: var(--btn-icon-hover-bg);
   }
+
+  .export-active {
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
+  }
+
+  .export-inactive {
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
+  }
 }
 
 .delete-btn {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -50,12 +50,14 @@ export class DetectorCardComponent implements OnChanges {
 
   @Input() deleteConfirmOpen = false;
   @Input() addLabelsOpen = false;
+  @Input() exportOpen = false;
 
   editing = false;
   wasEditing = false;
   editName = '';
   wasDeleteOpen = false;
   wasAddLabelsOpen = false;
+  wasExportOpen = false;
 
   startRename(event: MouseEvent): void {
     event.stopPropagation();
@@ -84,6 +86,9 @@ export class DetectorCardComponent implements OnChanges {
     if (changes['addLabelsOpen'] && !changes['addLabelsOpen'].currentValue && changes['addLabelsOpen'].previousValue) {
       this.wasAddLabelsOpen = true;
     }
+    if (changes['exportOpen'] && !changes['exportOpen'].currentValue && changes['exportOpen'].previousValue) {
+      this.wasExportOpen = true;
+    }
   }
 
   onPencilAnimationEnd(): void {
@@ -101,6 +106,12 @@ export class DetectorCardComponent implements OnChanges {
   onCapAnimationEnd(): void {
     if (!this.addLabelsOpen) {
       this.wasAddLabelsOpen = false;
+    }
+  }
+
+  onExportAnimationEnd(): void {
+    if (!this.exportOpen) {
+      this.wasExportOpen = false;
     }
   }
 

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -222,6 +222,7 @@
             [disabled]="!hasLabels || submitting"
             title="Send exported data to the selected destination"
           >
+            <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
             @if (submitting) {
               Exporting {{ filteredLabels.length | number }} labels to {{ activeTabExporter.display_name || activeTabExporter.name }}…
             } @else {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -175,6 +175,7 @@
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting) {
             Importing labels from {{ selectedImporter.display_name || selectedImporter.name }}…
           } @else {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -99,6 +99,7 @@
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting) {
             Exporting...
           } @else {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -105,6 +105,7 @@
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting) {
             Importing...
           } @else {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -505,3 +505,18 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
+// Icon waggle: rotate to 90° (0.3s), hold, rotate back (0.3s), hold; 2s cycle.
+// Signals "a slow job kicked off by this control is running" — the dashboard
+// Find/Train buttons, the dataset-card Browse eye while its projection builds,
+// and import/export submit buttons mid-request all opt in via `.icon-waggle`.
+// Global so any component can apply it; honored by the prefers-reduced-motion
+// rule in styles.scss.
+@keyframes icon-waggle {
+  0%, 65%, 100% { transform: rotate(0deg); }
+  15%, 50% { transform: rotate(90deg); }
+}
+
+.icon-waggle {
+  animation: icon-waggle 2s ease-in-out infinite;
+}


### PR DESCRIPTION
Extends two existing button micro-animations to more buttons that share the same trigger shape.

## 1. Icon waggle — buttons that kick off a slow progress-bar job

Mirrors the Find/Train icon waggle. Keyframes + `.icon-waggle` promoted from dashboard-scoped SCSS to global `frontend/src/scss/_components.scss` so any component can opt in (the Find/Train waggle now uses the global rule; behavior unchanged).

- **Dataset-card Browse (eye)** — while the dataset's UMAP projection pre-builds (`taskKind === 'projection'`), the eye stays in the actions column and waggles; the inline projection progress bar + Cancel are preserved. Cold datasets still show the real load bar first.
- **Import/Export submit buttons** — `label-importer`, `export`, `settings-importer`, `settings-exporter` modals get an import/export glyph that waggles while `submitting`.

## 2. Tilt-while-open — buttons that open a persistent modal

Mirrors the Settings gear, which tilts its icon on open, holds the tilt while the modal is open, and animates back on close (`*-open`/`*-close` classes + `(animationend)` reset). Generalized the gear keyframes to shared `header-icon-tilt-open/close`.

- **Header Achievements (trophy)** and **Help (?)** buttons — tilt while their modal is open. The Help open/close paths (button click, `?` keyboard toggle, modal close) are routed through `onHelp()`/`onKeyboardHelpClosed()` so the closing flag is always set.
- **Detector-card Export button** — tilts while that detector's export modal is open, completing the card's animated-icon family (rename/import-labels/delete already tilt) via the established `active`/`inactive` + `wasOpen` + `(animationend)` pattern.

## Scope notes
- Buttons whose trigger is hidden once their job/modal starts were excluded: dataset/detector **Load** and **Stats** (row collapses to an inline bar / covering modal), and the right-panel Import/Export buttons (text-only, no icon to tilt).

## Accessibility
- Both animations are neutralized by the global `prefers-reduced-motion: reduce` rule in `styles.scss`.

## Testing
- `npm run build:prod` — clean, no warnings/errors.
- `./run-tests.sh core` — 749 passed (includes the frontend build check).

https://claude.ai/code/session_012AyHg2uGA3d6MJa3R3n5X9