### PR TITLE
Extract settings persistence engine into UserSettingsStore

### DIFF
--- a/app.py
+++ b/app.py
@@ -552,9 +552,9 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
 
     Per-user ``settings_source`` sync runs lazily on each user's first
     settings access (see
-    :func:`vtsearch.settings._run_sync_from_source`) and re-fires
-    whenever the source's ``peek_version`` token changes, not at
-    server boot; there is no server-wide user to sync for.
+    ``vtsearch.settings_store.UserSettingsStore._run_sync_from_source``)
+    and re-fires whenever the source's ``peek_version`` token changes,
+    not at server boot; there is no server-wide user to sync for.
     """
     print(f"\U0001f680 Running in {mode_label} mode", flush=True)
 

--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -4,8 +4,10 @@
 **Theme A** in full (the `vtscore` ↔ `vtsearch` boundary — fat-controller
 extractions, `workflow.py` de-coupling, training-pipeline merge,
 inverse-leak sweep), **Theme C quick wins** (the `_ClapBase` mixin and the
-settings dispatch-table generation + drift guard), and **Theme E quick
-wins** (the "shim" rename and the `labelset_ops` facade). For the details of
+settings dispatch-table generation + drift guard), **Theme E quick
+wins** (the "shim" rename and the `labelset_ops` facade), and the first
+**Theme B** mega-file split (the `settings.py` engine extraction into
+`UserSettingsStore` — see the Theme B section). For the details of
 what landed, see the git history / merged PRs on `dev`. **Everything below
 is the remaining planned work.**
 
@@ -29,12 +31,24 @@ responsibilities.
   gunicorn imports. Extract `vtsearch/cli_main.py` (argparse/dispatch) and
   `vtsearch/app/server.py` (port preflight); optionally `hooks.py` +
   `errors.py` for the request lifecycle and error handlers.
-- **`vtsearch/settings.py` (1887 lines).** Conflates cache state,
-  cross-process file locking, two-tier routing, a one-shot legacy migration,
-  bidirectional sync state-machines, and dynamic accessor generation. The
-  lock-ordering discipline (`file_lock → settings_lock`, re-entrance guards)
-  would be safer encapsulated in a `UserSettingsStore`; the legacy-migration
-  path could move to a one-shot script.
+- **`vtsearch/settings.py`** — **DONE (engine extraction).** The
+  lock-ordering-sensitive engine (cross-process file locking, the two-tier
+  server/per-user caches, the one-shot legacy migration, and the
+  bidirectional sync state-machine) now lives in
+  `vtsearch/settings_store.py` as `UserSettingsStore`; `settings.py` (down
+  from 1935 → ~1410 lines) keeps the schema/policy layer (Pydantic-driven
+  accessor generation, tier routing, CLI fallbacks, effective-value
+  resolvers) and delegates engine work to a module-level store instance.
+  The shared mutable containers (`_settings_lock`, `_user_caches`,
+  `_sync_state`, `_syncing`) stay as module globals and are passed *by
+  reference* into the store so external importers (`vtsearch.achievements`,
+  the sync-source tests) and the store mutate one set of objects.
+  **Open follow-up:** the legacy-migration path is still lazy (runs from
+  `UserSettingsStore.ensure_server_loaded` on first server load) rather than
+  a one-shot admin script — left as-is deliberately because the lazy
+  trigger is what the default-user read-through and the CLI `--settings`
+  flat-file flow rely on; moving it to a script is a behavior change worth
+  its own scoped task, not a free win.
 - **`vtscore/datasets/load_pipeline.py` (1588 lines).** Six concerns:
   `ConcurrencyGate`, progress/step mapping, clipper-chain fixup, embedding,
   dedup/diversity, registry/migration, background-task orchestration. Move
@@ -134,8 +148,9 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
 
 ## Prioritized backlog (remaining)
 
-1. **Theme B** — split `app.py`, `load_pipeline.py`, `settings.py`,
-   `importers/base.py`.
+1. **Theme B** — split `app.py`, `load_pipeline.py`,
+   `importers/base.py`. (`settings.py` engine extraction shipped — see
+   the Theme B bullet above.)
 2. **Theme D** — converge frontend types onto the generated client.
 3. **Theme E** — `MediaSource` / `DatasetImporter` ingestion-concept overlap.
 4. **Theme F** — collapse `PluginField` aliases; revisit `SyncSource` if a

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -19,6 +19,7 @@ import json
 
 import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
+from vtsearch import settings_store as settings_store_mod
 from vtsearch.auth import set_thread_user
 
 
@@ -144,7 +145,7 @@ class TestLegacyMigration:
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
 
-        real_atomic_write = settings_mod._atomic_write
+        real_atomic_write = settings_store_mod._atomic_write
         user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
 
         def failing_atomic_write(path, data):
@@ -152,7 +153,7 @@ class TestLegacyMigration:
                 raise OSError("simulated user-file write failure")
             return real_atomic_write(path, data)
 
-        monkeypatch.setattr(settings_mod, "_atomic_write", failing_atomic_write)
+        monkeypatch.setattr(settings_store_mod, "_atomic_write", failing_atomic_write)
         try:
             # Triggers migration; user-file write raises and is swallowed.
             settings_mod.get_saved_datasets_dir()
@@ -162,9 +163,9 @@ class TestLegacyMigration:
             assert on_disk == legacy
 
             # In-memory server cache matches disk (legacy keys still there).
-            assert settings_mod._server_cache is not None
-            assert settings_mod._server_cache.get("volume") == 0.33
-            assert settings_mod._server_cache.get("theme") == "light"
+            assert settings_mod._store.server_cache is not None
+            assert settings_mod._store.server_cache.get("volume") == 0.33
+            assert settings_mod._store.server_cache.get("theme") == "light"
 
             # No phantom user file was created.
             assert not user_settings_path.exists()
@@ -189,7 +190,7 @@ class TestLegacyMigration:
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
 
-        real_atomic_write = settings_mod._atomic_write
+        real_atomic_write = settings_store_mod._atomic_write
         user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
 
         def failing_atomic_write(path, data):
@@ -197,7 +198,7 @@ class TestLegacyMigration:
                 raise OSError("simulated server-file write failure")
             return real_atomic_write(path, data)
 
-        monkeypatch.setattr(settings_mod, "_atomic_write", failing_atomic_write)
+        monkeypatch.setattr(settings_store_mod, "_atomic_write", failing_atomic_write)
         try:
             # Triggers migration; user write succeeds, server rewrite raises.
             settings_mod.get_saved_datasets_dir()
@@ -213,10 +214,10 @@ class TestLegacyMigration:
             assert on_disk == legacy
 
             # Crucially, in-memory cache matches disk; legacy keys NOT popped.
-            assert settings_mod._server_cache is not None
-            assert settings_mod._server_cache.get("volume") == 0.33
-            assert settings_mod._server_cache.get("theme") == "light"
-            assert settings_mod._server_cache.get("saved_datasets_dir") == "/tmp/legacy"
+            assert settings_mod._store.server_cache is not None
+            assert settings_mod._store.server_cache.get("volume") == 0.33
+            assert settings_mod._store.server_cache.get("theme") == "light"
+            assert settings_mod._store.server_cache.get("saved_datasets_dir") == "/tmp/legacy"
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -748,7 +748,7 @@ class TestConcurrentWrites:
         settings_mod.set_volume(0.5)
         # ``_atomic_write`` removes the tmp via rename, but the filename
         # shape is what we care about. Confirm by inspecting the helper.
-        from vtsearch.settings import _atomic_write
+        from vtsearch.settings_store import _atomic_write
 
         # Drive it once and check the tmp name pattern used by inspecting
         # the directory contents during a captured write.

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -28,6 +28,7 @@ from vtsearch.state import (
 import vtsearch.state as _state
 import vtscore.state.core as _core
 import vtsearch.settings as _settings_mod
+import vtsearch.settings_store as _settings_store_mod
 import vtscore.detectors.labeling_progress as _progress_mod
 
 
@@ -451,7 +452,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
 
         in_write_for_user_a = threading.Event()
         unblock = threading.Event()
-        real_atomic_write = _settings_mod._atomic_write
+        real_atomic_write = _settings_store_mod._atomic_write
 
         def selective_atomic_write(path, data):
             if "user_a" in str(path):
@@ -459,7 +460,7 @@ class TestSlowSettingsIODoesNotBlockOthers:
                 unblock.wait(timeout=30)
             real_atomic_write(path, data)
 
-        monkeypatch.setattr(_settings_mod, "_atomic_write", selective_atomic_write)
+        monkeypatch.setattr(_settings_store_mod, "_atomic_write", selective_atomic_write)
 
         errors: list[BaseException] = []
         user_b_done = threading.Event()
@@ -506,14 +507,14 @@ class TestSlowSettingsIODoesNotBlockOthers:
         """
         in_write = threading.Event()
         unblock = threading.Event()
-        real_atomic_write = _settings_mod._atomic_write
+        real_atomic_write = _settings_store_mod._atomic_write
 
         def slow_atomic_write(path, data):
             in_write.set()
             unblock.wait(timeout=30)
             real_atomic_write(path, data)
 
-        monkeypatch.setattr(_settings_mod, "_atomic_write", slow_atomic_write)
+        monkeypatch.setattr(_settings_store_mod, "_atomic_write", slow_atomic_write)
 
         errors: list[BaseException] = []
         reader_done = threading.Event()

--- a/tests_lib/detectors/test_store_atomic_write.py
+++ b/tests_lib/detectors/test_store_atomic_write.py
@@ -9,7 +9,7 @@ the second chased a tmp that was already renamed away, surfacing as
     FileNotFoundError: '<name>.json.tmp' -> '<name>.json'
 
 The writer now uses a per-writer unique tmp suffix (PID + UUID), matching
-``vtsearch.settings._atomic_write`` and ``vtscore.io.atomic_write_text``.
+``vtsearch.settings_store._atomic_write`` and ``vtscore.io.atomic_write_text``.
 """
 
 from __future__ import annotations

--- a/vtscore/detectors/store.py
+++ b/vtscore/detectors/store.py
@@ -57,7 +57,7 @@ def _write_detector(path: Path, data: dict) -> None:
     # overwrite the same detector file can't truncate each other's in-flight
     # tmp file or chase one that was already renamed away (which surfaced as
     # ``FileNotFoundError: '<name>.json.tmp' -> '<name>.json'`` from
-    # ``os.replace``).  Mirrors ``vtsearch.settings._atomic_write`` and
+    # ``os.replace``).  Mirrors ``vtsearch.settings_store._atomic_write`` and
     # ``vtscore.io.atomic_write_text``.
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:

--- a/vtscore/io.py
+++ b/vtscore/io.py
@@ -81,7 +81,7 @@ def atomic_write_text(path: Path | str, text: str) -> None:
     # Per-writer unique tmp suffix so two threads (or two processes)
     # racing to overwrite the same destination can't truncate each
     # other's in-flight tmp file or chase one that was already renamed
-    # away.  Mirrors the pattern in ``vtsearch.settings._atomic_write``.
+    # away.  Mirrors the pattern in ``vtsearch.settings_store._atomic_write``.
     tmp = p.with_name(f"{p.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
         with open(tmp, "w", encoding="utf-8", newline="") as f:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -20,24 +20,12 @@ the sync source is per-user and triggers only on per-user writes.
 
 from __future__ import annotations
 
-import contextlib
-import json
-import logging
-import os
 import threading
-import time
-import uuid
-from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
-
-try:
-    import fcntl as _fcntl  # POSIX-only; falls back to in-process locking on Windows.
-except ImportError:  # pragma: no cover - Windows
-    _fcntl = None
 
 from vtscore.config import DATA_DIR
 from vtsearch.settings_models import (
@@ -48,6 +36,7 @@ from vtsearch.settings_models import (
     ServerSettings,
     UserSettings,
 )
+from vtsearch.settings_store import UserSettingsStore, UserSyncState as _UserSyncState
 
 if TYPE_CHECKING:
     # The accessors below are generated dynamically by the loop at the
@@ -150,8 +139,6 @@ if TYPE_CHECKING:
     def get_hidden_plugins() -> dict[str, list[str]]: ...
     def set_hidden_plugins(value: dict[str, list[str]]) -> None: ...
 
-
-logger = logging.getLogger(__name__)
 
 #: Path to the server-tier settings file. Tests monkey-patch this; the CLI
 #: ``set_settings_path()`` helper also points it at a different file.
@@ -260,7 +247,8 @@ _SERVER_KEYS: frozenset[str] = frozenset(ServerSettings.model_fields.keys())
 #: still expect a value placed in ``settings.json`` to take effect. The
 #: read-through (see :func:`_read_value`) makes that work without the
 #: destructive legacy migration moving them out of the server file (see
-#: :func:`_maybe_migrate_legacy_settings_locked`, which skips these keys).
+#: ``UserSettingsStore._maybe_migrate_legacy_settings_locked``, which skips
+#: these keys).
 _DEFAULT_USER_FALLBACK_KEYS: frozenset[str] = frozenset(
     {"autofind_detectors", "autofind_exporter", "autofind_exporter_field_values"}
 )
@@ -285,64 +273,26 @@ _EXCLUDE_FROM_SOURCE_EXPORT = {
 # Caches
 # ---------------------------------------------------------------------------
 
-# Server-tier cache (one process-wide dict).
-_server_cache: dict[str, Any] | None = None
+# The mutable engine state below lives here (not on the store) because
+# other modules import these containers by name: ``vtsearch.achievements``
+# reads ``_user_caches`` / ``_settings_lock``, and the sync-source tests
+# poke ``_sync_state``. The :class:`~vtsearch.settings_store.UserSettingsStore`
+# instance (created at the bottom of this module) is handed these same
+# objects by reference, so both views mutate one set of containers. The
+# reassignable scalars (``server_cache``, ``legacy_migrated``) and the
+# per-user sync locks live solely on the store.
 
 # Per-user caches keyed by username.
 _user_caches: dict[str, dict[str, Any]] = {}
-
-
-@dataclass
-class _UserSyncState:
-    """Per-user sync-from-source bookkeeping.
-
-    - ``last_version``: opaque token from :meth:`SettingsSource.peek_version`
-      stashed at the last successful sync.  Compared on every read to
-      decide whether a re-sync is due.  ``None`` if the source can't
-      cheaply check freshness.
-    - ``last_check_monotonic``: :func:`time.monotonic` of the last peek.
-      Used to rate-limit ``peek_version`` calls so a hot read path doesn't
-      stat the source file on every ``get_volume()``.
-    - ``last_sync_succeeded``: ``False`` means the user has never been
-      successfully synced this process lifetime (or the last attempt
-      failed).  A transient source failure no longer permanently locks
-      the user out of sync - the slow-path retries (rate-limited) until
-      it succeeds.
-    - ``dirty_keys``: keys the user has set locally since the last
-      successful :func:`_sync_to_source`.  An auto re-sync (from a
-      version-bump on the source) skips these keys so a freshly clicked
-      local toggle isn't silently overwritten by an upstream value.
-      Cleared whenever ``_sync_to_source`` succeeds (because the source
-      then matches local) or when a manual :func:`sync_from_settings_source`
-      runs (explicit user pull).
-    """
-
-    last_version: Any = None
-    last_check_monotonic: float = 0.0
-    last_sync_succeeded: bool = False
-    dirty_keys: set[str] = field(default_factory=set)
-
 
 # Per-user sync bookkeeping.  Replaces the old ``_synced_users: set[str]``,
 # which couldn't distinguish "never synced" from "synced ages ago" or
 # "tried once and failed."
 _sync_state: dict[str, _UserSyncState] = {}
 
-# One-shot legacy-migration guard.
-_legacy_migrated: bool = False
-
 # Reentrant lock covering both tiers' caches, the syncing flag, and
 # ``_sync_state``.  Not held while running the actual sync I/O.
 _settings_lock = threading.RLock()
-
-# Per-user reentrant locks wrapping the sync-from-source critical
-# section.  Acquiring this means "I'm responsible for this user's
-# sync-from-source pass right now"; another thread for the same user
-# blocks until we're done and then sees the freshly-applied cache.
-# Reentrant so a setter called from inside ``_apply_settings`` (which
-# routes back through ``_ensure_user_loaded``) doesn't self-deadlock.
-_user_sync_locks: dict[str, threading.RLock] = {}
-_user_sync_locks_guard = threading.Lock()
 
 # Rate-limit window for the ``peek_version`` freshness probe.  Settings
 # reads happen in hot paths (``before_request``, every accessor); we
@@ -358,16 +308,6 @@ _FRESHNESS_CHECK_INTERVAL = 1.0
 # from inside ``_apply_settings`` re-enters the function but must skip
 # the sync path.
 _syncing: set[str] = set()
-
-
-def _per_user_sync_lock(username: str) -> threading.RLock:
-    """Return (creating if needed) the sync RLock for *username*."""
-    with _user_sync_locks_guard:
-        lock = _user_sync_locks.get(username)
-        if lock is None:
-            lock = threading.RLock()
-            _user_sync_locks[username] = lock
-        return lock
 
 
 # ---------------------------------------------------------------------------
@@ -389,438 +329,44 @@ def _user_settings_path(username: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# File I/O
-# ---------------------------------------------------------------------------
-
-
-def _load_path(path: Path) -> dict[str, Any]:
-    """Read settings from *path*, returning ``{}`` on any failure."""
-    if path.exists():
-        try:
-            text = path.read_text(encoding="utf-8")
-            data = json.loads(text)
-            if isinstance(data, dict):
-                return data
-        except Exception as exc:
-            logger.warning("Failed to read settings file %s: %s", path, exc)
-    return {}
-
-
-def _atomic_write(path: Path, data: dict[str, Any]) -> None:
-    """Write *data* to *path* via a per-writer temp file + rename.
-
-    The temp filename embeds PID + a UUID so two processes writing to the
-    same target can't truncate each other's in-flight temp file. The
-    final ``os.replace`` is atomic on POSIX, so a concurrent reader
-    always sees either the pre- or post-write content, never a partial
-    write.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    try:
-        with open(tmp, "w", encoding="utf-8") as f:
-            f.write(json.dumps(data, indent=2) + "\n")
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, path)
-    except Exception:
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(tmp)
-        raise
-
-
-# Per-path in-process locks. Used in two ways:
-# 1. As a fallback when ``fcntl`` is unavailable (Windows).
-# 2. Held in addition to the cross-process flock so that, within a single
-#    process, multiple threads serialise on the same path without
-#    repeatedly re-entering the kernel.
-_path_locks: dict[str, threading.Lock] = {}
-_path_locks_guard = threading.Lock()
-
-
-def _path_lock_for(path: Path) -> threading.Lock:
-    key = str(path.resolve()) if path.exists() else str(path)
-    with _path_locks_guard:
-        lock = _path_locks.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _path_locks[key] = lock
-        return lock
-
-
-@contextlib.contextmanager
-def _file_lock(path: Path):
-    """Acquire an exclusive cross-process lock for *path*.
-
-    The lock is taken on a sibling ``<path>.lock`` file rather than on
-    the data file itself, because ``_atomic_write`` replaces the data
-    file's inode via ``os.replace`` - any fd held against the old inode
-    would be useless. The sibling lock file's inode is stable.
-
-    The lock is released automatically if the process exits (POSIX
-    flock semantics), so there are no zombie locks after crashes.
-
-    On Windows (``fcntl`` unavailable) the in-process lock alone is
-    used; cross-process protection degrades silently. VTSearch is
-    deployed on Linux containers, so this only affects the rare
-    Windows-dev case where multiple processes shouldn't be writing
-    the same settings file anyway.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    in_proc = _path_lock_for(path)
-    in_proc.acquire()
-    fd: int | None = None
-    fcntl_mod = _fcntl  # snapshot so the narrowed binding survives the yield
-    if fcntl_mod is not None:
-        lock_path = path.with_name(path.name + ".lock")
-        try:
-            fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
-            fcntl_mod.flock(fd, fcntl_mod.LOCK_EX)
-        except OSError as exc:
-            logger.warning("Could not acquire file lock on %s: %s", lock_path, exc)
-            if fd is not None:
-                with contextlib.suppress(OSError):
-                    os.close(fd)
-                fd = None
-    try:
-        yield
-    finally:
-        if fd is not None and fcntl_mod is not None:
-            try:
-                fcntl_mod.flock(fd, fcntl_mod.LOCK_UN)
-            finally:
-                with contextlib.suppress(OSError):
-                    os.close(fd)
-        in_proc.release()
-
-
-# ---------------------------------------------------------------------------
-# Cache loaders
+# Cache loaders (thin delegators onto the store)
+#
+# ``_ensure_server_loaded`` / ``_ensure_user_loaded`` keep their names and
+# module-level identity because ``vtsearch.achievements`` imports
+# ``_ensure_user_loaded`` directly, and the rest of this module's read/write
+# paths call both by name. The actual two-tier cache + sync machinery lives
+# on ``_store`` (see :mod:`vtsearch.settings_store`).
 # ---------------------------------------------------------------------------
 
 
 def _ensure_server_loaded() -> dict[str, Any]:
     """Load the server-tier cache on first access and migrate legacy keys."""
-    global _server_cache
-    with _settings_lock:
-        if _server_cache is None:
-            _server_cache = _load_path(_server_settings_path())
-            _maybe_migrate_legacy_settings_locked()
-        return _server_cache
+    return _store.ensure_server_loaded()
 
 
 def _ensure_user_loaded(username: str) -> dict[str, Any]:
-    """Load *username*'s per-user cache on first access and reconcile with the source.
-
-    Fast path: take ``_settings_lock`` briefly, hydrate the local cache
-    if needed, and return immediately when no sync work is due (no
-    source configured, freshness window still valid, or we're already
-    inside an import for this user).
-
-    Slow path: take the per-user sync RLock so the actual ``peek_version``
-    + ``load`` + ``_apply_settings`` work happens serially for the same
-    user, and concurrent readers see the post-sync cache when they
-    acquire the lock.  Without this lock the previous design had a
-    TOCTOU race: thread A set the "synced" marker before running the
-    sync, so a concurrent thread B saw the marker and returned the
-    pre-sync local cache.
-    """
-    with _settings_lock:
-        cache = _user_caches.get(username)
-        if cache is None:
-            # Make sure server tier is loaded (and legacy migration has run)
-            # before we materialise a fresh user cache, otherwise the legacy
-            # migration step might not see this user yet.
-            _ensure_server_loaded()
-            cache = _user_caches.get(username)
-            if cache is None:
-                cache = _load_path(_user_settings_path(username))
-                _user_caches[username] = cache
-        # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
-        # this function while the outer call holds the sync lock.  Skip
-        # the sync path so we don't recurse or fire another peek probe.
-        if username in _syncing:
-            return cache
-        cfg = cache.get("settings_source")
-        has_source = isinstance(cfg, dict) and bool(cfg.get("source_name"))
-        if not has_source:
-            return cache
-        state = _sync_state.get(username)
-        if state is not None and state.last_sync_succeeded:
-            now = time.monotonic()
-            if now - state.last_check_monotonic < _FRESHNESS_CHECK_INTERVAL:
-                # Hot path: a recent successful sync exists and we're
-                # inside the rate-limit window.  No probe, no lock.
-                return cache
-
-    sync_lock = _per_user_sync_lock(username)
-    with sync_lock:
-        if _needs_sync_from_source(username):
-            _run_sync_from_source(username)
-
-    return _user_caches[username]
-
-
-def _needs_sync_from_source(username: str) -> bool:
-    """Decide whether a sync-from-source pass is due for *username*.
-
-    Called with the per-user sync lock held (so the decision and the
-    subsequent sync are atomic with respect to other threads on the
-    same user).  A sync is due when:
-
-    1. We've never attempted one this process lifetime, OR
-    2. The last attempt failed and the rate-limit window has elapsed
-       (so a transient source outage no longer permanently locks
-       the user out of sync - old ``_synced_users`` did exactly that), OR
-    3. A previous attempt succeeded but the source's
-       :meth:`SettingsSource.peek_version` token has changed since
-       (source file rewritten by another process, hand-edited, etc.).
-
-    Refreshes ``last_check_monotonic`` on the no-sync paths so the
-    freshness probe is rate-limited even when state is being mutated.
-    """
-    with _settings_lock:
-        state = _sync_state.get(username)
-        cache_cfg = _user_caches.get(username, {}).get("settings_source")
-    if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
-        return False
-
-    now = time.monotonic()
-
-    if state is None or state.last_check_monotonic == 0.0:
-        # No state, or state exists only because a setter populated it
-        # via ``_mark_user_keys_dirty`` before we'd ever talked to the
-        # source.  Either way: first sync attempt is due.
-        return True
-
-    if not state.last_sync_succeeded:
-        # Rate-limited retry after a failure.
-        return (now - state.last_check_monotonic) >= _FRESHNESS_CHECK_INTERVAL
-
-    # Last attempt succeeded.  If we're still inside the freshness
-    # window, skip (the fast path in ``_ensure_user_loaded`` usually
-    # handles this; keep the check here in case the slow path was
-    # entered via a different code route).
-    if (now - state.last_check_monotonic) < _FRESHNESS_CHECK_INTERVAL:
-        return False
-
-    # Window elapsed - cheap probe to detect upstream changes.
-    from vtsearch.settings_io.sources import get_settings_source
-
-    source = get_settings_source(cache_cfg["source_name"])
-    if source is None:
-        return False
-    field_values = cache_cfg.get("field_values", {})
-    try:
-        current_version = source.peek_version(field_values)
-    except Exception:
-        # Transient peek failure - back off until next window, keep
-        # serving the local cache.
-        with _settings_lock:
-            s = _sync_state.get(username)
-            if s is not None:
-                s.last_check_monotonic = now
-        return False
-
-    if current_version is None or current_version == state.last_version:
-        # Source can't cheaply check, or unchanged since last sync.
-        with _settings_lock:
-            s = _sync_state.get(username)
-            if s is not None:
-                s.last_check_monotonic = now
-        return False
-
-    return True
-
-
-def _run_sync_from_source(username: str) -> None:
-    """Pull settings from *username*'s configured source and apply them.
-
-    Called with the per-user sync lock held.  Respects ``dirty_keys``:
-    keys the user has set locally since the last successful
-    ``_sync_to_source`` are skipped so a clicked-toggle isn't silently
-    overwritten by an upstream value.
-
-    On success: stash the new ``peek_version`` token, mark the user as
-    successfully synced, and refresh the freshness-check timestamp.
-    On failure: log the error and refresh only the check timestamp
-    (``last_sync_succeeded`` stays ``False``) so the slow path retries
-    once the rate-limit window elapses.
-    """
-    with _settings_lock:
-        cache_cfg = _user_caches.get(username, {}).get("settings_source")
-        state = _sync_state.setdefault(username, _UserSyncState())
-        dirty_snapshot = set(state.dirty_keys)
-    if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
-        return
-
-    from vtsearch.settings_io.sources import get_settings_source
-
-    source = get_settings_source(cache_cfg["source_name"])
-    if source is None:
-        logger.warning("Unknown settings source: %s", cache_cfg["source_name"])
-        return
-
-    field_values = cache_cfg.get("field_values", {})
-    new_version: Any = None
-    try:
-        new_version = source.peek_version(field_values)
-    except Exception:
-        new_version = None
-
-    try:
-        imported = source.load(field_values)
-    except Exception as exc:
-        logger.exception("Failed to load from settings source for %s: %s", username, exc)
-        with _settings_lock:
-            state = _sync_state.setdefault(username, _UserSyncState())
-            state.last_check_monotonic = time.monotonic()
-            # Leave last_sync_succeeded as-is: a transient failure after
-            # a previous success must not erase the success flag (the
-            # local cache is still valid).
-        return
-
-    if imported:
-        with _settings_lock:
-            _syncing.add(username)
-        try:
-            _apply_settings(imported, skip_keys=dirty_snapshot)
-        finally:
-            with _settings_lock:
-                _syncing.discard(username)
-
-    with _settings_lock:
-        state = _sync_state.setdefault(username, _UserSyncState())
-        state.last_version = new_version
-        state.last_check_monotonic = time.monotonic()
-        state.last_sync_succeeded = True
-        # dirty_keys preserved across an auto re-sync - the user's local
-        # edits stay protected until an explicit ``_sync_to_source`` push
-        # confirms the source matches local (which clears them) or a
-        # manual POST sync clears them on purpose.
-
-
-def _maybe_migrate_legacy_settings_locked() -> None:
-    """Move per-user keys from a legacy ``data/settings.json`` into the
-    default user's per-user file (one-shot, idempotent).
-
-    Called from :func:`_ensure_server_loaded` with the settings lock held.
-    """
-    global _legacy_migrated
-    if _legacy_migrated:
-        return
-    _legacy_migrated = True
-    assert _server_cache is not None
-    # ``_DEFAULT_USER_FALLBACK_KEYS`` legitimately live in the server file (the
-    # default user reads through to them), so they are NOT "orphaned per-user"
-    # keys; leave them in place rather than moving them into the default user's
-    # file (which would also rewrite a CLI ``--settings`` file under the user).
-    legacy_user_entries = {
-        k: v for k, v in _server_cache.items() if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS
-    }
-    if not legacy_user_entries:
-        return
-
-    # Migrate into the "default" user's file. The default user is the one
-    # the single-user provider returns, and is also the safe target for
-    # multi-user upgrades (admins can copy it into other users' files).
-    default_user = "default"
-    user_path = _user_settings_path(default_user)
-    if user_path.exists():
-        existing = _load_path(user_path)
-        # Existing per-user values win - never clobber a real user file.
-        merged: dict[str, Any] = {**legacy_user_entries, **existing}
-    else:
-        merged = dict(legacy_user_entries)
-    try:
-        _atomic_write(user_path, merged)
-    except Exception as exc:
-        logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
-        return
-
-    # Build the server-tier shape first; a failure here must not pop the
-    # in-memory cache, or _server_cache and disk would silently diverge. Keep
-    # the default-user fallback keys in the server file (they are read through
-    # there, not migrated out).
-    new_server = {k: v for k, v in _server_cache.items() if k in _SERVER_KEYS or k in _DEFAULT_USER_FALLBACK_KEYS}
-    try:
-        _atomic_write(_server_settings_path(), new_server)
-    except Exception as exc:
-        logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
-        return
-    for k in list(_server_cache.keys()):
-        if k not in _SERVER_KEYS and k not in _DEFAULT_USER_FALLBACK_KEYS:
-            _server_cache.pop(k, None)
-
-    # Refresh the default user's cache if it was already materialised
-    # (unlikely, since this runs from _ensure_server_loaded, but safe).
-    _user_caches[default_user] = _load_path(user_path)
-    logger.info(
-        "Migrated %d legacy per-user setting(s) from %s into %s",
-        len(legacy_user_entries),
-        _server_settings_path(),
-        user_path,
-    )
+    """Load *username*'s per-user cache and reconcile with its source."""
+    return _store.ensure_user_loaded(username)
 
 
 # ---------------------------------------------------------------------------
-# Save helpers
+# Save helpers (thin delegators onto the store)
 # ---------------------------------------------------------------------------
 
 
 def _mutate_server_locked(mutator) -> None:
-    """Apply *mutator* to a fresh-from-disk server cache, atomically.
-
-    Acquires the cross-process file lock, re-reads ``data/settings.json``
-    so any changes a sibling process made since this process loaded are
-    picked up, runs ``mutator(cache)`` to mutate the dict in place, then
-    atomically writes the result back. This is the only correct way to
-    mutate a multi-writer settings file from a Python process.
-
-    The legacy migration is left to ``_ensure_server_loaded`` and never
-    fires from inside the lock - by the time any setter runs the cache
-    has been loaded at least once.
-
-    File I/O (``_load_path``, ``_atomic_write``) runs under the
-    cross-process file lock only; ``_settings_lock`` is acquired briefly
-    at the end just to swap the in-memory cache, so a slow local fsync
-    (NFS, full disk, hung disk controller) can't stall unrelated
-    settings reads - see H29 in ``docs/plans/logical-bug-audit.md``.
-    """
-    global _server_cache
-    path = _server_settings_path()
-    with _file_lock(path):
-        fresh = _load_path(path)
-        mutator(fresh)
-        _atomic_write(path, fresh)
-        with _settings_lock:
-            _server_cache = fresh
+    """Atomically read-modify-write the server-tier settings file."""
+    _store.mutate_server_locked(mutator)
 
 
 def _mutate_user_locked(username: str, mutator) -> dict[str, Any] | None:
-    """Apply *mutator* to a fresh-from-disk per-user cache, atomically.
+    """Atomically read-modify-write *username*'s per-user settings file.
 
-    Returns a snapshot of the cache after the mutation, intended for
-    ``_sync_to_source`` which is invoked **outside** the file lock so a
-    slow sync target (NFS, webhook) can't block other settings writes.
-    Returns ``None`` if the cache should not be synced (i.e. we are
-    currently importing from the source).
-
-    Like :func:`_mutate_server_locked`, file I/O runs under the
-    cross-process file lock only; ``_settings_lock`` is acquired briefly
-    at the end just to swap the in-memory cache and read the ``_syncing``
-    flag.
+    Returns a post-mutation snapshot for ``_sync_to_source`` (invoked
+    outside the file lock), or ``None`` when a sync-from-source import is
+    in progress for this user.
     """
-    path = _user_settings_path(username)
-    with _file_lock(path):
-        fresh = _load_path(path)
-        mutator(fresh)
-        _atomic_write(path, fresh)
-        with _settings_lock:
-            _user_caches[username] = fresh
-            if username in _syncing:
-                return None
-            return dict(fresh)
+    return _store.mutate_user_locked(username, mutator)
 
 
 def mutate_user(mutator) -> None:
@@ -910,11 +456,7 @@ def _write_value(key: str, value: Any) -> None:
 
 def _mark_user_keys_dirty(username: str, keys) -> None:
     """Add *keys* to the user's ``dirty_keys`` set."""
-    if not keys:
-        return
-    with _settings_lock:
-        state = _sync_state.setdefault(username, _UserSyncState())
-        state.dirty_keys.update(keys)
+    _store.mark_user_keys_dirty(username, keys)
 
 
 # ---------------------------------------------------------------------------
@@ -982,7 +524,7 @@ def get_all() -> dict[str, Any]:
     _ensure_server_loaded()
     _ensure_user_loaded(username)
     with _settings_lock:
-        server_copy = dict(_server_cache or {})
+        server_copy = dict(_store.server_cache or {})
         user_copy = dict(_user_caches.get(username, {}))
     result = dict(_all_defaults())
     result.update(server_copy)
@@ -1686,11 +1228,10 @@ def set_settings_path(path: str | Path) -> None:
     Does not affect per-user settings files - those still live under
     :func:`vtsearch.auth.get_user_data_dir`.
     """
-    global SETTINGS_PATH, _server_cache, _legacy_migrated
+    global SETTINGS_PATH
     with _settings_lock:
         SETTINGS_PATH = Path(path)
-        _server_cache = None
-        _legacy_migrated = False
+        _store.invalidate_server_cache()
 
 
 def set_user_data_dir_override(path: Path | None) -> None:
@@ -1707,15 +1248,7 @@ def set_user_data_dir_override(path: Path | None) -> None:
 
 def reset() -> None:
     """Reset every in-memory cache (for testing)."""
-    global _server_cache, _legacy_migrated
-    with _settings_lock:
-        _server_cache = None
-        _user_caches.clear()
-        _sync_state.clear()
-        _syncing.clear()
-        _legacy_migrated = False
-    with _user_sync_locks_guard:
-        _user_sync_locks.clear()
+    _store.reset()
 
 
 # -------------------------------------------------------------------
@@ -1763,8 +1296,7 @@ def set_settings_source_config(config: dict[str, Any] | None) -> None:
         # Source cleared - drop any cached sync state so a future
         # configure-then-read doesn't believe it's still "synced" to
         # the previously-configured target.
-        with _settings_lock:
-            _sync_state.pop(username, None)
+        _store.drop_sync_state(username)
         return
     if sync_data is not None:
         # ``_sync_to_source`` exports the full local dict to the new
@@ -1837,51 +1369,8 @@ def sync_from_settings_source() -> dict[str, Any] | None:
         return None
 
     from vtsearch.auth import get_current_user
-    from vtsearch.settings_io.sources import get_settings_source
 
-    source = get_settings_source(cfg["source_name"])
-    if source is None:
-        logger.warning("Unknown settings source: %s", cfg["source_name"])
-        return None
-
-    field_values = cfg.get("field_values", {})
-    new_version: Any = None
-    try:
-        new_version = source.peek_version(field_values)
-    except Exception:
-        new_version = None
-
-    try:
-        imported = source.load(field_values)
-    except Exception as exc:
-        logger.exception("Failed to load from settings source: %s", exc)
-        return None
-
-    if not imported:
-        return None
-
-    username = get_current_user()
-    # The setters invoked by ``_apply_settings`` acquire ``_file_lock``
-    # and then ``_settings_lock``. Holding ``_settings_lock`` here would
-    # invert the canonical order - take the lock only to mutate
-    # ``_syncing``, then drop it for the actual apply.
-    with _settings_lock:
-        _syncing.add(username)
-    try:
-        _apply_settings(imported)
-    finally:
-        with _settings_lock:
-            _syncing.discard(username)
-
-    with _settings_lock:
-        _sync_state[username] = _UserSyncState(
-            last_version=new_version,
-            last_check_monotonic=time.monotonic(),
-            last_sync_succeeded=True,
-            dirty_keys=set(),
-        )
-
-    return imported
+    return _store.sync_from_source_now(cfg, get_current_user())
 
 
 def _sync_to_source(username: str, data: dict[str, Any]) -> None:
@@ -1890,46 +1379,33 @@ def _sync_to_source(username: str, data: dict[str, Any]) -> None:
     Called from :func:`_write_value` / :func:`mutate_user` /
     :func:`set_settings_source_config` after the per-user file is
     written, **outside** the cross-process file lock so a slow sync
-    target can't block other settings writes.  Strips the
-    ``settings_source`` key itself to avoid circular config.
-
-    On successful save the user is stamped as freshly synced
-    (``last_version`` refreshed from the post-save ``peek_version``,
-    ``dirty_keys`` cleared) - source now matches local, so the next
-    :func:`_ensure_user_loaded` short-circuits via the fast path
-    instead of pulling back the values we just pushed.
+    target can't block other settings writes.
     """
-    cfg = data.get("settings_source")
-    if not isinstance(cfg, dict) or not cfg.get("source_name"):
-        return
+    _store.sync_to_source(username, data)
 
-    from vtsearch.settings_io.sources import get_settings_source
 
-    source = get_settings_source(cfg["source_name"])
-    if source is None:
-        return
+# ---------------------------------------------------------------------------
+# The persistence engine
+#
+# Instantiated last so every injected dependency (path resolvers, the
+# ``_apply_settings`` callback, the tier key sets) is already defined. The
+# shared mutable containers (``_settings_lock`` / ``_user_caches`` /
+# ``_sync_state`` / ``_syncing``) are passed by reference so the store and
+# the module-level names mutate one set of objects; the delegators above
+# reference ``_store`` lazily (at call time), so its position at the bottom
+# of the module is fine.
+# ---------------------------------------------------------------------------
 
-    field_values = cfg.get("field_values", {})
-    export_data = {k: v for k, v in data.items() if k not in _EXCLUDE_FROM_SOURCE_EXPORT}
-
-    try:
-        source.save(export_data, field_values)
-    except Exception as exc:
-        logger.exception("Failed to sync settings to source for %s: %s", username, exc)
-        return
-
-    # Source now matches local for every exported key - clear the dirty
-    # set and refresh the version token so an auto re-sync doesn't fire
-    # for the change we just exported.
-    new_version: Any = None
-    try:
-        new_version = source.peek_version(field_values)
-    except Exception:
-        new_version = None
-    with _settings_lock:
-        _sync_state[username] = _UserSyncState(
-            last_version=new_version,
-            last_check_monotonic=time.monotonic(),
-            last_sync_succeeded=True,
-            dirty_keys=set(),
-        )
+_store = UserSettingsStore(
+    settings_lock=_settings_lock,
+    user_caches=_user_caches,
+    sync_state=_sync_state,
+    syncing=_syncing,
+    server_path=_server_settings_path,
+    user_path=_user_settings_path,
+    apply_settings=_apply_settings,
+    server_keys=_SERVER_KEYS,
+    fallback_keys=_DEFAULT_USER_FALLBACK_KEYS,
+    exclude_from_source_export=_EXCLUDE_FROM_SOURCE_EXPORT,
+    freshness_check_interval=_FRESHNESS_CHECK_INTERVAL,
+)

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -1,0 +1,717 @@
+"""Two-tier settings persistence engine for :mod:`vtsearch.settings`.
+
+This module holds the lock-ordering-sensitive machinery that the settings
+accessors in :mod:`vtsearch.settings` delegate to: cross-process file
+locking, the server/per-user in-memory caches, the one-shot legacy
+migration, and the bidirectional sync-from/to-source state machine.
+
+The split keeps :mod:`vtsearch.settings` focused on the *schema* (the
+Pydantic-driven ``get_<key>`` / ``set_<key>`` surface, tier routing, CLI
+fallbacks, effective-value resolvers) while this module owns the *engine*.
+
+Why a class with injected dependencies rather than a second flat module:
+several mutable containers (``_settings_lock``, ``_user_caches``,
+``_sync_state``) are imported by name from :mod:`vtsearch.settings` by other
+modules (``vtsearch.achievements``, the sync-source tests), so they must
+stay as module globals there. The store receives those same objects *by
+reference* in its constructor, so both views mutate one set of containers.
+The reassignable scalars (``server_cache``, ``legacy_migrated``) and the
+per-user sync locks live solely on the store. Path resolution and the
+"apply an imported settings dict" callback are injected so this module
+never imports :mod:`vtsearch.settings` (no import cycle).
+
+The canonical lock order is **file lock → settings lock**: file I/O runs
+under the cross-process :func:`file_lock` only, and the in-process
+``settings_lock`` is taken briefly afterwards just to swap the in-memory
+cache, so a slow fsync can't stall unrelated settings reads.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import fcntl as _fcntl  # POSIX-only; falls back to in-process locking on Windows.
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# File I/O primitives (path-keyed, no settings state)
+# ---------------------------------------------------------------------------
+
+
+def _load_path(path: Path) -> dict[str, Any]:
+    """Read settings from *path*, returning ``{}`` on any failure."""
+    if path.exists():
+        try:
+            text = path.read_text(encoding="utf-8")
+            data = json.loads(text)
+            if isinstance(data, dict):
+                return data
+        except Exception as exc:
+            logger.warning("Failed to read settings file %s: %s", path, exc)
+    return {}
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* to *path* via a per-writer temp file + rename.
+
+    The temp filename embeds PID + a UUID so two processes writing to the
+    same target can't truncate each other's in-flight temp file. The
+    final ``os.replace`` is atomic on POSIX, so a concurrent reader
+    always sees either the pre- or post-write content, never a partial
+    write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
+        raise
+
+
+# Per-path in-process locks. Used in two ways:
+# 1. As a fallback when ``fcntl`` is unavailable (Windows).
+# 2. Held in addition to the cross-process flock so that, within a single
+#    process, multiple threads serialise on the same path without
+#    repeatedly re-entering the kernel.
+_path_locks: dict[str, threading.Lock] = {}
+_path_locks_guard = threading.Lock()
+
+
+def _path_lock_for(path: Path) -> threading.Lock:
+    key = str(path.resolve()) if path.exists() else str(path)
+    with _path_locks_guard:
+        lock = _path_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def file_lock(path: Path):
+    """Acquire an exclusive cross-process lock for *path*.
+
+    The lock is taken on a sibling ``<path>.lock`` file rather than on
+    the data file itself, because ``_atomic_write`` replaces the data
+    file's inode via ``os.replace`` - any fd held against the old inode
+    would be useless. The sibling lock file's inode is stable.
+
+    The lock is released automatically if the process exits (POSIX
+    flock semantics), so there are no zombie locks after crashes.
+
+    On Windows (``fcntl`` unavailable) the in-process lock alone is
+    used; cross-process protection degrades silently. VTSearch is
+    deployed on Linux containers, so this only affects the rare
+    Windows-dev case where multiple processes shouldn't be writing
+    the same settings file anyway.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    in_proc = _path_lock_for(path)
+    in_proc.acquire()
+    fd: int | None = None
+    fcntl_mod = _fcntl  # snapshot so the narrowed binding survives the yield
+    if fcntl_mod is not None:
+        lock_path = path.with_name(path.name + ".lock")
+        try:
+            fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+            fcntl_mod.flock(fd, fcntl_mod.LOCK_EX)
+        except OSError as exc:
+            logger.warning("Could not acquire file lock on %s: %s", lock_path, exc)
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                fd = None
+    try:
+        yield
+    finally:
+        if fd is not None and fcntl_mod is not None:
+            try:
+                fcntl_mod.flock(fd, fcntl_mod.LOCK_UN)
+            finally:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        in_proc.release()
+
+
+# ---------------------------------------------------------------------------
+# Per-user sync bookkeeping
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UserSyncState:
+    """Per-user sync-from-source bookkeeping.
+
+    - ``last_version``: opaque token from :meth:`SettingsSource.peek_version`
+      stashed at the last successful sync.  Compared on every read to
+      decide whether a re-sync is due.  ``None`` if the source can't
+      cheaply check freshness.
+    - ``last_check_monotonic``: :func:`time.monotonic` of the last peek.
+      Used to rate-limit ``peek_version`` calls so a hot read path doesn't
+      stat the source file on every ``get_volume()``.
+    - ``last_sync_succeeded``: ``False`` means the user has never been
+      successfully synced this process lifetime (or the last attempt
+      failed).  A transient source failure no longer permanently locks
+      the user out of sync - the slow-path retries (rate-limited) until
+      it succeeds.
+    - ``dirty_keys``: keys the user has set locally since the last
+      successful :func:`_sync_to_source`.  An auto re-sync (from a
+      version-bump on the source) skips these keys so a freshly clicked
+      local toggle isn't silently overwritten by an upstream value.
+      Cleared whenever ``_sync_to_source`` succeeds (because the source
+      then matches local) or when a manual :func:`sync_from_settings_source`
+      runs (explicit user pull).
+    """
+
+    last_version: Any = None
+    last_check_monotonic: float = 0.0
+    last_sync_succeeded: bool = False
+    dirty_keys: set[str] = field(default_factory=set)
+
+
+# ---------------------------------------------------------------------------
+# The store
+# ---------------------------------------------------------------------------
+
+
+class UserSettingsStore:
+    """Two-tier (server + per-user) settings persistence engine.
+
+    Owns the lock-ordering-sensitive load / mutate / sync machinery.  The
+    mutable containers passed in (``settings_lock``, ``user_caches``,
+    ``sync_state``, ``syncing``) are shared by reference with
+    :mod:`vtsearch.settings` so external importers see one set of objects.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings_lock: threading.RLock,
+        user_caches: dict[str, dict[str, Any]],
+        sync_state: dict[str, UserSyncState],
+        syncing: set[str],
+        server_path: Callable[[], Path],
+        user_path: Callable[[str], Path],
+        apply_settings: Callable[[dict[str, Any], set[str] | None], None],
+        server_keys: frozenset[str],
+        fallback_keys: frozenset[str],
+        exclude_from_source_export: set[str],
+        freshness_check_interval: float = 1.0,
+    ) -> None:
+        # Shared-by-reference containers (also module globals in vtsearch.settings).
+        self._lock = settings_lock
+        self._user_caches = user_caches
+        self._sync_state = sync_state
+        self._syncing = syncing
+
+        # Injected schema/policy + path resolution + apply callback.
+        self._server_path = server_path
+        self._user_path = user_path
+        self._apply_settings = apply_settings
+        self._server_keys = server_keys
+        self._fallback_keys = fallback_keys
+        self._exclude_from_source_export = exclude_from_source_export
+        self._freshness_check_interval = freshness_check_interval
+
+        # Store-only state (no external references).
+        self._server_cache: dict[str, Any] | None = None
+        self._legacy_migrated: bool = False
+        self._user_sync_locks: dict[str, threading.RLock] = {}
+        self._user_sync_locks_guard = threading.Lock()
+
+    # -- introspection used by the settings module's read paths ----------
+
+    @property
+    def server_cache(self) -> dict[str, Any] | None:
+        """The server-tier cache (``None`` until first load)."""
+        return self._server_cache
+
+    def per_user_sync_lock(self, username: str) -> threading.RLock:
+        """Return (creating if needed) the sync RLock for *username*."""
+        with self._user_sync_locks_guard:
+            lock = self._user_sync_locks.get(username)
+            if lock is None:
+                lock = threading.RLock()
+                self._user_sync_locks[username] = lock
+            return lock
+
+    # -- cache loaders ---------------------------------------------------
+
+    def ensure_server_loaded(self) -> dict[str, Any]:
+        """Load the server-tier cache on first access and migrate legacy keys."""
+        with self._lock:
+            if self._server_cache is None:
+                self._server_cache = _load_path(self._server_path())
+                self._maybe_migrate_legacy_settings_locked()
+            return self._server_cache
+
+    def ensure_user_loaded(self, username: str) -> dict[str, Any]:
+        """Load *username*'s per-user cache on first access and reconcile with the source.
+
+        Fast path: take ``settings_lock`` briefly, hydrate the local cache
+        if needed, and return immediately when no sync work is due (no
+        source configured, freshness window still valid, or we're already
+        inside an import for this user).
+
+        Slow path: take the per-user sync RLock so the actual ``peek_version``
+        + ``load`` + ``_apply_settings`` work happens serially for the same
+        user, and concurrent readers see the post-sync cache when they
+        acquire the lock.  Without this lock the previous design had a
+        TOCTOU race: thread A set the "synced" marker before running the
+        sync, so a concurrent thread B saw the marker and returned the
+        pre-sync local cache.
+        """
+        with self._lock:
+            cache = self._user_caches.get(username)
+            if cache is None:
+                # Make sure server tier is loaded (and legacy migration has run)
+                # before we materialise a fresh user cache, otherwise the legacy
+                # migration step might not see this user yet.
+                self.ensure_server_loaded()
+                cache = self._user_caches.get(username)
+                if cache is None:
+                    cache = _load_path(self._user_path(username))
+                    self._user_caches[username] = cache
+            # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
+            # this function while the outer call holds the sync lock.  Skip
+            # the sync path so we don't recurse or fire another peek probe.
+            if username in self._syncing:
+                return cache
+            cfg = cache.get("settings_source")
+            has_source = isinstance(cfg, dict) and bool(cfg.get("source_name"))
+            if not has_source:
+                return cache
+            state = self._sync_state.get(username)
+            if state is not None and state.last_sync_succeeded:
+                now = time.monotonic()
+                if now - state.last_check_monotonic < self._freshness_check_interval:
+                    # Hot path: a recent successful sync exists and we're
+                    # inside the rate-limit window.  No probe, no lock.
+                    return cache
+
+        sync_lock = self.per_user_sync_lock(username)
+        with sync_lock:
+            if self._needs_sync_from_source(username):
+                self._run_sync_from_source(username)
+
+        return self._user_caches[username]
+
+    def _needs_sync_from_source(self, username: str) -> bool:
+        """Decide whether a sync-from-source pass is due for *username*.
+
+        Called with the per-user sync lock held (so the decision and the
+        subsequent sync are atomic with respect to other threads on the
+        same user).  A sync is due when:
+
+        1. We've never attempted one this process lifetime, OR
+        2. The last attempt failed and the rate-limit window has elapsed
+           (so a transient source outage no longer permanently locks
+           the user out of sync - old ``_synced_users`` did exactly that), OR
+        3. A previous attempt succeeded but the source's
+           :meth:`SettingsSource.peek_version` token has changed since
+           (source file rewritten by another process, hand-edited, etc.).
+
+        Refreshes ``last_check_monotonic`` on the no-sync paths so the
+        freshness probe is rate-limited even when state is being mutated.
+        """
+        with self._lock:
+            state = self._sync_state.get(username)
+            cache_cfg = self._user_caches.get(username, {}).get("settings_source")
+        if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
+            return False
+
+        now = time.monotonic()
+
+        if state is None or state.last_check_monotonic == 0.0:
+            # No state, or state exists only because a setter populated it
+            # via ``mark_user_keys_dirty`` before we'd ever talked to the
+            # source.  Either way: first sync attempt is due.
+            return True
+
+        if not state.last_sync_succeeded:
+            # Rate-limited retry after a failure.
+            return (now - state.last_check_monotonic) >= self._freshness_check_interval
+
+        # Last attempt succeeded.  If we're still inside the freshness
+        # window, skip (the fast path in ``ensure_user_loaded`` usually
+        # handles this; keep the check here in case the slow path was
+        # entered via a different code route).
+        if (now - state.last_check_monotonic) < self._freshness_check_interval:
+            return False
+
+        # Window elapsed - cheap probe to detect upstream changes.
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source = get_settings_source(cache_cfg["source_name"])
+        if source is None:
+            return False
+        field_values = cache_cfg.get("field_values", {})
+        try:
+            current_version = source.peek_version(field_values)
+        except Exception:
+            # Transient peek failure - back off until next window, keep
+            # serving the local cache.
+            with self._lock:
+                s = self._sync_state.get(username)
+                if s is not None:
+                    s.last_check_monotonic = now
+            return False
+
+        if current_version is None or current_version == state.last_version:
+            # Source can't cheaply check, or unchanged since last sync.
+            with self._lock:
+                s = self._sync_state.get(username)
+                if s is not None:
+                    s.last_check_monotonic = now
+            return False
+
+        return True
+
+    def _run_sync_from_source(self, username: str) -> None:
+        """Pull settings from *username*'s configured source and apply them.
+
+        Called with the per-user sync lock held.  Respects ``dirty_keys``:
+        keys the user has set locally since the last successful
+        ``_sync_to_source`` are skipped so a clicked-toggle isn't silently
+        overwritten by an upstream value.
+
+        On success: stash the new ``peek_version`` token, mark the user as
+        successfully synced, and refresh the freshness-check timestamp.
+        On failure: log the error and refresh only the check timestamp
+        (``last_sync_succeeded`` stays ``False``) so the slow path retries
+        once the rate-limit window elapses.
+        """
+        with self._lock:
+            cache_cfg = self._user_caches.get(username, {}).get("settings_source")
+            state = self._sync_state.setdefault(username, UserSyncState())
+            dirty_snapshot = set(state.dirty_keys)
+        if not isinstance(cache_cfg, dict) or not cache_cfg.get("source_name"):
+            return
+
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source = get_settings_source(cache_cfg["source_name"])
+        if source is None:
+            logger.warning("Unknown settings source: %s", cache_cfg["source_name"])
+            return
+
+        field_values = cache_cfg.get("field_values", {})
+        new_version: Any = None
+        try:
+            new_version = source.peek_version(field_values)
+        except Exception:
+            new_version = None
+
+        try:
+            imported = source.load(field_values)
+        except Exception as exc:
+            logger.exception("Failed to load from settings source for %s: %s", username, exc)
+            with self._lock:
+                state = self._sync_state.setdefault(username, UserSyncState())
+                state.last_check_monotonic = time.monotonic()
+                # Leave last_sync_succeeded as-is: a transient failure after
+                # a previous success must not erase the success flag (the
+                # local cache is still valid).
+            return
+
+        if imported:
+            with self._lock:
+                self._syncing.add(username)
+            try:
+                self._apply_settings(imported, dirty_snapshot)
+            finally:
+                with self._lock:
+                    self._syncing.discard(username)
+
+        with self._lock:
+            state = self._sync_state.setdefault(username, UserSyncState())
+            state.last_version = new_version
+            state.last_check_monotonic = time.monotonic()
+            state.last_sync_succeeded = True
+            # dirty_keys preserved across an auto re-sync - the user's local
+            # edits stay protected until an explicit ``_sync_to_source`` push
+            # confirms the source matches local (which clears them) or a
+            # manual POST sync clears them on purpose.
+
+    def _maybe_migrate_legacy_settings_locked(self) -> None:
+        """Move per-user keys from a legacy ``data/settings.json`` into the
+        default user's per-user file (one-shot, idempotent).
+
+        Called from :meth:`ensure_server_loaded` with the settings lock held.
+        """
+        if self._legacy_migrated:
+            return
+        self._legacy_migrated = True
+        assert self._server_cache is not None
+        # ``fallback_keys`` legitimately live in the server file (the
+        # default user reads through to them), so they are NOT "orphaned per-user"
+        # keys; leave them in place rather than moving them into the default user's
+        # file (which would also rewrite a CLI ``--settings`` file under the user).
+        legacy_user_entries = {
+            k: v for k, v in self._server_cache.items() if k not in self._server_keys and k not in self._fallback_keys
+        }
+        if not legacy_user_entries:
+            return
+
+        # Migrate into the "default" user's file. The default user is the one
+        # the single-user provider returns, and is also the safe target for
+        # multi-user upgrades (admins can copy it into other users' files).
+        default_user = "default"
+        user_path = self._user_path(default_user)
+        if user_path.exists():
+            existing = _load_path(user_path)
+            # Existing per-user values win - never clobber a real user file.
+            merged: dict[str, Any] = {**legacy_user_entries, **existing}
+        else:
+            merged = dict(legacy_user_entries)
+        try:
+            _atomic_write(user_path, merged)
+        except Exception as exc:
+            logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
+            return
+
+        # Build the server-tier shape first; a failure here must not pop the
+        # in-memory cache, or server_cache and disk would silently diverge. Keep
+        # the default-user fallback keys in the server file (they are read through
+        # there, not migrated out).
+        new_server = {k: v for k, v in self._server_cache.items() if k in self._server_keys or k in self._fallback_keys}
+        try:
+            _atomic_write(self._server_path(), new_server)
+        except Exception as exc:
+            logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
+            return
+        for k in list(self._server_cache.keys()):
+            if k not in self._server_keys and k not in self._fallback_keys:
+                self._server_cache.pop(k, None)
+
+        # Refresh the default user's cache if it was already materialised
+        # (unlikely, since this runs from ensure_server_loaded, but safe).
+        self._user_caches[default_user] = _load_path(user_path)
+        logger.info(
+            "Migrated %d legacy per-user setting(s) from %s into %s",
+            len(legacy_user_entries),
+            self._server_path(),
+            user_path,
+        )
+
+    # -- save helpers ----------------------------------------------------
+
+    def mutate_server_locked(self, mutator: Callable[[dict[str, Any]], None]) -> None:
+        """Apply *mutator* to a fresh-from-disk server cache, atomically.
+
+        Acquires the cross-process file lock, re-reads ``data/settings.json``
+        so any changes a sibling process made since this process loaded are
+        picked up, runs ``mutator(cache)`` to mutate the dict in place, then
+        atomically writes the result back. This is the only correct way to
+        mutate a multi-writer settings file from a Python process.
+
+        The legacy migration is left to ``ensure_server_loaded`` and never
+        fires from inside the lock - by the time any setter runs the cache
+        has been loaded at least once.
+
+        File I/O (``_load_path``, ``_atomic_write``) runs under the
+        cross-process file lock only; ``settings_lock`` is acquired briefly
+        at the end just to swap the in-memory cache, so a slow local fsync
+        (NFS, full disk, hung disk controller) can't stall unrelated
+        settings reads - see H29 in ``docs/plans/logical-bug-audit.md``.
+        """
+        path = self._server_path()
+        with file_lock(path):
+            fresh = _load_path(path)
+            mutator(fresh)
+            _atomic_write(path, fresh)
+            with self._lock:
+                self._server_cache = fresh
+
+    def mutate_user_locked(self, username: str, mutator: Callable[[dict[str, Any]], None]) -> dict[str, Any] | None:
+        """Apply *mutator* to a fresh-from-disk per-user cache, atomically.
+
+        Returns a snapshot of the cache after the mutation, intended for
+        ``sync_to_source`` which is invoked **outside** the file lock so a
+        slow sync target (NFS, webhook) can't block other settings writes.
+        Returns ``None`` if the cache should not be synced (i.e. we are
+        currently importing from the source).
+
+        Like :meth:`mutate_server_locked`, file I/O runs under the
+        cross-process file lock only; ``settings_lock`` is acquired briefly
+        at the end just to swap the in-memory cache and read the ``syncing``
+        flag.
+        """
+        path = self._user_path(username)
+        with file_lock(path):
+            fresh = _load_path(path)
+            mutator(fresh)
+            _atomic_write(path, fresh)
+            with self._lock:
+                self._user_caches[username] = fresh
+                if username in self._syncing:
+                    return None
+                return dict(fresh)
+
+    def mark_user_keys_dirty(self, username: str, keys) -> None:
+        """Add *keys* to the user's ``dirty_keys`` set."""
+        if not keys:
+            return
+        with self._lock:
+            state = self._sync_state.setdefault(username, UserSyncState())
+            state.dirty_keys.update(keys)
+
+    # -- sync to source --------------------------------------------------
+
+    def sync_to_source(self, username: str, data: dict[str, Any]) -> None:
+        """Push *username*'s current settings to their active source (if any).
+
+        Called from ``_write_value`` / ``mutate_user`` /
+        ``set_settings_source_config`` after the per-user file is
+        written, **outside** the cross-process file lock so a slow sync
+        target can't block other settings writes.  Strips the
+        ``settings_source`` key itself to avoid circular config.
+
+        On successful save the user is stamped as freshly synced
+        (``last_version`` refreshed from the post-save ``peek_version``,
+        ``dirty_keys`` cleared) - source now matches local, so the next
+        :meth:`ensure_user_loaded` short-circuits via the fast path
+        instead of pulling back the values we just pushed.
+        """
+        cfg = data.get("settings_source")
+        if not isinstance(cfg, dict) or not cfg.get("source_name"):
+            return
+
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source = get_settings_source(cfg["source_name"])
+        if source is None:
+            return
+
+        field_values = cfg.get("field_values", {})
+        export_data = {k: v for k, v in data.items() if k not in self._exclude_from_source_export}
+
+        try:
+            source.save(export_data, field_values)
+        except Exception as exc:
+            logger.exception("Failed to sync settings to source for %s: %s", username, exc)
+            return
+
+        # Source now matches local for every exported key - clear the dirty
+        # set and refresh the version token so an auto re-sync doesn't fire
+        # for the change we just exported.
+        new_version: Any = None
+        try:
+            new_version = source.peek_version(field_values)
+        except Exception:
+            new_version = None
+        with self._lock:
+            self._sync_state[username] = UserSyncState(
+                last_version=new_version,
+                last_check_monotonic=time.monotonic(),
+                last_sync_succeeded=True,
+                dirty_keys=set(),
+            )
+
+    def sync_from_source_now(self, cfg: dict[str, Any], username: str) -> dict[str, Any] | None:
+        """Pull settings from *cfg*'s source and apply them (explicit/manual).
+
+        ``cfg`` is the active user's resolved ``settings_source`` config.
+        Returns the imported settings dict, or ``None`` if the source is
+        unknown, errors, or yields nothing.
+
+        This (explicit) path **ignores the local ``dirty_keys`` set**: the
+        user clicked "Sync now" precisely to get the source values, so a
+        locally-edited key is overwritten and the dirty marker is cleared.
+        """
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source = get_settings_source(cfg["source_name"])
+        if source is None:
+            logger.warning("Unknown settings source: %s", cfg["source_name"])
+            return None
+
+        field_values = cfg.get("field_values", {})
+        new_version: Any = None
+        try:
+            new_version = source.peek_version(field_values)
+        except Exception:
+            new_version = None
+
+        try:
+            imported = source.load(field_values)
+        except Exception as exc:
+            logger.exception("Failed to load from settings source: %s", exc)
+            return None
+
+        if not imported:
+            return None
+
+        # The setters invoked by ``_apply_settings`` acquire ``file_lock``
+        # and then ``settings_lock``. Holding ``settings_lock`` here would
+        # invert the canonical order - take the lock only to mutate
+        # ``syncing``, then drop it for the actual apply.
+        with self._lock:
+            self._syncing.add(username)
+        try:
+            self._apply_settings(imported, None)
+        finally:
+            with self._lock:
+                self._syncing.discard(username)
+
+        with self._lock:
+            self._sync_state[username] = UserSyncState(
+                last_version=new_version,
+                last_check_monotonic=time.monotonic(),
+                last_sync_succeeded=True,
+                dirty_keys=set(),
+            )
+
+        return imported
+
+    # -- lifecycle -------------------------------------------------------
+
+    def invalidate_server_cache(self) -> None:
+        """Drop the server cache and re-arm the one-shot legacy migration.
+
+        Used when the server settings path is repointed (CLI ``--settings``).
+        Caller already holds ``settings_lock``.
+        """
+        self._server_cache = None
+        self._legacy_migrated = False
+
+    def drop_sync_state(self, username: str) -> None:
+        """Forget *username*'s sync bookkeeping (e.g. when the source is cleared)."""
+        with self._lock:
+            self._sync_state.pop(username, None)
+
+    def reset(self) -> None:
+        """Reset every in-memory cache and sync state (for testing).
+
+        Clears the shared containers in place (so the module-level aliases
+        in :mod:`vtsearch.settings` stay valid) and the store-only state.
+        """
+        with self._lock:
+            self._server_cache = None
+            self._user_caches.clear()
+            self._sync_state.clear()
+            self._syncing.clear()
+            self._legacy_migrated = False
+        with self._user_sync_locks_guard:
+            self._user_sync_locks.clear()


### PR DESCRIPTION
## What

First Theme B mega-file split from `docs/plans/code-structure-review.md`: separate the lock-ordering-sensitive **engine** out of `vtsearch/settings.py` (1935 lines) into a new `vtsearch/settings_store.py` as `UserSettingsStore`.

- **`settings_store.py` (new)** owns the machinery: cross-process file locking (`file_lock` / `_atomic_write` / `_load_path`), the two-tier server/per-user caches, the one-shot legacy migration, and the bidirectional sync-from/to-source state machine. The canonical lock order (`file_lock → settings_lock`) and the re-entrance guards are now encapsulated in one documented place.
- **`settings.py` (1935 → ~1410 lines)** keeps the schema/policy layer: the Pydantic-driven `get_<key>` / `set_<key>` accessor generation, tier routing, CLI fallbacks, and effective-value resolvers. It delegates engine work to a module-level `_store` instance.

## How the seam works

The shared mutable containers (`_settings_lock`, `_user_caches`, `_sync_state`, `_syncing`) stay as module globals in `settings.py` — `vtsearch.achievements` and the sync-source tests import them by name — and are passed **by reference** into the store, so both views mutate one set of objects. Only the reassignable scalars (`server_cache`, `legacy_migrated`) and the per-user sync locks live solely on the store. Path resolution and the "apply an imported settings dict" callback are injected, so `settings_store.py` never imports `settings.py` (no import cycle).

Behavior is unchanged: the engine methods are faithful relocations (only `self.`/injected-config substitutions). The thin module-level delegators (`_ensure_user_loaded`, `_mutate_user_locked`, `_sync_to_source`, …) preserve the exact external/test surface.

## Tests

- Full fast suite green: **4803 passed, 1 skipped** (`./run-tests.sh`), including ruff/codespell/deptry/pyright/OpenAPI-snapshot preamble.
- Library-tier import-clean check green: **1310 passed** (`./run-tests.sh vtscore-clean`).
- The dedicated lock-ordering thread-safety tests and the sync-source state-machine tests both pass, confirming behavior preservation.
- Updated the three tests that monkeypatched `_atomic_write` / asserted on `_server_cache` to target the new location (`settings_store._atomic_write`, `settings._store.server_cache`), plus stale prose references in `app.py`, `vtscore/io.py`, `vtscore/detectors/store.py`.

## Follow-up (recorded in the plan)

The legacy-migration path stays lazy (runs from `UserSettingsStore.ensure_server_loaded` on first server load) rather than a one-shot admin script — deliberately, because the default-user read-through and the CLI `--settings` flat-file flow rely on the lazy trigger. Moving it to a script is a behavior change worth its own scoped task.

https://claude.ai/code/session_019NuiiHwJJe8zzghYTYquzh

---
_Generated by [Claude Code](https://claude.ai/code/session_019NuiiHwJJe8zzghYTYquzh)_