### PR TITLE
Fix VTSBrowse bin-popup view controls (toggle, sizing, hover-pop)

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -20,6 +20,7 @@
       side="popup"
       [currentMediaType]="mediaType"
       [showFocus]="false"
+      [allowSizeInList]="true"
       class="bin-popup-view-controls" />
     <button
       type="button"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -92,7 +92,10 @@
   color: var(--text-vote);
 
   // --- List mode: a horizontal row (thumbnail + name) --------------------
-  height: 36px;
+  // The row height is bound per render from ``rowSize`` (thumbnail size +
+  // padding), so the entry just fills it; the Larger/Smaller buttons resize
+  // the list thumbnails the same way they resize grid cells.
+  height: 100%;
   display: flex;
   align-items: center;
   gap: var(--space-md);
@@ -124,22 +127,40 @@
     padding: 2px;
     border-radius: var(--radius-sm);
     width: var(--popup-cell, 80px);
+    // Hover-pop: the whole tile scales up over its neighbors (raised above
+    // them) the way a hovered cell magnifies on the browse canvas.
+    position: relative;
+    transition: transform 0.12s ease;
+    transform-origin: center center;
 
     &.selected {
       // The list's inset accent bar reads oddly under a square thumbnail; use
       // a ring instead so the whole cell shows as selected.
       box-shadow: 0 0 0 2px var(--accent);
     }
+
+    &:hover {
+      z-index: 3;
+      transform: scale(1.4);
+    }
+
+    &:hover .bin-popup-thumb-wrap,
+    &:hover .bin-popup-placeholder {
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+    }
   }
 }
 
-// List-mode thumbnail/placeholder: fixed 28px square.
+// Thumbnail/placeholder square. Sized to the chosen icon size (``--popup-cell``,
+// bound per row) in both modes so the Larger/Smaller buttons resize list rows
+// too; falls back to a compact square if the variable is ever absent.
 .bin-popup-thumb-wrap {
   display: block;
-  width: 28px;
-  height: 28px;
+  width: var(--popup-cell, 28px);
+  height: var(--popup-cell, 28px);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
+  transition: box-shadow 0.12s ease;
 }
 
 .bin-popup-thumb {
@@ -155,13 +176,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: var(--popup-cell, 28px);
+  height: var(--popup-cell, 28px);
   border-radius: var(--radius-sm);
   background: var(--bg-body);
   color: var(--text-muted);
   font-size: var(--font-lg);
   flex-shrink: 0;
+  transition: box-shadow 0.12s ease;
 }
 
 .bin-popup-name {
@@ -174,15 +196,9 @@
   text-overflow: ellipsis;
 }
 
-// Grid mode resizes the thumbnail to the chosen cell size and stacks the name
-// underneath it, truncated to the cell width.
+// Grid mode stacks the name under the thumbnail (sized by the shared
+// ``--popup-cell`` rule above), truncated to the cell width.
 .bin-popup-entry.grid {
-  .bin-popup-thumb-wrap,
-  .bin-popup-placeholder {
-    width: var(--popup-cell, 80px);
-    height: var(--popup-cell, 80px);
-  }
-
   .bin-popup-name {
     flex: 0 0 auto;
     width: 100%;

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -22,8 +22,10 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 
-/** Row stride (px) for the virtualized list mode; matches ``.bin-popup-entry``. */
-const LIST_ROW_HEIGHT = 36;
+/** Vertical room (px) reserved around a list-mode thumbnail (its row height is
+ *  the chosen thumbnail size plus this padding), so the Larger/Smaller buttons
+ *  scale list rows the same way they scale grid cells. */
+const LIST_ROW_PADDING = 8;
 /** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
 const GRID_LABEL_HEIGHT = 18;
 /** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
@@ -234,11 +236,13 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual row (a list entry, or a grid row of cells). */
+  /** Pixel stride of one virtual row (a list entry, or a grid row of cells).
+   *  Both modes scale with the chosen thumbnail size so the Larger/Smaller
+   *  controls take effect in list view as well as grid view. */
   get rowSize(): number {
     return this.viewMode === 'grid'
       ? this.gridGoalWidth + GRID_LABEL_HEIGHT + GRID_GAP
-      : LIST_ROW_HEIGHT;
+      : this.gridGoalWidth + LIST_ROW_PADDING;
   }
 
   /** Height (px) the body takes: just enough for its rows, capped (to the room

--- a/frontend/src/app/components/view-controls/view-controls.component.html
+++ b/frontend/src/app/components/view-controls/view-controls.component.html
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMinSize || !currentMediaType || viewMode === 'list'"
+      [disabled]="atMinSize || !currentMediaType || (viewMode === 'list' && !allowSizeInList)"
       (click)="bumpSize(-1)"
       title="Smaller thumbnails"
       aria-label="Smaller thumbnails">
@@ -12,7 +12,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMaxSize || !currentMediaType || viewMode === 'list'"
+      [disabled]="atMaxSize || !currentMediaType || (viewMode === 'list' && !allowSizeInList)"
       (click)="bumpSize(1)"
       title="Bigger thumbnails"
       aria-label="Bigger thumbnails">

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -26,6 +26,14 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
    * good/bad voting, so it hides the focus group with ``[showFocus]="false"``.
    */
   @Input() showFocus = true;
+  /**
+   * Whether the thumbnail-size buttons stay active in list mode. The
+   * left/right Find panels keep the historic behavior (size applies to grid
+   * only, so the buttons disable in list mode), but the VTSBrowse bin popup
+   * scales its list-mode thumbnails too, so it opts in with
+   * ``[allowSizeInList]="true"``.
+   */
+  @Input() allowSizeInList = false;
 
   viewMode: 'grid' | 'list' = 'list';
   focusMode: 'click' | 'hover' = 'click';
@@ -92,7 +100,7 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   bumpSize(delta: 1 | -1): void {
-    if (!this.currentMediaType || this.viewMode === 'list') return;
+    if (!this.currentMediaType || (this.viewMode === 'list' && !this.allowSizeInList)) return;
     const idx = ICON_SIZES.indexOf(this.gridIconSize);
     const next = ICON_SIZES[Math.max(0, Math.min(ICON_SIZES.length - 1, idx + delta))];
     if (next === this.gridIconSize) return;

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -408,6 +408,34 @@ class TestSettingsAPI:
         assert "grid_icon_size_left" in data
         assert "grid_icon_size_right" in data
 
+    def test_update_view_mode_popup_per_type(self, client):
+        res = client.put("/api/settings", json={"view_mode_popup": {"audio": "list", "image": "grid"}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["view_mode_popup"]["audio"] == "list"
+        assert data["view_mode_popup"]["image"] == "grid"
+
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["view_mode_popup"]["audio"] == "list"
+
+    def test_update_view_mode_popup_invalid(self, client):
+        res = client.put("/api/settings", json={"view_mode_popup": {"audio": "invalid"}})
+        assert res.status_code == 400
+
+    def test_update_grid_icon_size_popup_per_type(self, client):
+        res = client.put("/api/settings", json={"grid_icon_size_popup": {"audio": "S", "video": "L"}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["grid_icon_size_popup"]["audio"] == "S"
+        assert data["grid_icon_size_popup"]["video"] == "L"
+
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["grid_icon_size_popup"]["audio"] == "S"
+
+    def test_update_grid_icon_size_popup_invalid(self, client):
+        res = client.put("/api/settings", json={"grid_icon_size_popup": {"audio": "TINY"}})
+        assert res.status_code == 400
+
     def test_update_focus_mode_left_per_type(self, client):
         res = client.put("/api/settings", json={"focus_mode_left": {"audio": "hover", "image": "click"}})
         assert res.status_code == 200

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -72,6 +72,8 @@ _SCALAR_SETTERS: dict[str, Callable[[Any], Any]] = {
     "focus_mode_right": settings.set_focus_mode_right,
     "panel_pct_left": settings.set_panel_pct_left,
     "panel_pct_right": settings.set_panel_pct_right,
+    "view_mode_popup": settings.set_view_mode_popup,
+    "grid_icon_size_popup": settings.set_grid_icon_size_popup,
     "autopilot_enabled": settings.set_autopilot_enabled,
     "hide_autopilot": settings.set_hide_autopilot,
     "autopilot_top_greens": settings.set_autopilot_top_greens,


### PR DESCRIPTION
## Summary

The right-click bin popup on the VTSBrowse canvas had several broken/missing controls. This fixes all three:

1. **List/Grid toggle and Larger/Smaller buttons did nothing.** Root cause was backend, not the popup: the `PUT /api/settings` dispatch table (`_SCALAR_SETTERS` in `vtsearch/routes/settings/api.py`) was missing `view_mode_popup` and `grid_icon_size_popup`, so those writes hit the `setter is None` branch in `_apply_one_key` and were **silently dropped**. The popup re-reads settings from the live stream, so it never saw a change. (This also silently broke the matching Settings → Browser tab widgets.) Both keys are now registered, so the writes persist and round-trip.

2. **Larger/Smaller now works in List view too, not just Grid.** Added an `allowSizeInList` input to the shared `view-controls` component (the left/right Find panels keep the historic grid-only behavior; the popup opts in). List-mode thumbnails and row height now scale with the chosen icon size via the shared `--popup-cell` variable.

3. **Grid cells magnify on hover.** Hovering a grid cell now scales the whole tile up over its neighbors (raised above them, with a drop shadow), mirroring the way a hovered cell pops on the browse canvas.

## Changes

- `vtsearch/routes/settings/api.py` — register `view_mode_popup` / `grid_icon_size_popup` setters.
- `frontend/.../view-controls` — `allowSizeInList` input; size buttons stay live in list mode when set.
- `frontend/.../browse-bin-popup` — list rows scale with icon size; grid hover-pop; thumbnail sizing unified on `--popup-cell`.
- `tests/core/test_settings_api_routes.py` — popup view-mode / icon-size round-trip + invalid-value tests.
- `pyproject.toml` — codespell ignore for the `ans` shell variable (unblocks the lint gate).

## Testing

- `./run-tests.sh api core` → **ALL 1254 TESTS PASSED** (includes the frontend `build:prod` check).
- `npm run build:prod` → clean (exit 0, no warnings/budget issues).

https://claude.ai/code/session_01DcgywLSrYT5VNXktQ55GwY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcgywLSrYT5VNXktQ55GwY)_