### PR TITLE
Scale browse bin-popup detail image to its largest fit

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -35,7 +35,7 @@
 
   <div class="bin-popup-body" [style.height.px]="bodyHeight">
     @if (showPreview) {
-      <div class="bin-popup-preview" [style.width.px]="previewSize">
+      <div class="bin-popup-preview" [style.width.px]="previewPaneSize">
         @if (previewUrl()) {
           <img
             class="bin-popup-preview-img"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -76,8 +76,9 @@
 }
 
 // The large preview: the hovered (or, by default, representative) item shown
-// full-resolution. Width is bound per render (50% larger than the on-canvas
-// mouse-over size); the square box centres the image at its native aspect.
+// full-resolution. The box is square (width is bound per render to the full body
+// height, see ``previewPaneSize``) so the image scales to its largest fit; the
+// image is letterboxed in one dimension to keep its native aspect undistorted.
 .bin-popup-preview {
   flex-shrink: 0;
   height: 100%;
@@ -90,8 +91,11 @@
 }
 
 .bin-popup-preview-img {
-  max-width: 100%;
-  max-height: 100%;
+  // Fill the square pane and let ``object-fit: contain`` scale the image up or
+  // down to the largest size that fits, preserving aspect (letterboxed on the
+  // shorter dimension). ``max-*: 100%`` alone would never scale a small image up.
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   display: block;
 }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -301,9 +301,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return Math.min(Math.max(this.rows.length, 1) * this.rowSize, this.bodyCapPx);
   }
 
-  /** Side (px) of the square preview pane: scaled up from the item's on-canvas
-   *  mouse-over break-out at the current main-canvas thumbnail size, clamped to
-   *  the room the visible region leaves. Zero when there is no preview. */
+  /** Target/minimum side (px) of the square preview pane: scaled up from the
+   *  item's on-canvas mouse-over break-out at the current main-canvas thumbnail
+   *  size, clamped to the room the visible region leaves. The rendered pane grows
+   *  to {@link previewPaneSize} (the full body height) when the member grid is
+   *  taller. Zero when there is no preview. */
   get previewSize(): number {
     if (!this.showPreview) return 0;
     const desired = this.hoverThumbRadius * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
@@ -324,6 +326,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  full. The preview may exceed the grid's cap; both are region-bounded. */
   get bodyHeight(): number {
     return Math.max(this.gridHeight, this.previewSize);
+  }
+
+  /** Side (px) of the *rendered* square preview pane. {@link previewSize} is the
+   *  pane's target/minimum side; here we grow it to the full body height so the
+   *  pane is always square and the image scales to the largest size that fits.
+   *  Without this the pane stays {@link previewSize} wide while the body is
+   *  stretched taller by the member grid beside it, leaving the detail image
+   *  pinned to a narrow column and floating small in a tall empty space. Zero
+   *  when there is no preview. */
+  get previewPaneSize(): number {
+    return this.showPreview ? this.bodyHeight : 0;
   }
 
   // --- Dismissal -----------------------------------------------------------
@@ -531,7 +544,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.maxWidthPx = Math.max(0, regionRight - regionLeft - 2 * EDGE_MARGIN);
     // A singleton bin drops the grid column and shows only the preview pane.
     const gridW = this.previewOnly ? 0 : GRID_COLUMN_WIDTH;
-    const previewW = this.previewSize ? this.previewSize + (gridW ? PREVIEW_GAP : 0) : 0;
+    const paneW = this.previewPaneSize;
+    const previewW = paneW ? paneW + (gridW ? PREVIEW_GAP : 0) : 0;
     const width = Math.min(previewW + gridW, this.maxWidthPx);
     const height = headerH + this.bodyHeight;
     let l = desiredLeft;


### PR DESCRIPTION
## What

Right-clicking a bin on the VTSBrowse canvas opens the bin popup, whose left pane is the large "detail" preview of the hovered/representative item. The preview image was floating small in a tall column: the pane was pinned to a fixed `previewSize` width while its height (`bodyHeight`) stretched to match the member-thumbnail grid beside it, so for any bin with several items the image only ever reached the narrow `previewSize` width and left a large empty vertical band.

This makes the detail image scale to its largest size on the canvas:

- The preview pane is now a true square at the full available body height (new `previewPaneSize` getter = `bodyHeight` when a preview is shown), so the image can grow to use all the vertical room instead of being capped to the old fixed width. `clampInto` uses the same rendered pane size when positioning the popup.
- `.bin-popup-preview-img` now uses `width/height: 100%` with `object-fit: contain` (matching the center-panel `vt-image-viewer`) instead of `max-width/max-height: 100%`. `object-fit: contain` scales the image up or down to the largest size that fits while preserving aspect; the previous `max-*` only ever scaled down (a smaller-than-pane image stayed small).

The image keeps its native aspect ratio — no distortion — and is letterboxed on the shorter dimension, exactly as before.

## Testing

- `npm run build:prod`: clean, zero errors and zero warnings.
- `./run-tests.sh core`: `ruff`, `ruff format`, `codespell`, `deptry`, `pip-audit`, and OpenAPI checks pass; the frontend `build:prod` check passes. The run is then blocked at the `npm audit` step by 6 pre-existing high-severity CVEs in the pinned Angular 19.2.x framework packages — unrelated to this change (no dependency files touched; clearing them needs a breaking Angular major upgrade).

https://claude.ai/code/session_0117Jvxvdm4nJPkNQ6LLGQPF

---
_Generated by [Claude Code](https://claude.ai/code/session_0117Jvxvdm4nJPkNQ6LLGQPF)_