### PR TITLE
Fix detector-file write race that broke rename (FileNotFoundError on .tmp)

### DIFF
--- a/tests_lib/detectors/test_store_atomic_write.py
+++ b/tests_lib/detectors/test_store_atomic_write.py
@@ -29,13 +29,13 @@ class TestDetectorAtomicWrite:
         clobber or chase each other's in-flight tmp.
         """
         seen: list[str] = []
-        real_open = store.open
+        real_replace = store.os.replace
 
-        def spy_open(file, *args, **kwargs):
-            seen.append(str(file))
-            return real_open(file, *args, **kwargs)
+        def spy_replace(src, dst, *args, **kwargs):
+            seen.append(str(src))
+            return real_replace(src, dst, *args, **kwargs)
 
-        monkeypatch.setattr(store, "open", spy_open, raising=False)
+        monkeypatch.setattr(store.os, "replace", spy_replace)
 
         path = tmp_path / "mammals.json"
         _write_detector(path, {"name": "mammals", "labelset": {"labels": []}})

--- a/tests_lib/detectors/test_store_atomic_write.py
+++ b/tests_lib/detectors/test_store_atomic_write.py
@@ -1,0 +1,68 @@
+"""Regression tests for the atomic detector-file writer in ``vtscore.detectors.store``.
+
+A renamed (or otherwise re-saved) detector used to write its JSON through a
+*fixed* sibling tmp path ``<name>.json.tmp``.  Two writers racing on the same
+target (e.g. a double-fired rename request, or a rename overlapping a label
+sync) therefore shared one tmp file: the first ``os.replace`` consumed it and
+the second chased a tmp that was already renamed away, surfacing as
+
+    FileNotFoundError: '<name>.json.tmp' -> '<name>.json'
+
+The writer now uses a per-writer unique tmp suffix (PID + UUID), matching
+``vtsearch.settings._atomic_write`` and ``vtscore.io.atomic_write_text``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from vtscore.detectors import store
+from vtscore.detectors.store import _read_detector, _write_detector
+
+
+class TestDetectorAtomicWrite:
+    def test_tmp_filename_is_unique_per_writer(self, tmp_path, monkeypatch):
+        """The tmp file must NOT be the fixed ``<name>.json.tmp`` (the racy
+        name); it carries a PID + hex suffix so concurrent writers can't
+        clobber or chase each other's in-flight tmp.
+        """
+        seen: list[str] = []
+        real_open = store.open
+
+        def spy_open(file, *args, **kwargs):
+            seen.append(str(file))
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(store, "open", spy_open, raising=False)
+
+        path = tmp_path / "mammals.json"
+        _write_detector(path, {"name": "mammals", "labelset": {"labels": []}})
+
+        assert _read_detector(path) == {"name": "mammals", "labelset": {"labels": []}}
+        assert len(seen) == 1
+        tmp_name = seen[0].rsplit("/", 1)[-1]
+        # Racy fixed name is rejected; unique pattern is required.
+        assert tmp_name != "mammals.json.tmp"
+        assert re.match(r"^mammals\.json\.\d+\.[0-9a-f]{32}\.tmp$", tmp_name), tmp_name
+
+    def test_no_tmp_left_behind_on_success(self, tmp_path):
+        path = tmp_path / "mammals.json"
+        _write_detector(path, {"name": "mammals"})
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_tmp_cleaned_up_on_replace_error(self, tmp_path, monkeypatch):
+        """A failed ``os.replace`` must not leak the half-written tmp file."""
+        path = tmp_path / "mammals.json"
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(store.os, "replace", boom)
+        with pytest.raises(OSError, match="disk full"):
+            _write_detector(path, {"name": "mammals"})
+
+        leftovers = [p.name for p in tmp_path.iterdir()]
+        assert leftovers == []

--- a/vtscore/detectors/store.py
+++ b/vtscore/detectors/store.py
@@ -7,9 +7,11 @@ persist or inspect detector data without importing the full route blueprint.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
+import uuid
 from pathlib import Path
 
 from vtscore.config import DATA_DIR
@@ -51,9 +53,22 @@ def _read_detector(path: Path) -> dict | None:
 
 def _write_detector(path: Path, data: dict) -> None:
     get_detectors_dir().mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, path)
+    # Per-writer unique tmp suffix so two threads (or two processes) racing to
+    # overwrite the same detector file can't truncate each other's in-flight
+    # tmp file or chase one that was already renamed away (which surfaced as
+    # ``FileNotFoundError: '<name>.json.tmp' -> '<name>.json'`` from
+    # ``os.replace``).  Mirrors ``vtsearch.settings._atomic_write`` and
+    # ``vtscore.io.atomic_write_text``.
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        # Best-effort tmp cleanup so a failed write doesn't leak a
+        # half-written tmp file next to the destination.
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
+        raise


### PR DESCRIPTION
## What happened

Renaming a detector could fail with:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../data/detectors/mammals.json.tmp' -> '.../data/detectors/mammals.json'
```

`_write_detector` (in `vtscore/detectors/store.py`) wrote the JSON through a **fixed** sibling tmp path, `<name>.json.tmp`. When two writers raced on the same target file — a double-fired rename request, or a rename overlapping a background label sync — they shared that one tmp file:

1. Writer A opens `mammals.json.tmp`, writes, closes.
2. Writer B opens the **same** `mammals.json.tmp` (truncating it), writes, closes.
3. Writer A `os.replace(mammals.json.tmp, mammals.json)` — succeeds, consuming the tmp.
4. Writer B `os.replace(mammals.json.tmp, mammals.json)` — the tmp is **already renamed away** → `FileNotFoundError`.

This is **not** a versioning/stale-data issue — it's a latent race in current code, so it can hit any user (new ones included). The detector being unloaded was incidental.

The two other atomic writers in the repo already guard against exactly this (`vtsearch.settings._atomic_write`, `vtscore.io.atomic_write_text`), and their docstrings even name the symptom ("chase one that was already renamed away"). `store.py` was the one writer that never got the treatment.

## Fix

Give `_write_detector` a **per-writer unique tmp suffix** (`PID + UUID`) plus best-effort tmp cleanup on error, matching the established pattern. Concurrent writers now each have their own in-flight tmp and can't clobber or chase each other's.

## Tests

New `tests_lib/detectors/test_store_atomic_write.py`:
- tmp filename is unique per writer (rejects the racy fixed `<name>.json.tmp`)
- no tmp leaked on success
- tmp cleaned up when `os.replace` fails

Full suite green (4779 passed), plus ruff / pyright / deptry / pip-audit gates.

https://claude.ai/code/session_01K74m5sjm4i9jShx83oMbYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01K74m5sjm4i9jShx83oMbYq)_