### PR TITLE
Stop spurious tile-404 banners during browse bin-shape switch

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -429,8 +429,13 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private switchBinShape(shape: BinShape, persist: boolean): void {
     if (shape === this.binShape) return;
     this.binShape = shape;
-    this.tileCache.setBinShape(shape);
     if (persist) this.persistBrowsePref('browse_bin_shape', shape);
+    // Don't repoint the tile cache here. While ``ready``, the canvas stays
+    // mounted across the switch (so pan/zoom survive), and its redraw loop
+    // keeps fetching tiles. Flipping the cache to a shape whose pyramid isn't
+    // built yet would make those fetches 404 until the build lands. Instead,
+    // the cache is repointed only once the new shape is confirmed ready — in
+    // ``applyMeta``/``pollBuildStatus`` (keyed to the shape the meta is for).
     if (this.status === 'ready') {
       this.ensureShape();
     } else {
@@ -450,11 +455,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (resp) => {
           if (resp.status === 'ready') {
+            const shape = this.binShape;
             this.projectionApi
-              .getMeta(this.binShape, this.subset)
+              .getMeta(shape, this.subset)
               .pipe(takeUntil(this.destroy$))
               .subscribe({
-                next: (meta) => this.applyMeta(meta),
+                next: (meta) => this.applyMeta(meta, shape),
                 error: () => this.loadProjection(),
               });
           } else {
@@ -647,14 +653,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       this.status = 'done';
       return;
     }
+    const shape = this.binShape;
     this.projectionApi
-      .subsetRemove(this.binShape, removedIds)
+      .subsetRemove(shape, removedIds)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (meta) => {
           // Leave the viewport where the user had it; don't yank the camera to
           // re-fit the survivors. They can hit Zoom Fit if they want that.
-          this.applyMeta(meta);
+          this.applyMeta(meta, shape);
         },
         error: () =>
           this.toast.error({
@@ -696,11 +703,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private loadProjection(): void {
     this.status = 'loading';
     this.polling = false;
+    const shape = this.binShape;
     this.projectionApi
-      .getMeta(this.binShape, this.subset)
+      .getMeta(shape, this.subset)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (meta) => this.applyMeta(meta),
+        next: (meta) => this.applyMeta(meta, shape),
         error: (err) => {
           // The meta endpoint reports "idle" rather than 404/409, but treat a
           // missing projection defensively the same way: build it, don't ask.
@@ -715,8 +723,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       });
   }
 
-  /** Route a freshly-fetched meta to the right state, auto-building if absent. */
-  private applyMeta(meta: ProjectionMeta): void {
+  /**
+   * Route a freshly-fetched meta to the right state, auto-building if absent.
+   * ``shape`` is the bin shape this meta was fetched for — passed explicitly
+   * (rather than read from ``this.binShape``) because ``applyBrowsePrefsFor‐
+   * MediaType`` below can switch the active shape mid-call; the tile cache must
+   * be pointed at the shape that is actually ready, not the one we're switching
+   * to.
+   */
+  private applyMeta(meta: ProjectionMeta, shape: BinShape): void {
     this.meta = meta;
     if (meta.media_type) {
       this.mediaType = meta.media_type;
@@ -726,6 +741,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.tileCache.setContentVersion(meta.content_version ?? 0);
 
     if (meta.point_count > 0) {
+      // This shape's pyramid is built, so the canvas can render it without
+      // 404ing — only now is it safe to point the tile cache at it.
+      this.tileCache.setBinShape(shape);
       this.status = 'ready';
       return;
     }
@@ -751,9 +769,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (this.polling) return;
     this.polling = true;
     this.pollErrors = 0;
+    const shape = this.binShape;
     const poll = (): void => {
       this.projectionApi
-        .getMeta(this.binShape, this.subset)
+        .getMeta(shape, this.subset)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (meta) => {
@@ -765,6 +784,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             }
             this.tileCache.setProjectionId(meta.projection_id);
             if (meta.point_count > 0) {
+              // Build finished — point the cache at the now-built shape before
+              // the canvas remounts and starts fetching its tiles.
+              this.tileCache.setBinShape(shape);
               this.polling = false;
               this.status = 'ready';
               return;

--- a/frontend/src/app/services/projection-api.service.ts
+++ b/frontend/src/app/services/projection-api.service.ts
@@ -90,8 +90,13 @@ export class ProjectionApiService {
     const params: Record<string, string> = {};
     if (subset) params['subset'] = '1';
     if (cacheToken) params['v'] = cacheToken;
-    return Object.keys(params).length
-      ? this.http.get<TilePayload>(url, { params })
-      : this.http.get<TilePayload>(url);
+    // Suppress the global error toast: a tile can 404 transiently when it is
+    // requested for a bin shape whose pyramid hasn't finished building (e.g.
+    // mid bin-shape switch). The caller (TileCacheService) already recovers by
+    // rendering an empty tile and refetching once the build lands, so the
+    // failure is expected and self-healing — surfacing it as a banner would
+    // just alarm the user. Mirrors getMeta's SKIP_ERROR_TOAST rationale.
+    const context = new HttpContext().set(SKIP_ERROR_TOAST, true);
+    return this.http.get<TilePayload>(url, { params, context });
   }
 }


### PR DESCRIPTION
## What was happening

Browsing a dataset popped a flurry of error banners like:

> **Not Found** — 404 — `GET /api/projection/tiles/square/1/5/4`

…even though the grid rendered fine. The banners were noise, not a real failure.

## Root cause

When the browse canvas switches bin shape (hex ⇄ square) while in the `ready` state, it deliberately stays mounted so pan/zoom survive, and its redraw loop keeps fetching tiles. But `switchBinShape()` repointed the tile cache to the new shape **synchronously**, before that shape's pyramid had finished building. During that gap the canvas fetched tiles for the not-yet-built shape, so the server's `get_tile` hit `ctx._pyramids.get(shape) is None` and returned 404 for a whole grid of tiles at once.

Two things turned that into a visible problem:
- Unlike `getMeta` (which sets `SKIP_ERROR_TOAST` for its expected 404/409s), `getTile` did **not** opt out of the global error interceptor, so every transient tile 404 raised a banner.
- The tile cache's own `catchError` swallowed the same 404 and refetched once the build landed — so the grid self-healed, leaving the banners as pure noise.

(The banner showed a generic "Not Found" rather than the route's `abort(404, message="Projection not built yet…")` because `@app.errorhandler(NotFound)` is more specific than flask-smorest's `HTTPException` handler and rewrites the body — but with the toast suppressed, that message no longer matters for tiles.)

## Fix

- **`getTile` now sets `SKIP_ERROR_TOAST`.** These tile 404s are expected and self-healing (the cache renders empty and refetches), so they shouldn't alarm the user. Mirrors `getMeta`'s rationale.
- **The tile cache is repointed to a bin shape only once that shape's pyramid is confirmed ready** (`applyMeta` / `pollBuildStatus`, keyed to the shape the meta was fetched for), never speculatively at switch time. `applyMeta` now takes the shape explicitly because `applyBrowsePrefsForMediaType` can switch the active shape mid-call.

Frontend-only change. `npm run build:prod` passes with no TS errors or budget warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdWxkoe4REzZb4JRrM6sju)_