### PR TITLE
VTSBrowse bin popup: grid-only with large detail-preview pane

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -682,6 +682,20 @@ in git history and the cited source files.
   produced. *Open follow-up:* if a future ordering wants true 1-D-UMAP semantics
   (not just a space-filling linearization of the 2-D layout), it would need that
   second fit and a persisted `order` field on `Projection`.
+- ~~**Bin-popup detail preview**~~ — the right-click bin popup is now grid-only
+  (the List/Grid toggle and the `view_mode_popup` setting were removed end to
+  end) and pairs the member grid with a large preview pane on its left, shown
+  for thumbnail media (image/video). Hovering a grid thumbnail paints that
+  item's *full-resolution* original (`/api/medias/<id>/image`, not its grid
+  thumbnail) into the pane; the pane opens on the bin's representative so even a
+  singleton lands on a large high-res view with no hover. The pane is sized to
+  +50% of the item's on-canvas mouse-over break-out at the current main-canvas
+  thumbnail size (`hoverThumbRadius` is passed from `browse-view`), so it tracks
+  the icon-size setting. The grid thumbnails no longer magnify on hover (the
+  preview pane replaces that affordance). *Open follow-up:* the pane is gated on
+  `usesThumbnails` (image/video); documents render a grid thumbnail but get no
+  large preview — if document detail-viewing is wanted, widen the gate and pick a
+  full-res document endpoint.
 
 **Active:**
 - **Dataset pickle size — drop inline `media_bytes` when the media is reachable

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -377,12 +377,6 @@
             },
             "type": "object"
           },
-          "view_mode_popup": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
           "view_mode_right": {
             "additionalProperties": {
               "type": "string"
@@ -4575,7 +4569,6 @@
             "type": "string"
           },
           "view_mode_left": {},
-          "view_mode_popup": {},
           "view_mode_right": {},
           "volume": {
             "type": "number"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -20,6 +20,7 @@
       side="popup"
       [currentMediaType]="mediaType"
       [showFocus]="false"
+      [showViewMode]="false"
       [allowSizeInList]="true"
       class="bin-popup-view-controls" />
     <button
@@ -32,49 +33,59 @@
     </button>
   </div>
 
-  <cdk-virtual-scroll-viewport
-    [itemSize]="rowSize"
-    [style.height.px]="bodyHeight"
-    class="bin-popup-body"
-    [class.grid]="isGrid"
-    (mouseleave)="onListLeave()">
-    <div
-      *cdkVirtualFor="let row of rows; trackBy: trackByRow"
-      class="bin-popup-row"
-      [class.grid]="isGrid"
-      [style.height.px]="rowSize"
-      [style.--popup-cols]="columns"
-      [style.--popup-cell]="gridGoalWidth + 'px'">
-      @for (id of row; track trackById($index, id)) {
-        <div
-          class="bin-popup-entry"
-          [class.grid]="isGrid"
-          [class.selected]="isSelected(id)"
-          role="button"
-          tabindex="0"
-          [attr.aria-pressed]="isSelected(id)"
-          [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
-          [title]="name(id)"
-          (click)="onEntryClick(id)"
-          (keydown)="onEntryKeydown($event, id)"
-          (mouseenter)="onEntryEnter(id)">
-          @if (hasThumbnailUrl(id)) {
-            <span class="bin-popup-thumb-wrap">
-              <img
-                class="bin-popup-thumb"
-                [src]="thumbnailUrl(id)"
-                [alt]="name(id)"
-                loading="lazy"
-                (error)="onThumbnailError(thumbnailUrl(id))" />
-            </span>
-          } @else {
-            <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
-          }
-          <span class="bin-popup-name">{{ name(id) }}</span>
-        </div>
-      }
-    </div>
-  </cdk-virtual-scroll-viewport>
+  <div class="bin-popup-body" [style.height.px]="bodyHeight">
+    @if (showPreview) {
+      <div class="bin-popup-preview" [style.width.px]="previewSize">
+        @if (previewUrl()) {
+          <img
+            class="bin-popup-preview-img"
+            [src]="previewUrl()"
+            [alt]="previewId != null ? name(previewId) : ''"
+            (error)="onPreviewError()" />
+        }
+      </div>
+    }
+
+    <cdk-virtual-scroll-viewport
+      [itemSize]="rowSize"
+      class="bin-popup-scroll"
+      (mouseleave)="onGridLeave()">
+      <div
+        *cdkVirtualFor="let row of rows; trackBy: trackByRow"
+        class="bin-popup-row"
+        [style.height.px]="rowSize"
+        [style.--popup-cols]="columns"
+        [style.--popup-cell]="gridGoalWidth + 'px'">
+        @for (id of row; track trackById($index, id)) {
+          <div
+            class="bin-popup-entry"
+            [class.selected]="isSelected(id)"
+            role="button"
+            tabindex="0"
+            [attr.aria-pressed]="isSelected(id)"
+            [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
+            [title]="name(id)"
+            (click)="onEntryClick(id)"
+            (keydown)="onEntryKeydown($event, id)"
+            (mouseenter)="onEntryEnter(id)">
+            @if (hasThumbnailUrl(id)) {
+              <span class="bin-popup-thumb-wrap">
+                <img
+                  class="bin-popup-thumb"
+                  [src]="thumbnailUrl(id)"
+                  [alt]="name(id)"
+                  loading="lazy"
+                  (error)="onThumbnailError(thumbnailUrl(id))" />
+              </span>
+            } @else {
+              <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+            }
+            <span class="bin-popup-name">{{ name(id) }}</span>
+          </div>
+        }
+      </div>
+    </cdk-virtual-scroll-viewport>
+  </div>
 
   @if (mediaType === 'audio') {
     <audio #audioEl class="sr-only" [src]="audioSrc"></audio>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -1,11 +1,11 @@
-// A small floating panel of a bin's media items, opened by right-clicking a bin
-// on the VTSBrowse canvas. A mini knock-off of the Find right panel: its header
-// carries the shared List/Grid + size controls and the body renders the bin's
-// members as a virtualized list or thumbnail grid.
+// A floating panel of a bin's media items, opened by right-clicking a bin on the
+// VTSBrowse canvas. Its body is a large hover-preview pane (image/video) beside
+// a virtualized thumbnail grid of the bin's members; hovering a grid thumbnail
+// paints that item's full-resolution original into the pane.
 .bin-popup {
   position: fixed;
   z-index: var(--z-burger-menu);
-  width: 280px;
+  width: fit-content;
   max-width: 90vw;
   display: flex;
   flex-direction: column;
@@ -64,43 +64,70 @@
   }
 }
 
+// --- Body: preview pane (left) beside the scrolling grid (right) ------------
+// Concrete height is bound per render (max of the grid's capped height and the
+// preview pane) so the virtual viewport scrolls and the pane shows in full.
 .bin-popup-body {
-  // Concrete height is bound per render (rows, capped) so the virtual viewport
-  // scrolls; the cap is applied inline via [style.height.px].
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  overflow: hidden;
+}
+
+// The large preview: the hovered (or, by default, representative) item shown
+// full-resolution. Width is bound per render (50% larger than the on-canvas
+// mouse-over size); the square box centres the image at its native aspect.
+.bin-popup-preview {
+  flex-shrink: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  background: var(--bg-body);
+  overflow: hidden;
+}
+
+.bin-popup-preview-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+// The scrolling thumbnail grid. Fixed-width column so the popup hugs it plus
+// the preview pane; height fills the bound body height so the viewport scrolls.
+.bin-popup-scroll {
+  width: 280px;
+  height: 100%;
+  flex-shrink: 0;
   overflow-x: hidden;
 }
 
 // --- Rows ------------------------------------------------------------------
-// One virtual item == one row. In list mode a row holds a single full-width
-// entry; in grid mode it is a CSS grid of fixed-size thumbnail cells.
+// One virtual item == one grid row: a CSS grid of fixed-size thumbnail cells.
 .bin-popup-row {
   box-sizing: border-box;
-
-  &.grid {
-    display: grid;
-    grid-template-columns: repeat(var(--popup-cols, 1), 1fr);
-    align-content: start;
-    justify-items: center;
-    column-gap: var(--space-2xs);
-    padding: 0 var(--space-sm);
-  }
+  display: grid;
+  grid-template-columns: repeat(var(--popup-cols, 1), 1fr);
+  align-content: start;
+  justify-items: center;
+  column-gap: var(--space-2xs);
 }
 
+// A grid cell: a thumbnail above its truncated name.
 .bin-popup-entry {
   box-sizing: border-box;
   cursor: pointer;
   color: var(--text-vote);
-
-  // --- List mode: a horizontal row (thumbnail + name) --------------------
-  // The row height is bound per render from ``rowSize`` (thumbnail size +
-  // padding), so the entry just fills it; the Larger/Smaller buttons resize
-  // the list thumbnails the same way they resize grid cells.
-  height: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: var(--space-md);
-  padding: 0 var(--space-md);
-  font-size: var(--font-sm);
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  width: var(--popup-cell, 80px);
 
   &:hover {
     background: var(--bg-hover);
@@ -110,57 +137,24 @@
   &.selected {
     background: color-mix(in srgb, var(--accent) 18%, transparent);
     color: var(--text-primary);
-    box-shadow: inset 3px 0 0 var(--accent);
+    // A ring (not the list's inset accent bar) reads better under a square thumb.
+    box-shadow: 0 0 0 2px var(--accent);
   }
 
   &:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: -2px;
   }
-
-  // --- Grid mode: a vertical cell (thumbnail above its name) -------------
-  &.grid {
-    height: auto;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    padding: 2px;
-    border-radius: var(--radius-sm);
-    width: var(--popup-cell, 80px);
-    // Hover-pop: the whole tile scales up over its neighbors (raised above
-    // them) the way a hovered cell magnifies on the browse canvas.
-    position: relative;
-    transition: transform 0.12s ease;
-    transform-origin: center center;
-
-    &.selected {
-      // The list's inset accent bar reads oddly under a square thumbnail; use
-      // a ring instead so the whole cell shows as selected.
-      box-shadow: 0 0 0 2px var(--accent);
-    }
-
-    &:hover {
-      z-index: 3;
-      transform: scale(1.4);
-    }
-
-    &:hover .bin-popup-thumb-wrap,
-    &:hover .bin-popup-placeholder {
-      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-    }
-  }
 }
 
-// Thumbnail/placeholder square. Sized to the chosen icon size (``--popup-cell``,
-// bound per row) in both modes so the Larger/Smaller buttons resize list rows
-// too; falls back to a compact square if the variable is ever absent.
+// Thumbnail/placeholder square, sized to the chosen icon size (``--popup-cell``,
+// bound per row); falls back to a compact square if the variable is ever absent.
 .bin-popup-thumb-wrap {
   display: block;
   width: var(--popup-cell, 28px);
   height: var(--popup-cell, 28px);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
-  transition: box-shadow 0.12s ease;
 }
 
 .bin-popup-thumb {
@@ -183,30 +177,20 @@
   color: var(--text-muted);
   font-size: var(--font-lg);
   flex-shrink: 0;
-  transition: box-shadow 0.12s ease;
 }
 
+// The name stacks under the thumbnail, truncated to the cell width.
 .bin-popup-name {
-  flex: 1;
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: var(--popup-cell, 80px);
   min-width: 0;
-  font-weight: var(--weight-medium);
-  font-size: var(--font-sm);
+  text-align: center;
+  font-weight: var(--weight-normal);
+  font-size: var(--font-xs);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-// Grid mode stacks the name under the thumbnail (sized by the shared
-// ``--popup-cell`` rule above), truncated to the cell width.
-.bin-popup-entry.grid {
-  .bin-popup-name {
-    flex: 0 0 auto;
-    width: 100%;
-    max-width: var(--popup-cell, 80px);
-    text-align: center;
-    font-size: var(--font-xs);
-    font-weight: var(--weight-normal);
-  }
 }
 
 .sr-only {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -21,18 +21,17 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { usesThumbnails } from '../browse-canvas/hex-render.util';
 
-/** Vertical room (px) reserved around a list-mode thumbnail (its row height is
- *  the chosen thumbnail size plus this padding), so the Larger/Smaller buttons
- *  scale list rows the same way they scale grid cells. */
-const LIST_ROW_PADDING = 8;
 /** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
 const GRID_LABEL_HEIGHT = 18;
 /** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
 const GRID_GAP = 4;
-/** Width (px) available to lay out cells inside the popup body (≈ popup width
- *  minus padding and the scrollbar). Columns are derived from this. */
+/** Width (px) available to lay out cells inside the popup's scroll column (≈ its
+ *  width minus padding and the scrollbar). Columns are derived from this. */
 const GRID_CONTENT_WIDTH = 256;
+/** Width (px) of the scrolling grid column; mirrors the historic popup width. */
+const GRID_COLUMN_WIDTH = 280;
 /** Tallest the scrolling body grows before it caps and scrolls internally. */
 const MAX_BODY_PX = 400;
 /** Shortest the scrolling body is ever squeezed to when the visible region is
@@ -42,30 +41,57 @@ const MIN_BODY_PX = 80;
 const PREFETCH_BUFFER = 50;
 /** Gap (px) kept between the popup and the visible edge when clamping. */
 const EDGE_MARGIN = 8;
-/** Default popup width (px); mirrors ``width`` in the component SCSS. */
-const POPUP_WIDTH = 280;
+/** Gap (px) between the preview pane and the scroll column. */
+const PREVIEW_GAP = 8;
+/** Smallest the preview pane is squeezed to in a tight region. */
+const MIN_PREVIEW_PX = 96;
+/** Largest the preview pane grows, regardless of icon size, so an extreme
+ *  thumbnail-size setting can't make the popup absurdly large. */
+const MAX_PREVIEW_PX = 520;
+/**
+ * How much larger the preview pane is than the item's on-canvas mouse-over size.
+ * The brief: "50% larger than the mouse-over size when we hover in the main
+ * canvas." 1.5 == +50%.
+ */
+const PREVIEW_OVERSIZE = 1.5;
+/**
+ * Full on-screen extent (px) of a square thumbnail's hover break-out on the main
+ * canvas, as a multiple of the bin radius. A hovered thumbnail grows until its
+ * edge just reaches the nearest neighbour centre; for a square image on a hex
+ * lattice the binding neighbour sits at ``1.5 * radius`` (see
+ * ``hoverThumbRect`` in browse-canvas), so the full height is ``2 * 1.5 = 3``
+ * radii. The preview tracks that reference size, oversized by
+ * {@link PREVIEW_OVERSIZE}.
+ */
+const HOVER_EXTENT_PER_RADIUS = 3;
 
 /**
- * The bin popup: a small floating panel showing the media items in the bin the
- * user right-clicked on the VTSBrowse canvas. It is a miniature knock-off of
- * the Find right panel — the same List/Grid + thumbnail-size controls (via
- * {@link ViewControlsComponent}) sit in its header, and the body renders the
- * bin's members in whichever mode is chosen. This is how you reach the
- * individual items folded into a dense bin without zooming all the way in.
+ * The bin popup: a floating panel showing the media items in the bin the user
+ * right-clicked on the VTSBrowse canvas, plus — for thumbnail media (image /
+ * video) — a large preview pane on the left.
  *
- * The view-mode + size choice is remembered per media type under the
- * ``view_mode_popup`` / ``grid_icon_size_popup`` settings (independent of the
- * left/right panels), so tuning the popup while browsing one bin becomes the
- * default for every future popup of that media type. The controls write those
- * settings and this component re-reads them from {@link SettingsStateService},
- * keyed by the active dataset's media type.
+ * The members render as a virtualized thumbnail grid (always grid; there is no
+ * list mode). Hovering a grid thumbnail paints that item's *full-resolution*
+ * original (not its grid thumbnail) into the preview pane, so the user can pull
+ * detail out of any pile member in turn. The pane opens showing the bin's
+ * representative, so even a singleton bin lands on a large high-res view without
+ * any hover. The pane is sized to {@link PREVIEW_OVERSIZE} (50%) larger than the
+ * item's on-canvas mouse-over break-out at the current main-canvas thumbnail
+ * size ({@link hoverThumbRadius}).
+ *
+ * The thumbnail size of the grid is remembered per media type under the
+ * ``grid_icon_size_popup`` setting (independent of the left/right panels), so
+ * tuning the popup while browsing one bin becomes the default for every future
+ * popup of that media type. The in-header {@link ViewControlsComponent} writes
+ * that setting (its Grid/List toggle is hidden here) and this component re-reads
+ * it from {@link SettingsStateService}, keyed by the active dataset's media type.
  *
  * It shares the {@link BrowseSelectionService} instance provided by the browse
  * view, so toggling an item here is the same selection the canvas rings and the
  * selection panel reflect; selected members render highlighted and update live.
  * Names/thumbnails resolve lazily through {@link MediaMetadataCacheService}
  * (the browse view never loads the full media list), prefetched around the
- * visible window so large bins stay responsive in either mode.
+ * visible window so large bins stay responsive.
  */
 @Component({
   selector: 'vt-browse-bin-popup',
@@ -86,6 +112,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  on-screen part of it so it stays fully visible. Null falls back to the
    *  full viewport. */
   @Input() bounds: DOMRect | null = null;
+  /** Current on-screen bin radius (CSS px) of the main canvas, i.e. the radius
+   *  the hovered thumbnail breaks out from. The preview pane is sized relative
+   *  to this so it tracks the main-canvas thumbnail-size setting. */
+  @Input() hoverThumbRadius = 28;
 
   /** Emitted when the popup should close (outside click, Escape, or the X). */
   @Output() dismissed = new EventEmitter<void>();
@@ -99,7 +129,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   left = 0;
   top = 0;
   /** Max width (px) the popup may take; shrunk to fit a narrow visible region. */
-  maxWidthPx = POPUP_WIDTH;
+  maxWidthPx = GRID_COLUMN_WIDTH;
   /** True once the user has dragged the popup by its header. While set, the
    *  popup keeps the user's chosen spot (re-clamped to stay on-screen) instead
    *  of re-anchoring to the summon point on content changes. Reset per bin. */
@@ -117,19 +147,26 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  together in the list (the server orders them; see ``tile_member_ids``). */
   ids: number[] = [];
 
-  /** Per-media-type view prefs, mirrored from settings. */
-  viewMode: 'grid' | 'list' = 'grid';
+  /** Grid thumbnail target width (px), mirrored from settings per media type. */
   gridGoalWidth = 80;
 
-  /** Number of columns the grid lays out; always 1 in list mode. */
+  /** Number of columns the grid lays out. */
   columns = 1;
   /** Member ids chunked into rows of {@link columns}; the virtual list's data. */
   rows: number[][] = [];
+
+  /** Id whose full-res original is painted into the preview pane. Defaults to
+   *  the bin's representative (first member) so the pane is never blank, and
+   *  follows the grid thumbnail under the cursor while hovering. */
+  previewId: number | null = null;
 
   /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
   audioSrc = '';
 
   private readonly failedThumbs = new Set<string>();
+  /** Ids whose full-res ``/image`` failed; the preview falls back to the
+   *  thumbnail for these so it still shows something. */
+  private readonly failedPreviews = new Set<number>();
   private readonly subs: Subscription[] = [];
   private scrollSub: Subscription | null = null;
 
@@ -146,6 +183,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     if (changes['memberIds']) {
       this.ids = this.memberIds ?? [];
       this.stopAudio();
+      // Open on the bin's representative so the pane is never blank (a singleton
+      // therefore lands straight on a large high-res view).
+      this.previewId = this.ids.length > 0 ? this.ids[0] : null;
       // A fresh bin is a fresh popup: forget any drag from the previous one so
       // it re-anchors to the new summon point.
       this.dragged = false;
@@ -155,10 +195,16 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       this.prefetchVisible();
     }
     if (changes['mediaType']) {
-      // A new media type may carry a different remembered view mode/size.
+      // A new media type may carry a different remembered thumbnail size.
       this.applyViewPrefs();
     }
-    if (changes['x'] || changes['y'] || changes['bounds'] || changes['memberIds']) {
+    if (
+      changes['x'] ||
+      changes['y'] ||
+      changes['bounds'] ||
+      changes['memberIds'] ||
+      changes['hoverThumbRadius']
+    ) {
       // Re-anchor to the summon point, unless the user has dragged the popup —
       // then keep their spot (``place`` re-clamps it back on-screen if needed).
       if (!this.dragged) {
@@ -176,12 +222,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
       // A selection change anywhere (here, the canvas, the panel) re-highlights.
       this.selection.changed$.subscribe(() => this.cdr.markForCheck()),
-      // Re-read the popup's view mode + size whenever settings change (this is
-      // how the in-header controls take effect, and how a change on one popup
+      // Re-read the popup's thumbnail size whenever settings change (this is how
+      // the in-header size buttons take effect, and how a change on one popup
       // becomes the default for every future popup of this media type).
       this.settingsState.settings$.subscribe((settings) => {
         if (!settings) return;
-        this.viewModeDict = (settings.view_mode_popup as Record<string, 'grid' | 'list'>) ?? {};
         this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
         this.applyViewPrefs();
       }),
@@ -199,19 +244,22 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.stopAudio();
   }
 
-  private viewModeDict: Record<string, 'grid' | 'list'> = {};
   private gridSizeDict: Record<string, string> = {};
 
-  /** Pull the remembered view mode + thumbnail size for the active media type,
-   *  rechunk the rows, and re-clamp (the body height may have changed). */
+  /** True for media types that carry real visual thumbnails (image / video):
+   *  the ones that magnify on the main canvas and are worth a large preview. */
+  get showPreview(): boolean {
+    return usesThumbnails(this.mediaType);
+  }
+
+  /** Pull the remembered thumbnail size for the active media type, rechunk the
+   *  rows, and re-clamp (the body height may have changed). */
   private applyViewPrefs(): void {
-    const prevMode = this.viewMode;
     const prevGoal = this.gridGoalWidth;
-    this.viewMode = this.mediaType ? (this.viewModeDict[this.mediaType] ?? 'grid') : 'grid';
     this.gridGoalWidth = iconSizeToGoalWidth(
       (this.mediaType && this.gridSizeDict[this.mediaType]) || 'M',
     );
-    if (this.viewMode !== prevMode || this.gridGoalWidth !== prevGoal) {
+    if (this.gridGoalWidth !== prevGoal) {
       this.rebuildRows();
       // The row stride changed; let the virtual viewport remeasure, then clamp.
       setTimeout(() => {
@@ -222,12 +270,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.cdr.markForCheck();
   }
 
-  /** Recompute the column count + row chunking for the current mode/size. */
+  /** Recompute the column count + row chunking for the current thumbnail size. */
   private rebuildRows(): void {
-    this.columns =
-      this.viewMode === 'grid'
-        ? Math.max(1, Math.floor((GRID_CONTENT_WIDTH + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)))
-        : 1;
+    this.columns = Math.max(
+      1,
+      Math.floor((GRID_CONTENT_WIDTH + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)),
+    );
     const cols = this.columns;
     const rows: number[][] = [];
     for (let i = 0; i < this.ids.length; i += cols) {
@@ -236,23 +284,33 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual row (a list entry, or a grid row of cells).
-   *  Both modes scale with the chosen thumbnail size so the Larger/Smaller
-   *  controls take effect in list view as well as grid view. */
+  /** Pixel stride of one virtual grid row (a row of cells plus its labels). */
   get rowSize(): number {
-    return this.viewMode === 'grid'
-      ? this.gridGoalWidth + GRID_LABEL_HEIGHT + GRID_GAP
-      : this.gridGoalWidth + LIST_ROW_PADDING;
+    return this.gridGoalWidth + GRID_LABEL_HEIGHT + GRID_GAP;
   }
 
-  /** Height (px) the body takes: just enough for its rows, capped (to the room
+  /** Height (px) the grid takes: just enough for its rows, capped (to the room
    *  the visible region leaves, see {@link bodyCapPx}) then scrolled. */
-  get bodyHeight(): number {
+  get gridHeight(): number {
     return Math.min(Math.max(this.rows.length, 1) * this.rowSize, this.bodyCapPx);
   }
 
-  get isGrid(): boolean {
-    return this.viewMode === 'grid';
+  /** Side (px) of the square preview pane: 50% larger than the item's on-canvas
+   *  mouse-over break-out at the current main-canvas thumbnail size, clamped to
+   *  the room the visible region leaves. Zero when there is no preview. */
+  get previewSize(): number {
+    if (!this.showPreview) return 0;
+    const desired = this.hoverThumbRadius * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
+    // Keep it within the vertical room the region leaves and a sane absolute cap.
+    return Math.round(
+      Math.max(MIN_PREVIEW_PX, Math.min(desired, MAX_PREVIEW_PX, this.bodyCapPx)),
+    );
+  }
+
+  /** Height (px) of the body row: tall enough for the grid, but at least the
+   *  preview pane's height so the pane is shown in full. Capped to the region. */
+  get bodyHeight(): number {
+    return Math.min(this.bodyCapPx, Math.max(this.gridHeight, this.previewSize));
   }
 
   // --- Dismissal -----------------------------------------------------------
@@ -323,9 +381,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     }
   }
 
-  // --- Hover-to-hear (audio only; other types just highlight, via CSS) ------
+  // --- Hover: preview the full-res original (image/video) + hear (audio) ----
 
   onEntryEnter(id: number): void {
+    // Thumbnail media: paint the hovered item's full-res original into the pane.
+    if (this.showPreview) this.previewId = id;
     if (this.mediaType !== 'audio') return;
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
@@ -339,8 +399,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     });
   }
 
-  onListLeave(): void {
+  /** Cursor left the grid: stop any hover audio and fall the preview back to the
+   *  bin's representative so the pane stays populated. */
+  onGridLeave(): void {
     this.stopAudio();
+    if (this.showPreview) this.previewId = this.ids.length > 0 ? this.ids[0] : null;
   }
 
   private stopAudio(): void {
@@ -379,6 +442,24 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     if (url) this.failedThumbs.add(url);
   }
 
+  /** Full-res source for the preview pane: the original ``/image`` unless it has
+   *  failed for this id, in which case fall back to the thumbnail. Empty when
+   *  there is nothing to preview. */
+  previewUrl(): string {
+    const id = this.previewId;
+    if (id == null) return '';
+    if (this.failedPreviews.has(id)) return this.thumbnailUrl(id);
+    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
+  }
+
+  onPreviewError(): void {
+    const id = this.previewId;
+    if (id != null && !this.failedPreviews.has(id)) {
+      this.failedPreviews.add(id);
+      this.cdr.markForCheck();
+    }
+  }
+
   placeholderIcon(id: number): string {
     if (this.hasThumbnailUrl(id)) return '';
     const media = this.metadataCache.get(id);
@@ -407,11 +488,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Clamp ``(desiredLeft, desiredTop)`` so the *whole* popup sits inside the
    *  visible part of the canvas — the canvas rect intersected with the viewport
    *  — so it never spills off an edge, onto the side panel, or below the bottom
-   *  of the window. Sizing is derived from known quantities (the fixed width and
-   *  the header + body heights) rather than a possibly-mid-layout measurement,
-   *  so the clamp is correct even before the virtualized body has settled. When
-   *  the region is too short to hold the full popup, the body is capped (and
-   *  scrolls internally) so the popup still fits top-to-bottom. */
+   *  of the window. Sizing is derived from known quantities (the column widths
+   *  and the header + body heights) rather than a possibly-mid-layout
+   *  measurement, so the clamp is correct even before the virtualized body has
+   *  settled. When the region is too short to hold the full popup, the body is
+   *  capped (and scrolls internally) so the popup still fits top-to-bottom. */
   private clampInto(desiredLeft: number, desiredTop: number): void {
     const panel = this.panelRef?.nativeElement;
     if (!panel) return;
@@ -432,9 +513,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       MIN_BODY_PX,
       Math.min(MAX_BODY_PX, regionBottom - regionTop - 2 * EDGE_MARGIN - headerH),
     );
-    // Likewise shrink the width to fit a narrow region.
+    // Likewise shrink the overall width to fit a narrow region.
     this.maxWidthPx = Math.max(0, regionRight - regionLeft - 2 * EDGE_MARGIN);
-    const width = Math.min(POPUP_WIDTH, this.maxWidthPx);
+    const previewW = this.previewSize ? this.previewSize + PREVIEW_GAP : 0;
+    const width = Math.min(previewW + GRID_COLUMN_WIDTH, this.maxWidthPx);
     const height = headerH + this.bodyHeight;
     let l = desiredLeft;
     let t = desiredTop;
@@ -450,7 +532,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.cdr.markForCheck();
   }
 
-  /** Prefetch metadata for the items around the visible window of the body. */
+  /** Prefetch metadata for the items around the visible window of the grid. */
   private prefetchVisible(): void {
     if (this.ids.length === 0) return;
     const cols = this.columns;
@@ -462,7 +544,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     }
     const startRow = Math.floor(vp.measureScrollOffset('top') / this.rowSize);
     const visibleRows = Math.ceil(
-      (vp.elementRef.nativeElement.clientHeight || this.bodyHeight) / this.rowSize,
+      (vp.elementRef.nativeElement.clientHeight || this.gridHeight) / this.rowSize,
     );
     const from = Math.max(0, (startRow - Math.ceil(PREFETCH_BUFFER / cols)) * cols);
     const to = Math.min(this.ids.length, (startRow + visibleRows) * cols + PREFETCH_BUFFER);

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -89,6 +89,7 @@
               [bounds]="contextBounds"
               [memberIds]="contextMembers"
               [mediaType]="mediaType"
+              [hoverThumbRadius]="thumbnailRadius"
               (dismissed)="dismissContextMenu()"
             />
           }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -311,8 +311,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     return this.hexScaleIndex === this.HEX_SCALES.length - 1;
   }
 
-  /** Target bin radius (CSS px) for the current named thumbnail size. */
-  private get thumbnailRadius(): number {
+  /** Target bin radius (CSS px) for the current named thumbnail size. Also
+   *  passed to the bin popup so its preview pane tracks the on-canvas hover
+   *  size. */
+  get thumbnailRadius(): number {
     return BrowseCanvasComponent.DEFAULT_TARGET_RADIUS * this.HEX_SCALES[this.hexScaleIndex];
   }
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -344,19 +344,8 @@
                   aria-label="Browser thumbnail border width" />
               </div>
               <div class="form-group">
-                <label class="form-label" title="How a right-clicked bin's items are shown in the popup">Bin popup<vt-field-hint-icon hint="How the right-click bin popup shows a bin’s items. Changing it on a popup while browsing remembers the choice here for this media type."></vt-field-hint-icon></label>
-                <div class="toggle-group">
-                  <button class="toggle-btn" [class.toggle-btn--active]="getPopupViewMode(activeBrowseTab) === 'grid'" (click)="onPopupViewModeChange(activeBrowseTab, 'grid')" title="Show a right-clicked bin's items as a thumbnail grid">
-                    Grid
-                  </button>
-                  <button class="toggle-btn" [class.toggle-btn--active]="getPopupViewMode(activeBrowseTab) === 'list'" (click)="onPopupViewModeChange(activeBrowseTab, 'list')" title="Show a right-clicked bin's items as a list">
-                    List
-                  </button>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="form-label" title="Thumbnail size in the bin popup's grid">Popup thumbnail size</label>
-                <select class="form-select" [ngModel]="getPopupGridIconSize(activeBrowseTab)" (ngModelChange)="onPopupGridIconSizeChange(activeBrowseTab, $event)" [disabled]="getPopupViewMode(activeBrowseTab) === 'list'" aria-label="Bin popup thumbnail size">
+                <label class="form-label" title="Thumbnail size in the bin popup's grid">Popup thumbnail size<vt-field-hint-icon hint="Thumbnail size in the right-click bin popup's grid. Changing it on a popup while browsing remembers the choice here for this media type."></vt-field-hint-icon></label>
+                <select class="form-select" [ngModel]="getPopupGridIconSize(activeBrowseTab)" (ngModelChange)="onPopupGridIconSizeChange(activeBrowseTab, $event)" aria-label="Bin popup thumbnail size">
                   <option value="XS">XS</option>
                   <option value="S">S</option>
                   <option value="M">M</option>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -385,23 +385,11 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     this.save();
   }
 
-  // --- Browser tab: right-click bin-popup view prefs ---
-  // The bin popup keeps its own per-media-type view mode + thumbnail size
-  // (``view_mode_popup`` / ``grid_icon_size_popup``), independent of the
-  // left/right panels. The popup's in-header controls write the same maps, so
-  // these widgets and the live popup stay in step.
-
-  getPopupViewMode(typeId: string): string {
-    const dict = this.settings.view_mode_popup as Record<string, string> | undefined;
-    return (dict && dict[typeId]) || 'grid';
-  }
-
-  onPopupViewModeChange(typeId: string, value: string): void {
-    const dict = { ...((this.settings.view_mode_popup as Record<string, string> | undefined) || {}) };
-    dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['view_mode_popup'] = dict;
-    this.save();
-  }
+  // --- Browser tab: right-click bin-popup thumbnail size ---
+  // The bin popup keeps its own per-media-type thumbnail size
+  // (``grid_icon_size_popup``), independent of the left/right panels. The
+  // popup's in-header size buttons write the same map, so this widget and the
+  // live popup stay in step. (The popup is grid-only — it has no list mode.)
 
   getPopupGridIconSize(typeId: string): string {
     const dict = this.settings.grid_icon_size_popup as Record<string, string> | undefined;

--- a/frontend/src/app/components/view-controls/view-controls.component.html
+++ b/frontend/src/app/components/view-controls/view-controls.component.html
@@ -20,6 +20,7 @@
     </button>
   </div>
 
+  @if (showViewMode) {
   <div class="vc-group">
     <button
       type="button"
@@ -42,6 +43,7 @@
       <vt-icon type="grid" [size]="13"></vt-icon>
     </button>
   </div>
+  }
 
   @if (showFocus) {
   <div class="vc-group">

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -34,6 +34,12 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
    * ``[allowSizeInList]="true"``.
    */
   @Input() allowSizeInList = false;
+  /**
+   * Whether to show the Grid/List toggle. The VTSBrowse bin popup is grid-only
+   * (it pairs the grid with a large hover preview), so it hides the toggle with
+   * ``[showViewMode]="false"`` while keeping the thumbnail-size buttons.
+   */
+  @Input() showViewMode = true;
 
   viewMode: 'grid' | 'list' = 'list';
   focusMode: 'click' | 'hover' = 'click';

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -408,20 +408,6 @@ class TestSettingsAPI:
         assert "grid_icon_size_left" in data
         assert "grid_icon_size_right" in data
 
-    def test_update_view_mode_popup_per_type(self, client):
-        res = client.put("/api/settings", json={"view_mode_popup": {"audio": "list", "image": "grid"}})
-        assert res.status_code == 200
-        data = res.get_json()
-        assert data["view_mode_popup"]["audio"] == "list"
-        assert data["view_mode_popup"]["image"] == "grid"
-
-        res2 = client.get("/api/settings")
-        assert res2.get_json()["view_mode_popup"]["audio"] == "list"
-
-    def test_update_view_mode_popup_invalid(self, client):
-        res = client.put("/api/settings", json={"view_mode_popup": {"audio": "invalid"}})
-        assert res.status_code == 400
-
     def test_update_grid_icon_size_popup_per_type(self, client):
         res = client.put("/api/settings", json={"grid_icon_size_popup": {"audio": "S", "video": "L"}})
         assert res.status_code == 200

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -72,7 +72,6 @@ _SCALAR_SETTERS: dict[str, Callable[[Any], Any]] = {
     "focus_mode_right": settings.set_focus_mode_right,
     "panel_pct_left": settings.set_panel_pct_left,
     "panel_pct_right": settings.set_panel_pct_right,
-    "view_mode_popup": settings.set_view_mode_popup,
     "grid_icon_size_popup": settings.set_grid_icon_size_popup,
     "autopilot_enabled": settings.set_autopilot_enabled,
     "hide_autopilot": settings.set_hide_autopilot,

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -97,9 +97,8 @@ class AppSettingsSchema(Schema):
     focus_mode_right = _PerMediaTypeStringDict()
     panel_pct_left = _PerMediaTypeNumberDict()
     panel_pct_right = _PerMediaTypeNumberDict()
-    # VTSBrowse bin-popup view mode + thumbnail size, per media type. Driven by
-    # the popup's own view controls and the Settings → Browser tab.
-    view_mode_popup = _PerMediaTypeStringDict()
+    # VTSBrowse bin-popup thumbnail size, per media type. Driven by the popup's
+    # own size buttons and the Settings → Browser tab. (The popup is grid-only.)
     grid_icon_size_popup = _PerMediaTypeStringDict()
 
     # Server-tier. These are fixed at server start (config file /
@@ -199,7 +198,6 @@ class SettingsUpdateSchema(Schema):
     focus_mode_right = fields.Raw()
     panel_pct_left = fields.Raw()
     panel_pct_right = fields.Raw()
-    view_mode_popup = fields.Raw()
     grid_icon_size_popup = fields.Raw()
 
     autopilot_enabled = fields.Boolean()

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -274,17 +274,17 @@ class UserSettings(BaseModel):
     focus_mode_left: dict[str, FocusMode] = Field(default_factory=dict)
     focus_mode_right: dict[str, FocusMode] = Field(default_factory=dict)
 
-    # VTSBrowse bin-popup display prefs, per media type. The right-click bin
-    # popup renders the bin's members like a mini Find panel with its own
-    # List/Grid + thumbnail-size controls, independent of the left/right
-    # panels. Empty entries fall back on the frontend to grid + ``M``.
-    # Driven by the popup's own view-controls AND the Settings → Browser tab;
-    # both write the same maps keyed by the active dataset's media type, so
-    # tuning the popup while browsing one bin becomes the default for every
-    # future popup of that media type. Unlike ``view_mode_{left,right}`` these
-    # are plain per-media-type dicts (no per-side machinery): the popup is a
-    # single, third context, so it uses the generic Pydantic-driven accessors.
-    view_mode_popup: dict[str, ViewMode] = Field(default_factory=dict)
+    # VTSBrowse bin-popup thumbnail size, per media type. The right-click bin
+    # popup renders the bin's members as a thumbnail grid (always grid; there is
+    # no list mode) beside a large hover-preview pane, with its own size control
+    # independent of the left/right panels. Empty entries fall back on the
+    # frontend to ``M``. Driven by the popup's own size buttons AND the
+    # Settings → Browser tab; both write the same map keyed by the active
+    # dataset's media type, so tuning the popup while browsing one bin becomes
+    # the default for every future popup of that media type. Unlike
+    # ``grid_icon_size_{left,right}`` this is a plain per-media-type dict (no
+    # per-side machinery): the popup is a single, third context, so it uses the
+    # generic Pydantic-driven accessors.
     grid_icon_size_popup: dict[str, Annotated[GridIconSize, BeforeValidator(_upper)]] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)


### PR DESCRIPTION
## What

Makes the VTSBrowse right-click bin popup more powerful for inspecting detail.

- **Grid-only.** Removed the popup's List/Grid toggle — it's always a thumbnail grid now. The `view_mode_popup` setting is removed end to end (Pydantic model, marshmallow schema, settings route map, the Settings → Browser tab widget, and the obsolete API tests). The OpenAPI snapshot was regenerated.
- **Large detail-preview pane.** For thumbnail media (image/video), a big preview pane sits to the **left** of the scrolling grid. Hovering a grid thumbnail paints that item's **full-resolution original** (`/api/medias/<id>/image`, not its grid thumbnail) into the pane — so the user can pull detail out of each pile member in turn.
- **Singletons open with detail.** The pane opens on the bin's representative (first member), so even a singleton bin lands on a large high-res view without any hover.
- **Pane size tracks the canvas.** The pane is sized **+50%** of the item's on-canvas mouse-over break-out at the current main-canvas thumbnail size (`hoverThumbRadius` is passed down from `browse-view`), so it grows/shrinks with the icon-size setting. Clamped to a sane absolute cap and to whatever room the visible region leaves.
- **Grid thumbnails no longer magnify on hover** — the preview pane replaces that affordance.

The shared `vt-view-controls` gained a `[showViewMode]` input (default true) so the popup can hide the Grid/List toggle while keeping the thumbnail-size buttons; the Find left/right panels are unaffected.

## Decisions (confirmed with the requester)

- Default preview content when the popup opens: **the bin's representative at full res**.
- Pane sizing: **tracks the current main-canvas thumbnail-size setting** (faithful to "the mouse-over size in the main canvas").

## Testing

- `./run-tests.sh core api` → **ALL 1253 TESTS PASSED** (includes ruff / codespell / deptry / OpenAPI-diff / frontend `build:prod`, all clean).
- `npm run build:prod` → succeeds, no TypeScript errors and no budget warnings.

## Notes

- Breaking change: the `view_mode_popup` user setting is gone (per repo policy, no compat shim). Any persisted value is simply ignored.
- Follow-up recorded in `docs/plans/vtsbrowse.md`: the pane is gated on `usesThumbnails` (image/video); documents render a grid thumbnail but get no large preview.

https://claude.ai/code/session_01UAqQ9jtQwSnGSiJ8mMNQsS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAqQ9jtQwSnGSiJ8mMNQsS)_