### PR TITLE
Round hovered singleton break-out tiles in VTSBrowser

### DIFF
--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -8,6 +8,7 @@
 
 import {
   SQRT3,
+  HEX_INRADIUS_RATIO,
   traceCellPath as traceHexCellPath,
   densityColor,
   resolveColormap,
@@ -43,6 +44,16 @@ export interface BinGeometry {
     radius: number,
     single: boolean,
   ): void;
+  /**
+   * The absolute corner radius (screen px) a singleton cell's outline curves
+   * with at the given bin `radius` — the inscribed disc's radius in hex mode,
+   * the rounded square's corner radius in square mode. The hovered break-out
+   * thumbnail reuses this fixed ("total", not proportional) value so an
+   * enlarged singleton keeps the *same* corner curvature it had in the grid:
+   * it still reads as a singleton when blown up, while only nibbling the image
+   * corners instead of cropping more as the tile grows.
+   */
+  singleCornerRadius(radius: number): number;
   /**
    * Whether a projection-space offset `(ox, oy)` from a cell center falls
    * inside a cell of the given `radius` — the hover hit-test predicate.
@@ -87,6 +98,7 @@ const HEX_GEOMETRY: BinGeometry = {
   dx: (radius) => radius * SQRT3,
   dy: (radius) => radius * 1.5,
   traceCell: (ctx, cx, cy, radius, single) => traceHexCellPath(ctx, cx, cy, radius, single),
+  singleCornerRadius: (radius) => radius * HEX_INRADIUS_RATIO,
   contains: (ox, oy, radius) => ox * ox + oy * oy < radius * radius,
   neighborOffsets: () => HEX_NEIGHBORS,
 };
@@ -114,6 +126,7 @@ const SQUARE_GEOMETRY: BinGeometry = {
     }
     ctx.closePath();
   },
+  singleCornerRadius: (radius) => ((radius * SQRT3) / 2) * SQUARE_SINGLE_CORNER_RATIO,
   contains: (ox, oy, radius) => {
     const half = (radius * SQRT3) / 2;
     return Math.abs(ox) < half && Math.abs(oy) < half;

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1198,14 +1198,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   ): void {
     // A cell with one item is drawn as a disc (slightly smaller than the cell);
     // multi-item cells keep their full shape so they tile the space. The hovered
-    // cell instead passes `trim`: a plain rectangle of the thumbnail's native
-    // aspect ratio, so the enlarged tile breaks out of the bin silhouette and
-    // shows the whole frame (no hex/square clip, no background bars).
+    // cell instead passes `trim`: a rectangle of the thumbnail's native aspect
+    // ratio, so the enlarged tile breaks out of the bin silhouette and shows the
+    // whole frame (no hex/square clip, no background bars). A singleton's
+    // break-out keeps rounded corners (see `traceTrimRect`) so it still reads as
+    // a singleton; a pile's stays sharp and is marked by its colormap band.
     const single = cell.count === 1;
     if (trim) {
-      ctx.beginPath();
-      ctx.rect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
-      ctx.closePath();
+      this.traceTrimRect(ctx, cx, cy, trim, single, radius);
     } else {
       this.geom.traceCell(ctx, cx, cy, radius, single);
     }
@@ -1287,10 +1287,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     selectionActive: boolean,
   ): void {
     // A hovered thumbnail breaks out of its bin: it's shown whole at its native
-    // aspect ratio as a plain rectangle (no silhouette), sized to grow until its
-    // edge just reaches the nearest neighbour cell's centre (`hoverThumbRect`).
-    // A non-thumbnail (flat density) cell has no such rectangle, so it keeps its
-    // silhouette and simply lifts off with a fixed size bump.
+    // aspect ratio as a rectangle (no silhouette), sized to grow until its edge
+    // just reaches the nearest neighbour cell's centre (`hoverThumbRect`). A
+    // singleton's rectangle keeps rounded corners so it stays distinguishable
+    // from a pile (`traceTrimRect`). A non-thumbnail (flat density) cell has no
+    // such rectangle, so it keeps its silhouette and simply lifts off with a
+    // fixed size bump.
     const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
     const trim = thumb ? this.hoverThumbRect(thumb, radius) : null;
     const bumped = radius * HOVER_RADIUS_SCALE;
@@ -1303,9 +1305,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.shadowBlur = Math.max(4, radius * 0.3);
     ctx.shadowOffsetY = Math.max(1, radius * 0.1);
     if (trim) {
-      ctx.beginPath();
-      ctx.rect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
-      ctx.closePath();
+      this.traceTrimRect(ctx, cx, cy, trim, cell.count === 1, radius);
     } else {
       this.geom.traceCell(ctx, cx, cy, bumped, cell.count === 1);
     }
@@ -1316,6 +1316,35 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // `radius` is unused for the shape when `trim` is set (the rectangle drives
     // it), so the un-bumped radius is fine there; flat-density cells use the bump.
     this.drawHex(ctx, cx, cy, trim ? radius : bumped, cell, cmap, selectionActive, trim);
+  }
+
+  /**
+   * Trace the hovered break-out thumbnail's rectangle as the current path,
+   * centred on `(cx, cy)` with half-extents `trim`. A singleton rounds its
+   * corners with the *same absolute* radius its grid disc / rounded square
+   * curved with (`geom.singleCornerRadius`, computed from the un-bumped bin
+   * `radius`) — a fixed "total" round, not one proportional to the enlarged
+   * rectangle, so the blown-up tile keeps the singleton's corner curvature and
+   * only nibbles the image corners. Piles stay sharp-cornered; their colormap
+   * band is what marks them. The radius is clamped so it never exceeds half a
+   * side of a narrow break-out rectangle.
+   */
+  private traceTrimRect(
+    ctx: CanvasRenderingContext2D,
+    cx: number,
+    cy: number,
+    trim: { hw: number; hh: number },
+    single: boolean,
+    radius: number,
+  ): void {
+    ctx.beginPath();
+    if (single) {
+      const r = Math.min(this.geom.singleCornerRadius(radius), trim.hw, trim.hh);
+      ctx.roundRect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2, r);
+    } else {
+      ctx.rect(cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
+    }
+    ctx.closePath();
   }
 
   /** Cover-fit an image over the hex's 2*radius square (the path must be clipped). */


### PR DESCRIPTION
## What

When you hover a cell in VTSBrowser, the tile breaks out of its bin and is shown whole at native aspect ratio. Multi-item piles keep their colormap-coloured band, which sticks nicely with the enlarged view. Singletons, however, were enlarged as the same **sharp** rectangle as a pile — so the only on-hover cue separating a singleton from a pile was the pile's band (and nothing at all when the band width is set to 0).

This rounds a hovered **singleton's** break-out rectangle so it stays visually distinct: round = one item, sharp (+ band) = a pile.

## How

- The corner radius is the **same absolute** radius the singleton's grid shape curved with — the inscribed disc's radius in hex mode, the rounded square's corner radius in square mode — not a radius proportional to the (much larger) enlarged tile. So the blown-up singleton keeps the grid's corner curvature and only nibbles the image corners rather than cropping more as the tile grows.
- New `BinGeometry.singleCornerRadius(radius)` keeps that per-shape value next to the existing `traceCell` geometry (hex vs square), so the two stay consistent.
- New `traceTrimRect(...)` helper in `browse-canvas` traces the break-out rectangle (rounded for singletons, sharp for piles), clamped so the radius never exceeds half a side of a narrow tile. Both the drop-shadow base shape and the real fill/clip/border use it.

## Notes

- Frontend `npm run build:prod` is clean (no errors/warnings).

https://claude.ai/code/session_01BD3fHFrXjYuAnm5oAjywRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BD3fHFrXjYuAnm5oAjywRt)_