### PR TITLE
Let the VTSBrowse right panel get narrower

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -57,6 +57,9 @@
 
 .bsp-actions {
   display: flex;
+  // Wrap the pair onto two stacked rows once the panel is too narrow to hold
+  // both side by side, rather than forcing a panel-width floor.
+  flex-wrap: wrap;
   gap: var(--space-sm);
   padding: 0 var(--space-lg) var(--space-sm);
   flex-shrink: 0;
@@ -68,6 +71,9 @@
 .bsp-verify-good,
 .bsp-verify-bad {
   flex: 1;
+  // Never shrink below the label width; when both labels can't share a row the
+  // pair wraps (each button then spans the full width on its own line).
+  min-width: max-content;
   color: var(--btn-filled-text);
 }
 
@@ -94,6 +100,9 @@
 .bsp-toolbar {
   display: flex;
   align-items: center;
+  // Let the view controls drop below the "Sort: [select]" pair when the panel
+  // is too narrow to keep them on one line.
+  flex-wrap: wrap;
   gap: var(--space-sm);
   padding: 0 var(--space-lg) var(--space-md);
   border-bottom: 1px solid var(--border);

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -150,7 +150,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   panelWidth = 300;
   /** Clamp + divider geometry, mirroring the Find view's panel dividers. */
-  private static readonly PANEL_MIN = 260;
+  private static readonly PANEL_MIN = 160;
   private static readonly PANEL_MAX = 800;
   private static readonly CANVAS_MIN = 200;
   private static readonly DIVIDER_WIDTH = 8;


### PR DESCRIPTION
## Summary

Allows the VTSBrowse right panel to be dragged narrower than it could before. Previously a `PANEL_MIN = 260px` floor — plus two non-wrapping flex rows — kept the panel wide. This loosens both so the panel can shrink, letting its controls reflow instead of forcing a width floor.

## Changes

- **`browse-view.component.ts`**: lowered `PANEL_MIN` from `260` → `160`, so the drag clamp and persisted-width clamp allow a much narrower panel.
- **`browse-selection-panel.component.scss`**:
  - `.bsp-actions` now `flex-wrap: wrap`, and the **Verified Good / Verified Bad** buttons get `min-width: max-content`. When both labels can't share a row they wrap, each spanning the full width on its own line.
  - `.bsp-toolbar` now `flex-wrap: wrap`, so the view-control buttons drop below the `Sort: [select]` pair when the row is too narrow.

The minimap and density legend already adapt to width (`min-width: 0` / `width: 100%`), so they simply render narrower with no change needed.

## Testing

- `npm run build:prod` — clean, no errors or budget warnings.

https://claude.ai/code/session_01GXnZrZWZXdw9nLZEGoCb9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXnZrZWZXdw9nLZEGoCb9F)_