### PR TITLE
Suppress global error toast for detect-media-type probe

### DIFF
--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { ClearStagingResponse } from '../generated/api-client/models/clear-staging-response';
 import type { DatasetAllImportersListResponse } from '../generated/api-client/models/dataset-all-importers-list-response';
@@ -65,18 +66,23 @@ export class DatasetsCrudApiService {
     );
   }
 
+  /** Best-effort media-type hint for a picked folder. A 404 here is an
+   *  expected, benign outcome (the path may not exist yet, e.g. a partially
+   *  typed absolute path), and every caller handles the failure itself by
+   *  clearing its detection state. Pass {@link SKIP_ERROR_TOAST} so the probe
+   *  never raises a global error toast. */
   detectMediaType(
     source: string,
     path: string,
     recursive: boolean,
     limit = 50,
   ): Observable<DetectMediaTypeResponse> {
-    return detectMediaType(this.http, this.config.rootUrl, {
-      source,
-      path,
-      recursive,
-      limit,
-    }).pipe(map((r) => r.body));
+    return detectMediaType(
+      this.http,
+      this.config.rootUrl,
+      { source, path, recursive, limit },
+      new HttpContext().set(SKIP_ERROR_TOAST, true),
+    ).pipe(map((r) => r.body));
   }
 
   getAvailableFiles(): Observable<DatasetAvailableFilesResponse> {


### PR DESCRIPTION
## Problem

Users hit a loud, structured "VTSearch error" report (`GET /api/dataset/detect-media-type` → `404 Not Found`) while picking a folder in the dataset importer modal.

The `detect-media-type` endpoint is a **best-effort hint**: the importer modal calls it after a folder is picked/typed to pre-fill the media-type dropdown. A 404 is an expected, benign outcome — e.g. when the typed absolute path doesn't exist yet, or the resolved directory isn't present. The sole caller (`sfRunDetection`) already handles the failure locally by clearing its detection state (`sfDetection = null`).

The noise came from the **global** `errorInterceptor`, which raises an error toast for every non-zero HTTP status unless the request opts out via the purpose-built `SKIP_ERROR_TOAST` `HttpContext` token (documented as: *"a probe that expects 404"*). The `detectMediaType` service call wasn't setting it, so these benign probe failures surfaced as a global error report.

## Fix

Pass `SKIP_ERROR_TOAST` on the `detectMediaType` request in `DatasetsCrudApiService`. The error still propagates to the caller's `error:` handler exactly as before (so `sfDetection` is still cleared); only the global UI toast is suppressed. This mirrors the existing pattern in `auth.service.ts` and `projection-api.service.ts`.

The fix lives at the service level because the endpoint is inherently a best-effort probe and its single caller already handles its own failures.

## Testing

`./run-tests.sh core` → `ALL 759 TESTS PASSED` (includes the frontend build, which regenerates the OpenAPI client and typechecks the new `context` argument).

https://claude.ai/code/session_01SUptXFNPYC2fnEhdtKAcfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUptXFNPYC2fnEhdtKAcfY)_