### PR TITLE
Auto-Find tab + per-user autorun & results exporter + detector access-list model

### DIFF
--- a/app.py
+++ b/app.py
@@ -814,6 +814,25 @@ if __name__ == "__main__":
         help="Run a detector on a dataset from the command line and print predicted-Good items",
     )
     parser.add_argument(
+        "--user",
+        type=str,
+        default=None,
+        help=(
+            "Run --autodetect as this user, so their per-user Auto-Find list "
+            "(autorun_detectors) and results exporter apply. Requires --api-key "
+            "to authenticate against data/api_keys.json (same credentials as the "
+            "server's api_key login). Without --user the run uses the built-in "
+            "'default' user, which reads the --settings file."
+        ),
+    )
+    parser.add_argument(
+        "--api-key",
+        dest="api_key",
+        type=str,
+        default=None,
+        help="Bearer key authenticating --user against data/api_keys.json.",
+    )
+    parser.add_argument(
         "--list-plugins",
         action="store_true",
         dest="list_plugins",
@@ -1200,6 +1219,37 @@ if __name__ == "__main__":
         cli_progress.set_format(args.progress_format)
         if args.progress_format == "json":
             set_progress_callback(cli_progress.progress_callback)
+
+        # Establish (and authenticate) the user this Auto-Find runs as, mirroring
+        # the server's api_key login. With --user the run reads that user's
+        # per-user autorun list + results exporter; without it, the built-in
+        # "default" user applies (which reads the --settings flat file).
+        if args.user:
+            from vtscore.config import DATA_DIR
+
+            from vtsearch.auth import ApiKeyLoginProvider, set_thread_user
+
+            if not args.api_key:
+                parser.error("--user requires --api-key <key> to authenticate against data/api_keys.json")
+
+            class _CliRequest:
+                headers = {"Authorization": f"Bearer {args.api_key}"}
+
+            _req = _CliRequest()
+            _provider = ApiKeyLoginProvider(keys_file=DATA_DIR / "api_keys.json")
+            if not _provider.is_authenticated(_req):
+                parser.error("Invalid --api-key: no matching key in data/api_keys.json")
+            _authed = _provider.get_user(_req)
+            if _authed != args.user:
+                parser.error(f"--api-key authenticates as {_authed!r}, not --user {args.user!r}")
+            set_thread_user(args.user)
+            cli_progress.emit(
+                "authenticated_user",
+                text=f"Running Auto-Find as user {args.user!r}.",
+                user=args.user,
+            )
+        elif args.api_key:
+            parser.error("--api-key requires --user <name>")
 
         # Collect exporter field values if an exporter was specified
         exporter_field_values = None

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -530,14 +530,17 @@ suggestions) and resolve via the active `DatasetContext` /
 
 Persistent settings live in `vtsearch/settings.py`, split across two
 tiers.  **Server tier** (shared, `data/settings.json`): `saved_datasets_dir`,
-`detectors_dir`, `max_concurrent_*`, `autorun_detectors`, `hidden_plugins`.
+`detectors_dir`, `max_concurrent_*`, `hidden_plugins`.
 **Per-user tier** (`<user_data_dir>/user_settings.json`): everything else;
 `volume`, `theme`, `inclusion`, `enrich_descriptions`, `safe_thresholds`,
 `calibrate_count`, `calibration_fraction`, `audio_playing`, `swipe_animation`,
 `show_metadata`, `view_mode_*`, `grid_icon_size_*`, `focus_mode_*`,
 `panel_pct_*`, `autopilot_*`, `solo_media_type`, `settings_source`,
-`achievement_state`.  Theme supports three modes: `dark`, `light`, and
-`highviz` (high-contrast).
+`achievement_state`, and the **Auto-Find** keys `autorun_detectors`,
+`autofind_exporter`, `autofind_exporter_field_values`.  The Auto-Find keys read
+through to the server file for the built-in `default` user (CLI / single-user
+back-compat); see `_DEFAULT_USER_FALLBACK_KEYS`.  Theme supports three modes:
+`dark`, `light`, and `highviz` (high-contrast).
 
 Detectors are persisted as JSON files in `data/detectors/`
 via the `detectors_crud_bp` / `detectors_labels_bp` route blueprints.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,6 +13,26 @@ maps to `data/detectors/<name>.json`; the CLI re-resolves the
 labelset's origins, embeds them with the dataset's embedder, trains an
 MLP, and applies it to the dataset.  See below for the exact format.
 
+### Which user's Auto-Find list runs
+
+`autorun_detectors` (and the Auto-Find results exporter) are **per-user**:
+each user curates their own list in **Settings → Auto-Find**. By default the
+CLI runs as the built-in **`default`** user, which reads its list from the
+`--settings` file (so the flat-file workflow above is unchanged).
+
+To run *another* user's Auto-Find list (e.g. a nightly cron of their favorite
+detectors), authenticate with `--user` + `--api-key`, mirroring the server's
+`api_key` login:
+
+```bash
+python app.py --autodetect --dataset data.pkl --user alice --api-key "$ALICE_KEY"
+```
+
+The key is checked against `data/api_keys.json` (the same file the server's
+`--login api_key` uses); on success the run reads `alice`'s autorun list and
+results exporter. Without `--user`, the `default` user (and the `--settings`
+file) applies.
+
 **From a pickle file:**
 
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -358,8 +358,11 @@ Notable fields:
 
 - `autorun_detectors`: list of registered detector names
   to run during `/api/auto-detect` and the CLI `--autodetect` flow.
-  Toggle a model's flag through the UI or
-  `PUT /api/detectors/registry/<id>/autorun`.
+  This is a **per-user** setting (each user curates their own list in
+  Settings → Auto-Find or via `PUT /api/detectors/registry/<id>/autorun`).
+  A list placed here in `data/settings.json` applies to the built-in
+  `default` user — i.e. single-user deployments and the CLI's default
+  `--autodetect` run, which read through to this file.
 - `saved_datasets_dir`, `detectors_dir`:
   infrastructure directories (overridable for custom data layouts)
 - `max_concurrent_dataset_downloads` /

--- a/docs/plans/auto-find-settings-tab.md
+++ b/docs/plans/auto-find-settings-tab.md
@@ -1,9 +1,11 @@
 # Auto-Find settings tab + results exporter wiring
 
-Status: **Phase 1 shipped.** Adds a dedicated "Auto-Find" settings tab, makes
-the autorun-detector list editable from the UI, and wires a user-chosen
-"results exporter" so an Auto-Find (autodetect) run hands its results to the
-configured exporter automatically.
+Status: **Shipped.** Adds a dedicated "Auto-Find" settings tab, makes the
+autorun-detector list editable and **per-user**, wires a user-chosen "results
+exporter" so an Auto-Find run hands results to it automatically, and gives
+**detectors the same per-user access-list model as datasets** (owner + readers,
+a security button, and a dashboard access column that auto-hides in single-user
+mode).
 
 ## What shipped
 
@@ -19,24 +21,46 @@ configured exporter automatically.
 
 ### Auto-Find settings tab
 New `Settings → Auto-Find` tab (`auto-find` icon), housing:
-- **Auto-Find detectors** — editable checklist of registered detectors. Reuses
-  the existing per-detector autorun toggle
+- **Auto-Find detectors** — editable checklist of the detectors visible to the
+  user. Reuses the per-detector autorun toggle
   (`PUT /api/detectors/registry/<id>/autorun`), which persists into the
-  server-tier `autorun_detectors` list. (Moved here from the read-only Server
-  tab, renamed from "Auto-run detectors".)
+  caller's **per-user** `autorun_detectors` list. (Moved here from the
+  read-only Server tab, renamed from "Auto-run detectors".)
 - **Results Exporter** — a dropdown (None + each pickable exporter) with a
   sub-tab per exporter type (Server JSON File, Server CSV File, Send by Email,
   Webhook). Each sub-tab renders that exporter's own fields; values persist
   per-exporter so switching the dropdown keeps each exporter's config.
 
-### Settings model (server-tier, editable)
-Two new `ServerSettings` keys (shared across users, like `autorun_detectors`;
-editable from the UI now that they live on a user-facing tab):
+### Settings model (per-user)
+`autorun_detectors` moved from `ServerSettings` to `UserSettings`, joined by two
+new per-user keys:
 - `autofind_exporter: str` — chosen exporter name (`""` = no auto-export).
 - `autofind_exporter_field_values: dict[str, dict[str, str]]` — per-exporter
   field values, keyed by exporter name.
 
-Both are excluded from the "Default" reset (like `autorun_detectors`).
+All three are excluded from the "Default" reset. For the built-in **`default`**
+user, reads fall back to the *server* settings file when the key is absent from
+its own file (`_DEFAULT_USER_FALLBACK_KEYS` + the read-through in
+`vtsearch.settings._read_value`), and the destructive legacy migration skips
+these keys. This keeps the CLI `--settings` flat file and single-user
+deployments working while named multi-user users get a fully isolated list.
+
+### Detector access-list model (mirrors datasets)
+- Registry entries gain a `readers: list[str]` field (empty = private to
+  creator, `["*"]` = public), alongside the existing `created_by`.
+- `vtscore.detectors.registry` gains `can_user_access_detector`,
+  `is_detector_owner`, `list_detectors_for_user`, `set_detector_readers`.
+- `GET /api/detectors/registry` filters to the current user and returns
+  `created_by` / `readers` / `is_owner`; `load` / `delete` / `rename` /
+  `autorun` enforce access/ownership; new `PUT /api/detectors/registry/<id>/readers`.
+- Dashboard: `created_by` / `readers` columns (auto-hidden when
+  `provider === 'default'`) and a per-row security button → access-list prompt.
+
+### CLI user identity
+`--autodetect` defaults to the `default` user; `--user <name> --api-key <key>`
+authenticates against `data/api_keys.json` (same as the server's `api_key`
+login) and sets the thread-local user so the run reads that user's Auto-Find
+list + exporter.
 
 ### End-to-end wiring
 - **CLI** (`python app.py --autodetect`): when no explicit `--exporter` is

--- a/docs/plans/auto-find-settings-tab.md
+++ b/docs/plans/auto-find-settings-tab.md
@@ -1,0 +1,58 @@
+# Auto-Find settings tab + results exporter wiring
+
+Status: **Phase 1 shipped.** Adds a dedicated "Auto-Find" settings tab, makes
+the autorun-detector list editable from the UI, and wires a user-chosen
+"results exporter" so an Auto-Find (autodetect) run hands its results to the
+configured exporter automatically.
+
+## What shipped
+
+### Icons (frontend)
+- `Settings → Browser` tab now uses the **eye** glyph, matching the Browse
+  buttons throughout the app (dashboard cards, Find right-panel goods actions).
+- `Settings → Data Imports` tab uses a new **import** glyph (rounded box open at
+  the upper-left, arrow running from that corner into the centre) — a deliberate
+  mirror of the export icon, so import/export read as a matched pair instead of
+  the old upload arrow that looked like export.
+- New **auto-find** glyph: a small magnifying glass inside a ring of three
+  arrows chasing each other clockwise.
+
+### Auto-Find settings tab
+New `Settings → Auto-Find` tab (`auto-find` icon), housing:
+- **Auto-Find detectors** — editable checklist of registered detectors. Reuses
+  the existing per-detector autorun toggle
+  (`PUT /api/detectors/registry/<id>/autorun`), which persists into the
+  server-tier `autorun_detectors` list. (Moved here from the read-only Server
+  tab, renamed from "Auto-run detectors".)
+- **Results Exporter** — a dropdown (None + each pickable exporter) with a
+  sub-tab per exporter type (Server JSON File, Server CSV File, Send by Email,
+  Webhook). Each sub-tab renders that exporter's own fields; values persist
+  per-exporter so switching the dropdown keeps each exporter's config.
+
+### Settings model (server-tier, editable)
+Two new `ServerSettings` keys (shared across users, like `autorun_detectors`;
+editable from the UI now that they live on a user-facing tab):
+- `autofind_exporter: str` — chosen exporter name (`""` = no auto-export).
+- `autofind_exporter_field_values: dict[str, dict[str, str]]` — per-exporter
+  field values, keyed by exporter name.
+
+Both are excluded from the "Default" reset (like `autorun_detectors`).
+
+### End-to-end wiring
+- **CLI** (`python app.py --autodetect`): when no explicit `--exporter` is
+  passed, the run falls back to `autofind_exporter` /
+  `autofind_exporter_field_values` from settings (threaded through
+  `CoreConfig`). An explicit `--exporter` still wins; if neither is set the
+  legacy `gui` default applies.
+- **Server** (`POST /api/auto-detect`): after scoring, if `autofind_exporter`
+  is configured the route runs that exporter on the results and returns an
+  `auto_export` status block (`{exporter, success, message?, error?}`), surfaced
+  in the auto-detect results modal.
+
+## Open follow-ups
+- The `/api/auto-detect` route currently has no first-party UI caller (the
+  feature is CLI-driven); the server-side auto-export is wired and tested so it
+  works the moment a UI flow calls the route.
+- Streaming CLI exports (`--stream-results`) still require an explicit
+  `--exporter`; the settings fallback only covers the buffered path. Wiring the
+  fallback into the streaming pipeline is deferred.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -158,6 +158,18 @@
           "audio_playing": {
             "type": "boolean"
           },
+          "autofind_exporter": {
+            "type": "string"
+          },
+          "autofind_exporter_field_values": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
           "autopilot_enabled": {
             "type": "boolean"
           },
@@ -423,6 +435,10 @@
       "AutoDetectResponse": {
         "additionalProperties": false,
         "properties": {
+          "auto_export": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "detectors_run": {
             "type": "integer"
           },
@@ -4269,6 +4285,10 @@
           "audio_playing": {
             "type": "boolean"
           },
+          "autofind_exporter": {
+            "type": "string"
+          },
+          "autofind_exporter_field_values": {},
           "autopilot_enabled": {
             "type": "boolean"
           },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -189,7 +189,6 @@
             "items": {
               "type": "string"
             },
-            "readOnly": true,
             "type": "array"
           },
           "browse_bin_shape": {
@@ -2025,6 +2024,9 @@
           "id": {
             "type": "string"
           },
+          "is_owner": {
+            "type": "boolean"
+          },
           "last_trained_at": {
             "nullable": true,
             "type": "number"
@@ -2043,6 +2045,12 @@
           },
           "num_training": {
             "type": "integer"
+          },
+          "readers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "text_query": {
             "type": "string"
@@ -2102,6 +2110,41 @@
         },
         "required": [
           "ok"
+        ],
+        "type": "object"
+      },
+      "DetectorRegistryReadersRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "readers": {
+            "description": "List of usernames; ``[\"*\"]`` makes the detector public.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "readers"
+        ],
+        "type": "object"
+      },
+      "DetectorRegistryReadersResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "readers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ok",
+          "readers"
         ],
         "type": "object"
       },
@@ -9229,6 +9272,7 @@
     },
     "/api/detectors/registry": {
       "get": {
+        "description": "Detectors are user-shared like datasets: each entry is the creator's plus\nanyone the creator added to ``readers`` (or everyone via ``\"*\"``). The\nresponse also carries ``created_by``, ``readers``, and ``is_owner`` so the\ndashboard can render the access column and gate the security button.",
         "operationId": "list_registered_detectors",
         "responses": {
           "200": {
@@ -9245,7 +9289,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Return all registered detectors with their loaded state and autorun flag.",
+        "summary": "Return detectors visible to the current user, with loaded/autorun flags.",
         "tags": [
           "detectors_registry"
         ]
@@ -9424,6 +9468,9 @@
             },
             "description": "OK"
           },
+          "403": {
+            "description": "Access denied for the current user."
+          },
           "404": {
             "description": "Detector not found."
           },
@@ -9453,6 +9500,9 @@
               }
             },
             "description": "OK"
+          },
+          "403": {
+            "description": "Only the detector creator can delete it."
           },
           "404": {
             "description": "Detector not found."
@@ -9491,7 +9541,7 @@
         }
       ],
       "put": {
-        "description": "The flag is stored in ``settings.json`` under ``autorun_detectors`` so the\nCLI's ``--autodetect`` flow and the active-dataset ``/api/auto-detect``\nroute both see it.",
+        "description": "The flag is stored per-user under ``autorun_detectors`` (see\n:func:`vtsearch.settings.add_autorun_detector`), so each user curates their\nown Auto-Find list. The CLI's ``--autodetect`` flow reads the running\nuser's list (the built-in ``default`` user falls back to the server\nsettings file). The user must be able to access the detector to flag it.",
         "operationId": "set_detector_autorun",
         "requestBody": {
           "content": {
@@ -9514,6 +9564,9 @@
             },
             "description": "OK"
           },
+          "403": {
+            "description": "Access denied for the current user."
+          },
           "404": {
             "description": "Detector not found."
           },
@@ -9527,7 +9580,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Toggle the autorun flag for a registered detector.",
+        "summary": "Toggle the calling user's autorun flag for a registered detector.",
         "tags": [
           "detectors_registry"
         ]
@@ -9591,6 +9644,61 @@
         ]
       }
     },
+    "/api/detectors/registry/{detector_id}/readers": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "description": "Body: ``{\"readers\": [\"alice\", \"bob\"]}``. Use ``[\"*\"]`` to make the\ndetector visible to all users. Mirrors the dataset readers endpoint.",
+        "operationId": "update_detector_readers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetectorRegistryReadersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectorRegistryReadersResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "description": "Only the detector creator can update readers."
+          },
+          "404": {
+            "description": "Detector not found."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Update a detector's access list. Only the creator may call this.",
+        "tags": [
+          "detectors_registry"
+        ]
+      }
+    },
     "/api/detectors/registry/{detector_id}/rename": {
       "parameters": [
         {
@@ -9628,6 +9736,9 @@
           },
           "400": {
             "description": "Empty name after stripping."
+          },
+          "403": {
+            "description": "Only the detector creator can rename it."
           },
           "404": {
             "description": "Detector not found."

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -263,6 +263,8 @@
             @for (detector of sortedDetectors; track detector.id) {
               <vt-detector-card
                 [detector]="detector"
+                [currentUser]="currentUser"
+                [isDefaultLogin]="isDefaultLogin"
                 [columnOrder]="visibleDetectorColumns"
                 [selected]="isDetectorSelected(detector.id)"
                 [dimmed]="isLoading && !isDetectorSelected(detector.id)"
@@ -279,6 +281,7 @@
                 (export)="openExportModal(detector)"
                 (addLabels)="openAddLabelsModal(detector)"
                 (autorunToggle)="toggleAutorun(detector, $event)"
+                (security)="editDetectorSecurity(detector)"
                 (cancelTask)="loadingTasksSvc.cancelDetectorLoadingTask($event)"
                 (dismissTask)="loadingTasksSvc.dismissDetectorLoadingTask($event)"
               />

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -122,7 +122,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   get visibleDetectorColumns(): DetectorColumn[] {
-    return this.detectorCols.columnOrder;
+    let cols = this.detectorCols.columnOrder;
+    if (this.isDefaultLogin) {
+      cols = cols.filter((c) => c !== 'created_by' && c !== 'readers');
+    }
+    return cols;
   }
 
   onDatasetHeaderClick(col: string): void {
@@ -739,6 +743,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .map((s: string) => s.trim())
       .filter((s: string) => s.length > 0);
     this.datasetsRegistryApi.updateReaders(dataset.id, readers).subscribe({
+      next: () => this.datasetState.refresh(),
+    });
+  }
+
+  async editDetectorSecurity(detector: DetectorRegistryEntry): Promise<void> {
+    const current = (detector.readers || []).join(', ');
+    const result = await this.dialog.prompt(
+      `Edit access list for "${detector.name}".\nEnter usernames separated by commas, or * for public:`,
+      current,
+    );
+    if (result === null) return;
+    const readers = result
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
+    this.detectorsRegistryApi.updateReaders(detector.id, readers).subscribe({
       next: () => this.datasetState.refresh(),
     });
   }

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -114,6 +114,12 @@
       @case ('created_at') {
         <td>{{ formatDate(detector.created_at) }}</td>
       }
+      @case ('created_by') {
+        <td>{{ detector.created_by || '-' }}</td>
+      }
+      @case ('readers') {
+        <td [title]="(detector.readers || []).join(', ')">{{ (detector.readers || []).length ? (detector.readers || []).join(', ') : '-' }}</td>
+      }
       @case ('detector_loaded') {
         <td>
           @if (detector.detector_loaded) {
@@ -136,6 +142,13 @@
   }
   <td class="actions-col">
     <div class="actions-cell">
+    @if (!isDefaultLogin) {
+      <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+        </svg>
+      </button>
+    }
     <button class="edit-btn" (click)="startRename($event)" aria-label="Rename detector" title="Rename">
       <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -309,3 +309,25 @@ td.select-col {
     background: var(--btn-icon-hover-bg);
   }
 }
+
+.security-btn {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover:not(.disabled) {
+    background: var(--btn-icon-hover-bg);
+  }
+
+  &.disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -19,6 +19,8 @@ import { formatTimestamp } from '../../../utils/format-date';
 })
 export class DetectorCardComponent implements OnChanges {
   @Input() detector: any;
+  @Input() currentUser = '';
+  @Input() isDefaultLogin = true;
   @Input() columnOrder: string[] = [];
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
@@ -45,6 +47,18 @@ export class DetectorCardComponent implements OnChanges {
   @Output() dismissTask = new EventEmitter<string>();
   @Output() autorunToggle = new EventEmitter<boolean>();
   @Output() checkboxToggle = new EventEmitter<void>();
+  @Output() security = new EventEmitter<void>();
+
+  /** True when the current user created this detector (only the creator may
+   *  rename/delete it or edit its access list). */
+  get isOwner(): boolean {
+    return this.detector?.created_by === this.currentUser;
+  }
+
+  onSecurity(event: MouseEvent): void {
+    event.stopPropagation();
+    this.security.emit();
+  }
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -32,6 +32,22 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="9" y1="14" x2="15" y2="14"/></svg>',
   upload:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>',
+  // Data-import glyph: a rounded box whose upper-LEFT corner is open, with a
+  // diagonal arrow running from that corner INTO the centre. A deliberate
+  // mirror of the export icon (open top-right, arrow pointing out) so the two
+  // read as a matched in/out pair.
+  import:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/><polyline points="12 6 12 12 6 12"/><line x1="3" y1="3" x2="12" y2="12"/></svg>',
+  // Browse glyph: an eye, matching the Browse buttons used throughout the app
+  // (dashboard dataset cards, the Find right-panel goods actions, etc.).
+  eye:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>',
+  // Auto-Find glyph: a small magnifying glass (the Find icon) sitting inside a
+  // ring built from three arrows chasing each other clockwise — the "keep
+  // searching automatically" idea. Three ~90 deg arcs (r=8.5 about the centre)
+  // with 30 deg gaps, each capped by an arrowhead pointing clockwise.
+  'auto-find':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5 A8.5 8.5 0 0 1 20.5 12"/><polyline points="19 9.8 20.5 12 22 9.8"/><path d="M19.36 16.25 A8.5 8.5 0 0 1 7.75 19.36"/><polyline points="10.41 19.16 7.75 19.36 8.91 21.76"/><path d="M4.64 16.25 A8.5 8.5 0 0 1 7.75 4.64"/><polyline points="6.59 7.04 7.75 4.64 5.09 4.44"/><circle cx="11" cy="11" r="2.6"/><line x1="12.85" y1="12.85" x2="14.4" y2="14.4"/></svg>',
   database:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4.03 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/></svg>',
   graduation:

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -12,6 +12,17 @@
     }
   </div>
 
+  <!-- Auto-export status (only when a results exporter ran) -->
+  @if (data.auto_export; as ax) {
+    <div class="auto-export-status" [class.auto-export-status--error]="!ax.success">
+      @if (ax.success) {
+        &#10003; Auto-exported via {{ ax.exporter }}{{ ax.message ? ' — ' + ax.message : '' }}
+      } @else {
+        &#9888; Auto-export via {{ ax.exporter }} failed{{ ax.error ? ': ' + ax.error : '' }}
+      }
+    </div>
+  }
+
   <!-- Results table -->
   <div class="results-table-wrapper">
     @if (displayHits.length === 0) {

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -69,3 +69,17 @@
   gap: var(--space-md);
   justify-content: flex-end;
 }
+
+.auto-export-status {
+  margin: var(--space-sm) 0;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-md);
+  background: var(--color-success-bg, rgba(0, 128, 0, 0.12));
+  color: var(--color-success-fg, inherit);
+
+  &--error {
+    background: var(--color-error-bg, rgba(200, 0, 0, 0.12));
+    color: var(--color-error-fg, inherit);
+  }
+}

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -1,0 +1,103 @@
+<p class="info-text">
+  Detectors flagged here run automatically against each dataset as it is
+  imported (an &ldquo;Auto-Find&rdquo;). Choose a results exporter below to have
+  those results emailed, saved, or posted automatically when a run finishes.
+  These apply server-wide.
+</p>
+
+<!-- Auto-Find detectors --------------------------------------------------- -->
+<h4 class="subhead" title="Detectors that auto-run against each newly imported dataset">Auto-Find detectors</h4>
+@if (loadingDetectors) {
+  <p class="empty-state">Loading detectors&hellip;</p>
+} @else if (detectors.length === 0) {
+  <p class="empty-state">No detectors registered yet. Train or import a detector first.</p>
+} @else {
+  <div class="detector-list">
+    @for (d of detectors; track d.id) {
+      <label class="checkbox-row" [title]="'Auto-run ' + d.name + (d.media_type ? ' (' + d.media_type + ')' : '')">
+        <input type="checkbox" [ngModel]="d.autorun" (ngModelChange)="toggleDetector(d, $event)" />
+        {{ d.name }}
+        @if (d.media_type) {
+          <span class="detector-type">{{ d.media_type }}</span>
+        }
+      </label>
+    }
+  </div>
+}
+@if (detectorError) {
+  <p class="error-text">{{ detectorError }}</p>
+}
+
+<!-- Results Exporter ------------------------------------------------------ -->
+<h4 class="subhead" title="What to do with results after an Auto-Find finishes">Results Exporter:</h4>
+@if (loadingExporters) {
+  <p class="empty-state">Loading exporters&hellip;</p>
+} @else {
+  <div class="view-tabs">
+    <button
+      class="view-tab"
+      [class.view-tab--active]="activeExporter === ''"
+      (click)="selectExporter('')"
+      title="Do not export results automatically">
+      None
+    </button>
+    @for (exp of exporters; track exp.name) {
+      <button
+        class="view-tab"
+        [class.view-tab--active]="activeExporter === exp.name"
+        (click)="selectExporter(exp.name)"
+        [title]="exp.description || exp.display_name">
+        <vt-icon [icon]="exp.icon" [size]="14"></vt-icon>
+        {{ exp.display_name || exp.name }}
+      </button>
+    }
+  </div>
+
+  <div class="view-tab-content">
+    @if (activeExporter === '') {
+      <p class="form-hint">
+        Results stay in the app and are not exported automatically. Pick an
+        exporter above to email, save, or post them when an Auto-Find finishes.
+      </p>
+    } @else if (activeFields.length === 0) {
+      <p class="form-hint">This exporter needs no configuration.</p>
+    } @else {
+      @for (field of activeFields; track field.key) {
+        <div class="form-group">
+          <label class="form-label">{{ field.label || field.key }}{{ field.required ? ' *' : '' }}</label>
+          @if (field.field_type === 'select') {
+            <select
+              class="form-select"
+              [ngModel]="fieldValue(field.key)"
+              (ngModelChange)="setFieldValue(field.key, $event)"
+              [attr.aria-label]="field.label || field.key">
+              @for (opt of field.options || []; track opt) {
+                <option [value]="opt">{{ opt }}</option>
+              }
+            </select>
+          } @else if (field.field_type === 'number') {
+            <input
+              type="number"
+              class="form-input"
+              [ngModel]="fieldValue(field.key)"
+              (ngModelChange)="setFieldValue(field.key, $event)"
+              [placeholder]="field.placeholder || field.description || ''"
+              [attr.min]="field.min || null"
+              [attr.max]="field.max || null"
+              [attr.step]="field.step || null" />
+          } @else {
+            <input
+              [type]="inputType(field)"
+              class="form-input"
+              [ngModel]="fieldValue(field.key)"
+              (ngModelChange)="setFieldValue(field.key, $event)"
+              [placeholder]="field.placeholder || field.description || ''" />
+          }
+          @if (field.hint) {
+            <p class="form-hint">{{ field.hint }}</p>
+          }
+        </div>
+      }
+    }
+  </div>
+}

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.scss
@@ -1,0 +1,18 @@
+// Auto-Find settings tab. Most controls reuse global classes
+// (.checkbox-row, .view-tabs, .form-group, .form-hint); only the detector
+// checklist needs local rules.
+
+.detector-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 220px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.detector-type {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.6;
+}

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,0 +1,228 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { IconComponent } from '../../../icon/icon.component';
+import { ImporterField } from '../../../../models/api.models';
+import { DetectorsRegistryApiService } from '../../../../services/detectors-registry-api.service';
+import { ExportersApiService } from '../../../../services/exporters-api.service';
+import type { ExporterEntry } from '../../../../generated/api-client/models/exporter-entry';
+
+/** One registered detector, narrowed to what the autorun checklist needs. */
+interface AutorunDetectorEntry {
+  id: string;
+  name: string;
+  autorun: boolean;
+  media_type: string;
+}
+
+/** The selected exporter + its per-exporter field-value map, emitted to the
+ *  parent so it can persist both onto the settings object. */
+export interface AutoFindExporterChange {
+  exporter: string;
+  fieldValues: Record<string, Record<string, string>>;
+}
+
+/**
+ * Settings tab body for "Auto-Find".
+ *
+ * Two sections:
+ *  1. **Auto-Find detectors** - an editable checklist of every registered
+ *     detector. Each checkbox drives the existing per-detector autorun toggle
+ *     (`PUT /api/detectors/registry/<id>/autorun`), which persists into the
+ *     shared `autorun_detectors` list. (Moved here from the read-only Server
+ *     tab.)
+ *  2. **Results Exporter** - a tab strip with one tab per pickable exporter
+ *     (plus "None"). The active tab is the exporter that runs automatically
+ *     after an Auto-Find; its tab body renders that exporter's own fields.
+ *     Field values are kept per-exporter so switching tabs keeps each
+ *     exporter's config. Edits are emitted to the parent, which saves them as
+ *     `autofind_exporter` / `autofind_exporter_field_values`.
+ */
+@Component({
+  selector: 'vt-auto-find-settings',
+  standalone: true,
+  imports: [CommonModule, FormsModule, IconComponent],
+  templateUrl: './auto-find-settings.component.html',
+  styleUrl: './auto-find-settings.component.scss',
+})
+export class AutoFindSettingsComponent implements OnInit, OnChanges, OnDestroy {
+  /** Currently configured results-exporter name ('' = no auto-export). */
+  @Input() autofindExporter = '';
+  /** Per-exporter saved field values: `{exporter_name: {field_key: value}}`. */
+  @Input() autofindExporterFieldValues: Record<string, Record<string, string>> = {};
+
+  /** Emits the new exporter selection + field-value map for the parent to
+   *  persist whenever the user changes the exporter or any of its fields. */
+  @Output() exporterChange = new EventEmitter<AutoFindExporterChange>();
+
+  detectors: AutorunDetectorEntry[] = [];
+  exporters: ExporterEntry[] = [];
+  loadingDetectors = true;
+  loadingExporters = true;
+  detectorError = '';
+
+  /** Active exporter tab ('' = the "None" tab). Mirrors ``autofindExporter``
+   *  but is the single source of truth for which tab body is shown. */
+  activeExporter = '';
+  /** Working copy of the per-exporter field values (cloned from the input so
+   *  edits don't mutate the parent's object before it persists them). */
+  fieldValues: Record<string, Record<string, string>> = {};
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private detectorsRegistryApi: DetectorsRegistryApiService,
+    private exportersApi: ExportersApiService,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['autofindExporter']) {
+      this.activeExporter = this.autofindExporter || '';
+    }
+    if (changes['autofindExporterFieldValues']) {
+      this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues);
+    }
+  }
+
+  ngOnInit(): void {
+    this.activeExporter = this.autofindExporter || '';
+    this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues);
+
+    this.detectorsRegistryApi
+      .getRegistry()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          this.detectors = (res.detectors || []).map((d) => ({
+            id: String((d as Record<string, unknown>)['id'] ?? ''),
+            name: String((d as Record<string, unknown>)['name'] ?? ''),
+            autorun: Boolean((d as Record<string, unknown>)['autorun']),
+            media_type: String((d as Record<string, unknown>)['media_type'] ?? ''),
+          }));
+          this.loadingDetectors = false;
+        },
+        error: () => {
+          this.detectorError = 'Failed to load detectors';
+          this.loadingDetectors = false;
+        },
+      });
+
+    this.exportersApi
+      .getExporters()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (list) => {
+          this.exporters = (list || []).filter((exp) => !exp.hidden_from_picker);
+          this.loadingExporters = false;
+        },
+        error: () => {
+          this.loadingExporters = false;
+        },
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  // --- Auto-Find detectors -------------------------------------------------
+
+  /** Toggle a detector's autorun flag. Persists immediately via the existing
+   *  registry endpoint; the shared ``autorun_detectors`` list is the backing
+   *  store, so this affects every user (autorun is a deployment-level knob). */
+  toggleDetector(detector: AutorunDetectorEntry, checked: boolean): void {
+    const prev = detector.autorun;
+    detector.autorun = checked;
+    this.detectorsRegistryApi
+      .setAutorun(detector.id, checked)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        error: () => {
+          detector.autorun = prev; // revert on failure
+          this.detectorError = `Failed to update autorun for "${detector.name}"`;
+        },
+      });
+  }
+
+  // --- Results Exporter ----------------------------------------------------
+
+  /** Select an exporter tab. ``''`` is the "None" tab (auto-export off). When
+   *  an exporter is chosen for the first time its fields are seeded from their
+   *  defaults so the form is never blank. Emits the change for persistence. */
+  selectExporter(name: string): void {
+    this.activeExporter = name;
+    if (name && !this.fieldValues[name]) {
+      this.fieldValues[name] = this.defaultFieldValues(name);
+    }
+    this.emitChange();
+  }
+
+  /** Fields of the active exporter, or ``[]`` for the "None" tab. */
+  get activeFields(): ImporterField[] {
+    if (!this.activeExporter) return [];
+    const exp = this.exporters.find((e) => e.name === this.activeExporter);
+    return ((exp?.fields ?? []) as ImporterField[]) || [];
+  }
+
+  /** Current value for a field of the active exporter. */
+  fieldValue(key: string): string {
+    return this.fieldValues[this.activeExporter]?.[key] ?? '';
+  }
+
+  /** Write a field value for the active exporter and emit the change. */
+  setFieldValue(key: string, value: string): void {
+    if (!this.activeExporter) return;
+    const current = { ...(this.fieldValues[this.activeExporter] || {}) };
+    current[key] = value;
+    this.fieldValues = { ...this.fieldValues, [this.activeExporter]: current };
+    this.emitChange();
+  }
+
+  /** Concrete `<input type>` for a plugin field, mirroring the auto-detect
+   *  results modal's field rendering. */
+  inputType(field: ImporterField): string {
+    if (field.field_type === 'password') return 'password';
+    if (field.field_type === 'email') return 'email';
+    if (field.field_type === 'url') return 'url';
+    return 'text';
+  }
+
+  private defaultFieldValues(name: string): Record<string, string> {
+    const exp = this.exporters.find((e) => e.name === name);
+    const out: Record<string, string> = {};
+    for (const field of (exp?.fields ?? []) as ImporterField[]) {
+      if (field.default) out[field.key] = field.default;
+    }
+    return out;
+  }
+
+  private cloneFieldValues(
+    src: Record<string, Record<string, string>>,
+  ): Record<string, Record<string, string>> {
+    const out: Record<string, Record<string, string>> = {};
+    for (const [name, vals] of Object.entries(src || {})) {
+      out[name] = { ...vals };
+    }
+    return out;
+  }
+
+  private emitChange(): void {
+    this.exporterChange.emit({
+      exporter: this.activeExporter,
+      fieldValues: this.cloneFieldValues(this.fieldValues),
+    });
+  }
+}

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -33,15 +33,23 @@
           [class.settings-tab--active]="activeSettingsTab === 'imports'"
           (click)="activeSettingsTab = 'imports'"
           title="Default embedder, clipper, and converters to apply when importing each kind of dataset">
-          <vt-icon type="upload" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'imports'"></vt-icon>
+          <vt-icon type="import" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'imports'"></vt-icon>
           Data Imports
+        </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'autofind'"
+          (click)="activeSettingsTab = 'autofind'"
+          title="Detectors that auto-run on import, and what to do with their results">
+          <vt-icon type="auto-find" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'autofind'"></vt-icon>
+          Auto-Find
         </button>
         <button
           class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'browser'"
           (click)="activeSettingsTab = 'browser'"
           title="VTSBrowse projection-browser look per media type: bin shape, density colormap, and cell size">
-          <vt-icon type="grid" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'browser'"></vt-icon>
+          <vt-icon type="eye" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'browser'"></vt-icon>
           Browser
         </button>
         <button
@@ -217,6 +225,16 @@
           ></vt-import-defaults-settings>
         }
 
+        <!-- Auto-Find -->
+        @if (activeSettingsTab === 'autofind') {
+          <h3>Auto-Find</h3>
+          <vt-auto-find-settings
+            [autofindExporter]="autofindExporter"
+            [autofindExporterFieldValues]="autofindExporterFieldValues"
+            (exporterChange)="onAutofindExporterChange($event)"
+          ></vt-auto-find-settings>
+        }
+
         <!-- Autopilot & Actions -->
         @if (activeSettingsTab === 'autopilot') {
           <h3>Autopilot &amp; Actions</h3>
@@ -369,14 +387,6 @@
           <div class="form-group">
             <label class="form-label" title="Maximum number of dataset embedding jobs the server runs in parallel">Max concurrent dataset embeddings</label>
             <div class="server-value">{{ settings.max_concurrent_dataset_embeddings ?? '—' }}</div>
-          </div>
-          <div class="form-group">
-            <label class="form-label" title="Detectors automatically run against each dataset as it is imported">Auto-run detectors</label>
-            @if (autorunDetectorsDisplay) {
-              <div class="server-value">{{ autorunDetectorsDisplay }}</div>
-            } @else {
-              <div class="server-value server-value--empty">None</div>
-            }
           </div>
           <div class="form-group">
             <label class="form-label" title="Plugins hidden from pickers and listings for this deployment (still callable by name). Combines the persisted setting with any --hide-plugin CLI flags.">Hidden plugins</label>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -9,6 +9,10 @@ import { SettingsImporterModalComponent } from '../settings-importer-modal/setti
 import { SettingsExporterModalComponent } from '../settings-exporter-modal/settings-exporter-modal.component';
 import { ImportDefaultsSettingsComponent } from './import-defaults/import-defaults-settings.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
+import {
+  AutoFindExporterChange,
+  AutoFindSettingsComponent,
+} from './auto-find/auto-find-settings.component';
 import { ImportDefaultsByMediaType } from '../../../models/api.models';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
@@ -27,7 +31,7 @@ import {
 @Component({
   selector: 'vt-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, ImportDefaultsSettingsComponent, FieldHintIconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, ImportDefaultsSettingsComponent, FieldHintIconComponent, AutoFindSettingsComponent],
   templateUrl: './settings-modal.component.html',
   styleUrl: './settings-modal.component.scss',
 })
@@ -444,12 +448,27 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     return this.settings.effective_solo_media_type || null;
   }
 
-  /** Comma-separated list of auto-run detector names for the read-only
-   *  Server tab, or ``''`` when none are configured (so the template can
-   *  fall back to a muted "None"). */
-  get autorunDetectorsDisplay(): string {
-    const list = (this.settings as Record<string, unknown>)['autorun_detectors'] as string[] | undefined;
-    return list && list.length ? list.join(', ') : '';
+  /** Configured Auto-Find results-exporter name (''=none), read from the
+   *  settings object for the Auto-Find tab's child component. */
+  get autofindExporter(): string {
+    return ((this.settings as Record<string, unknown>)['autofind_exporter'] as string) || '';
+  }
+
+  /** Per-exporter saved field values for the Auto-Find tab's child component. */
+  get autofindExporterFieldValues(): Record<string, Record<string, string>> {
+    return (
+      ((this.settings as Record<string, unknown>)['autofind_exporter_field_values'] as Record<
+        string,
+        Record<string, string>
+      >) || {}
+    );
+  }
+
+  /** Persist the user's Auto-Find results-exporter choice + field values. */
+  onAutofindExporterChange(change: AutoFindExporterChange): void {
+    (this.settings as Record<string, unknown>)['autofind_exporter'] = change.exporter;
+    (this.settings as Record<string, unknown>)['autofind_exporter_field_values'] = change.fieldValues;
+    this.save();
   }
 
   /** Effective hidden-plugins map flattened to ``[{family, names}]`` rows

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -265,6 +265,12 @@ export interface DetectorRegistryEntry {
   /** Embedder this detector's label-vector cache is built against.
    *  Populated only for loaded detectors; empty for unloaded entries. */
   embedder?: string;
+  /** Username of the detector's creator (shown in multi-user mode). */
+  created_by?: string;
+  /** Usernames granted access besides the creator; ``["*"]`` = public. */
+  readers?: string[];
+  /** Whether the current user created this detector (creator-only actions). */
+  is_owner?: boolean;
   [key: string]: unknown;
 }
 

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -342,10 +342,22 @@ export interface AutoDetectDetectorResult {
   [key: string]: unknown;
 }
 
+/** Outcome of auto-exporting Auto-Find results, present on the auto-detect
+ *  response only when a results exporter is configured in settings. */
+export interface AutoFindExportStatus {
+  exporter: string;
+  success: boolean;
+  message?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
 export interface AutoDetectResultsData {
   media_type?: string;
   detectors_run?: string | number;
   results: Record<string, AutoDetectDetectorResult>;
+  /** Auto-export outcome (only when a results exporter ran). */
+  auto_export?: AutoFindExportStatus;
   // Find mode fields
   detectors?: string[];
   datasets?: string[];

--- a/frontend/src/app/services/dashboard-columns.service.ts
+++ b/frontend/src/app/services/dashboard-columns.service.ts
@@ -19,6 +19,8 @@ export type DetectorColumn =
   | 'autodetect'
   | 'last_trained_at'
   | 'created_at'
+  | 'created_by'
+  | 'readers'
   | 'detector_loaded'
   | 'actions';
 
@@ -43,6 +45,8 @@ const DETECTOR_COLUMNS_DEFAULT: DetectorColumn[] = [
   'autodetect',
   'last_trained_at',
   'created_at',
+  'created_by',
+  'readers',
   'detector_loaded',
 ];
 
@@ -65,9 +69,11 @@ export const DETECTOR_COL_META: Record<string, ColMeta> = {
   name: { label: 'Name', title: 'Detector display name (click to sort)', sortable: true },
   media_type: { label: 'Type', title: 'Media type this detector operates on (click to sort)', sortable: true },
   num_training: { label: '# Training', title: 'Number of labeled training examples (click to sort)', sortable: true },
-  autodetect: { label: 'Autorun?', title: 'Include this detector in CLI autorun (click to sort)', sortable: true },
+  autodetect: { label: 'Auto-Find?', title: 'Include this detector in your Auto-Find list (click to sort)', sortable: true },
   last_trained_at: { label: 'Last Trained', title: 'When the detector was last trained (click to sort)', sortable: true },
   created_at: { label: 'Created', title: 'When the detector was created (click to sort)', sortable: true },
+  created_by: { label: 'Creator', title: 'User who created this detector (click to sort)', sortable: true },
+  readers: { label: 'Readers', title: 'Users with access to this detector (click to sort)', sortable: true },
   detector_loaded: { label: 'Loaded?', title: "Whether the detector's inference data is cached in memory", sortable: false },
   actions: { label: 'Actions', title: 'Available operations for this detector', sortable: false },
 };

--- a/frontend/src/app/services/detectors-registry-api.service.ts
+++ b/frontend/src/app/services/detectors-registry-api.service.ts
@@ -13,6 +13,7 @@ import type { DetectorRegistryDeleteResponse } from '../generated/api-client/mod
 import type { DetectorRegistryListResponse } from '../generated/api-client/models/detector-registry-list-response';
 import type { DetectorRegistryLoadResponse } from '../generated/api-client/models/detector-registry-load-response';
 import type { DetectorRegistryRenameResponse } from '../generated/api-client/models/detector-registry-rename-response';
+import type { DetectorRegistryReadersResponse } from '../generated/api-client/models/detector-registry-readers-response';
 import type { DetectorRegistryUnloadResponse } from '../generated/api-client/models/detector-registry-unload-response';
 import { cancelDetectorLoadingTask } from '../generated/api-client/fn/detectors-registry/cancel-detector-loading-task';
 import { deleteRegisteredDetector } from '../generated/api-client/fn/detectors-registry/delete-registered-detector';
@@ -22,6 +23,7 @@ import { moveLabelsetSourceFile } from '../generated/api-client/fn/detectors-reg
 import { registerDetectorRoute } from '../generated/api-client/fn/detectors-registry/register-detector-route';
 import { renameRegisteredDetector } from '../generated/api-client/fn/detectors-registry/rename-registered-detector';
 import { setDetectorAutorun } from '../generated/api-client/fn/detectors-registry/set-detector-autorun';
+import { updateDetectorReaders } from '../generated/api-client/fn/detectors-registry/update-detector-readers';
 import { unloadDetectorRoute } from '../generated/api-client/fn/detectors-registry/unload-detector-route';
 import { VtDialogService } from './dialog.service';
 
@@ -147,6 +149,15 @@ export class DetectorsRegistryApiService {
     return setDetectorAutorun(this.http, this.config.rootUrl, {
       detector_id: detectorId,
       body: { autorun },
+    }).pipe(map((r) => r.body));
+  }
+
+  /** Update a detector's access list (creator-only on the backend).
+   *  ``["*"]`` makes it visible to all users. */
+  updateReaders(detectorId: string, readers: string[]): Observable<DetectorRegistryReadersResponse> {
+    return updateDetectorReaders(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+      body: { readers },
     }).pipe(map((r) => r.body));
   }
 }

--- a/tests/api/test_multi_user_detector_access.py
+++ b/tests/api/test_multi_user_detector_access.py
@@ -1,0 +1,254 @@
+"""Tests for multi-user detector access: readers list and access control.
+
+Detectors are user-shared just like datasets (see
+``test_multi_user_dataset_access.py``). Verifies that:
+
+- Detectors have a ``readers`` field controlling who can see/load them
+- Only the creator and listed readers (or ``"*"`` for public) can see one
+- Only the creator can modify readers, rename, or delete a detector
+- ``PUT /api/detectors/registry/<id>/readers`` works correctly
+- ``GET /api/detectors/registry`` filters by access
+- Load, delete, rename, and autorun-toggle enforce access/ownership
+"""
+
+from __future__ import annotations
+
+from vtsearch.auth import (
+    get_login_provider,
+    set_login_provider,
+    TrivialLoginProvider,
+)
+from vtscore.detectors.registry import (
+    can_user_access_detector,
+    is_detector_owner,
+    list_detectors_for_user,
+    register_detector,
+    set_detector_readers,
+)
+
+
+def _make_detector(name="det", created_by="alice", readers=None, **kw):
+    """Register a detector and return the entry."""
+    return register_detector(
+        name=name,
+        media_type="audio",
+        created_by=created_by,
+        readers=readers,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry-level access control
+# ---------------------------------------------------------------------------
+
+
+class TestReadersField:
+    def test_default_readers_is_empty_list(self):
+        assert _make_detector("d1")["readers"] == []
+
+    def test_readers_stored_on_register(self):
+        assert _make_detector("d2", readers=["bob", "carol"])["readers"] == ["bob", "carol"]
+
+    def test_wildcard_readers(self):
+        assert _make_detector("d3", readers=["*"])["readers"] == ["*"]
+
+
+class TestCanUserAccess:
+    def test_creator_always_has_access(self):
+        e = _make_detector("acc1", created_by="alice")
+        assert can_user_access_detector(e["id"], "alice") is True
+
+    def test_non_reader_denied(self):
+        e = _make_detector("acc2", created_by="alice")
+        assert can_user_access_detector(e["id"], "bob") is False
+
+    def test_listed_reader_allowed(self):
+        e = _make_detector("acc3", created_by="alice", readers=["bob"])
+        assert can_user_access_detector(e["id"], "bob") is True
+
+    def test_wildcard_grants_all(self):
+        e = _make_detector("acc4", created_by="alice", readers=["*"])
+        assert can_user_access_detector(e["id"], "anyone") is True
+
+    def test_nonexistent_detector(self):
+        assert can_user_access_detector("nope", "alice") is False
+
+
+class TestIsOwner:
+    def test_creator_is_owner(self):
+        e = _make_detector("own1", created_by="alice")
+        assert is_detector_owner(e["id"], "alice") is True
+
+    def test_reader_is_not_owner(self):
+        e = _make_detector("own2", created_by="alice", readers=["bob"])
+        assert is_detector_owner(e["id"], "bob") is False
+
+
+class TestListDetectorsForUser:
+    def test_creator_sees_own_private_detector(self):
+        e = _make_detector("l1", created_by="alice")
+        assert e["id"] in [r["id"] for r in list_detectors_for_user("alice")]
+
+    def test_other_user_cannot_see_private_detector(self):
+        e = _make_detector("l2", created_by="alice")
+        assert e["id"] not in [r["id"] for r in list_detectors_for_user("bob")]
+
+    def test_reader_sees_shared_detector(self):
+        e = _make_detector("l3", created_by="alice", readers=["bob"])
+        assert e["id"] in [r["id"] for r in list_detectors_for_user("bob")]
+
+    def test_wildcard_visible_to_everyone(self):
+        e = _make_detector("l4", created_by="alice", readers=["*"])
+        assert e["id"] in [r["id"] for r in list_detectors_for_user("zed")]
+
+
+class TestSetReaders:
+    def test_creator_can_set_readers(self):
+        e = _make_detector("sr1", created_by="alice")
+        ok, err = set_detector_readers(e["id"], ["bob"], "alice")
+        assert ok is True and err == ""
+        assert can_user_access_detector(e["id"], "bob") is True
+
+    def test_non_creator_cannot_set_readers(self):
+        e = _make_detector("sr2", created_by="alice")
+        ok, err = set_detector_readers(e["id"], ["bob"], "bob")
+        assert ok is False and "creator" in err
+
+    def test_set_readers_nonexistent(self):
+        ok, err = set_detector_readers("nope", ["bob"], "alice")
+        assert ok is False and "not found" in err.lower()
+
+    def test_set_readers_to_empty_revokes(self):
+        e = _make_detector("sr3", created_by="alice", readers=["bob"])
+        assert can_user_access_detector(e["id"], "bob") is True
+        set_detector_readers(e["id"], [], "alice")
+        assert can_user_access_detector(e["id"], "bob") is False
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests (default user = "default")
+# ---------------------------------------------------------------------------
+
+
+class TestReadersEndpoint:
+    def test_set_readers_via_api(self, client):
+        e = _make_detector("api1", created_by="default")
+        resp = client.put(f"/api/detectors/registry/{e['id']}/readers", json={"readers": ["bob", "carol"]})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True and data["readers"] == ["bob", "carol"]
+
+    def test_set_readers_non_string_items(self, client):
+        e = _make_detector("api2", created_by="default")
+        resp = client.put(f"/api/detectors/registry/{e['id']}/readers", json={"readers": [123]})
+        assert resp.status_code == 422
+
+    def test_set_readers_non_creator_forbidden(self, client):
+        e = _make_detector("api3", created_by="other_user")
+        resp = client.put(f"/api/detectors/registry/{e['id']}/readers", json={"readers": ["bob"]})
+        assert resp.status_code == 403
+
+    def test_set_readers_nonexistent(self, client):
+        resp = client.put("/api/detectors/registry/nope/readers", json={"readers": ["bob"]})
+        assert resp.status_code == 404
+
+
+class TestRegistryListingFiltered:
+    def test_default_user_sees_own(self, client):
+        e = _make_detector("f1", created_by="default")
+        ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+        assert e["id"] in ids
+
+    def test_default_user_cannot_see_others_private(self, client):
+        e = _make_detector("f2", created_by="other_user")
+        ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+        assert e["id"] not in ids
+
+    def test_default_user_sees_shared(self, client):
+        e = _make_detector("f3", created_by="other_user", readers=["default"])
+        ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+        assert e["id"] in ids
+
+    def test_response_has_readers_and_is_owner(self, client):
+        e = _make_detector("f4", created_by="default", readers=["bob"])
+        match = [d for d in client.get("/api/detectors/registry").get_json()["detectors"] if d["id"] == e["id"]]
+        assert len(match) == 1
+        assert match[0]["readers"] == ["bob"]
+        assert match[0]["is_owner"] is True
+
+
+class TestAccessEnforcement:
+    def test_load_private_detector_denied(self, client):
+        e = _make_detector("load1", created_by="other_user")
+        resp = client.post("/api/detectors/registry/load", json={"detector_id": e["id"]})
+        assert resp.status_code == 403
+
+    def test_delete_others_detector_denied(self, client):
+        e = _make_detector("del1", created_by="other_user")
+        assert client.delete(f"/api/detectors/registry/{e['id']}").status_code == 403
+
+    def test_rename_others_detector_denied(self, client):
+        e = _make_detector("ren1", created_by="other_user")
+        resp = client.put(f"/api/detectors/registry/{e['id']}/rename", json={"name": "new"})
+        assert resp.status_code == 403
+
+    def test_autorun_toggle_on_inaccessible_denied(self, client):
+        e = _make_detector("ar1", created_by="other_user")
+        resp = client.put(f"/api/detectors/registry/{e['id']}/autorun", json={"autorun": True})
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Multi-user flow with TrivialLoginProvider
+# ---------------------------------------------------------------------------
+
+
+class TestMultiUserDetectorFlow:
+    def test_share_and_access_flow(self, client):
+        original = get_login_provider()
+        try:
+            set_login_provider(TrivialLoginProvider())
+
+            client.post("/api/auth/login", json={"username": "alice"})
+            e = _make_detector("flow1", created_by="alice")
+            ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+            assert e["id"] in ids
+
+            client.post("/api/auth/login", json={"username": "bob"})
+            ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+            assert e["id"] not in ids
+
+            client.post("/api/auth/login", json={"username": "alice"})
+            assert (
+                client.put(f"/api/detectors/registry/{e['id']}/readers", json={"readers": ["bob"]}).status_code == 200
+            )
+
+            client.post("/api/auth/login", json={"username": "bob"})
+            ids = [d["id"] for d in client.get("/api/detectors/registry").get_json()["detectors"]]
+            assert e["id"] in ids
+            # Bob (a reader) cannot delete or re-share.
+            assert client.delete(f"/api/detectors/registry/{e['id']}").status_code == 403
+            assert client.put(f"/api/detectors/registry/{e['id']}/readers", json={"readers": ["x"]}).status_code == 403
+        finally:
+            set_login_provider(original)
+
+    def test_per_user_autorun_is_isolated(self, client):
+        """Flagging a detector for autorun affects only the calling user."""
+        original = get_login_provider()
+        try:
+            set_login_provider(TrivialLoginProvider())
+
+            # Alice creates a public detector and flags it for her autorun.
+            client.post("/api/auth/login", json={"username": "alice"})
+            e = _make_detector("flow2", created_by="alice", readers=["*"])
+            assert client.put(f"/api/detectors/registry/{e['id']}/autorun", json={"autorun": True}).status_code == 200
+            alice_autorun = client.get("/api/settings").get_json()["autorun_detectors"]
+            assert e["name"] in alice_autorun
+
+            # Bob can see it (public) but his autorun list is untouched.
+            client.post("/api/auth/login", json={"username": "bob"})
+            bob_autorun = client.get("/api/settings").get_json()["autorun_detectors"]
+            assert e["name"] not in bob_autorun
+        finally:
+            set_login_provider(original)

--- a/tests/cli/test_per_user_autorun_cli.py
+++ b/tests/cli/test_per_user_autorun_cli.py
@@ -1,0 +1,41 @@
+"""The CLI resolves autorun + Auto-Find exporter from the running user.
+
+``--autodetect --user X`` authenticates X and sets the thread-local user; the
+pipeline then builds its config via ``CoreConfig.from_settings()``, which must
+reflect that user's per-user Auto-Find settings (autorun list + exporter).
+Without ``--user`` the built-in "default" user applies, reading through to the
+server ``--settings`` file. See ``docs/plans/auto-find-settings-tab.md``.
+"""
+
+from __future__ import annotations
+
+from vtsearch import settings
+from vtsearch.auth import thread_user
+from vtscore.config import CoreConfig
+
+
+class TestCliPerUserAutorun:
+    def test_named_user_autorun_isolated(self, isolated_settings):
+        with thread_user("alice"):
+            settings.set_autorun_detectors(["alice-det"])
+            settings.set_autofind_exporter("server_json_file")
+        with thread_user("bob"):
+            cfg = CoreConfig.from_settings()
+            assert list(cfg.autorun_detectors) == []
+            assert cfg.autofind_exporter == ""
+        with thread_user("alice"):
+            cfg = CoreConfig.from_settings()
+            assert list(cfg.autorun_detectors) == ["alice-det"]
+            assert cfg.autofind_exporter == "server_json_file"
+
+    def test_default_user_reads_through_to_settings_file(self, isolated_settings):
+        """The default user (CLI without --user) sees the --settings file's list."""
+        import json
+
+        # Simulate a CLI ``--settings`` file that carries autorun_detectors at
+        # the (server) file the default user reads through to.
+        isolated_settings._server.write_text(json.dumps({"autorun_detectors": ["from-settings-file"]}))
+        settings.reset()
+        # No thread user -> "default".
+        cfg = CoreConfig.from_settings()
+        assert list(cfg.autorun_detectors) == ["from-settings-file"]

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -86,7 +86,8 @@ class TestPerUserIsolation:
         assert "volume" in out
         # Server-tier keys are filtered out.
         assert "saved_datasets_dir" not in out
-        assert "autorun_detectors" not in out
+        # autorun_detectors is now a per-user key, so it IS surfaced here.
+        assert "autorun_detectors" in out
 
 
 class TestLegacyMigration:

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -842,23 +842,25 @@ class TestConcurrentWrites:
     def test_add_autorun_detector_rmw(self, isolated_settings):
         """Concurrent ``add_autorun_detector`` calls must not lose entries.
 
-        Simulates the cross-process race: our cache says ``[]`` but disk
-        has ``["other-detector"]`` because a sibling process added it.
+        ``autorun_detectors`` is per-user now, so the cross-process race plays
+        out on the (default) user's settings file: our cache says
+        ``["ours-pre"]`` but disk also has ``"sibling"`` because a sibling
+        process added it. The atomic per-user RMW must merge, not clobber.
         """
-        # Force-load the server cache (so add_autorun_detector below
+        # Force-load the per-user cache (so add_autorun_detector below
         # doesn't trigger a fresh load).
         settings_mod.add_autorun_detector("ours-pre")
 
-        # Sibling process directly adds an entry on disk.
-        server_path = isolated_settings._server
-        disk = json.loads(server_path.read_text())
+        # Sibling process directly adds an entry on disk (the per-user file).
+        user_path = isolated_settings._user
+        disk = json.loads(user_path.read_text())
         disk["autorun_detectors"] = list(disk.get("autorun_detectors", [])) + ["sibling"]
-        server_path.write_text(json.dumps(disk))
+        user_path.write_text(json.dumps(disk))
 
         # We add another; should merge with disk, not clobber.
         settings_mod.add_autorun_detector("ours-post")
 
-        final = json.loads(server_path.read_text())
+        final = json.loads(user_path.read_text())
         assert "sibling" in final["autorun_detectors"]
         assert "ours-pre" in final["autorun_detectors"]
         assert "ours-post" in final["autorun_detectors"]

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -171,6 +171,41 @@ class TestSettingsAPI:
         # List-of-string validation runs in the schema → 422.
         assert res.status_code == 422
 
+    def test_update_autofind_exporter_valid(self, client):
+        res = client.put("/api/settings", json={"autofind_exporter": "server_json_file"})
+        assert res.status_code == 200
+        assert res.get_json()["autofind_exporter"] == "server_json_file"
+
+    def test_update_autofind_exporter_empty_clears(self, client):
+        client.put("/api/settings", json={"autofind_exporter": "server_json_file"})
+        res = client.put("/api/settings", json={"autofind_exporter": ""})
+        assert res.status_code == 200
+        assert res.get_json()["autofind_exporter"] == ""
+
+    def test_update_autofind_exporter_unknown_rejected(self, client):
+        res = client.put("/api/settings", json={"autofind_exporter": "no_such_exporter"})
+        assert res.status_code == 400
+
+    def test_update_autofind_exporter_field_values(self, client):
+        res = client.put(
+            "/api/settings",
+            json={
+                "autofind_exporter_field_values": {
+                    "server_json_file": {"filepath": "/tmp/out.json"},
+                }
+            },
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["autofind_exporter_field_values"]["server_json_file"]["filepath"] == "/tmp/out.json"
+
+    def test_autofind_exporter_excluded_from_defaults(self, client):
+        res = client.get("/api/settings/defaults")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "autofind_exporter" not in data
+        assert "autofind_exporter_field_values" not in data
+
     def test_get_defaults(self, client):
         res = client.get("/api/settings/defaults")
         assert res.status_code == 200

--- a/tests/detectors/test_autofind_export.py
+++ b/tests/detectors/test_autofind_export.py
@@ -45,9 +45,7 @@ class TestAutofindExport:
     def test_success_writes_json_file(self, isolated_settings, tmp_path):
         out = tmp_path / "autofind_results.json"
         settings.set_autofind_exporter("server_json_file")
-        settings.set_autofind_exporter_field_values(
-            {"server_json_file": {"filepath": str(out)}}
-        )
+        settings.set_autofind_exporter_field_values({"server_json_file": {"filepath": str(out)}})
         status = _run_autofind_export(dict(_SAMPLE_RESULTS))
         assert status is not None
         assert status["exporter"] == "server_json_file"

--- a/tests/detectors/test_autofind_export.py
+++ b/tests/detectors/test_autofind_export.py
@@ -1,0 +1,57 @@
+"""Tests for the Auto-Find server-side results auto-export.
+
+Covers :func:`vtsearch.routes.detectors.scoring._run_autofind_export`, which
+hands an autodetect run's results to the exporter configured under
+``autofind_exporter`` (see ``docs/plans/auto-find-settings-tab.md``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from vtsearch import settings
+from vtsearch.routes.detectors.scoring import _run_autofind_export
+
+_SAMPLE_RESULTS = {
+    "media_type": "audio",
+    "detectors_run": 1,
+    "results": {
+        "det-a": {
+            "detector_name": "det-a",
+            "threshold": 0.5,
+            "total_hits": 1,
+            "hits": [{"id": 1, "score": 0.9, "filename": "a.wav", "md5": "abc"}],
+            "negative_hits": [],
+        }
+    },
+}
+
+
+class TestAutofindExport:
+    def test_no_exporter_returns_none(self, isolated_settings):
+        settings.set_autofind_exporter("")
+        assert _run_autofind_export(dict(_SAMPLE_RESULTS)) is None
+
+    def test_unknown_exporter_reports_error(self, isolated_settings):
+        # The raw setter skips the route-layer registry check, so a stale /
+        # bogus name can reach the function; it must report rather than raise.
+        settings.set_autofind_exporter("no_such_exporter")
+        status = _run_autofind_export(dict(_SAMPLE_RESULTS))
+        assert status is not None
+        assert status["exporter"] == "no_such_exporter"
+        assert status["success"] is False
+        assert "error" in status
+
+    def test_success_writes_json_file(self, isolated_settings, tmp_path):
+        out = tmp_path / "autofind_results.json"
+        settings.set_autofind_exporter("server_json_file")
+        settings.set_autofind_exporter_field_values(
+            {"server_json_file": {"filepath": str(out)}}
+        )
+        status = _run_autofind_export(dict(_SAMPLE_RESULTS))
+        assert status is not None
+        assert status["exporter"] == "server_json_file"
+        assert status["success"] is True
+        assert out.exists()
+        written = json.loads(out.read_text())
+        assert "results" in written or "det-a" in json.dumps(written)

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -612,28 +612,34 @@ class TestConcurrentDownloads:
 
         def run():
             try:
-                with (
-                    patch.object(dl_module.core, "DATA_DIR", data_dir),
-                    patch.object(dl_module.core, "download_file_with_progress", slow_download),
-                ):
-                    dl_module._download_and_extract(
-                        url="http://example.com/test.zip",
-                        archive_name="test.zip",
-                        extract_to=extract_to,
-                        check_path=check_path,
-                        download_size_mb=1,
-                        dataset_name="Test",
-                        on_progress=lambda *a: None,
-                    )
+                dl_module._download_and_extract(
+                    url="http://example.com/test.zip",
+                    archive_name="test.zip",
+                    extract_to=extract_to,
+                    check_path=check_path,
+                    download_size_mb=1,
+                    dataset_name="Test",
+                    on_progress=lambda *a: None,
+                )
             except Exception as exc:
                 errors.append(exc)
 
-        t1 = threading.Thread(target=run)
-        t2 = threading.Thread(target=run)
-        t1.start()
-        t2.start()
-        t1.join(timeout=30)
-        t2.join(timeout=30)
+        # Patch on the MAIN thread (around start+join) rather than inside each
+        # worker. ``patch.object`` mutates a module-global, so applying it per
+        # thread is not thread-safe: under load a worker could still be inside
+        # its ``with`` block (or hung on the barrier) when the block was meant
+        # to exit, leaking ``slow_download`` into later tests. Keeping the patch
+        # on the main thread guarantees it is restored only after both joins.
+        with (
+            patch.object(dl_module.core, "DATA_DIR", data_dir),
+            patch.object(dl_module.core, "download_file_with_progress", slow_download),
+        ):
+            t1 = threading.Thread(target=run)
+            t2 = threading.Thread(target=run)
+            t1.start()
+            t2.start()
+            t1.join(timeout=30)
+            t2.join(timeout=30)
 
         assert not errors, f"Concurrent downloads raised errors: {errors}"
         assert check_path.exists()

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -781,6 +781,15 @@ def _run_pipeline(
     config = CoreConfig.from_settings(settings_path=settings_path) if settings_path else CoreConfig.from_settings()
     autorun_detectors = list(config.autorun_detectors)
 
+    # When no explicit ``--exporter`` was given, fall back to the Auto-Find
+    # results exporter configured in settings (its per-exporter field values
+    # come along too). An explicit ``--exporter`` always wins; if neither is
+    # set the downstream default (``gui``) applies.
+    if exporter_name is None and config.autofind_exporter:
+        exporter_name = config.autofind_exporter
+        if exporter_field_values is None:
+            exporter_field_values = dict(config.autofind_exporter_field_values.get(config.autofind_exporter, {}))
+
     if dry_run:
         _run_dry_run(
             source_description,

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 # Data paths are anchored to the repository root, NOT to the current working
@@ -229,6 +229,14 @@ class CoreConfig:
     # Filesystem root for caches, embeddings, model downloads.  Phase 4 will
     # route every hardcoded ``data/`` path through this field.
     data_dir: Path
+
+    # Auto-Find results exporter (server-tier). When an autodetect run has no
+    # explicit ``--exporter``, the CLI falls back to this exporter +
+    # field-value map. ``""`` means "no configured exporter" (CLI defaults to
+    # ``gui``). Defaulted here so library-only ``CoreConfig(...)`` constructions
+    # without the app shim keep working unchanged.
+    autofind_exporter: str = ""
+    autofind_exporter_field_values: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @classmethod
     def from_settings(cls, settings_path: str | Path | None = None) -> CoreConfig:

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -133,6 +133,10 @@ def register_detector(
         "created_by": created_by,
         "created_at": time.time(),
         "embedder": embedder,
+        # Access list (mirrors datasets): usernames allowed to see/load this
+        # detector besides the creator. Empty = private to the creator;
+        # ``["*"]`` = visible to everyone. See ``can_user_access_detector``.
+        "readers": [],
     }
     with _lock:
         entries = _ensure_loaded()
@@ -210,6 +214,74 @@ def find_by_name(name: str) -> dict[str, Any] | None:
             if entry.get("name") == name:
                 return dict(entry)
     return None
+
+
+# ---------------------------------------------------------------------------
+# Access control (mirrors vtscore.datasets.registry)
+#
+# Detectors are user-shared just like datasets: the creator always has access,
+# plus anyone listed in ``readers`` (or everyone when ``readers`` contains the
+# wildcard ``"*"``). Entries created before this feature have no ``readers``
+# key; ``.get("readers", [])`` treats them as private to their creator.
+# ---------------------------------------------------------------------------
+
+
+def can_user_access_detector(detector_id: str, username: str) -> bool:
+    """Return ``True`` if *username* may view/load the detector.
+
+    Granted when the user is the creator, is listed in ``readers``, or
+    ``readers`` contains the wildcard ``"*"``.
+    """
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry["id"] == detector_id:
+                if entry.get("created_by", "default") == username:
+                    return True
+                readers = entry.get("readers", [])
+                return username in readers or "*" in readers
+    return False
+
+
+def is_detector_owner(detector_id: str, username: str) -> bool:
+    """Return ``True`` if *username* is the creator of the detector."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry["id"] == detector_id:
+                return entry.get("created_by", "default") == username
+    return False
+
+
+def list_detectors_for_user(username: str) -> list[dict[str, Any]]:
+    """Return only detectors *username* is allowed to see.
+
+    Visible when the user is the creator, is listed in ``readers``, or
+    ``"*"`` is in ``readers``.
+    """
+    with _lock:
+        result = []
+        for entry in _ensure_loaded():
+            creator = entry.get("created_by", "default")
+            readers = entry.get("readers", [])
+            if creator == username or username in readers or "*" in readers:
+                result.append(dict(entry))
+        return result
+
+
+def set_detector_readers(detector_id: str, readers: list[str], requesting_user: str) -> tuple[bool, str]:
+    """Update a detector's ``readers`` list. Only the creator may call this.
+
+    Returns ``(success, error_message)``.
+    """
+    with _lock:
+        entries = _ensure_loaded()
+        for entry in entries:
+            if entry["id"] == detector_id:
+                if entry.get("created_by", "default") != requesting_user:
+                    return False, "Only the detector creator can modify readers"
+                entry["readers"] = readers
+                _save(entries)
+                return True, ""
+        return False, "Detector not found"
 
 
 def add_loaded_detector_id(detector_id: str) -> None:

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -100,6 +100,7 @@ def register_detector(
     media_example: str = "",
     created_by: str = "default",
     embedder: str = "",
+    readers: list[str] | None = None,
 ) -> dict[str, Any]:
     """Add a new detector to the registry and persist.
 
@@ -136,7 +137,7 @@ def register_detector(
         # Access list (mirrors datasets): usernames allowed to see/load this
         # detector besides the creator. Empty = private to the creator;
         # ``["*"]`` = visible to everyone. See ``can_user_access_detector``.
-        "readers": [],
+        "readers": list(readers) if readers else [],
     }
     with _lock:
         entries = _ensure_loaded()

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -55,6 +55,8 @@ from vtsearch.schemas.detectors import (
     DetectorRegistryListResponseSchema,
     DetectorRegistryLoadRequestSchema,
     DetectorRegistryLoadResponseSchema,
+    DetectorRegistryReadersRequestSchema,
+    DetectorRegistryReadersResponseSchema,
     DetectorRegistryRenameRequestSchema,
     DetectorRegistryRenameResponseSchema,
     DetectorRegistryUnloadResponseSchema,
@@ -77,13 +79,20 @@ detectors_registry_bp = Blueprint(
 @detectors_registry_bp.route("/api/detectors/registry")
 @detectors_registry_bp.response(200, DetectorRegistryListResponseSchema)
 def list_registered_detectors():
-    """Return all registered detectors with their loaded state and autorun flag."""
-    from vtscore.detectors.registry import get_loaded_detector_ids, list_detectors
+    """Return detectors visible to the current user, with loaded/autorun flags.
+
+    Detectors are user-shared like datasets: each entry is the creator's plus
+    anyone the creator added to ``readers`` (or everyone via ``"*"``). The
+    response also carries ``created_by``, ``readers``, and ``is_owner`` so the
+    dashboard can render the access column and gate the security button.
+    """
+    from vtscore.detectors.registry import get_loaded_detector_ids, list_detectors_for_user
     from vtsearch.settings import get_autorun_detectors
 
     from vtscore.state.core import get_detector_context
 
-    entries = list_detectors()
+    current_user = get_current_user()
+    entries = list_detectors_for_user(current_user)
     loaded_ids = get_loaded_detector_ids()
     autorun_names = set(get_autorun_detectors())
     for entry in entries:
@@ -91,6 +100,9 @@ def list_registered_detectors():
         entry["loaded"] = did in loaded_ids
         entry["autorun"] = entry.get("name", "") in autorun_names
         entry.setdefault("last_trained_at", None)
+        entry.setdefault("created_by", "default")
+        entry.setdefault("readers", [])
+        entry["is_owner"] = entry.get("created_by", "default") == current_user
         entry["detector_loaded"] = did in loaded_ids
         # Expose the loaded detector's recorded embedder so the frontend
         # can detect a cross-embedder switch and trigger a label re-embed
@@ -397,6 +409,7 @@ def _maybe_start_label_reembed(det_ctx, entry: dict) -> str | None:
 @detectors_registry_bp.route("/api/detectors/registry/load", methods=["POST"])
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
 def load_detector_route(body: dict):  # noqa: C901
     """Load a detector into memory and make it active.
@@ -405,6 +418,7 @@ def load_detector_route(body: dict):  # noqa: C901
     detector without loading another one.
     """
     from vtscore.detectors.registry import (
+        can_user_access_detector,
         get_detector,
         is_detector_loaded,
     )
@@ -422,6 +436,8 @@ def load_detector_route(body: dict):  # noqa: C901
         entry = get_detector(detector_id)
         if entry is None:
             abort(404, message="Detector not found")
+        if not can_user_access_detector(detector_id, get_current_user()):
+            abort(403, message="You do not have access to this detector")
 
     if good_votes or bad_votes:
         sync_labels_to_loaded_detector()
@@ -644,14 +660,17 @@ def unload_detector_route(detector_id: str):
 
 @detectors_registry_bp.route("/api/detectors/registry/<detector_id>", methods=["DELETE"])
 @detectors_registry_bp.response(200, DetectorRegistryDeleteResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Only the detector creator can delete it.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
 def delete_registered_detector(detector_id: str):
     """Remove a detector from the registry, including its labelset file."""
-    from vtscore.detectors.registry import get_detector, unregister_detector
+    from vtscore.detectors.registry import get_detector, is_detector_owner, unregister_detector
 
     entry = get_detector(detector_id)
     if entry is None:
         abort(404, message="Detector not found")
+    if not is_detector_owner(detector_id, get_current_user()):
+        abort(403, message="Only the detector creator can delete it")
 
     try:
         det_name = entry.get("name", "")
@@ -711,11 +730,12 @@ def cancel_detector_loading_task(task_id: str):
 @detectors_registry_bp.arguments(DetectorRegistryRenameRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryRenameResponseSchema)
 @detectors_registry_bp.alt_response(400, description="Empty name after stripping.")
+@detectors_registry_bp.alt_response(403, description="Only the detector creator can rename it.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
 def rename_registered_detector(body: dict, detector_id: str):
     """Rename a registered detector and its on-disk labelset file."""
     from vtscore.detectors.labelset_rename import detect_pending_labelset_move
-    from vtscore.detectors.registry import get_detector, rename_detector
+    from vtscore.detectors.registry import get_detector, is_detector_owner, rename_detector
     from vtscore.state.core import get_detector_context
 
     new_name = body["name"].strip()
@@ -725,6 +745,8 @@ def rename_registered_detector(body: dict, detector_id: str):
     entry = get_detector(detector_id)
     if entry is None:
         abort(404, message="Detector not found")
+    if not is_detector_owner(detector_id, get_current_user()):
+        abort(403, message="Only the detector creator can rename it")
 
     pending_move: dict[str, str] | None = None
     old_name = entry.get("name", "")
@@ -818,16 +840,19 @@ def move_labelset_source_file(body: dict, detector_id: str):
 @detectors_registry_bp.route("/api/detectors/registry/<detector_id>/autorun", methods=["PUT"])
 @detectors_registry_bp.arguments(DetectorRegistryAutorunRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryAutorunResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
 @detectors_registry_bp.alt_response(500, description="Detector has no associated name.")
 def set_detector_autorun(body: dict, detector_id: str):
-    """Toggle the autorun flag for a registered detector.
+    """Toggle the calling user's autorun flag for a registered detector.
 
-    The flag is stored in ``settings.json`` under ``autorun_detectors`` so the
-    CLI's ``--autodetect`` flow and the active-dataset ``/api/auto-detect``
-    route both see it.
+    The flag is stored per-user under ``autorun_detectors`` (see
+    :func:`vtsearch.settings.add_autorun_detector`), so each user curates their
+    own Auto-Find list. The CLI's ``--autodetect`` flow reads the running
+    user's list (the built-in ``default`` user falls back to the server
+    settings file). The user must be able to access the detector to flag it.
     """
-    from vtscore.detectors.registry import get_detector
+    from vtscore.detectors.registry import can_user_access_detector, get_detector
     from vtsearch.settings import (
         add_autorun_detector,
         remove_autorun_detector,
@@ -836,6 +861,8 @@ def set_detector_autorun(body: dict, detector_id: str):
     entry = get_detector(detector_id)
     if entry is None:
         abort(404, message="Detector not found")
+    if not can_user_access_detector(detector_id, get_current_user()):
+        abort(403, message="You do not have access to this detector")
 
     flag = body["autorun"]
 
@@ -848,6 +875,32 @@ def set_detector_autorun(body: dict, detector_id: str):
     else:
         remove_autorun_detector(name)
     return {"ok": True, "autorun": flag}
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/detectors/registry/<detector_id>/readers
+# ---------------------------------------------------------------------------
+
+
+@detectors_registry_bp.route("/api/detectors/registry/<detector_id>/readers", methods=["PUT"])
+@detectors_registry_bp.arguments(DetectorRegistryReadersRequestSchema)
+@detectors_registry_bp.response(200, DetectorRegistryReadersResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Only the detector creator can update readers.")
+@detectors_registry_bp.alt_response(404, description="Detector not found.")
+def update_detector_readers(body: dict, detector_id: str):
+    """Update a detector's access list. Only the creator may call this.
+
+    Body: ``{"readers": ["alice", "bob"]}``. Use ``["*"]`` to make the
+    detector visible to all users. Mirrors the dataset readers endpoint.
+    """
+    from vtscore.detectors.registry import set_detector_readers
+
+    readers = body["readers"]
+    ok, err = set_detector_readers(detector_id, readers, get_current_user())
+    if not ok:
+        status = 403 if "creator" in err else 404
+        abort(status, message=err)
+    return {"ok": True, "readers": readers}
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -622,8 +622,53 @@ def auto_detect(body: dict):
 
         record_find(len(all_ids) * len(results))
 
-    return {
+    response = {
         "media_type": media_type,
         "detectors_run": len(results),
         "results": results,
     }
+    auto_export = _run_autofind_export(response)
+    if auto_export is not None:
+        response["auto_export"] = auto_export
+    return response
+
+
+def _run_autofind_export(response: dict) -> dict | None:
+    """Run the configured Auto-Find results exporter on *response*.
+
+    Returns ``None`` when no exporter is configured (the common case), or a
+    status dict ``{exporter, success, message?, error?}`` otherwise. Export
+    failures are reported in the status block rather than raised: the scored
+    results are valuable on their own, so a misconfigured exporter must not
+    sink the whole request. See ``docs/plans/auto-find-settings-tab.md``.
+    """
+    from vtsearch.settings import (  # noqa: PLC0415
+        get_autofind_exporter,
+        get_autofind_exporter_field_values,
+    )
+
+    exporter_name = get_autofind_exporter()
+    if not exporter_name:
+        return None
+
+    from vtscore.exporters import get_exporter  # noqa: PLC0415
+
+    exporter = get_exporter(exporter_name)
+    if exporter is None:
+        return {"exporter": exporter_name, "success": False, "error": f"Unknown exporter '{exporter_name}'"}
+
+    field_values = dict(get_autofind_exporter_field_values().get(exporter_name, {}))
+    try:
+        from vtscore.plugins.normalize import normalize_field_values  # noqa: PLC0415
+
+        normalize_field_values(exporter, field_values)
+        outcome = exporter.export(response, field_values) or {}
+    except Exception as exc:  # noqa: BLE001 - surfaced to the caller, never raised
+        logger.exception("Auto-Find export via %s failed", exporter_name)
+        return {"exporter": exporter_name, "success": False, "error": str(exc)}
+
+    status = {"exporter": exporter_name, "success": True, "message": outcome.get("message", "Export complete.")}
+    for key, value in outcome.items():
+        if key != "message":
+            status[key] = value
+    return status

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -287,6 +287,49 @@ def _apply_enable_achievements_guarded(value) -> None:
         abort(400, message=str(exc))
 
 
+def _apply_autofind_exporter(value) -> None:
+    """Validate the Auto-Find results exporter name and persist it.
+
+    ``""``/``None`` clears auto-export. Any other value must name a
+    registered (pickable) exporter; an unknown name aborts 400. Field
+    values are validated lazily at export time against the chosen
+    plugin's schema, not here.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        settings.set_autofind_exporter("")
+        return
+    if not isinstance(value, str):
+        abort(400, message="autofind_exporter must be a string")
+    from vtscore.exporters import list_exporters
+
+    name = value.strip()
+    valid = {exp.name for exp in list_exporters() if not getattr(exp, "hidden_from_picker", False)}
+    if name not in valid:
+        abort(400, message=f"Unknown exporter {name!r}. Available: {sorted(valid)}")
+    settings.set_autofind_exporter(name)
+
+
+def _apply_autofind_exporter_field_values(value) -> None:
+    """Validate and persist the per-exporter ``{name: {key: value}}`` map.
+
+    ``None`` clears every exporter's stored config. Otherwise the value
+    must be a dict whose entries are themselves ``{str: str}`` dicts;
+    non-string values are coerced to strings so the persisted shape stays
+    flat (exporter fields are always rendered/sent as strings).
+    """
+    if value is None:
+        settings.set_autofind_exporter_field_values({})
+        return
+    if not isinstance(value, dict):
+        abort(400, message="autofind_exporter_field_values must be a dict")
+    cleaned: dict[str, dict[str, str]] = {}
+    for exp_name, fvals in value.items():
+        if not isinstance(exp_name, str) or not isinstance(fvals, dict):
+            abort(400, message="autofind_exporter_field_values must map exporter names to field dicts")
+        cleaned[exp_name] = {str(k): "" if v is None else str(v) for k, v in fvals.items()}
+    settings.set_autofind_exporter_field_values(cleaned)
+
+
 def _apply_saved_datasets_dir(value) -> None:
     _apply_dir("saved_datasets_dir", value, settings.set_saved_datasets_dir)
 
@@ -305,6 +348,8 @@ _CUSTOM_SETTERS: dict[str, Callable[[Any], None]] = {
     "enable_achievements": _apply_enable_achievements_guarded,
     "solo_media_type": _apply_solo_media_type,
     "solo_embedder_per_media_type": _apply_solo_embedder_per_media_type,
+    "autofind_exporter": _apply_autofind_exporter,
+    "autofind_exporter_field_values": _apply_autofind_exporter_field_values,
 }
 
 

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -273,6 +273,10 @@ class DetectorRegistryEntrySchema(Schema):
     media_example = fields.String()
     created_by = fields.String()
     created_at = fields.Float()
+    # Access list (mirrors datasets): usernames allowed besides the creator,
+    # ``["*"]`` = public. ``is_owner`` is computed per-request for the caller.
+    readers = fields.List(fields.String())
+    is_owner = fields.Boolean()
     loaded = fields.Boolean()
     detector_loaded = fields.Boolean()
     autorun = fields.Boolean()

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -497,6 +497,11 @@ class AutoDetectResponseSchema(Schema):
         values=fields.Nested(_AutoDetectResultSchema),
         required=True,
     )
+    # Present only when an Auto-Find results exporter is configured: the
+    # outcome of auto-exporting these results. ``{exporter, success,
+    # message?, error?, ...}`` (extra keys like ``filepath`` may appear for
+    # file-based exporters). See ``docs/plans/auto-find-settings-tab.md``.
+    auto_export = fields.Dict(keys=fields.String(), values=fields.Raw(), required=False)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -68,9 +68,19 @@ The labelset-element shape is shared with :mod:`vtsearch.schemas.labels`.
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, ValidationError, fields, validate
 
 from vtsearch.schemas.labels import LabeledElementSchema
+
+
+def _list_of_strings(value):
+    """Validator: *value* must be a ``list`` whose every entry is a ``str``.
+
+    Mirrors the dataset readers validator so non-string items are rejected at
+    the schema layer (422) rather than coerced.
+    """
+    if not isinstance(value, list) or not all(isinstance(r, str) for r in value):
+        raise ValidationError("Must be a list of strings.")
 
 
 class _ExampleSchema(Schema):
@@ -400,6 +410,32 @@ class DetectorRegistryAutorunResponseSchema(Schema):
 
     ok = fields.Boolean(required=True)
     autorun = fields.Boolean(required=True)
+
+
+class DetectorRegistryReadersRequestSchema(Schema):
+    """Body for ``PUT /api/detectors/registry/<id>/readers``.
+
+    Declared as ``fields.Raw`` with a custom validator (rather than
+    ``fields.List(fields.String())``) so non-string items are rejected as 422
+    instead of being silently coerced. Mirrors the dataset readers schema.
+    """
+
+    readers = fields.Raw(
+        required=True,
+        validate=_list_of_strings,
+        metadata={
+            "description": 'List of usernames; ``["*"]`` makes the detector public.',
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    )
+
+
+class DetectorRegistryReadersResponseSchema(Schema):
+    """Response for ``PUT /api/detectors/registry/<id>/readers``."""
+
+    ok = fields.Boolean(required=True)
+    readers = fields.List(fields.String(), required=True)
 
 
 class DetectorCancelResponseSchema(Schema):

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -111,17 +111,19 @@ class AppSettingsSchema(Schema):
     detectors_dir = fields.String(dump_only=True)
     max_concurrent_dataset_downloads = fields.Integer(dump_only=True)
     max_concurrent_dataset_embeddings = fields.Integer(dump_only=True)
-    autorun_detectors = fields.List(fields.String(), dump_only=True)
-    # Auto-Find results exporter (server-tier but editable from the Auto-Find
-    # tab). ``autofind_exporter`` is the chosen exporter name ("" = none);
-    # ``autofind_exporter_field_values`` keeps each exporter's field values
-    # under its own name so switching the picker preserves prior config.
+    dataset_max_age_days = fields.Integer(load_default=None, allow_none=True)
+
+    # Auto-Find (per-user, editable from the Auto-Find settings tab).
+    # ``autorun_detectors`` is each user's own list of detectors that auto-run
+    # on import; ``autofind_exporter`` is the chosen results-exporter name
+    # ("" = none); ``autofind_exporter_field_values`` keeps each exporter's
+    # field values under its own name so switching the picker preserves config.
+    autorun_detectors = fields.List(fields.String())
     autofind_exporter = fields.String()
     autofind_exporter_field_values = fields.Dict(
         keys=fields.String(),
         values=fields.Dict(keys=fields.String(), values=fields.String()),
     )
-    dataset_max_age_days = fields.Integer(load_default=None, allow_none=True)
     # Effective ``{plugin_family: [name, ...]}`` hide map (the persisted
     # ``hidden_plugins`` server setting unioned with any ``--hide-plugin``
     # CLI flags). Populated by the route from

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -112,6 +112,15 @@ class AppSettingsSchema(Schema):
     max_concurrent_dataset_downloads = fields.Integer(dump_only=True)
     max_concurrent_dataset_embeddings = fields.Integer(dump_only=True)
     autorun_detectors = fields.List(fields.String(), dump_only=True)
+    # Auto-Find results exporter (server-tier but editable from the Auto-Find
+    # tab). ``autofind_exporter`` is the chosen exporter name ("" = none);
+    # ``autofind_exporter_field_values`` keeps each exporter's field values
+    # under its own name so switching the picker preserves prior config.
+    autofind_exporter = fields.String()
+    autofind_exporter_field_values = fields.Dict(
+        keys=fields.String(),
+        values=fields.Dict(keys=fields.String(), values=fields.String()),
+    )
     dataset_max_age_days = fields.Integer(load_default=None, allow_none=True)
     # Effective ``{plugin_family: [name, ...]}`` hide map (the persisted
     # ``hidden_plugins`` server setting unioned with any ``--hide-plugin``
@@ -211,6 +220,12 @@ class SettingsUpdateSchema(Schema):
     browse_compact = fields.Raw()
 
     autorun_detectors = fields.List(fields.String())
+    # Auto-Find results exporter. ``autofind_exporter`` is validated against the
+    # exporter registry in the route layer; ``autofind_exporter_field_values``
+    # is a free-form ``{exporter_name: {field_key: value}}`` map (per-field
+    # validation runs at export time against the chosen plugin's schema).
+    autofind_exporter = fields.String()
+    autofind_exporter_field_values = fields.Raw()
 
     saved_datasets_dir = fields.String()
     detectors_dir = fields.String()

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -248,6 +248,8 @@ _SERVER_KEYS: frozenset[str] = frozenset(ServerSettings.model_fields.keys())
 #: should not be reset by the Default button).
 _EXCLUDE_FROM_DEFAULTS = {
     "autorun_detectors",
+    "autofind_exporter",
+    "autofind_exporter_field_values",
     "saved_datasets_dir",
     "detectors_dir",
     "settings_source",

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -1437,22 +1437,38 @@ def set_autorun_detectors(value: list[str]) -> None:
 
 
 def add_autorun_detector(name: str) -> None:
-    """Add a detector name to the current user's autorun list (idempotent)."""
-    current = get_autorun_detectors()
-    if name not in current:
-        set_autorun_detectors([*current, name])
+    """Add a detector name to the current user's autorun list (idempotent).
+
+    Atomic per-user read-modify-write: ``mutate_user`` re-reads the on-disk
+    file under the cross-process lock, so a concurrent writer's entry is
+    merged rather than clobbered. The ``seed`` captures the effective value
+    (including the default-user read-through) for the first write, before the
+    user has any entry of its own.
+    """
+    seed = get_autorun_detectors()
+
+    def _add(cache: dict[str, Any]) -> None:
+        base = cache["autorun_detectors"] if "autorun_detectors" in cache else seed
+        cache["autorun_detectors"] = list(dict.fromkeys([*base, name]))
+
+    mutate_user(_add)
 
 
 def remove_autorun_detector(name: str) -> bool:
     """Remove a detector name from the current user's autorun list.
 
-    Returns ``True`` if the name was present.
+    Returns ``True`` if the name was present (pre-read). Atomic per-user RMW,
+    same merge semantics as :func:`add_autorun_detector`.
     """
-    current = get_autorun_detectors()
-    if name not in current:
-        return False
-    set_autorun_detectors([n for n in current if n != name])
-    return True
+    seed = get_autorun_detectors()
+    found = name in seed
+
+    def _remove(cache: dict[str, Any]) -> None:
+        base = cache["autorun_detectors"] if "autorun_detectors" in cache else seed
+        cache["autorun_detectors"] = [n for n in base if n != name]
+
+    mutate_user(_remove)
+    return found
 
 
 def is_autorun_detector(name: str) -> bool:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -707,9 +707,7 @@ def _maybe_migrate_legacy_settings_locked() -> None:
     # keys; leave them in place rather than moving them into the default user's
     # file (which would also rewrite a CLI ``--settings`` file under the user).
     legacy_user_entries = {
-        k: v
-        for k, v in _server_cache.items()
-        if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS
+        k: v for k, v in _server_cache.items() if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS
     }
     if not legacy_user_entries:
         return
@@ -735,9 +733,7 @@ def _maybe_migrate_legacy_settings_locked() -> None:
     # in-memory cache, or _server_cache and disk would silently diverge. Keep
     # the default-user fallback keys in the server file (they are read through
     # there, not migrated out).
-    new_server = {
-        k: v for k, v in _server_cache.items() if k in _SERVER_KEYS or k in _DEFAULT_USER_FALLBACK_KEYS
-    }
+    new_server = {k: v for k, v in _server_cache.items() if k in _SERVER_KEYS or k in _DEFAULT_USER_FALLBACK_KEYS}
     try:
         _atomic_write(_server_settings_path(), new_server)
     except Exception as exc:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -992,8 +992,8 @@ def get_all() -> dict[str, Any]:
     # plain ``result.update(server_copy)`` above would otherwise leak a legacy
     # server-file autorun list to every named user.
     result["autorun_detectors"] = get_autorun_detectors()
-    result["autofind_exporter"] = get_autofind_exporter()  # noqa: F821  # autogen'd accessor
-    result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()  # noqa: F821  # autogen'd accessor
+    result["autofind_exporter"] = get_autofind_exporter()  # type: ignore[name-defined]  # noqa: F821
+    result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()  # type: ignore[name-defined]  # noqa: F821
     return result
 
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -996,8 +996,8 @@ def get_all() -> dict[str, Any]:
     # plain ``result.update(server_copy)`` above would otherwise leak a legacy
     # server-file autorun list to every named user.
     result["autorun_detectors"] = get_autorun_detectors()
-    result["autofind_exporter"] = get_autofind_exporter()
-    result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()
+    result["autofind_exporter"] = get_autofind_exporter()  # noqa: F821  # autogen'd accessor
+    result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()  # noqa: F821  # autogen'd accessor
     return result
 
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -244,6 +244,18 @@ def __getattr__(name: str) -> Any:
 #: Reading ``model_fields`` doesn't instantiate the model, so this stays eager.
 _SERVER_KEYS: frozenset[str] = frozenset(ServerSettings.model_fields.keys())
 
+#: Per-user keys for which the built-in "default" user reads through to the
+#: *server* settings file when the key is absent from its own per-user file.
+#: These are the Auto-Find knobs: per-user in multi-user deployments, but the
+#: single-user GUI (everyone is "default") and the CLI ``--settings`` flat file
+#: still expect a value placed in ``settings.json`` to take effect. The
+#: read-through (see :func:`_read_value`) makes that work without the
+#: destructive legacy migration moving them out of the server file (see
+#: :func:`_maybe_migrate_legacy_settings_locked`, which skips these keys).
+_DEFAULT_USER_FALLBACK_KEYS: frozenset[str] = frozenset(
+    {"autorun_detectors", "autofind_exporter", "autofind_exporter_field_values"}
+)
+
 #: Keys excluded from the "defaults" endpoint (infrastructure settings that
 #: should not be reset by the Default button).
 _EXCLUDE_FROM_DEFAULTS = {
@@ -690,7 +702,15 @@ def _maybe_migrate_legacy_settings_locked() -> None:
         return
     _legacy_migrated = True
     assert _server_cache is not None
-    legacy_user_entries = {k: v for k, v in _server_cache.items() if k not in _SERVER_KEYS}
+    # ``_DEFAULT_USER_FALLBACK_KEYS`` legitimately live in the server file (the
+    # default user reads through to them), so they are NOT "orphaned per-user"
+    # keys; leave them in place rather than moving them into the default user's
+    # file (which would also rewrite a CLI ``--settings`` file under the user).
+    legacy_user_entries = {
+        k: v
+        for k, v in _server_cache.items()
+        if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS
+    }
     if not legacy_user_entries:
         return
 
@@ -711,16 +731,20 @@ def _maybe_migrate_legacy_settings_locked() -> None:
         logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
         return
 
-    # Build the server-tier-only shape first; a failure here must not pop
-    # the in-memory cache, or _server_cache and disk would silently diverge.
-    new_server = {k: v for k, v in _server_cache.items() if k in _SERVER_KEYS}
+    # Build the server-tier shape first; a failure here must not pop the
+    # in-memory cache, or _server_cache and disk would silently diverge. Keep
+    # the default-user fallback keys in the server file (they are read through
+    # there, not migrated out).
+    new_server = {
+        k: v for k, v in _server_cache.items() if k in _SERVER_KEYS or k in _DEFAULT_USER_FALLBACK_KEYS
+    }
     try:
         _atomic_write(_server_settings_path(), new_server)
     except Exception as exc:
         logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
         return
     for k in list(_server_cache.keys()):
-        if k not in _SERVER_KEYS:
+        if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS:
             _server_cache.pop(k, None)
 
     # Refresh the default user's cache if it was already materialised
@@ -837,7 +861,18 @@ def _read_value(key: str) -> Any:
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
-    return _ensure_user_loaded(username).get(key, _user_defaults().get(key))
+    user_cache = _ensure_user_loaded(username)
+    if key in user_cache:
+        return user_cache[key]
+    # Default-user read-through: the single-user GUI and the CLI ``--settings``
+    # flat file carry these Auto-Find keys in the server settings file. Honor
+    # them for the built-in "default" user when not set in its own file, so
+    # those workflows keep working without making the setting truly server-wide.
+    if username == "default" and key in _DEFAULT_USER_FALLBACK_KEYS:
+        server_cache = _ensure_server_loaded()
+        if key in server_cache:
+            return server_cache[key]
+    return _user_defaults().get(key)
 
 
 def _write_value(key: str, value: Any) -> None:
@@ -956,6 +991,13 @@ def get_all() -> dict[str, Any]:
     result["focus_mode_right"] = get_focus_mode_right()
     result["panel_pct_left"] = get_panel_pct_left()
     result["panel_pct_right"] = get_panel_pct_right()
+    # Auto-Find keys go through their accessors so the default-user read-through
+    # (and per-user isolation for named users) is applied consistently: the
+    # plain ``result.update(server_copy)`` above would otherwise leak a legacy
+    # server-file autorun list to every named user.
+    result["autorun_detectors"] = get_autorun_detectors()
+    result["autofind_exporter"] = get_autofind_exporter()
+    result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()
     return result
 
 
@@ -1377,59 +1419,40 @@ def apply_user_solo_embedder_per_media_type(value: dict[str, str] | None) -> Non
 
 
 def get_autorun_detectors() -> list[str]:
-    """Return the list of detector names flagged for autorun.
+    """Return the current user's list of detector names flagged for autorun.
 
     Each name maps to a JSON file under ``data/detectors/``; scoring resolves
     the labelset's origins, re-embeds, trains an MLP, and applies it to the
-    loaded dataset.
+    loaded dataset. Per-user (with a read-through to the server file for the
+    built-in "default" user; see :func:`_read_value`).
     """
-    with _settings_lock:
-        raw = _ensure_server_loaded().get("autorun_detectors", [])
-        if isinstance(raw, list):
-            return list(raw)
-        return []
+    raw = _read_value("autorun_detectors")
+    return list(raw) if isinstance(raw, list) else []
 
 
 def set_autorun_detectors(value: list[str]) -> None:
-    """Set and persist the full list of autorun detector names."""
-    _ensure_server_loaded()
+    """Set and persist the current user's full autorun detector list."""
     deduped = list(dict.fromkeys(value))  # dedupe, preserve order
-    _mutate_server_locked(lambda c: c.__setitem__("autorun_detectors", deduped))
+    _write_value("autorun_detectors", deduped)
 
 
 def add_autorun_detector(name: str) -> None:
-    """Add a detector name to the autorun list (idempotent).
-
-    Single read-modify-write under the file lock: two processes adding
-    different names concurrently can no longer clobber each other's
-    addition.
-    """
-    _ensure_server_loaded()
-
-    def _add(cache: dict[str, Any]) -> None:
-        current = list(cache.get("autorun_detectors", []))
-        if name not in current:
-            current.append(name)
-            cache["autorun_detectors"] = current
-
-    _mutate_server_locked(_add)
+    """Add a detector name to the current user's autorun list (idempotent)."""
+    current = get_autorun_detectors()
+    if name not in current:
+        set_autorun_detectors([*current, name])
 
 
 def remove_autorun_detector(name: str) -> bool:
-    """Remove a detector name from the autorun list. Returns True if found."""
-    _ensure_server_loaded()
-    found = False
+    """Remove a detector name from the current user's autorun list.
 
-    def _remove(cache: dict[str, Any]) -> None:
-        nonlocal found
-        current = list(cache.get("autorun_detectors", []))
-        if name in current:
-            current.remove(name)
-            cache["autorun_detectors"] = current
-            found = True
-
-    _mutate_server_locked(_remove)
-    return found
+    Returns ``True`` if the name was present.
+    """
+    current = get_autorun_detectors()
+    if name not in current:
+        return False
+    set_autorun_detectors([n for n in current if n != name])
+    return True
 
 
 def is_autorun_detector(name: str) -> bool:

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -144,6 +144,17 @@ class ServerSettings(BaseModel):
     )
     autorun_detectors: list[str] = Field(default_factory=list)
 
+    # Auto-Find results exporter. After an Auto-Find (autodetect) run, the
+    # results are handed to this exporter automatically. ``""`` disables
+    # auto-export (the CLI falls back to the ``gui`` exporter; the server route
+    # simply returns results without exporting). Field values are kept
+    # per-exporter (``{exporter_name: {field_key: value}}``) so switching the
+    # picker preserves each exporter's configuration. Server-tier and shared,
+    # like ``autorun_detectors``, but editable from the Settings → Auto-Find
+    # tab. See ``docs/plans/auto-find-settings-tab.md``.
+    autofind_exporter: str = ""
+    autofind_exporter_field_values: dict[str, dict[str, str]] = Field(default_factory=dict)
+
     # Admin-side plugin hiding. Maps a plugin-family id (e.g.
     # ``"converters"``, ``"embedders"``, ``"importers"`` - the keys used by
     # :mod:`vtscore.plugins.inventory`) to a list of plugin ``name``s that

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -142,19 +142,6 @@ class ServerSettings(BaseModel):
     max_concurrent_dataset_embeddings: Annotated[int, _clamp(1, 16)] = Field(
         default_factory=_default_concurrent_embeddings
     )
-    autorun_detectors: list[str] = Field(default_factory=list)
-
-    # Auto-Find results exporter. After an Auto-Find (autodetect) run, the
-    # results are handed to this exporter automatically. ``""`` disables
-    # auto-export (the CLI falls back to the ``gui`` exporter; the server route
-    # simply returns results without exporting). Field values are kept
-    # per-exporter (``{exporter_name: {field_key: value}}``) so switching the
-    # picker preserves each exporter's configuration. Server-tier and shared,
-    # like ``autorun_detectors``, but editable from the Settings → Auto-Find
-    # tab. See ``docs/plans/auto-find-settings-tab.md``.
-    autofind_exporter: str = ""
-    autofind_exporter_field_values: dict[str, dict[str, str]] = Field(default_factory=dict)
-
     # Admin-side plugin hiding. Maps a plugin-family id (e.g.
     # ``"converters"``, ``"embedders"``, ``"importers"`` - the keys used by
     # :mod:`vtscore.plugins.inventory`) to a list of plugin ``name``s that
@@ -209,6 +196,26 @@ class UserSettings(BaseModel):
     autopilot_hard_reds: Annotated[int, _clamp_min(1)] = 4
     autopilot_resort_interval: Annotated[int, _clamp_min(1)] = 10
     autopilot_goal_diversity: Annotated[int, _clamp_min(1)] = 40
+
+    # Auto-Find: each user's own list of detectors that auto-run against a newly
+    # imported dataset, plus what to do with the results. Per-user (everyone
+    # curates their own favorites from the shared detector pool). For the
+    # built-in "default" user, reads fall back to the server settings file when
+    # absent here, so the CLI ``--settings`` flat file and single-user
+    # deployments keep working (see ``_DEFAULT_USER_FALLBACK_KEYS`` and the
+    # read-through in ``vtsearch.settings._read_value``).
+    #
+    # - ``autorun_detectors``: detector names flagged for autorun (each maps to
+    #   a JSON file under ``data/detectors/``).
+    # - ``autofind_exporter``: results-exporter name run after an Auto-Find
+    #   (``""`` = no auto-export; CLI then falls back to the ``gui`` exporter).
+    # - ``autofind_exporter_field_values``: per-exporter field values
+    #   (``{exporter_name: {field_key: value}}``) so switching the picker
+    #   preserves each exporter's configuration.
+    # See ``docs/plans/auto-find-settings-tab.md``.
+    autorun_detectors: list[str] = Field(default_factory=list)
+    autofind_exporter: str = ""
+    autofind_exporter_field_values: dict[str, dict[str, str]] = Field(default_factory=dict)
 
     # VTSBrowse side-panel width (CSS px). The browse view docks a
     # selection panel (selected-item grid + the legend and overview

--- a/vtsearch/shim/__init__.py
+++ b/vtsearch/shim/__init__.py
@@ -175,6 +175,10 @@ def build_core_config(settings_path: str | Path | None = None) -> CoreConfig:
         autopilot_goal_diversity=_settings.get_autopilot_goal_diversity(),
         inclusion=_settings.get_inclusion(),
         data_dir=DATA_DIR,
+        autofind_exporter=_settings.get_autofind_exporter(),
+        autofind_exporter_field_values={
+            name: dict(vals) for name, vals in _settings.get_autofind_exporter_field_values().items()
+        },
     )
 
 


### PR DESCRIPTION
## Summary

A dedicated **Auto-Find** settings tab, made **per-user**, plus a full **per-user access-list model for detectors** that mirrors datasets, and a CLI way to run as (and authenticate) a specific user. See `docs/plans/auto-find-settings-tab.md`.

Rebased onto `dev`; cleanly mergeable (no conflicts). Full suite green: **4762 passed, 1 skipped**; frontend `build:prod` clean; lint/codespell/deptry/pyright/OpenAPI-drift all pass.

## Icons
- **Browser** tab → **eye** glyph (matches the Browse buttons used app-wide).
- **Data Imports** tab → new **import** glyph (rounded box open at the upper-left, arrow flowing into the centre — a deliberate mirror of the export icon).
- New **auto-find** glyph: a magnifying glass inside a ring of three clockwise arrows.

## Auto-Find tab (per-user)
- **Auto-Find detectors** — editable checklist (moved off the read-only Server tab, renamed from "Auto-run detectors"). Drives the per-detector autorun toggle, now persisting into the **caller's own** `autorun_detectors`.
- **Results Exporter** — a sub-tab per pickable exporter (Server JSON File, Server CSV File, Send by Email, Webhook) plus "None"; each renders that exporter's fields, persisted per-exporter.

## Per-user settings
`autorun_detectors` moved `ServerSettings → UserSettings`, joined by `autofind_exporter` and `autofind_exporter_field_values`. The built-in **`default`** user reads through to the server settings file when a key is absent from its own (and the destructive legacy migration skips these keys), so the CLI `--settings` flat file and single-user deployments keep working; named multi-user users get fully isolated lists.

## Detector access-list model (mirrors datasets)
- Registry entries gain `readers` (empty = private, `["*"]` = public) beside `created_by`; new `can_user_access_detector` / `is_detector_owner` / `list_detectors_for_user` / `set_detector_readers`.
- `GET /api/detectors/registry` filters to the current user and returns `created_by`/`readers`/`is_owner`; **load/delete/rename/autorun** enforce access/ownership; new `PUT /api/detectors/registry/<id>/readers`.
- Dashboard: `created_by`/`readers` columns that auto-hide in single-user mode, plus a per-row **security button** → access-list editor (same UX as datasets).

## End-to-end exporter wiring
- **CLI** `--autodetect`: with no explicit `--exporter`, falls back to the running user's configured exporter + field values (via `CoreConfig`).
- **Server** `POST /api/auto-detect`: runs the configured exporter after scoring and returns an `auto_export` status (shown in the results modal). Export failures are reported, never fatal.

## CLI user identity
`--autodetect` defaults to the `default` user; `--user <name> --api-key <key>` authenticates against `data/api_keys.json` (same as the server's `api_key` login) and runs as that user, so their Auto-Find list + exporter apply (e.g. a nightly cron of someone's favorite detectors).

## Backwards compatibility
- "Auto-run detectors" no longer appears on the read-only Server tab — it lives, editable and per-user, on the Auto-Find tab.
- Detector listing is now access-filtered (previously every user saw every detector).

## Tests
New coverage: per-user settings semantics, server-side auto-export, detector ACL (registry + routes + multi-user flow), CLI per-user resolution. Also fixed a pre-existing thread-unsafe `patch.object` leak in dev's concurrent-download test that surfaced under full-suite ordering.

https://claude.ai/code/session_01QwazhDkG4TPjuxVyL3QSSo