### PR TITLE
Theme A (A2): decouple vtscore/detectors/workflow.py from the app tier

### DIFF
--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -229,14 +229,29 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
   `vtscore/detectors/model_loading.py` (`resolve_or_train_detector`). It had
   no Flask/request-context dependency; the route is now request↔library glue.
   Full suite green.
+- **Theme A, slice 2 (A2):** `vtscore/detectors/workflow.py` no longer imports
+  the app tier. `apply_and_retrain` now pulls its helpers (`apply_label`,
+  `snapshot_medias`, `build_media_lookup`, `resolve_media_ids`, the calibration
+  getters) from `vtscore.state` and reads the candidate votes from the passed
+  `det_ctx` directly (`det_ctx.good_votes` / `bad_votes` / `vote_region_boxes`)
+  instead of the `vtsearch.state` proxies. The function keeps setting up its own
+  `override_detector_context(det_ctx)` so `apply_label` /
+  `sync_labels_to_loaded_detector` resolve to `det_ctx` regardless of caller,
+  leaving it self-contained for routes, background threads, and tests alike.
+  The only remaining `vtsearch` reference in the file is gone; full suite green.
 
 ## Open follow-ups
 
 - **Theme A, remaining:** extract `_maybe_start_label_reembed` from
   `detectors/registry.py` (→ `vtscore.detectors.embedder_sync`), pull the
-  learned-sort orchestration helpers out of `routes/sorting.py`, decouple
-  `vtscore/detectors/workflow.py` from `flask.g` (A2 — use the passed-in
-  `det_ctx` directly instead of the proxy/`override_detector_context`
-  machinery), and merge the two training pipelines (A3).
+  learned-sort orchestration helpers out of `routes/sorting.py`, and merge the
+  two training pipelines (A3).
+- **Theme A, broader inverse-leak sweep (not in original A2 scope):** ~15 other
+  `vtscore/` modules still import from `vtsearch` (e.g.
+  `detectors/label_sync.py`, `detectors/training.py`, `state/votes.py`,
+  `datasets/load_pipeline.py`). Most are cosmetic (a pure `vtscore` function
+  imported via the `vtsearch.state` re-export); some may be genuine app-tier
+  reaches. Worth a dedicated pass that audits each and points the cosmetic ones
+  back at `vtscore.state` directly.
 - **Themes B–F:** see the prioritized backlog above; none started.
 </content>

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -44,14 +44,11 @@ def apply_and_retrain(  # noqa: C901
     Returns ``(resolved_count, trained_bool)``.
     """
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
-    from vtsearch.state import (
+    from vtscore.state import (
         apply_label,
-        bad_votes,
         build_media_lookup,
-        good_votes,
         resolve_media_ids,
         snapshot_medias,
-        vote_region_boxes,
     )
     from vtscore.state.core import _state_lock, override_detector_context
 
@@ -79,8 +76,8 @@ def apply_and_retrain(  # noqa: C901
         # 2) Build the *proposed* vote dicts (current + new resolutions)
         #    for a dry-run training pass.  Same-side dedup is automatic
         #    via dict; new opposite-side labels supersede the old ones.
-        proposed_good = dict(good_votes)
-        proposed_bad = dict(bad_votes)
+        proposed_good = dict(det_ctx.good_votes)
+        proposed_bad = dict(det_ctx.bad_votes)
         for cid, label in resolved_pairs:
             if label == "good":
                 proposed_bad.pop(cid, None)
@@ -96,7 +93,7 @@ def apply_and_retrain(  # noqa: C901
         new_threshold = 0.5
         if proposed_good and proposed_bad:
             from vtscore.detectors.training import train_and_score
-            from vtsearch.state import (
+            from vtscore.state import (
                 get_calibrate_count,
                 get_calibration_fraction,
                 get_inclusion,
@@ -111,7 +108,7 @@ def apply_and_retrain(  # noqa: C901
                 safe_thresholds=get_safe_thresholds(),
                 calibrate_count=get_calibrate_count(),
                 calibration_fraction=get_calibration_fraction(),
-                vote_region_boxes=dict(vote_region_boxes),
+                vote_region_boxes=dict(det_ctx.vote_region_boxes),
                 det_ctx=det_ctx,
             )
 
@@ -162,7 +159,7 @@ def apply_and_retrain(  # noqa: C901
             det_ctx.model = new_model
             det_ctx.threshold = new_threshold
             training = {}
-            for cid in list(good_votes) + list(bad_votes):
+            for cid in list(det_ctx.good_votes) + list(det_ctx.bad_votes):
                 if cid in snap:
                     training[cid] = snap[cid]
             det_ctx.training_medias = training


### PR DESCRIPTION
## What this is

The next slice of **Theme A** (the `vtscore` ↔ `vtsearch` boundary) from
`docs/plans/code-structure-review.md`. Slice 1 (A1) already extracted the
cold-path detector model resolution into `vtscore/detectors/model_loading.py`;
this is **slice 2 (A2)** — fixing the inverse leak where the library tier reached
back into the app tier.

## The problem

`vtscore/detectors/workflow.py` (`apply_and_retrain`) imported `flask.g`-backed
state from `vtsearch.state` — `good_votes`, `bad_votes`, `vote_region_boxes`
(app-tier proxies) plus a handful of helpers that are actually pure `vtscore`
functions re-exported through the app shim. A library module depending on the
request tier undermines the testability/reuse story the architecture doc is
built around.

## The fix

- `apply_and_retrain` now imports its helpers (`apply_label`, `snapshot_medias`,
  `build_media_lookup`, `resolve_media_ids`, the calibration getters) from
  `vtscore.state` directly instead of `vtsearch.state`.
- The candidate votes are read off the passed `det_ctx` directly
  (`det_ctx.good_votes` / `bad_votes` / `vote_region_boxes`) rather than the
  module-level proxies.
- The `override_detector_context(det_ctx)` wrapper stays **internal** to the
  function (it's a `vtscore` primitive, not the leak), so `apply_and_retrain`
  remains self-contained for routes, background threads, and tests — no caller
  is required to pre-establish the active context. (Chosen over the plan's
  "move the override up to the route" wording to avoid giving the function an
  implicit precondition + a read/write context mismatch.)

The file now has **zero** `vtsearch` references.

## Scope note

A broader sweep found ~15 other `vtscore/` modules with the same inverse-leak
pattern (mostly cosmetic — a pure `vtscore` function imported via the
`vtsearch.state` re-export). That's logged as an open follow-up in the plan, not
folded into this PR.

## Testing

- `./run-tests.sh detectors vtscore-clean` — 1200 passed (covers
  `test_workflow.py` + the library import-purity gate).
- `./run-tests.sh` (full fast suite) — 4789 passed, 1 skipped, 2 xpassed.

Plan doc updated: A2 moved to "What shipped"; follow-ups refreshed.

https://claude.ai/code/session_011YwY51iubqq8MFP1FToYuW

---
_Generated by [Claude Code](https://claude.ai/code/session_011YwY51iubqq8MFP1FToYuW)_