### PR TITLE
Frontend offline circuit breaker with manual retry

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,4 +1,5 @@
 <vt-toast-container />
+<vt-offline-banner />
 @if (auth.needsLogin) {
   <vt-login (loggedIn)="auth.checkStatus()" />
 } @else {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { combineLatest } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
 import { ToastContainerComponent } from './components/toast-container/toast-container.component';
+import { OfflineBannerComponent } from './components/offline-banner/offline-banner.component';
 import { AchievementUnlockHostComponent } from './components/achievement-unlock-host/achievement-unlock-host.component';
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
 import { AchievementsModalComponent } from './components/modals/achievements-modal/achievements-modal.component';
@@ -44,6 +45,7 @@ import { isPairCompatible } from './utils/context-compat';
     RouterOutlet,
     DialogHostComponent,
     ToastContainerComponent,
+    OfflineBannerComponent,
     AchievementUnlockHostComponent,
     SettingsModalComponent,
     AchievementsModalComponent,

--- a/frontend/src/app/components/offline-banner/offline-banner.component.html
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.html
@@ -1,0 +1,33 @@
+@if ((connection.status$ | async) === 'offline') {
+  <div class="offline-banner" role="alert" aria-live="assertive">
+    <svg
+      class="offline-banner__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M1 1l14 14" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+      <path
+        d="M3.2 6.4a8 8 0 019.6 0M5.4 9a4.8 4.8 0 015.2 0"
+        stroke="currentColor"
+        stroke-width="1.4"
+        stroke-linecap="round"
+        fill="none"
+      />
+      <circle cx="8" cy="12" r="0.9" fill="currentColor" />
+    </svg>
+    <span class="offline-banner__text">
+      <strong>Can't reach the server.</strong>
+      Background updates are paused.
+    </span>
+    <button
+      type="button"
+      class="offline-banner__retry"
+      (click)="connection.retry()"
+      [disabled]="connection.retrying$ | async"
+    >
+      {{ (connection.retrying$ | async) ? 'Retrying…' : 'Retry' }}
+    </button>
+  </div>
+}

--- a/frontend/src/app/components/offline-banner/offline-banner.component.scss
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.scss
@@ -1,0 +1,65 @@
+.offline-banner {
+  position: fixed;
+  bottom: var(--space-xl);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-offline-banner);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  max-width: min(560px, calc(100vw - 24px));
+  padding: var(--space-md) var(--space-lg);
+  background: var(--bg-panel);
+  border: 1px solid var(--error);
+  border-left: 4px solid var(--error);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  color: var(--text-primary);
+  font-size: var(--font-md);
+  line-height: 1.4;
+  animation: offline-banner-in 180ms ease-out;
+}
+
+@keyframes offline-banner-in {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.offline-banner__icon {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--error);
+}
+
+.offline-banner__text {
+  flex: 1 1 auto;
+  min-width: 0;
+
+  strong {
+    color: var(--error-text);
+    font-weight: var(--weight-semibold);
+  }
+}
+
+.offline-banner__retry {
+  flex: 0 0 auto;
+  background: var(--accent, var(--text-primary));
+  color: var(--accent-text, var(--bg));
+  border: 1px solid transparent;
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  padding: var(--space-xs) var(--space-lg);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.05);
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: default;
+  }
+}

--- a/frontend/src/app/components/offline-banner/offline-banner.component.ts
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ConnectionStateService } from '../../services/connection-state.service';
+
+/**
+ * Bottom-centre banner shown while the frontend's connection circuit
+ * breaker ({@link ConnectionStateService}) is tripped. Mounted once in
+ * `AppComponent`, outside the login gate so it surfaces even on the login
+ * screen. Replaces the per-request "could not reach the server" toasts with
+ * a single persistent surface plus a manual Retry — background polling and
+ * the SSE stream stay paused until the user reconnects.
+ */
+@Component({
+  selector: 'vt-offline-banner',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './offline-banner.component.html',
+  styleUrl: './offline-banner.component.scss',
+})
+export class OfflineBannerComponent {
+  constructor(public connection: ConnectionStateService) {}
+}

--- a/frontend/src/app/interceptors/error.interceptor.ts
+++ b/frontend/src/app/interceptors/error.interceptor.ts
@@ -1,7 +1,13 @@
-import { HttpContextToken, HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import {
+  HttpContextToken,
+  HttpErrorResponse,
+  HttpEventType,
+  HttpInterceptorFn,
+} from '@angular/common/http';
 import { inject } from '@angular/core';
-import { catchError, throwError } from 'rxjs';
+import { catchError, tap, throwError } from 'rxjs';
 import { ActiveContextService } from '../services/active-context.service';
+import { CONNECTION_PROBE, ConnectionStateService } from '../services/connection-state.service';
 import { ErrorContext, ToastService } from '../services/toast.service';
 
 /**
@@ -29,16 +35,56 @@ export const SKIP_ERROR_TOAST = new HttpContextToken<boolean>(() => false);
  * Repeating the same endpoint+status (e.g. a retry loop hammering a
  * broken backend) replaces the existing toast via dedup key rather
  * than stacking duplicates.
+ *
+ * This interceptor is also the chokepoint for the connection circuit
+ * breaker ({@link ConnectionStateService}): it feeds every outcome to the
+ * service (status 0 → network failure, any HTTP response → reachable) and,
+ * while the breaker is tripped, short-circuits every non-probe request with
+ * an immediate synthetic network error. Suppressing the request at the wire
+ * is the only way to stop the browser console flooding with
+ * `net::ERR_CONNECTION_REFUSED` (the browser logs those itself for every
+ * real failed fetch; JS cannot mute them). Raw network errors (status 0) no
+ * longer raise a toast — the offline banner is their single surface.
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const toast = inject(ToastService);
   const ctx = inject(ActiveContextService);
+  const connection = inject(ConnectionStateService);
+
+  // Circuit breaker: while offline, suppress every request except the
+  // recovery probe. Returns a synthetic status-0 error so callers'
+  // existing error handlers (catchError → EMPTY, etc.) behave exactly as
+  // they would for a real network failure, but no request hits the wire.
+  if (connection.isOffline && !req.context.get(CONNECTION_PROBE)) {
+    return throwError(
+      () =>
+        new HttpErrorResponse({
+          status: 0,
+          statusText: 'Offline (client circuit breaker)',
+          url: req.url,
+          error: new Error('Request suppressed: backend is offline. Click Retry to reconnect.'),
+        }),
+    );
+  }
 
   return next(req).pipe(
+    tap((event) => {
+      // Any full response proves the backend is reachable.
+      if (event.type === HttpEventType.Response) connection.recordSuccess();
+    }),
     catchError((err: unknown) => {
       if (!(err instanceof HttpErrorResponse)) {
         return throwError(() => err);
       }
+      if (err.status === 0) {
+        // True network failure: count it toward the offline threshold and
+        // stay silent (no toast); the offline banner is the surface for this.
+        connection.recordNetworkFailure();
+        return throwError(() => err);
+      }
+      // A non-zero HTTP status means the server answered, so it is reachable
+      // even though this request failed — clear any pending offline tally.
+      connection.recordSuccess();
       if (req.context.get(SKIP_ERROR_TOAST)) {
         return throwError(() => err);
       }

--- a/frontend/src/app/services/connection-state.service.spec.ts
+++ b/frontend/src/app/services/connection-state.service.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ConnectionStateService } from './connection-state.service';
+
+describe('ConnectionStateService', () => {
+  let service: ConnectionStateService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ConnectionStateService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('starts online', () => {
+    expect(service.isOffline).toBe(false);
+  });
+
+  it('stays online below the failure threshold', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(false);
+  });
+
+  it('trips offline once consecutive failures reach the threshold', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(true);
+  });
+
+  it('a success resets the failure tally', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    service.recordSuccess();
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(false);
+  });
+
+  it('recordSuccess clears the offline state', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(true);
+    service.recordSuccess();
+    expect(service.isOffline).toBe(false);
+  });
+
+  it('retry() probes /healthz and comes back online on any response', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(true);
+
+    let retrying = false;
+    service.retrying$.subscribe((v) => (retrying = v));
+
+    service.retry();
+    expect(retrying).toBe(true);
+
+    const req = httpMock.expectOne('/healthz');
+    expect(req.request.method).toBe('GET');
+    req.flush('ok');
+
+    expect(service.isOffline).toBe(false);
+    expect(retrying).toBe(false);
+  });
+
+  it('retry() is a no-op while a probe is already in flight', () => {
+    service.retry();
+    // A second call while the first probe is still pending must not enqueue
+    // another request.
+    service.retry();
+    const reqs = httpMock.match('/healthz');
+    expect(reqs.length).toBe(1);
+    reqs[0].flush('ok');
+  });
+});

--- a/frontend/src/app/services/connection-state.service.ts
+++ b/frontend/src/app/services/connection-state.service.ts
@@ -1,0 +1,149 @@
+import {
+  HttpClient,
+  HttpContext,
+  HttpContextToken,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+/**
+ * Marks a request as the connection-recovery probe so the
+ * {@link errorInterceptor} lets it through the offline circuit breaker.
+ *
+ * Every other request is short-circuited while offline (returned an
+ * immediate synthetic network error without touching the wire), which is
+ * what stops the browser console from filling with `net::ERR_CONNECTION_REFUSED`
+ * lines — those are emitted by the browser for every real failed fetch and
+ * cannot be silenced from JS; the only cure is to not make the request. The
+ * probe is the one exception: it is the single request allowed to test the
+ * wire so a manual Retry can discover the backend is back.
+ */
+export const CONNECTION_PROBE = new HttpContextToken<boolean>(() => false);
+
+export type ConnectionStatus = 'online' | 'offline';
+
+/**
+ * Front-end circuit breaker for backend connectivity.
+ *
+ * The app fires a handful of background pollers (votes, labelset, active
+ * jobs, disk/RAM) plus a persistent SSE stream. When the backend goes away
+ * (e.g. `Ctrl-C` on `app.py`) every one of those keeps retrying on its own
+ * timer, flooding the console with connection-refused errors and hammering
+ * the port on restart. This service watches the central
+ * {@link errorInterceptor} for network failures (HTTP status 0), and once a
+ * small number pile up it flips to `offline`. While offline:
+ *
+ *  - the interceptor suppresses every request (no wire traffic, no console
+ *    flood), and
+ *  - {@link ProgressEventsService} closes the SSE EventSource so its native
+ *    auto-reconnect stops trying.
+ *
+ * Recovery is **manual**: nothing probes the backend until the user clicks
+ * Retry (or the browser fires an `online` event after an `offline` one is
+ * intentionally NOT treated as recovery — see the constructor). {@link retry}
+ * sends a single `/healthz` probe; any HTTP response at all (even an error
+ * status) proves the server is reachable and flips back to `online`, which
+ * resumes the pollers and reconnects the stream.
+ *
+ * Per the repo's "no persisted vectors/state" spirit this is purely
+ * in-memory, process-scoped UI state: it exists so the frontend degrades
+ * gracefully while the backend is down, which is exactly the case where
+ * nothing can be persisted anyway.
+ */
+@Injectable({ providedIn: 'root' })
+export class ConnectionStateService {
+  /**
+   * Consecutive network failures needed to declare the backend offline. A
+   * threshold above 1 keeps a single transient blip (one dropped request
+   * while the backend is otherwise healthy) from locking the whole app into
+   * the offline state; with pollers ticking every 1.5–3s a genuinely-down
+   * backend still trips the breaker within a few seconds.
+   */
+  private static readonly OFFLINE_THRESHOLD = 3;
+
+  private readonly statusSubject = new BehaviorSubject<ConnectionStatus>('online');
+  private readonly retryingSubject = new BehaviorSubject<boolean>(false);
+
+  /** Current connectivity, `online` until proven otherwise. */
+  readonly status$ = this.statusSubject.asObservable();
+  /** True while a Retry probe is in flight (drives the button's busy state). */
+  readonly retrying$ = this.retryingSubject.asObservable();
+
+  private consecutiveFailures = 0;
+
+  constructor(private http: HttpClient) {
+    // A browser-level `offline` event (the OS lost its network interface) is
+    // an unambiguous, immediate signal — trip the breaker at once rather
+    // than waiting for the failure threshold. The matching `online` event is
+    // deliberately ignored: recovery is manual (the user's Retry click), and
+    // the network returning does not guarantee the backend is back.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('offline', () => this.goOffline());
+    }
+  }
+
+  get isOffline(): boolean {
+    return this.statusSubject.value === 'offline';
+  }
+
+  get status(): ConnectionStatus {
+    return this.statusSubject.value;
+  }
+
+  /**
+   * Record that a request reached the server (any HTTP response, including
+   * an error status — a 404/500 still proves connectivity). Resets the
+   * failure tally and clears the offline state.
+   */
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    if (this.statusSubject.value !== 'online') {
+      this.statusSubject.next('online');
+    }
+  }
+
+  /**
+   * Record a network-level failure (HTTP status 0: the request never got a
+   * response). Trips the breaker once enough pile up consecutively.
+   */
+  recordNetworkFailure(): void {
+    this.consecutiveFailures += 1;
+    if (this.consecutiveFailures >= ConnectionStateService.OFFLINE_THRESHOLD) {
+      this.goOffline();
+    }
+  }
+
+  private goOffline(): void {
+    if (this.statusSubject.value !== 'offline') {
+      this.statusSubject.next('offline');
+    }
+  }
+
+  /**
+   * Manually probe the backend. Sends a single `/healthz` request that
+   * bypasses the offline circuit breaker; the interceptor records the
+   * outcome (success → back online, network error → still offline), so this
+   * only needs to manage the in-flight flag. No-ops if a probe is already
+   * running.
+   */
+  retry(): void {
+    if (this.retryingSubject.value) return;
+    this.retryingSubject.next(true);
+    this.http
+      .get('/healthz', {
+        context: new HttpContext().set(CONNECTION_PROBE, true),
+        responseType: 'text',
+      })
+      .subscribe({
+        next: () => {
+          this.recordSuccess();
+          this.retryingSubject.next(false);
+        },
+        // A network error leaves us offline (the interceptor already counted
+        // it); any HTTP error status means the server answered, so the
+        // interceptor will have flipped us back online. Either way the probe
+        // is done.
+        error: () => this.retryingSubject.next(false),
+      });
+  }
+}

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,10 +1,12 @@
 import { Injectable, OnDestroy, NgZone } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 import {
   LoadingTask,
   ProgressEvent,
   VotingIterationsResponse,
 } from '../models/api.models';
+import { ConnectionStateService } from './connection-state.service';
 
 /**
  * Single EventSource subscription that fans out progress updates to every
@@ -58,8 +60,20 @@ export class ProgressEventsService implements OnDestroy {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private lastBootId: string | null = null;
 
-  constructor(private zone: NgZone) {
-    this.connect();
+  constructor(
+    private zone: NgZone,
+    private connection: ConnectionStateService,
+  ) {
+    // Track the circuit breaker: stay connected while online, and tear the
+    // EventSource down when the breaker trips so its native auto-reconnect
+    // stops hammering a dead backend. The BehaviorSubject replays the current
+    // status, so this also performs the initial connect.
+    this.connection.status$
+      .pipe(distinctUntilChanged())
+      .subscribe((status) => {
+        if (status === 'offline') this.disconnect();
+        else this.connect();
+      });
   }
 
   ngOnDestroy(): void {
@@ -133,7 +147,12 @@ export class ProgressEventsService implements OnDestroy {
       this.zone.run(() => this.evalSubject.next(this.parse<ProgressEvent>(e, {}))),
     );
 
+    es.onopen = () => this.zone.run(() => this.connection.recordSuccess());
+
     es.onerror = () => {
+      // Feed the circuit breaker: an SSE error is a connectivity signal too,
+      // so a dashboard sitting on only the stream still trips offline.
+      this.connection.recordNetworkFailure();
       // EventSource reconnects on its own for transient failures, but
       // schedules an extra reconnect in case the server closed the stream
       // permanently. Idempotent: if `source` is already non-null the next
@@ -158,6 +177,9 @@ export class ProgressEventsService implements OnDestroy {
 
   private scheduleReconnect(): void {
     if (this.reconnectTimer != null) return;
+    // Don't queue a reconnect while the breaker is tripped — the status$
+    // subscription owns reconnection once we're back online.
+    if (this.connection.isOffline) return;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.connect();

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -70,6 +70,7 @@
   --z-modal-backdrop: 1000;
   --z-modal: 1001;
   --z-burger-menu: 2000;
+  --z-offline-banner: 4500;
   --z-toast: 5000;
   --z-login: 9999;
 


### PR DESCRIPTION
## Problem

`Ctrl-C` on `app.py` floods the browser console with `net::ERR_CONNECTION_REFUSED`. The frontend runs several independent background pollers (votes ~2s, labelset ~1.5s, active jobs ~3s, disk/RAM ~10s) plus a persistent SSE stream that auto-reconnects every 2s. When the backend dies, every one keeps retrying on its own timer — flooding the console and hammering the port on restart. Those red console lines are emitted by the browser for every real failed fetch and **cannot be silenced from JS**; the only cure is to stop making the requests.

## Solution

A frontend-only circuit breaker. After a few consecutive network failures the app flips to an `offline` state and stops all traffic until the user clicks **Retry**.

- **`ConnectionStateService`** (new) — single source of truth (`online`/`offline` + `retrying`). Trips offline after 3 consecutive status-0 failures (so a single transient blip doesn't lock the app), and also on the browser `offline` event. Recovery is **manual**: `retry()` fires one `/healthz` probe; any HTTP response at all proves the server is reachable and flips back online.
- **`error.interceptor`** — the chokepoint. Feeds every outcome to the service (status 0 → network failure; any HTTP response, even an error status → reachable). While offline it **short-circuits every non-probe request** with an immediate synthetic status-0 error, so callers' existing `catchError` handlers behave exactly as for a real failure but nothing hits the wire. Raw network errors no longer raise a toast — the banner is their single surface.
- **`ProgressEventsService`** — gates the SSE EventSource on connection state, closing it when offline so its native auto-reconnect stops hammering, and reconnecting when back online.
- **`OfflineBannerComponent`** (new) — persistent bottom-centre banner with the Retry button, mounted in the app root outside the login gate.

## Behaviour change

Raw status-0 "could not reach the server" toasts are gone; connectivity loss now surfaces through the offline banner instead. A sub-threshold one-off network blip is silent (it recovers before the breaker trips).

## Testing

- `./run-tests.sh core` — all 749 pass (includes ruff / codespell / deptry / frontend `build:prod` check).
- `npm run build:prod` — clean, no budget warnings.
- Added `connection-state.service.spec.ts` covering the threshold, recovery, and the single-flight retry probe.

https://claude.ai/code/session_01Q1E21MrsQqCsokH1wSw5HZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1E21MrsQqCsokH1wSw5HZ)_