### PR TITLE
Rename find-stats heading to "Detector Accuracy" and simplify browse tooltip

### DIFF
--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -28,7 +28,7 @@
       </tbody>
     </table>
 
-    <h3 class="section-title">Adopted vs. detector's original call</h3>
+    <h3 class="section-title">Detector Accuracy</h3>
     <table class="stats-table confusion">
       <thead>
         <tr>

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -69,7 +69,7 @@
     >
       @if (mode === 'find') {
         <div list-actions class="goods-actions">
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse the positive results (verified + unverified good) as their own 2-D UMAP projection (builds on click)">
+          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse positive items (verified and unverified).">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
               <circle cx="12" cy="12" r="3"></circle>


### PR DESCRIPTION
Two UI copy fixes:

- Find-stats modal: the confusion-matrix section heading "Adopted vs. detector's original call" is now just **"Detector Accuracy"**.
- Right-panel browse button: the verbose tooltip "Browse the positive results (verified + unverified good) as their own 2-D UMAP projection (builds on click)" is now **"Browse positive items (verified and unverified)."**

No behavior change — copy only.

https://claude.ai/code/session_01GZ8FACus6WPfCSfbBG2Lhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ8FACus6WPfCSfbBG2Lhv)_