### PR TITLE
Theme A: extract label re-embed orchestration into vtscore.detectors.embedder_sync

### DIFF
--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -239,13 +239,22 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
   `sync_labels_to_loaded_detector` resolve to `det_ctx` regardless of caller,
   leaving it self-contained for routes, background threads, and tests alike.
   The only remaining `vtsearch` reference in the file is gone; full suite green.
+- **Theme A, slice 3 (A1):** the label re-embed orchestration
+  (`_maybe_start_label_reembed` plus its `_active_dataset_embedder_name` /
+  `_embedder_display_name` helpers) moved out of
+  `vtsearch/routes/detectors/registry.py` into a new Flask-free
+  `vtscore/detectors/embedder_sync.py` (`maybe_start_label_reembed`). Its one
+  app-tier dependency — the `vtsearch.threading.spawn` worker that replays the
+  request's user thread-local — is injected by the route, so the module stays
+  import-clean. The `registry.py` load route is now request↔library glue. Full
+  suite green.
 
 ## Open follow-ups
 
-- **Theme A, remaining:** extract `_maybe_start_label_reembed` from
-  `detectors/registry.py` (→ `vtscore.detectors.embedder_sync`), pull the
-  learned-sort orchestration helpers out of `routes/sorting.py`, and merge the
-  two training pipelines (A3).
+- **Theme A, remaining:** pull the learned-sort orchestration helpers out of
+  `routes/sorting.py` (`_resolve_labelset_local_state`,
+  `_model_matches_local_votes`, `_update_det_ctx_with_trained_model`,
+  `_build_learned_sort_signature`), and merge the two training pipelines (A3).
 - **Theme A, broader inverse-leak sweep (not in original A2 scope):** ~15 other
   `vtscore/` modules still import from `vtsearch` (e.g.
   `detectors/label_sync.py`, `detectors/training.py`, `state/votes.py`,

--- a/tests/detectors/test_cross_embedder_switch.py
+++ b/tests/detectors/test_cross_embedder_switch.py
@@ -180,7 +180,7 @@ class TestLoadEndpointReembedTask:
         detector_id = entry["id"]
 
         det_ctx = DetectorContext(detector_id, name=name, media_type="audio", embedder=embedder)
-        # Pre-stamp a cached labelset so ``_maybe_start_label_reembed`` has
+        # Pre-stamp a cached labelset so ``maybe_start_label_reembed`` has
         # something to walk.
         det_ctx.cached_labelset = LabelSet.from_dict(labelset_dict)
         det_ctx.cached_labelset_media_type = "audio"

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -181,7 +181,7 @@ def invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder: str) -
       reset and risk surprising any caller that reads the cache directly.
     * ``det_ctx.embedder`` is the "what was the last training pass aligned
       with" marker.  Leaving it stamped as the old value lets the load
-      endpoint's :func:`~vtsearch.routes.detectors.registry._maybe_start_label_reembed`
+      endpoint's :func:`~vtscore.detectors.embedder_sync.maybe_start_label_reembed`
       still detect the mismatch and schedule its progress-tracked
       re-embed task.  The marker is restamped to *new_embedder* by the
       next training pass (via

--- a/vtscore/detectors/embedder_sync.py
+++ b/vtscore/detectors/embedder_sync.py
@@ -1,0 +1,131 @@
+"""Re-embed a loaded detector's labels when the active dataset's space changes.
+
+:func:`maybe_start_label_reembed` is the cold-path fired when an
+already-loaded detector is re-selected while the active dataset uses a
+different embedder than the one its cached label embeddings were built
+against (e.g. switching from a SigLIP-embedded image dataset to a
+CLIP-embedded one).  It schedules a progress-tracked background re-embed so
+the work is visible to the user instead of running lazily inside the next
+vote / learned-sort request.
+
+This logic lived inline in ``vtsearch/routes/detectors/registry.py`` until it
+grew its own mismatch-detection + task-orchestration branches.  Everything it
+touches except the thread-spawn helper already lives in the library tier, so
+it belongs here where it can be exercised without a Flask client (see
+docs/plans/code-structure-review.md, Theme A).  The one app-tier dependency —
+``vtsearch.threading.spawn``, which replays the request's user thread-local
+into the worker — is injected by the caller so this module stays Flask-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# A ``spawn``-style callable: ``spawn(target, *, name=...) -> Thread``.  The
+# route injects ``vtsearch.threading.spawn`` (which carries the user /
+# dataset / detector thread-locals into the worker); tests can inject a
+# synchronous stand-in.
+SpawnFn = Callable[..., Any]
+
+
+def active_dataset_embedder_name() -> str:
+    """Return the embedder name recorded on the active dataset's medias, or ``""``."""
+    from vtscore.state import snapshot_medias
+
+    snap = snapshot_medias()
+    if not snap:
+        return ""
+    first = next(iter(snap.values()), {})
+    return first.get("embedder", "") or ""
+
+
+def embedder_display_name(embedder_name: str) -> str:
+    """Return a human-friendly name for *embedder_name*, falling back to the id."""
+    if not embedder_name:
+        return ""
+    from vtscore.media import get_embedder
+
+    try:
+        return get_embedder(embedder_name).display_name or embedder_name
+    except KeyError:
+        return embedder_name
+
+
+def maybe_start_label_reembed(det_ctx, entry: dict, *, spawn: SpawnFn) -> str | None:
+    """Fire a re-embed task when the active dataset uses a different embedder.
+
+    Returns the task id when work was started, or ``None`` when the cache is
+    already aligned (same embedder, empty dataset, no labelset cached, etc.)
+    so the caller can return the synchronous fast-path.
+
+    *spawn* starts the background worker (see :data:`SpawnFn`); it must replay
+    the caller's execution context into the new thread.
+    """
+    new_embedder = active_dataset_embedder_name()
+    if not new_embedder or not det_ctx.embedder or new_embedder == det_ctx.embedder:
+        return None
+
+    labelset = det_ctx.cached_labelset
+    if labelset is None or not labelset.elements:
+        # Nothing to re-embed; just update the stamp so we don't re-enter
+        # this branch on every subsequent switch.
+        det_ctx.embedder = new_embedder
+        return None
+
+    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
+    from vtscore.state import get_active_context
+    from vtscore.state.core import thread_dataset_context, thread_detector_context
+
+    _thread_ds_ctx = get_active_context()
+    media_type = det_ctx.cached_labelset_media_type or entry.get("media_type", "") or ""
+    display = embedder_display_name(new_embedder)
+    base_msg = f"Re-resolving labels for {display}…" if display else "Re-resolving labels…"
+
+    task_id = f"_detreembed_{det_ctx.detector_id[:8]}"
+    tracker = detector_loading_tasks.create_task(
+        task_id,
+        entry.get("name", det_ctx.detector_id),
+        detector_id=det_ctx.detector_id,
+        media_type=media_type,
+        embedder=new_embedder,
+    )
+    tracker.update("loading", base_msg, 0, 0, step=1, total_steps=1)
+
+    def reembed_task():
+        from vtscore.detectors.labelset_training import train_from_labelset
+
+        try:
+            with thread_dataset_context(_thread_ds_ctx), thread_detector_context(det_ctx):
+
+                def _embed_progress(name: str, done: int, total: int) -> None:
+                    tracker.check_cancelled()
+                    tracker.update("loading", base_msg, done, total, step=1, total_steps=1)
+
+                # ``populate_label_embeddings`` clears the cache when it detects
+                # the embedder change, so this rebuilds against the new embedder
+                # from scratch. The stamp on ``det_ctx.embedder`` is updated
+                # inside ``populate_label_embeddings``.
+                from vtscore.state import snapshot_medias
+
+                try:
+                    train_from_labelset(
+                        det_ctx,
+                        labelset,
+                        media_type=media_type,
+                        snap=snapshot_medias(),
+                        on_progress=_embed_progress,
+                    )
+                    tracker.update("idle", "", 0, 0, step=None, total_steps=None)
+                except CancelledError:
+                    tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+                except Exception as e:
+                    import traceback as _tb
+
+                    _tb.print_exc()
+                    error_msg = str(e) or repr(e) or "Unknown error during label re-embedding"
+                    tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
+        finally:
+            detector_loading_tasks.mark_finished(task_id)
+
+    spawn(reembed_task, name=f"det-reembed-{det_ctx.detector_id[:8]}")
+    return task_id

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -307,108 +307,6 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
 # ---------------------------------------------------------------------------
 
 
-def _active_dataset_embedder_name() -> str:
-    """Return the embedder name recorded on the active dataset's medias, or ``""``."""
-    from vtsearch.state import snapshot_medias
-
-    snap = snapshot_medias()
-    if not snap:
-        return ""
-    first = next(iter(snap.values()), {})
-    return first.get("embedder", "") or ""
-
-
-def _embedder_display_name(embedder_name: str) -> str:
-    """Return a human-friendly name for *embedder_name*, falling back to the id."""
-    if not embedder_name:
-        return ""
-    from vtscore.media import get_embedder
-
-    try:
-        return get_embedder(embedder_name).display_name or embedder_name
-    except KeyError:
-        return embedder_name
-
-
-def _maybe_start_label_reembed(det_ctx, entry: dict) -> str | None:
-    """Fire a re-embed task when the active dataset uses a different embedder.
-
-    Returns the task id when work was started, or ``None`` when the cache is
-    already aligned (same embedder, empty dataset, no labelset cached, etc.)
-    so the caller can return the synchronous fast-path.
-    """
-    new_embedder = _active_dataset_embedder_name()
-    if not new_embedder or not det_ctx.embedder or new_embedder == det_ctx.embedder:
-        return None
-
-    labelset = det_ctx.cached_labelset
-    if labelset is None or not labelset.elements:
-        # Nothing to re-embed; just update the stamp so we don't re-enter
-        # this branch on every subsequent switch.
-        det_ctx.embedder = new_embedder
-        return None
-
-    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
-    from vtsearch.state import get_active_context
-    from vtscore.state.core import thread_dataset_context, thread_detector_context
-
-    _thread_ds_ctx = get_active_context()
-    media_type = det_ctx.cached_labelset_media_type or entry.get("media_type", "") or ""
-    display = _embedder_display_name(new_embedder)
-    base_msg = f"Re-resolving labels for {display}…" if display else "Re-resolving labels…"
-
-    task_id = f"_detreembed_{det_ctx.detector_id[:8]}"
-    tracker = detector_loading_tasks.create_task(
-        task_id,
-        entry.get("name", det_ctx.detector_id),
-        detector_id=det_ctx.detector_id,
-        media_type=media_type,
-        embedder=new_embedder,
-    )
-    tracker.update("loading", base_msg, 0, 0, step=1, total_steps=1)
-
-    def reembed_task():
-        from vtscore.detectors.labelset_training import train_from_labelset
-
-        try:
-            with thread_dataset_context(_thread_ds_ctx), thread_detector_context(det_ctx):
-
-                def _embed_progress(name: str, done: int, total: int) -> None:
-                    tracker.check_cancelled()
-                    tracker.update("loading", base_msg, done, total, step=1, total_steps=1)
-
-                # ``populate_label_embeddings`` clears the cache when it detects
-                # the embedder change, so this rebuilds against the new embedder
-                # from scratch. The stamp on ``det_ctx.embedder`` is updated
-                # inside ``populate_label_embeddings``.
-                from vtsearch.state import snapshot_medias
-
-                try:
-                    train_from_labelset(
-                        det_ctx,
-                        labelset,
-                        media_type=media_type,
-                        snap=snapshot_medias(),
-                        on_progress=_embed_progress,
-                    )
-                    tracker.update("idle", "", 0, 0, step=None, total_steps=None)
-                except CancelledError:
-                    tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
-                except Exception as e:
-                    import traceback as _tb
-
-                    _tb.print_exc()
-                    error_msg = str(e) or repr(e) or "Unknown error during label re-embedding"
-                    tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
-        finally:
-            detector_loading_tasks.mark_finished(task_id)
-
-    from vtsearch.threading import spawn
-
-    spawn(reembed_task, name=f"det-reembed-{det_ctx.detector_id[:8]}")
-    return task_id
-
-
 @detectors_registry_bp.route("/api/detectors/registry/load", methods=["POST"])
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
@@ -469,9 +367,12 @@ def load_detector_route(body: dict):  # noqa: C901
         # ``populate_label_embeddings``; this branch just makes the work
         # visible via a progress task instead of letting it run lazily
         # inside the next vote or learned-sort request.
+        from vtscore.detectors.embedder_sync import maybe_start_label_reembed
+        from vtsearch.threading import spawn
+
         det_ctx_existing = get_active_detector_context()
         if det_ctx_existing.detector_id == detector_id:
-            task_id = _maybe_start_label_reembed(det_ctx_existing, entry)
+            task_id = maybe_start_label_reembed(det_ctx_existing, entry, spawn=spawn)
             if task_id is not None:
                 return {
                     "ok": True,


### PR DESCRIPTION
Continues Phase A (Theme A — the `vtscore` ↔ `vtsearch` boundary) of `docs/plans/code-structure-review.md`. Slices 1 (A1 cold-path) and 2 (A2 inverse-leak) already shipped; this is slice 3.

## What changed

Moved the label re-embed orchestration out of the fat `registry.py` route into the library tier:

- **New `vtscore/detectors/embedder_sync.py`** holding `maybe_start_label_reembed` plus its `active_dataset_embedder_name` / `embedder_display_name` helpers (formerly `_maybe_start_label_reembed` etc. in `vtsearch/routes/detectors/registry.py`).
- The module is Flask-free: everything it touches (`snapshot_medias`, `get_active_context`, `get_embedder`, the thread-context managers, the progress tasks, `train_from_labelset`) already lives in `vtscore`. Its one app-tier dependency — the `vtsearch.threading.spawn` worker that replays the request's user thread-local into the background thread — is **injected** by the route via a `spawn=` parameter, so the library stays import-clean and the orchestration is unit-testable with a synchronous stand-in.
- The `POST /api/detectors/registry/load` handler is now request↔library glue: it imports `maybe_start_label_reembed` and passes `spawn`.
- Updated the cross-reference docstring in `vtscore/detectors/dataset_sync.py` and the comment in `tests/detectors/test_cross_embedder_switch.py` to the new name/location.

No behavior change — the function body is preserved verbatim aside from pointing its lazy imports at `vtscore.state` (the `vtsearch.state` versions were re-exports of the same functions).

## Testing

Full suite green: `ALL 4789 TESTS PASSED (1 skipped)`. The cross-embedder-switch tests (which drive this path through the HTTP endpoint) pass unchanged.

https://claude.ai/code/session_01AHJPFsNAE2SjMCZvN2WDoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHJPFsNAE2SjMCZvN2WDoV)_