### PR TITLE
Detector stats page + detector-row Browse button; fix dataset-stats label casing

### DIFF
--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -240,3 +240,38 @@ PUT /api/detectors/registry/{detector_id}/rename
 **Body:** `{"name": "New Name"}`
 
 → `{"ok": true, "name": "New Name"}`
+
+### Detector statistics
+
+```
+GET /api/detectors/registry/{detector_id}/stats
+```
+
+Returns labelset composition and provenance for a registered detector.
+Counts and metadata only — never embeddings or MLP weights.
+`num_positive_resolved` / `active_dataset_name` report how many of the
+detector's positive labels currently resolve into the loaded dataset (the
+set the dashboard's Browse button projects).
+
+→ ```json
+{
+  "name": "cat-sounds",
+  "media_type": "audio",
+  "num_positive": 24,
+  "num_negative": 18,
+  "num_total": 42,
+  "num_positive_resolved": 20,
+  "active_dataset_name": "ESC-50",
+  "embedder": "laion_clap",
+  "text_query": "cat meowing",
+  "media_example": "",
+  "clipper": "",
+  "created_at": 1743412500.0,
+  "last_trained_at": 1743419700.0,
+  "created_by": "default",
+  "readers": [],
+  "autofind": false
+}
+```
+
+403 if the caller cannot access the detector; 404 if it does not exist.

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -275,3 +275,38 @@ set the dashboard's Browse button projects).
 ```
 
 403 if the caller cannot access the detector; 404 if it does not exist.
+
+### Browse a detector's positives
+
+```
+POST /api/detectors/registry/{detector_id}/browse-positives
+```
+
+Prepare an in-memory VTSBrowse map of just this detector's positive labels.
+Each positive's origin is resolved to its file and embedded with the
+**detector's own** embedder (not whatever dataset is selected) — so
+mixed-source detectors work and no dataset need be loaded. The resulting
+throwaway context (vectors + preview bytes, never persisted) is registered
+under a synthetic `dataset_id` the browse view opens.
+
+→ ```json
+{
+  "ok": true,
+  "dataset_id": "__detpos__<detector_id>",
+  "task_id": "_detbrowse_<id>",
+  "media_type": "audio"
+}
+```
+
+The build runs in the background; its progress rides the detector-loading
+task channel (the dashboard row shows it). 409 if the detector has no
+positive labels; 403/404 as above.
+
+```
+POST /api/detectors/registry/{detector_id}/browse-positives/release
+```
+
+Free the ephemeral positives-browse context (called when leaving the view).
+Idempotent.
+
+→ `{"ok": true, "released": true}`

--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -645,6 +645,30 @@ in git history and the cited source files.
   button UMAPs only the positive ids into an ephemeral, never-persisted `_subset_*`
   projection (`?subset=1`). *Known limitation:* in-memory id handoff, so a hard
   reload of the subset URL loses it.
+- ~~**Browse a saved detector's positives (dataset-free)**~~ — the dashboard's
+  detector-row `Browse` button maps just that detector's positive labels,
+  independent of any selected dataset. `POST /api/detectors/registry/<id>/browse-positives`
+  resolves each positive's origin and embeds it with the **detector's own**
+  embedder (so mixed-source detectors work and no dataset need be loaded;
+  reuses the loaded detector's `label_embeddings` when it's already in that
+  space), assembles a throwaway in-memory `DatasetContext` keyed
+  `__detpos__<id>` (vectors + preview bytes, never persisted), projects it,
+  and registers it. The browse stack is reused unchanged: the canvas reads
+  tiles + previews via the standard `/api/medias/<id>/...` endpoints off the
+  context's `media_bytes`. The guard skips the registry check for the
+  `__detpos__` prefix; the browse view releases the context (and clears the
+  active pair) on exit. Build runs async with progress on the detector row
+  (`_detbrowse_*` detector-loading task). See `vtscore/detectors/positives_browse.py`.
+  *Open follow-ups:* (a) clipped/region positives are embedded image-level
+  (`embed_file`), not patch-pooled like training — fine for layout, but it can
+  place a region-voted item slightly differently than its trained vector;
+  reuse the cached `label_embeddings` covers the loaded-detector case exactly.
+  (b) Ephemeral-context cleanup leans on the browse-view's release call (plus
+  rebuild-evict and process exit); there's no server-side TTL, so a client that
+  vanishes mid-browse leaves the context until the next browse of that detector.
+  (c) Preview bytes are held in memory for the session — fine for labelset-sized
+  sets, but a very large positive set would be heavy; a lazy `media_path`/origin
+  re-resolution path could replace the eager byte read if that ever bites.
 - ~~**Bin-popup member ordering**~~ — a bin's `member_ids` are served in a
   locality-preserving 1-D order (a Hilbert space-filling-curve traversal of the
   frozen 2-D layout, `_hilbert_order` in `pyramid.py`) rather than by media id,

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2196,6 +2196,79 @@
         ],
         "type": "object"
       },
+      "DetectorRegistryStatsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "active_dataset_name": {
+            "type": "string"
+          },
+          "autofind": {
+            "type": "boolean"
+          },
+          "clipper": {
+            "type": "string"
+          },
+          "created_at": {
+            "nullable": true
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "embedder": {
+            "type": "string"
+          },
+          "last_trained_at": {
+            "nullable": true
+          },
+          "media_example": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "num_negative": {
+            "type": "integer"
+          },
+          "num_positive": {
+            "type": "integer"
+          },
+          "num_positive_resolved": {
+            "type": "integer"
+          },
+          "num_total": {
+            "type": "integer"
+          },
+          "readers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "text_query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "active_dataset_name",
+          "autofind",
+          "clipper",
+          "created_by",
+          "embedder",
+          "media_example",
+          "media_type",
+          "name",
+          "num_negative",
+          "num_positive",
+          "num_positive_resolved",
+          "num_total",
+          "readers",
+          "text_query"
+        ],
+        "type": "object"
+      },
       "DetectorRegistryUnloadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -9790,6 +9863,48 @@
           "detectors_registry"
         ]
       }
+    },
+    "/api/detectors/registry/{detector_id}/stats": {
+      "get": {
+        "description": "Counts/metadata only \u2014 no embeddings or MLP weights are read or\nreturned (the labelset file is the canonical persisted form). The\n``num_positive_resolved`` / ``active_dataset_name`` pair reports how\nmuch of the positive set the Browse button could currently project.",
+        "operationId": "get_detector_stats",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectorRegistryStatsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "description": "Access denied for the current user."
+          },
+          "404": {
+            "description": "Detector not found."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return labelset composition and provenance for a registered detector.",
+        "tags": [
+          "detectors_registry"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ]
     },
     "/api/detectors/registry/{detector_id}/unload": {
       "parameters": [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1561,6 +1561,46 @@
         ],
         "type": "object"
       },
+      "DetectorBrowsePositivesReleaseResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "released": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "released"
+        ],
+        "type": "object"
+      },
+      "DetectorBrowsePositivesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "task_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataset_id",
+          "media_type",
+          "ok",
+          "task_id"
+        ],
+        "type": "object"
+      },
       "DetectorCancelResponse": {
         "additionalProperties": false,
         "properties": {
@@ -9689,6 +9729,84 @@
           }
         },
         "summary": "Toggle the calling user's Auto-Find flag for a registered detector.",
+        "tags": [
+          "detectors_registry"
+        ]
+      }
+    },
+    "/api/detectors/registry/{detector_id}/browse-positives": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Resolves every positive label's origin to its file and embeds it with the\n**detector's** embedder (reusing the loaded detector's cached vectors when\nit's already in that space), assembles a throwaway ``DatasetContext`` whose\nmedia carry those embeddings + preview bytes, projects it, and registers it\nunder a synthetic ``dataset_id`` the browse view can open. Nothing is\npersisted \u2014 the context (vectors and bytes) lives only in memory until\nreleased. Mixed-source detectors work: a positive needn't be in any loaded\ndataset, only origin-resolvable.\n\nReturns immediately with the ``dataset_id`` and the ``task_id`` whose\nprogress the detector's dashboard row renders while the build runs.",
+        "operationId": "browse_detector_positives",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectorBrowsePositivesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "description": "Access denied for the current user."
+          },
+          "404": {
+            "description": "Detector not found."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Prepare an in-memory VTSBrowse map of just this detector's positives.",
+        "tags": [
+          "detectors_registry"
+        ]
+      }
+    },
+    "/api/detectors/registry/{detector_id}/browse-positives/release": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Called when the user leaves the browse view. Idempotent: ``released`` is\n``False`` when there was nothing to drop.",
+        "operationId": "release_detector_positives_browse",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectorBrowsePositivesReleaseResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Free the ephemeral positives-browse context for *detector_id*.",
         "tags": [
           "detectors_registry"
         ]

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -19,6 +19,7 @@ import { ProjectionApiService } from '../../services/projection-api.service';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
+import { DetectorsRegistryApiService } from '../../services/detectors-registry-api.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
@@ -187,6 +188,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private tileCache: TileCacheService,
     private activeContext: ActiveContextService,
     private datasetsRegistryApi: DatasetsRegistryApiService,
+    private detectorsRegistryApi: DetectorsRegistryApiService,
     private settingsState: SettingsStateService,
     private route: ActivatedRoute,
     private router: Router,
@@ -265,6 +267,27 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     document.removeEventListener('mousemove', this.boundPanelMove);
     document.removeEventListener('mouseup', this.boundPanelUp);
     this.tileCache.clear();
+    this.releaseEphemeralPositivesContext();
+  }
+
+  /** Free a detector-positives browse context (`__detpos__<detectorId>`) when
+   *  leaving the view, so its in-memory vectors + preview bytes aren't leaked. */
+  private releaseEphemeralPositivesContext(): void {
+    const datasetId = this.route.snapshot.paramMap.get('datasetId') || '';
+    const prefix = '__detpos__';
+    if (!datasetId.startsWith(prefix)) return;
+    const detectorId = datasetId.slice(prefix.length);
+    // Clear the active pair if it still points at this throwaway context, so
+    // dashboard requests don't keep tagging a released id (unless the user
+    // already switched to another dataset, in which case leave that alone).
+    if (this.activeContext.datasetId === datasetId) {
+      this.activeContext.setActive('', '');
+    }
+    this.detectorsRegistryApi.releasePositivesBrowse(detectorId).subscribe({
+      error: () => {
+        /* best-effort cleanup; the context is harmless if it lingers */
+      },
+    });
   }
 
   onHexHover(event: HexHoverEvent | null): void {

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -273,12 +273,15 @@
                 [deleteConfirmOpen]="deletingDetectorId === detector.id"
                 [addLabelsOpen]="modals.addLabels.open && modals.addLabels.detectorId === detector.id"
                 [exportOpen]="modals.export.open && modals.export.detectorName === detector.name"
+                [statsOpen]="modals.detectorStats.open && modals.detectorStats.detectorId === detector.id"
                 (rowClick)="!isLoading && toggleDetectorSelection(detector.id, $event)"
                 (checkboxToggle)="!isLoading && toggleDetectorCheckbox(detector.id)"
                 (rename)="renameDetector(detector, $event)"
                 (delete)="deleteDetector(detector)"
                 (load)="loadDetector(detector)"
                 (unload)="unloadDetector(detector)"
+                (browse)="browseDetector(detector)"
+                (stats)="showDetectorStats(detector)"
                 (export)="openExportModal(detector)"
                 (addLabels)="openAddLabelsModal(detector)"
                 (security)="editDetectorSecurity(detector)"
@@ -383,5 +386,13 @@
     [datasetId]="modals.stats.datasetId"
     [datasetName]="modals.stats.datasetName"
     (closed)="modals.closeStats()"
+  />
+}
+
+@if (modals.detectorStats.open) {
+  <vt-detector-stats-modal
+    [detectorId]="modals.detectorStats.detectorId"
+    [detectorName]="modals.detectorStats.detectorName"
+    (closed)="modals.closeDetectorStats()"
   />
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -8,8 +8,6 @@ import { DatasetsRegistryApiService } from '../../services/datasets-registry-api
 import { DatasetsUiApiService } from '../../services/datasets-ui-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DetectorsRegistryApiService } from '../../services/detectors-registry-api.service';
-import { DetectorsCrudApiService } from '../../services/detectors-crud-api.service';
-import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { ToastService } from '../../services/toast.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
@@ -169,8 +167,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private datasetsUiApi: DatasetsUiApiService,
     private detectorsFindApi: DetectorsFindApiService,
     private detectorsRegistryApi: DetectorsRegistryApiService,
-    private detectorsCrudApi: DetectorsCrudApiService,
-    private browseSubset: BrowseSubsetService,
     private toast: ToastService,
     private dialog: VtDialogService,
     private labelSession: LabelSessionService,
@@ -869,43 +865,41 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.modals.openDetectorStats(model.id, model.name);
   }
 
-  /** Launch the VTSBrowse view over just this detector's positively-labeled
-   *  elements. Loads the detector (and its dataset) if needed so the labels
-   *  resolve into the active dataset, then hands the resolved positive ids to
-   *  the browse subset projection — mirroring Find's "Browse positives". The
-   *  positives are projected against the *active* dataset, so a compatible
-   *  dataset must be loaded for there to be anything to show. */
+  /** Launch the VTSBrowse view over just this detector's positive labels.
+   *  The backend resolves each positive's origin and embeds it with the
+   *  *detector's own* embedder (mixed sources included, no dataset required),
+   *  building a throwaway in-memory browse context; we show that build's
+   *  progress on the detector row, then navigate once it's ready. */
   browseDetector(model: DetectorRegistryEntry): void {
-    const datasetId = this.activeContext.datasetId;
-    if (!datasetId) {
-      this.toast.error({
-        message: 'Load a dataset first',
-        detail: `Browsing "${model.name}" projects its positives against a loaded dataset, but none is active.`,
-      });
-      return;
-    }
-    this.contextSwitch
-      .applyActivePair(datasetId, model.id)
-      .pipe(take(1))
-      .subscribe(() => {
-        this.detectorsCrudApi.getLabelsDetail(model.name).subscribe({
-          next: (detail) => {
-            const ids = (detail.good ?? [])
-              .map((g) => g.cid)
-              .filter((cid): cid is number => cid != null);
-            if (ids.length === 0) {
-              this.toast.error({
-                message: 'No positives to browse',
-                detail: `None of "${model.name}"'s positive labels resolve into the active dataset.`,
-              });
-              return;
-            }
-            this.browseSubset.set({ datasetId, ids, label: `${model.name} — positives` });
-            this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
-          },
-          error: () => this.toast.error({ message: 'Failed to load detector labels' }),
-        });
-      });
+    this.detectorsRegistryApi.browsePositives(model.id).subscribe({
+      next: (resp) => {
+        this.loadingTasksSvc.startDetectorProgressPolling();
+        let seenRunning = false;
+        this.progressEvents.detectorLoadingTasks$
+          .pipe(
+            filter((tasks) => {
+              const t = tasks.find((x) => x.task_id === resp.task_id);
+              if (t && t.status !== 'idle' && !t.error) {
+                seenRunning = true;
+                return false;
+              }
+              // Finished (idle), errored, or vanished after we saw it running.
+              return (!!t && (t.status === 'idle' || !!t.error)) || (!t && seenRunning);
+            }),
+            take(1),
+            takeUntil(this.destroy$),
+          )
+          .subscribe(() => {
+            const failed = this.progressEvents.detectorLoadingTasks.some(
+              (t) => t.task_id === resp.task_id && !!t.error,
+            );
+            if (failed) return; // ToastService surfaces the build error from the SSE task
+            this.activeContext.setActive(resp.dataset_id, '');
+            this.router.navigate(['/browse', resp.dataset_id]);
+          });
+      },
+      error: () => this.toast.error({ message: 'Failed to prepare browse' }),
+    });
   }
 
   // --- Export / Add-Labels modal openers (state lives on DashboardModalsService) ---

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -8,6 +8,9 @@ import { DatasetsRegistryApiService } from '../../services/datasets-registry-api
 import { DatasetsUiApiService } from '../../services/datasets-ui-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DetectorsRegistryApiService } from '../../services/detectors-registry-api.service';
+import { DetectorsCrudApiService } from '../../services/detectors-crud-api.service';
+import { BrowseSubsetService } from '../../services/browse-subset.service';
+import { ToastService } from '../../services/toast.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
@@ -43,6 +46,7 @@ import { CombineDetectorsModalComponent } from './combine-detectors-modal/combin
 import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { DatasetStatsModalComponent } from '../modals/dataset-stats-modal/dataset-stats-modal.component';
+import { DetectorStatsModalComponent } from '../modals/detector-stats-modal/detector-stats-modal.component';
 import { IconComponent } from '../icon/icon.component';
 import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
 
@@ -60,6 +64,7 @@ import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
     LabelExporterModalComponent,
     LabelImporterModalComponent,
     DatasetStatsModalComponent,
+    DetectorStatsModalComponent,
     IconComponent,
     UsageBarComponent,
     SkeletonComponent,
@@ -164,6 +169,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private datasetsUiApi: DatasetsUiApiService,
     private detectorsFindApi: DetectorsFindApiService,
     private detectorsRegistryApi: DetectorsRegistryApiService,
+    private detectorsCrudApi: DetectorsCrudApiService,
+    private browseSubset: BrowseSubsetService,
+    private toast: ToastService,
     private dialog: VtDialogService,
     private labelSession: LabelSessionService,
     public datasetState: DatasetStateService,
@@ -853,6 +861,51 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.detectorsRegistryApi.unloadDetector(model.id).subscribe({
       next: () => this.datasetState.refresh(),
     });
+  }
+
+  /** Open the read-only stats modal for a detector (labelset composition +
+   *  provenance). Mirrors `showDatasetStats`. */
+  showDetectorStats(model: DetectorRegistryEntry): void {
+    this.modals.openDetectorStats(model.id, model.name);
+  }
+
+  /** Launch the VTSBrowse view over just this detector's positively-labeled
+   *  elements. Loads the detector (and its dataset) if needed so the labels
+   *  resolve into the active dataset, then hands the resolved positive ids to
+   *  the browse subset projection — mirroring Find's "Browse positives". The
+   *  positives are projected against the *active* dataset, so a compatible
+   *  dataset must be loaded for there to be anything to show. */
+  browseDetector(model: DetectorRegistryEntry): void {
+    const datasetId = this.activeContext.datasetId;
+    if (!datasetId) {
+      this.toast.error({
+        message: 'Load a dataset first',
+        detail: `Browsing "${model.name}" projects its positives against a loaded dataset, but none is active.`,
+      });
+      return;
+    }
+    this.contextSwitch
+      .applyActivePair(datasetId, model.id)
+      .pipe(take(1))
+      .subscribe(() => {
+        this.detectorsCrudApi.getLabelsDetail(model.name).subscribe({
+          next: (detail) => {
+            const ids = (detail.good ?? [])
+              .map((g) => g.cid)
+              .filter((cid): cid is number => cid != null);
+            if (ids.length === 0) {
+              this.toast.error({
+                message: 'No positives to browse',
+                detail: `None of "${model.name}"'s positive labels resolve into the active dataset.`,
+              });
+              return;
+            }
+            this.browseSubset.set({ datasetId, ids, label: `${model.name} — positives` });
+            this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
+          },
+          error: () => this.toast.error({ message: 'Failed to load detector labels' }),
+        });
+      });
   }
 
   // --- Export / Add-Labels modal openers (state lives on DashboardModalsService) ---

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -117,6 +117,12 @@
         </svg>
       </button>
     }
+    <button class="browse-btn" (click)="onBrowse($event)" aria-label="Browse this detector's positives" title="Browse positives">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+        <circle cx="12" cy="12" r="3"></circle>
+      </svg>
+    </button>
     @if (!isDefaultLogin) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -139,6 +145,15 @@
         <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
         <polyline points="15 3 21 3 21 9"></polyline>
         <line x1="12" y1="12" x2="21" y2="3"></line>
+      </svg>
+    </button>
+    <button class="stats-btn" (click)="onStats($event)" aria-label="Detector stats" title="Stats">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 2a10 10 0 0 1 0 20"/>
+        <line x1="12" y1="12" x2="12" y2="2"/>
+        <line x1="12" y1="12" x2="20.66" y2="17"/>
+        <line x1="12" y1="12" x2="2" y2="12"/>
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete">

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -132,6 +132,48 @@ td.actions-col {
   }
 }
 
+.browse-btn {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+  }
+}
+
+.stats-btn {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+  }
+
+  .pie-active {
+    animation: icon-rotate-open var(--transition-slow) ease-in-out forwards;
+  }
+
+  .pie-inactive {
+    animation: icon-rotate-close var(--transition-slow) ease-in-out forwards;
+  }
+}
+
 // Inline loading progress (replaces data columns while loading). Mirrors the
 // stack layout used by the dataset card's `.inline-loading-progress` so the
 // dashboard's loading rows have a consistent shape.

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -43,6 +43,8 @@ export class DetectorCardComponent implements OnChanges {
   @Output() addLabels = new EventEmitter<void>();
   @Output() load = new EventEmitter<void>();
   @Output() unload = new EventEmitter<void>();
+  @Output() browse = new EventEmitter<void>();
+  @Output() stats = new EventEmitter<void>();
   @Output() cancelTask = new EventEmitter<string>();
   @Output() dismissTask = new EventEmitter<string>();
   @Output() checkboxToggle = new EventEmitter<void>();
@@ -64,6 +66,7 @@ export class DetectorCardComponent implements OnChanges {
   @Input() deleteConfirmOpen = false;
   @Input() addLabelsOpen = false;
   @Input() exportOpen = false;
+  @Input() statsOpen = false;
 
   editing = false;
   wasEditing = false;
@@ -71,6 +74,7 @@ export class DetectorCardComponent implements OnChanges {
   wasDeleteOpen = false;
   wasAddLabelsOpen = false;
   wasExportOpen = false;
+  wasStatsOpen = false;
 
   startRename(event: MouseEvent): void {
     event.stopPropagation();
@@ -102,6 +106,9 @@ export class DetectorCardComponent implements OnChanges {
     if (changes['exportOpen'] && !changes['exportOpen'].currentValue && changes['exportOpen'].previousValue) {
       this.wasExportOpen = true;
     }
+    if (changes['statsOpen'] && !changes['statsOpen'].currentValue && changes['statsOpen'].previousValue) {
+      this.wasStatsOpen = true;
+    }
   }
 
   onPencilAnimationEnd(): void {
@@ -128,6 +135,12 @@ export class DetectorCardComponent implements OnChanges {
     }
   }
 
+  onPieAnimationEnd(): void {
+    if (!this.statsOpen) {
+      this.wasStatsOpen = false;
+    }
+  }
+
   onRenameKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter') {
       this.confirmRename();
@@ -139,6 +152,16 @@ export class DetectorCardComponent implements OnChanges {
   onLoad(event: MouseEvent): void {
     event.stopPropagation();
     this.load.emit();
+  }
+
+  onBrowse(event: MouseEvent): void {
+    event.stopPropagation();
+    this.browse.emit();
+  }
+
+  onStats(event: MouseEvent): void {
+    event.stopPropagation();
+    this.stats.emit();
   }
 
   onDelete(event: MouseEvent): void {

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -40,7 +40,7 @@
         }
         @for (p of originParams; track p.key) {
           <tr>
-            <td class="stat-label" [title]="'Importer field: ' + p.key">{{ p.key }}</td>
+            <td class="stat-label" [title]="'Importer field: ' + p.key">{{ p.label }}</td>
             <td class="stat-value">{{ p.value }}</td>
           </tr>
         }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -52,13 +52,22 @@ export class DatasetStatsModalComponent implements OnInit {
     return src?.importer || '';
   }
 
-  get originParams(): { key: string; value: string }[] {
+  get originParams(): { key: string; label: string; value: string }[] {
     const src = this.stats?.source as { params?: Record<string, unknown> } | undefined;
     const params = src?.params;
     if (!params) return [];
     return Object.entries(params)
       .filter(([, v]) => v !== '' && v != null)
-      .map(([key, value]) => ({ key, value: String(value) }));
+      .map(([key, value]) => ({ key, label: this.formatParamKey(key), value: String(value) }));
+  }
+
+  /** Render a raw origin-param key (e.g. ``media_type``, ``name``) as a label
+   *  that matches the hardcoded stat labels: underscores become spaces and the
+   *  first letter is capitalized, so a demo dataset's ``name`` param reads
+   *  "Name" alongside "Importer" / "Clipper" / "Embedder" instead of lowercase. */
+  private formatParamKey(key: string): string {
+    const spaced = key.replace(/_/g, ' ');
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
   }
 
   formatTimestamp(ts: number | null): string {

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
@@ -1,0 +1,90 @@
+<vt-modal [open]="true" [title]="'Stats: ' + detectorName" (closed)="close()">
+  @if (loading) {
+    <p class="loading-text">Loading stats...</p>
+  } @else if (error) {
+    <p class="error-text">{{ error }}</p>
+  } @else if (stats) {
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="Positively-labeled elements in this detector's labelset">Positives</td>
+          <td class="stat-value">{{ stats.num_positive | number }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Negatively-labeled elements in this detector's labelset">Negatives</td>
+          <td class="stat-value">{{ stats.num_negative | number }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Total labeled elements (positives + negatives)">Total labels</td>
+          <td class="stat-value">{{ stats.num_total | number }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="How many positives currently resolve into the loaded dataset — the set the Browse button would project">In current dataset</td>
+          <td class="stat-value">{{ resolvedSummary }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="section-title">Creation</h3>
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="The media type this detector operates on">Media type</td>
+          <td class="stat-value">{{ (stats.media_type | titlecase) || '-' }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="MediaEmbedder whose space the labels are resolved against">Embedder</td>
+          <td class="stat-value">{{ (stats.embedder | titlecase) || '-' }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Clipper granularity this detector was trained on">Clipper</td>
+          <td class="stat-value">{{ stats.clipper || '-' }}</td>
+        </tr>
+        @if (stats.text_query) {
+          <tr>
+            <td class="stat-label" title="Text query this detector was seeded from">Text query</td>
+            <td class="stat-value">{{ stats.text_query }}</td>
+          </tr>
+        }
+        @if (stats.media_example) {
+          <tr>
+            <td class="stat-label" title="Media example this detector was seeded from">Media example</td>
+            <td class="stat-value">{{ stats.media_example }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    <h3 class="section-title">Provenance</h3>
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="When this detector was created">Created</td>
+          <td class="stat-value">{{ formatTimestamp(stats.created_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="When this detector's labelset was last trained">Last trained</td>
+          <td class="stat-value">{{ formatTimestamp(stats.last_trained_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="The user who created this detector">Created by</td>
+          <td class="stat-value">{{ stats.created_by || '-' }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Whether this detector runs automatically during CLI autodetect">Auto-Find</td>
+          <td class="stat-value">{{ stats.autofind ? 'On' : 'Off' }}</td>
+        </tr>
+        @if (stats.readers.length > 0) {
+          <tr>
+            <td class="stat-label" title="Users who can access this detector (* means everyone)">Access</td>
+            <td class="stat-value">{{ stats.readers.join(', ') }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+
+  <div modal-footer>
+    <button class="btn btn--secondary" (click)="close()">Close</button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.scss
@@ -1,0 +1,32 @@
+.loading-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+// `.error-text` comes from `_components.scss` (uses `--color-bad`).
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-lg);
+
+  th,
+  td {
+    padding: var(--space-sm) var(--space-md);
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}
+
+.stat-label {
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.stat-value {
+  color: var(--text-primary);
+}
+
+// Section rhythm provided by the shared `.section-title` utility in
+// _components.scss.

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
@@ -1,0 +1,60 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+import { DetectorsRegistryApiService } from '../../../services/detectors-registry-api.service';
+import type { DetectorRegistryStatsResponse } from '../../../generated/api-client/models/detector-registry-stats-response';
+import { formatTimestamp as formatTs } from '../../../utils/format-date';
+
+/** Read-only stats for a registered detector. Mirrors the dataset stats
+ *  modal: labelset composition (positives / negatives / total, plus how
+ *  many positives currently resolve into the active dataset) and the
+ *  detector's creation/provenance metadata. Counts only — no embeddings
+ *  or MLP weights are read (see the "No Persisted Vectors" rule). */
+@Component({
+  selector: 'vt-detector-stats-modal',
+  standalone: true,
+  imports: [CommonModule, ModalComponent],
+  templateUrl: './detector-stats-modal.component.html',
+  styleUrl: './detector-stats-modal.component.scss',
+})
+export class DetectorStatsModalComponent implements OnInit {
+  @Input() detectorId = '';
+  @Input() detectorName = '';
+  @Output() closed = new EventEmitter<void>();
+
+  loading = true;
+  error = '';
+  stats: DetectorRegistryStatsResponse | null = null;
+
+  constructor(private detectorsRegistryApi: DetectorsRegistryApiService) {}
+
+  ngOnInit(): void {
+    this.detectorsRegistryApi.getDetectorStats(this.detectorId).subscribe({
+      next: (data) => {
+        this.stats = data;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err.error?.error || err.error?.message || 'Failed to load stats';
+        this.loading = false;
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  formatTimestamp(ts: number | null): string {
+    return formatTs(ts);
+  }
+
+  /** "N of M (in \"dataset\")" for the resolved-positives row, or a hint
+   *  when no dataset is loaded to resolve against. */
+  get resolvedSummary(): string {
+    const s = this.stats;
+    if (!s) return '-';
+    if (!s.active_dataset_name) return 'No dataset loaded';
+    return `${s.num_positive_resolved} of ${s.num_positive} in "${s.active_dataset_name}"`;
+  }
+}

--- a/frontend/src/app/guards/browse-context.guard.ts
+++ b/frontend/src/app/guards/browse-context.guard.ts
@@ -20,6 +20,14 @@ export const browseContextGuard: CanActivateFn = (route) => {
     return router.parseUrl('/dashboard');
   }
 
+  // Ephemeral detector-positives browse contexts (`__detpos__<id>`) are built
+  // server-side and reached via the X-Dataset-Id header; they are deliberately
+  // absent from the dataset registry, so skip the registry/load checks. The
+  // dashboard's Browse button already set the active context before navigating.
+  if (datasetId.startsWith('__detpos__')) {
+    return true;
+  }
+
   if (!datasetState.loaded) {
     datasetState.refresh();
   }

--- a/frontend/src/app/services/dashboard-modals.service.ts
+++ b/frontend/src/app/services/dashboard-modals.service.ts
@@ -33,6 +33,12 @@ export interface StatsState {
   datasetName: string;
 }
 
+export interface DetectorStatsState {
+  open: boolean;
+  detectorId: string;
+  detectorName: string;
+}
+
 /**
  * Singleton owner of the Dashboard's row-action and selection-action
  * modal states. Lifting these out of `DashboardComponent` keeps the
@@ -71,6 +77,11 @@ export class DashboardModalsService {
     datasetId: '',
     datasetName: '',
   });
+  private readonly detectorStatsSubject = new BehaviorSubject<DetectorStatsState>({
+    open: false,
+    detectorId: '',
+    detectorName: '',
+  });
 
   readonly combineDatasets$ = this.combineDatasetsSubject.asObservable();
   readonly combineDetectors$ = this.combineDetectorsSubject.asObservable();
@@ -78,6 +89,7 @@ export class DashboardModalsService {
   readonly addLabels$ = this.addLabelsSubject.asObservable();
   readonly findResults$ = this.findResultsSubject.asObservable();
   readonly stats$ = this.statsSubject.asObservable();
+  readonly detectorStats$ = this.detectorStatsSubject.asObservable();
 
   get combineDatasets(): CombineDatasetsState {
     return this.combineDatasetsSubject.value;
@@ -101,6 +113,10 @@ export class DashboardModalsService {
 
   get stats(): StatsState {
     return this.statsSubject.value;
+  }
+
+  get detectorStats(): DetectorStatsState {
+    return this.detectorStatsSubject.value;
   }
 
   openCombineDatasets(datasets: DatasetRegistryEntry[]): void {
@@ -149,5 +165,13 @@ export class DashboardModalsService {
 
   closeStats(): void {
     this.statsSubject.next({ open: false, datasetId: '', datasetName: '' });
+  }
+
+  openDetectorStats(detectorId: string, detectorName: string): void {
+    this.detectorStatsSubject.next({ open: true, detectorId, detectorName });
+  }
+
+  closeDetectorStats(): void {
+    this.detectorStatsSubject.next({ open: false, detectorId: '', detectorName: '' });
   }
 }

--- a/frontend/src/app/services/detectors-registry-api.service.ts
+++ b/frontend/src/app/services/detectors-registry-api.service.ts
@@ -14,9 +14,11 @@ import type { DetectorRegistryListResponse } from '../generated/api-client/model
 import type { DetectorRegistryLoadResponse } from '../generated/api-client/models/detector-registry-load-response';
 import type { DetectorRegistryRenameResponse } from '../generated/api-client/models/detector-registry-rename-response';
 import type { DetectorRegistryReadersResponse } from '../generated/api-client/models/detector-registry-readers-response';
+import type { DetectorRegistryStatsResponse } from '../generated/api-client/models/detector-registry-stats-response';
 import type { DetectorRegistryUnloadResponse } from '../generated/api-client/models/detector-registry-unload-response';
 import { cancelDetectorLoadingTask } from '../generated/api-client/fn/detectors-registry/cancel-detector-loading-task';
 import { deleteRegisteredDetector } from '../generated/api-client/fn/detectors-registry/delete-registered-detector';
+import { getDetectorStats } from '../generated/api-client/fn/detectors-registry/get-detector-stats';
 import { listRegisteredDetectors } from '../generated/api-client/fn/detectors-registry/list-registered-detectors';
 import { loadDetectorRoute } from '../generated/api-client/fn/detectors-registry/load-detector-route';
 import { moveLabelsetSourceFile } from '../generated/api-client/fn/detectors-registry/move-labelset-source-file';
@@ -158,6 +160,12 @@ export class DetectorsRegistryApiService {
     return updateDetectorReaders(this.http, this.config.rootUrl, {
       detector_id: detectorId,
       body: { readers },
+    }).pipe(map((r) => r.body));
+  }
+
+  getDetectorStats(detectorId: string): Observable<DetectorRegistryStatsResponse> {
+    return getDetectorStats(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
     }).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/detectors-registry-api.service.ts
+++ b/frontend/src/app/services/detectors-registry-api.service.ts
@@ -16,9 +16,13 @@ import type { DetectorRegistryRenameResponse } from '../generated/api-client/mod
 import type { DetectorRegistryReadersResponse } from '../generated/api-client/models/detector-registry-readers-response';
 import type { DetectorRegistryStatsResponse } from '../generated/api-client/models/detector-registry-stats-response';
 import type { DetectorRegistryUnloadResponse } from '../generated/api-client/models/detector-registry-unload-response';
+import type { DetectorBrowsePositivesResponse } from '../generated/api-client/models/detector-browse-positives-response';
+import type { DetectorBrowsePositivesReleaseResponse } from '../generated/api-client/models/detector-browse-positives-release-response';
+import { browseDetectorPositives } from '../generated/api-client/fn/detectors-registry/browse-detector-positives';
 import { cancelDetectorLoadingTask } from '../generated/api-client/fn/detectors-registry/cancel-detector-loading-task';
 import { deleteRegisteredDetector } from '../generated/api-client/fn/detectors-registry/delete-registered-detector';
 import { getDetectorStats } from '../generated/api-client/fn/detectors-registry/get-detector-stats';
+import { releaseDetectorPositivesBrowse } from '../generated/api-client/fn/detectors-registry/release-detector-positives-browse';
 import { listRegisteredDetectors } from '../generated/api-client/fn/detectors-registry/list-registered-detectors';
 import { loadDetectorRoute } from '../generated/api-client/fn/detectors-registry/load-detector-route';
 import { moveLabelsetSourceFile } from '../generated/api-client/fn/detectors-registry/move-labelset-source-file';
@@ -165,6 +169,22 @@ export class DetectorsRegistryApiService {
 
   getDetectorStats(detectorId: string): Observable<DetectorRegistryStatsResponse> {
     return getDetectorStats(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+    }).pipe(map((r) => r.body));
+  }
+
+  /** Prepare an in-memory VTSBrowse map of this detector's positives,
+   *  embedded with the detector's own embedder. Returns the synthetic
+   *  ``dataset_id`` to navigate to plus the progress ``task_id``. */
+  browsePositives(detectorId: string): Observable<DetectorBrowsePositivesResponse> {
+    return browseDetectorPositives(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+    }).pipe(map((r) => r.body));
+  }
+
+  /** Free the ephemeral positives-browse context when leaving the view. */
+  releasePositivesBrowse(detectorId: string): Observable<DetectorBrowsePositivesReleaseResponse> {
+    return releaseDetectorPositivesBrowse(this.http, this.config.rootUrl, {
       detector_id: detectorId,
     }).pipe(map((r) => r.body));
   }

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -816,6 +816,51 @@ class TestDetectorStats:
         assert res.status_code == 404
 
 
+class TestDetectorBrowsePositives:
+    """Tests for the detector-positives browse endpoints."""
+
+    def _register(self, client, name="BrowseMe"):
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "text_query": "x"},
+        )
+        assert res.status_code == 201
+        return res.get_json()["detector"]["id"]
+
+    def test_browse_positives_404_for_unknown(self, client):
+        res = client.post("/api/detectors/registry/nonexistent_id/browse-positives")
+        assert res.status_code == 404
+
+    def test_browse_positives_409_without_positives(self, client):
+        detector_id = self._register(client)
+        res = client.post(f"/api/detectors/registry/{detector_id}/browse-positives")
+        assert res.status_code == 409
+
+    def test_browse_positives_returns_synthetic_dataset_id(self, client):
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        detector_id = self._register(client, name="BrowsePos")
+        path = _detector_path("BrowsePos")
+        data = _read_detector(path)
+        assert data is not None
+        data["labelset"] = {"labels": [{"md5": "a" * 32, "label": "good"}]}
+        _write_detector(path, data)
+
+        res = client.post(f"/api/detectors/registry/{detector_id}/browse-positives")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["ok"] is True
+        assert data["dataset_id"] == f"__detpos__{detector_id}"
+        assert data["task_id"]
+
+    def test_release_is_idempotent(self, client):
+        detector_id = self._register(client)
+        # Nothing built yet → released is False, still ok.
+        res = client.post(f"/api/detectors/registry/{detector_id}/browse-positives/release")
+        assert res.status_code == 200
+        assert res.get_json() == {"ok": True, "released": False}
+
+
 class TestLoadModelEndpoint:
     """Tests for POST /api/detectors/registry/load."""
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -785,6 +785,7 @@ class TestDetectorStats:
         detector_id = self._register(client, name="CountMe")
         path = _detector_path("CountMe")
         data = _read_detector(path)
+        assert data is not None
         data["labelset"] = {
             "labels": [
                 {"md5": "a" * 32, "label": "good"},

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -752,6 +752,69 @@ class TestDeleteRegisteredModel:
         assert get_detector(detector_id) is None
 
 
+class TestDetectorStats:
+    """Tests for GET /api/detectors/registry/<detector_id>/stats."""
+
+    def _register(self, client, name="StatMe", **extra):
+        body = {"name": name, "media_type": "audio", "text_query": "meow", **extra}
+        res = client.post("/api/detectors/registry", json=body)
+        assert res.status_code == 201
+        return res.get_json()["detector"]["id"]
+
+    def test_stats_basic_shape(self, client):
+        detector_id = self._register(client)
+        res = client.get(f"/api/detectors/registry/{detector_id}/stats")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["name"] == "StatMe"
+        assert data["media_type"] == "audio"
+        assert data["text_query"] == "meow"
+        assert data["num_positive"] == 0
+        assert data["num_negative"] == 0
+        assert data["num_total"] == 0
+        assert data["autofind"] is False
+        # Resolution + provenance fields are always present.
+        assert "num_positive_resolved" in data
+        assert "active_dataset_name" in data
+        assert "created_by" in data
+        assert isinstance(data["readers"], list)
+
+    def test_stats_counts_positives_and_negatives(self, client):
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        detector_id = self._register(client, name="CountMe")
+        path = _detector_path("CountMe")
+        data = _read_detector(path)
+        data["labelset"] = {
+            "labels": [
+                {"md5": "a" * 32, "label": "good"},
+                {"md5": "b" * 32, "label": "good"},
+                {"md5": "c" * 32, "label": "bad"},
+            ]
+        }
+        _write_detector(path, data)
+
+        res = client.get(f"/api/detectors/registry/{detector_id}/stats")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["num_positive"] == 2
+        assert data["num_negative"] == 1
+        assert data["num_total"] == 3
+
+    def test_stats_reflects_autofind_flag(self, client):
+        from vtsearch.settings import add_autofind_detector
+
+        detector_id = self._register(client, name="AutoStat")
+        add_autofind_detector("AutoStat")
+        res = client.get(f"/api/detectors/registry/{detector_id}/stats")
+        assert res.status_code == 200
+        assert res.get_json()["autofind"] is True
+
+    def test_stats_404_for_unknown_detector(self, client):
+        res = client.get("/api/detectors/registry/nonexistent_id/stats")
+        assert res.status_code == 404
+
+
 class TestLoadModelEndpoint:
     """Tests for POST /api/detectors/registry/load."""
 

--- a/tests_lib/detectors/test_positives_browse.py
+++ b/tests_lib/detectors/test_positives_browse.py
@@ -1,0 +1,111 @@
+"""Tests for the ephemeral detector-positives browse context builder.
+
+These exercise the library-tier logic (no Flask): resolving + embedding a
+detector's positives into a throwaway ``DatasetContext`` with a ready
+projection. Origin resolution and embedding are monkeypatched so the test
+stays fast and offline.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+import vtscore.detectors.resolver as resolver
+from vtscore.detectors.positives_browse import (
+    build_positives_browse_context,
+    detpos_dataset_id,
+)
+
+
+def _detector_data(labels):
+    return {"media_type": "text", "labelset": {"labels": labels}}
+
+
+def _patch_resolve_and_embed(monkeypatch, tmp_path, *, resolvable=True):
+    """Make every element resolve to a temp file and embed to a seeded vector."""
+    f = tmp_path / "item.txt"
+    f.write_text("hello")
+
+    @contextmanager
+    def fake_resolve(origin, origin_name="", filename=""):
+        yield (f if resolvable else None)
+
+    counter = {"n": 0}
+
+    def fake_embed(file_path, media_type, embedder_name=""):
+        # Seed per-call so the matrix has distinct, deterministic rows.
+        counter["n"] += 1
+        rng = np.random.default_rng(counter["n"])
+        return rng.standard_normal(16).astype(np.float32)
+
+    monkeypatch.setattr(resolver, "resolve_file_context", fake_resolve)
+    monkeypatch.setattr(resolver, "embed_file", fake_embed)
+
+
+def test_detpos_dataset_id_prefix():
+    assert detpos_dataset_id("abc123").startswith("__detpos__")
+    assert detpos_dataset_id("abc123").endswith("abc123")
+
+
+def test_builds_context_over_positives_only(monkeypatch, tmp_path):
+    _patch_resolve_and_embed(monkeypatch, tmp_path)
+    data = _detector_data(
+        [
+            {"md5": "a" * 32, "label": "good"},
+            {"md5": "b" * 32, "label": "good"},
+            {"md5": "c" * 32, "label": "good"},
+            {"md5": "d" * 32, "label": "bad"},  # excluded
+        ]
+    )
+
+    ctx = build_positives_browse_context(
+        data,
+        detpos_dataset_id("det1"),
+        embedder_name="e5",
+        display_name="Det — positives",
+    )
+
+    # Only the 3 positives are materialised; the negative is dropped.
+    assert len(ctx.medias) == 3
+    for media in ctx.medias.values():
+        assert media["media_type"] == "text"
+        assert isinstance(media["embedding"], np.ndarray)
+        assert media["media_bytes"] == b"hello"
+        assert media["embedder"] == "e5"
+    # A ready projection + hex pyramid is built up front.
+    assert ctx._projection is not None
+    assert "hex" in ctx._pyramids
+    assert ctx.dataset_display_name == "Det — positives"
+
+
+def test_reuses_cached_embeddings(monkeypatch, tmp_path):
+    _patch_resolve_and_embed(monkeypatch, tmp_path)
+
+    from vtscore.detectors.labelset_elements import stable_element_id
+    from vtscore.datasets.labelset import LabeledElement
+
+    elem = LabeledElement.from_dict({"md5": "a" * 32, "label": "good"})
+    eid = stable_element_id(elem)
+    cached = {eid: np.full(16, 0.5, dtype=np.float32)}
+
+    data = _detector_data([{"md5": "a" * 32, "label": "good"}])
+    ctx = build_positives_browse_context(
+        data,
+        detpos_dataset_id("det2"),
+        embedder_name="e5",
+        cached_embeddings=cached,
+    )
+
+    (media,) = ctx.medias.values()
+    # The cached vector is used verbatim (not re-embedded).
+    assert np.allclose(media["embedding"], 0.5)
+
+
+def test_raises_when_nothing_resolves(monkeypatch, tmp_path):
+    _patch_resolve_and_embed(monkeypatch, tmp_path, resolvable=False)
+    data = _detector_data([{"md5": "a" * 32, "label": "good"}])
+    with pytest.raises(ValueError, match="nothing to browse"):
+        build_positives_browse_context(data, detpos_dataset_id("det3"), embedder_name="e5")

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -1,0 +1,142 @@
+"""Build an ephemeral browse context over a detector's positive labels.
+
+VTSBrowse is a *dataset* browser: it projects a :class:`DatasetContext`'s
+embedding matrix to 2-D and previews items from that context's ``medias``.
+A trained detector, however, is a labelset whose positives can come from
+**mixed sources** that aren't all present in any one loaded dataset — and
+whose embedder is the detector's own, not whatever dataset happens to be
+selected on the dashboard.
+
+This module bridges the two by materialising the detector's positives as an
+**in-memory, throwaway** :class:`DatasetContext`:
+
+* each positive is origin-resolved to its file (read once for preview bytes),
+* embedded with the *detector's* embedder (or reused from the loaded
+  detector's cache when it's already in that space),
+* and the resulting ``(embedding, media_bytes)`` media dicts are projected
+  with the normal UMAP + hex-pyramid pipeline.
+
+The whole context — vectors and bytes — lives only in process memory and is
+never persisted (no ``pkl_path``), satisfying the "No Persisted Vectors"
+rule. The browse stack then works unchanged: the canvas reads tiles and
+previews via the standard ``/api/medias/<id>/...`` endpoints, resolving them
+from this context's ``media_bytes``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import numpy as np
+
+from vtscore.datasets.labelset import LabelSet
+from vtscore.detectors.labelset_elements import stable_element_id
+from vtscore.state.core import DatasetContext
+
+#: ``dataset_id`` prefix for ephemeral detector-positives browse contexts.
+#: The frontend keys off this to skip the dataset-registry check in the
+#: browse route guard and to release the context when leaving the view.
+DETPOS_PREFIX = "__detpos__"
+
+#: Progress callback: ``(current, total, message)``.
+ProgressCb = Callable[[int, int, str], None]
+
+
+def detpos_dataset_id(detector_id: str) -> str:
+    """The synthetic browse ``dataset_id`` for *detector_id*'s positives."""
+    return f"{DETPOS_PREFIX}{detector_id}"
+
+
+def build_positives_browse_context(
+    detector_data: dict[str, Any],
+    dataset_id: str,
+    *,
+    embedder_name: str,
+    cached_embeddings: dict[str, np.ndarray] | None = None,
+    display_name: str = "",
+    bin_shape: str = "hex",
+    on_progress: ProgressCb | None = None,
+) -> DatasetContext:
+    """Build a ready-to-browse ephemeral context over the positives.
+
+    *embedder_name* is the **detector's** embedder; every uncached positive is
+    embedded with it, regardless of any loaded dataset. *cached_embeddings*
+    (typically the loaded detector's ``label_embeddings``) is reused when it
+    already holds a vector for an element built in that same space, so a
+    detector loaded against its own dataset isn't re-embedded.
+
+    Builds the UMAP projection + *bin_shape* pyramid so the browse view finds
+    a ready projection on arrival. Raises :class:`ValueError` when no positive
+    could be resolved + embedded (nothing to browse).
+    """
+    from vtscore.detectors.resolver import embed_file, resolve_file_context
+
+    media_type = detector_data.get("media_type", "") or ""
+    labelset = LabelSet.from_dict(detector_data.get("labelset") or {})
+    positives = [el for el in labelset.elements if el.label == "good"]
+
+    medias: dict[int, dict[str, Any]] = {}
+    total = len(positives)
+    next_cid = 0
+    for idx, elem in enumerate(positives):
+        if on_progress is not None:
+            on_progress(idx, total, "Resolving positives…")
+
+        # Resolve the backing file once: bytes power the preview, and (when we
+        # have no cached vector) the same path is embedded with the detector's
+        # embedder. The ``with`` block keeps temp-materialised sources alive.
+        emb: np.ndarray | None = None
+        if cached_embeddings is not None:
+            cached = cached_embeddings.get(stable_element_id(elem))
+            if cached is not None:
+                emb = np.asarray(cached, dtype=np.float32)
+
+        media_bytes: bytes | None = None
+        with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
+            if file_path is not None and file_path.is_file():
+                try:
+                    media_bytes = file_path.read_bytes()
+                except OSError:
+                    media_bytes = None
+                if emb is None and media_bytes is not None:
+                    emb = embed_file(file_path, media_type, embedder_name)
+
+        if emb is None or media_bytes is None:
+            # Origin couldn't be located or embedded → it simply won't appear
+            # on the map. Skipping keeps a partially-resolvable detector usable.
+            continue
+
+        medias[next_cid] = {
+            "id": next_cid,
+            "media_type": media_type,
+            "embedding": np.asarray(emb, dtype=np.float32),
+            "media_bytes": media_bytes,
+            "filename": elem.filename or elem.origin_name or "",
+            "origin_name": elem.origin_name or "",
+            "origin": elem.origin or {},
+            "md5": elem.md5 or "",
+            "embedder": embedder_name,
+        }
+        next_cid += 1
+
+    if not medias:
+        raise ValueError(
+            "None of this detector's positive labels could be resolved and embedded — nothing to browse."
+        )
+
+    ctx = DatasetContext(dataset_id)
+    ctx.medias = medias
+    ctx.dataset_display_name = display_name or None
+
+    # Project + tile up front so the browse view lands on a ready layout.
+    from vtscore.embedding.matrix import get_embedding_matrix
+    from vtscore.projection import build_pyramid, fit_projection
+
+    if on_progress is not None:
+        on_progress(total, total, "Building projection…")
+    sorted_ids, matrix = get_embedding_matrix(ctx)
+    proj = fit_projection(matrix, sorted_ids)
+    pyr = build_pyramid(proj, bin_shape=bin_shape)
+    ctx._projection = proj
+    ctx._pyramids[bin_shape] = pyr
+    return ctx

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -133,9 +133,7 @@ def build_positives_browse_context(
         medias[cid] = media
 
     if not medias:
-        raise ValueError(
-            "None of this detector's positive labels could be resolved and embedded — nothing to browse."
-        )
+        raise ValueError("None of this detector's positive labels could be resolved and embedded — nothing to browse.")
 
     ctx = DatasetContext(dataset_id)
     ctx.medias = medias

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -47,6 +47,45 @@ def detpos_dataset_id(detector_id: str) -> str:
     return f"{DETPOS_PREFIX}{detector_id}"
 
 
+def _materialize_positive(
+    elem,
+    *,
+    media_type: str,
+    embedder_name: str,
+    cached: np.ndarray | None,
+) -> dict[str, Any] | None:
+    """Resolve + embed one positive into a media dict, or ``None`` to skip it.
+
+    Reads the origin file once: its bytes power the preview, and (when no
+    cached vector is supplied) the same path is embedded with *embedder_name*.
+    """
+    from vtscore.detectors.resolver import embed_file, resolve_file_context
+
+    emb = np.asarray(cached, dtype=np.float32) if cached is not None else None
+    media_bytes: bytes | None = None
+    with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
+        if file_path is not None and file_path.is_file():
+            try:
+                media_bytes = file_path.read_bytes()
+            except OSError:
+                media_bytes = None
+            if emb is None and media_bytes is not None:
+                emb = embed_file(file_path, media_type, embedder_name)
+
+    if emb is None or media_bytes is None:
+        return None
+    return {
+        "media_type": media_type,
+        "embedding": np.asarray(emb, dtype=np.float32),
+        "media_bytes": media_bytes,
+        "filename": elem.filename or elem.origin_name or "",
+        "origin_name": elem.origin_name or "",
+        "origin": elem.origin or {},
+        "md5": elem.md5 or "",
+        "embedder": embedder_name,
+    }
+
+
 def build_positives_browse_context(
     detector_data: dict[str, Any],
     dataset_id: str,
@@ -69,55 +108,29 @@ def build_positives_browse_context(
     a ready projection on arrival. Raises :class:`ValueError` when no positive
     could be resolved + embedded (nothing to browse).
     """
-    from vtscore.detectors.resolver import embed_file, resolve_file_context
-
     media_type = detector_data.get("media_type", "") or ""
     labelset = LabelSet.from_dict(detector_data.get("labelset") or {})
     positives = [el for el in labelset.elements if el.label == "good"]
 
     medias: dict[int, dict[str, Any]] = {}
     total = len(positives)
-    next_cid = 0
     for idx, elem in enumerate(positives):
         if on_progress is not None:
             on_progress(idx, total, "Resolving positives…")
-
-        # Resolve the backing file once: bytes power the preview, and (when we
-        # have no cached vector) the same path is embedded with the detector's
-        # embedder. The ``with`` block keeps temp-materialised sources alive.
-        emb: np.ndarray | None = None
-        if cached_embeddings is not None:
-            cached = cached_embeddings.get(stable_element_id(elem))
-            if cached is not None:
-                emb = np.asarray(cached, dtype=np.float32)
-
-        media_bytes: bytes | None = None
-        with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
-            if file_path is not None and file_path.is_file():
-                try:
-                    media_bytes = file_path.read_bytes()
-                except OSError:
-                    media_bytes = None
-                if emb is None and media_bytes is not None:
-                    emb = embed_file(file_path, media_type, embedder_name)
-
-        if emb is None or media_bytes is None:
-            # Origin couldn't be located or embedded → it simply won't appear
-            # on the map. Skipping keeps a partially-resolvable detector usable.
+        cached = cached_embeddings.get(stable_element_id(elem)) if cached_embeddings is not None else None
+        # An origin that can't be located or embedded simply won't appear on
+        # the map — skipping keeps a partially-resolvable detector usable.
+        media = _materialize_positive(
+            elem,
+            media_type=media_type,
+            embedder_name=embedder_name,
+            cached=cached,
+        )
+        if media is None:
             continue
-
-        medias[next_cid] = {
-            "id": next_cid,
-            "media_type": media_type,
-            "embedding": np.asarray(emb, dtype=np.float32),
-            "media_bytes": media_bytes,
-            "filename": elem.filename or elem.origin_name or "",
-            "origin_name": elem.origin_name or "",
-            "origin": elem.origin or {},
-            "md5": elem.md5 or "",
-            "embedder": embedder_name,
-        }
-        next_cid += 1
+        cid = len(medias)
+        media["id"] = cid
+        medias[cid] = media
 
     if not medias:
         raise ValueError(

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -59,6 +59,7 @@ from vtsearch.schemas.detectors import (
     DetectorRegistryReadersResponseSchema,
     DetectorRegistryRenameRequestSchema,
     DetectorRegistryRenameResponseSchema,
+    DetectorRegistryStatsResponseSchema,
     DetectorRegistryUnloadResponseSchema,
 )
 
@@ -901,6 +902,118 @@ def update_detector_readers(body: dict, detector_id: str):
         status = 403 if "creator" in err else 404
         abort(status, message=err)
     return {"ok": True, "readers": readers}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/detectors/registry/<detector_id>/stats
+# ---------------------------------------------------------------------------
+
+
+def _resolved_positive_count(elements) -> int:
+    """How many of *elements* (positives) resolve into the active dataset.
+
+    Builds the media lookup once and resolves every element against it, so
+    this is one pass rather than one rebuild per element. Returns 0 when no
+    dataset is loaded.
+    """
+    from vtsearch.state import build_media_lookup, resolve_media_ids, snapshot_medias
+
+    snap = snapshot_medias()
+    if not snap:
+        return 0
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    count = 0
+    for el in elements:
+        if resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup):
+            count += 1
+    return count
+
+
+def _active_dataset_name() -> str:
+    """Display name of the active dataset, or ``""`` when none is loaded."""
+    from vtsearch.state import get_active_context
+
+    ds_id = get_active_context().dataset_id
+    if not ds_id:
+        return ""
+    from vtscore.datasets.registry import get_dataset
+
+    entry = get_dataset(ds_id)
+    return (entry or {}).get("name", "") if entry else ""
+
+
+@detectors_registry_bp.route("/api/detectors/registry/<detector_id>/stats")
+@detectors_registry_bp.response(200, DetectorRegistryStatsResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
+@detectors_registry_bp.alt_response(404, description="Detector not found.")
+def get_detector_stats(detector_id: str):
+    """Return labelset composition and provenance for a registered detector.
+
+    Counts/metadata only — no embeddings or MLP weights are read or
+    returned (the labelset file is the canonical persisted form). The
+    ``num_positive_resolved`` / ``active_dataset_name`` pair reports how
+    much of the positive set the Browse button could currently project.
+    """
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.registry import (
+        can_user_access_detector,
+        get_detector,
+        get_loaded_detector_ids,
+    )
+    from vtscore.media import get_clipper
+    from vtscore.state.core import get_detector_context
+    from vtsearch.settings import get_autofind_detectors
+
+    entry = get_detector(detector_id)
+    if entry is None:
+        abort(404, message="Detector not found")
+    if not can_user_access_detector(detector_id, get_current_user()):
+        abort(403, message="You do not have access to this detector")
+
+    name = entry.get("name", "") or ""
+    data = _read_detector(_detector_path(name)) or {}
+
+    labelset = LabelSet.from_dict(data.get("labelset") or {})
+    positives = [el for el in labelset.elements if el.label == "good"]
+    negatives = [el for el in labelset.elements if el.label == "bad"]
+
+    # Embedder: the loaded context's live value wins (it reflects the space
+    # the labels are currently resolved against); otherwise the registry's
+    # persisted stamp.
+    if detector_id in get_loaded_detector_ids():
+        ctx = get_detector_context(detector_id)
+        embedder = (ctx.embedder if ctx is not None else "") or entry.get("embedder", "") or ""
+    else:
+        embedder = entry.get("embedder", "") or ""
+
+    input_spec = data.get("input_spec") or {}
+    raw_clipper = (input_spec.get("clipper", "") if isinstance(input_spec, dict) else "") or ""
+    if not raw_clipper or raw_clipper.endswith("_default"):
+        clipper_display = ""
+    else:
+        try:
+            clipper_display = get_clipper(raw_clipper).display_name
+        except KeyError:
+            clipper_display = raw_clipper
+
+    return {
+        "name": name,
+        "media_type": entry.get("media_type", "") or "",
+        "num_positive": len(positives),
+        "num_negative": len(negatives),
+        "num_total": len(labelset.elements),
+        "num_positive_resolved": _resolved_positive_count(positives),
+        "active_dataset_name": _active_dataset_name(),
+        "embedder": embedder,
+        "text_query": data.get("text_query", "") or "",
+        "media_example": data.get("media_example", "") or "",
+        "clipper": clipper_display,
+        "created_at": entry.get("created_at"),
+        "last_trained_at": entry.get("last_trained_at"),
+        "created_by": entry.get("created_by", "default") or "default",
+        "readers": entry.get("readers", []) or [],
+        "autofind": name in set(get_autofind_detectors()),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -1041,6 +1041,56 @@ def _detector_browse_embedder(entry: dict, media_type: str) -> str:
     return avail[0].name if avail else ""
 
 
+def _run_positives_browse_build(
+    tracker,
+    task_id: str,
+    detector_data: dict,
+    dataset_id: str,
+    *,
+    embedder_name: str,
+    cached_embeddings: dict | None,
+    display_name: str,
+) -> None:
+    """Background worker: build + register the ephemeral browse context.
+
+    Mirrors the error handling of the detector-load task: a cancel or an
+    "empty after resolution" :class:`ValueError` surfaces as a task error on
+    the detector row; anything else logs a traceback and surfaces its message.
+    """
+    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
+    from vtscore.detectors.positives_browse import build_positives_browse_context
+    from vtscore.state.core import register_context
+
+    def _on_progress(current: int, total: int, message: str) -> None:
+        tracker.check_cancelled()
+        tracker.update("loading", message, current, total, step=1, total_steps=1)
+
+    try:
+        ctx = build_positives_browse_context(
+            detector_data,
+            dataset_id,
+            embedder_name=embedder_name,
+            cached_embeddings=cached_embeddings,
+            display_name=display_name,
+            on_progress=_on_progress,
+        )
+        register_context(ctx)
+        tracker.update("idle", "", 0, 0, step=None, total_steps=None)
+    except CancelledError:
+        tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+    except ValueError as e:
+        tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+    except Exception as e:
+        import traceback as _tb
+
+        _tb.print_exc()
+        tracker.update(
+            "idle", "", 0, 0, error=str(e) or repr(e) or "Unknown error preparing browse", step=None, total_steps=None
+        )
+    finally:
+        detector_loading_tasks.mark_finished(task_id)
+
+
 @detectors_registry_bp.route("/api/detectors/registry/<detector_id>/browse-positives", methods=["POST"])
 @detectors_registry_bp.response(200, DetectorBrowsePositivesResponseSchema)
 @detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
@@ -1060,14 +1110,15 @@ def browse_detector_positives(detector_id: str):
     Returns immediately with the ``dataset_id`` and the ``task_id`` whose
     progress the detector's dashboard row renders while the build runs.
     """
-    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
-    from vtscore.detectors.positives_browse import build_positives_browse_context, detpos_dataset_id
+    from vtscore.concurrency.progress import detector_loading_tasks
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.positives_browse import detpos_dataset_id
     from vtscore.detectors.registry import (
         can_user_access_detector,
         get_detector,
         get_loaded_detector_ids,
     )
-    from vtscore.state.core import get_detector_context, register_context, unregister_context
+    from vtscore.state.core import get_detector_context, unregister_context
     from vtsearch.threading import spawn
 
     entry = get_detector(detector_id)
@@ -1079,8 +1130,6 @@ def browse_detector_positives(detector_id: str):
     name = entry.get("name", "") or ""
     data = _read_detector(_detector_path(name)) or {}
     media_type = entry.get("media_type", "") or data.get("media_type", "") or ""
-
-    from vtscore.datasets.labelset import LabelSet
 
     labelset = LabelSet.from_dict(data.get("labelset") or {})
     if not any(el.label == "good" for el in labelset.elements):
@@ -1110,37 +1159,19 @@ def browse_detector_positives(detector_id: str):
     )
     tracker.update("loading", "Preparing browse…", 0, 0, step=1, total_steps=1)
 
-    def build_task():
-        try:
-            def _on_progress(current: int, total: int, message: str) -> None:
-                tracker.check_cancelled()
-                tracker.update("loading", message, current, total, step=1, total_steps=1)
-
-            try:
-                ctx = build_positives_browse_context(
-                    data,
-                    dataset_id,
-                    embedder_name=embedder_name,
-                    cached_embeddings=cached_embeddings,
-                    display_name=f"{name} — positives" if name else "Detector positives",
-                    on_progress=_on_progress,
-                )
-                register_context(ctx)
-                tracker.update("idle", "", 0, 0, step=None, total_steps=None)
-            except CancelledError:
-                tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
-            except ValueError as e:
-                tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
-            except Exception as e:
-                import traceback as _tb
-
-                _tb.print_exc()
-                error_msg = str(e) or repr(e) or "Unknown error preparing browse"
-                tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
-        finally:
-            detector_loading_tasks.mark_finished(task_id)
-
-    spawn(build_task, name=f"det-browse-{detector_id[:8]}")
+    display_name = f"{name} — positives" if name else "Detector positives"
+    spawn(
+        lambda: _run_positives_browse_build(
+            tracker,
+            task_id,
+            data,
+            dataset_id,
+            embedder_name=embedder_name,
+            cached_embeddings=cached_embeddings,
+            display_name=display_name,
+        ),
+        name=f"det-browse-{detector_id[:8]}",
+    )
     return {
         "ok": True,
         "dataset_id": dataset_id,

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -44,6 +44,8 @@ from vtscore.detectors.label_restoration import (
 from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
 from vtscore.detectors.media_seeding import seed_good_votes_from_examples as _seed_good_votes_from_examples
 from vtsearch.schemas.detectors import (
+    DetectorBrowsePositivesReleaseResponseSchema,
+    DetectorBrowsePositivesResponseSchema,
     DetectorCancelResponseSchema,
     DetectorLabelsetMoveRequestSchema,
     DetectorLabelsetMoveResponseSchema,
@@ -1014,6 +1016,155 @@ def get_detector_stats(detector_id: str):
         "readers": entry.get("readers", []) or [],
         "autofind": name in set(get_autofind_detectors()),
     }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/detectors/registry/<detector_id>/browse-positives
+# POST /api/detectors/registry/<detector_id>/browse-positives/release
+# ---------------------------------------------------------------------------
+
+
+def _detector_browse_embedder(entry: dict, media_type: str) -> str:
+    """The embedder to project a detector's positives with.
+
+    The detector's own recorded embedder wins — browsing a detector must not
+    depend on whatever dataset is incidentally selected on the dashboard.
+    Falls back to the media type's default embedder when the detector has
+    never recorded one (e.g. never trained against a dataset).
+    """
+    recorded = entry.get("embedder", "") or ""
+    if recorded:
+        return recorded
+    from vtscore.media import embedders_for_type
+
+    avail = embedders_for_type(media_type)
+    return avail[0].name if avail else ""
+
+
+@detectors_registry_bp.route("/api/detectors/registry/<detector_id>/browse-positives", methods=["POST"])
+@detectors_registry_bp.response(200, DetectorBrowsePositivesResponseSchema)
+@detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
+@detectors_registry_bp.alt_response(404, description="Detector not found.")
+def browse_detector_positives(detector_id: str):
+    """Prepare an in-memory VTSBrowse map of just this detector's positives.
+
+    Resolves every positive label's origin to its file and embeds it with the
+    **detector's** embedder (reusing the loaded detector's cached vectors when
+    it's already in that space), assembles a throwaway ``DatasetContext`` whose
+    media carry those embeddings + preview bytes, projects it, and registers it
+    under a synthetic ``dataset_id`` the browse view can open. Nothing is
+    persisted — the context (vectors and bytes) lives only in memory until
+    released. Mixed-source detectors work: a positive needn't be in any loaded
+    dataset, only origin-resolvable.
+
+    Returns immediately with the ``dataset_id`` and the ``task_id`` whose
+    progress the detector's dashboard row renders while the build runs.
+    """
+    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
+    from vtscore.detectors.positives_browse import build_positives_browse_context, detpos_dataset_id
+    from vtscore.detectors.registry import (
+        can_user_access_detector,
+        get_detector,
+        get_loaded_detector_ids,
+    )
+    from vtscore.state.core import get_detector_context, register_context, unregister_context
+    from vtsearch.threading import spawn
+
+    entry = get_detector(detector_id)
+    if entry is None:
+        abort(404, message="Detector not found")
+    if not can_user_access_detector(detector_id, get_current_user()):
+        abort(403, message="You do not have access to this detector")
+
+    name = entry.get("name", "") or ""
+    data = _read_detector(_detector_path(name)) or {}
+    media_type = entry.get("media_type", "") or data.get("media_type", "") or ""
+
+    from vtscore.datasets.labelset import LabelSet
+
+    labelset = LabelSet.from_dict(data.get("labelset") or {})
+    if not any(el.label == "good" for el in labelset.elements):
+        abort(409, message="This detector has no positive labels to browse.")
+
+    embedder_name = _detector_browse_embedder(entry, media_type)
+
+    # Reuse the loaded detector's cached label vectors only when they were built
+    # in the same space we're about to project in; otherwise re-embed fresh.
+    cached_embeddings = None
+    if detector_id in get_loaded_detector_ids():
+        det_ctx = get_detector_context(detector_id)
+        if det_ctx is not None and det_ctx.embedder and det_ctx.embedder == embedder_name:
+            cached_embeddings = dict(det_ctx.label_embeddings)
+
+    dataset_id = detpos_dataset_id(detector_id)
+    # Drop any stale context from a previous browse of this detector.
+    unregister_context(dataset_id)
+
+    task_id = f"_detbrowse_{detector_id[:8]}"
+    tracker = detector_loading_tasks.create_task(
+        task_id,
+        name or detector_id,
+        detector_id=detector_id,
+        media_type=media_type,
+        embedder=embedder_name,
+    )
+    tracker.update("loading", "Preparing browse…", 0, 0, step=1, total_steps=1)
+
+    def build_task():
+        try:
+            def _on_progress(current: int, total: int, message: str) -> None:
+                tracker.check_cancelled()
+                tracker.update("loading", message, current, total, step=1, total_steps=1)
+
+            try:
+                ctx = build_positives_browse_context(
+                    data,
+                    dataset_id,
+                    embedder_name=embedder_name,
+                    cached_embeddings=cached_embeddings,
+                    display_name=f"{name} — positives" if name else "Detector positives",
+                    on_progress=_on_progress,
+                )
+                register_context(ctx)
+                tracker.update("idle", "", 0, 0, step=None, total_steps=None)
+            except CancelledError:
+                tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+            except ValueError as e:
+                tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+            except Exception as e:
+                import traceback as _tb
+
+                _tb.print_exc()
+                error_msg = str(e) or repr(e) or "Unknown error preparing browse"
+                tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
+        finally:
+            detector_loading_tasks.mark_finished(task_id)
+
+    spawn(build_task, name=f"det-browse-{detector_id[:8]}")
+    return {
+        "ok": True,
+        "dataset_id": dataset_id,
+        "task_id": str(task_id),
+        "media_type": media_type,
+    }
+
+
+@detectors_registry_bp.route(
+    "/api/detectors/registry/<detector_id>/browse-positives/release",
+    methods=["POST"],
+)
+@detectors_registry_bp.response(200, DetectorBrowsePositivesReleaseResponseSchema)
+def release_detector_positives_browse(detector_id: str):
+    """Free the ephemeral positives-browse context for *detector_id*.
+
+    Called when the user leaves the browse view. Idempotent: ``released`` is
+    ``False`` when there was nothing to drop.
+    """
+    from vtscore.detectors.positives_browse import detpos_dataset_id
+    from vtscore.state.core import unregister_context
+
+    dropped = unregister_context(detpos_dataset_id(detector_id))
+    return {"ok": True, "released": dropped is not None}
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -470,6 +470,27 @@ class DetectorRegistryStatsResponseSchema(Schema):
     autofind = fields.Boolean(required=True)
 
 
+class DetectorBrowsePositivesResponseSchema(Schema):
+    """Response for ``POST /api/detectors/registry/<id>/browse-positives``.
+
+    ``dataset_id`` is the synthetic, in-memory browse context the canvas
+    navigates to; ``task_id`` is the detector-loading task whose progress the
+    dashboard row renders while the positives are resolved + embedded.
+    """
+
+    ok = fields.Boolean(required=True)
+    dataset_id = fields.String(required=True)
+    task_id = fields.String(required=True)
+    media_type = fields.String(required=True)
+
+
+class DetectorBrowsePositivesReleaseResponseSchema(Schema):
+    """Response for ``POST /api/detectors/registry/<id>/browse-positives/release``."""
+
+    ok = fields.Boolean(required=True)
+    released = fields.Boolean(required=True)
+
+
 class DetectorCancelResponseSchema(Schema):
     """Response for ``POST /api/detectors/cancel/<task_id>``."""
 
@@ -786,6 +807,8 @@ class FindCorrectionsToDetectorResponseSchema(Schema):
 __all__ = [
     "AutoDetectRequestSchema",
     "AutoDetectResponseSchema",
+    "DetectorBrowsePositivesReleaseResponseSchema",
+    "DetectorBrowsePositivesResponseSchema",
     "DetectorCancelResponseSchema",
     "DetectorCombineRequestSchema",
     "DetectorCombineResponseSchema",

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -442,6 +442,34 @@ class DetectorRegistryReadersResponseSchema(Schema):
     readers = fields.List(fields.String(), required=True)
 
 
+class DetectorRegistryStatsResponseSchema(Schema):
+    """Response for ``GET /api/detectors/registry/<id>/stats``.
+
+    Counts and metadata only — never embeddings or MLP weights (see the
+    "No Persisted Vectors" rule). ``num_positive_resolved`` is how many of
+    the detector's positive labels currently resolve into the active
+    dataset (the set the Browse button would project), with
+    ``active_dataset_name`` naming that dataset (``""`` when none is loaded).
+    """
+
+    name = fields.String(required=True)
+    media_type = fields.String(required=True)
+    num_positive = fields.Integer(required=True)
+    num_negative = fields.Integer(required=True)
+    num_total = fields.Integer(required=True)
+    num_positive_resolved = fields.Integer(required=True)
+    active_dataset_name = fields.String(required=True)
+    embedder = fields.String(required=True)
+    text_query = fields.String(required=True)
+    media_example = fields.String(required=True)
+    clipper = fields.String(required=True)
+    created_at = fields.Raw(allow_none=True)
+    last_trained_at = fields.Raw(allow_none=True)
+    created_by = fields.String(required=True)
+    readers = fields.List(fields.String(), required=True)
+    autofind = fields.Boolean(required=True)
+
+
 class DetectorCancelResponseSchema(Schema):
     """Response for ``POST /api/detectors/cancel/<task_id>``."""
 
@@ -783,6 +811,7 @@ __all__ = [
     "DetectorRegistryLoadResponseSchema",
     "DetectorRegistryRenameRequestSchema",
     "DetectorRegistryRenameResponseSchema",
+    "DetectorRegistryStatsResponseSchema",
     "DetectorRegistryUnloadResponseSchema",
     "DetectorRenameRequestSchema",
     "DetectorRenameResponseSchema",


### PR DESCRIPTION
Three dashboard improvements for the Datasets/Detectors tables.

## 1. Dataset stats: lowercase "name" row
The stats "Creation" section rendered origin-param keys verbatim. For a demo dataset the only param key is the literal `name`, so it showed lowercase next to the capitalized "Importer"/"Clipper"/"Embedder". Param keys are now formatted (underscores → spaces, capitalized), so `name` reads "Name", `media_type` reads "Media type", etc.

## 2. Detector Stats page
New `GET /api/detectors/registry/<id>/stats` + a `vt-detector-stats-modal` opened from a **Stats (pie)** button on each detector row (parallel to the dataset stats modal). Surfaces labelset composition (positives / negatives / total, plus how many positives currently resolve into the loaded dataset), embedder, clipper, the text/media seed, and provenance (created / last-trained / creator / Auto-Find / access). Counts/metadata only — no embeddings or MLP weights (No Persisted Vectors).

## 3. Browse button on each detector row — dataset-free, detector-embedded
New **Browse (eye)** button that maps just a detector's **positive** labels as a VTSBrowse UMAP, **independent of any selected dataset**:

- `POST /api/detectors/registry/<id>/browse-positives` resolves each positive's origin to its file and embeds it with the **detector's own** embedder (reusing the loaded detector's cached `label_embeddings` when it's already in that space). So mixed-source detectors work and no dataset need be loaded — the dashboard's selected dataset is irrelevant.
- It assembles a throwaway in-memory `DatasetContext` keyed `__detpos__<id>` (vectors + preview bytes, **never persisted**), projects it, and registers it. The whole browse stack is reused unchanged — the canvas reads tiles + previews via the standard `/api/medias/<id>/...` endpoints off the context's `media_bytes`.
- Frontend: the build runs async with progress on the detector row; the Browse button navigates to `/browse/<__detpos__id>` once ready; the guard skips the registry check for the prefix; the browse view releases the context (and clears the active pair) on exit. `POST …/browse-positives/release` frees it.

(An earlier iteration projected positives as a subset of the *active* dataset; that was replaced per review — the detector carries its own embedder, so the active dataset shouldn't drive how its positives are embedded.)

## Tests / checks
- New `vtscore/detectors/positives_browse.py` with library-tier tests; route tests for stats + browse-positives (+ release); `TestDetectorStats`.
- Regenerated `frontend/openapi.json`; OpenAPI drift check passes.
- Full `./run-tests.sh` green (4788 passed) — includes the Angular prod build (regenerated client + typecheck + SCSS budget) and `vtscore-clean` (the new library module is Flask-clean).
- Docs: `docs/api/detectors.md` (endpoints) + `docs/plans/vtsbrowse.md` (what shipped + open follow-ups).

https://claude.ai/code/session_01T7Wj1PmRqkeXDWas3w2M9i