### PR TITLE
Import media from local zip/tar/rar archives

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,9 +124,10 @@ VTSearch/
 │   │   │                           finalize (drop-none/dedup/diversity), projection, registry save
 │   │   ├── registry.py             Persistent dataset registry (data/dataset_registry.json)
 │   │   ├── downloader/             Demo dataset downloaders (audio, image, video, text, docs)
-│   │   ├── sources/                MediaSource abstraction (local_folder, http_archive, pullwrest);
-│   │   │                           all fetch/resolve ops return FetchedItem (path + optional
-│   │   │                           embedding, embedder_name, extra metadata)
+│   │   ├── archive.py              Local zip/tar/rar extraction + cached loading (local_archive origin)
+│   │   ├── sources/                MediaSource abstraction (local_folder, local_archive, http_archive,
+│   │   │                           pullwrest); all fetch/resolve ops return FetchedItem (path +
+│   │   │                           optional embedding, embedder_name, extra metadata)
 │   │   └── importers/              Plugin importers (server_folder, server_files, local_folder,
 │   │                               local_files, pickle, http_archive, combine_datasets,
 │   │                               demo, synthetic, recaller)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -39,11 +39,17 @@ file) applies.
 python app.py --autodetect --dataset path/to/dataset.pkl --settings settings.json
 ```
 
-**From any supported data source** (folder, HTTP archive):
+**From any supported data source** (folder, archive file, HTTP archive):
 
 ```bash
 python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --settings settings.json
+# --path may point at a single archive file, which is extracted and imported:
+python app.py --autodetect --importer server_folder --path /data/sounds.zip --media-type audio --settings settings.json
+# --dig-archives also extracts any archives found inside the scanned folder:
+python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --dig-archives --settings settings.json
+# http_archive accepts a web URL or a local server path to an archive:
 python app.py --autodetect --importer http_archive --url https://example.com/data.zip --settings settings.json
+python app.py --autodetect --importer http_archive --url /data/sounds.tar.gz --media-type audio --settings settings.json
 ```
 
 Use `python app.py --list-importers` to see all available importers. The full set includes: `server_folder`, `server_files`, `local_folder`, `local_files`, `pickle`, `http_archive`, `combine_datasets`, `demo`, `synthetic`. Each importer adds its own flags; run `python app.py --autodetect --importer <name> --help` to see them.

--- a/docs/plans/dataset-import-archives.md
+++ b/docs/plans/dataset-import-archives.md
@@ -1,0 +1,62 @@
+# Dataset import from local archives
+
+**Status: shipped.** Folder and URL importers can now read media out of a
+local zip/tar/rar archive. Open follow-ups are listed at the bottom.
+
+## Motivation
+
+Before this change there was no way to import a local archive of media:
+
+- `server_folder` scanned a directory by media-extension and silently skipped
+  any `.zip` / `.tar` inside it.
+- `http_archive` could extract archives but only from an `http(s)://` URL (it
+  streamed via `download_file_with_progress`); a local path in its
+  "Path or URL" field was rejected.
+
+## What shipped
+
+- **`vtscore/datasets/archive.py`** — central home for archive handling:
+  - `extract_archive` (moved here from the `http_archive` importer, with the
+    `_reject_traversal` guard) — extracts `.zip` / `.tar(.gz|.bz2|.xz)` /
+    `.rar`, validating every member against path traversal first.
+  - `extract_archive_cached` — extracts into a directory under `DATA_DIR`
+    keyed by the archive's path + size + mtime, so re-imports and later
+    resolves reuse one extraction and a replaced archive busts the cache.
+  - `is_archive_path`, `find_archives`, `append_medias`.
+  - `iter_archive_chunks` / `load_archive_into` — load an archive's contents
+    through the same direct/PDF/converter pipeline as the folder loader.
+- **`local_archive` origin** — media loaded from an archive carry
+  `{"importer": "local_archive", "params": {"path": <abs archive>, "media_type": ...}}`.
+  Only the archive path is persisted; the system re-derives
+  `origin → archive → extracted file → embedding` on demand (no-persist rule).
+  - Resolved by **`vtscore/datasets/sources/local_archive.py`**
+    (`LocalArchiveSource`, auto-discovered as `name="local_archive"`), which
+    extracts (cached) and delegates to `LocalFolderSource`.
+  - Converter-derived media re-derive via the converter origin's
+    `parent_importer` / `parent_path`; PDF pages via the resolver's generic
+    `params.path` fallback against the cached extraction dir.
+- **`server_folder`** — the folder field accepts a single archive file; a new
+  opt-in **`dig_archives`** checkbox extracts archives found inside the scanned
+  folder. The CLI `is_dir` guard was relaxed to allow archive paths.
+- **`http_archive`** — accepts a local server path (not just a URL); local
+  paths route through `load_archive_into` and emit `local_archive` origins.
+- **Frontend** — "Dig into archives" checkbox added to the server-folder view;
+  the existing typed folder-path input already accepts an archive path.
+- The PDF page-expansion helper moved to `vtscore/datasets/pdf.py`
+  (`load_pdf_images_into`), shared by the folder importer and archive loader.
+
+## Open follow-ups
+
+- **Media-type detection on archive paths.** The server-folder picker's
+  auto-detect (`detectMediaType('server_fs', path, recursive)`) runs against a
+  directory; when the path is an archive it returns nothing and the user picks
+  the media type manually. Could peek inside the archive to suggest a type.
+- **PDF-in-archive provenance.** PDF *pages* extracted from a PDF inside an
+  archive carry a `pdf` origin whose `params.path` points at the cached
+  extraction directory (resolved via the generic path fallback). This works as
+  long as the cache survives; it is not re-derivable through the archive the
+  way direct/converter media are. Niche (a zip of PDFs imported as *image*
+  pages — importing PDFs as the `document` type goes through the direct path
+  and is fully re-derivable).
+- **Slow CLI subprocess tests** (`-m slow`, ~290s) were not run for this
+  change; the fast suite plus new `run_cli` unit tests cover the paths.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5936,6 +5936,9 @@
             "default": null,
             "nullable": true
           },
+          "dig_archives": {
+            "default": null
+          },
           "embedder": {
             "default": null,
             "nullable": true
@@ -6412,6 +6415,9 @@
           "dataset_name": {
             "default": null,
             "nullable": true
+          },
+          "dig_archives": {
+            "default": null
           },
           "media_type": {
             "default": "audio",

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -125,6 +125,18 @@
       </div>
 
       <div class="form-group">
+        <label class="form-label" for="sf-dig-archives" title="When enabled, archives (.zip, .tar, .rar …) found inside the chosen folder are extracted and their media imported too. The folder path can also point directly at a single archive file.">
+          <input
+            id="sf-dig-archives"
+            type="checkbox"
+            [ngModel]="sfDigArchives"
+            (ngModelChange)="sfDigArchives = $event"
+          />
+          Dig into archives
+        </label>
+      </div>
+
+      <div class="form-group">
         <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
         <input
           id="sf-dataset-name"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -154,6 +154,9 @@ export class DatasetImporterModalComponent implements OnInit {
   sfSubmitting = false;
   /** Whether subdirectories of the picked server folder are scanned. */
   sfRecursive = true;
+  /** Whether archives inside the picked folder are extracted and imported.
+   *  Also enables pointing the folder path directly at a single archive. */
+  sfDigArchives = false;
   /** Optional user-supplied dataset name for server-folder imports. */
   sfDatasetName = '';
   /** Whether the user has manually edited :prop:`sfDatasetName`. */
@@ -1564,6 +1567,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfDetection = null;
     this.sfSubmitting = false;
     this.sfRecursive = this.readRecursiveDefault(this.selectedImporter);
+    this.sfDigArchives = false;
     this.sfDatasetName = '';
     this.sfDatasetNameDirty = false;
     this.sfPathInputValue = '';
@@ -2002,6 +2006,7 @@ export class DatasetImporterModalComponent implements OnInit {
       path: this.sfAbsolutePath,
       media_type: this.sfMediaType,
       recursive: this.sfRecursive,
+      dig_archives: this.sfDigArchives,
     };
     const sfName = (this.sfDatasetName || '').trim();
     if (sfName) {

--- a/tests_lib/io/test_importer_loading.py
+++ b/tests_lib/io/test_importer_loading.py
@@ -634,7 +634,7 @@ class TestHttpArchiveExtractDirIsolation:
                 side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
             ),
             mock.patch(
-                "vtscore.datasets.importers.http_archive._extract_archive",
+                "vtscore.datasets.importers.http_archive.extract_archive",
             ),
             mock.patch(
                 "vtscore.datasets.loader.load_dataset_from_folder_chunked",
@@ -653,7 +653,7 @@ class TestHttpArchiveExtractDirIsolation:
 
 
 def _write_zip_to(archive_path, tmp_path):
-    """Helper: write a minimal .zip so _extract_archive succeeds."""
+    """Helper: write a minimal .zip so extract_archive succeeds."""
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("dummy.wav", _make_wav_bytes())
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -3,7 +3,7 @@
 These tests verify:
 - HTTP Archive importer metadata (name, icon, description)
 - Folder importer metadata (icon, description, field ordering)
-- _extract_archive helper (zip and tar)
+- extract_archive helper (zip and tar)
 - DatasetImporter base class icon field and content_vectors attribute
 - DatasetImporter base class content_md5s attribute
 - Folder importer is not in _BUILTIN_IMPORTER_NAMES
@@ -498,13 +498,13 @@ class TestBuiltinImporterNames:
 
 
 # ---------------------------------------------------------------------------
-# _extract_archive helper
+# extract_archive helper
 # ---------------------------------------------------------------------------
 
 
 class TestExtractArchive:
     def test_extract_zip(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         wav_data = _make_wav_bytes()
         zip_path = tmp_path / "test.zip"
@@ -512,11 +512,11 @@ class TestExtractArchive:
             zf.writestr("sounds/tone.wav", wav_data)
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
-        _extract_archive(zip_path, extract_dir)
+        extract_archive(zip_path, extract_dir)
         assert (extract_dir / "sounds" / "tone.wav").exists()
 
     def test_extract_tar_uncompressed(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         wav_data = _make_wav_bytes()
         tar_path = tmp_path / "test.tar"
@@ -526,11 +526,11 @@ class TestExtractArchive:
             tf.addfile(info, io.BytesIO(wav_data))
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
-        _extract_archive(tar_path, extract_dir)
+        extract_archive(tar_path, extract_dir)
         assert (extract_dir / "tone.wav").exists()
 
     def test_extract_tar_gz(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         wav_data = _make_wav_bytes()
         tar_path = tmp_path / "test.tar.gz"
@@ -540,11 +540,11 @@ class TestExtractArchive:
             tf.addfile(info, io.BytesIO(wav_data))
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
-        _extract_archive(tar_path, extract_dir)
+        extract_archive(tar_path, extract_dir)
         assert (extract_dir / "sounds" / "tone.wav").exists()
 
     def test_extract_tar_bz2(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         wav_data = _make_wav_bytes()
         tar_path = tmp_path / "test.tar.bz2"
@@ -554,11 +554,11 @@ class TestExtractArchive:
             tf.addfile(info, io.BytesIO(wav_data))
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
-        _extract_archive(tar_path, extract_dir)
+        extract_archive(tar_path, extract_dir)
         assert (extract_dir / "tone.wav").exists()
 
     def test_unsupported_extension_raises_value_error(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         # A file that is not a zip or tar and doesn't end in .rar
         bad_archive = tmp_path / "test.7z"
@@ -566,14 +566,14 @@ class TestExtractArchive:
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
         with pytest.raises((ValueError, Exception)):
-            _extract_archive(bad_archive, extract_dir)
+            extract_archive(bad_archive, extract_dir)
 
     def test_rar_without_rarfile_raises_runtime_error(self, tmp_path):
         """Attempting RAR extraction without rarfile installed should fail gracefully."""
         import sys
         import unittest.mock as mock
 
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         rar_path = tmp_path / "test.rar"
         # Write RAR v4 magic bytes so it's identified as .rar by extension
@@ -583,10 +583,10 @@ class TestExtractArchive:
 
         with mock.patch.dict(sys.modules, {"rarfile": None}):
             with pytest.raises((RuntimeError, ImportError, Exception)):
-                _extract_archive(rar_path, extract_dir)
+                extract_archive(rar_path, extract_dir)
 
     def test_zip_preserves_multiple_files(self, tmp_path):
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         zip_path = tmp_path / "multi.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
@@ -594,12 +594,12 @@ class TestExtractArchive:
                 zf.writestr(f"file{i}.wav", _make_wav_bytes())
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
-        _extract_archive(zip_path, extract_dir)
+        extract_archive(zip_path, extract_dir)
         assert len(list(extract_dir.glob("*.wav"))) == 3
 
     def test_zip_traversal_rejected_before_extraction(self, tmp_path):
         """A zip member with ``..`` traversal must be rejected before any file lands on disk."""
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         zip_path = tmp_path / "evil.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
@@ -607,14 +607,14 @@ class TestExtractArchive:
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
         with pytest.raises(ValueError, match="traversal"):
-            _extract_archive(zip_path, extract_dir)
+            extract_archive(zip_path, extract_dir)
         # Neither the in-tree nor the escaped target should exist.
         assert not (tmp_path / "escape.wav").exists()
         assert not (extract_dir / "escape.wav").exists()
 
     def test_zip_absolute_path_rejected(self, tmp_path):
         """A zip member with an absolute path must be rejected."""
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         zip_path = tmp_path / "abs.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
@@ -622,7 +622,7 @@ class TestExtractArchive:
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
         with pytest.raises(ValueError, match="traversal"):
-            _extract_archive(zip_path, extract_dir)
+            extract_archive(zip_path, extract_dir)
 
     def test_zip_prefix_collision_rejected(self, tmp_path):
         """``extract_dir`` prefix collision must NOT pass the traversal check.
@@ -631,7 +631,7 @@ class TestExtractArchive:
         accept ``../out_evil/x`` when extracting into ``.../out`` because
         ``str.startswith`` does not respect path separators.
         """
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         zip_path = tmp_path / "prefix.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
@@ -639,12 +639,12 @@ class TestExtractArchive:
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
         with pytest.raises(ValueError, match="traversal"):
-            _extract_archive(zip_path, extract_dir)
+            extract_archive(zip_path, extract_dir)
         assert not (tmp_path / "out_evil").exists()
 
     def test_tar_traversal_rejected_before_extraction(self, tmp_path):
         """A tar member with ``..`` traversal must be rejected before extraction."""
-        from vtscore.datasets.importers.http_archive import _extract_archive
+        from vtscore.datasets.archive import extract_archive
 
         tar_path = tmp_path / "evil.tar"
         wav_data = _make_wav_bytes()
@@ -655,8 +655,262 @@ class TestExtractArchive:
         extract_dir = tmp_path / "out"
         extract_dir.mkdir()
         with pytest.raises((ValueError, Exception), match="(?i)traversal|outside"):
-            _extract_archive(tar_path, extract_dir)
+            extract_archive(tar_path, extract_dir)
         assert not (tmp_path / "escape.wav").exists()
+
+
+# ---------------------------------------------------------------------------
+# Archive helpers: is_archive_path / find_archives / extract_archive_cached /
+# append_medias
+# ---------------------------------------------------------------------------
+
+
+def _write_zip(zip_path, members):
+    """Write *members* ({rel_path: bytes}) into a zip at *zip_path*."""
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for rel, data in members.items():
+            zf.writestr(rel, data)
+    return zip_path
+
+
+def _mock_audio_mt():
+    """A mock 'audio' media type usable for both get() and get_by_folder_name()."""
+    import unittest.mock as mock
+
+    mt = mock.MagicMock()
+    mt.type_id = "audio"
+    mt.folder_import_name = "audio"
+    mt.file_extensions = ["*.wav"]
+    mt.load_media_data.return_value = {"duration": 1.0}
+    return mt
+
+
+def _patch_audio_registry(mt):
+    """Patch vtscore.media.get and get_by_folder_name to return *mt*."""
+    import unittest.mock as mock
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(mock.patch("vtscore.media.get", return_value=mt))
+    stack.enter_context(mock.patch("vtscore.media.get_by_folder_name", return_value=mt))
+    return stack
+
+
+class TestArchiveHelpers:
+    def test_is_archive_path_recognises_suffixes(self):
+        from vtscore.datasets.archive import is_archive_path
+
+        for name in ("a.zip", "a.tar", "a.tar.gz", "a.tgz", "a.tar.bz2", "a.tar.xz", "a.rar", "A.ZIP"):
+            assert is_archive_path(name), name
+        for name in ("a.wav", "a.txt", "archive", "a.zip.txt"):
+            assert not is_archive_path(name), name
+
+    def test_find_archives_recursive_and_top_level(self, tmp_path):
+        from vtscore.datasets.archive import find_archives
+
+        (tmp_path / "top.zip").write_bytes(b"x")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "nested.tar.gz").write_bytes(b"x")
+        (tmp_path / "note.txt").write_bytes(b"x")
+
+        top_only = find_archives(tmp_path, recursive=False)
+        assert [p.name for p in top_only] == ["top.zip"]
+
+        recursive = find_archives(tmp_path, recursive=True)
+        assert {p.name for p in recursive} == {"top.zip", "nested.tar.gz"}
+
+    def test_append_medias_rekeys_sequentially(self):
+        from vtscore.datasets.archive import append_medias
+
+        dst = {1: {"id": 1}, 2: {"id": 2}}
+        src = {1: {"id": 1, "tag": "a"}, 2: {"id": 2, "tag": "b"}}
+        added = append_medias(dst, src)
+        assert added == 2
+        assert sorted(dst.keys()) == [1, 2, 3, 4]
+        assert dst[3]["id"] == 3 and dst[3]["tag"] == "a"
+        assert dst[4]["id"] == 4 and dst[4]["tag"] == "b"
+
+    def test_extract_archive_cached_reuses_and_busts(self, tmp_path, monkeypatch):
+        import time
+
+        from vtscore.datasets import archive as archive_mod
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        monkeypatch.setattr(archive_mod, "DATA_DIR", data_dir)
+
+        zip_path = _write_zip(tmp_path / "a.zip", {"sounds/tone.wav": _make_wav_bytes()})
+
+        first = archive_mod.extract_archive_cached(zip_path)
+        assert (first / "sounds" / "tone.wav").exists()
+        # Second call with the unchanged archive returns the same cached dir.
+        second = archive_mod.extract_archive_cached(zip_path)
+        assert second == first
+
+        # Rewriting the archive (new size/mtime) busts the cache.
+        time.sleep(0.01)
+        _write_zip(zip_path, {"sounds/tone.wav": _make_wav_bytes(), "sounds/two.wav": _make_wav_bytes()})
+        third = archive_mod.extract_archive_cached(zip_path)
+        assert third != first
+        assert (third / "sounds" / "two.wav").exists()
+
+    def test_extract_archive_cached_rejects_non_archive(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        not_archive = tmp_path / "note.txt"
+        not_archive.write_bytes(b"hello")
+        with pytest.raises(ValueError, match="archive"):
+            archive_mod.extract_archive_cached(not_archive)
+
+
+class TestLocalArchiveSource:
+    def test_source_resolves_file_inside_archive(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.sources.local_archive import LocalArchiveSource
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        zip_path = _write_zip(tmp_path / "a.zip", {"sounds/tone.wav": _make_wav_bytes()})
+
+        source = LocalArchiveSource(zip_path)
+        item = source.resolve_path("sounds/tone.wav")
+        assert item.path is not None and item.path.is_file()
+        # Unknown inner path resolves to nothing.
+        assert source.resolve_path("missing.wav").path is None
+
+    def test_factory_discovered_for_local_archive_origin(self):
+        from vtscore.datasets.sources import get_source_for_origin
+        from vtscore.datasets.sources.local_archive import LocalArchiveSource
+
+        origin = {"importer": "local_archive", "params": {"path": "/data/a.zip"}}
+        source = get_source_for_origin(origin)
+        assert isinstance(source, LocalArchiveSource)
+        assert get_source_for_origin({"importer": "local_archive", "params": {}}) is None
+
+
+class TestLocalArchiveImport:
+    """server_folder + http_archive loading media out of a local archive."""
+
+    def test_load_archive_into_stamps_local_archive_origin(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.archive import load_archive_into
+        from vtscore.datasets.importers.base import SourceSpec
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        zip_path = _write_zip(
+            tmp_path / "a.zip",
+            {"sounds/one.wav": _make_wav_bytes(), "sounds/two.wav": _make_wav_bytes()},
+        )
+
+        medias: dict = {}
+        with _patch_audio_registry(_mock_audio_mt()):
+            added = load_archive_into(zip_path, "audio", [SourceSpec("audio")], medias)
+
+        assert added == 2 and len(medias) == 2
+        origins = {m["origin"]["importer"] for m in medias.values()}
+        assert origins == {"local_archive"}
+        first = medias[1]
+        assert first["origin"]["params"]["path"] == str(zip_path.resolve())
+        assert first["origin"]["params"]["media_type"] == "audio"
+        assert first["origin_name"] in {"sounds/one.wav", "sounds/two.wav"}
+
+    def test_server_folder_single_archive_path(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        zip_path = _write_zip(tmp_path / "clips.zip", {"a.wav": _make_wav_bytes()})
+
+        medias: dict = {}
+        with _patch_audio_registry(_mock_audio_mt()):
+            IMPORTER.run({"path": str(zip_path), "media_type": "audio"}, medias)
+
+        assert len(medias) == 1
+        assert medias[1]["origin"]["importer"] == "local_archive"
+
+    def test_server_folder_dig_archives_mixes_folder_and_archive(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        # One loose wav in the folder, plus a zip containing another wav.
+        (tmp_path / "loose.wav").write_bytes(_make_wav_bytes())
+        _write_zip(tmp_path / "more.zip", {"inner.wav": _make_wav_bytes()})
+
+        medias: dict = {}
+        with _patch_audio_registry(_mock_audio_mt()):
+            IMPORTER.run(
+                {"path": str(tmp_path), "media_type": "audio", "dig_archives": True},
+                medias,
+            )
+
+        assert len(medias) == 2
+        importers = sorted(
+            (m["origin"]["importer"] if m["origin"] else None) for m in medias.values()
+        )
+        # Loose folder file has origin=None (the dataset origin is stamped later
+        # by the load pipeline); the archived file carries a local_archive origin.
+        assert importers == [None, "local_archive"]
+
+    def test_server_folder_dig_off_ignores_archives(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        (tmp_path / "loose.wav").write_bytes(_make_wav_bytes())
+        _write_zip(tmp_path / "more.zip", {"inner.wav": _make_wav_bytes()})
+
+        medias: dict = {}
+        with _patch_audio_registry(_mock_audio_mt()):
+            IMPORTER.run({"path": str(tmp_path), "media_type": "audio"}, medias)
+
+        # Only the loose file; the archive is left untouched.
+        assert len(medias) == 1
+        assert medias[1]["origin"] is None
+
+    def test_server_folder_has_dig_archives_field(self):
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        keys = [f.key for f in IMPORTER.fields]
+        assert "dig_archives" in keys
+        dig = next(f for f in IMPORTER.fields if f.key == "dig_archives")
+        assert dig.field_type == "checkbox"
+        assert str(dig.default).lower() == "false"
+
+    def test_server_folder_run_cli_rejects_missing_path(self):
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        with pytest.raises(FileNotFoundError):
+            IMPORTER.run_cli({"path": "/nonexistent/zip-or-dir", "media_type": "audio"}, {})
+
+    def test_http_archive_local_path_uses_local_archive_origin(self, tmp_path, monkeypatch):
+        from vtscore.datasets import archive as archive_mod
+        from vtscore.datasets.importers.http_archive import IMPORTER
+
+        monkeypatch.setattr(archive_mod, "DATA_DIR", tmp_path / "data")
+        zip_path = _write_zip(tmp_path / "a.zip", {"a.wav": _make_wav_bytes()})
+
+        medias: dict = {}
+        with _patch_audio_registry(_mock_audio_mt()):
+            IMPORTER.run({"url": str(zip_path), "media_type": "audio"}, medias)
+
+        assert len(medias) == 1
+        assert medias[1]["origin"]["importer"] == "local_archive"
+
+    def test_http_archive_run_cli_rejects_nonexistent_local_path(self):
+        from vtscore.datasets.importers.http_archive import IMPORTER
+
+        with pytest.raises(FileNotFoundError):
+            IMPORTER.run_cli({"url": "/nope/a.zip", "media_type": "audio"}, {})
+
+    def test_http_archive_run_cli_rejects_non_archive_local_path(self, tmp_path):
+        from vtscore.datasets.importers.http_archive import IMPORTER
+
+        f = tmp_path / "note.txt"
+        f.write_bytes(b"hi")
+        with pytest.raises(ValueError, match="archive"):
+            IMPORTER.run_cli({"url": str(f), "media_type": "audio"}, {})
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -846,12 +846,11 @@ class TestLocalArchiveImport:
             )
 
         assert len(medias) == 2
-        importers = sorted(
-            (m["origin"]["importer"] if m["origin"] else None) for m in medias.values()
-        )
+        importers = [(m["origin"]["importer"] if m["origin"] else None) for m in medias.values()]
         # Loose folder file has origin=None (the dataset origin is stamped later
         # by the load pipeline); the archived file carries a local_archive origin.
-        assert importers == [None, "local_archive"]
+        assert importers.count(None) == 1
+        assert importers.count("local_archive") == 1
 
     def test_server_folder_dig_off_ignores_archives(self, tmp_path, monkeypatch):
         from vtscore.datasets import archive as archive_mod

--- a/tests_lib/io/test_pdf_import.py
+++ b/tests_lib/io/test_pdf_import.py
@@ -375,7 +375,7 @@ class TestPdfSymlinkDiscovery:
         """PDFs inside a symlinked subdirectory should be found and rendered."""
         from contextlib import ExitStack
 
-        from vtscore.datasets.importers.server_folder import _load_pdf_images
+        from vtscore.datasets.pdf import load_pdf_images_into as _load_pdf_images
 
         root = tmp_path / "root"
         root.mkdir()

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -1,0 +1,404 @@
+"""Local-archive support – extract zip/tar/rar archives and load their media.
+
+This module centralises everything related to reading media out of an
+archive **file** (as opposed to a plain directory).  It is shared by:
+
+* the ``server_folder`` importer – which can take a single archive path in
+  its folder field, or (with ``dig_archives`` enabled) extract any archives
+  found *inside* the scanned folder; and
+* the ``http_archive`` importer – which uses :func:`extract_archive` for
+  downloaded URLs and routes local server paths through here too.
+
+Origin model
+------------
+Media loaded from an archive carry a ``local_archive`` origin::
+
+    {"importer": "local_archive", "params": {"path": "<abs archive path>",
+                                             "media_type": "<output type>"}}
+
+The origin records only the archive's path – never the extracted bytes – so
+the system re-derives ``origin → archive → extracted file → embedding`` on
+demand via
+:class:`~vtscore.datasets.sources.local_archive.LocalArchiveSource`, in line
+with the "no persisted vectors" rule.  Converter-produced media re-derive
+through the converter origin's ``parent_importer`` / ``parent_path`` (see
+:func:`~vtscore.converters.runner._build_converter_origin`); PDF pages
+re-derive through the resolver's generic ``params.path`` fallback against the
+cached extraction directory.
+
+Extraction is cached under :data:`~vtscore.config.DATA_DIR` keyed by the
+archive's path, size, and mtime, so re-imports and later resolves reuse the
+same directory (and a replaced archive busts the cache).  Extracted contents
+are source files, not embeddings/MLPs, so caching them on disk is consistent
+with the existing ``http_archive`` resolve cache and the dataset-pickle
+exception to the no-persist rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tarfile
+import threading
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional
+from uuid import uuid4
+
+from vtscore.config import DATA_DIR
+from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+
+if TYPE_CHECKING:
+    from vtscore.datasets.importers.base import SourceSpec
+
+__all__ = [
+    "ARCHIVE_SUFFIXES",
+    "append_medias",
+    "build_local_archive_origin",
+    "extract_archive",
+    "extract_archive_cached",
+    "find_archives",
+    "is_archive_path",
+    "iter_archive_chunks",
+    "load_archive_into",
+]
+
+ProgressCallback = Callable[[str, str, int, int], None]
+
+#: File suffixes recognised as archives.  Compound tar suffixes are listed
+#: explicitly so :func:`is_archive_path` matches e.g. ``foo.tar.gz``.
+ARCHIVE_SUFFIXES: tuple[str, ...] = (
+    ".zip",
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+    ".tbz2",
+    ".tar.xz",
+    ".txz",
+    ".rar",
+)
+
+#: Glob patterns matching :data:`ARCHIVE_SUFFIXES`, for folder scans.
+_ARCHIVE_GLOBS: tuple[str, ...] = tuple(f"*{suffix}" for suffix in ARCHIVE_SUFFIXES)
+
+#: Synthetic origin importer name for media loaded out of a local archive.
+#: Resolves through
+#: :class:`~vtscore.datasets.sources.local_archive.LocalArchiveSource`.
+LOCAL_ARCHIVE_IMPORTER = "local_archive"
+
+_cache_lock = threading.Lock()
+
+
+def _default_progress() -> ProgressCallback:
+    from vtscore.concurrency.progress import get_thread_progress, update_progress  # noqa: PLC0415
+
+    cb = get_thread_progress()
+    return cb if cb is not None else update_progress
+
+
+def is_archive_path(path: str | Path) -> bool:
+    """Return ``True`` when *path*'s name ends with a known archive suffix.
+
+    Purely lexical – does not touch the filesystem – so it works for paths
+    that don't (yet) exist.
+    """
+    return Path(path).name.lower().endswith(ARCHIVE_SUFFIXES)
+
+
+def find_archives(folder: Path, recursive: bool) -> list[Path]:
+    """Return the archive files inside *folder* (sorted, de-duplicated)."""
+    found: set[Path] = set()
+    for pattern in _ARCHIVE_GLOBS:
+        if recursive:
+            found.update(rglob_follow_symlinks(folder, pattern))
+        else:
+            found.update(glob_top_level(folder, pattern))
+    return sorted(found)
+
+
+def build_local_archive_origin(archive_path: Path, output_type: str) -> dict[str, Any]:
+    """Build the ``local_archive`` origin dict for media from *archive_path*."""
+    return {
+        "importer": LOCAL_ARCHIVE_IMPORTER,
+        "params": {"path": str(Path(archive_path).resolve()), "media_type": output_type},
+    }
+
+
+def _reject_traversal(extract_dir_resolved: Path, member_name: str) -> None:
+    """Raise ValueError if *member_name* would extract outside extract_dir.
+
+    Validates before extraction so a malicious member is never written to disk.
+    Rejects absolute paths, ``..`` traversal, and any name that – once joined
+    and normalised – escapes the extraction root.
+    """
+    # Reject absolute member names outright; on Windows they'd also drop the
+    # root prefix when joined, but we want to fail loudly either way.
+    if member_name.startswith(("/", "\\")) or (len(member_name) > 1 and member_name[1] == ":"):
+        raise ValueError(f"Path traversal detected in archive: {member_name}")
+
+    # Use os.path.normpath-style joining without resolving symlinks: the
+    # extract_dir is freshly created and contains no symlinks yet, and we
+    # don't want a symlink planted by an earlier member in the same archive
+    # to mask a later traversal.
+    target = Path(os.path.normpath(extract_dir_resolved / member_name))
+    if target != extract_dir_resolved and not target.is_relative_to(extract_dir_resolved):
+        raise ValueError(f"Path traversal detected in archive: {member_name}")
+
+
+def extract_archive(  # noqa: C901
+    archive_path: Path,
+    extract_dir: Path,
+    on_progress: Optional[ProgressCallback] = None,
+) -> None:
+    """Extract *archive_path* into *extract_dir*, supporting zip/tar/rar.
+
+    Supported formats: ``.zip``, ``.tar``, ``.tar.gz`` / ``.tgz``,
+    ``.tar.bz2``, ``.tar.xz``, and ``.rar`` (the last requires the optional
+    ``rarfile`` package).  Every member is validated against path traversal
+    before it is written to disk.
+    """
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    name = archive_path.name.lower()
+    extract_dir_resolved = extract_dir.resolve()
+
+    if name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            members = zf.namelist()
+            total = len(members)
+            for i, member in enumerate(members, 1):
+                on_progress(
+                    "loading",
+                    f"Extracting {member.split('/')[-1]}...",
+                    i,
+                    total,
+                )
+                _reject_traversal(extract_dir_resolved, member)
+                zf.extract(member, extract_dir)
+
+    elif tarfile.is_tarfile(archive_path):
+        with tarfile.open(archive_path, "r:*") as tf:
+            members = tf.getmembers()
+            total = len(members)
+            for i, member in enumerate(members, 1):
+                on_progress(
+                    "loading",
+                    f"Extracting {member.name.split('/')[-1]}...",
+                    i,
+                    total,
+                )
+                _reject_traversal(extract_dir_resolved, member.name)
+                tf.extract(member, extract_dir, filter="data")
+
+    elif name.endswith(".rar"):
+        try:
+            import rarfile  # optional dependency  # pyright: ignore[reportMissingImports]  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError(
+                "RAR extraction requires the 'rarfile' package. Install it with: pip install rarfile"
+            ) from exc
+        with rarfile.RarFile(archive_path, "r") as rf:
+            members = rf.namelist()
+            total = len(members)
+            for i, member in enumerate(members, 1):
+                on_progress(
+                    "loading",
+                    f"Extracting {member.split('/')[-1]}...",
+                    i,
+                    total,
+                )
+                _reject_traversal(extract_dir_resolved, member)
+                rf.extract(member, extract_dir)
+
+    else:
+        raise ValueError(
+            f"Unsupported archive format: {archive_path.name}. "
+            "Supported formats: .zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar"
+        )
+
+
+def extract_archive_cached(
+    archive_path: str | Path,
+    on_progress: Optional[ProgressCallback] = None,
+) -> Path:
+    """Extract *archive_path* into a cached directory and return it.
+
+    The cache key folds in the archive's absolute path, size, and mtime, so
+    repeated imports/resolves of the same archive reuse one extraction while
+    a replaced archive busts the cache.  Concurrent extractions of the same
+    archive race safely: each writes to a unique temp dir and the first to
+    finish publishes it; the losers discard their copy.
+    """
+    archive_path = Path(archive_path)
+    if not archive_path.is_file():
+        raise FileNotFoundError(f"Archive not found: {archive_path}")
+    if not is_archive_path(archive_path):
+        raise ValueError(
+            f"Not a recognised archive: {archive_path.name}. "
+            "Supported formats: .zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar"
+        )
+
+    resolved = archive_path.resolve()
+    st = resolved.stat()
+    signature = f"{resolved}|{st.st_size}|{st.st_mtime_ns}".encode()
+    digest = hashlib.md5(signature).hexdigest()[:16]
+    cached_dir = DATA_DIR / f"local_archive_{digest}"
+
+    if cached_dir.is_dir():
+        return cached_dir
+
+    DATA_DIR.mkdir(exist_ok=True)
+    tmp_dir = DATA_DIR / f"local_archive_tmp_{uuid4().hex[:12]}"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        extract_archive(resolved, tmp_dir, on_progress)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    # Publish atomically.  Re-check under the lock: two concurrent extractions
+    # of the same archive can both miss the earlier is_dir() check, and without
+    # this guard they'd both try to rename onto the same destination.
+    with _cache_lock:
+        if cached_dir.is_dir():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        else:
+            try:
+                tmp_dir.rename(cached_dir)
+            except OSError:
+                # e.g. cross-device rename; fall back to a copy + cleanup.
+                shutil.copytree(tmp_dir, cached_dir, dirs_exist_ok=True)
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+    return cached_dir
+
+
+def append_medias(dst: dict[int, dict[str, Any]], src: dict[int, dict[str, Any]]) -> int:
+    """Merge *src* medias into *dst*, re-keying with fresh sequential IDs.
+
+    Returns the number of medias added.  *dst* is never cleared.
+    """
+    next_id = max(dst.keys(), default=0) + 1
+    added = 0
+    for media in src.values():
+        media["id"] = next_id
+        dst[next_id] = media
+        next_id += 1
+        added += 1
+    return added
+
+
+def iter_archive_chunks(
+    archive_path: str | Path,
+    output_type: str,
+    specs: list["SourceSpec"],
+    chunk_size: int,
+    *,
+    thin: bool = False,
+    content_vectors: dict[str, Any] | None = None,
+    content_md5s: dict[str, str] | None = None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None = None,
+    on_progress: Optional[ProgressCallback] = None,
+) -> Iterator[dict[int, dict[str, Any]]]:
+    """Extract *archive_path* and yield its media in chunks.
+
+    Mirrors the folder import pipeline against the extracted directory:
+    direct (no-converter) rows stream through
+    :func:`~vtscore.datasets.loader.load_dataset_from_folder_chunked`, PDFs
+    expand into images when *output_type* is ``"image"``, and converter rows
+    run via :func:`~vtscore.converters.runner.run_converters_on_folder`.  All
+    media carry a ``local_archive`` origin pointing at *archive_path* so they
+    re-derive on demand.  Each yielded chunk is a self-contained medias dict
+    with IDs starting at 1.
+    """
+    from vtscore.converters.runner import run_converters_on_folder  # noqa: PLC0415
+    from vtscore.datasets.loader import load_dataset_from_folder_chunked  # noqa: PLC0415
+    from vtscore.datasets.pdf import load_pdf_images_into  # noqa: PLC0415
+    from vtscore.media import get  # noqa: PLC0415
+
+    cached_dir = extract_archive_cached(archive_path, on_progress)
+    origin = build_local_archive_origin(Path(archive_path), output_type)
+
+    for spec in specs:
+        if spec.converter is not None:
+            continue
+        mt = get(spec.source_type)
+        try:
+            yield from load_dataset_from_folder_chunked(
+                cached_dir,
+                mt.folder_import_name,
+                chunk_size,
+                thin=thin,
+                origin=origin,
+                content_vectors=content_vectors or None,
+                content_md5s=content_md5s or None,
+                custom_metadata_map=custom_metadata_map or None,
+                recursive=True,
+            )
+        except ValueError:
+            # No files of this source type inside the archive – keep going;
+            # PDF / converter rows may still produce output.
+            pass
+
+    if output_type == "image":
+        pdf_chunk: dict[int, dict[str, Any]] = {}
+        load_pdf_images_into(cached_dir, pdf_chunk, thin=thin, recursive=True)
+        if pdf_chunk:
+            yield pdf_chunk
+
+    converter_specs = [s for s in specs if s.converter is not None]
+    if converter_specs:
+        converter_chunk: dict[int, dict[str, Any]] = {}
+        run_converters_on_folder(
+            folder_path=cached_dir,
+            converter_specs=converter_specs,
+            target_media_type=output_type,
+            medias=converter_chunk,
+            thin=thin,
+            base_origin=origin,
+            recursive=True,
+        )
+        if converter_chunk:
+            yield converter_chunk
+
+
+# A chunk size large enough that the chunked loader yields everything in one
+# pass – used by the non-chunked :func:`load_archive_into` accumulator.
+_UNBOUNDED_CHUNK = 1_000_000_000
+
+
+def load_archive_into(
+    archive_path: str | Path,
+    output_type: str,
+    specs: list["SourceSpec"],
+    medias: dict[int, dict[str, Any]],
+    *,
+    thin: bool = False,
+    content_vectors: dict[str, Any] | None = None,
+    content_md5s: dict[str, str] | None = None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None = None,
+    on_progress: Optional[ProgressCallback] = None,
+) -> int:
+    """Extract *archive_path* and append its media into *medias*.
+
+    Non-chunked accumulator over :func:`iter_archive_chunks`; *medias* is
+    appended to (never cleared) so a caller can merge several archives (and a
+    surrounding folder scan) into one dataset.  Returns the number of media
+    added.
+    """
+    added = 0
+    for chunk in iter_archive_chunks(
+        archive_path,
+        output_type,
+        specs,
+        _UNBOUNDED_CHUNK,
+        thin=thin,
+        content_vectors=content_vectors,
+        content_md5s=content_md5s,
+        custom_metadata_map=custom_metadata_map,
+        on_progress=on_progress,
+    ):
+        added += append_medias(medias, chunk)
+    return added

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import shutil
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Iterator
 from uuid import uuid4
 
 from vtscore.config import DATA_DIR

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -21,15 +21,13 @@ The importer participates in the multi-media import flow.  Each
 from __future__ import annotations
 
 import json
-import os
 import shutil
-import tarfile
-import zipfile
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 from uuid import uuid4
 
 from vtscore.config import DATA_DIR
+from vtscore.datasets.archive import extract_archive, is_archive_path, load_archive_into
 from vtscore.datasets.downloader import download_file_with_progress
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder
@@ -48,92 +46,9 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
-def _reject_traversal(extract_dir_resolved: Path, member_name: str) -> None:
-    """Raise ValueError if *member_name* would extract outside extract_dir.
-
-    Validates before extraction so a malicious member is never written to disk.
-    Rejects absolute paths, ``..`` traversal, and any name that - once joined
-    and normalised - escapes the extraction root.
-    """
-    # Reject absolute member names outright; on Windows they'd also drop the
-    # root prefix when joined, but we want to fail loudly either way.
-    if member_name.startswith(("/", "\\")) or (len(member_name) > 1 and member_name[1] == ":"):
-        raise ValueError(f"Path traversal detected in archive: {member_name}")
-
-    # Use os.path.normpath-style joining without resolving symlinks: the
-    # extract_dir is freshly created and contains no symlinks yet, and we
-    # don't want a symlink planted by an earlier member in the same archive
-    # to mask a later traversal.
-    target = Path(os.path.normpath(extract_dir_resolved / member_name))
-    if target != extract_dir_resolved and not target.is_relative_to(extract_dir_resolved):
-        raise ValueError(f"Path traversal detected in archive: {member_name}")
-
-
-def _extract_archive(  # noqa: C901
-    archive_path: Path,
-    extract_dir: Path,
-    on_progress: Optional[ProgressCallback] = None,
-) -> None:
-    """Extract *archive_path* into *extract_dir*, supporting zip/tar/rar."""
-    if on_progress is None:
-        on_progress = _default_progress()
-
-    name = archive_path.name.lower()
-    extract_dir_resolved = extract_dir.resolve()
-
-    if name.endswith(".zip"):
-        with zipfile.ZipFile(archive_path, "r") as zf:
-            members = zf.namelist()
-            total = len(members)
-            for i, member in enumerate(members, 1):
-                on_progress(
-                    "loading",
-                    f"Extracting {member.split('/')[-1]}...",
-                    i,
-                    total,
-                )
-                _reject_traversal(extract_dir_resolved, member)
-                zf.extract(member, extract_dir)
-
-    elif tarfile.is_tarfile(archive_path):
-        with tarfile.open(archive_path, "r:*") as tf:
-            members = tf.getmembers()
-            total = len(members)
-            for i, member in enumerate(members, 1):
-                on_progress(
-                    "loading",
-                    f"Extracting {member.name.split('/')[-1]}...",
-                    i,
-                    total,
-                )
-                _reject_traversal(extract_dir_resolved, member.name)
-                tf.extract(member, extract_dir, filter="data")
-
-    elif name.endswith(".rar"):
-        try:
-            import rarfile  # optional dependency  # pyright: ignore[reportMissingImports]
-        except ImportError as exc:
-            raise RuntimeError(
-                "RAR extraction requires the 'rarfile' package. Install it with: pip install rarfile"
-            ) from exc
-        with rarfile.RarFile(archive_path, "r") as rf:
-            members = rf.namelist()
-            total = len(members)
-            for i, member in enumerate(members, 1):
-                on_progress(
-                    "loading",
-                    f"Extracting {member.split('/')[-1]}...",
-                    i,
-                    total,
-                )
-                _reject_traversal(extract_dir_resolved, member)
-                rf.extract(member, extract_dir)
-
-    else:
-        raise ValueError(
-            f"Unsupported archive format: {archive_path.name}. "
-            "Supported formats: .zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar"
-        )
+def _is_url(value: str) -> bool:
+    """Return ``True`` when *value* looks like an http(s) URL (vs a local path)."""
+    return value.startswith(("http://", "https://"))
 
 
 def _run_converter_specs(
@@ -169,13 +84,18 @@ def _run_converter_specs(
 
 
 class HttpArchiveDatasetImporter(DatasetImporter):
-    """Download a publicly-accessible archive and load its media files.
+    """Load media files from an archive given by a web URL **or** a local path.
 
-    The archive is streamed to a temporary file in ``DATA_DIR``, extracted
-    to a unique ``DATA_DIR/http_archive_extract_<id>/`` directory, then
-    scanned with the standard
-    :func:`~vtscore.datasets.loader.load_dataset_from_folder` pipeline.
-    Both temporary paths are cleaned up after the run completes.
+    For an ``http://`` / ``https://`` URL the archive is streamed to a
+    temporary file in ``DATA_DIR``, extracted to a unique
+    ``DATA_DIR/http_archive_extract_<id>/`` directory, then scanned with the
+    standard :func:`~vtscore.datasets.loader.load_dataset_from_folder`
+    pipeline (both temporary paths are cleaned up afterwards).
+
+    For a local **server path** to an archive file, the download step is
+    skipped and the archive is extracted (and cached) via
+    :func:`~vtscore.datasets.archive.load_archive_into`; the resulting media
+    carry a ``local_archive`` origin so they re-derive on demand.
 
     Supported archive formats: ``.zip``, ``.tar``, ``.tar.gz``,
     ``.tar.bz2``, ``.tar.xz``, ``.rar`` (requires ``rarfile`` package).
@@ -189,7 +109,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
     name = "http_archive"
     display_name = "Import from URL"
-    description = "Download an archive (.zip, .tar, .rar) from a web URL and embed the media files inside"
+    description = "Download an archive (.zip, .tar, .rar) from a web URL or local path and embed the media inside"
     icon = "\U0001f310"
     hidden_from_picker = True
     fields = [
@@ -197,8 +117,11 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             key="url",
             label="Path or URL",
             field_type="url",
-            description="A publicly accessible archive of media files to download and unpack.",
-            hint="Supported archive formats: .zip, .tar, .tar.gz / .tgz, .tar.bz2, .rar.",
+            description="A web URL or local server path to an archive of media files to unpack.",
+            hint=(
+                "An http(s):// URL or an absolute server path. "
+                "Supported archive formats: .zip, .tar, .tar.gz / .tgz, .tar.bz2, .rar."
+            ),
         ),
         ImporterField(
             key="media_type",
@@ -219,10 +142,35 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
+    def _output_type_id(self, media_type: str) -> str:
+        """Resolve a folder-name media type (e.g. ``"audio"``) to its type id."""
+        from vtscore.media import get_by_folder_name  # noqa: PLC0415
+
+        try:
+            return get_by_folder_name(media_type).type_id
+        except (KeyError, AttributeError):
+            return media_type
+
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         url = field_values["url"]
         media_type = field_values.get("media_type", "audio")
         specs = self.effective_source_specs(field_values)
+
+        if not _is_url(url):
+            # Local server path to an archive: extract (cached) and load,
+            # stamping local_archive origins for on-demand re-derivation.
+            medias.clear()
+            load_archive_into(
+                url,
+                self._output_type_id(media_type),
+                specs,
+                medias,
+                thin=thin,
+                content_vectors=self.content_vectors,
+                content_md5s=self.content_md5s,
+                custom_metadata_map=self.custom_metadata_map,
+            )
+            return
 
         DATA_DIR.mkdir(exist_ok=True)
 
@@ -240,7 +188,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         progress("loading", "Extracting archive...", 0, 0)
         extract_dir.mkdir(exist_ok=True)
-        _extract_archive(archive_path, extract_dir, on_progress=progress)
+        extract_archive(archive_path, extract_dir, on_progress=progress)
         archive_path.unlink(missing_ok=True)
 
         try:
@@ -259,6 +207,13 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             shutil.rmtree(extract_dir, ignore_errors=True)
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        url = field_values.get("url", "")
+        if not _is_url(url):
+            path = Path(url)
+            if not path.exists():
+                raise FileNotFoundError(f"Archive not found: {path}")
+            if not is_archive_path(path):
+                raise ValueError(f"Not a supported archive: {path}")
         self.run(field_values, medias, thin=thin)
 
     @property
@@ -288,7 +243,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         progress("loading", "Extracting archive...", 0, 0)
         extract_dir.mkdir(exist_ok=True)
-        _extract_archive(archive_path, extract_dir, on_progress=progress)
+        extract_archive(archive_path, extract_dir, on_progress=progress)
         archive_path.unlink(missing_ok=True)
 
         return extract_dir
@@ -300,6 +255,14 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
         from vtscore.datasets.loader import load_dataset_from_folder_chunked
+
+        if not _is_url(field_values.get("url", "")):
+            # Local archive path: load everything as a single chunk via run().
+            local_medias: dict[int, dict[str, Any]] = {}
+            self.run(field_values, local_medias, thin=thin)
+            if local_medias:
+                yield local_medias
+            return
 
         extract_dir = self._download_and_extract(field_values)
         media_type = field_values.get("media_type", "audio")
@@ -337,8 +300,12 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
         url = field_values.get("url", "")
-        if not url.startswith(("http://", "https://")):
-            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        if not _is_url(url):
+            path = Path(url)
+            if not path.exists():
+                raise FileNotFoundError(f"Archive not found: {path}")
+            if not is_archive_path(path):
+                raise ValueError(f"Not a supported archive: {path}")
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
     def build_cli_args(self, field_values: dict[str, Any]) -> str:
@@ -357,7 +324,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             tail = url_path.split("/")[-1]
             if tail:
                 # Strip a few common archive extensions for a tidier label.
-                for suffix in (".tar.gz", ".tar.bz2", ".tar.xz", ".tar", ".zip", ".rar"):
+                for suffix in (".tar.gz", ".tar.bz2", ".tar.xz", ".tgz", ".tbz2", ".txz", ".tar", ".zip", ".rar"):
                     if tail.lower().endswith(suffix):
                         return tail[: -len(suffix)] or self.display_name
                 return tail

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -16,18 +16,34 @@ When the output type is ``"image"``, ``*.pdf`` files in the folder are
 also expanded as per-page images.  (PDFs participate independently of
 the explicit converter rows - they are tied to the "image" output type
 rather than to a converter.)
+
+Archives
+--------
+The folder field accepts either a directory **or** a single archive file
+(``.zip`` / ``.tar`` / ``.rar`` …): an archive path is extracted and its
+contents loaded directly.  Additionally, when the ``dig_archives`` checkbox
+is enabled, any archives found *inside* the scanned directory are extracted
+and their media folded into the dataset.  Archive-derived media carry a
+``local_archive`` origin so they re-derive by re-extracting on demand (see
+:mod:`vtscore.datasets.archive`).
 """
 
 from __future__ import annotations
 
-import hashlib
-import io
 from pathlib import Path
 from typing import Any, Iterator
 
+from vtscore.datasets.archive import (
+    append_medias,
+    extract_archive_cached,
+    find_archives,
+    is_archive_path,
+    iter_archive_chunks,
+    load_archive_into,
+)
 from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
-from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+from vtscore.datasets.pdf import load_pdf_images_into
 
 
 def _coerce_recursive(field_values: dict[str, Any]) -> bool:
@@ -38,67 +54,12 @@ def _coerce_recursive(field_values: dict[str, Any]) -> bool:
     return str(val).lower() != "false"
 
 
-def _load_pdf_images(
-    folder: Path,
-    medias: dict[int, dict[str, Any]],
-    thin: bool = False,
-    recursive: bool = True,
-) -> None:
-    """Expand all PDFs in *folder* into per-page image medias.
-
-    Each page is rendered at 150 DPI and appended to *medias* with
-    sequential IDs continuing from the current maximum.  Pages leave
-    here with ``embedding=None``; the framework embed stage fills the
-    vectors in.  The ``origin`` is set to ``{"importer": "pdf",
-    "params": {"path": ...}}`` so provenance points back to the source
-    document.
-    """
-    pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
-    if not pdf_files:
-        return
-
-    from vtscore.datasets.pdf import render_pdf_pages  # noqa: PLC0415
-    from vtscore.media import get_by_folder_name  # noqa: PLC0415
-
-    mt = get_by_folder_name("image")
-    media_id = max(medias.keys(), default=0) + 1
-
-    for pdf_path in pdf_files:
-        origin = {"importer": "pdf", "params": {"path": str(pdf_path)}}
-        pages = render_pdf_pages(pdf_path)
-        pdf_rel = pdf_path.relative_to(folder).as_posix()
-
-        for page_name, pil_image in pages:
-            buf = io.BytesIO()
-            pil_image.save(buf, format="PNG")
-            image_bytes = buf.getvalue()
-
-            rel_dir = str(Path(pdf_rel).parent)
-            if rel_dir and rel_dir != ".":
-                full_page_name = f"{rel_dir}/{page_name}"
-            else:
-                full_page_name = page_name
-
-            media_data: dict[str, Any] = {
-                "id": media_id,
-                "media_type": mt.type_id,
-                "embedder": "",
-                "file_size": len(image_bytes),
-                "md5": hashlib.md5(image_bytes).hexdigest(),
-                "embedding": None,
-                "filename": full_page_name,
-                "category": "custom",
-                "origin": origin,
-                "origin_name": full_page_name,
-                "media_bytes": None if thin else image_bytes,
-                "media_string": None,
-                "media_path": str(pdf_path.resolve()),
-                "duration": 0,
-                "width": pil_image.width,
-                "height": pil_image.height,
-            }
-            medias[media_id] = media_data
-            media_id += 1
+def _coerce_dig_archives(field_values: dict[str, Any]) -> bool:
+    """Parse the ``dig_archives`` field value as a bool; default ``False``."""
+    val = field_values.get("dig_archives", False)
+    if isinstance(val, bool):
+        return val
+    return str(val).lower() == "true"
 
 
 def _run_converter_specs(
@@ -140,6 +101,11 @@ class ServerFolderDatasetImporter(DatasetImporter):
     which source types to scan for (and which converters to apply).  See
     :doc:`/docs/EXTENDING-media` for the full design.
 
+    The path may also point at a single **archive file** (``.zip`` / ``.tar``
+    / ``.rar`` …), in which case the archive is extracted and its contents
+    imported.  With ``dig_archives`` enabled, archives found inside the
+    scanned directory are extracted and folded in too.
+
     When the output media type is ``"image"``, any ``*.pdf`` files in the
     folder are also processed: each page is rendered as a separate image.
 
@@ -157,7 +123,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
 
     name = "server_folder"
     display_name = "Folder"
-    description = "Browse the server's filesystem and import media files from a directory"
+    description = "Browse the server's filesystem and import media files from a directory or archive"
     icon = "\U0001f4c1"  # 📁 - frontend renders as a folder icon
     picker_view = "server_folder"
     category = "server"
@@ -172,9 +138,12 @@ class ServerFolderDatasetImporter(DatasetImporter):
         ),
         ImporterField(
             key="path",
-            label="Folder",
+            label="Folder or archive",
             field_type="folder",
-            description="Absolute path to the directory containing media files.",
+            description=(
+                "Absolute path to a directory containing media files, or to a single "
+                "archive file (.zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar)."
+            ),
         ),
         ImporterField(
             key="recursive",
@@ -185,6 +154,18 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 "only files directly inside the chosen folder are imported."
             ),
             default="true",
+            required=False,
+        ),
+        ImporterField(
+            key="dig_archives",
+            label="Dig into archives",
+            field_type="checkbox",
+            description=(
+                "When enabled, archives (.zip, .tar, .rar …) found inside the chosen "
+                "folder are extracted and their media imported too.  Has no effect when "
+                "the path itself is an archive (that is always extracted)."
+            ),
+            default="false",
             required=False,
         ),
     ]
@@ -198,28 +179,41 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
-    def _load_direct(
+    def _resolve_output_type(self, field_values: dict[str, Any], specs: list[SourceSpec]) -> str:
+        """Resolve the output media type from the direct spec or ``media_type``."""
+        for spec in specs:
+            if spec.converter is None:
+                return spec.source_type
+        # Multi-media imports without a direct row still have an output type
+        # from ``media_type``; resolve it explicitly so PDF expansion and
+        # origin recording behave correctly.
+        from vtscore.media import get_by_folder_name  # noqa: PLC0415
+
+        return get_by_folder_name(field_values.get("media_type", "")).type_id
+
+    def _accumulate_direct(
         self,
         folder: Path,
         spec: SourceSpec,
-        field_values: dict[str, Any],
         medias: dict,
         thin: bool,
         recursive: bool,
     ) -> bool:
-        """Load files of ``spec.source_type`` directly into *medias*.
+        """Load files of ``spec.source_type`` and append them to *medias*.
 
-        Returns ``True`` if any files were found (i.e. the loader did not
-        raise ``ValueError`` for an empty folder), ``False`` otherwise.
+        Loads into a temporary dict (so the per-call ``medias.clear()`` of
+        :func:`load_dataset_from_folder` doesn't wipe earlier rows / archives)
+        and merges the result in.  Returns ``True`` if any files were found.
         """
         from vtscore.media import get  # noqa: PLC0415
 
         mt = get(spec.source_type)
+        temp: dict[int, dict[str, Any]] = {}
         try:
             load_dataset_from_folder(
                 folder,
                 mt.folder_import_name,
-                medias,
+                temp,
                 thin=thin,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
@@ -228,59 +222,69 @@ class ServerFolderDatasetImporter(DatasetImporter):
             )
         except ValueError:
             return False
+        append_medias(medias, temp)
         return True
 
-    def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:  # noqa: C901
-        folder = Path(field_values["path"])
+    def _load_archive(self, archive: Path, output_type: str, specs: list[SourceSpec], medias: dict, thin: bool) -> None:
+        load_archive_into(
+            archive,
+            output_type,
+            specs,
+            medias,
+            thin=thin,
+            content_vectors=self.content_vectors,
+            content_md5s=self.content_md5s,
+            custom_metadata_map=self.custom_metadata_map,
+        )
+
+    def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
+        path = Path(field_values["path"])
         recursive = _coerce_recursive(field_values)
-
+        dig_archives = _coerce_dig_archives(field_values)
         specs = self.effective_source_specs(field_values)
-        output_type = ""
-        for spec in specs:
-            if spec.converter is None:
-                output_type = spec.source_type
-                break
-        if not output_type:
-            # Multi-media imports without a direct row still have an
-            # output type from ``media_type``; resolve it explicitly so
-            # PDF expansion and origin recording behave correctly.
-            from vtscore.media import get_by_folder_name  # noqa: PLC0415
+        output_type = self._resolve_output_type(field_values, specs)
 
-            output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
+        # Single clear up front: every loader below appends from here.
+        medias.clear()
+
+        if is_archive_path(path):
+            self._load_archive(path, output_type, specs, medias, thin)
+            if not medias:
+                raise ValueError(f"No {output_type} files found in archive")
+            return
 
         has_direct_files = False
         for spec in specs:
             if spec.converter is None:
-                if self._load_direct(folder, spec, field_values, medias, thin, recursive):
+                if self._accumulate_direct(path, spec, medias, thin, recursive):
                     has_direct_files = True
 
         if output_type == "image":
-            _load_pdf_images(
-                folder,
-                medias,
-                thin=thin,
-                recursive=recursive,
-            )
+            load_pdf_images_into(path, medias, thin=thin, recursive=recursive)
 
         _run_converter_specs(
-            folder,
+            path,
             output_type,
             [s for s in specs if s.converter is not None],
             medias,
             thin=thin,
             recursive=recursive,
-            folder_path_for_origin=str(folder),
+            folder_path_for_origin=str(path),
         )
+
+        if dig_archives:
+            for archive in find_archives(path, recursive):
+                self._load_archive(archive, output_type, specs, medias, thin)
 
         if not has_direct_files and not medias:
             raise ValueError(f"No {output_type} files found in folder")
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
-        folder = Path(field_values["path"])
-        if not folder.exists():
-            raise FileNotFoundError(f"Folder not found: {folder}")
-        if not folder.is_dir():
-            raise NotADirectoryError(f"Not a directory: {folder}")
+        path = Path(field_values["path"])
+        if not path.exists():
+            raise FileNotFoundError(f"Path not found: {path}")
+        if not is_archive_path(path) and not path.is_dir():
+            raise NotADirectoryError(f"Not a directory or supported archive: {path}")
         self.run(field_values, medias, thin=thin)
 
     @property
@@ -293,29 +297,28 @@ class ServerFolderDatasetImporter(DatasetImporter):
         chunk_size: int,
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
-        folder = Path(field_values["path"])
+        path = Path(field_values["path"])
         recursive = _coerce_recursive(field_values)
+        dig_archives = _coerce_dig_archives(field_values)
 
         specs = self.effective_source_specs(field_values)
         direct_specs = [s for s in specs if s.converter is None]
         converter_specs = [s for s in specs if s.converter is not None]
+        output_type = self._resolve_output_type(field_values, specs)
 
-        output_type = direct_specs[0].source_type if direct_specs else ""
-        if not output_type:
-            from vtscore.media import get_by_folder_name  # noqa: PLC0415
+        if is_archive_path(path):
+            yield from self._chunk_archive(path, output_type, specs, chunk_size, thin)
+            return
 
-            output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
-
-        # Chunked load only fires for the direct row.  Converter rows
-        # produce a separate chunk afterwards (matching legacy
-        # behaviour).
+        # Chunked load only fires for the direct rows.  Converter rows produce
+        # a separate chunk afterwards (matching legacy behaviour).
         for spec in direct_specs:
             from vtscore.media import get  # noqa: PLC0415
 
             mt = get(spec.source_type)
             try:
                 yield from load_dataset_from_folder_chunked(
-                    folder,
+                    path,
                     mt.folder_import_name,
                     chunk_size,
                     thin=thin,
@@ -331,23 +334,46 @@ class ServerFolderDatasetImporter(DatasetImporter):
 
         if output_type == "image":
             chunk: dict[int, dict[str, Any]] = {}
-            _load_pdf_images(folder, chunk, thin=thin, recursive=recursive)
+            load_pdf_images_into(path, chunk, thin=thin, recursive=recursive)
             if chunk:
                 yield chunk
 
         if converter_specs:
             converter_chunk: dict[int, dict[str, Any]] = {}
             _run_converter_specs(
-                folder,
+                path,
                 output_type,
                 converter_specs,
                 converter_chunk,
                 thin=thin,
                 recursive=recursive,
-                folder_path_for_origin=str(folder),
+                folder_path_for_origin=str(path),
             )
             if converter_chunk:
                 yield converter_chunk
+
+        if dig_archives:
+            for archive in find_archives(path, recursive):
+                yield from self._chunk_archive(archive, output_type, specs, chunk_size, thin)
+
+    def _chunk_archive(
+        self,
+        archive: Path,
+        output_type: str,
+        specs: list[SourceSpec],
+        chunk_size: int,
+        thin: bool,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        yield from iter_archive_chunks(
+            archive,
+            output_type,
+            specs,
+            chunk_size,
+            thin=thin,
+            content_vectors=self.content_vectors,
+            content_md5s=self.content_md5s,
+            custom_metadata_map=self.custom_metadata_map,
+        )
 
     def run_chunked_cli(
         self,
@@ -355,11 +381,11 @@ class ServerFolderDatasetImporter(DatasetImporter):
         chunk_size: int,
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
-        folder = Path(field_values["path"])
-        if not folder.exists():
-            raise FileNotFoundError(f"Folder not found: {folder}")
-        if not folder.is_dir():
-            raise NotADirectoryError(f"Not a directory: {folder}")
+        path = Path(field_values["path"])
+        if not path.exists():
+            raise FileNotFoundError(f"Path not found: {path}")
+        if not is_archive_path(path) and not path.is_dir():
+            raise NotADirectoryError(f"Not a directory or supported archive: {path}")
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
     def build_cli_args(self, field_values: dict[str, Any]) -> str:
@@ -377,6 +403,11 @@ class ServerFolderDatasetImporter(DatasetImporter):
         path_str = (field_values.get("path") or "").strip()
         if path_str:
             leaf = Path(path_str).name
+            if leaf and is_archive_path(leaf):
+                # Strip the archive extension for a tidier dataset name.
+                for suffix in (".tar.gz", ".tar.bz2", ".tar.xz", ".tgz", ".tbz2", ".txz", ".tar", ".zip", ".rar"):
+                    if leaf.lower().endswith(suffix):
+                        return leaf[: -len(suffix)] or self.display_name
             if leaf:
                 return leaf
         return self.display_name
@@ -388,7 +419,10 @@ class ServerFolderDatasetImporter(DatasetImporter):
     def can_reload_from_origin(self, origin: dict[str, Any]) -> bool:
         params = origin.get("params", {})
         folder_path = params.get("path", "")
-        return bool(folder_path) and Path(folder_path).is_dir()
+        if not folder_path:
+            return False
+        p = Path(folder_path)
+        return p.is_dir() or (is_archive_path(p) and p.is_file())
 
     def resolve_file(
         self,
@@ -399,7 +433,14 @@ class ServerFolderDatasetImporter(DatasetImporter):
         folder = origin.get("params", {}).get("path", "")
         if not folder:
             return None
-        from vtscore.datasets.sources.local_folder import LocalFolderSource
+        if is_archive_path(folder):
+            # A server_folder dataset whose path is a single archive: resolve
+            # via the extracted (cached) directory.
+            from vtscore.datasets.sources.local_folder import LocalFolderSource  # noqa: PLC0415
+
+            extract_dir = extract_archive_cached(folder)
+            return LocalFolderSource(extract_dir).resolve_path(origin_name, filename).path
+        from vtscore.datasets.sources.local_folder import LocalFolderSource  # noqa: PLC0415
 
         source = LocalFolderSource(folder)
         return source.resolve_path(origin_name, filename).path

--- a/vtscore/datasets/pdf.py
+++ b/vtscore/datasets/pdf.py
@@ -2,12 +2,18 @@
 
 Converts each page of a PDF document into a PIL Image at a specified DPI.
 Requires the ``pymupdf`` package (``pip install pymupdf``).
+
+Also provides :func:`load_pdf_images_into`, the shared folder-scan helper that
+expands every PDF in a directory into per-page image medias (used by the
+``server_folder`` importer and the local-archive loader).
 """
 
 from __future__ import annotations
 
+import hashlib
+import io
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -44,3 +50,65 @@ def render_pdf_pages(pdf_path: Path, dpi: int = 150) -> list[tuple[str, "Image.I
         doc.close()
 
     return pages
+
+
+def load_pdf_images_into(
+    folder: Path,
+    medias: dict[int, dict[str, Any]],
+    thin: bool = False,
+    recursive: bool = True,
+) -> None:
+    """Expand all PDFs in *folder* into per-page image medias.
+
+    Each page is rendered at 150 DPI and appended to *medias* with sequential
+    IDs continuing from the current maximum.  Pages leave here with
+    ``embedding=None``; the framework embed stage fills the vectors in.  The
+    ``origin`` is set to ``{"importer": "pdf", "params": {"path": ...}}`` so
+    provenance points back to the source document.
+    """
+    from vtscore.media import get_by_folder_name  # noqa: PLC0415
+    from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks  # noqa: PLC0415
+
+    pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
+    if not pdf_files:
+        return
+
+    mt = get_by_folder_name("image")
+    media_id = max(medias.keys(), default=0) + 1
+
+    for pdf_path in pdf_files:
+        origin = {"importer": "pdf", "params": {"path": str(pdf_path)}}
+        pages = render_pdf_pages(pdf_path)
+        pdf_rel = pdf_path.relative_to(folder).as_posix()
+
+        for page_name, pil_image in pages:
+            buf = io.BytesIO()
+            pil_image.save(buf, format="PNG")
+            image_bytes = buf.getvalue()
+
+            rel_dir = str(Path(pdf_rel).parent)
+            if rel_dir and rel_dir != ".":
+                full_page_name = f"{rel_dir}/{page_name}"
+            else:
+                full_page_name = page_name
+
+            media_data: dict[str, Any] = {
+                "id": media_id,
+                "media_type": mt.type_id,
+                "embedder": "",
+                "file_size": len(image_bytes),
+                "md5": hashlib.md5(image_bytes).hexdigest(),
+                "embedding": None,
+                "filename": full_page_name,
+                "category": "custom",
+                "origin": origin,
+                "origin_name": full_page_name,
+                "media_bytes": None if thin else image_bytes,
+                "media_string": None,
+                "media_path": str(pdf_path.resolve()),
+                "duration": 0,
+                "width": pil_image.width,
+                "height": pil_image.height,
+            }
+            medias[media_id] = media_data
+            media_id += 1

--- a/vtscore/datasets/sources/http_archive.py
+++ b/vtscore/datasets/sources/http_archive.py
@@ -68,8 +68,8 @@ class HttpArchiveSource(MediaSource):
             self._inner = LocalFolderSource(cached_dir)
             return self._inner
 
+        from vtscore.datasets.archive import extract_archive
         from vtscore.datasets.downloader import download_file_with_progress
-        from vtscore.datasets.importers.http_archive import _extract_archive
         from vtscore.security.url_validation import validate_url
 
         validate_url(self._url)
@@ -86,7 +86,7 @@ class HttpArchiveSource(MediaSource):
             log.info("Downloading %s for media source...", self._url)
             download_file_with_progress(self._url, archive_path)
             extract_dir.mkdir(exist_ok=True)
-            _extract_archive(archive_path, extract_dir)
+            extract_archive(archive_path, extract_dir)
         finally:
             archive_path.unlink(missing_ok=True)
 

--- a/vtscore/datasets/sources/local_archive.py
+++ b/vtscore/datasets/sources/local_archive.py
@@ -1,0 +1,85 @@
+"""Local-archive media source – access media files inside an archive on disk.
+
+Extracts the archive on first access (to a cached directory under
+:data:`~vtscore.config.DATA_DIR`) and delegates all file operations to a
+:class:`~vtscore.datasets.sources.local_folder.LocalFolderSource` over the
+extracted contents.  This is the resolver counterpart of the ``local_archive``
+origin emitted by :mod:`vtscore.datasets.archive`, so media imported from a
+zip/tar re-derive their files on demand without ever persisting the extracted
+bytes in the dataset.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator
+
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
+
+if TYPE_CHECKING:
+    from vtscore.datasets.sources.local_folder import LocalFolderSource
+
+__all__ = ["LocalArchiveSource"]
+
+
+class LocalArchiveSource(MediaSource):
+    """A media source backed by a local archive file (.zip, .tar.gz, etc.).
+
+    The archive is extracted lazily on first access to :meth:`list_items`,
+    :meth:`fetch_item`, or :meth:`resolve_path`.  Extraction is cached, so
+    repeated resolves of the same archive reuse one directory.
+
+    Args:
+        archive_path: Absolute path to the archive file on the server.
+    """
+
+    name = "local_archive"
+
+    def __init__(self, archive_path: str | Path) -> None:
+        self._archive_path = Path(archive_path)
+        self._inner: LocalFolderSource | None = None
+
+    @property
+    def archive_path(self) -> Path:
+        return self._archive_path
+
+    def _ensure_extracted(self) -> LocalFolderSource:
+        if self._inner is not None:
+            return self._inner
+
+        from vtscore.datasets.archive import extract_archive_cached  # noqa: PLC0415
+        from vtscore.datasets.sources.local_folder import LocalFolderSource  # noqa: PLC0415
+
+        extract_dir = extract_archive_cached(self._archive_path)
+        self._inner = LocalFolderSource(extract_dir)
+        return self._inner
+
+    def list_items(self, extensions: list[str] | None = None) -> Iterator[MediaItem]:
+        inner = self._ensure_extracted()
+        for item in inner.list_items(extensions):
+            yield MediaItem(key=item.key, filename=item.filename, source_name=self.name)
+
+    def fetch_item(self, key: str) -> FetchedItem:
+        return self._ensure_extracted().fetch_item(key)
+
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
+        return self._ensure_extracted().resolve_path(origin_name, filename)
+
+
+class _LocalArchiveSourceFactory:
+    """Factory for auto-discovery by :class:`~vtscore.plugins.PluginRegistry`.
+
+    Resolves the ``local_archive`` origins emitted by
+    :mod:`vtscore.datasets.archive` (used by the ``server_folder`` and
+    ``http_archive`` importers when loading from a local archive).
+    """
+
+    name = "local_archive"
+
+    def create_from_origin(self, origin: dict) -> LocalArchiveSource | None:
+        params = origin.get("params", {})
+        path = params.get("path", "")
+        return LocalArchiveSource(path) if path else None
+
+
+SOURCE = _LocalArchiveSourceFactory()


### PR DESCRIPTION
## What & why

There was no way to import a local archive of media. The **Folder** importer
(`server_folder`) silently skipped any `.zip`/`.tar` inside a scanned
directory, and the **URL** importer (`http_archive`) only accepted
`http(s)://` URLs despite its "Path or URL" label. This adds local-archive
support to both, per the discussion in the issue.

## What landed

- **Folder importer (`server_folder`)**
  - The folder path may now point directly at a **single archive file** — it's
    extracted and its contents imported.
  - New opt-in **"Dig into archives"** checkbox: archives found *inside* the
    scanned folder are extracted and folded into the dataset. Off by default,
    so existing folder imports are unchanged.
- **URL importer (`http_archive`)** now accepts a **local server path** to an
  archive in addition to an `http(s)://` URL (CLI + reload-from-origin).
- **`vtscore/datasets/archive.py`** (new) centralizes archive handling:
  `extract_archive` (moved from the http_archive importer, keeping its
  path-traversal guards), `extract_archive_cached` (cached under `DATA_DIR`,
  keyed by path+size+mtime), `is_archive_path`, `find_archives`, and the shared
  `iter_archive_chunks` / `load_archive_into`.
- **`local_archive` origin + `LocalArchiveSource`** (new, auto-discovered):
  archive-derived media persist only the archive path and re-derive
  `origin → archive → extracted file → embedding` on demand — honoring the
  no-persisted-artifacts rule. Converter media re-derive via
  `parent_importer`/`parent_path`; PDF pages via the resolver's generic path
  fallback.
- The PDF page-expansion helper moved to `vtscore/datasets/pdf.py`
  (`load_pdf_images_into`), shared by the folder importer and archive loader.
- Frontend: "Dig into archives" checkbox in the server-folder view (the typed
  folder-path input already accepts an archive path).
- Docs: `docs/CLI.md`, `docs/ARCHITECTURE.md`, and a new
  `docs/plans/dataset-import-archives.md` (with open follow-ups).

## Testing

- `./run-tests.sh io` → all 748 pass (ruff / ruff format / codespell / deptry /
  pip-audit / pyright / OpenAPI snapshot all green).
- Full fast Python suite (`pytest -m 'not gpu and not slow'`) → **4819 passed,
  1 skipped**.
- `npm run build:prod` → clean (no errors/warnings/budget issues).
- New tests cover archive helpers, `extract_archive_cached` caching/busting,
  `LocalArchiveSource` resolution + factory discovery, single-archive import,
  `dig_archives` on/off, and the http_archive local-path path.

### Notes / out of scope
- `npm audit --omit=dev` reports pre-existing Angular **production-dependency**
  advisories that block the `run-tests.sh` frontend gate. No dependency files
  were changed in this PR (identical on `dev`); fixing them needs a breaking
  Angular major upgrade. The frontend build itself is clean.
- Media-type auto-detection on an archive path and PDF-in-archive provenance
  are documented as follow-ups in the plan file.

https://claude.ai/code/session_01LSEW2CbNWFb7XJQF4FHjZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSEW2CbNWFb7XJQF4FHjZE)_