### PR TITLE
Replace export icon with box-and-diagonal-arrow glyph

### DIFF
--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -148,8 +148,9 @@
     </button>
     <button class="export-btn" (click)="onExport($event)" aria-label="Export detector" title="Export">
       <svg aria-hidden="true" [class.export-active]="exportOpen" [class.export-inactive]="!exportOpen && wasExportOpen" (animationend)="onExportAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="15 14 20 9 15 4"></polyline>
-        <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+        <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="12" y1="12" x2="21" y2="3"></line>
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete">

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -44,8 +44,9 @@
             title="Export the unverified positives (above-threshold items you haven't acted on) — e.g. to re-import as a dataset"
           >
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="15 14 20 9 15 4"></polyline>
-              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+              <polyline points="15 3 21 3 21 9"></polyline>
+              <line x1="12" y1="12" x2="21" y2="3"></line>
             </svg>
           </button>
         </div>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -222,7 +222,7 @@
             [disabled]="!hasLabels || submitting"
             title="Send exported data to the selected destination"
           >
-            <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
             @if (submitting) {
               Exporting {{ filteredLabels.length | number }} labels to {{ activeTabExporter.display_name || activeTabExporter.name }}…
             } @else {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -99,7 +99,7 @@
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
           @if (submitting) {
             Exporting...
           } @else {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -415,7 +415,13 @@
     <span class="settings-saved" [class.settings-saved--visible]="savedVisible" role="status" aria-live="polite" title="Settings auto-save as you change them">&#10003; saved</span>
     <button class="btn btn--secondary" (click)="resetDefaults()" title="Reset all settings to their factory defaults">Default</button>
     <button class="btn btn--secondary" (click)="openImporter()" title="Import settings from a file">Import</button>
-    <button class="btn btn--secondary" (click)="openExporter()" title="Export settings to a file">Export</button>
+    <button class="btn btn--secondary" (click)="openExporter()" aria-label="Export" title="Export settings to a file">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="12" y1="12" x2="21" y2="3"></line>
+      </svg>
+    </button>
     <button class="btn btn--primary" (click)="close()" title="Close the settings panel">Close</button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -80,8 +80,9 @@
           </button>
           <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onExportGood()" aria-label="Export" title="Export the full good set (verified + unverified) to clipboard, file, email, or webhook">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="15 14 20 9 15 4"></polyline>
-              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+              <polyline points="15 3 21 3 21 9"></polyline>
+              <line x1="12" y1="12" x2="21" y2="3"></line>
             </svg>
           </button>
           <button class="goods-action-btn" [disabled]="disabled" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
@@ -116,8 +117,9 @@
         <div list-actions class="goods-actions">
           <button class="goods-action-btn" [disabled]="disabled || badIds.length === 0" (click)="onExportBad()" aria-label="Export" title="Export the full bad set (verified + unverified) to clipboard, file, email, or webhook">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="15 14 20 9 15 4"></polyline>
-              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+              <polyline points="15 3 21 3 21 9"></polyline>
+              <line x1="12" y1="12" x2="21" y2="3"></line>
             </svg>
           </button>
         </div>
@@ -127,7 +129,13 @@
 
   @if (mode !== 'find') {
     <div class="export-row">
-      <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" title="Export labeled items to clipboard, file, email, or webhook">Export</button>
+      <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
+          <polyline points="15 3 21 3 21 9"></polyline>
+          <line x1="12" y1="12" x2="21" y2="3"></line>
+        </svg>
+      </button>
     </div>
   }
 </aside>

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -121,7 +121,10 @@
 
 .export-btn {
   flex: 1;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
 }
 
 .browse-btn {


### PR DESCRIPTION
## What changed

Replaces the old curved-arrow export icon with a new glyph: a slightly-rounded box with the upper-right corner missing, and an arrow running from the center of the box diagonally to the upper right. The arrowhead's two strokes lie along the box's top and right sides, meeting at the point where the box's right-angle corner would be.

Applied to every export button:

- **Detector card** export button (dashboard) — kept the existing open/close animation classes.
- **Right panel** good-set and bad-set export buttons (Find mode).
- **Left panel** unverified-positives export button (Find mode).
- **Right panel footer** "Export" button — was text-only, now icon-only (per user choice), with `aria-label`/tooltip retained.
- **Settings modal footer** "Export" button — was text-only, now icon-only, with `aria-label`/tooltip retained.
- **Export modal** and **settings-exporter modal** submit buttons — swapped the upload-style glyph for the new export glyph, keeping the text label and the `icon-waggle` submitting animation.

Also gave the right-panel footer `.export-btn` flex centering so the lone icon sits centered in the button.

## Verification

`./run-tests.sh` full suite: ALL 4711 TESTS PASSED (1 skipped), including ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, and the frontend TypeScript production build.

https://claude.ai/code/session_01SFbAaGeLRJFSubHiTPvs6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFbAaGeLRJFSubHiTPvs6j)_