### PR TITLE
Crop Good-pile thumbnails to the voted region

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4827,6 +4827,15 @@
             },
             "type": "array"
           },
+          "good_region_boxes": {
+            "additionalProperties": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
           "labelset_bad_count": {
             "type": "integer"
           },
@@ -4850,6 +4859,7 @@
           "bad",
           "click_times",
           "good",
+          "good_region_boxes",
           "labelset_bad_count",
           "labelset_good_count",
           "learned_scores",
@@ -5157,6 +5167,13 @@
           },
           "origin_name": {
             "type": "string"
+          },
+          "region_box": {
+            "items": {
+              "type": "number"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "score": {
             "type": "number"
@@ -12586,7 +12603,7 @@
     },
     "/api/medias/{media_id}/thumbnail": {
       "get": {
-        "description": "Grid and list tiles use this instead of ``/image`` so a gallery of many\nhigh-resolution items doesn't force the browser to decode every full-size\nbitmap at once.  The thumbnail is bounded to a fixed longest-side length\n(see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the\nsame regardless of zoom level, so an ``ETag`` lets the browser reuse it\nacross scrolls and zoom changes.\n\nWhen the media carries a precomputed ``thumbnail_bytes`` (generated at\ningest for image/audio/video), the bytes are streamed directly with no\nrequest-time decode/resize -- the path that keeps a fresh browse-canvas\nzoom responsive.  Media without one (old pickles, thin loads, undecodable\nSVGs) fall back to generating the thumbnail from the display image.",
+        "description": "Grid and list tiles use this instead of ``/image`` so a gallery of many\nhigh-resolution items doesn't force the browser to decode every full-size\nbitmap at once.  The thumbnail is bounded to a fixed longest-side length\n(see :data:`vtscore.media.image.thumbnail.DEFAULT_MAX_DIM`) and is the\nsame regardless of zoom level, so an ``ETag`` lets the browser reuse it\nacross scrolls and zoom changes.\n\nWhen the media carries a precomputed ``thumbnail_bytes`` (generated at\ningest for image/audio/video), the bytes are streamed directly with no\nrequest-time decode/resize -- the path that keeps a fresh browse-canvas\nzoom responsive.  Media without one (old pickles, thin loads, undecodable\nSVGs) fall back to generating the thumbnail from the display image.\n\nAn optional ``region=x0,y0,x1,y1`` query (normalised fractions in\n``[0, 1]``) crops the thumbnail to a sub-region of the image -- used so the\nGood pile shows a region-voted item's crop rather than the whole frame.\nA region request always regenerates from the display image (the\nprecomputed full-frame thumbnail can't be cropped after the fact).",
         "operationId": "media_thumbnail",
         "responses": {
           "400": {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -39,6 +39,12 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   @Input() medias: Media[] = [];
   @Input() clickTimes: Record<string, number> = {};
   @Input() learnedScores: Record<string, number> = {};
+  /**
+   * Normalised [x0, y0, x1, y1] region boxes keyed by media id. When an id has
+   * a box (a region vote drawn on an image), its thumbnail is cropped to that
+   * region rather than showing the whole frame.
+   */
+  @Input() regionBoxes: Record<string, number[]> = {};
   @Input() sortMode: LabelSortMode = 'time-desc';
   @Input() viewMode: 'grid' | 'list' = 'grid';
   @Input() gridGoalWidth: number = 80;
@@ -170,7 +176,16 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     // Downscaled tile, not the full-resolution ``/image``: the labeled set can
     // hold hundreds of items, and decoding every full-size bitmap at once
     // exhausts browser memory.
-    return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
+    let url = this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
+    // A region-voted item shows a thumbnail of just the voted crop. The box
+    // coordinates ride in the query string so a re-vote with a different box
+    // is a distinct URL (and cache entry) rather than a stale tile.
+    const box = this.regionBoxes[String(id)];
+    if (box && box.length === 4) {
+      const sep = url.includes('?') ? '&' : '?';
+      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
+    }
+    return url;
   }
 
   onThumbnailError(url: string): void {

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -117,7 +117,16 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
 
   thumbnailUrl(entry: DetectorLabelView): string {
     if (!this.modelName) return '';
-    return this.detectorsCrudApi.labelThumbnailUrl(this.modelName, entry.id);
+    let url = this.detectorsCrudApi.labelThumbnailUrl(this.modelName, entry.id);
+    // The route crops to the element's stored region box server-side; fold the
+    // box into the URL so a re-vote with a different box busts the cached tile
+    // (the box coords aren't otherwise part of the URL).
+    const box = entry.region_box;
+    if (box && box.length === 4) {
+      const sep = url.includes('?') ? '&' : '?';
+      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
+    }
+    return url;
   }
 
   onThumbnailError(url: string): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -60,6 +60,7 @@
       [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
+      [regionBoxes]="goodRegionBoxes"
       [sortMode]="sortMode"
       [viewMode]="viewMode"
       [gridGoalWidth]="gridGoalWidth"

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -74,6 +74,9 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   verifiedIds: Set<number> = new Set();
   clickTimes: Record<string, number> = {};
   learnedScores: Record<string, number> = {};
+  /** Normalised region boxes for good votes, keyed by media id; drives cropped
+   *  Good-pile thumbnails when an item was region-voted. */
+  goodRegionBoxes: Record<string, number[]> = {};
   goodElements: DetectorLabelView[] = [];
   badElements: DetectorLabelView[] = [];
   sortMode: LabelSortMode = 'time-desc';
@@ -289,6 +292,11 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((scores) => {
         this.learnedScores = scores;
+      });
+    this.voteState.goodRegionBoxes$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((boxes) => {
+        this.goodRegionBoxes = boxes;
       });
   }
 

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -41,6 +41,10 @@ export interface VotesResponse {
   learned_scores: Record<string, number>;
   labelset_good_count?: number;
   labelset_bad_count?: number;
+  /** Normalised [x0, y0, x1, y1] region boxes for good votes cast by drawing
+   *  a box on an image, keyed by media id. Lets the Good pile request a
+   *  cropped thumbnail of just the voted region. Empty when no region votes. */
+  good_region_boxes?: Record<string, number[]>;
 }
 
 // --- Progress ---

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -36,6 +36,7 @@ export class VoteStateService implements OnDestroy {
   private readonly learnedScoresSubject = new BehaviorSubject<Record<string, number>>({});
   private readonly labelsetGoodCountSubject = new BehaviorSubject<number>(0);
   private readonly labelsetBadCountSubject = new BehaviorSubject<number>(0);
+  private readonly goodRegionBoxesSubject = new BehaviorSubject<Record<string, number[]>>({});
   private readonly destroy$ = new Subject<void>();
   private readonly stopPolling$ = new Subject<void>();
   private polling = false;
@@ -67,6 +68,16 @@ export class VoteStateService implements OnDestroy {
    */
   private pendingVerified = new Map<number, boolean>();
 
+  /**
+   * Optimistic per-media region box for an in-flight good vote (the box drawn
+   * on an image), or ``null`` when an in-flight vote cleared the box (un-vote /
+   * bad / box-less good).  Merged over the server's ``good_region_boxes`` in
+   * {@link applyVotes} so the Good pile crops to the voted region immediately,
+   * without waiting for the next /api/votes poll.  Each entry is cleared once
+   * the server's response agrees.
+   */
+  private pendingRegionBoxes = new Map<number, number[] | null>();
+
   /** Past votes available to undo, most-recent last.  Capped at UNDO_STACK_MAX. */
   private past: UndoEntry[] = [];
   /** Votes that have been undone and can be redone via Cmd/Ctrl-Shift-Z. */
@@ -81,6 +92,9 @@ export class VoteStateService implements OnDestroy {
   readonly learnedScores$ = this.learnedScoresSubject.asObservable();
   readonly labelsetGoodCount$ = this.labelsetGoodCountSubject.asObservable();
   readonly labelsetBadCount$ = this.labelsetBadCountSubject.asObservable();
+  /** Normalised [x0, y0, x1, y1] region boxes for good votes, keyed by media
+   *  id (string). Drives cropped Good-pile thumbnails for region votes. */
+  readonly goodRegionBoxes$ = this.goodRegionBoxesSubject.asObservable();
   /** Emits a short message every time an undo or redo executes. */
   readonly toast$ = this.toastSubject.asObservable();
 
@@ -167,6 +181,10 @@ export class VoteStateService implements OnDestroy {
     return this.labelsetBadCountSubject.value;
   }
 
+  get goodRegionBoxes(): Record<string, number[]> {
+    return this.goodRegionBoxesSubject.value;
+  }
+
   /**
    * True when the active detector has at least one good and one bad label
    * available for training (i.e. `/api/learned-sort` would succeed).
@@ -219,7 +237,9 @@ export class VoteStateService implements OnDestroy {
   ): Observable<MediaVoteResponse> {
     const target = this.toggleTargetFor(id, clickedDirection);
     this.applyOptimisticState(id, target);
-    return this.mediasApi.vote(id, target, target === 'good' ? regionBox : null).pipe(
+    const effectiveBox = target === 'good' && regionBox && regionBox.length === 4 ? regionBox : null;
+    this.applyOptimisticRegionBox(id, effectiveBox);
+    return this.mediasApi.vote(id, target, effectiveBox).pipe(
       tap((resp) => this.reconcileVoteResponse(id, resp)),
     );
   }
@@ -298,6 +318,20 @@ export class VoteStateService implements OnDestroy {
   }
 
   /**
+   * Optimistically record the region box for an in-flight good vote (or
+   * ``null`` to clear it).  Mirrors {@link applyOptimisticState} for region
+   * crops: the Good-pile thumbnail crops to the box immediately, and the entry
+   * is reconciled against the server's ``good_region_boxes`` on the next poll.
+   */
+  private applyOptimisticRegionBox(id: number, box: number[] | null): void {
+    this.pendingRegionBoxes.set(id, box ? [...box] : null);
+    const boxes = { ...this.goodRegionBoxesSubject.value };
+    if (box) boxes[String(id)] = [...box];
+    else delete boxes[String(id)];
+    this.goodRegionBoxesSubject.next(boxes);
+  }
+
+  /**
    * Apply the absolute state the server confirmed in its vote response,
    * regardless of what the optimistic prediction was.  Pending optimism is
    * cleared deterministically here; even if our prediction was wrong, the
@@ -364,8 +398,10 @@ export class VoteStateService implements OnDestroy {
     this.learnedScoresSubject.next({});
     this.labelsetGoodCountSubject.next(0);
     this.labelsetBadCountSubject.next(0);
+    this.goodRegionBoxesSubject.next({});
     this.pendingOptimistic.clear();
     this.pendingVerified.clear();
+    this.pendingRegionBoxes.clear();
     this.past = [];
     this.future = [];
   }
@@ -442,6 +478,12 @@ export class VoteStateService implements OnDestroy {
     this.toastSubject.next({ action: 'redo', mediaName: entry.mediaName });
   }
 
+  /** True when two region boxes match coordinate-for-coordinate (both 4-tuples). */
+  private boxesEqual(a: number[] | null, b: number[] | null): boolean {
+    if (a === null || b === null) return a === b;
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+
   private applyVotes(votes: VotesResponse): void {
     const good = new Set(votes.good);
     const bad = new Set(votes.bad);
@@ -478,10 +520,28 @@ export class VoteStateService implements OnDestroy {
       }
     }
 
+    // Region boxes: start from the server map, then apply pending optimistic
+    // overrides (clearing each once the server already agrees) so an in-flight
+    // region vote isn't clobbered by a poll that raced the vote POST.
+    const regionBoxes: Record<string, number[]> = { ...(votes.good_region_boxes ?? {}) };
+    for (const [id, want] of this.pendingRegionBoxes) {
+      const key = String(id);
+      const server = regionBoxes[key] ?? null;
+      const agrees = want === null ? server === null : this.boxesEqual(server, want);
+      if (agrees) {
+        this.pendingRegionBoxes.delete(id);
+      } else if (want) {
+        regionBoxes[key] = [...want];
+      } else {
+        delete regionBoxes[key];
+      }
+    }
+
     this.goodVotesSubject.next(good);
     this.badVotesSubject.next(bad);
     this.verifiedIdsSubject.next(verified);
     this.clickTimesSubject.next(times);
+    this.goodRegionBoxesSubject.next(regionBoxes);
     this.learnedScoresSubject.next(votes.learned_scores);
     this.labelsetGoodCountSubject.next(votes.labelset_good_count ?? good.size);
     this.labelsetBadCountSubject.next(votes.labelset_bad_count ?? bad.size);

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -323,7 +323,7 @@ export class VoteStateService implements OnDestroy {
    * crops: the Good-pile thumbnail crops to the box immediately, and the entry
    * is reconciled against the server's ``good_region_boxes`` on the next poll.
    */
-  private applyOptimisticRegionBox(id: number, box: number[] | null): void {
+  private applyOptimisticRegionBox(id: number, box: readonly number[] | null): void {
     this.pendingRegionBoxes.set(id, box ? [...box] : null);
     const boxes = { ...this.goodRegionBoxesSubject.value };
     if (box) boxes[String(id)] = [...box];

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -510,6 +510,44 @@ class TestMediaThumbnail:
             else:
                 media["thumbnail_bytes"] = original
 
+    def test_region_query_crops_thumbnail(self, client):
+        # A ``region=`` query crops to a sub-region; the bytes differ from the
+        # whole-frame thumbnail (here the audio waveform stands in for an image).
+        full = client.get("/api/medias/1/thumbnail")
+        cropped = client.get("/api/medias/1/thumbnail?region=0,0,0.5,1")
+        assert full.status_code == 200
+        assert cropped.status_code == 200
+        assert cropped.data != full.data
+        assert cropped.headers.get("ETag") != full.headers.get("ETag")
+
+    def test_region_query_bounded(self, client):
+        from PIL import Image  # noqa: PLC0415
+
+        from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM  # noqa: PLC0415
+
+        resp = client.get("/api/medias/1/thumbnail?region=0.1,0.1,0.4,0.9")
+        assert resp.status_code == 200
+        with Image.open(io.BytesIO(resp.data)) as img:
+            assert max(img.size) <= DEFAULT_MAX_DIM
+
+    def test_invalid_region_query_falls_back_to_full(self, client):
+        full = client.get("/api/medias/1/thumbnail")
+        bad = client.get("/api/medias/1/thumbnail?region=not,a,box")
+        assert bad.status_code == 200
+        assert bad.data == full.data
+
+    def test_full_image_region_is_not_cropped(self, client):
+        # Near-full boxes are treated as "no crop": two different near-full
+        # boxes yield identical (uncropped) bytes, and both differ from a real
+        # half-frame crop. (Compared against each other rather than the plain
+        # thumbnail, which may be served from precomputed bytes.)
+        whole = client.get("/api/medias/1/thumbnail?region=0,0,1,1")
+        almost = client.get("/api/medias/1/thumbnail?region=0,0,0.999,0.999")
+        half = client.get("/api/medias/1/thumbnail?region=0,0,0.5,1")
+        assert whole.status_code == 200
+        assert whole.data == almost.data
+        assert whole.data != half.data
+
 
 class TestMediaAudio:
     def test_returns_wav_for_valid_id(self, client):

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -142,6 +142,41 @@ class TestLabelsDetail:
             assert elem["cid"] is None
             assert elem["media_type"] == "audio"
             assert elem["name"]  # display string non-empty
+            # No region boxes were seeded, so the field is present but null.
+            assert elem["region_box"] is None
+
+    def test_region_box_surfaces_in_label_view(self, client):
+        """A region-voted good label exposes its box so the Good pile can bust
+        the thumbnail cache when the voted region changes."""
+        from vtscore.detectors.registry import register_detector, reset_for_tests
+        from vtscore.detectors.store import _detector_path, _write_detector
+
+        reset_for_tests()
+        _write_detector(
+            _detector_path("region-model"),
+            {
+                "name": "region-model",
+                "text_query": "",
+                "media_type": "image",
+                "examples": [],
+                "labelset": {
+                    "labels": [
+                        {
+                            "md5": "d4" * 16,
+                            "label": "good",
+                            "origin": {"importer": "ds_a", "params": {}},
+                            "origin_name": "boxed.png",
+                            "filename": "boxed.png",
+                            "region_box": [0.1, 0.2, 0.7, 0.8],
+                        },
+                    ]
+                },
+            },
+        )
+        register_detector(name="region-model", media_type="image")
+
+        body = client.get("/api/detectors/region-model/labels-detail").get_json()
+        assert body["good"][0]["region_box"] == [0.1, 0.2, 0.7, 0.8]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1001,6 +1001,28 @@ class TestVoteEndpointRegionBox:
         assert 1 in good_votes
         assert vote_region_boxes[1] == (0.1, 0.2, 0.7, 0.8)
 
+    def test_votes_response_exposes_good_region_boxes(self, client):
+        # A region good-vote's box surfaces in GET /api/votes so the Good pile
+        # can request a cropped thumbnail of just the voted region.
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        votes = client.get("/api/votes")
+        assert votes.status_code == 200
+        boxes = votes.get_json()["good_region_boxes"]
+        assert boxes["1"] == [0.1, 0.2, 0.7, 0.8]
+
+    def test_votes_response_drops_region_box_on_revote_bad(self, client):
+        # Re-voting the item bad clears its region box from the votes payload.
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        client.post("/api/medias/1/vote", json={"target": "bad"})
+        votes = client.get("/api/votes")
+        assert "1" not in votes.get_json()["good_region_boxes"]
+
     def test_good_vote_without_region_box_omits_from_state(self, client):
         from vtsearch.state import (
             good_votes,

--- a/tests_lib/core/test_image_thumbnail.py
+++ b/tests_lib/core/test_image_thumbnail.py
@@ -11,7 +11,11 @@ import io
 
 from PIL import Image
 
-from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM, make_image_thumbnail
+from vtscore.media.image.thumbnail import (
+    DEFAULT_MAX_DIM,
+    make_image_thumbnail,
+    normalize_region_crop,
+)
 
 
 def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
@@ -85,3 +89,67 @@ class TestMakeImageThumbnail:
         with Image.open(io.BytesIO(thumb_bytes)) as out:
             # Width/height swapped relative to the stored 400×200.
             assert out.size[1] > out.size[0]
+
+
+class TestNormalizeRegionCrop:
+    def test_accepts_valid_box(self):
+        assert normalize_region_crop([0.1, 0.2, 0.6, 0.8]) == (0.1, 0.2, 0.6, 0.8)
+
+    def test_orders_and_clamps_coordinates(self):
+        # Reversed + out-of-range coords are canonicalised to x0<x1, y0<y1 in [0,1].
+        assert normalize_region_crop([0.6, 0.9, 0.1, -0.5]) == (0.1, 0.0, 0.6, 0.9)
+
+    def test_rejects_none_and_wrong_length(self):
+        assert normalize_region_crop(None) is None
+        assert normalize_region_crop([0.1, 0.2, 0.3]) is None
+        assert normalize_region_crop("0,0,1,1") is None
+
+    def test_rejects_non_numbers_and_nan(self):
+        assert normalize_region_crop(["a", "b", "c", "d"]) is None
+        assert normalize_region_crop([0.0, 0.0, float("nan"), 1.0]) is None
+
+    def test_rejects_degenerate_zero_area(self):
+        assert normalize_region_crop([0.5, 0.2, 0.5, 0.8]) is None  # zero width
+        assert normalize_region_crop([0.2, 0.5, 0.8, 0.5]) is None  # zero height
+
+    def test_rejects_near_full_image_box(self):
+        # A box covering essentially the whole frame is treated as "no crop".
+        assert normalize_region_crop([0.0, 0.0, 1.0, 1.0]) is None
+        assert normalize_region_crop([0.0, 0.0, 0.995, 0.995]) is None
+
+
+class TestMakeImageThumbnailCrop:
+    def test_crops_to_region_before_downscaling(self):
+        # A 1000×1000 source cropped to the left quarter-width / full height
+        # yields a portrait thumbnail (taller than wide).
+        big = Image.new("RGB", (1000, 1000), color=(10, 20, 30))
+        result = make_image_thumbnail(_encode(big, "JPEG"), crop=(0.0, 0.0, 0.25, 1.0))
+        assert result is not None
+        thumb_bytes, _ = result
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert out.size[1] > out.size[0]
+            assert max(out.size) <= DEFAULT_MAX_DIM
+
+    def test_crop_differs_from_full_thumbnail(self):
+        # Two visually distinct halves: cropping each gives different bytes, and
+        # both differ from the uncropped thumbnail.
+        img = Image.new("RGB", (400, 200))
+        for x in range(400):
+            for y in range(200):
+                img.putpixel((x, y), (255, 0, 0) if x < 200 else (0, 0, 255))
+        src = _encode(img, "PNG")
+        full = make_image_thumbnail(src)
+        left = make_image_thumbnail(src, crop=(0.0, 0.0, 0.5, 1.0))
+        right = make_image_thumbnail(src, crop=(0.5, 0.0, 1.0, 1.0))
+        assert full and left and right
+        assert left[0] != right[0]
+        assert left[0] != full[0]
+
+    def test_sliver_box_widened_to_one_pixel(self):
+        # A box so thin it rounds to zero pixels is widened, not crashed.
+        big = Image.new("RGB", (500, 500), color=(0, 0, 0))
+        result = make_image_thumbnail(_encode(big, "JPEG"), crop=(0.5, 0.0, 0.5001, 1.0))
+        assert result is not None
+        thumb_bytes, _ = result
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert out.size[0] >= 1 and out.size[1] >= 1

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -126,6 +126,10 @@ def build_element_view(
         "cid": cid,
         "time": time_,
         "score": score,
+        # Present only for region votes; lets the Good pile bust its thumbnail
+        # cache when the voted box changes (the thumbnail route crops to the
+        # element's stored box server-side).
+        "region_box": list(elem.region_box) if elem.region_box is not None else None,
     }
 
 

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -23,8 +23,48 @@ import io
 #: when the user zooms in or out.
 DEFAULT_MAX_DIM = 384
 
+#: A region box whose width *and* height both reach this fraction of the image
+#: covers (effectively) the whole frame, so cropping to it is a no-op worth
+#: skipping.  Mirrors the frontend's near-full-image guard in
+#: ``media-item.component.ts`` (``bestRegionStyle``).
+_FULL_BOX_THRESHOLD = 0.99
 
-def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> tuple[bytes, str] | None:
+
+def normalize_region_crop(
+    box: object,
+) -> tuple[float, float, float, float] | None:
+    """Validate and canonicalise a normalised crop box.
+
+    Accepts a 4-element sequence ``(x0, y0, x1, y1)`` of fractions of the image
+    width/height.  Returns a clean tuple with ``x0 < x1`` and ``y0 < y1``, each
+    coordinate clamped to ``[0, 1]``.  Returns ``None`` (meaning "don't crop")
+    when the box is missing, malformed, degenerate (zero area), or covers
+    effectively the whole image, so callers can pass a raw box through and let
+    this decide whether a crop is warranted.
+    """
+    if not isinstance(box, (list, tuple)) or len(box) != 4:
+        return None
+    try:
+        x0, y0, x1, y1 = (float(v) for v in box)
+    except (TypeError, ValueError):
+        return None
+    if not all(v == v for v in (x0, y0, x1, y1)):  # reject NaN
+        return None
+    x0, x1 = sorted((min(max(x0, 0.0), 1.0), min(max(x1, 0.0), 1.0)))
+    y0, y1 = sorted((min(max(y0, 0.0), 1.0), min(max(y1, 0.0), 1.0)))
+    w, h = x1 - x0, y1 - y0
+    if w <= 0.0 or h <= 0.0:
+        return None
+    if w >= _FULL_BOX_THRESHOLD and h >= _FULL_BOX_THRESHOLD:
+        return None
+    return (x0, y0, x1, y1)
+
+
+def make_image_thumbnail(
+    media_bytes: bytes,
+    max_dim: int = DEFAULT_MAX_DIM,
+    crop: tuple[float, float, float, float] | None = None,
+) -> tuple[bytes, str] | None:
     """Return ``(thumbnail_bytes, mimetype)`` downscaled to ``max_dim`` px.
 
     The longest side of the result is at most ``max_dim``; images already
@@ -32,6 +72,11 @@ def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> 
     compact, decode-cheap artifact.  Opaque images become JPEG; images that
     carry an alpha channel become PNG so transparency survives.  Camera EXIF
     orientation is applied so portrait photos aren't shown sideways.
+
+    When ``crop`` is given (a normalised ``(x0, y0, x1, y1)`` box, already
+    canonicalised via :func:`normalize_region_crop`), the image is cropped to
+    that sub-region *before* downscaling, so the thumbnail shows only the
+    user's voted region rather than the whole frame.
 
     Returns ``None`` when the bytes can't be decoded as an image (e.g. SVG or
     a corrupt file), letting the caller fall back to the original bytes.
@@ -41,6 +86,8 @@ def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> 
     try:
         with Image.open(io.BytesIO(media_bytes)) as src:
             img = ImageOps.exif_transpose(src) or src
+            if crop is not None:
+                img = _crop_to_region(img, crop)
             has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
             img.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
             out = io.BytesIO()
@@ -53,3 +100,23 @@ def make_image_thumbnail(media_bytes: bytes, max_dim: int = DEFAULT_MAX_DIM) -> 
             return out.getvalue(), mimetype
     except Exception:
         return None
+
+
+def _crop_to_region(img, crop: tuple[float, float, float, float]):
+    """Crop a PIL image to a normalised ``(x0, y0, x1, y1)`` box.
+
+    Coordinates are fractions of the (EXIF-corrected) image dimensions.  The
+    pixel box is rounded to integers and widened to at least one pixel on each
+    axis so a sliver-thin box still yields a decodable crop.
+    """
+    x0, y0, x1, y1 = crop
+    w, h = img.size
+    px0, px1 = int(round(x0 * w)), int(round(x1 * w))
+    py0, py1 = int(round(y0 * h)), int(round(y1 * h))
+    if px1 <= px0:
+        px1 = min(px0 + 1, w)
+        px0 = max(px1 - 1, 0)
+    if py1 <= py0:
+        py1 = min(py0 + 1, h)
+        py0 = max(py1 - 1, 0)
+    return img.crop((px0, py0, px1, py1))

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -54,7 +54,12 @@ def cached_thumbnail_response(thumb_bytes: bytes, download_name: str):
     return resp
 
 
-def image_thumbnail_response(image_bytes: bytes, fallback_mimetype: str, download_name: str):
+def image_thumbnail_response(
+    image_bytes: bytes,
+    fallback_mimetype: str,
+    download_name: str,
+    crop: object = None,
+):
     """Build a cached, downscaled-image thumbnail response from ``image_bytes``.
 
     Shared by every route that serves a small image tile (the media grid/list,
@@ -65,17 +70,31 @@ def image_thumbnail_response(image_bytes: bytes, fallback_mimetype: str, downloa
     bytes.  An ``ETag`` fingerprints the *source* bytes so the browser reuses
     one thumbnail per item across scrolls and zoom levels, and conditional
     requests short-circuit to a 304 without regenerating the thumbnail.
-    """
-    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
-    etag = hashlib.md5(image_bytes).hexdigest()
+    When ``crop`` is a valid normalised ``(x0, y0, x1, y1)`` region (see
+    :func:`vtscore.media.image.thumbnail.normalize_region_crop`), the thumbnail
+    shows only that sub-region -- used so a region-voted item displays its crop
+    rather than the whole frame.  The crop is folded into the ``ETag`` so a
+    re-vote with a different box invalidates the cached tile.
+    """
+    from vtscore.media.image.thumbnail import (  # noqa: PLC0415
+        make_image_thumbnail,
+        normalize_region_crop,
+    )
+
+    crop_box = normalize_region_crop(crop) if crop is not None else None
+
+    hasher = hashlib.md5(image_bytes)
+    if crop_box is not None:
+        hasher.update(repr(crop_box).encode("ascii"))
+    etag = hasher.hexdigest()
     if etag in request.if_none_match:
         resp = make_response("", 304)
         resp.set_etag(etag)
         resp.headers["Cache-Control"] = "private, max-age=86400"
         return resp
 
-    result = make_image_thumbnail(image_bytes)
+    result = make_image_thumbnail(image_bytes, crop=crop_box)
     thumb, mimetype = result if result is not None else (image_bytes, fallback_mimetype)
 
     resp = make_response(send_file(io.BytesIO(thumb), mimetype=mimetype, download_name=download_name))

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -406,7 +406,7 @@ def preview_detector_label(name: str, element_id: str):
 # ---------------------------------------------------------------------------
 
 
-def _in_memory_thumbnail_response(media: dict, media_type: str):
+def _in_memory_thumbnail_response(media: dict, media_type: str, crop=None):
     """Build a small thumbnail send_file from an in-memory media dict.
 
     Images: serve the resolved media bytes via the media type's
@@ -417,6 +417,9 @@ def _in_memory_thumbnail_response(media: dict, media_type: str):
     item the center can display. Audio/video/document: defer to the media
     type's ``image_response`` (cached waveform / midframe PNG). Returns
     ``None`` if no thumbnail can be produced.
+
+    ``crop`` (a normalised region box) restricts an image thumbnail to the
+    voted sub-region; ignored for non-image types.
     """
     from vtscore.media import get as get_media_type  # noqa: PLC0415
 
@@ -429,7 +432,7 @@ def _in_memory_thumbnail_response(media: dict, media_type: str):
         resp = mt.media_response(media)
         if not isinstance(resp.data, (bytes, bytearray)) or not resp.data:
             return None
-        return image_thumbnail_response(bytes(resp.data), resp.mimetype, resp.download_name)
+        return image_thumbnail_response(bytes(resp.data), resp.mimetype, resp.download_name, crop=crop)
 
     image_response_fn = getattr(mt, "image_response", None)
     if image_response_fn is None:
@@ -444,8 +447,12 @@ def _in_memory_thumbnail_response(media: dict, media_type: str):
     )
 
 
-def _origin_thumbnail_response(file_path: Path, media_type: str, elem):
-    """Build a thumbnail response from an on-disk file resolved via origin."""
+def _origin_thumbnail_response(file_path: Path, media_type: str, elem, crop=None):
+    """Build a thumbnail response from an on-disk file resolved via origin.
+
+    ``crop`` (a normalised region box) restricts an image thumbnail to the
+    voted sub-region; ignored for non-image types.
+    """
     if media_type == "image":
         suffix = file_path.suffix.lower()
         mimetype = _MIMETYPE_BY_SUFFIX.get(suffix) or "image/jpeg"
@@ -454,7 +461,7 @@ def _origin_thumbnail_response(file_path: Path, media_type: str, elem):
         except OSError:
             abort(404, message="Element media file unreadable")
         download_name = elem.origin_name or elem.filename or f"label{suffix}"
-        return image_thumbnail_response(image_bytes, mimetype, download_name)
+        return image_thumbnail_response(image_bytes, mimetype, download_name, crop=crop)
 
     if media_type == "audio":
         from vtscore.media.audio.media_type import generate_waveform_thumbnail_from_file  # noqa: PLC0415
@@ -520,11 +527,16 @@ def thumbnail_detector_label(name: str, element_id: str):
     _, elem = found
     media_type = data.get("media_type", "") or ""
 
+    # Region boxes are only attached to good votes; show the voted crop rather
+    # than the whole frame.  ``normalize_region_crop`` (inside the response
+    # helper) treats a near-full or absent box as "no crop".
+    crop = elem.region_box if elem.label == "good" else None
+
     cid = resolve_current_dataset_cid(elem)
     if cid is not None:
         media = get_media(cid)
         if media:
-            resp = _in_memory_thumbnail_response(media, media_type)
+            resp = _in_memory_thumbnail_response(media, media_type, crop=crop)
             if resp is not None:
                 return resp
 
@@ -532,7 +544,7 @@ def thumbnail_detector_label(name: str, element_id: str):
         if file_path is None or not file_path.is_file():
             abort(404, message="Element media file unavailable")
 
-        return _origin_thumbnail_response(file_path, media_type, elem)
+        return _origin_thumbnail_response(file_path, media_type, elem, crop=crop)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -86,6 +86,26 @@ def _parse_region_box(raw: Any) -> tuple[float, float, float, float] | None:
     return (x0, y0, x1, y1)
 
 
+def _parse_region_query(raw: str | None) -> tuple[float, float, float, float] | None:
+    """Parse a ``region=x0,y0,x1,y1`` thumbnail query argument.
+
+    Returns ``None`` when the argument is absent or malformed (the route then
+    serves the whole-image thumbnail).  Out-of-range / degenerate / near-full
+    boxes are tolerated here and canonicalised downstream by
+    :func:`vtscore.media.image.thumbnail.normalize_region_crop`.
+    """
+    if not raw:
+        return None
+    parts = raw.split(",")
+    if len(parts) != 4:
+        return None
+    try:
+        x0, y0, x1, y1 = (float(p) for p in parts)
+    except ValueError:
+        return None
+    return (x0, y0, x1, y1)
+
+
 def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:  # noqa: C901
     """Transcode video bytes to browser-playable MP4.
 
@@ -497,10 +517,20 @@ def media_thumbnail(media_id: int):
     request-time decode/resize -- the path that keeps a fresh browse-canvas
     zoom responsive.  Media without one (old pickles, thin loads, undecodable
     SVGs) fall back to generating the thumbnail from the display image.
+
+    An optional ``region=x0,y0,x1,y1`` query (normalised fractions in
+    ``[0, 1]``) crops the thumbnail to a sub-region of the image -- used so the
+    Good pile shows a region-voted item's crop rather than the whole frame.
+    A region request always regenerates from the display image (the
+    precomputed full-frame thumbnail can't be cropped after the fact).
     """
     c = get_media(media_id)
     if not c:
         abort(404, message="not found")
+    region = _parse_region_query(request.args.get("region"))
+    if region is not None:
+        data, src_mimetype, _ = _resolve_display_image(media_id)
+        return image_thumbnail_response(data, src_mimetype, f"thumb_{media_id}", crop=region)
     thumb = c.get("thumbnail_bytes")
     if thumb:
         return cached_thumbnail_response(thumb, f"thumb_{media_id}")

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -428,6 +428,13 @@ def get_votes():
         "learned_scores": {str(k): round(finite_or(v), 4) for k, v in learned_scores.items()},
         "labelset_good_count": labelset_good_count,
         "labelset_bad_count": labelset_bad_count,
+        # Region boxes live only on good votes (popped on bad/un-vote); intersect
+        # with ``good_votes`` defensively so a stale entry can't leak through.
+        "good_region_boxes": {
+            str(k): [float(c) for c in box]
+            for k, box in vote_region_boxes.items()
+            if k in good_votes and box is not None
+        },
     }
 
 

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -722,6 +722,10 @@ class _DetectorLabelViewSchema(Schema):
     cid = fields.Integer(allow_none=True)
     time = fields.Float(required=True)
     score = fields.Float(required=True)
+    # Normalised [x0, y0, x1, y1] region box for a region vote, else null. The
+    # thumbnail route crops to this box; the frontend uses it only to bust the
+    # cached tile when the box changes.
+    region_box = fields.List(fields.Float(), allow_none=True)
 
 
 class DetectorLabelsDetailResponseSchema(Schema):

--- a/vtsearch/schemas/sorting.py
+++ b/vtsearch/schemas/sorting.py
@@ -144,6 +144,15 @@ class VotesResponseSchema(Schema):
     learned_scores = fields.Dict(keys=fields.String(), values=fields.Float(), required=True)
     labelset_good_count = fields.Integer(required=True)
     labelset_bad_count = fields.Integer(required=True)
+    # Per-media normalised region boxes ([x0, y0, x1, y1]) for good votes cast
+    # by drawing a box on an image.  Keyed by media id (string).  Lets the Good
+    # pile request a cropped thumbnail of just the voted region.  Only good
+    # votes that carry a box appear; empty otherwise.
+    good_region_boxes = fields.Dict(
+        keys=fields.String(),
+        values=fields.List(fields.Float()),
+        required=True,
+    )
 
 
 class SeedFromExamplesRequestSchema(Schema):


### PR DESCRIPTION
## What

When you region-vote an image in Train (draw a box for a good vote), the Good pile now shows a thumbnail **of just the cropped region** instead of the whole frame. The crop is generated on request from the display image, as expected.

## How

The Good pile is rendered two ways in Train, and both now crop:

- **`vt-labelset-list`** (active when a trainable detector is loaded — the usual Train case): the detector label-thumbnail route crops to the element's stored `region_box` server-side. The element view now exposes `region_box` so the tile's cache is busted when the voted box changes.
- **`vt-label-list`** (no detector): `/api/medias/<id>/thumbnail` gains a `?region=x0,y0,x1,y1` query; `/api/votes` exposes `good_region_boxes`, which `vote-state` plumbs to the pile (with an optimistic box so the crop appears immediately rather than after the next poll).

Shared backend support lives in the image thumbnail helper:
- `normalize_region_crop()` canonicalises a box (clamps/orders coords, rejects degenerate or near-full boxes) and `make_image_thumbnail(crop=...)` crops before downscaling.
- The crop is folded into the response `ETag` so a re-vote with a different box invalidates the cached tile.

## Tests

- Library-tier: `normalize_region_crop` validation + `make_image_thumbnail` crop behaviour.
- App-tier: `?region=` crops the media thumbnail (and near-full/invalid boxes fall back); `/api/votes` exposes/clears `good_region_boxes`; the detector label view surfaces `region_box`.
- Full Python suite green (4835 passed); frontend builds clean; ruff/codespell/deptry/pyright/OpenAPI-snapshot checks pass.

> Note: `./run-tests.sh` is currently blocked before pytest by its `npm audit` gate flagging pre-existing Angular 19 framework CVEs (fix requires a breaking Angular 21 upgrade) — repo-wide and unrelated to this change. Python tests were therefore run directly via `pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjvvEsg46S7cvXtKd7TsN8)_