### PR TITLE
Add media-type icons to per-media-type Settings tabs

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
@@ -12,6 +12,9 @@
         [class.view-tab--active]="activeType === mt.type_id"
         (click)="selectTab(mt.type_id)"
         [title]="'Set import defaults for ' + mt.name + ' datasets'">
+        @if (mt.icon) {
+          <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
+        }
         {{ mt.name }}
       </button>
     }

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
@@ -20,6 +20,7 @@ import {
   SourceSpec,
 } from '../../../../models/api.models';
 import { DatasetsListingsApiService } from '../../../../services/datasets-listings-api.service';
+import { IconComponent } from '../../../icon/icon.component';
 import { SourceSpecsPickerComponent } from '../../../dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component';
 import {
   ClipperChooserComponent,
@@ -40,7 +41,7 @@ import {
 @Component({
   selector: 'vt-import-defaults-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, SourceSpecsPickerComponent, ClipperChooserComponent],
+  imports: [CommonModule, FormsModule, IconComponent, SourceSpecsPickerComponent, ClipperChooserComponent],
   templateUrl: './import-defaults-settings.component.html',
   styleUrl: './import-defaults-settings.component.scss',
 })

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -104,6 +104,9 @@
                   class="view-tab"
                   [class.view-tab--active]="activeViewTab === mt.type_id"
                   (click)="activeViewTab = mt.type_id">
+                  @if (mt.icon) {
+                    <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
+                  }
                   {{ mt.name }}
                 </button>
               }
@@ -256,6 +259,9 @@
                   [class.view-tab--active]="activeBrowseTab === mt.type_id"
                   (click)="activeBrowseTab = mt.type_id"
                   [title]="'Browser settings for ' + mt.name + ' datasets'">
+                  @if (mt.icon) {
+                    <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
+                  }
                   {{ mt.name }}
                 </button>
               }

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -413,6 +413,9 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 }
 
 .view-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;


### PR DESCRIPTION
## Summary

The per-media-type tab strips in Settings showed only the media type's name. This adds the media type's icon to the left of the name, matching the icon + label layout already used by the main Settings tabs (Appearance, Sorting, etc.).

The icons now appear in all three per-media-type tab strips:
- **Appearance → Scroll Style**
- **Browser**
- **Data Imports**

## Changes

- `settings-modal.component.html` — render `<vt-icon [type]="mt.icon">` before the name in the Scroll Style and Browser tab buttons (guarded by `@if (mt.icon)`).
- `import-defaults/import-defaults-settings.component.{ts,html}` — import `IconComponent` and render the same icon in the Data Imports tab buttons.
- `_components.scss` — give shared `.view-tab` an `inline-flex` / `align-items: center` / `gap` layout so the icon and label sit side by side. Text-only `.view-tab` consumers are unaffected.

## Testing

- `npm run build:prod` passes with no errors or warnings.

https://claude.ai/code/session_01SqwPuRfxG9Ga3uSR66CXT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqwPuRfxG9Ga3uSR66CXT6)_