### PR TITLE
Keep marquee resize handles a constant screen size when zoomed

### DIFF
--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -24,6 +24,7 @@
       [style.width.px]="renderedW"
       [style.height.px]="renderedH"
       [style.transform]="'translate(-50%, -50%) ' + imageTransform"
+      [style.--region-zoom]="zoom"
     >
       <div
         class="region-box"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -92,6 +92,12 @@
   border: 1px solid rgba(0, 0, 0, 0.6);
   box-sizing: border-box;
   pointer-events: auto;
+  // The .region-stage carries the image's scale(zoom), so without a counter-scale
+  // the handles would grow with the zoom factor. Cancel it with scale(1 / zoom) so
+  // the handles stay a constant on-screen size (~10px) at any zoom. Each handle is
+  // already centred on its anchor (corner/edge midpoint) via the -5px offsets, so
+  // scaling about its own centre (the default origin) keeps it pinned in place.
+  transform: scale(calc(1 / var(--region-zoom, 1)));
 }
 
 .region-handle-n,


### PR DESCRIPTION
## Summary

In the Train interface image canvas, the region-annotation (marquee) resize handles grew along with the zoom level, making them awkward when drawing tiny boxes or when zoomed in (large box, x-large handles getting in the way).

The handles live inside `.region-stage`, which carries the image's `scale(zoom)` transform, so the fixed `10px` handles were being multiplied by the zoom factor. This change counter-scales each handle by `1 / zoom` (via a `--region-zoom` CSS custom property bound from the component), so the handles stay ~10px on screen at any zoom level while the box itself continues to track the image.

Each handle is already centered on its anchor (corner / edge midpoint) via the `-5px` offsets, so scaling about the handle's own center (the default transform origin) keeps it pinned in place.

## Changes
- `image-viewer.component.html`: bind `--region-zoom` to the current `zoom` on `.region-stage`.
- `image-viewer.component.scss`: apply `transform: scale(calc(1 / var(--region-zoom, 1)))` to `.region-handle`.

## Testing
- `npm run build:prod` — clean, no TS errors or budget warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hug9Lse1tz6dZ5hhvxfvQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hug9Lse1tz6dZ5hhvxfvQf)_