### PR TITLE
Add "Add Corrections to Detector" button to the Find view

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2703,6 +2703,34 @@
         ],
         "type": "object"
       },
+      "FindCorrectionsToDetectorResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "corrections_added": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "num_labels": {
+            "type": "integer"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "trained": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "corrections_added",
+          "name",
+          "num_labels",
+          "ok",
+          "trained"
+        ],
+        "type": "object"
+      },
       "FindLabelRequest": {
         "additionalProperties": false,
         "properties": {
@@ -11117,6 +11145,40 @@
         "summary": "Pre-flight check: report how many detector labels can be resolved.",
         "tags": [
           "detector_find"
+        ]
+      }
+    },
+    "/api/find/corrections-to-detector": {
+      "post": {
+        "description": "A *correction* is an item whose adopted Find label differs from the\ndetector's original call (``find_initial_labels``): a rescued\nfalse-negative (now good, the detector said bad) or a culled false-positive\n(now bad, the detector said good).  This matches the ``corrections`` export\nfilter and the Stats \"corrections\" count.\n\nThe correction items are written into the detector's on-disk labelset\n(superseding any prior entry for the same source media), the detector's MLP\nis retrained from the *merged* labelset (not the whole-dataset Find\npredictions), and the registry's training counters are refreshed.\n\nDestructive by design: it changes the detector, so the current Find\nevaluation (which scored against the *old* detector) no longer applies.\nThe caller is expected to re-score afterwards.",
+        "operationId": "find_corrections_to_detector",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindCorrectionsToDetectorResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "No Find run to take corrections from."
+          },
+          "404": {
+            "description": "No active detector to update."
+          },
+          "409": {
+            "description": "Detector vote state is not aligned with the active dataset."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Fold the Find corrections into the active detector's labelset and retrain.",
+        "tags": [
+          "detector_scoring"
         ]
       }
     },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2717,17 +2717,13 @@
           },
           "ok": {
             "type": "boolean"
-          },
-          "trained": {
-            "type": "boolean"
           }
         },
         "required": [
           "corrections_added",
           "name",
           "num_labels",
-          "ok",
-          "trained"
+          "ok"
         ],
         "type": "object"
       },
@@ -2879,6 +2875,9 @@
           "rescued_false_neg": {
             "type": "integer"
           },
+          "stale": {
+            "type": "boolean"
+          },
           "sweep": {
             "items": {
               "$ref": "#/components/schemas/FindStatsSweepPoint"
@@ -2908,6 +2907,7 @@
           "inclusion",
           "precision",
           "rescued_false_neg",
+          "stale",
           "sweep",
           "threshold",
           "total_bad",
@@ -11150,7 +11150,7 @@
     },
     "/api/find/corrections-to-detector": {
       "post": {
-        "description": "A *correction* is an item whose adopted Find label differs from the\ndetector's original call (``find_initial_labels``): a rescued\nfalse-negative (now good, the detector said bad) or a culled false-positive\n(now bad, the detector said good).  This matches the ``corrections`` export\nfilter and the Stats \"corrections\" count.\n\nThe correction items are written into the detector's on-disk labelset\n(superseding any prior entry for the same source media), the detector's MLP\nis retrained from the *merged* labelset (not the whole-dataset Find\npredictions), and the registry's training counters are refreshed.\n\nDestructive by design: it changes the detector, so the current Find\nevaluation (which scored against the *old* detector) no longer applies.\nThe caller is expected to re-score afterwards.",
+        "description": "A *correction* is an item whose adopted Find label differs from the\ndetector's original call (``find_initial_labels``): a rescued\nfalse-negative (now good, the detector said bad) or a culled false-positive\n(now bad, the detector said good).  This matches the ``corrections`` export\nfilter and the Stats \"corrections\" count.\n\nThe correction items are written into the detector's on-disk labelset\n(superseding any prior entry for the same source media) and the registry's\ntraining counters are refreshed.  The cached MLP is invalidated so the next\nscoring pass retrains from the merged labelset.\n\nThe current Find session is deliberately *not* re-scored or reset: its\nscores, queue, votes, and verification stay pinned to the detector version\nthat produced them, so the displayed evaluation (and ``GET /api/find/stats``)\nkeeps showing the previous detector's results.  That evaluation is now out of\ndate relative to the retrained detector, which ``find_eval_stale`` records so\nthe Stats note can say so; the retrained detector takes effect the next time\nthe dataset is scored.",
         "operationId": "find_corrections_to_detector",
         "responses": {
           "200": {
@@ -11176,7 +11176,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Fold the Find corrections into the active detector's labelset and retrain.",
+        "summary": "Fold the Find corrections into the active detector's labelset for *future*\nscoring, leaving the current Find session frozen.",
         "tags": [
           "detector_scoring"
         ]

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -77,6 +77,7 @@
       (toDataset)="onToDataset()"
       (exportLabels)="onExportRequest($event)"
       (stats)="onStats()"
+      (addCorrections)="onAddCorrections()"
     />
   </div>
 </div>

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -540,34 +540,30 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * Fold the corrections (items whose adopted label differs from the
-   * detector's original call) into the active detector's labelset and retrain
-   * its MLP. This changes the detector, so the current evaluation no longer
-   * applies; on success we re-score the dataset against the retrained detector
-   * from a clean slate (nothing verified).
+   * Fold the corrections (items whose adopted label differs from the detector's
+   * original call) into the active detector's labelset for future use. The
+   * current Find session stays frozen — its scores, queue, votes, and Stats keep
+   * showing the detector version that produced them — so the only visible effect
+   * is the Stats being flagged out of date. The retrained detector applies the
+   * next time the dataset is scored.
    */
   onAddCorrections(): void {
     if (this.sortState.sortBusy) return;
     this.dialog
       .confirmDestructive(
         'Add your corrections to this detector?',
-        "Every item you changed from the detector's call is added to its labelset and the detector is retrained. " +
-          'This changes the detector, so the current evaluation no longer applies and the dataset is re-scored.',
-        'Add & Retrain',
+        "Every item you changed from the detector's call is added to its labelset, so the detector learns from them next time you score. " +
+          'Your current results and evaluation stay as they are — the Stats will be marked out of date — and nothing is re-scored now.',
+        'Add Corrections',
       )
       .then((ok) => {
         if (!ok) return;
-        // Busy spinner for the add+retrain call.  We do NOT clear it in the
-        // success-with-corrections branch: runFindLabel() owns the busy state
-        // from there through the re-score so the overlay never flickers off.
-        this.sortState.setSortBusy(true);
         this.detectorsFindApi
           .addCorrectionsToDetector()
           .pipe(takeUntil(this.destroy$))
           .subscribe({
             next: (resp) => {
               if (resp.corrections_added === 0) {
-                this.sortState.setSortBusy(false);
                 this.toast.success({
                   message: 'No corrections to add',
                   detail: "Every item still matches the detector's original call.",
@@ -577,17 +573,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
               }
               this.toast.success({
                 message: `Added ${resp.corrections_added} correction${resp.corrections_added === 1 ? '' : 's'} to the detector`,
-                detail: `Detector now has ${resp.num_labels} label${resp.num_labels === 1 ? '' : 's'}. Re-scoring with the retrained detector…`,
+                detail: `The detector now has ${resp.num_labels} label${resp.num_labels === 1 ? '' : 's'} and will use them next time you score. Your current results stay put; Stats are now marked out of date.`,
                 dedupKey: 'find-corrections-added',
               });
-              // Fresh evaluation against the changed detector: drop the prior
-              // votes/verifications and re-score (runFindLabel keeps the busy
-              // overlay up until the new scores land).
-              this.voteState.clear();
-              this.runFindLabel();
             },
             error: (err: { error?: { message?: string; error?: string } }) => {
-              this.sortState.setSortBusy(false);
               const body = err?.error;
               const message = body?.message || body?.error || 'Failed to add corrections';
               this.toast.error({ message, dedupKey: 'find-corrections-error' });

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -539,6 +539,63 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.showStats = true;
   }
 
+  /**
+   * Fold the corrections (items whose adopted label differs from the
+   * detector's original call) into the active detector's labelset and retrain
+   * its MLP. This changes the detector, so the current evaluation no longer
+   * applies; on success we re-score the dataset against the retrained detector
+   * from a clean slate (nothing verified).
+   */
+  onAddCorrections(): void {
+    if (this.sortState.sortBusy) return;
+    this.dialog
+      .confirmDestructive(
+        'Add your corrections to this detector?',
+        "Every item you changed from the detector's call is added to its labelset and the detector is retrained. " +
+          'This changes the detector, so the current evaluation no longer applies and the dataset is re-scored.',
+        'Add & Retrain',
+      )
+      .then((ok) => {
+        if (!ok) return;
+        // Busy spinner for the add+retrain call.  We do NOT clear it in the
+        // success-with-corrections branch: runFindLabel() owns the busy state
+        // from there through the re-score so the overlay never flickers off.
+        this.sortState.setSortBusy(true);
+        this.detectorsFindApi
+          .addCorrectionsToDetector()
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: (resp) => {
+              if (resp.corrections_added === 0) {
+                this.sortState.setSortBusy(false);
+                this.toast.success({
+                  message: 'No corrections to add',
+                  detail: "Every item still matches the detector's original call.",
+                  dedupKey: 'find-corrections-none',
+                });
+                return;
+              }
+              this.toast.success({
+                message: `Added ${resp.corrections_added} correction${resp.corrections_added === 1 ? '' : 's'} to the detector`,
+                detail: `Detector now has ${resp.num_labels} label${resp.num_labels === 1 ? '' : 's'}. Re-scoring with the retrained detector…`,
+                dedupKey: 'find-corrections-added',
+              });
+              // Fresh evaluation against the changed detector: drop the prior
+              // votes/verifications and re-score (runFindLabel keeps the busy
+              // overlay up until the new scores land).
+              this.voteState.clear();
+              this.runFindLabel();
+            },
+            error: (err: { error?: { message?: string; error?: string } }) => {
+              this.sortState.setSortBusy(false);
+              const body = err?.error;
+              const message = body?.message || body?.error || 'Failed to add corrections';
+              this.toast.error({ message, dedupKey: 'find-corrections-error' });
+            },
+          });
+      });
+  }
+
   /** Open the export modal pre-set to a label filter (good / bad / unverified). */
   onExportRequest(filter: LabelFilter): void {
     this.exportFilter = filter;

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -4,6 +4,13 @@
   } @else if (error) {
     <p class="error-text">{{ error }}</p>
   } @else if (stats) {
+    @if (stats.stale) {
+      <p class="stale-note" role="note">
+        ⚠ Out of date: these numbers evaluate the detector <strong>before</strong> your last corrections were added.
+        They're kept here because the recent evaluation is more useful than none; re-score the dataset (re-enter Find) to
+        evaluate the retrained detector.
+      </p>
+    }
     <table class="stats-table">
       <tbody>
         <tr>

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -3,6 +3,21 @@
 // dataset-stats-modal + _components.scss); only the find-specific confusion
 // grid and the inline chart are styled here.
 
+.stale-note {
+  margin: 0 0 var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-left: 3px solid var(--text-warning);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-warning);
+  font-size: var(--font-sm);
+  line-height: 1.4;
+
+  strong {
+    font-weight: var(--weight-semibold);
+  }
+}
+
 .confusion {
   .row-head {
     font-weight: var(--weight-medium);

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -127,6 +127,20 @@
     </vt-label-list>
   }
 
+  @if (mode === 'find') {
+    <div class="corrections-row">
+      <button
+        class="panel-btn corrections-btn"
+        [disabled]="disabled"
+        (click)="onAddCorrections()"
+        title="Add the corrections you've made (items you changed from the detector's call) into this detector's labelset and retrain it. This changes the detector, so the current evaluation no longer applies."
+      >
+        <vt-icon type="graduation" [size]="16"></vt-icon>
+        Add Corrections to Detector
+      </button>
+    </div>
+  }
+
   @if (mode !== 'find') {
     <div class="export-row">
       <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -131,3 +131,21 @@
   flex: 1;
   text-align: center;
 }
+
+// Find mode: "Add Corrections to Detector" sits at the foot of the verified
+// (right) pile, where we deal with the human-decided labels. Carries the same
+// graduation-cap mark as the dashboard's Train button.
+.corrections-row {
+  display: flex;
+  padding: var(--space-md) var(--space-xl);
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+}
+
+.corrections-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+}

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -66,6 +66,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Output() exportLabels = new EventEmitter<'good' | 'bad'>();
   /** Find mode: open the detector-evaluation Stats modal. */
   @Output() stats = new EventEmitter<void>();
+  /** Find mode: fold the corrections into the detector's labelset and retrain. */
+  @Output() addCorrections = new EventEmitter<void>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
@@ -215,6 +217,10 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   onStats(): void {
     this.stats.emit();
+  }
+
+  onAddCorrections(): void {
+    this.addCorrections.emit();
   }
 
   onDetectorRenamed(newName: string): void {

--- a/frontend/src/app/services/detectors-find-api.service.ts
+++ b/frontend/src/app/services/detectors-find-api.service.ts
@@ -12,10 +12,12 @@ import type { FindLabelResponse } from '../generated/api-client/models/find-labe
 import type { FindRequest } from '../generated/api-client/models/find-request';
 import type { FindResponse } from '../generated/api-client/models/find-response';
 import type { FindStatsResponse } from '../generated/api-client/models/find-stats-response';
+import type { FindCorrectionsToDetectorResponse } from '../generated/api-client/models/find-corrections-to-detector-response';
 import { cancelFind } from '../generated/api-client/fn/detector-find/cancel-find';
 import { findCheckLabels } from '../generated/api-client/fn/detector-find/find-check-labels';
 import { findLabel } from '../generated/api-client/fn/detector-scoring/find-label';
 import { findStats } from '../generated/api-client/fn/detector-scoring/find-stats';
+import { findCorrectionsToDetector } from '../generated/api-client/fn/detector-scoring/find-corrections-to-detector';
 import { multiFind } from '../generated/api-client/fn/detector-find/multi-find';
 
 /** Multi-dataset Find, single-label Find, the check-labels precheck, and
@@ -50,5 +52,12 @@ export class DetectorsFindApiService {
    *  + the FP/FN-vs-inclusion sweep). Pure read. */
   getFindStats(): Observable<FindStatsResponse> {
     return findStats(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Fold the Find corrections into the active detector's labelset and retrain
+   *  its MLP. Destructive: changes the detector, so the current Find evaluation
+   *  no longer applies and the caller should re-score afterwards. */
+  addCorrectionsToDetector(): Observable<FindCorrectionsToDetectorResponse> {
+    return findCorrectionsToDetector(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/scripts/grid/vtsearch-grid.sh
+++ b/scripts/grid/vtsearch-grid.sh
@@ -60,8 +60,8 @@ exec srun --job-name=vtsearch --pty \
             echo
             echo ">>> app.py stopped. GPU node ($node) is still yours."
             printf ">>> [Enter] = restart (picks up code changes)   |   q + [Enter] = quit & release node: "
-            read -r ans || break
-            [ "$ans" = "q" ] && break
+            read -r reply || break
+            [ "$reply" = "q" ] && break
         done
         echo ">>> Releasing the allocation. Bye."
     '

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -220,7 +220,8 @@ class TestFindStats:
 
 class TestCorrectionsToDetector:
     """``POST /api/find/corrections-to-detector`` folds the Find corrections
-    into the active detector's labelset and retrains it."""
+    into the active detector's labelset for future scoring while leaving the
+    current Find session frozen (and flagged out of date)."""
 
     def _labelset_labels(self, name: str) -> list[dict]:
         """Return the on-disk labelset entries for detector *name*."""
@@ -241,6 +242,16 @@ class TestCorrectionsToDetector:
         resp = client.post("/api/find-label", json={"detector_id": detector_id})
         assert resp.status_code == 200, resp.get_json()
         return detector_id
+
+    def _make_two_corrections(self, client):
+        """Flip the detector's call on one good and one bad item; return the ids."""
+        ctx = get_active_detector_context()
+        initial = dict(ctx.find_initial_labels)
+        good_item = next(cid for cid, lbl in initial.items() if lbl == "good")
+        bad_item = next(cid for cid, lbl in initial.items() if lbl == "bad")
+        assert client.post(f"/api/medias/{good_item}/vote", json={"target": "bad"}).status_code == 200
+        assert client.post(f"/api/medias/{bad_item}/vote", json={"target": "good"}).status_code == 200
+        return good_item, bad_item
 
     def test_no_find_run_returns_400(self, client):
         """Without a find-label baseline there are no corrections to take."""
@@ -263,38 +274,73 @@ class TestCorrectionsToDetector:
         assert resp.status_code == 200, resp.get_json()
         data = resp.get_json()
         assert data["corrections_added"] == 0
-        assert data["trained"] is False
         after = len(self._labelset_labels("corrections-model"))
         assert after == before
+        # Nothing changed, so the evaluation is not stale.
+        assert get_active_detector_context().find_eval_stale is False
 
-    def test_corrections_added_and_retrained(self, client):
+    def test_corrections_added_to_labelset(self, client):
         """Flipping the detector's call on two items folds those corrections
-        into the labelset (with the human label) and retrains the MLP."""
+        into the labelset with the human label."""
         self._setup_find(client)
-        ctx = get_active_detector_context()
-        initial = dict(ctx.find_initial_labels)
-
-        # One culled false-positive (detector good -> human bad) and one rescued
-        # false-negative (detector bad -> human good).
-        good_item = next(cid for cid, lbl in initial.items() if lbl == "good")
-        bad_item = next(cid for cid, lbl in initial.items() if lbl == "bad")
-        assert client.post(f"/api/medias/{good_item}/vote", json={"target": "bad"}).status_code == 200
-        assert client.post(f"/api/medias/{bad_item}/vote", json={"target": "good"}).status_code == 200
+        good_item, bad_item = self._make_two_corrections(client)
 
         resp = client.post("/api/find/corrections-to-detector")
         assert resp.status_code == 200, resp.get_json()
         data = resp.get_json()
         assert data["corrections_added"] == 2
-        assert data["trained"] is True
 
-        # The on-disk labelset now carries the human label for both items.
         labels = self._labelset_labels("corrections-model")
         by_md5 = {el["md5"]: el["label"] for el in labels}
         assert by_md5[app_module.medias[good_item]["md5"]] == "bad"
         assert by_md5[app_module.medias[bad_item]["md5"]] == "good"
         assert data["num_labels"] == len(labels)
 
-        # The prior Find evaluation baseline is cleared so a re-score starts clean.
-        assert dict(ctx.verified_ids) == {}
-        assert dict(ctx.find_initial_labels) == {}
-        assert dict(ctx.find_scores) == {}
+    def test_session_frozen_and_marked_stale(self, client):
+        """The Find session is NOT reset: votes / verified / find baseline hold,
+        the cached MLP is invalidated for the next scoring pass, and the
+        evaluation is flagged stale."""
+        self._setup_find(client)
+        good_item, bad_item = self._make_two_corrections(client)
+        ctx = get_active_detector_context()
+        initial_before = dict(ctx.find_initial_labels)
+        scores_before = dict(ctx.find_scores)
+
+        resp = client.post("/api/find/corrections-to-detector")
+        assert resp.status_code == 200, resp.get_json()
+
+        # Frozen: the find baseline, scores, and verifications are untouched.
+        assert dict(ctx.find_initial_labels) == initial_before
+        assert dict(ctx.find_scores) == scores_before
+        assert good_item in ctx.verified_ids
+        assert bad_item in ctx.verified_ids
+        assert good_item in ctx.bad_votes  # the human vote held
+        assert bad_item in ctx.good_votes
+        # The cached MLP is dropped so the next scoring pass retrains.
+        assert ctx.model is None
+        assert ctx.find_eval_stale is True
+
+    def test_stale_survives_rehydrate_and_shows_in_stats(self, client):
+        """A follow-up request must not rehydrate the frozen votes away (the
+        labelset write bumped the file mtime), and Stats reports ``stale``."""
+        self._setup_find(client)
+        self._make_two_corrections(client)
+        assert client.post("/api/find/corrections-to-detector").status_code == 200
+
+        # A later request runs before_request -> ensure_votes_match_active_dataset.
+        # The cached-mtime re-point must keep it a no-op so the frozen eval holds.
+        data = client.get("/api/find/stats").get_json()
+        assert data["stale"] is True
+        assert data["corrections"] == 2
+
+    def test_fresh_find_label_clears_stale(self, client):
+        """Re-scoring (a genuine new evaluation) clears the stale flag."""
+        detector_id = self._setup_find(client)
+        self._make_two_corrections(client)
+        assert client.post("/api/find/corrections-to-detector").status_code == 200
+        assert get_active_detector_context().find_eval_stale is True
+
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        assert get_active_detector_context().find_eval_stale is False
+        assert client.get("/api/find/stats").get_json()["stale"] is False

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -222,6 +222,12 @@ class TestCorrectionsToDetector:
     """``POST /api/find/corrections-to-detector`` folds the Find corrections
     into the active detector's labelset and retrains it."""
 
+    def _labelset_labels(self, name: str) -> list[dict]:
+        """Return the on-disk labelset entries for detector *name*."""
+        data = _read_detector(_detector_path(name))
+        assert data is not None
+        return data["labelset"]["labels"]
+
     def _setup_find(self, client):
         """Register + load a detector, then run find-label so it enters find
         mode with a full ``find_initial_labels`` baseline."""
@@ -252,13 +258,13 @@ class TestCorrectionsToDetector:
         """Right after find-label, every adopted label matches the detector's
         call, so there is nothing to add and the labelset is untouched."""
         self._setup_find(client)
-        before = len(_read_detector(_detector_path("corrections-model"))["labelset"]["labels"])
+        before = len(self._labelset_labels("corrections-model"))
         resp = client.post("/api/find/corrections-to-detector")
         assert resp.status_code == 200, resp.get_json()
         data = resp.get_json()
         assert data["corrections_added"] == 0
         assert data["trained"] is False
-        after = len(_read_detector(_detector_path("corrections-model"))["labelset"]["labels"])
+        after = len(self._labelset_labels("corrections-model"))
         assert after == before
 
     def test_corrections_added_and_retrained(self, client):
@@ -282,7 +288,7 @@ class TestCorrectionsToDetector:
         assert data["trained"] is True
 
         # The on-disk labelset now carries the human label for both items.
-        labels = _read_detector(_detector_path("corrections-model"))["labelset"]["labels"]
+        labels = self._labelset_labels("corrections-model")
         by_md5 = {el["md5"]: el["label"] for el in labels}
         assert by_md5[app_module.medias[good_item]["md5"]] == "bad"
         assert by_md5[app_module.medias[bad_item]["md5"]] == "good"

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -12,9 +12,12 @@ See docs/plans/find-verification-workflow.md.
 from __future__ import annotations
 
 import app as app_module
+from helpers import setup_trainable_model_in_registry
+from tests import load_detector_and_wait
+from vtscore.detectors.store import _detector_path, _read_detector
 from vtscore.state.core import get_active_detector_context
 from vtscore.state.votes import rethreshold_unverified_find_items
-from vtsearch.state import set_find_initial_labels, set_find_scores, set_vote
+from vtsearch.state import set_find_initial_labels, set_find_scores, set_vote, snapshot_medias
 
 
 class TestMarkVerified:
@@ -213,3 +216,79 @@ class TestFindStats:
         assert data["agreement_rate"] == 0.0
         assert data["precision"] == 0.0
         assert len(data["sweep"]) == 21
+
+
+class TestCorrectionsToDetector:
+    """``POST /api/find/corrections-to-detector`` folds the Find corrections
+    into the active detector's labelset and retrains it."""
+
+    def _setup_find(self, client):
+        """Register + load a detector, then run find-label so it enters find
+        mode with a full ``find_initial_labels`` baseline."""
+        detector_id = setup_trainable_model_in_registry(
+            "corrections-model",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        load_detector_and_wait(client, detector_id)
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        return detector_id
+
+    def test_no_find_run_returns_400(self, client):
+        """Without a find-label baseline there are no corrections to take."""
+        detector_id = setup_trainable_model_in_registry(
+            "no-find-run",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        load_detector_and_wait(client, detector_id)
+        resp = client.post("/api/find/corrections-to-detector")
+        assert resp.status_code == 400
+
+    def test_no_corrections_is_noop(self, client):
+        """Right after find-label, every adopted label matches the detector's
+        call, so there is nothing to add and the labelset is untouched."""
+        self._setup_find(client)
+        before = len(_read_detector(_detector_path("corrections-model"))["labelset"]["labels"])
+        resp = client.post("/api/find/corrections-to-detector")
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+        assert data["corrections_added"] == 0
+        assert data["trained"] is False
+        after = len(_read_detector(_detector_path("corrections-model"))["labelset"]["labels"])
+        assert after == before
+
+    def test_corrections_added_and_retrained(self, client):
+        """Flipping the detector's call on two items folds those corrections
+        into the labelset (with the human label) and retrains the MLP."""
+        self._setup_find(client)
+        ctx = get_active_detector_context()
+        initial = dict(ctx.find_initial_labels)
+
+        # One culled false-positive (detector good -> human bad) and one rescued
+        # false-negative (detector bad -> human good).
+        good_item = next(cid for cid, lbl in initial.items() if lbl == "good")
+        bad_item = next(cid for cid, lbl in initial.items() if lbl == "bad")
+        assert client.post(f"/api/medias/{good_item}/vote", json={"target": "bad"}).status_code == 200
+        assert client.post(f"/api/medias/{bad_item}/vote", json={"target": "good"}).status_code == 200
+
+        resp = client.post("/api/find/corrections-to-detector")
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+        assert data["corrections_added"] == 2
+        assert data["trained"] is True
+
+        # The on-disk labelset now carries the human label for both items.
+        labels = _read_detector(_detector_path("corrections-model"))["labelset"]["labels"]
+        by_md5 = {el["md5"]: el["label"] for el in labels}
+        assert by_md5[app_module.medias[good_item]["md5"]] == "bad"
+        assert by_md5[app_module.medias[bad_item]["md5"]] == "good"
+        assert data["num_labels"] == len(labels)
+
+        # The prior Find evaluation baseline is cleared so a re-score starts clean.
+        assert dict(ctx.verified_ids) == {}
+        assert dict(ctx.find_initial_labels) == {}
+        assert dict(ctx.find_scores) == {}

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -104,6 +104,7 @@ def ensure_votes_match_active_dataset() -> None:
             det_ctx.find_initial_labels.clear()
             det_ctx.verified_ids.clear()
             det_ctx.find_scores.clear()
+            det_ctx.find_eval_stale = False
             det_ctx.training_medias.clear()
             # The detector now has no votes for the active dataset, so they
             # can't be find/scoring output; let the next vote sync normally.

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -359,6 +359,13 @@ class DetectorContext:
         # re-scoring.  Both are in-memory only and never persisted.
         "verified_ids",
         "find_scores",
+        # True when the on-disk labelset has been changed (e.g. Find corrections
+        # folded in + retrain) *since* this frozen Find evaluation was scored, so
+        # the still-displayed find_initial_labels / find_scores reflect the
+        # previous detector version.  Drives the "out of date" note in
+        # ``GET /api/find/stats``.  Cleared on a fresh find-label scoring pass and
+        # on any session reset (clear votes / dataset switch).
+        "find_eval_stale",
         "inclusion",
         # Cached in-memory data (never exported)
         "training_medias",  # voted media items with embeddings
@@ -432,6 +439,10 @@ class DetectorContext:
         # Find-session verification state (see docs/plans/find-verification-workflow.md).
         self.verified_ids: dict[int, None] = {}
         self.find_scores: dict[int, float] = {}
+        # See the slot comment: the displayed Find evaluation is for the detector
+        # version that scored this pass; flipped True when its labelset changes
+        # underneath (corrections folded in + retrain).
+        self.find_eval_stale: bool = False
         self.inclusion: int | None = None
         # Cached in-memory data (never exported)
         self.training_medias: dict[int, dict[str, Any]] = {}
@@ -657,6 +668,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "find_initial_labels", _FrozenDict("detector"))
         object.__setattr__(self, "verified_ids", _FrozenDict("detector"))
         object.__setattr__(self, "find_scores", _FrozenDict("detector"))
+        object.__setattr__(self, "find_eval_stale", False)
         object.__setattr__(self, "inclusion", None)
         object.__setattr__(self, "training_medias", _FrozenDict("detector"))
         object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -50,6 +50,7 @@ def clear_votes() -> None:
         ctx.find_initial_labels.clear()
         ctx.verified_ids.clear()
         ctx.find_scores.clear()
+        ctx.find_eval_stale = False
         ds_tree = get_active_context().diversity_tree
         if ds_tree is not None:
             ds_tree.reset_seen()

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -22,6 +22,7 @@ from vtsearch.routes._shared import require_dataset_header, require_detector_hea
 from vtsearch.schemas.detectors import (
     AutoDetectRequestSchema,
     AutoDetectResponseSchema,
+    FindCorrectionsToDetectorResponseSchema,
     FindLabelRequestSchema,
     FindLabelResponseSchema,
     FindStatsResponseSchema,
@@ -560,6 +561,133 @@ def find_stats():
         "inclusion": get_inclusion(),
         "threshold": round(det_ctx.threshold, 4),
         "sweep": sweep,
+    }
+
+
+@detector_scoring_bp.route("/api/find/corrections-to-detector", methods=["POST"])
+@detector_scoring_bp.response(200, FindCorrectionsToDetectorResponseSchema)
+@detector_scoring_bp.alt_response(400, description="No Find run to take corrections from.")
+@detector_scoring_bp.alt_response(404, description="No active detector to update.")
+@detector_scoring_bp.alt_response(409, description="Detector vote state is not aligned with the active dataset.")
+@require_dataset_header
+@require_detector_header
+def find_corrections_to_detector():
+    """Fold the Find corrections into the active detector's labelset and retrain.
+
+    A *correction* is an item whose adopted Find label differs from the
+    detector's original call (``find_initial_labels``): a rescued
+    false-negative (now good, the detector said bad) or a culled false-positive
+    (now bad, the detector said good).  This matches the ``corrections`` export
+    filter and the Stats "corrections" count.
+
+    The correction items are written into the detector's on-disk labelset
+    (superseding any prior entry for the same source media), the detector's MLP
+    is retrained from the *merged* labelset (not the whole-dataset Find
+    predictions), and the registry's training counters are refreshed.
+
+    Destructive by design: it changes the detector, so the current Find
+    evaluation (which scored against the *old* detector) no longer applies.
+    The caller is expected to re-score afterwards.
+    """
+    from vtscore.datasets.labelset import LabelSet, element_key
+    from vtscore.detectors.dataset_sync import validated_vote_snapshot
+    from vtscore.detectors.input_spec import extract_input_spec_from_medias
+    from vtscore.detectors.labelset_training import train_from_labelset
+    from vtscore.detectors.registry import get_detector as reg_get_detector
+    from vtscore.detectors.registry import update_detector
+    from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+    from vtscore.state.core import get_active_detector_context
+
+    det_ctx = get_active_detector_context()
+    detector_id = det_ctx.detector_id or ""
+    reg = reg_get_detector(detector_id) if detector_id else None
+    if reg is None or not reg.get("name"):
+        abort(404, message="No active detector to update")
+    name = reg["name"]
+
+    path = _detector_path(name)
+    data = _read_detector(path)
+    if data is None:
+        abort(404, message=f"Detector '{name}' not found")
+
+    # Atomic (medias, good_votes, bad_votes, region boxes) snapshot keyed in the
+    # active dataset's cid space, so the votes we compose with the medias can't
+    # straddle a concurrent dataset switch on this detector.
+    snap = validated_vote_snapshot()
+    if not snap.safe:
+        abort(409, message="Cannot add corrections: detector vote state is not aligned with the active dataset")
+
+    initial = det_ctx.find_initial_labels
+    if not initial:
+        abort(400, message="No Find run to take corrections from. Score the dataset first.")
+
+    existing_ls = LabelSet.from_dict(data.get("labelset") or {})
+
+    # A correction's adopted label differs from the detector's original call.
+    corr_good = {cid: None for cid in snap.good_votes if initial.get(cid) == "bad"}
+    corr_bad = {cid: None for cid in snap.bad_votes if initial.get(cid) == "good"}
+    num_corrections = len(corr_good) + len(corr_bad)
+
+    if num_corrections == 0:
+        return {
+            "ok": True,
+            "name": name,
+            "corrections_added": 0,
+            "num_labels": len(existing_ls),
+            "trained": False,
+        }
+
+    corrections_ls = LabelSet.from_clips_and_votes(
+        snap.medias,
+        corr_good,
+        corr_bad,
+        expand_dupes=False,
+        vote_region_boxes=snap.vote_region_boxes,
+    )
+
+    # Merge: a correction supersedes any prior entry for the same source media
+    # (so a culled false-positive flips its old "good" entry to "bad").
+    corr_keys = {element_key(el) for el in corrections_ls.elements}
+    corr_keys.discard(None)
+    merged_elements = [el for el in existing_ls.elements if element_key(el) not in corr_keys]
+    merged_elements.extend(corrections_ls.elements)
+    merged = LabelSet(merged_elements)
+
+    data["labelset"] = merged.to_dict()
+
+    # Keep the stored input_spec in sync with the active dataset's clipper, as
+    # ``save_detector_labels`` does.
+    captured_spec = extract_input_spec_from_medias(snap.medias)
+    if captured_spec is not None:
+        data["input_spec"] = captured_spec
+    elif "input_spec" in data:
+        data.pop("input_spec", None)
+    _write_detector(path, data)
+
+    media_type = data.get("media_type", "") or next(iter(snap.medias.values()), {}).get("media_type", "")
+    trained = train_from_labelset(det_ctx, merged, media_type=media_type, snap=snap.medias)
+
+    # The prior Find evaluation scored against the *old* detector, so its
+    # verified pile and frozen baseline (find_initial_labels / find_scores) no
+    # longer apply.  Clear them so the caller's re-score starts a clean
+    # evaluation against the retrained detector.
+    from vtscore.state.core import _state_lock
+
+    with _state_lock:
+        det_ctx.verified_ids.clear()
+        det_ctx.find_initial_labels.clear()
+        det_ctx.find_scores.clear()
+
+    import time as _time
+
+    update_detector(reg["id"], num_training=len(merged), last_trained_at=_time.time())
+
+    return {
+        "ok": True,
+        "name": name,
+        "corrections_added": num_corrections,
+        "num_labels": len(merged),
+        "trained": bool(trained),
     }
 
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -362,6 +362,12 @@ def find_label(body: dict):  # noqa: C901
 
     set_find_mode(True)
 
+    # A fresh scoring pass IS the current evaluation, so any "stale" flag left by
+    # a prior corrections-to-detector fold no longer applies.
+    from vtscore.state.core import get_active_detector_context
+
+    get_active_detector_context().find_eval_stale = False
+
     from vtscore.labels.sync import sync_to_labelset_source
 
     sync_to_labelset_source()
@@ -560,6 +566,7 @@ def find_stats():
         "precision": round(precision, 4),
         "inclusion": get_inclusion(),
         "threshold": round(det_ctx.threshold, 4),
+        "stale": getattr(det_ctx, "find_eval_stale", False),
         "sweep": sweep,
     }
 
@@ -572,7 +579,8 @@ def find_stats():
 @require_dataset_header
 @require_detector_header
 def find_corrections_to_detector():
-    """Fold the Find corrections into the active detector's labelset and retrain.
+    """Fold the Find corrections into the active detector's labelset for *future*
+    scoring, leaving the current Find session frozen.
 
     A *correction* is an item whose adopted Find label differs from the
     detector's original call (``find_initial_labels``): a rescued
@@ -581,22 +589,25 @@ def find_corrections_to_detector():
     filter and the Stats "corrections" count.
 
     The correction items are written into the detector's on-disk labelset
-    (superseding any prior entry for the same source media), the detector's MLP
-    is retrained from the *merged* labelset (not the whole-dataset Find
-    predictions), and the registry's training counters are refreshed.
+    (superseding any prior entry for the same source media) and the registry's
+    training counters are refreshed.  The cached MLP is invalidated so the next
+    scoring pass retrains from the merged labelset.
 
-    Destructive by design: it changes the detector, so the current Find
-    evaluation (which scored against the *old* detector) no longer applies.
-    The caller is expected to re-score afterwards.
+    The current Find session is deliberately *not* re-scored or reset: its
+    scores, queue, votes, and verification stay pinned to the detector version
+    that produced them, so the displayed evaluation (and ``GET /api/find/stats``)
+    keeps showing the previous detector's results.  That evaluation is now out of
+    date relative to the retrained detector, which ``find_eval_stale`` records so
+    the Stats note can say so; the retrained detector takes effect the next time
+    the dataset is scored.
     """
     from vtscore.datasets.labelset import LabelSet, element_key
-    from vtscore.detectors.dataset_sync import validated_vote_snapshot
+    from vtscore.detectors.dataset_sync import _detector_file_mtime, validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtscore.detectors.labelset_training import train_from_labelset
     from vtscore.detectors.registry import get_detector as reg_get_detector
     from vtscore.detectors.registry import update_detector
     from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
-    from vtscore.state.core import get_active_detector_context
+    from vtscore.state.core import _state_lock, get_active_detector_context
 
     det_ctx = get_active_detector_context()
     detector_id = det_ctx.detector_id or ""
@@ -634,7 +645,6 @@ def find_corrections_to_detector():
             "name": name,
             "corrections_added": 0,
             "num_labels": len(existing_ls),
-            "trained": False,
         }
 
     corrections_ls = LabelSet.from_clips_and_votes(
@@ -664,19 +674,22 @@ def find_corrections_to_detector():
         data.pop("input_spec", None)
     _write_detector(path, data)
 
-    media_type = data.get("media_type", "") or next(iter(snap.medias.values()), {}).get("media_type", "")
-    trained = train_from_labelset(det_ctx, merged, media_type=media_type, snap=snap.medias)
-
-    # The prior Find evaluation scored against the *old* detector, so its
-    # verified pile and frozen baseline (find_initial_labels / find_scores) no
-    # longer apply.  Clear them so the caller's re-score starts a clean
-    # evaluation against the retrained detector.
-    from vtscore.state.core import _state_lock
-
+    # Freeze the current Find session.  Writing the file bumped its mtime, which
+    # would make the before_request rehydrate wipe the in-memory votes /
+    # find_scores / find_initial_labels and re-derive them from the new labelset.
+    # Re-point the cached labelset + mtime at the file we just wrote so that
+    # rehydrate is a no-op, invalidate the cached MLP so the next scoring pass
+    # retrains from the merged labelset, and flag the displayed evaluation stale.
+    new_mtime = _detector_file_mtime(path)
+    media_type = data.get("media_type", "") or ""
     with _state_lock:
-        det_ctx.verified_ids.clear()
-        det_ctx.find_initial_labels.clear()
-        det_ctx.find_scores.clear()
+        det_ctx.cached_labelset = merged
+        det_ctx.cached_labelset_mtime = new_mtime
+        det_ctx.cached_labelset_media_type = media_type or det_ctx.cached_labelset_media_type
+        det_ctx.labelset_good_count = sum(1 for el in merged.elements if el.label == "good")
+        det_ctx.labelset_bad_count = sum(1 for el in merged.elements if el.label == "bad")
+        det_ctx.model = None
+        det_ctx.find_eval_stale = True
 
     import time as _time
 
@@ -687,7 +700,6 @@ def find_corrections_to_detector():
         "name": name,
         "corrections_added": num_corrections,
         "num_labels": len(merged),
-        "trained": bool(trained),
     }
 
 

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -727,6 +727,10 @@ class FindStatsResponseSchema(Schema):
     # Run context.
     inclusion = fields.Integer(required=True)
     threshold = fields.Float(required=True)
+    # True when the detector's labelset changed (Find corrections folded in +
+    # retrain) after this evaluation was scored, so these numbers reflect the
+    # previous detector version.  Drives the "out of date" note in the UI.
+    stale = fields.Boolean(required=True)
     # FP/FN at every inclusion from -10..10 over all adopted items.
     sweep = fields.List(fields.Nested(FindStatsSweepPointSchema), required=True)
 
@@ -735,7 +739,8 @@ class FindCorrectionsToDetectorResponseSchema(Schema):
     """Response for ``POST /api/find/corrections-to-detector``.
 
     Reports how many corrections were folded into the active detector's
-    labelset, the resulting labelset size, and whether the MLP retrained.
+    labelset and the resulting labelset size.  The current Find session stays
+    frozen; the retrained detector applies on the next scoring pass.
     See docs/plans/find-verification-workflow.md.
     """
 
@@ -743,7 +748,6 @@ class FindCorrectionsToDetectorResponseSchema(Schema):
     name = fields.String(required=True)
     corrections_added = fields.Integer(required=True)
     num_labels = fields.Integer(required=True)
-    trained = fields.Boolean(required=True)
 
 
 __all__ = [

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -731,6 +731,21 @@ class FindStatsResponseSchema(Schema):
     sweep = fields.List(fields.Nested(FindStatsSweepPointSchema), required=True)
 
 
+class FindCorrectionsToDetectorResponseSchema(Schema):
+    """Response for ``POST /api/find/corrections-to-detector``.
+
+    Reports how many corrections were folded into the active detector's
+    labelset, the resulting labelset size, and whether the MLP retrained.
+    See docs/plans/find-verification-workflow.md.
+    """
+
+    ok = fields.Boolean(required=True)
+    name = fields.String(required=True)
+    corrections_added = fields.Integer(required=True)
+    num_labels = fields.Integer(required=True)
+    trained = fields.Boolean(required=True)
+
+
 __all__ = [
     "AutoDetectRequestSchema",
     "AutoDetectResponseSchema",
@@ -767,6 +782,7 @@ __all__ = [
     "FindCancelResponseSchema",
     "FindCheckLabelsRequestSchema",
     "FindCheckLabelsResponseSchema",
+    "FindCorrectionsToDetectorResponseSchema",
     "FindLabelRequestSchema",
     "FindLabelResponseSchema",
     "FindRequestSchema",


### PR DESCRIPTION
## What

Adds a button to the **Find** view's right panel that folds the corrections you've made into the active detector's LabelSet for future scoring.

A *correction* is an item whose adopted Find label differs from the detector's original call (`find_initial_labels`): a rescued false-negative (now good, the detector said bad) or a culled false-positive (now bad, the detector said good). This matches the existing `corrections` export filter and the Stats "corrections" count.

## Behavior (freeze the session, retrain for next time)

Clicking the button (after a confirm dialog) merges your corrections into the detector's on-disk labelset and invalidates its cached MLP, so the **next** scoring pass retrains from the merged labels. The **current Find session stays frozen** — scores, ranking, work queue, votes, and verification all keep showing the detector version that produced them. Nothing is re-scored now.

Because that frozen evaluation is now out of date relative to the retrained detector, the **Stats modal shows an "out of date" note** (driven by a new `find_eval_stale` flag): *"these numbers evaluate the detector before your last corrections… kept here because a recent evaluation is more useful than none; re-score to evaluate the retrained detector."* The flag clears on a fresh find-label pass or any session reset (clear votes / dataset or detector switch).

## Where

The button sits at the **foot of the right panel** (the verified-labels side), carrying the same graduation-cap mark as the Dashboard's Train button. Labeled "Add Corrections to Detector".

## How it works

1. **Backend** — `POST /api/find/corrections-to-detector` (`vtsearch/routes/detectors/scoring.py`):
   - Computes the corrections (adopted label ≠ detector's original call).
   - Merges `LabeledElement`s for those items into the on-disk labelset, superseding any prior entry for the same source media (so a culled false-positive flips its old "good" entry to "bad").
   - Re-points `cached_labelset` + `cached_labelset_mtime` at the freshly-written file so the `before_request` rehydrate (which the mtime bump would otherwise trigger) does **not** wipe the frozen votes / `find_scores` / `find_initial_labels`.
   - Invalidates the cached MLP (`det_ctx.model = None`) for a lazy retrain on the next scoring pass, and sets `find_eval_stale = True`.
   - Refreshes registry training counters. Returns `{ corrections_added, num_labels }`.
   - `find/stats` now returns a `stale` boolean; `find-label` clears the flag on a fresh pass.

2. **Frontend** — a confirm dialog explaining the freeze, then a toast on success. No re-score, no reset. The Stats modal renders the staleness banner when `stale` is true.

## Tests

`TestCorrectionsToDetector` in `tests/detectors/test_find_verification.py`: the 400 "no find run" case, the zero-corrections no-op, corrections merged with the human label, the session staying frozen (votes/verified/baseline held, MLP invalidated, `stale` set), staleness surviving the post-write rehydrate and showing in `find/stats`, and a fresh find-label clearing the flag.

Full suite green: **4768 passed** (ruff/format/codespell/deptry/pip-audit/pyright/OpenAPI-snapshot/frontend-build all pass). Also cleared a pre-existing codespell false positive in `scripts/grid/vtsearch-grid.sh`.

## Backwards compatibility

No breaking changes. New endpoint, a new in-memory `DetectorContext.find_eval_stale` flag (never persisted), and a new UI affordance.

https://claude.ai/code/session_01FfLE2X8riSN36edg1SZtw5