### PR TITLE
Add generic SLURM GPU cluster (Grid) launch scripts + SETUP guide

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,6 +16,11 @@
   - [GPU](#gpu)
   - [Data persistence](#data-persistence)
   - [Rebuilding](#rebuilding)
+- [Running on a SLURM GPU cluster (Grid)](#running-on-a-slurm-gpu-cluster-grid)
+  - [One-time setup on the cluster](#one-time-setup-on-the-cluster)
+  - [One-time setup on your laptop](#one-time-setup-on-your-laptop)
+  - [Daily workflow](#daily-workflow)
+  - [Tuning the allocation](#tuning-the-allocation)
 - [Running the tests](#running-the-tests)
 - [Environment variables](#environment-variables)
 - [Next steps](#next-steps)
@@ -372,6 +377,158 @@ docker compose -f docker/compose/docker-compose.labbench.yml build  # LabBench (
 ```
 
 Add `--no-cache` to force a full rebuild (e.g. after dependency changes).
+
+## Running on a SLURM GPU cluster (Grid)
+
+VTSearch is happiest with a GPU (for embedding and detector training). On a
+shared SLURM cluster — like the JHU HLTCOE "Grid" — you don't run heavy work on
+the login nodes; you ask SLURM for a GPU compute node and run the app there,
+then forward its port back to your laptop so you can use the browser UI.
+
+Two helper scripts in [`scripts/grid/`](../scripts/grid/) automate the loop:
+
+- **`vtsearch-grid.sh`** runs *on the cluster*. It allocates a GPU node with
+  `srun`, activates the virtualenv, and runs `app.py` on the node — printing
+  which node it landed on. It holds the allocation until you quit.
+- **`vtsearch-tunnel.sh`** runs *on your laptop*. It finds your running
+  VTSearch job, SSH-forwards `localhost:5000` to that compute node, and drops
+  you into the project directory for git/edits.
+
+Both scripts are parameterized entirely by environment variables (no hard-coded
+usernames, hostnames, or paths), so they should adapt to most SLURM clusters
+with a shared filesystem.
+
+### One-time setup on the cluster
+
+1. **SSH in** to a login node and clone VTSearch onto the cluster's shared
+   filesystem. Many clusters give each user a large scratch/experiment area
+   (the HLTCOE Grid uses `/exp/$USER`); the helper scripts default to
+   `/exp/$USER/projects/VTSearch`, but you can put it anywhere and set
+   `VTS_DIR` (see [Tuning](#tuning-the-allocation)).
+
+   ```bash
+   mkdir -p /exp/$USER/projects && cd /exp/$USER/projects
+   git clone git@github.com:samggreenberg/VTSearch.git
+   cd VTSearch
+   ```
+
+2. **Create the virtualenv and install the GPU dependencies.** Match the CUDA
+   wheel to your cluster's drivers (HLTCOE L40S nodes use CUDA 12.4 → `cu124`):
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   bash scripts/install-gpu.sh cu124     # or cu121 / cu118 to match your cluster
+   ```
+
+   The scripts default to a venv named `.venv` in the project dir; override with
+   `VTS_VENV` if yours differs.
+
+3. **Build the frontend** (needs Node.js 22+; see [Building the
+   frontend](#building-the-frontend)):
+
+   ```bash
+   cd frontend && npm install && npm run build:prod && cd ..
+   ```
+
+4. **Install the launcher on your PATH** so you can just type `vtsearch`:
+
+   ```bash
+   mkdir -p ~/.local/bin
+   cp scripts/grid/vtsearch-grid.sh ~/.local/bin/vtsearch
+   chmod +x ~/.local/bin/vtsearch
+   ```
+
+   > **Tip:** caches (HuggingFace, pip, etc.) can be large; on clusters where
+   > `/home` is small, redirect them onto your scratch area in `~/.bashrc`
+   > (e.g. `export HF_HOME=/exp/$USER/.cache/huggingface`). Setting `HF_TOKEN`
+   > there too avoids anonymous Hugging Face rate limits on a shared egress IP.
+
+### One-time setup on your laptop
+
+1. **Add an SSH host entry** for the cluster login node so the tunnel script
+   can reach it by a short name. In `~/.ssh/config`:
+
+   ```sshconfig
+   Host grid
+       HostName login.your-cluster.edu     # e.g. login1.hltcoe.jhu.edu
+       User your-cluster-username
+       IdentityFile ~/.ssh/id_ed25519
+   ```
+
+   Verify it works: `ssh grid true` should connect without prompting. If your
+   cluster is only reachable through a VPN or campus network, connect to that
+   first.
+
+2. **Install the tunnel script** on your PATH:
+
+   ```bash
+   mkdir -p ~/.local/bin
+   cp scripts/grid/vtsearch-tunnel.sh ~/.local/bin/vtsearch-tunnel
+   chmod +x ~/.local/bin/vtsearch-tunnel
+   ```
+
+   (Clone VTSearch on your laptop too, or just copy the one script — it only
+   needs SSH access to the cluster.) If you named your SSH host something other
+   than `grid`, point the script at it with `GRID_HOST=mycluster vtsearch-tunnel`.
+
+### Daily workflow
+
+1. **On the cluster**, start VTSearch and leave the terminal running:
+
+   ```bash
+   ssh grid
+   vtsearch
+   ```
+
+   This queues a GPU allocation; once it lands, the app starts and the terminal
+   prints the compute node it got. Keep this terminal open — closing it releases
+   the node.
+
+2. **On your laptop**, in a second terminal, open the tunnel:
+
+   ```bash
+   vtsearch-tunnel
+   ```
+
+   It finds the running job automatically (no need to know the node name),
+   forwards `localhost:5000`, and drops you into the project directory on the
+   login node for git pulls / edits. Browse **http://localhost:5000**.
+
+3. **To pick up code changes**: pull on the cluster, then in the `vtsearch`
+   terminal press **Ctrl+C** (this stops `app.py` but *keeps* the GPU node) and
+   press **Enter** to restart the app. Press **q** then Enter to release the
+   node and quit.
+
+> Interactive SLURM jobs don't persist — you re-allocate each session. Only run
+> **one** `app.py` per allocation; VTSearch keeps all model/dataset state in one
+> process, and a second copy would double the memory and can OOM the job.
+
+### Tuning the allocation
+
+`vtsearch-grid.sh` reads these environment variables (defaults shown). Set them
+inline, e.g. `VTS_MEM=64G VTS_GPU=a100 vtsearch`:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `VTS_DIR` | `/exp/$USER/projects/VTSearch` | Path to the VTSearch checkout on the cluster |
+| `VTS_VENV` | `.venv` | Virtualenv to activate (relative to `VTS_DIR`, or absolute) |
+| `VTS_PART` | `gpu` | SLURM partition |
+| `VTS_GPU` | `l40s` | GPU type requested via `--gres=gpu:<type>:1` |
+| `VTS_CPUS` | `8` | CPU cores |
+| `VTS_MEM` | `48G` | Memory (headroom for two model loads in one process) |
+| `VTS_TIME` | `8:00:00` | Walltime |
+
+`vtsearch-tunnel.sh` reads:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `GRID_HOST` | `grid` | SSH host alias for the cluster login node |
+| `VTS_DIR` | `/exp/$USER/projects/VTSearch` | Project dir to drop into on the login node |
+
+Adjust `VTS_GPU`, `VTS_PART`, and the CUDA wheel in `install-gpu.sh` to match
+your cluster's hardware. Check what's available with `sinfo` and your cluster's
+documentation.
 
 ## Running the tests
 

--- a/scripts/grid/README.md
+++ b/scripts/grid/README.md
@@ -1,0 +1,32 @@
+# Running VTSearch on a SLURM GPU cluster
+
+VTSearch needs a GPU to be comfortable (embedding + training), and on a shared
+SLURM cluster you don't run anything heavy on the login nodes. These two helper
+scripts make the day-to-day loop a two-command affair:
+
+| Script | Runs on | What it does |
+|--------|---------|--------------|
+| [`vtsearch-grid.sh`](vtsearch-grid.sh) | the **cluster** (a login node) | Allocates a GPU compute node with `srun`, activates the venv, and runs `app.py` on it. Prints the node it landed on. Holds the allocation until you quit. |
+| [`vtsearch-tunnel.sh`](vtsearch-tunnel.sh) | your **laptop** | Finds your running VTSearch job, SSH-forwards `localhost:5000` to that compute node, and drops you into the project dir. |
+
+Both are parameterized by environment variables (no hard-coded usernames,
+hostnames, or paths) so they should work on most SLURM clusters with a shared
+filesystem. See the comment block at the top of each script for the knobs, and
+[`docs/SETUP.md`](../../docs/SETUP.md#running-on-a-slurm-gpu-cluster-grid) for a
+full first-time walkthrough.
+
+## Quick start
+
+On the cluster (after cloning VTSearch and setting up the venv + frontend):
+
+```bash
+cp scripts/grid/vtsearch-grid.sh ~/.local/bin/vtsearch && chmod +x ~/.local/bin/vtsearch
+vtsearch          # allocates a GPU node and starts the app; leave it running
+```
+
+On your laptop (after adding a `grid` host to `~/.ssh/config`):
+
+```bash
+cp scripts/grid/vtsearch-tunnel.sh ~/.local/bin/vtsearch-tunnel && chmod +x ~/.local/bin/vtsearch-tunnel
+vtsearch-tunnel   # forwards localhost:5000 to the GPU node; browse there
+```

--- a/scripts/grid/vtsearch-grid.sh
+++ b/scripts/grid/vtsearch-grid.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Allocate a GPU node on a SLURM cluster and run VTSearch on it.
+#
+# Run this in a terminal ON THE CLUSTER (a login node) and LEAVE IT RUNNING --
+# it holds the SLURM allocation and the app. When the allocation lands, it
+# prints the compute node it got and a hint for the tunnel script you run on
+# your laptop (see scripts/grid/vtsearch-tunnel.sh).
+#
+# Ctrl+C stops the APP but KEEPS the node, then offers to restart it (handy
+# after a git pull / code edit). Type q at that prompt to release the node and
+# quit.
+#
+# Install: copy this somewhere on your PATH on the cluster and make it
+# executable, e.g.
+#     cp scripts/grid/vtsearch-grid.sh ~/.local/bin/vtsearch && chmod +x ~/.local/bin/vtsearch
+#
+# Override any default with an env var, e.g.:  VTS_MEM=64G VTS_GPU=a100 vtsearch
+set -u
+
+# --- Allocation knobs (override via env vars) -------------------------------
+# Where the VTSearch checkout lives on the cluster's shared filesystem. Default
+# follows the common "/exp/$USER" convention; set VTS_DIR if yours differs.
+DIR=${VTS_DIR:-/exp/$USER/projects/VTSearch}
+# Path (relative to $DIR, or absolute) to the Python virtualenv to activate.
+VENV=${VTS_VENV:-.venv}
+PART=${VTS_PART:-gpu}       # SLURM partition
+GPU=${VTS_GPU:-l40s}        # GPU type for --gres=gpu:<type>:1
+CPUS=${VTS_CPUS:-8}         # CPU cores
+MEM=${VTS_MEM:-48G}         # memory (one app.py needs headroom for two model loads)
+TIME=${VTS_TIME:-8:00:00}   # walltime
+
+echo ">>> Requesting 1x $GPU, $CPUS cores, $MEM, ${TIME} walltime on partition '$PART'..."
+echo ">>> (this may queue; once it lands, VTSearch starts and prints its node + tunnel hint)"
+
+# Export the resolved dir/venv so they survive into the srun child shell.
+export VTS_DIR="$DIR" VTS_VENV="$VENV"
+
+exec srun --job-name=vtsearch --pty \
+    -p "$PART" --gres=gpu:${GPU}:1 -c "$CPUS" --mem "$MEM" -t "$TIME" \
+    bash -lc '
+        # A no-op INT handler keeps THIS wrapper alive on Ctrl+C while still
+        # letting child processes (python) take the default SIGINT and die.
+        trap ":" INT
+        cd "$VTS_DIR" || { echo "project dir missing: $VTS_DIR (set VTS_DIR)"; exit 1; }
+        source "$VTS_VENV/bin/activate" || { echo "venv missing: $VTS_VENV (set VTS_VENV)"; exit 1; }
+        node=$(hostname)
+        echo
+        echo "========================================================="
+        echo "  VTSearch node: $node   (branch: $(git branch --show-current 2>/dev/null))"
+        echo "  On your LAPTOP, in a new terminal, run:"
+        echo "      vtsearch-tunnel        (then browse http://localhost:5000)"
+        echo "========================================================="
+        while true; do
+            echo
+            echo ">>> Starting app.py  (Ctrl+C stops it but keeps the node)..."
+            echo
+            # Embedders run on CPU; give torch all the cores SLURM gave us
+            # (default is 1 thread, which is painfully slow for SigLIP etc.).
+            VTSEARCH_TORCH_THREADS=${SLURM_CPUS_ON_NODE:-8} python app.py
+            echo
+            echo ">>> app.py stopped. GPU node ($node) is still yours."
+            printf ">>> [Enter] = restart (picks up code changes)   |   q + [Enter] = quit & release node: "
+            read -r ans || break
+            [ "$ans" = "q" ] && break
+        done
+        echo ">>> Releasing the allocation. Bye."
+    '

--- a/scripts/grid/vtsearch-tunnel.sh
+++ b/scripts/grid/vtsearch-tunnel.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Find your running VTSearch GPU job on the cluster and forward its port to this
+# laptop. Run this ON YOUR LAPTOP, AFTER starting VTSearch on the cluster (the
+# `vtsearch` command from scripts/grid/vtsearch-grid.sh).
+#
+# Browse http://localhost:5000 once it connects. Ctrl+C closes the tunnel.
+#
+# Requires an SSH host entry for the cluster login node. By default this script
+# connects to the host alias `grid`; define it in ~/.ssh/config, e.g.
+#
+#     Host grid
+#         HostName login.your-cluster.edu
+#         User your-cluster-username
+#
+# or point this script at a different alias with:  GRID_HOST=mycluster vtsearch-tunnel
+set -u
+
+GRID_HOST=${GRID_HOST:-grid}
+# Where the VTSearch checkout lives on the cluster (used only to drop you into
+# the project dir for git/edits). Mirrors VTS_DIR in vtsearch-grid.sh.
+VTS_DIR=${VTS_DIR:-/exp/\$USER/projects/VTSearch}
+
+# The login node may be reachable directly (on-campus / same network) or only
+# through a VPN. Rather than guess the path, just probe whether we can actually
+# reach it over SSH.
+echo ">>> Checking connectivity to '$GRID_HOST'..."
+if ! ssh -o BatchMode=yes -o ConnectTimeout=8 "$GRID_HOST" true 2>/dev/null; then
+    echo "!!! Can't reach '$GRID_HOST' over SSH."
+    echo "    - Make sure '$GRID_HOST' is defined in ~/.ssh/config (see top of this script)."
+    echo "    - If your cluster requires it, connect to its network / VPN first."
+    exit 1
+fi
+
+echo ">>> Locating your VTSearch job on the cluster..."
+NODE=$(ssh -o BatchMode=yes "$GRID_HOST" \
+    'squeue --me -h -o "%j %N %T" | awk "\$1==\"vtsearch\" && \$3==\"RUNNING\" {print \$2; exit}"')
+
+if [ -z "$NODE" ]; then
+    echo "!!! No RUNNING VTSearch job found."
+    echo "    Start it on the cluster first:  ssh $GRID_HOST   then   vtsearch"
+    echo "    (If it's still queuing, wait for it to start, then re-run this.)"
+    exit 1
+fi
+
+echo ">>> VTSearch is on $NODE. Forwarding localhost:5000 -> $NODE:5000."
+echo ">>> Browse  http://localhost:5000   (Ctrl+C here closes the tunnel)"
+echo ">>> Dropping you into the VTSearch dir on the login node for git/edits."
+# -t: interactive TTY. The remote command cd's into the project (same shared
+# filesystem the compute node sees) and starts a login shell, so this terminal
+# is both the tunnel and a ready-to-use git workspace.
+exec ssh -t -L 5000:"$NODE":5000 "$GRID_HOST" \
+    "cd \"$VTS_DIR\" 2>/dev/null; exec bash -l"


### PR DESCRIPTION
## What

Shares the two scripts we use to run VTSearch on a shared SLURM GPU cluster (built against the JHU HLTCOE "Grid", but de-personalized so anyone can use them), plus a setup walkthrough.

### New: `scripts/grid/`
- **`vtsearch-grid.sh`** — runs *on the cluster*. `srun`-allocates a GPU node, activates the venv, runs `app.py` on the node, and prints which node it landed on. Holds the allocation; Ctrl+C stops the app but keeps the node and offers to restart (handy after a `git pull`), `q` releases it.
- **`vtsearch-tunnel.sh`** — runs *on your laptop*. Finds the running VTSearch job via `squeue` (no need to know the node name), SSH-forwards `localhost:5000` to the compute node, and drops you into the project dir.
- **`README.md`** — quick reference for the two scripts.

Both are parameterized entirely by environment variables — `VTS_DIR`, `VTS_VENV`, `VTS_GPU`, `VTS_MEM`, `VTS_CPUS`, `VTS_TIME`, `VTS_PART`, and `GRID_HOST` — with **no hard-coded usernames, hostnames, or paths**. Defaults follow common conventions (`/exp/$USER/...`, `.venv`, an SSH alias `grid`).

### Docs: `docs/SETUP.md`
New **"Running on a SLURM GPU cluster (Grid)"** section covering one-time setup on the cluster (clone, GPU venv, frontend build, install launcher), one-time setup on the laptop (SSH host entry, install tunnel), the daily two-command workflow, and a table of all the tuning env vars.

## Notes
- Targets `dev` per repo policy.
- Shell-only change; `bash -n` syntax-checks clean. No Python/frontend code touched.