### PR TITLE
Use pie-chart icon for right-panel Stats button

### DIFF
--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -87,9 +87,11 @@
           </button>
           <button class="goods-action-btn" [disabled]="disabled" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="18" y1="20" x2="18" y2="10"></line>
-              <line x1="12" y1="20" x2="12" y2="4"></line>
-              <line x1="6" y1="20" x2="6" y2="14"></line>
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M12 2a10 10 0 0 1 0 20"/>
+              <line x1="12" y1="12" x2="12" y2="2"/>
+              <line x1="12" y1="12" x2="20.66" y2="17"/>
+              <line x1="12" y1="12" x2="2" y2="12"/>
             </svg>
           </button>
         </div>


### PR DESCRIPTION
## Summary

The "Stats" button in the right-side goods-actions panel used a bar-chart icon, while the Stats buttons on the Dashboard dataset/detector cards use a pie-chart icon. This swaps the right-panel button's SVG to the same pie-chart glyph for visual consistency.

## Changes

- `frontend/src/app/components/right-panel/right-panel.component.html`: replaced the three-bar bar-chart SVG with the pie-chart SVG used by the dashboard cards (same `width`/`height`/`stroke-width`).

## Testing

- `npm run build:prod` — clean, no warnings.

https://claude.ai/code/session_013te3asFmuUECYyeforuvkE

---
_Generated by [Claude Code](https://claude.ai/code/session_013te3asFmuUECYyeforuvkE)_