### PR TITLE
Scale embed concurrency by cores/RAM + add env overrides for Grid vs laptop

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -27,6 +27,15 @@ installation and getting started, see [SETUP.md](SETUP.md).
 | `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `INFO`/`DEBUG` also turn on the per-request access log. |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
 
+### Dataset-ingest concurrency
+
+How many datasets the server downloads / embeds in parallel. Both knobs **autodetect from hardware** on every startup (no config needed): downloads scale with CPU count (cap 4), and embeddings scale with the scarcer of cores and RAM (~1 job per 4 cores, ~1 per 4 GiB; cap 4), flooring to 1 on small/RAM-starved boxes so a laptop stays constrained. The env vars below override the autodetect **without** persisting to `data/settings.json` — so the same `python app.py` launch picks a small default on a laptop and a bigger one on a fat node that exports the var (e.g. a single-GPU SLURM allocation, which the autodetect alone would otherwise throttle to one embed worker since embedders currently run on CPU). Values are clamped to `[1, 16]`; a non-integer value is ignored (logged, falls back to autodetect). An explicit value set via the settings UI still wins over both.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VTSEARCH_MAX_CONCURRENT_DOWNLOADS` | autodetect (CPU count, cap 4) | Max datasets downloaded in parallel |
+| `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` | autodetect (min of cores/4 and RAM/4 GiB, cap 4) | Max dataset embedding jobs run in parallel |
+
 ### Gunicorn / WSGI (production)
 
 | Variable | Default | Description |

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -120,8 +120,8 @@ class TestSettingsModule:
     def test_max_concurrent_embeddings_default_from_hardware(self, isolated_settings):
         """The default mirrors the hardware-derived value and is not persisted.
 
-        The concrete scaling (GPU count, CPU cores, total RAM) is unit-tested in
-        ``tests_lib/embedding/test_concurrency_defaults.py``; here we only assert
+        The concrete scaling (CPU cores, total RAM) is unit-tested in
+        ``tests_lib/datasets/test_concurrency_defaults.py``; here we only assert
         the settings layer surfaces that value and doesn't write it to disk.
         """
         from vtscore.embedding.loader import default_concurrent_embeddings

--- a/tests_lib/datasets/test_concurrency_defaults.py
+++ b/tests_lib/datasets/test_concurrency_defaults.py
@@ -1,14 +1,19 @@
-"""Hardware-derived default for ``max_concurrent_dataset_embeddings``.
+"""Hardware-derived (and env-overridable) defaults for the dataset-ingest
+concurrency knobs.
 
 Unit-tests the scaling logic in
-:func:`vtscore.embedding.loader.default_concurrent_embeddings` in isolation by
-faking the GPU count, CPU core count, and total RAM. The settings layer's
-integration with this value (surfaced via ``get_max_concurrent_dataset_embeddings``
-and never persisted) is covered in ``tests/core/test_settings.py``.
+:func:`vtscore.embedding.loader.default_concurrent_embeddings` and the shared
+:func:`vtscore.embedding.loader._env_concurrency_override` in isolation by
+faking the CPU core count, total RAM, and environment. The settings layer's
+integration with these values (surfaced via
+``get_max_concurrent_dataset_embeddings`` / ``...downloads`` and never persisted)
+is covered in ``tests/core/test_settings.py``.
 
 The guard these tests pin down: a memory- or core-starved box must resolve to a
 single embed worker (the old fully-serial behaviour), so raising the default for
-capable hardware never freezes a small one.
+capable hardware never freezes a small one. The companion guard: GPU presence no
+longer caps the embed default - embedders run on CPU today, so a single-GPU
+SLURM node scales by its cores/RAM instead of being throttled to one device.
 """
 
 from __future__ import annotations
@@ -22,10 +27,14 @@ GIB = 1024 * 1024 * 1024
 
 @pytest.fixture
 def fake_hw(monkeypatch):
-    """Pin (gpus, cpus, total RAM) and return the resolved default."""
+    """Pin (cpus, total RAM) and return the resolved embed default.
 
-    def _resolve(*, gpus: int, cpus: int, ram_gib: float) -> int:
-        monkeypatch.setattr(loader, "_detect_cuda_devices", lambda: gpus)
+    Clears the env override so the hardware probe is exercised; the override
+    path has its own tests below.
+    """
+
+    def _resolve(*, cpus: int, ram_gib: float) -> int:
+        monkeypatch.delenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", raising=False)
         monkeypatch.setattr(loader.os, "cpu_count", lambda: cpus)
         monkeypatch.setattr(loader, "_total_memory_bytes", lambda: int(ram_gib * GIB))
         return loader.default_concurrent_embeddings()
@@ -36,35 +45,75 @@ def fake_hw(monkeypatch):
 class TestDefaultConcurrentEmbeddings:
     def test_small_cpu_box_stays_serial(self, fake_hw):
         # The 2-core / 3.7 GB laptop this guard exists for: both factors floor to 1.
-        assert fake_hw(gpus=0, cpus=2, ram_gib=3.7) == 1
+        assert fake_hw(cpus=2, ram_gib=3.7) == 1
 
     def test_ram_starved_many_cores_stays_serial(self, fake_hw):
         # 32 cores but only 3 GB RAM -> RAM is the binding constraint.
-        assert fake_hw(gpus=0, cpus=32, ram_gib=3.0) == 1
+        assert fake_hw(cpus=32, ram_gib=3.0) == 1
 
     def test_core_starved_huge_ram_stays_serial(self, fake_hw):
         # 256 GB RAM but 2 cores -> cores are the binding constraint.
-        assert fake_hw(gpus=0, cpus=2, ram_gib=256) == 1
+        assert fake_hw(cpus=2, ram_gib=256) == 1
 
     def test_midrange_workstation_scales_to_two(self, fake_hw):
         # 8 cores / 16 GB -> min(8 // 4, 16 // 4) = min(2, 4) = 2.
-        assert fake_hw(gpus=0, cpus=8, ram_gib=16) == 2
+        assert fake_hw(cpus=8, ram_gib=16) == 2
+
+    def test_single_gpu_grid_node_scales_by_cores(self, fake_hw):
+        # The HLTCOE Grid lockout case: a single-GPU SLURM allocation with 8
+        # cores / 48 GB. The old GPU branch returned 1 (one job per visible
+        # device) and serialised every embed; now it scales by cores -> 2.
+        assert fake_hw(cpus=8, ram_gib=48) == 2
 
     def test_large_box_caps_at_four(self, fake_hw):
         # 64 cores / 256 GB would compute far higher; the cap holds it at 4.
-        assert fake_hw(gpus=0, cpus=64, ram_gib=256) == 4
+        assert fake_hw(cpus=64, ram_gib=256) == 4
 
     def test_unreadable_ram_falls_back_to_serial(self, fake_hw):
         # _total_memory_bytes() == 0 (couldn't read) -> conservative 1 even on a
         # many-core box, rather than guessing generously.
-        assert fake_hw(gpus=0, cpus=64, ram_gib=0) == 1
+        assert fake_hw(cpus=64, ram_gib=0) == 1
 
-    def test_single_gpu_unaffected_by_cpu_ram(self, fake_hw):
-        # GPU path returns early and ignores the CPU/RAM scaling.
-        assert fake_hw(gpus=1, cpus=2, ram_gib=3.7) == 1
 
-    def test_multi_gpu_caps_at_two(self, fake_hw):
-        assert fake_hw(gpus=4, cpus=64, ram_gib=256) == 2
+class TestEnvConcurrencyOverride:
+    @pytest.fixture(autouse=True)
+    def _fat_hardware(self, monkeypatch):
+        # Pin generous hardware so any test asserting the override value can't
+        # be confused with a hardware-derived result (which caps at 4 anyway).
+        monkeypatch.setattr(loader.os, "cpu_count", lambda: 64)
+        monkeypatch.setattr(loader, "_total_memory_bytes", lambda: 256 * GIB)
+
+    def test_embeddings_override_wins_over_hardware(self, monkeypatch):
+        # The launcher lever: push past the auto cap of 4 on a fat node.
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", "8")
+        assert loader.default_concurrent_embeddings() == 8
+
+    def test_downloads_override_wins_over_hardware(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_DOWNLOADS", "10")
+        assert loader.default_concurrent_downloads() == 10
+
+    def test_override_clamps_above_max(self, monkeypatch):
+        # Above the settings-layer clamp -> pinned to 16, not handed through.
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", "999")
+        assert loader.default_concurrent_embeddings() == 16
+
+    def test_override_clamps_below_min(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", "0")
+        assert loader.default_concurrent_embeddings() == 1
+
+    def test_blank_override_ignored(self, monkeypatch):
+        # Blank -> autodetect runs; fat hardware caps at 4.
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", "   ")
+        assert loader.default_concurrent_embeddings() == 4
+
+    def test_non_integer_override_ignored(self, monkeypatch):
+        # A launcher typo must not block startup: fall back to autodetect.
+        monkeypatch.setenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", "lots")
+        assert loader.default_concurrent_embeddings() == 4
+
+    def test_unset_override_returns_none(self, monkeypatch):
+        monkeypatch.delenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", raising=False)
+        assert loader._env_concurrency_override("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS") is None
 
 
 class TestTotalMemoryBytes:

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -11,6 +11,7 @@ to work unchanged.
 """
 
 import gc
+import logging
 import os
 import re
 import sys
@@ -26,6 +27,8 @@ def _strip_time_suffix(msg: str) -> str:
 from vtscore.config import MODELS_CACHE_DIR, resolve_device
 from vtscore.media.torch_setup import ensure_torch_configured
 
+logger = logging.getLogger(__name__)
+
 
 def get_torch_device():
     """Return the preferred ``torch.device`` for MLP training / scoring.
@@ -39,31 +42,56 @@ def get_torch_device():
     return torch.device(resolve_device())
 
 
-def _detect_cuda_devices() -> int:
-    """Return the count of visible CUDA GPUs, or 0 if none / torch missing.
+# Concurrency defaults are clamped into this range, matching the
+# ``_clamp(1, 16)`` on the settings fields they feed (see
+# ``vtsearch/settings_models.py``). Bounding here means neither the env
+# override nor the hardware probe can hand the settings layer a value it would
+# only reject.
+_CONCURRENCY_MIN = 1
+_CONCURRENCY_MAX = 16
 
-    Imports torch lazily so callers (e.g. settings default factories) can
-    run before torch is loaded. All exceptions degrade to ``0`` - a missing
-    or broken CUDA stack must not block startup.
+
+def _env_concurrency_override(var: str) -> int | None:
+    """Explicit concurrency override read from environment variable *var*.
+
+    Lets a launcher pin concurrency *without* writing ``data/settings.json`` -
+    which would otherwise freeze the value at first-run hardware and defeat the
+    per-startup autodetect. The HLTCOE Grid launcher uses this to give a fat
+    single-GPU SLURM node more parallelism than the conservative auto caps,
+    while a laptop (var unset) keeps its hardware default - so ``python app.py``
+    stays the launch command on both.
+
+    Returns the clamped override, or ``None`` when the var is unset/blank so the
+    hardware probe runs. A non-integer value also returns ``None`` (logged once,
+    never fatal - a launcher typo must not block startup); an out-of-range
+    integer is clamped into ``[_CONCURRENCY_MIN, _CONCURRENCY_MAX]``.
     """
+    raw = os.environ.get(var)
+    if raw is None or not raw.strip():
+        return None
     try:
-        import torch  # noqa: PLC0415
-
-        if torch.cuda.is_available():
-            return int(torch.cuda.device_count())
-    except Exception:
-        pass
-    return 0
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning("Ignoring non-integer %s=%r; falling back to hardware autodetect", var, raw)
+        return None
+    clamped = max(_CONCURRENCY_MIN, min(_CONCURRENCY_MAX, value))
+    if clamped != value:
+        logger.warning("Clamped %s=%d into [%d, %d] -> %d", var, value, _CONCURRENCY_MIN, _CONCURRENCY_MAX, clamped)
+    return clamped
 
 
 def default_concurrent_downloads() -> int:
-    """Default for ``max_concurrent_dataset_downloads`` derived from hardware.
+    """Default for ``max_concurrent_dataset_downloads``.
 
-    The download phase is bandwidth- and disk-bound. Allowing a handful of
-    parallel downloads usually saturates a home connection without thrashing
-    the disk; capped at 4 to keep memory and FD pressure reasonable on small
-    boxes.
+    Honours ``VTSEARCH_MAX_CONCURRENT_DOWNLOADS`` when set; otherwise derives
+    from hardware. The download phase is bandwidth- and disk-bound. Allowing a
+    handful of parallel downloads usually saturates a home connection without
+    thrashing the disk; capped at 4 to keep memory and FD pressure reasonable on
+    small boxes.
     """
+    override = _env_concurrency_override("VTSEARCH_MAX_CONCURRENT_DOWNLOADS")
+    if override is not None:
+        return override
     return max(1, min(4, os.cpu_count() or 1))
 
 
@@ -72,8 +100,14 @@ def default_concurrent_downloads() -> int:
 # boxes at one worker while letting roomy workstations run a few in parallel.
 _RAM_BYTES_PER_CPU_EMBED = 4 * 1024 * 1024 * 1024
 
-# Upper bound on the CPU embed default regardless of how big the box is; a
-# hand override in ``data/settings.json`` can still go higher (clamped to 16).
+# Cores budgeted per concurrent embed job (embedders run on CPU today).
+_CPUS_PER_CPU_EMBED = 4
+
+# Upper bound on the auto-derived embed default regardless of how big the box
+# is. The ``VTSEARCH_MAX_CONCURRENT_EMBEDDINGS`` env override (and a hand edit
+# in ``data/settings.json``) can still go higher, up to the settings clamp of
+# 16 - that env override is the lever for fat cluster nodes that want more
+# parallelism than this conservative auto cap.
 _MAX_CPU_EMBED_DEFAULT = 4
 
 
@@ -103,27 +137,34 @@ def _total_memory_bytes() -> int:
 
 
 def default_concurrent_embeddings() -> int:
-    """Default for ``max_concurrent_dataset_embeddings`` derived from hardware.
+    """Default for ``max_concurrent_dataset_embeddings``.
 
-    The embed phase is CPU/GPU- and RAM-bound, so the default scales with the
-    scarcer of the two resources:
+    Honours ``VTSEARCH_MAX_CONCURRENT_EMBEDDINGS`` when set; otherwise derives
+    from hardware.
 
-    * **GPU boxes** allow one task per visible CUDA device (capped at 2) so two
-      datasets can embed in parallel on a multi-GPU rig without overcommitting a
-      single device's VRAM.
-    * **CPU-only boxes** allow roughly one job per 4 cores and one job per
-      ``_RAM_BYTES_PER_CPU_EMBED`` of total RAM, whichever is smaller, capped at
-      :data:`_MAX_CPU_EMBED_DEFAULT`. Constrained machines (few cores or little
-      RAM) still resolve to 1 - preserving the old fully-serial behaviour where
-      a second concurrent embed would thrash or OOM - while workstations get
-      genuine parallel embedding with no config change. When total RAM can't be
-      read we fall back to 1 rather than guess generously.
+    The embed phase is **CPU- and RAM-bound today**: every embedder loads on CPU
+    regardless of an available GPU (see the ``DEVICE`` note in
+    ``vtscore/config.py`` - device-aware embedding is a future refactor). So the
+    default scales with the scarcer of cores and RAM and ignores GPU count:
+    roughly one job per :data:`_CPUS_PER_CPU_EMBED` cores and one per
+    ``_RAM_BYTES_PER_CPU_EMBED`` of total RAM, whichever is smaller, capped at
+    :data:`_MAX_CPU_EMBED_DEFAULT`. Constrained machines (few cores or little
+    RAM) resolve to 1 - preserving the old fully-serial behaviour where a second
+    concurrent embed would thrash or OOM - while workstations and fat cluster
+    nodes get genuine parallel embedding with no config change. When total RAM
+    can't be read we fall back to 1 rather than guess generously.
+
+    A single-GPU SLURM allocation is exactly the case the old GPU branch got
+    wrong: it returned ``min(2, visible_gpus) == 1`` and serialised every embed
+    on an otherwise capable node. Scaling by the allocation's cores/RAM instead
+    lets such a node ingest several datasets at once; set
+    ``VTSEARCH_MAX_CONCURRENT_EMBEDDINGS`` past the auto cap to go further.
     """
-    gpus = _detect_cuda_devices()
-    if gpus > 0:
-        return max(1, min(2, gpus))
+    override = _env_concurrency_override("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS")
+    if override is not None:
+        return override
 
-    by_cpu = (os.cpu_count() or 1) // 4
+    by_cpu = (os.cpu_count() or 1) // _CPUS_PER_CPU_EMBED
     total_ram = _total_memory_bytes()
     by_ram = total_ram // _RAM_BYTES_PER_CPU_EMBED if total_ram else 1
     return max(1, min(_MAX_CPU_EMBED_DEFAULT, by_cpu, by_ram))


### PR DESCRIPTION
## Problem

The Max Concurrent settings already autodetect from hardware on every `python app.py` startup (pydantic `default_factory` → `default_concurrent_*()` in `vtscore/embedding/loader.py`, recomputed per machine, never persisted unless explicitly set in the UI). But the **embeddings** default took a GPU early-return:

```python
gpus = _detect_cuda_devices()
if gpus > 0:
    return max(1, min(2, gpus))
```

Inside a single-GPU SLURM allocation (`--gres=gpu:l40s:1`) only one device is visible, so this resolved to **1** and serialised every embed — freezing an otherwise capable Grid node whenever a single dataset was ingesting. The branch was also the wrong resource entirely: embedders load on **CPU** today (see the `DEVICE` note in `vtscore/config.py`), so the embed phase is CPU/RAM-bound regardless of GPU presence.

## Change

- **Drop the GPU branch** from `default_concurrent_embeddings()`. It now scales purely by the scarcer of cores and RAM (≈1 job per 4 cores, ≈1 per 4 GiB, cap 4). A fat single-GPU node gets genuine parallel embedding; a small/RAM-starved laptop still floors to **1** (the constrained behavior that's desirable there).
- **Add env overrides** `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` / `VTSEARCH_MAX_CONCURRENT_DOWNLOADS`, honored by the `default_factory` before autodetect via a shared `_env_concurrency_override()` helper (clamped to `[1, 16]`; non-integer values log a warning and fall back to autodetect). These override **without** persisting to `data/settings.json`, so the value can't freeze at first-run hardware — a launcher exports the var on the Grid, the laptop leaves it unset, and `python app.py` stays the launch command on both.
- An explicit value set via the settings UI still wins over both.

## Result

| Machine | Before | After (autodetect) | With env override |
|---|---|---|---|
| 2c/3.7 GB laptop | 1 | 1 (unchanged) | n/a (var unset) |
| 8c/48 GB single-GPU Grid node | **1** (GPU branch) | 2 | `=6/8` → 6/8 |

## Tests

- Rewrote `tests_lib/datasets/test_concurrency_defaults.py` to the CPU-bound model (GPU count no longer caps) and added env-override coverage (wins/clamp/blank/non-integer/unset).
- Verified locally: the concurrency unit tests, `tests/core/test_settings.py`, `tests/datasets/test_parallel_loading.py`, and `tests/core/test_settings_api_routes.py` (258 passed), plus ruff/format/codespell.
- Documented both vars in `docs/DEPLOYMENT.md`.

> Note: run full `./run-tests.sh` on the Grid before merge — the laptop venv is partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)