### PR TITLE
Replace Settings exposition paragraphs with hover bubbles

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
@@ -1,10 +1,6 @@
 @if (visibleTypes.length === 0) {
   <p class="empty-state">No media types registered.</p>
 } @else {
-  <p class="info-text import-defaults-intro" title="These defaults auto-fill the Add Dataset modal whenever you start an import whose output is the matching media type.">
-    Default import settings per media type.
-  </p>
-
   <div class="view-tabs">
     @for (mt of visibleTypes; track mt.type_id) {
       <button

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
@@ -1,7 +1,3 @@
-.import-defaults-intro {
-  margin-bottom: var(--space-sm);
-}
-
 // Adds the inner column-flex layout on top of the shared `.view-tab-content`
 // base (border, padding, background) defined in global `_components.scss`.
 .import-defaults-body {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -279,7 +279,7 @@
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label" title="Slide clusters together to close the empty space between them when the projection is built">Compaction</label>
+                <label class="form-label" title="Slide clusters together to close the empty space between them when the projection is built">Compaction<vt-field-hint-icon hint="Slides clusters together to close the empty “oceans” between them, keeping each cluster’s shape intact. Applies to the next projection build or Re-project."></vt-field-hint-icon></label>
                 <div class="toggle-group">
                   <button class="toggle-btn" [class.toggle-btn--active]="getBrowseCompact(activeBrowseTab)" (click)="onBrowseCompactChange(activeBrowseTab, true)" title="Close the empty space between clusters">
                     On
@@ -288,15 +288,13 @@
                     Off
                   </button>
                 </div>
-                <p class="form-hint">Slides clusters together to close the empty &ldquo;oceans&rdquo; between them, keeping each cluster&rsquo;s shape intact. Applies to the next projection build or Re-project.</p>
               </div>
               <div class="form-group">
-                <label class="form-label" title="Colors the density heatmap. Auto follows your theme: blue (Ocean) in light mode, red→yellow (Heat) in dark mode.">Colormap</label>
+                <label class="form-label" title="Colors the density heatmap. Auto follows your theme: blue (Ocean) in light mode, red→yellow (Heat) in dark mode.">Colormap<vt-field-hint-icon [hint]="browseTabUsesThumbnails(activeBrowseTab) ? 'Thumbnail datasets (image, video) always use grayscale, so the density shading never tints the thumbnails.' : 'Darker bins mean more items in light mode; brighter bins mean more in dark mode.'"></vt-field-hint-icon></label>
                 @if (browseTabUsesThumbnails(activeBrowseTab)) {
                   <select class="form-select" disabled aria-label="Browser colormap" title="Thumbnail datasets always use grayscale">
                     <option value="gray" selected>Grayscale</option>
                   </select>
-                  <p class="form-hint">Thumbnail datasets (image, video) always use grayscale, so the density shading never tints the thumbnails.</p>
                 } @else {
                   <select class="form-select" [ngModel]="getBrowseColormap(activeBrowseTab)" (ngModelChange)="onBrowseColormapChange(activeBrowseTab, $event)" aria-label="Browser colormap">
                     <option value="auto">Auto (match theme)</option>
@@ -304,7 +302,6 @@
                     <option value="ocean">Ocean (blue)</option>
                     <option value="gray">Grayscale</option>
                   </select>
-                  <p class="form-hint">Darker bins mean more items in light mode; brighter bins mean more in dark mode.</p>
                 }
               </div>
               <div class="form-group">
@@ -320,7 +317,7 @@
                 </select>
               </div>
               <div class="form-group">
-                <label class="form-label" title="Width in pixels of the colored border drawn around stacked (pile) thumbnails">Thumbnail border</label>
+                <label class="form-label" title="Width in pixels of the colored border drawn around stacked (pile) thumbnails">Thumbnail border<vt-field-hint-icon hint="Only affects datasets that show thumbnails (image, video). Draws a colored band around each stacked tile; its color shows how many items are piled there. Set to 0 to hide it."></vt-field-hint-icon></label>
                 <input
                   class="form-input"
                   type="number"
@@ -330,10 +327,9 @@
                   [ngModel]="getBrowseThumbnailBorder(activeBrowseTab)"
                   (ngModelChange)="onBrowseThumbnailBorderChange(activeBrowseTab, $event)"
                   aria-label="Browser thumbnail border width" />
-                <p class="form-hint">Only affects datasets that show thumbnails (image, video). Draws a colored band around each stacked tile; its color shows how many items are piled there. Set to 0 to hide it.</p>
               </div>
               <div class="form-group">
-                <label class="form-label" title="How a right-clicked bin's items are shown in the popup">Bin popup</label>
+                <label class="form-label" title="How a right-clicked bin's items are shown in the popup">Bin popup<vt-field-hint-icon hint="How the right-click bin popup shows a bin’s items. Changing it on a popup while browsing remembers the choice here for this media type."></vt-field-hint-icon></label>
                 <div class="toggle-group">
                   <button class="toggle-btn" [class.toggle-btn--active]="getPopupViewMode(activeBrowseTab) === 'grid'" (click)="onPopupViewModeChange(activeBrowseTab, 'grid')" title="Show a right-clicked bin's items as a thumbnail grid">
                     Grid
@@ -342,7 +338,6 @@
                     List
                   </button>
                 </div>
-                <p class="form-hint">How the right-click bin popup shows a bin&rsquo;s items. Changing it on a popup while browsing remembers the choice here for this media type.</p>
               </div>
               <div class="form-group">
                 <label class="form-label" title="Thumbnail size in the bin popup's grid">Popup thumbnail size</label>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -68,7 +68,9 @@
             </select>
           </div>
           <div class="form-group" title="Streamline the UI for a single media type. Importer and detector flows will hide their media-type pickers and lock to this type; converters that produce other types are filtered out.">
-            <label class="form-label">Solo media type</label>
+            <label class="form-label">Solo media type@if (soloMediaTypeNote) {
+              <vt-field-hint-icon [hint]="soloMediaTypeNote"></vt-field-hint-icon>
+            }</label>
             <select
               class="form-select"
               [ngModel]="soloMediaTypeSelectValue"
@@ -79,9 +81,6 @@
                 <option [value]="mt.type_id">{{ mt.name }}</option>
               }
             </select>
-            @if (soloMediaTypeNote) {
-              <p class="form-hint">{{ soloMediaTypeNote }}</p>
-            }
           </div>
           <label class="checkbox-row" title="Animate media transitions when voting (swipe left/right effect)">
             <input type="checkbox" [ngModel]="settings.swipe_animation" (ngModelChange)="onToggle('swipe_animation', $event)" />
@@ -209,7 +208,7 @@
 
         <!-- Data Imports -->
         @if (activeSettingsTab === 'imports') {
-          <h3>Data Imports</h3>
+          <h3>Data Imports<vt-field-hint-icon hint="Default import settings per media type. These defaults auto-fill the Add Dataset modal whenever you start an import whose output is the matching media type."></vt-field-hint-icon></h3>
           <vt-import-defaults-settings
             [mediaTypes]="mediaTypes"
             [defaults]="importDefaults"
@@ -246,11 +245,7 @@
 
         <!-- Browser (VTSBrowse projection browser) -->
         @if (activeSettingsTab === 'browser') {
-          <h3>Browser</h3>
-          <p class="info-text">
-            How the VTSBrowse projection browser looks, per media type. The same controls
-            live on the browse canvas itself; changes here are remembered for next time.
-          </p>
+          <h3>Browser<vt-field-hint-icon hint="How the VTSBrowse projection browser looks, per media type. The same controls live on the browse canvas itself; changes here are remembered for next time."></vt-field-hint-icon></h3>
           @if (mediaTypes.length > 0) {
             <div class="view-tabs">
               @for (mt of mediaTypes; track mt.type_id) {
@@ -357,11 +352,7 @@
 
         <!-- Server Settings (read-only) -->
         @if (activeSettingsTab === 'server') {
-          <h3>Server Settings</h3>
-          <p class="info-text">
-            These are fixed when the server starts (via config file, environment, or CLI flags)
-            and shared by everyone. They&rsquo;re shown here for reference and can&rsquo;t be changed.
-          </p>
+          <h3>Server Settings<vt-field-hint-icon hint="These are fixed when the server starts (via config file, environment, or CLI flags) and shared by everyone. They’re shown here for reference and can’t be changed."></vt-field-hint-icon></h3>
 
           <div class="form-group">
             <label class="form-label" title="Root directory where saved datasets are stored on the server">Saved datasets directory</label>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -8,6 +8,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { SettingsImporterModalComponent } from '../settings-importer-modal/settings-importer-modal.component';
 import { SettingsExporterModalComponent } from '../settings-exporter-modal/settings-exporter-modal.component';
 import { ImportDefaultsSettingsComponent } from './import-defaults/import-defaults-settings.component';
+import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import { ImportDefaultsByMediaType } from '../../../models/api.models';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
@@ -26,7 +27,7 @@ import {
 @Component({
   selector: 'vt-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, ImportDefaultsSettingsComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, ImportDefaultsSettingsComponent, FieldHintIconComponent],
   templateUrl: './settings-modal.component.html',
   styleUrl: './settings-modal.component.scss',
 })


### PR DESCRIPTION
## What & why

The Settings window carried several blocks of open prose: the per-field `.form-hint` paragraphs (styled monospace + `pre-wrap`, which read as hideous fixed-width body copy) and the per-tab `.info-text` intros. Settings shouldn't have open paragraphs of exposition — that's what the `?` hint bubbles (the shared `vt-field-hint-icon`) are for, and they're already the convention across the new-detector / importer / exporter modals.

This sweeps every exposition paragraph out of the Settings window and into `?` bubbles.

## Changes

**Browser tab** (initial pass)
- The 5 field `.form-hint` paragraphs (Compaction, Colormap, Thumbnail border, Bin popup) became `?` bubbles on their labels. The Colormap hint is now a single conditional bubble (thumbnail vs. non-thumbnail) instead of two paragraphs across the `@if/@else`.

**Rest of the Settings window** (follow-up)
- **Browser**, **Server**, and **Data Imports** tab intros (`.info-text`) now hang off their section `<h3>` as bubbles. The Data Imports intro moved up from the child `import-defaults` component, dropping its now-dead `.import-defaults-intro` rule.
- The conditional **Solo media type** CLI-fallback note (`Currently set to … by the --solo-media-type CLI flag`) became a bubble on the Solo media type label, rendered only when the note is present.

`FieldHintIconComponent` is imported into `SettingsModalComponent`. No `.info-text` or `.form-hint` paragraphs remain anywhere in the Settings window.

The shared `.form-hint` / `.info-text` rules and their uses in *other* (non-Settings) modals are untouched.

## Verification

- `npm run build:prod` passes cleanly (no errors, no budget warnings).
