### PR TITLE
Expand browse cell sizes (2XL–5XL) and serve full-res at large zoom

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -617,6 +617,15 @@ in git history and the cited source files.
 ## Open follow-ups
 
 **Shipped (struck through):**
+- ~~**Wider cell-size range + full-res at large zoom**~~ — the browse canvas's
+  bigger/smaller buttons now walk nine named levels (`XS`..`XL`, then `2XL`..`5XL`)
+  instead of five, so a user can blow a cell up close to the full media. Past the
+  point where a cell is drawn wider than the thumbnail's native longest side
+  (`THUMB_NATIVE_MAX_DIM`, 384px), `BrowseCanvasComponent.getThumb` fetches the
+  full-res `/image` instead of the capped `/thumbnail` (the cache is dropped when
+  the zoom crosses the threshold so cells reload sharp; only a few such giant cells
+  fit on screen, so the LRU still bounds memory). The backend `BrowseIconSize`
+  literal / `VALID_BROWSE_ICON_SIZES` accept the four new labels.
 - ~~**Live elapsed-time during the UMAP fit**~~ — fit runs on a worker thread and
   ticks a 1 s elapsed-seconds heartbeat (`total=0` → indeterminate progress bar),
   since UMAP's numba epoch loop exposes no per-epoch callback.

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -77,6 +77,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   /** On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
    * default before any saved size is applied. See {@link targetRadius}. */
   static readonly DEFAULT_TARGET_RADIUS = 28;
+  /** Longest side (px) the ``/thumbnail`` route caps images at (mirrors
+   * ``vtscore`` ``DEFAULT_MAX_DIM``). Once a cell is drawn wider than this the
+   * capped thumbnail would upscale, so at those zoom levels the canvas fetches
+   * the full-res ``/image`` instead. See {@link useFullResThumbs}. */
+  static readonly THUMB_NATIVE_MAX_DIM = 384;
   /**
    * Target on-screen bin radius in CSS px: the size each bin/thumbnail aims to
    * render at. Level selection picks the pyramid level whose bins land closest
@@ -124,6 +129,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   /** Media ids whose thumbnail failed to load, so we don't retry every frame. */
   private thumbFailed = new Set<number>();
   private readonly MAX_THUMBS = 2048;
+  /** Resolution tier the {@link thumbCache} is currently filled at. Flips to
+   * ``true`` once the zoom is large enough that {@link getThumb} fetches the
+   * full-res ``/image`` instead of the capped ``/thumbnail``; crossing the
+   * threshold drops the cache so cells reload at the matching resolution. */
+  private thumbsAreFullRes = false;
 
   private ctx!: CanvasRenderingContext2D;
   private width = 0;
@@ -290,6 +300,25 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     return usesThumbnails(this.mediaType);
   }
 
+  /** At the largest zoom levels a cell is drawn wider (in device px) than the
+   * thumbnail's native longest side, so painting the capped ``/thumbnail`` would
+   * just upscale a blurry bitmap. Past that point fetch the full-res ``/image``
+   * instead. Only a handful of such giant cells fit on screen at once, so the
+   * LRU still bounds memory. */
+  private get useFullResThumbs(): boolean {
+    return 2 * this.targetRadius * this.dpr > BrowseCanvasComponent.THUMB_NATIVE_MAX_DIM;
+  }
+
+  /** Drop the thumbnail cache when the zoom crosses the full-res threshold so
+   * cells reload at the resolution matching the new tier. Cheap no-op while the
+   * tier is unchanged. */
+  private syncThumbResolutionTier(): void {
+    if (this.useFullResThumbs === this.thumbsAreFullRes) return;
+    this.thumbsAreFullRes = this.useFullResThumbs;
+    this.thumbCache.clear();
+    this.thumbFailed.clear();
+  }
+
   /** Geometry (hex or square) for the active projection's bin shape. */
   private get geom(): BinGeometry {
     return binGeometry(this.meta?.bin_shape);
@@ -453,6 +482,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     canvas.style.width = `${this.width / rootZoom}px`;
     canvas.style.height = `${this.height / rootZoom}px`;
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    // A devicePixelRatio change (e.g. dragging to a different-density display)
+    // can also cross the full-res threshold, so re-evaluate the tier here.
+    this.syncThumbResolutionTier();
     // The initial fit may have run against the 800x600 fallback (meta arrived
     // before layout). Now that the real size is known, refit to it so the
     // framing and the viewport bounds published to the minimap match the actual
@@ -1298,11 +1330,15 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.thumbCache.delete(representativeId);
       this.thumbFailed.add(representativeId);
     };
-    // Downscaled tile, not full-res /image: a browse projection can hold
-    // thousands of points, so painting full-size bitmaps onto the hexes would
-    // exhaust memory. The /thumbnail route serves the frame for video via the
-    // same image_response hook, then downscales it.
-    img.src = this.activeContext.mediaUrl(`/api/medias/${representativeId}/thumbnail`);
+    // Downscaled /thumbnail by default: a browse projection can hold thousands
+    // of points, so painting full-size bitmaps onto every hex would exhaust
+    // memory. The /thumbnail route serves the frame for video via the same
+    // image_response hook, then downscales it. At the largest zoom levels,
+    // though, a cell is drawn wider than the thumbnail's native resolution, so
+    // we fetch the full-res /image instead (only a few such giant cells fit on
+    // screen, so memory stays bounded). See {@link useFullResThumbs}.
+    const endpoint = this.thumbsAreFullRes ? 'image' : 'thumbnail';
+    img.src = this.activeContext.mediaUrl(`/api/medias/${representativeId}/${endpoint}`);
     this.thumbCache.set(representativeId, img);
     return null;
   }
@@ -1651,6 +1687,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.transform.zoom *= radius / this.targetRadius;
     }
     this.targetRadius = radius;
+    // A large enough size crosses into full-res /image territory; drop any
+    // capped thumbnails so cells reload sharp (and vice versa on shrink).
+    this.syncThumbResolutionTier();
     // On initial load (the user hasn't framed yet) a saved cell size changes the
     // bin radius, so re-fit to keep the whole projection in view rather than
     // letting the now-larger edge bins spill past the default-radius framing.

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -89,9 +89,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * instead re-bins a smaller region more finely. The persisted per-media value
    * is the size *label* (see {@link ICON_SIZES}), not the multiplier.
    */
-  private readonly HEX_SCALES = [0.5, 0.75, 1, 1.6, 2.5, 4, 6.25];
-  /** Named icon sizes, index-aligned with {@link HEX_SCALES}. */
-  static readonly ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'] as const;
+  private readonly HEX_SCALES = [0.5, 0.75, 1, 1.6, 2.5, 4, 6.25, 10, 16];
+  /** Named icon sizes, index-aligned with {@link HEX_SCALES}. The top steps
+   * (4XL/5XL) render a cell close to the full media, so some users use them to
+   * inspect (essentially) the whole image rather than a thumbnail. */
+  static readonly ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL'] as const;
   hexScaleIndex = 2;
 
   /**

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -325,8 +325,10 @@
                   <option value="M">M</option>
                   <option value="L">L</option>
                   <option value="XL">XL</option>
-                  <option value="XXL">XXL</option>
-                  <option value="XXXL">XXXL</option>
+                  <option value="2XL">2XL</option>
+                  <option value="3XL">3XL</option>
+                  <option value="4XL">4XL</option>
+                  <option value="5XL">5XL</option>
                 </select>
               </div>
               <div class="form-group">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,8 +240,9 @@ exclude_lines = [
 skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,static,model_cache,.git,*.ipynb,package-lock.json,*venv*,.venv,venv"
 # Domain terms (clap/siglip/xclip = embedder names; wrest/caller/recaller =
 # extension scaffold names), legitimate code identifiers (numer/denom in
-# slope formulas, medias as the global state proxy, goup as a TS method),
+# slope formulas, medias as the global state proxy, goup as a TS method,
+# ans as a shell read-loop variable in scripts/grid),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable). usera = the "userA" persona in
 # design docs; teh = Yee Whye Teh in references.
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh"
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,ans,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh"

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -715,6 +715,16 @@ class TestBrowserSettings:
         res = client.put("/api/settings", json={"browse_icon_size": {"audio": "huge"}})
         assert res.status_code == 400
 
+    def test_update_browse_icon_size_accepts_larger_levels(self, client):
+        # The browse canvas walks seven zoom levels (XS..XXXL), two beyond the
+        # grid icon size's XS..XL; the backend must accept the larger labels the
+        # bigger/smaller buttons persist.
+        res = client.put("/api/settings", json={"browse_icon_size": {"audio": "XXL", "image": "xxxl"}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["browse_icon_size"]["audio"] == "XXL"
+        assert data["browse_icon_size"]["image"] == "XXXL"
+
     def test_update_browse_thumbnail_border_per_type(self, client):
         res = client.put("/api/settings", json={"browse_thumbnail_border": {"image": 3, "video": 0}})
         assert res.status_code == 200

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -716,14 +716,14 @@ class TestBrowserSettings:
         assert res.status_code == 400
 
     def test_update_browse_icon_size_accepts_larger_levels(self, client):
-        # The browse canvas walks seven zoom levels (XS..XXXL), two beyond the
+        # The browse canvas walks nine zoom levels (XS..5XL), four beyond the
         # grid icon size's XS..XL; the backend must accept the larger labels the
         # bigger/smaller buttons persist.
-        res = client.put("/api/settings", json={"browse_icon_size": {"audio": "XXL", "image": "xxxl"}})
+        res = client.put("/api/settings", json={"browse_icon_size": {"audio": "2XL", "image": "5xl"}})
         assert res.status_code == 200
         data = res.get_json()
-        assert data["browse_icon_size"]["audio"] == "XXL"
-        assert data["browse_icon_size"]["image"] == "XXXL"
+        assert data["browse_icon_size"]["audio"] == "2XL"
+        assert data["browse_icon_size"]["image"] == "5XL"
 
     def test_update_browse_thumbnail_border_per_type(self, client):
         res = client.put("/api/settings", json={"browse_thumbnail_border": {"image": 3, "video": 0}})

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -58,10 +58,12 @@ BinShape = Literal["hex", "square"]
 # VTSBrowse density colormap preset. ``auto`` follows the active theme (Ocean
 # in light mode, Heat in dark/high-viz); the rest lock to a specific map.
 BrowseColormap = Literal["auto", "heat", "ocean", "gray"]
-# VTSBrowse on-screen cell size. Extends the grid icon size label set with two
-# larger steps (XXL, XXXL): the browse canvas's bigger/smaller buttons walk
-# seven zoom levels, index-aligned with the frontend ``ICON_SIZES`` array.
-BrowseIconSize = Literal["XS", "S", "M", "L", "XL", "XXL", "XXXL"]
+# VTSBrowse on-screen cell size. Extends the grid icon size label set with four
+# larger steps (2XL..5XL): the browse canvas's bigger/smaller buttons walk nine
+# zoom levels, index-aligned with the frontend ``ICON_SIZES`` array. The largest
+# steps render a cell close to the full media, so the canvas serves the original
+# image rather than a low-res thumbnail at those sizes.
+BrowseIconSize = Literal["XS", "S", "M", "L", "XL", "2XL", "3XL", "4XL", "5XL"]
 
 VALID_THEMES: tuple[str, ...] = ("dark", "light", "highviz", "system")
 VALID_VIEW_MODES: tuple[str, ...] = ("grid", "list")
@@ -69,7 +71,7 @@ VALID_GRID_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL")
 VALID_FOCUS_MODES: tuple[str, ...] = ("click", "hover")
 VALID_BIN_SHAPES: tuple[str, ...] = ("hex", "square")
 VALID_BROWSE_COLORMAPS: tuple[str, ...] = ("auto", "heat", "ocean", "gray")
-VALID_BROWSE_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL", "XXL", "XXXL")
+VALID_BROWSE_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL", "2XL", "3XL", "4XL", "5XL")
 # Allowed range (CSS px) for the saved left/right panel widths. The floor keeps
 # a panel usable; the ceiling is a sanity bound only. The frontend resize logic
 # already constrains a panel to the available layout space (viewport minus the

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -58,8 +58,10 @@ BinShape = Literal["hex", "square"]
 # VTSBrowse density colormap preset. ``auto`` follows the active theme (Ocean
 # in light mode, Heat in dark/high-viz); the rest lock to a specific map.
 BrowseColormap = Literal["auto", "heat", "ocean", "gray"]
-# VTSBrowse on-screen cell size, shared label set with the grid icon size.
-BrowseIconSize = Literal["XS", "S", "M", "L", "XL"]
+# VTSBrowse on-screen cell size. Extends the grid icon size label set with two
+# larger steps (XXL, XXXL): the browse canvas's bigger/smaller buttons walk
+# seven zoom levels, index-aligned with the frontend ``ICON_SIZES`` array.
+BrowseIconSize = Literal["XS", "S", "M", "L", "XL", "XXL", "XXXL"]
 
 VALID_THEMES: tuple[str, ...] = ("dark", "light", "highviz", "system")
 VALID_VIEW_MODES: tuple[str, ...] = ("grid", "list")
@@ -67,7 +69,7 @@ VALID_GRID_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL")
 VALID_FOCUS_MODES: tuple[str, ...] = ("click", "hover")
 VALID_BIN_SHAPES: tuple[str, ...] = ("hex", "square")
 VALID_BROWSE_COLORMAPS: tuple[str, ...] = ("auto", "heat", "ocean", "gray")
-VALID_BROWSE_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL")
+VALID_BROWSE_ICON_SIZES: tuple[str, ...] = ("XS", "S", "M", "L", "XL", "XXL", "XXXL")
 # Allowed range (CSS px) for the saved left/right panel widths. The floor keeps
 # a panel usable; the ceiling is a sanity bound only. The frontend resize logic
 # already constrains a panel to the available layout space (viewport minus the


### PR DESCRIPTION
## Why

`PUT /api/settings` was rejecting `browse_icon_size` with `400 Invalid browse_icon_size: Input should be 'XS', 'S', 'M', 'L' or 'XL'`. This was not a stale settings file — it was a frontend/backend mismatch: the browse canvas's bigger/smaller buttons stepped through more zoom levels than the backend `BrowseIconSize` literal allowed, so persisting the larger sizes failed on write.

## What changed

- **Wider, renamed size range.** The browse canvas now walks nine named levels — `XS, S, M, L, XL, 2XL, 3XL, 4XL, 5XL` — up from five. The two extra levels are named `2XL`/`3XL` (not `XXL`/`XXXL`) and two more (`4XL`/`5XL`) were added so a cell can grow close to the full media. Frontend `HEX_SCALES`/`ICON_SIZES`, the Settings → Browser dropdown, the backend `BrowseIconSize` literal, and `VALID_BROWSE_ICON_SIZES` all updated. Grid icon size stays `XS–XL`.
- **Full-res at large zoom.** Once a cell is drawn wider than the thumbnail's native longest side (`THUMB_NATIVE_MAX_DIM`, 384px), `BrowseCanvasComponent.getThumb` fetches the full-res `/image` instead of upscaling the capped `/thumbnail`. The thumbnail cache is dropped when the zoom crosses that threshold (in either direction) so cells reload at the matching resolution. Only a handful of such giant cells fit on screen, so the existing LRU still bounds memory.
- **Codespell.** Whitelisted the shell read-loop variable `ans` (a false positive in `scripts/grid/vtsearch-grid.sh`) that was blocking the test runner.

## Notes

- No persisted vectors/MLPs touched; thumbnails are served on demand as before.
- Breaking change for anyone who had `XXL`/`XXXL` persisted from the prior commit on this branch — those labels are gone (no shim, per repo policy). Fresh `dev` never shipped them.

## Tests

`./run-tests.sh core` (755 passed, includes the frontend build) and `./run-tests.sh api` (496 passed) both green. Added `test_update_browse_icon_size_accepts_larger_levels` covering the new labels and lowercase normalization.

https://claude.ai/code/session_01EEPwqSKn6uqvvnxQ4XJQdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEPwqSKn6uqvvnxQ4XJQdg)_