### PR TITLE
Theme A (A3): consolidate the two detector training pipelines

### DIFF
--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -1,9 +1,11 @@
 # Code-structure review
 
-**Status:** Review complete; acting on **Theme A** (the `vtscore` ↔ `vtsearch`
-boundary) first. The other themes are scoped below as a prioritized backlog
-for later passes. See "What shipped" + "Open follow-ups" at the bottom for
-live status.
+**Status:** Review complete. **Theme A** (the `vtscore` ↔ `vtsearch`
+boundary) is shipped: A1 (fat-controller extractions), A2 (workflow
+de-coupling), and A3 (training-pipeline merge) all landed. The other themes
+are scoped below as a prioritized backlog for later passes; the broader
+inverse-leak sweep is the one remaining Theme A item. See "What shipped" +
+"Open follow-ups" at the bottom for live status.
 
 This is a systematic, repo-wide structural review: where have design
 decisions that were right at small scale been outgrown, and what is worth
@@ -208,7 +210,8 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
 ## Prioritized backlog
 
 1. **Theme A** — extract fat-controller logic into `vtscore`; de-couple
-   `workflow.py` from `flask.g`. (In progress.)
+   `workflow.py` from `flask.g`; merge the two training pipelines. (Shipped;
+   only the broader inverse-leak sweep remains — see Open follow-ups.)
 2. **Theme C quick wins** — settings `SettingSpec` registry; `_ClapBase`
    mixin; per-side settings factory.
 3. **Theme E** — "shim" rename; `labelset_ops` facade.
@@ -259,13 +262,21 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
   settings/votes, short-circuits on the signature cache, and owns only the
   job-result envelope. `_validate_learned_sort_inputs` stays in the route
   because it calls `abort()` (a 400 request-layer concern). Full suite green.
+- **Theme A, slice 5 (A3):** the two detector training pipelines now share a
+  single core. `vtscore/detectors/training.py` grew `_train_and_score_xy`,
+  which owns the guard → threshold → train → score → format tail; both
+  `train_and_score` (vote-driven) and
+  `labelset_training.labelset_train_and_score` (labelset-driven) now just
+  assemble their own `(X_list, y_list)` (`_build_vote_xy` /
+  `populate_label_embeddings` + `build_xy_from_labelset`) and defer to it. The
+  labelset path thereby picks up the vote path's region-aware scoring
+  (`_score_all_media`) and NaN sanitisation it previously lacked, and the
+  duplicated patch-region pooling (`_training_vec_for_vote`'s inline pooling vs
+  `labelset_training._pool_box_from_media`) collapsed into one
+  `pool_box_from_media` helper in `training.py`. Full suite green.
 
 ## Open follow-ups
 
-- **Theme A, remaining:** merge the two training pipelines (A3) —
-  `vtscore/detectors/training.py` and `labelset_training.py` both implement
-  resolve → build X/y → threshold → train → score; consolidate behind a shared
-  training-data-builder seam and one parameterized scoring function.
 - **Theme A, broader inverse-leak sweep (not in original A2 scope):** ~15 other
   `vtscore/` modules still import from `vtsearch` (e.g.
   `detectors/label_sync.py`, `detectors/training.py`, `state/votes.py`,

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -22,7 +22,6 @@ from typing import Any, Callable
 import numpy as np
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet
-from vtscore.utils.scores import sigmoid_to_finite_scores
 
 
 log = logging.getLogger(__name__)
@@ -151,30 +150,6 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
         return embed_file(file_path, media_type, embedder_name)
 
 
-def _pool_box_from_media(
-    media: dict[str, Any],
-    region_box: tuple[float, float, float, float] | None,
-) -> np.ndarray | None:
-    """Return the region-pooled training vector for *media*, if applicable.
-
-    When *region_box* is set **and** the media has a stored ``patch_grid``,
-    pool the box on-the-fly via
-    :func:`vtscore.media.patch_embed.box_to_vote_vector` and return that
-    vector.  Otherwise return ``None`` so the caller can fall back to
-    ``media["embedding"]`` - i.e. the legacy image-level training vector for
-    image-level votes, single-vector embedders, and patch datasets that
-    haven't been re-loaded under the v1 storage scheme.  Patch-embedder v2.
-    """
-    if region_box is None:
-        return None
-    grid = media.get("patch_grid")
-    if grid is None:
-        return None
-    from vtscore.media.patch_embed import box_to_vote_vector
-
-    return box_to_vote_vector(np.asarray(grid), region_box)
-
-
 def _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name: str) -> None:
     """Drop the label-embedding cache when the active dataset's embedder changed.
 
@@ -204,12 +179,13 @@ def _resolve_uncached_embedding(
     produces a vector.
     """
     from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
+    from vtscore.detectors.training import pool_box_from_media
 
     if snap:
         cid = resolve_current_dataset_cid(elem)
         if cid is not None and cid in snap:
             media = snap[cid]
-            pooled = _pool_box_from_media(media, elem.region_box)
+            pooled = pool_box_from_media(media, elem.region_box)
             emb = pooled if pooled is not None else media.get("embedding")
             if emb is not None:
                 return np.asarray(emb)
@@ -361,66 +337,29 @@ def labelset_train_and_score(
 ) -> tuple[list[dict[str, Any]], float, Any | None]:
     """Train an MLP on the full labelset, then score every media in *clips_dict*.
 
-    Replacement for :func:`~vtscore.detectors.training.train_and_score` that
-    trains on cross-dataset labels.  Scoring is still scoped to the active
+    Counterpart to :func:`~vtscore.detectors.training.train_and_score` that
+    trains on cross-dataset labels.  It assembles ``(X_list, y_list)`` from
+    the resolved labelset (populating the embedding cache on the way) and
+    then defers the threshold → train → score → format tail to the shared
+    :func:`~vtscore.detectors.training._train_and_score_xy` core, so the two
+    pipelines stay in lock-step (region-aware scoring, NaN sanitisation,
+    safe-threshold blending).  Scoring is still scoped to the active
     dataset's media, since that is what the user is sorting in the UI.
     """
-    import torch
-
-    from vtscore.training.mlp import _auto_hidden_dim, train_model
-    from vtscore.training.thresholds import (
-        calculate_safe_threshold,
-        cross_calibration_threshold_cached,
-    )
+    from vtscore.detectors.training import _train_and_score_xy
 
     populate_label_embeddings(det_ctx, labelset, media_type=media_type, snap=clips_dict)
     X_list, y_list = build_xy_from_labelset(det_ctx, labelset)
-
-    num_good = sum(1 for v in y_list if v == 1.0)
-    num_bad = len(y_list) - num_good
-    if len(X_list) < 2 or num_good == 0 or num_bad == 0:
-        return [], 0.5, None
-
-    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
-    hidden_dim = _auto_hidden_dim(len(X_list))
-
-    # Skip cross-cal trainings below the ``calculate_safe_threshold`` ramp
-    # floor - they're expensive and the result is discarded by the blend
-    # (label_weight=0 → pure GMM) or unreliable with so few labels.
-    if len(X_list) < 6:
-        threshold = 0.5
-    else:
-        threshold = cross_calibration_threshold_cached(
-            X_list,
-            y_list,
-            input_dim,
-            inclusion_value,
-            calibrate_count=calibrate_count,
-            calibration_fraction=calibration_fraction,
-            hidden_dim=hidden_dim,
-            det_ctx=det_ctx,
-        )
-
-    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
-
-    from vtscore.embedding.matrix import get_embedding_matrix_for_snap
-
-    all_ids, all_embs = get_embedding_matrix_for_snap(clips_dict)
-    if not all_ids:
-        return [], threshold, model
-    X_all = torch.from_numpy(all_embs)
-    with torch.no_grad():
-        X_all = X_all.to(next(model.parameters()).device)
-        scores = sigmoid_to_finite_scores(model(X_all))
-
-    if safe_thresholds:
-        threshold = calculate_safe_threshold(threshold, scores, len(X_list))
-
-    results = [{"id": cid, "score": s} for cid, s in zip(all_ids, scores, strict=True)]
-    results.sort(key=lambda r: r["score"], reverse=True)
-    return results, threshold, model
+    return _train_and_score_xy(
+        X_list,
+        y_list,
+        clips_dict,
+        inclusion_value=inclusion_value,
+        safe_thresholds=safe_thresholds,
+        calibrate_count=calibrate_count,
+        calibration_fraction=calibration_fraction,
+        det_ctx=det_ctx,
+    )
 
 
 def update_cache_for_cid(

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -126,49 +126,63 @@ def serialize_weights(model) -> dict[str, list]:
 # ---------------------------------------------------------------------------
 
 
+def pool_box_from_media(
+    media: dict[str, Any],
+    region_box: tuple[float, float, float, float] | None,
+) -> np.ndarray | None:
+    """Return the region-pooled training vector for *media*, or ``None``.
+
+    When *region_box* is set **and** *media* has a stored ``patch_grid``,
+    pool the box on-the-fly via
+    :func:`vtscore.media.patch_embed.box_to_vote_vector` and return it.
+    Otherwise return ``None`` so the caller can fall back to the media's
+    image-level ``embedding`` - the legacy training vector for image-level
+    votes, single-vector embedders, and patch datasets that haven't been
+    re-loaded under the v1 storage scheme.  Patch-embedder v2.
+
+    Shared by the in-dataset vote path (:func:`_training_vec_for_vote`) and
+    the cross-dataset labelset path
+    (:func:`vtscore.detectors.labelset_training._resolve_uncached_embedding`).
+    """
+    if region_box is None:
+        return None
+    grid = media.get("patch_grid")
+    if grid is None:
+        return None
+    from vtscore.media.patch_embed import box_to_vote_vector  # noqa: PLC0415
+
+    return box_to_vote_vector(np.asarray(grid), region_box)
+
+
 def _training_vec_for_vote(
     media: dict[str, Any],
     region_box: tuple[float, float, float, float] | None,
 ) -> np.ndarray:
     """Return the training vector for one vote on *media*.
 
-    When *region_box* is set **and** *media* has a stored ``patch_grid``,
-    pool the box on-the-fly via
-    :func:`vtscore.media.patch_embed.box_to_vote_vector`.  Otherwise
-    fall back to ``media["embedding"]`` - the v1/legacy image-level vector.
-    Patch-embedder v2.
+    Region-pools via :func:`pool_box_from_media` when the vote designated a
+    box and *media* carries a ``patch_grid``; otherwise falls back to
+    ``media["embedding"]`` - the v1/legacy image-level vector.
     """
-    if region_box is not None:
-        grid = media.get("patch_grid")
-        if grid is not None:
-            from vtscore.media.patch_embed import box_to_vote_vector  # noqa: PLC0415
-
-            return box_to_vote_vector(np.asarray(grid), region_box)
-    return media["embedding"]
+    pooled = pool_box_from_media(media, region_box)
+    return pooled if pooled is not None else media["embedding"]
 
 
-def _build_vote_tensors(
+def _build_vote_xy(
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
     bad_votes: dict[int, None],
     region_boxes: dict[int, tuple[float, float, float, float]],
-) -> tuple[Any, Any, list, list[float], int, int] | None:
-    """Build training tensors from filtered votes.
+) -> tuple[list[np.ndarray], list[float]]:
+    """Build ``(X_list, y_list)`` from filtered votes.
 
-    Returns ``(X, y, X_list, y_list, input_dim, hidden_dim)`` when the
-    filtered labels satisfy ≥2 samples AND at least one good AND one bad;
-    returns ``None`` otherwise so the caller can early-return with an
-    empty result.
-
-    ``hidden_dim`` is sized from the *full* label count so that fold
-    models use the same architecture as the final model - making cross-
-    calibration thresholds directly comparable to final-model scores.
+    Good votes that designated a region are region-pooled via
+    :func:`_training_vec_for_vote`; bad votes always use the image-level
+    embedding.  Returns the raw lists - the caller
+    (:func:`_train_and_score_xy`) enforces the ≥2-samples / ≥1-good /
+    ≥1-bad guard.
     """
-    import torch  # noqa: PLC0415
-
-    from vtscore.training.mlp import _auto_hidden_dim  # noqa: PLC0415
-
-    X_list: list = []
+    X_list: list[np.ndarray] = []
     y_list: list[float] = []
     for cid in good_votes:
         if cid in clips_dict:
@@ -178,17 +192,7 @@ def _build_vote_tensors(
         if cid in clips_dict:
             X_list.append(clips_dict[cid]["embedding"])
             y_list.append(0.0)
-
-    num_good = sum(1 for v in y_list if v == 1.0)
-    num_bad = len(y_list) - num_good
-    if len(X_list) < 2 or num_good == 0 or num_bad == 0:
-        return None
-
-    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
-    hidden_dim = _auto_hidden_dim(len(X_list))
-    return X, y, X_list, y_list, input_dim, hidden_dim
+    return X_list, y_list
 
 
 def _score_all_media(
@@ -283,6 +287,80 @@ def _format_results(
     return results
 
 
+def _train_and_score_xy(
+    X_list: list[np.ndarray],
+    y_list: list[float],
+    clips_dict: dict[int, dict[str, Any]],
+    *,
+    inclusion_value: int,
+    safe_thresholds: bool,
+    calibrate_count: int,
+    calibration_fraction: float,
+    det_ctx: Any,
+) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
+    """Train an MLP on ``(X_list, y_list)`` and score every media in *clips_dict*.
+
+    Shared core of :func:`train_and_score` (vote-driven) and
+    :func:`vtscore.detectors.labelset_training.labelset_train_and_score`
+    (labelset-driven): the two pipelines differ only in how they assemble
+    ``(X_list, y_list)``, so the guard → threshold → train → score → format
+    tail lives here once.
+
+    ``hidden_dim`` is sized from the label count so the cross-calibration
+    fold models share the final model's architecture, making fold thresholds
+    directly comparable to final-model scores.  Returns ``([], 0.5, None)``
+    when the labels don't satisfy ≥2 samples AND ≥1 good AND ≥1 bad.
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.mlp import _auto_hidden_dim, train_model  # noqa: PLC0415
+    from vtscore.training.thresholds import (  # noqa: PLC0415
+        calculate_safe_threshold,
+        cross_calibration_threshold_cached,
+    )
+
+    num_good = sum(1 for v in y_list if v == 1.0)
+    num_bad = len(y_list) - num_good
+    if len(X_list) < 2 or num_good == 0 or num_bad == 0:
+        return [], 0.5, None
+
+    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+    input_dim = X.shape[1]
+    hidden_dim = _auto_hidden_dim(len(X_list))
+
+    # Skip k-fold calibration when the label count is below the
+    # ``calculate_safe_threshold`` ramp floor: the calibration trainings
+    # would be expensive (two 200-epoch fits) and the result is either
+    # discarded (safe_thresholds=True blends with label_weight=0 → pure
+    # GMM) or unreliable.  0.5 is a sensible neutral mid-point.
+    if len(X_list) < 6:
+        threshold = 0.5
+    else:
+        threshold = cross_calibration_threshold_cached(
+            X_list,
+            y_list,
+            input_dim,
+            inclusion_value,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            hidden_dim=hidden_dim,
+            det_ctx=det_ctx,
+        )
+
+    # Training is image-level in v1 - the MLP only ever sees one vector
+    # per labelled media, mirroring the "vote on whole images" rule.
+    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
+
+    all_ids, scores, best_region = _score_all_media(model, clips_dict)
+
+    if safe_thresholds:
+        threshold = calculate_safe_threshold(threshold, scores, len(X_list))
+
+    results = _format_results(all_ids, scores, best_region, clips_dict)
+    return results, threshold, model
+
+
 def train_and_score(
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
@@ -334,48 +412,18 @@ def train_and_score(
         - ``model`` is the trained ``nn.Sequential`` model (``None`` when
           training was not possible).
     """
-    from vtscore.training.mlp import train_model  # noqa: PLC0415
-    from vtscore.training.thresholds import (  # noqa: PLC0415
-        calculate_safe_threshold,
-        cross_calibration_threshold_cached,
-    )
-
     region_boxes = vote_region_boxes or {}
-    built = _build_vote_tensors(clips_dict, good_votes, bad_votes, region_boxes)
-    if built is None:
-        return [], 0.5, None
-    X, y, X_list, y_list, input_dim, hidden_dim = built
-
-    # Skip k-fold calibration when the label count is below the
-    # ``calculate_safe_threshold`` ramp floor: the calibration trainings
-    # would be expensive (two 200-epoch fits) and the result is either
-    # discarded (safe_thresholds=True blends with label_weight=0 → pure
-    # GMM) or unreliable.  0.5 is a sensible neutral mid-point.
-    if len(X_list) < 6:
-        threshold = 0.5
-    else:
-        threshold = cross_calibration_threshold_cached(
-            X_list,
-            y_list,
-            input_dim,
-            inclusion_value,
-            calibrate_count=calibrate_count,
-            calibration_fraction=calibration_fraction,
-            hidden_dim=hidden_dim,
-            det_ctx=det_ctx,
-        )
-
-    # Training is image-level in v1 - the MLP only ever sees one vector
-    # per voted media, mirroring the "vote on whole images" rule.
-    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
-
-    all_ids, scores, best_region = _score_all_media(model, clips_dict)
-
-    if safe_thresholds:
-        threshold = calculate_safe_threshold(threshold, scores, len(X_list))
-
-    results = _format_results(all_ids, scores, best_region, clips_dict)
-    return results, threshold, model
+    X_list, y_list = _build_vote_xy(clips_dict, good_votes, bad_votes, region_boxes)
+    return _train_and_score_xy(
+        X_list,
+        y_list,
+        clips_dict,
+        inclusion_value=inclusion_value,
+        safe_thresholds=safe_thresholds,
+        calibrate_count=calibrate_count,
+        calibration_fraction=calibration_fraction,
+        det_ctx=det_ctx,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Continues the `docs/plans/code-structure-review.md` work. This is **Theme A, slice 5 (A3)** — the last code item in Theme A (the `vtscore` ↔ `vtsearch` boundary); only the broader inverse-leak sweep remains as a follow-up.

## What changed

The two detector training pipelines both implemented the same resolve → build X/y → threshold → train → score shape, with `labelset_train_and_score` re-implementing rather than reusing `train_and_score`. They now share one core:

- **`vtscore/detectors/training.py`** gains `_train_and_score_xy(X_list, y_list, clips_dict, ...)`, which owns the guard → threshold → train → score → format tail.
- **`train_and_score`** (vote-driven) builds `(X_list, y_list)` via the new `_build_vote_xy` and defers to the core.
- **`labelset_train_and_score`** (labelset-driven) builds `(X_list, y_list)` via `populate_label_embeddings` + `build_xy_from_labelset` and defers to the same core.
- Patch-region pooling, previously duplicated as `_training_vec_for_vote`'s inline pooling and `labelset_training._pool_box_from_media`, collapses into one `pool_box_from_media` helper in `training.py`.

## Behavior note (intentional)

The labelset path now goes through `_score_all_media`, so it picks up the vote path's **region-aware scoring** and **NaN sanitisation** that it previously lacked, and its result scores are now rounded to 4 decimals like the vote path. Both pipelines stay in lock-step by construction.

## Testing

`./run-tests.sh` — full suite green (4789 passed, 1 skipped, 2 xpassed).

https://claude.ai/code/session_01NvHMmXFv2rh1X2z7R3eZ5P

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvHMmXFv2rh1X2z7R3eZ5P)_