### PR TITLE
Make the left panel pop-to-size in Grid view

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -45,7 +45,7 @@
 } @else if (useGridVirtual) {
   <!-- Virtual scrolling for large galleries: cards are chunked into rows so
        only the visible rows are mounted, instead of every thumbnail at once. -->
-  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual">
+  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual" [style.--grid-goal-width]="gridGoalWidth + 'px'">
     <div
       class="grid-virtual-row"
       *cdkVirtualFor="let row of gridRows; trackBy: trackByGridRow"

--- a/frontend/src/app/utils/grid-icon-size.ts
+++ b/frontend/src/app/utils/grid-icon-size.ts
@@ -16,14 +16,21 @@ const GRID_GAP = 4;
  * When the user releases the panel resize divider, snap the panel width down to
  * the minimum width that still shows the same number of grid columns.
  *
- * Finds the active grid container (.media-list.grid-layout or .vote-list.grid-layout)
- * inside panelEl, reads the current column count from the live DOM (so scrollbar width
- * and all structural offsets are automatically accounted for), and returns the snapped
- * panel width. Returns null if the panel is not in grid mode or the element is not found.
+ * Finds the active grid container (.media-list.grid-layout, .vote-list.grid-layout,
+ * .bsp-list.grid-layout, or the virtualized .media-list.grid-virtual viewport) inside
+ * panelEl, reads the current column count from the live DOM (so scrollbar width and all
+ * structural offsets are automatically accounted for), and returns the snapped panel
+ * width. Returns null if the panel is not in grid mode or the element is not found.
+ *
+ * The left panel switches to a CDK virtual-scroll viewport (.grid-virtual) once a view
+ * grows past its grid-virtualization threshold; that viewport carries the same
+ * --grid-goal-width and padding-inline as the plain grid, so the column math below is
+ * identical and snapping works in both modes.
  */
 export function snapPanelWidthToGridColumns(panelEl: HTMLElement, currentPanelWidth: number): number | null {
   const gridEl = (
     panelEl.querySelector('.media-list.grid-layout') ??
+    panelEl.querySelector('.media-list.grid-virtual') ??
     panelEl.querySelector('.vote-list.grid-layout') ??
     panelEl.querySelector('.bsp-list.grid-layout')
   ) as HTMLElement | null;


### PR DESCRIPTION
## What

The right panel in the Find/Train window "pops-to-size" after dragging the divider in Grid view — it narrows to fit a whole number of thumbnail columns with no wasted space. The left panel was supposed to do the same (`onMouseUp` already calls `snapPanelWidthToGridColumns`), but in practice it never popped.

## Why it didn't work

The right panel's `label-list` never virtualizes — it always renders `.vote-list.grid-layout` with `--grid-goal-width` inline, so the snap always matched.

The left panel's `media-list` switches to a **CDK virtual-scroll viewport** once a view exceeds the grid-virtualization threshold (`>80` items) — the common case for real datasets. That viewport:

- has class `grid-virtual`, **not** `grid-layout`, so the snap selector `.media-list.grid-layout` never matched it, and
- carried `--grid-goal-width` only on its child rows, not on the viewport itself.

So `snapPanelWidthToGridColumns` returned `null` and the divider-release snap silently no-opped for any realistically-sized dataset.

## Change

- Expose `--grid-goal-width` on the virtual-scroll viewport element (`media-list.component.html`).
- Add `.media-list.grid-virtual` to the snap selector (`grid-icon-size.ts`).

The viewport's `clientWidth` and `padding-inline` mirror the plain grid (both reduce by `2×4px` and divide by `goalWidth + 4`), so the existing column math is identical — the snapped width fits exactly the same number of columns the live `recomputeGridColumns` produces, with no wasted space. The small-dataset (`≤80` items) plain-grid path already worked and is unaffected.

## Testing

- `npm run build:prod` — clean, no errors/warnings/budget violations.
- No backend changes; Python test suite unaffected.

https://claude.ai/code/session_01VtKkEARqURgsnjxauhW7C6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtKkEARqURgsnjxauhW7C6)_