### PR TITLE
Fix region-box draw offset under app-wide CSS zoom

### DIFF
--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -226,6 +226,41 @@ describe('ImageViewerComponent', () => {
       expect(local.y).toBeCloseTo(0, 5);
     });
 
+    it('compensates for an ancestor CSS zoom (visual getBoundingClientRect vs layout coords)', () => {
+      // Regression: the app renders <html> at `zoom: 1.1` (styles.scss). A CSS
+      // `zoom` scales an element's rendered box without changing its layout box,
+      // so getBoundingClientRect() and MouseEvent client coords report VISUAL
+      // pixels while clientWidth / renderedW / panX are LAYOUT pixels. Here the
+      // wrap is 100 layout px wide but 110 visual px (Z = 1.1). Without the
+      // visual→layout conversion, every offset from the wrap centre came out
+      // 1.1× too large, drawing the box further from the view centre than the
+      // cursor (proportional to distance from centre, sign-flipping across it).
+      component.renderedW = 100;
+      component.renderedH = 100;
+      component.wrapRef = {
+        nativeElement: {
+          clientWidth: 100,
+          clientHeight: 100,
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 110,
+            height: 110,
+            right: 110,
+            bottom: 110,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>;
+      // Visual centre is at (55, 55). A click 11 visual px right of centre is
+      // 10 layout px → 0.1 normalised, so image x = 0.6, y stays 0.5.
+      const local = component.screenToImageNormalized(makeEvent(66, 55))!;
+      expect(local.x).toBeCloseTo(0.6, 6);
+      expect(local.y).toBeCloseTo(0.5, 6);
+    });
+
     it('combines pan + zoom + rotate self-consistently', () => {
       setupWrap(component);
       component.zoom = 2;

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -184,8 +184,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const wrap = this.wrapRef?.nativeElement;
     if (wrap) {
       const rect = wrap.getBoundingClientRect();
-      const cx = event.clientX - rect.left - rect.width / 2;
-      const cy = event.clientY - rect.top - rect.height / 2;
+      const s = this.layoutScale(wrap, rect);
+      const cx = (event.clientX - rect.left - rect.width / 2) / s;
+      const cy = (event.clientY - rect.top - rect.height / 2) / s;
       const ratio = this.zoom / oldZoom;
       this.panX = cx - ratio * (cx - this.panX);
       this.panY = cy - ratio * (cy - this.panY);
@@ -381,6 +382,20 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     };
   }
 
+  /** Ratio between the wrap's on-screen (visual) size and its layout size.
+   *  The app renders ``<html>`` at ``zoom: 1.1`` (see styles.scss), and a CSS
+   *  ``zoom`` scales an element's rendered box without changing its layout box:
+   *  ``getBoundingClientRect()`` and ``MouseEvent`` client coords come back in
+   *  VISUAL pixels, while ``clientWidth`` / ``renderedW`` / ``panX`` are LAYOUT
+   *  pixels. Dividing a client-space delta by this ratio converts it back to the
+   *  layout space the region overlay is drawn in, so the box lands under the
+   *  cursor. Returns 1 when there's no zoom (ratio is exactly 1) or the wrap
+   *  isn't measurable (e.g. the test mock exposes no ``clientWidth``). */
+  private layoutScale(wrap: HTMLElement, rect: DOMRect): number {
+    const cw = wrap.clientWidth;
+    return cw && rect.width ? rect.width / cw : 1;
+  }
+
   /** Convert a screen-space mouse event to normalised image coords (pre-rotation).
    *  Returns null when the image isn't laid out yet. Public so tests can drive it
    *  with a mocked wrapRef + arbitrary pan/zoom/rotate state. */
@@ -388,8 +403,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const wrap = this.wrapRef?.nativeElement;
     if (!wrap || !this.renderedW || !this.renderedH) return null;
     const rect = wrap.getBoundingClientRect();
-    const dx = event.clientX - (rect.left + rect.width / 2) - this.panX;
-    const dy = event.clientY - (rect.top + rect.height / 2) - this.panY;
+    const s = this.layoutScale(wrap, rect);
+    const dx = (event.clientX - (rect.left + rect.width / 2)) / s - this.panX;
+    const dy = (event.clientY - (rect.top + rect.height / 2)) / s - this.panY;
     const sx = dx / this.zoom;
     const sy = dy / this.zoom;
     const rad = (-this.rotation * Math.PI) / 180;
@@ -426,8 +442,12 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     if (!this.drag) return;
     const d = this.drag;
     if (d.kind === 'pan') {
-      this.panX = d.originX + (e.clientX - d.startX);
-      this.panY = d.originY + (e.clientY - d.startY);
+      // clientX deltas are VISUAL px (the app renders at zoom: 1.1) but panX is
+      // a LAYOUT-px transform value; convert so the image tracks the cursor 1:1.
+      const wrap = this.wrapRef?.nativeElement;
+      const s = wrap ? this.layoutScale(wrap, wrap.getBoundingClientRect()) : 1;
+      this.panX = d.originX + (e.clientX - d.startX) / s;
+      this.panY = d.originY + (e.clientY - d.startY) / s;
       this.applyTransform();
       return;
     }


### PR DESCRIPTION
## Problem

Shift-clicking to draw a region-voting box placed the starting corner offset from the cursor. The offset was zero at the view centre and grew proportionally with distance from centre, flipping sign across it (left of centre → corner further left; right → further right). It tracked the **view** centre, not the image centre, and survived pan/zoom.

## Root cause

The app renders `<html>` at `zoom: 1.1` (`frontend/src/styles.scss`). A CSS `zoom` scales an element's *rendered* box without changing its *layout* box, so:

- `event.clientX` / `getBoundingClientRect()` report **visual** (zoomed) pixels.
- `renderedW` (from `clientWidth`) and `panX` — what the region overlay is actually drawn against — are **layout** pixels.

`screenToImageNormalized` divided a visual-pixel offset by the layout `renderedW`, so every offset from the view centre came out ~1.1× too large, and the box rendered that much further from centre than the cursor. At dead centre the offset is 0, so it looked fine there.

## Fix

Convert client-space deltas back to layout space using the measured visual/layout ratio (`getBoundingClientRect().width / clientWidth`, which is exactly 1 when there's no CSS zoom). Applied in the three places that mix the two spaces:

- `screenToImageNormalized` (the draw/move/resize anchor math)
- the zoom-to-cursor wheel handler
- the pan-drag handler (image now tracks the cursor 1:1 instead of drifting ~10%)

Added a regression test covering a wrap that is 100 layout px wide but 110 visual px (Z = 1.1).

## Testing

`./run-tests.sh core` reports **`Frontend build OK`** (the change is frontend-only; the build typechecks the component and spec). The suite then stops at a pre-existing `npm audit` gate flagging Angular 19 framework CVEs that require a breaking upgrade to Angular 21 — unrelated to this change (no dependencies touched) and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011FFuQkjwL3yiCiUDqv3vpC)_