### PR TITLE
Add focus-pane "Highlight" toggle for the best-match region

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -442,6 +442,24 @@ Closeout, struck through:
 **Deferred (out of scope for v2):** touch support (no Shift modifier); multiple
 regions per vote; region votes on non-image media types.
 
+## Focus-pane best-match Highlight toggle - DONE
+
+Extends the v1 gallery-card `best_region` outline into the center/focus viewer.
+A **Highlight** toggle sits next to the Marquee button in the image-view controls
+(image media only) and is **hidden unless the active dataset's embedder reports
+`supports_patch_regions`**. When on, the focused image overlays a yellow **dashed**
+box (distinct from the solid yellow voting box) around the region the detector
+matched best at inference.
+
+No new bookkeeping: reuses the `best_region` the backend already returns on every
+sort/train result and which the frontend already keeps in
+`SortStateService.sortOrder[*].bestRegion` (in-memory, kept exactly as long as the
+score). `CenterPanelComponent` looks the box up by media id and passes it to
+`ImageViewerComponent` as `highlightBox`; the viewer owns the `highlightMode`
+toggle and renders the box in its own `.region-stage` so it tracks pan/zoom/rotate.
+Read-only (`pointer-events: none`), and the near-full `(0,0,1,1)` single-vector
+fallback box is suppressed (same rule as the gallery outline). Frontend-only.
+
 ## V3 - design
 
 V3 lets a dataset bind **up to one text-capable embedder + up to one

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -11,6 +11,7 @@
           <vt-image-viewer
             [media]="media"
             [pendingBadConfirm]="pendingBadConfirm"
+            [highlightBox]="highlightBox"
             (regionBoxChange)="onRegionBoxChange($event)"
             (armedConfirmCanceled)="onArmedConfirmCanceled()"
           ></vt-image-viewer>
@@ -42,6 +43,18 @@
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3 2.5" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5"/></svg>
         </button>
+        @if (patchCapable) {
+          <button
+            class="ivc-btn ivc-btn-toggle"
+            [class.active]="imageViewer.highlightMode"
+            (click)="imageViewer.toggleHighlightMode()"
+            title="Highlight: outline the region the detector matched best"
+            aria-label="Highlight: outline best-matched region"
+            [attr.aria-pressed]="imageViewer.highlightMode"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5" stroke-dasharray="3 2.5"/><circle cx="12" cy="12" r="2.5" fill="currentColor" stroke="none"/></svg>
+          </button>
+        }
         <span class="ivc-sep" aria-hidden="true"></span>
         <button class="ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
         <button class="ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,11 +1,13 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
-import { Media } from '../../models/api.models';
+import { EmbedderInfo, Media } from '../../models/api.models';
 import { MediasApiService } from '../../services/medias-api.service';
 import { KeyboardService } from '../../services/keyboard.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { SortStateService } from '../../services/sort-state.service';
+import { DatasetsListingsApiService } from '../../services/datasets-listings-api.service';
 import { AudioPlayerComponent } from './audio-player/audio-player.component';
 import { ImageViewerComponent, RegionBox } from './image-viewer/image-viewer.component';
 import { VideoPlayerComponent } from './video-player/video-player.component';
@@ -65,6 +67,11 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   currentRegionBox: RegionBox | null = null;
   pendingBadConfirm = false;
 
+  /** Embedder capability listings, loaded once in init(). Used to decide
+   *  whether the active dataset's embedder is patch-region-aware, which gates
+   *  the Highlight toggle in the image-view controls. */
+  private embedderInfos: EmbedderInfo[] = [];
+
   private spinTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _pausedByVisibility = false;
@@ -75,6 +82,8 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     private keyboard: KeyboardService,
     public voteState: VoteStateService,
     private settingsState: SettingsStateService,
+    private sortState: SortStateService,
+    private datasetsListingsApi: DatasetsListingsApiService,
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -117,6 +126,11 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   init(): void {
     this.loadSettings();
     this.keyboard.start();
+    this.subs.push(
+      this.datasetsListingsApi.getEmbedders().subscribe({
+        next: (embedders) => (this.embedderInfos = embedders),
+      }),
+    );
     document.addEventListener('visibilitychange', this.onVisibilityChange);
     this.subs.push(
       this.keyboard.action$.subscribe((action) => {
@@ -181,6 +195,30 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   get mediaType(): string {
     return this.media?.media_type || 'audio';
+  }
+
+  /** Whether the active dataset's embedder produces patch regions. Gates the
+   *  Highlight toggle: only patch-region-aware embedders (DINOv2/v3, EUPE) emit
+   *  a best-match region, so the button is hidden entirely otherwise. Defaults
+   *  to false when the embedder is unknown (embedders not yet loaded, or the
+   *  media carries no embedder field) so a dead toggle never appears. */
+  get patchCapable(): boolean {
+    const name = this.media?.embedder;
+    if (!name || this.embedderInfos.length === 0) return false;
+    const info = this.embedderInfos.find((e) => e.name === name);
+    return info?.supports_patch_regions === true;
+  }
+
+  /** The focused media's best-match region (the argmax patch region from the
+   *  most recent sort/train), looked up by id from the in-memory sort results.
+   *  ``null`` when the media wasn't scored or carries no region. Passed to the
+   *  image viewer, which draws it only while Highlight is toggled on. */
+  get highlightBox(): RegionBox | null {
+    if (!this.media) return null;
+    const id = this.media.id;
+    const box = this.sortState.sortOrder?.find((s) => s.id === id)?.bestRegion;
+    if (!box || box.length !== 4) return null;
+    return [box[0], box[1], box[2], box[3]];
   }
 
   get isGood(): boolean {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -18,6 +18,21 @@
     draggable="false"
     fetchpriority="high"
   />
+  @if (highlightVisible && renderedW > 0 && renderedH > 0) {
+    <div
+      class="region-stage"
+      [style.width.px]="renderedW"
+      [style.height.px]="renderedH"
+      [style.transform]="'translate(-50%, -50%) ' + imageTransform"
+    >
+      <div
+        class="highlight-box"
+        [ngStyle]="highlightBoxStyle!"
+        aria-hidden="true"
+        title="Region the detector matched best"
+      ></div>
+    </div>
+  }
   @if (regionBox && renderedW > 0 && renderedH > 0) {
     <div
       class="region-stage"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -70,6 +70,20 @@
   }
 }
 
+// Read-only overlay marking the region the detector matched best at inference.
+// Dashed (vs the voting box's solid stroke) so the two are never confused, and
+// pointer-events: none so it never intercepts a pan/draw on the image beneath.
+.highlight-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1.5px dashed rgba(255, 224, 102, 0.95);
+  background: rgba(255, 224, 102, 0.06);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.45) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
 @keyframes region-box-shake {
   0%, 100% { transform: translateX(0); border-color: rgba(255, 224, 102, 0.95); }
   15% { transform: translateX(-3px); border-color: rgba(255, 110, 110, 0.95); }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -422,6 +422,55 @@ describe('ImageViewerComponent', () => {
     });
   });
 
+  describe('best-match highlight overlay', () => {
+    it('starts off and flips on toggle', () => {
+      expect(component.highlightMode).toBeFalse();
+      component.toggleHighlightMode();
+      expect(component.highlightMode).toBeTrue();
+      component.toggleHighlightMode();
+      expect(component.highlightMode).toBeFalse();
+    });
+
+    it('is not visible until both the toggle is on and a box is present', () => {
+      expect(component.highlightVisible).toBeFalse();
+      component.highlightMode = true;
+      expect(component.highlightVisible).toBeFalse(); // no box yet
+      component.highlightBox = [0.1, 0.2, 0.6, 0.7];
+      expect(component.highlightVisible).toBeTrue();
+    });
+
+    it('positions the box as percent-of-stage', () => {
+      component.highlightBox = [0.1, 0.2, 0.6, 0.8];
+      expect(component.highlightBoxStyle).toEqual({
+        left: '10.000%',
+        top: '20.000%',
+        width: '50.000%',
+        height: '60.000%',
+      });
+    });
+
+    it('rejects malformed, degenerate, and near-full-image boxes', () => {
+      component.highlightBox = null;
+      expect(component.highlightBoxStyle).toBeNull();
+      component.highlightBox = [0.5, 0.5, 0.4, 0.6]; // x1 < x0 -> zero/negative width
+      expect(component.highlightBoxStyle).toBeNull();
+      component.highlightBox = [0, 0, 1, 1]; // whole-image fallback
+      expect(component.highlightBoxStyle).toBeNull();
+      component.highlightBox = [0, 0, NaN, 0.5];
+      expect(component.highlightBoxStyle).toBeNull();
+    });
+
+    it('persists the toggle across media changes', () => {
+      component.highlightMode = true;
+      const next: Media = { ...mockMedia, id: 77, filename: 'c.png' };
+      component.media = next;
+      component.ngOnChanges({
+        media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
+      });
+      expect(component.highlightMode).toBeTrue();
+    });
+  });
+
   describe('armed-confirm cancel routing', () => {
     it('emits armedConfirmCanceled instead of clearing the box when Esc is pressed while armed', () => {
       component.regionBox = [0.1, 0.2, 0.5, 0.6];

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -39,6 +39,15 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    * mouse-on-box back to the parent via `armedConfirmCanceled` instead of clearing the box.
    */
   @Input() pendingBadConfirm = false;
+  /**
+   * The region the detector/embedder matched best at inference, as a normalised
+   * ``[x0, y0, x1, y1]`` box (the argmax over patch regions that produced this
+   * media's score).  ``null`` when the active dataset isn't patch-region-aware
+   * or the focused media hasn't been scored.  Rendered as a yellow dashed
+   * overlay only while the Highlight toggle (``highlightMode``) is on; purely
+   * informational, never interactive (no drag/resize, no vote semantics).
+   */
+  @Input() highlightBox: RegionBox | null = null;
   @Output() regionBoxChange = new EventEmitter<RegionBox | null>();
   /**
    * Fired when the user does something that cancels the armed bad-vote-confirm without
@@ -72,6 +81,12 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   // new region instead of panning. Shift+drag remains a power-user shortcut even when
   // the toggle is off; toggling the button just turns the gesture on without a modifier.
   marqueeMode = false;
+  // Sticky toggle exposed by the Highlight button in .image-view-controls. While
+  // true the viewer overlays a yellow dashed box (`highlightBox`) around the
+  // region the detector matched best at inference. Independent of marqueeMode -
+  // both can be on at once (the highlight is read-only and sits behind the
+  // interactive voting box).
+  highlightMode = false;
   renderedW = 0;
   renderedH = 0;
 
@@ -185,6 +200,36 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   toggleMarqueeMode(): void {
     this.marqueeMode = !this.marqueeMode;
+  }
+
+  toggleHighlightMode(): void {
+    this.highlightMode = !this.highlightMode;
+  }
+
+  /** True when the best-match highlight box should be drawn over the image. */
+  get highlightVisible(): boolean {
+    return this.highlightMode && this.highlightBoxStyle !== null;
+  }
+
+  /** Percent-position style for the best-match highlight overlay.  Returns null
+   *  when the box is missing, malformed, degenerate, or covers (effectively) the
+   *  whole image - mirrors the gallery thumbnail's `bestRegionStyle` so the
+   *  near-full single-vector fallback box never paints a frame round everything. */
+  get highlightBoxStyle(): { [k: string]: string } | null {
+    const box = this.highlightBox;
+    if (!box || box.length !== 4) return null;
+    const [x0, y0, x1, y1] = box;
+    if (![x0, y0, x1, y1].every((v) => Number.isFinite(v))) return null;
+    const w = x1 - x0;
+    const h = y1 - y0;
+    if (w <= 0 || h <= 0) return null;
+    if (w >= 0.99 && h >= 0.99) return null;
+    return {
+      left: pct(x0),
+      top: pct(y0),
+      width: pct(w),
+      height: pct(h),
+    };
   }
 
   onMouseDown(event: MouseEvent): void {


### PR DESCRIPTION
## What

Adds a **Highlight** toggle to the center/focus image viewer, next to the Marquee button. When on, the currently viewed image overlays a yellow **dashed** box around the region the detector matched best at inference (the argmax over patch regions that produced this media's score).

The button is **hidden unless the active dataset's embedder is patch-region-aware** (`supports_patch_regions` — DINOv2/v3, EUPE), so it never appears as a dead control on non-patch datasets.

## How

No new bookkeeping was needed — the requested "keep the max-score region alongside the score" already exists end-to-end:

- The backend's `_score_all_media` already records the argmax region index and ships it as `best_region` on every sort/train result.
- The frontend already keeps it in memory next to each score in `SortStateService.sortOrder[*].bestRegion` (in-memory only, kept exactly as long as the score), and the gallery thumbnails already draw a faint outline.

So this change reuses that existing data:

- `ImageViewerComponent` gains a `highlightBox` input, a `highlightMode` toggle, and a validated `highlightBoxStyle` getter. The box renders in its own `.region-stage` so it tracks pan/zoom/rotate, is `pointer-events: none` (read-only, no vote semantics), and uses a dashed stroke to stay distinct from the solid voting box. The near-full `(0,0,1,1)` single-vector fallback box is suppressed (same rule as the gallery outline).
- `CenterPanelComponent` looks up the focused media's `bestRegion` by id and passes it down, and gates the new button on the active embedder's `supports_patch_regions` (mirrors the existing `supports_text` capability pattern in the left panel).

Frontend-only; backend untouched.

## Tests

- New `image-viewer.component.spec.ts` cases cover the toggle, visibility gating, percent positioning, and rejection of malformed/degenerate/near-full boxes. Specs typecheck (`tsc -p tsconfig.spec.json`).
- `./run-tests.sh core` passes ruff / format / codespell / deptry and the frontend production build ("Frontend build OK"). The suite then stops at the pre-existing `npm audit` block (Angular 19 CVEs needing a breaking 19→21 upgrade, already separately scoped) — unrelated to this change and present on `dev`.

## Docs

`docs/plans/patch-embedder.md` records the shipped focus-pane Highlight toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffVsKFX8w29K88h71voTL)_