### PR TITLE
Fix file browser dropping leading slash at filesystem root

### DIFF
--- a/tests/api/test_file_browser.py
+++ b/tests/api/test_file_browser.py
@@ -462,6 +462,41 @@ class TestMultiUserBrowseIsolation:
         assert "file.csv" in file_names
 
 
+class TestFilesystemRootPaths:
+    """When the browse root is the filesystem root (single-user / no-auth
+    mode), returned paths must keep their leading ``/`` so the picked path is
+    a usable absolute path. ``relative_to('/')`` would otherwise strip the
+    slash and the downstream importer would resolve it against the CWD."""
+
+    def test_paths_are_absolute_at_filesystem_root(self, client):
+        """Listing ``/`` returns entry paths with a leading slash."""
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=Path("/")):
+            resp = client.get("/api/browse")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        entries = data["directories"] + data["files"]
+        assert entries, "expected at least one entry at filesystem root"
+        for e in entries:
+            assert e["path"].startswith("/"), e
+            assert e["path"] == "/" + e["name"]
+
+    def test_subdir_path_and_current_path_absolute(self, client):
+        """Navigating into a real subdir of ``/`` keeps absolute paths."""
+        # /usr exists on Linux CI; skip gracefully if not.
+        if not Path("/usr").is_dir():
+            pytest.skip("/usr not present")
+
+        with patch("vtsearch.routes.file_browser._get_browse_root", return_value=Path("/")):
+            resp = client.get("/api/browse?path=/usr")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["current_path"] == "/usr"
+        for e in data["directories"] + data["files"]:
+            assert e["path"].startswith("/usr/"), e
+
+
 class TestMultiUserServerMediaFiles:
     """Verify that server media file endpoints are per-user in multi-user mode."""
 

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -51,6 +51,26 @@ def _get_browse_root() -> Path:
     return base
 
 
+def _display_path(entry: Path, root: Path) -> str:
+    """Return the path to expose for *entry* under *root*.
+
+    Confinement always uses ``relative_to(root)``; the *displayed* form
+    keeps the leading slash when the browse root is the filesystem root
+    (single-user / no-auth mode) so the path the user picks is a usable
+    absolute path. Otherwise the bare relative form (e.g.
+    ``exp/mlucio/walkingtour.txt``) is handed to the importer/exporter,
+    whose path validation resolves relative paths against the process CWD;
+    the leading ``/`` would be silently dropped and the wrong file opened.
+
+    For a confined per-user root we keep the relative form so the server's
+    absolute filesystem layout never leaks into responses.
+    """
+    rel = str(entry.relative_to(root))
+    if root == Path(root.anchor):  # filesystem root, e.g. "/"
+        return "/" + rel if rel != "." else ""
+    return rel
+
+
 @file_browser_bp.route("/api/browse")
 @file_browser_bp.arguments(BrowseQuerySchema, location="query")
 @file_browser_bp.response(200, BrowseResponseSchema)
@@ -112,7 +132,7 @@ def browse(query: dict):  # noqa: C901
                 entry.resolve(strict=True).relative_to(root)
             except (OSError, ValueError):
                 continue
-        rel = str(entry.relative_to(root))
+        rel = _display_path(entry, root)
         if entry.is_dir():
             directories.append({"name": entry.name, "path": rel, "modified_at": format_mtime(entry)})
         elif entry.is_file():
@@ -124,7 +144,7 @@ def browse(query: dict):  # noqa: C901
                 size = 0
             files.append({"name": entry.name, "path": rel, "size_bytes": size, "modified_at": format_mtime(entry)})
 
-    current_path = str(target.relative_to(root)) if target != root else ""
+    current_path = _display_path(target, root) if target != root else ""
 
     return {
         "directories": directories,


### PR DESCRIPTION
## Problem

When browsing server file paths in single-user / no-auth mode, the picker dropped the leading `/`: selecting `/exp/mlucio/manifests/walkingtour.txt` came back as `exp/mlucio/manifests/walkingtour.txt`.

## Cause

In single-user mode `_get_browse_root()` returns the filesystem root `/`. The `/api/browse` handler computed each entry's path with `entry.relative_to(root)`, and `relative_to('/')` strips the leading slash. That bare relative path was then handed to the importer/exporter, whose `validate_server_filepath()` resolves relative paths against the **process CWD** — so the wrong file would be opened.

## Fix

Return absolute paths **only** when the browse root is the filesystem root (the unrestricted single-user case, where there's nothing to hide). Confined per-user roots in multi-user mode keep relative paths so the server's absolute filesystem layout never leaks into responses. Both entry paths and `current_path` now go through a small `_display_path()` helper.

## Tests

Added `TestFilesystemRootPaths` covering the `/`-root case (entry paths and `current_path` keep their leading slash); all 27 tests in `tests/api/test_file_browser.py` pass. Existing multi-user isolation / no-leak tests are unaffected since they use a non-anchor tmp root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVofDaKvwKCTUaCCYEkKTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVofDaKvwKCTUaCCYEkKTY)_