### PR TITLE
Theme A: inverse-leak sweep — point cosmetic vtscore→vtsearch.state imports at vtscore.state

### DIFF
--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -1,11 +1,11 @@
 # Code-structure review
 
 **Status:** Review complete. **Theme A** (the `vtscore` ↔ `vtsearch`
-boundary) is shipped: A1 (fat-controller extractions), A2 (workflow
-de-coupling), and A3 (training-pipeline merge) all landed. The other themes
-are scoped below as a prioritized backlog for later passes; the broader
-inverse-leak sweep is the one remaining Theme A item. See "What shipped" +
-"Open follow-ups" at the bottom for live status.
+boundary) is fully shipped: A1 (fat-controller extractions), A2 (workflow
+de-coupling), A3 (training-pipeline merge), and the broader inverse-leak
+sweep all landed. The other themes are scoped below as a prioritized
+backlog for later passes. See "What shipped" + "Open follow-ups" at the
+bottom for live status.
 
 This is a systematic, repo-wide structural review: where have design
 decisions that were right at small scale been outgrown, and what is worth
@@ -210,8 +210,8 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
 ## Prioritized backlog
 
 1. **Theme A** — extract fat-controller logic into `vtscore`; de-couple
-   `workflow.py` from `flask.g`; merge the two training pipelines. (Shipped;
-   only the broader inverse-leak sweep remains — see Open follow-ups.)
+   `workflow.py` from `flask.g`; merge the two training pipelines; inverse-leak
+   sweep. (Shipped in full — see What shipped.)
 2. **Theme C quick wins** — settings `SettingSpec` registry; `_ClapBase`
    mixin; per-side settings factory.
 3. **Theme E** — "shim" rename; `labelset_ops` facade.
@@ -274,15 +274,36 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
   duplicated patch-region pooling (`_training_vec_for_vote`'s inline pooling vs
   `labelset_training._pool_box_from_media`) collapsed into one
   `pool_box_from_media` helper in `training.py`. Full suite green.
+- **Theme A, slice 6 (inverse-leak sweep):** every `from vtsearch.state import`
+  inside `vtscore/` now points at `vtscore.state` directly. The audit found all
+  eight sites (`detectors/{labelset_elements,training,label_sync,
+  label_restoration,media_seeding}.py`, `datasets/{ingest,load_pipeline}.py`)
+  pulled only pure `vtscore.state` re-exports — the lone proxy use, `medias` in
+  `media_seeding.py`, became `get_active_context().medias` (equivalent, and
+  Flask-free). The one remaining *module-level* app-tier import,
+  `from vtsearch.auth import get_current_user` in `load_pipeline.py`, was made
+  function-local at its three call sites to match the file's other lazy
+  `vtsearch.auth` imports, so importing the library module no longer drags in
+  the app tier at import time. The remaining `vtsearch` references in `vtscore/`
+  are all genuine app-tier reaches (`vtsearch.auth`, `vtsearch.achievements`,
+  `vtsearch.logging_config`, `vtsearch.routes._shared`) and are all
+  function-local lazy imports — the established escape hatch for optional
+  app-tier side effects (auth identity, achievement counters, the transformers
+  logging bridge, the routes-layer embedder resolver). Full suite green,
+  including `./run-tests.sh vtscore-clean`.
 
 ## Open follow-ups
 
-- **Theme A, broader inverse-leak sweep (not in original A2 scope):** ~15 other
-  `vtscore/` modules still import from `vtsearch` (e.g.
-  `detectors/label_sync.py`, `detectors/training.py`, `state/votes.py`,
-  `datasets/load_pipeline.py`). Most are cosmetic (a pure `vtscore` function
-  imported via the `vtsearch.state` re-export); some may be genuine app-tier
-  reaches. Worth a dedicated pass that audits each and points the cosmetic ones
-  back at `vtscore.state` directly.
+- **Theme A — genuine app-tier reaches (deferred, optional):** the lazy
+  `vtsearch.auth` / `vtsearch.achievements` / `vtsearch.logging_config` /
+  `vtsearch.routes._shared` imports that remain in `vtscore/` are real
+  cross-tier calls, not cosmetic. They are correct as lazy imports today (the
+  library tier degrades gracefully without them), but the architecturally
+  "pure" form is dependency injection via registration hooks — the pattern the
+  codebase already uses for `register_setting_persister` /
+  `register_core_config_builder`. Converting the achievement counters and
+  auth-identity lookups to injected hooks would make `vtscore/` import-clean of
+  `vtsearch` entirely. Not urgent; do it if/when the library tier is actually
+  extracted.
 - **Themes B–F:** see the prioritized backlog above; none started.
 </content>

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -20,7 +20,7 @@ import hashlib
 import json
 from typing import Any, Callable, Optional
 
-from vtsearch.state import next_media_id
+from vtscore.state import next_media_id
 from vtscore.embedding.normalize import l2_normalize
 from vtscore.state.core import _state_lock
 

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -103,7 +103,6 @@ def register_last_embedder_persistence_hook(fn: Callable[[str, str], None]) -> N
     _last_embedder_persistence_hook = fn
 
 
-from vtsearch.auth import get_current_user
 from vtscore.config import DATA_DIR
 from vtscore.datasets import export_dataset_to_file
 from vtscore.datasets.loader import apply_custom_metadata_md5
@@ -113,7 +112,7 @@ from vtscore.datasets.registry import (
     add_loaded_id as _reg_add_loaded,
     unregister_dataset as _reg_unregister,
 )
-from vtsearch.state import (
+from vtscore.state import (
     DatasetContext,
     build_diversity_tree_for_context,
     clear_all,
@@ -1292,6 +1291,8 @@ def _run_origin_load_in_background(
 
     # Snapshot the user that triggered the load so background per-user
     # state (settings writes, settings_source sync) resolves correctly.
+    from vtsearch.auth import get_current_user  # noqa: PLC0415
+
     request_user = created_by or get_current_user()
 
     def task():
@@ -1464,6 +1465,8 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # the reload-from-origin path supplies a server path string that
     # needs CliUploadedFile wrapping so ``run()`` doesn't have to
     # branch on the input shape.
+    from vtsearch.auth import get_current_user  # noqa: PLC0415
+
     field_values = wrap_cli_file_fields(importer.fields, field_values)
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
@@ -1518,6 +1521,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     :data:`STAGING_DIR` and sets the ``staging_result`` field on the progress
     tracker when finished.
     """
+    from vtsearch.auth import get_current_user  # noqa: PLC0415
     from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
 
     field_values = wrap_cli_file_fields(importer.fields, field_values)

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -25,7 +25,7 @@ def restore_labels_from_detector(det_data: dict) -> int:  # noqa: C901
     Returns the number of labels successfully restored.
     """
     from vtscore.datasets.labelset import LabeledElement, LabelSet
-    from vtsearch.state import (
+    from vtscore.state import (
         apply_label,
         build_media_lookup,
         resolve_media_ids,

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -29,7 +29,7 @@ def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], 
     """
     from vtscore.detectors.registry import get_detector, is_find_mode
     from vtscore.detectors.store import _detector_path, _read_detector
-    from vtsearch.state import get_active_detector_context
+    from vtscore.state import get_active_detector_context
 
     if is_find_mode():
         return None

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -58,7 +58,7 @@ def resolve_current_dataset_cid(elem: LabeledElement) -> int | None:
     media post-dedup without re-running it, this contract breaks; the
     invariant is covered by ``test_collapse_duplicates_yields_unique_md5_lookup``.
     """
-    from vtsearch.state import (
+    from vtscore.state import (
         build_media_lookup,
         resolve_media_ids,
         snapshot_medias,
@@ -134,7 +134,7 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
 
     Returns ``{"good": [...], "bad": [...], "media_type": "..."}``.
     """
-    from vtsearch.state import get_active_detector_context
+    from vtscore.state import get_active_detector_context
 
     media_type = detector_data.get("media_type", "") or ""
     labelset = LabelSet.from_dict(detector_data.get("labelset") or {})

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -26,11 +26,11 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
     import hashlib
 
     from vtscore.config import DATA_DIR
-    from vtsearch.state import (
+    from vtscore.state import (
         _state_lock,
         apply_label,
         build_media_lookup,
-        medias,
+        get_active_context,
         next_media_id,
         snapshot_medias,
     )
@@ -102,8 +102,9 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
                 continue
 
             with _state_lock:
-                new_id = next_media_id(medias)
-                medias[new_id] = {
+                active_medias = get_active_context().medias
+                new_id = next_media_id(active_medias)
+                active_medias[new_id] = {
                     "id": new_id,
                     "media_type": dataset_media_type,
                     "embedder": dataset_embedder_name,

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -66,7 +66,7 @@ def train_and_threshold(
     """
     import torch
 
-    from vtsearch.state import (
+    from vtscore.state import (
         get_calibrate_count,
         get_calibration_fraction,
         get_inclusion,


### PR DESCRIPTION
Completes the last open Theme A item from `docs/plans/code-structure-review.md`: the broader inverse-leak sweep of `vtscore/` → `vtsearch` imports.

## What changed

Audited every `from vtsearch...` import inside `vtscore/`. All eight `from vtsearch.state import` sites pulled only pure `vtscore.state` re-exports, so they now import from `vtscore.state` directly:

- `detectors/labelset_elements.py`, `detectors/training.py`, `detectors/label_sync.py`, `detectors/label_restoration.py`, `datasets/ingest.py`, `datasets/load_pipeline.py` — straight re-export swaps.
- `detectors/media_seeding.py` — the lone proxy use (`medias`) became `get_active_context().medias`, which is equivalent (the proxy resolves to the active context's medias dict) and Flask-free. Safe under the existing `with _state_lock` because `_state_lock` is reentrant.

The one remaining **module-level** app-tier import — `from vtsearch.auth import get_current_user` in `load_pipeline.py` — was made function-local at its three call sites, matching the file's other lazy `vtsearch.auth` imports. Importing the library module no longer drags in the app tier at import time.

## What deliberately stayed

The remaining `vtsearch` references in `vtscore/` are genuine app-tier reaches (`vtsearch.auth`, `vtsearch.achievements`, `vtsearch.logging_config`, `vtsearch.routes._shared`), all already function-local lazy imports — the established escape hatch for optional app-tier side effects. The architecturally pure form (DI via registration hooks) is recorded as an optional deferred follow-up in the plan.

## Testing

- `./run-tests.sh` — 4789 passed, 1 skipped, 2 xpassed.
- `./run-tests.sh vtscore-clean` — 1310 passed (library tier still import-clean).

https://claude.ai/code/session_01BeZb2c88oyy1A5KJDk2nqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeZb2c88oyy1A5KJDk2nqW)_