### PR TITLE
Move dataset/detector Load action out of the Loaded? column

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -123,28 +123,19 @@
       @case ('readers') {
         <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
       }
-      @case ('loaded') {
-        <td>
-          @if (dataset.loaded) {
-            <span class="status-loaded" aria-label="Loaded" title="Dataset is loaded">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            </span>
-          } @else {
-            <button class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-          }
-        </td>
-      }
     }
   }
   <td class="actions-col">
     <div class="actions-cell">
+    @if (!dataset.loaded) {
+      <button class="load-btn" (click)="onLoad($event)" aria-label="Load dataset" title="Load dataset">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/>
+          <polyline points="12 6 12 12 6 12"/>
+          <line x1="3" y1="3" x2="12" y2="12"/>
+        </svg>
+      </button>
+    }
     <button class="browse-btn" (click)="onBrowse($event)" aria-label="Browse dataset" title="Browse dataset">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -119,15 +119,7 @@ td.actions-col {
   opacity: 0.7;
 }
 
-.status-loaded {
-  color: inherit;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-xs);
-}
-
-.load-action {
+.load-btn {
   background: none;
   border: none;
   color: var(--text-primary);

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -120,28 +120,19 @@
       @case ('readers') {
         <td [title]="(detector.readers || []).join(', ')">{{ (detector.readers || []).length ? (detector.readers || []).join(', ') : '-' }}</td>
       }
-      @case ('detector_loaded') {
-        <td>
-          @if (detector.detector_loaded) {
-            <span class="status-loaded" aria-label="Loaded" title="Detector is loaded">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            </span>
-          } @else {
-            <button class="load-action" (click)="onLoad($event)" title="Click to load this detector" aria-label="Load detector">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-          }
-        </td>
-      }
     }
   }
   <td class="actions-col">
     <div class="actions-cell">
+    @if (!detector.detector_loaded) {
+      <button class="load-btn" (click)="onLoad($event)" aria-label="Load detector" title="Load detector">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/>
+          <polyline points="12 6 12 12 6 12"/>
+          <line x1="3" y1="3" x2="12" y2="12"/>
+        </svg>
+      </button>
+    }
     @if (!isDefaultLogin) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -115,16 +115,7 @@ td.actions-col {
   opacity: 0.7;
 }
 
-.status-icon,
-.status-loaded {
-  color: inherit;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-xs);
-}
-
-.load-action,
+.load-btn,
 .autorun-toggle {
   background: none;
   border: none;

--- a/frontend/src/app/services/dashboard-columns.service.ts
+++ b/frontend/src/app/services/dashboard-columns.service.ts
@@ -9,7 +9,6 @@ export type DatasetColumn =
   | 'expires_at'
   | 'created_by'
   | 'readers'
-  | 'loaded'
   | 'actions';
 
 export type DetectorColumn =
@@ -21,7 +20,6 @@ export type DetectorColumn =
   | 'created_at'
   | 'created_by'
   | 'readers'
-  | 'detector_loaded'
   | 'actions';
 
 // `name` is pinned at the far left and `actions` at the far right; both are
@@ -36,7 +34,6 @@ const DATASET_COLUMNS_DEFAULT: DatasetColumn[] = [
   'expires_at',
   'created_by',
   'readers',
-  'loaded',
 ];
 
 const DETECTOR_COLUMNS_DEFAULT: DetectorColumn[] = [
@@ -47,7 +44,6 @@ const DETECTOR_COLUMNS_DEFAULT: DetectorColumn[] = [
   'created_at',
   'created_by',
   'readers',
-  'detector_loaded',
 ];
 
 const DATASET_COL_ORDER_KEY = 'vtsearch.dashboard.datasetColumnOrder';
@@ -61,7 +57,6 @@ export const DATASET_COL_META: Record<string, ColMeta> = {
   expires_at: { label: 'Age-Off', title: 'When this dataset ages off and is automatically removed (click to sort)', sortable: true },
   created_by: { label: 'Creator', title: 'User who created this dataset (click to sort)', sortable: true },
   readers: { label: 'Readers', title: 'Users with access to this dataset (click to sort)', sortable: true },
-  loaded: { label: 'Loaded?', title: 'Whether the dataset is currently loaded in memory', sortable: false },
   actions: { label: 'Actions', title: 'Available operations for this dataset', sortable: false },
 };
 
@@ -74,7 +69,6 @@ export const DETECTOR_COL_META: Record<string, ColMeta> = {
   created_at: { label: 'Created', title: 'When the detector was created (click to sort)', sortable: true },
   created_by: { label: 'Creator', title: 'User who created this detector (click to sort)', sortable: true },
   readers: { label: 'Readers', title: 'Users with access to this detector (click to sort)', sortable: true },
-  detector_loaded: { label: 'Loaded?', title: "Whether the detector's inference data is cached in memory", sortable: false },
   actions: { label: 'Actions', title: 'Available operations for this detector', sortable: false },
 };
 


### PR DESCRIPTION
## What changed

Loaded/unloaded state is still tracked on datasets and detectors, but it no longer gets a dedicated, always-visible **Loaded?** column in either dashboard grid. In the real production workflow an object lands in the Loaded state and stays there for the life of the backend, so a permanent column for it wasn't earning its space.

- **Removed the `Loaded?` column** from both the datasets and detectors grids (`loaded` / `detector_loaded` dropped from the column types, defaults, and metadata in `dashboard-columns.service.ts`). Persisted column orders that still reference the old columns are filtered out automatically by `ManagedColumns.normalizeColumnOrder`.
- **Added a new Load button** to the Actions cell of each grid. It appears **first** in the actions, and **only while the object is unloaded** — once loaded, it disappears. It uses the same import glyph as the **Data Imports** tab in Settings.
- The explicit-load affordance that used to live as the "X" in the `Loaded?` column now lives on this button (same `load` output / handlers, unchanged).
- Cleaned up the now-unused `.status-loaded` / `.load-action` SCSS in favor of a `.load-btn` rule matching the sibling action buttons.

State tracking itself is untouched: the `dataset.loaded` / `detector.detector_loaded` model fields and the logic that consumes them (context switching, context pulldown) are unchanged.

## Testing

- `npm run build:prod` — clean, no errors or warnings.

https://claude.ai/code/session_01TqJLZ29L9nAa731MrHPLf6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqJLZ29L9nAa731MrHPLf6)_