### PR TITLE
Add seconds-per-frame option to video→image converter

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -52,6 +52,7 @@ families use the same field type (aliased as `ImporterField`,
 | `placeholder` | `str`       | `""`     | Hint shown as placeholder text in the input widget      |
 | `dynamic_options` | `bool`  | `False`  | When `True`, options for this `"select"` field are fetched at runtime from the plugin's `get_field_options()` method (see [Dynamic field options](#dynamic-field-options)) |
 | `depends_on`  | `list[str]` | `[]`     | Other field keys whose values this field's options depend on; the frontend re-fetches whenever any depended-on field changes |
+| `clears`      | `list[str]` | `[]`     | Field keys this field is mutually exclusive with; entering a non-empty value here blanks each listed field in the UI (list each peer back for symmetry), so only one of the set is active at a time |
 
 ### PluginBase
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -200,7 +200,16 @@ export class SourceSpecsPickerComponent implements OnChanges {
 
   setParam(sourceType: string, key: string, value: string | number | null): void {
     const draft = this.getDraft(sourceType);
-    const updated: SourceSpec = { ...draft, params: { ...draft.params, [key]: value } };
+    const params = { ...draft.params, [key]: value };
+    // Mutually-exclusive fields: entering a non-empty value blanks the
+    // peers it declares via ``clears`` so only one stays active.
+    if (value !== null && value !== undefined && String(value) !== '') {
+      const f = this.currentConverter(sourceType)?.fields?.find((x) => x.key === key);
+      for (const peer of f?.clears ?? []) {
+        params[peer] = '';
+      }
+    }
+    const updated: SourceSpec = { ...draft, params };
     this.drafts.set(sourceType, updated);
     if (this.isNonNativeChecked(sourceType)) {
       this.specsChange.emit(this.specs.map((s) =>

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -191,6 +191,10 @@ export interface ImporterField {
   max?: string;
   /** For ``number`` fields: step increment (empty / ``"any"`` = unconstrained). */
   step?: string;
+  /** Field keys this field is mutually exclusive with.  Entering a
+   *  non-empty value here blanks each listed field (and they list this
+   *  one back), so only one of the set is ever active at a time. */
+  clears?: string[];
 }
 
 export interface ImporterPickerTab {

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -412,6 +412,55 @@ class TestVideo2ImageMediaConverter:
         c = Video2ImageMediaConverter()
         assert c.convert(media) == []
 
+    def test_seconds_per_frame_field_is_mutually_exclusive_with_n_clips(self):
+        """Both sampling fields exist and clear each other so only one is
+        ever active at a time in the UI."""
+        from vtscore.converters.video2image import Video2ImageMediaConverter
+
+        c = Video2ImageMediaConverter()
+        n_clips = next(f for f in c.fields if f.key == "n_clips")
+        spf = next(f for f in c.fields if f.key == "seconds_per_frame")
+        assert n_clips.clears == ["seconds_per_frame"]
+        assert spf.clears == ["n_clips"]
+        assert spf.default == ""
+        # Surfaced to the frontend so the renderer can honour the blanking.
+        assert n_clips.to_dict()["clears"] == ["seconds_per_frame"]
+
+    def test_convert_seconds_per_frame_scales_with_duration(self):
+        """The test video is 10 fps; 30 frames == 3 seconds, so one frame
+        every 1s yields 3 frames and every 0.5s yields 6."""
+        from vtscore.converters.video2image import Video2ImageMediaConverter
+
+        video_bytes = _make_minimal_video(frames=30)
+        c = Video2ImageMediaConverter()
+
+        media = {"filename": "v.mp4", "media_bytes": video_bytes}
+        assert len(c.convert(media, {"seconds_per_frame": "1"})) == 3
+        assert len(c.convert(media, {"seconds_per_frame": "0.5"})) == 6
+
+    def test_seconds_per_frame_takes_precedence_over_n_clips(self):
+        """When both arrive non-empty (e.g. via the API/CLI), seconds wins."""
+        from vtscore.converters.video2image import Video2ImageMediaConverter
+
+        video_bytes = _make_minimal_video(frames=30)
+        c = Video2ImageMediaConverter()
+        media = {"filename": "v.mp4", "media_bytes": video_bytes}
+        # n_clips=10 would give 10 frames; 1s cadence on a 3s clip gives 3.
+        assert len(c.convert(media, {"n_clips": "10", "seconds_per_frame": "1"})) == 3
+
+    def test_blank_seconds_per_frame_falls_back_to_n_clips(self):
+        """A blank seconds field must not blow up marshmallow validation and
+        should leave the fixed frames-per-video path active."""
+        from vtscore.converters.video2image import Video2ImageMediaConverter
+
+        video_bytes = _make_minimal_video(frames=30)
+        c = Video2ImageMediaConverter()
+        media = {"filename": "v.mp4", "media_bytes": video_bytes}
+        # Mirrors what the frontend submits once the user types into n_clips:
+        # n_clips set, seconds_per_frame blanked to "".
+        results = c.convert_normalized(media, {"n_clips": "4", "seconds_per_frame": ""})
+        assert len(results) == 4
+
 
 # ===========================================================================
 # Video2AudioMediaConverter tests

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -165,8 +165,16 @@ class MediaConverter(PluginBase, ABC):
         if params:
             scrubbed: dict[str, Any] = {}
             default_for: dict[str, str] = {f.key: f.default for f in self.fields if f.default}
+            optional_keys: set[str] = {f.key for f in self.fields if not f.required}
             for key, value in params.items():
-                if isinstance(value, str) and not value and key in default_for:
+                # Drop empty-string values for any field that has a declared
+                # default *or* is optional.  Without this an empty optional
+                # ``number`` field (e.g. a blank "seconds per frame" left
+                # unset in favour of "frames per video") would reach
+                # marshmallow's Integer/Float loader as ``""`` and be
+                # rejected as "Not a valid number"; treating "" as "unset"
+                # lets it fall back to the default (or stay absent).
+                if isinstance(value, str) and not value and (key in default_for or key in optional_keys):
                     continue
                 scrubbed[key] = value
             params = scrubbed

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -11,33 +11,58 @@ from vtscore.plugins import PluginField
 
 
 class Video2ImageMediaConverter(MediaConverter):
-    """Cut a video into *n_clips* segments and extract the middle frame
+    """Cut a video into evenly-spaced segments and extract the middle frame
     from each segment as a PNG image.
 
     Uses OpenCV (``cv2``) to read the video and sample frames.
 
-    User-configurable parameters
-    ----------------------------
-    ``n_clips``
-        Number of clips to divide the video into.  One frame is extracted
-        from the temporal centre of each clip.  Defaults to 10.  Set via
-        the per-import form (or the converter's :attr:`fields`).
+    The number of frames is driven by one of two mutually-exclusive,
+    user-configurable parameters — supply one *or* the other, never both:
+
+    ``n_clips`` (Frames per video)
+        Fixed number of evenly-spaced frames to extract from each video,
+        regardless of its length.  Defaults to 10.
+
+    ``seconds_per_frame`` (Seconds per frame)
+        Sampling cadence: extract one frame per this many seconds of video,
+        so longer videos yield more frames.  When set (non-empty and
+        positive) it takes precedence over ``n_clips``.  Left blank by
+        default, meaning ``n_clips`` is used.
+
+    The two fields :attr:`clear <vtscore.plugins.PluginField.clears>` each
+    other in the UI, so only one is ever active at a time; the backend
+    likewise honours ``seconds_per_frame`` when present and falls back to
+    ``n_clips`` otherwise.
     """
 
     display_name = "Video → Images"
     description = "Extract frames from video files"
-    summary_template = "Cut each video into {n_clips} evenly-spaced frames."
+    summary_template = "Sample {n_clips} frames per video, or one frame every {seconds_per_frame}s."
     fields = [
         PluginField(
             key="n_clips",
             label="Frames per video",
             field_type="number",
-            description="Number of evenly-spaced frames to extract from each video.",
+            description="Fixed number of evenly-spaced frames to extract from each video.",
             default="10",
             required=False,
             min="1",
             max="1000",
             step="1",
+            clears=["seconds_per_frame"],
+        ),
+        PluginField(
+            key="seconds_per_frame",
+            label="Seconds per frame",
+            field_type="number",
+            description="Extract one frame per this many seconds of video (longer videos yield more frames). "
+            "Leave blank to use 'Frames per video' instead.",
+            default="",
+            required=False,
+            min="0.1",
+            max="3600",
+            step="0.5",
+            clears=["n_clips"],
         ),
     ]
 
@@ -58,6 +83,12 @@ class Video2ImageMediaConverter(MediaConverter):
             n_clips = 10
         if n_clips < 1:
             n_clips = 1
+
+        seconds_raw = self.get_param(params, "seconds_per_frame")
+        try:
+            seconds_per_frame = float(seconds_raw) if seconds_raw not in (None, "") else 0.0
+        except (TypeError, ValueError):
+            seconds_per_frame = 0.0
 
         media_bytes = media.get("media_bytes")
         media_path = media.get("media_path")
@@ -94,7 +125,19 @@ class Video2ImageMediaConverter(MediaConverter):
                 if frame_count <= 0:
                     return []
 
-                n = min(n_clips, frame_count)
+                # "Seconds per frame" wins when supplied: derive the frame
+                # count from the video's duration so longer videos yield more
+                # frames.  Otherwise fall back to the fixed "frames per video".
+                if seconds_per_frame > 0:
+                    fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+                    if fps > 0:
+                        duration = frame_count / fps
+                        n = max(1, round(duration / seconds_per_frame))
+                    else:
+                        n = n_clips
+                else:
+                    n = n_clips
+                n = min(n, frame_count)
                 # Divide video into n equal segments, pick middle frame of each
                 segment_size = frame_count / n
                 mid_indices = [int((i + 0.5) * segment_size) for i in range(n)]

--- a/vtscore/docs/extending/converters.md
+++ b/vtscore/docs/extending/converters.md
@@ -38,7 +38,7 @@ something else through it. Examples that ship in the box:
 | `audio2image` | audio → image | Apply SigLIP / DINOv3 over spectrograms; visualise audio patterns |
 | `audio2text` | audio → text | ASR (Whisper) so audio is searchable by text content |
 | `image2text` | image → text | OCR so scanned text is searchable |
-| `video2image` | video → image | Sample N frames per video as separate images |
+| `video2image` | video → image | Sample frames as separate images — a fixed count per video, or one frame every N seconds |
 | `video2audio` | video → audio | Extract the audio track for CLAP embedding |
 | `document2image` | document → image | Render PDF pages as searchable images |
 | `document2text` | document → text | Extract embedded text from PDFs |

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -149,6 +149,15 @@ class PluginField:
     #: CLI parser to use :class:`float`; an integer step uses :class:`int`.
     step: str = ""
 
+    #: Field keys this field is mutually exclusive with.  When the user
+    #: enters a non-empty value into this field, the frontend blanks every
+    #: field listed here (and they should list this field back, so the
+    #: relationship is symmetric).  Use for "supply A *or* B" inputs where
+    #: only one can be active at a time, e.g. video frame sampling by
+    #: frames-per-video *or* seconds-per-frame.  Purely a UI affordance:
+    #: the backend still reads whichever value arrives non-empty.
+    clears: list[str] = field(default_factory=list)
+
     #: Whether this field's value should be copied into the importer's
     #: persisted origin dict (see :meth:`DatasetImporter.build_origin`).
     #: ``None`` means "use the field-type default": ``False`` for
@@ -198,6 +207,7 @@ class PluginField:
             "min": self.min,
             "max": self.max,
             "step": self.step,
+            "clears": list(self.clears),
             "template_vars": list(self.template_vars),
         }
 


### PR DESCRIPTION
## What

When splitting a video into images, the `video2image` converter now supports two mutually-exclusive sampling controls in the Details view:

- **Frames per video** (`n_clips`, existing) — a fixed count regardless of length.
- **Seconds per frame** (`seconds_per_frame`, new) — a cadence; longer videos yield more frames.

Both fields are shown in the Details view, but only one is active at a time: typing into one blanks the other (and vice versa). The backend honors `seconds_per_frame` when it arrives non-empty/positive, falling back to `n_clips` otherwise.

## How

- **New `clears` field on `PluginField`** — a declarative, reusable "mutually-exclusive" hint. Entering a non-empty value into a field blanks every peer it lists. Surfaced through `to_dict()` and honored by the shared converter Details renderer (`source-specs-picker`), so any future plugin can opt into the same "supply A *or* B" UX. `n_clips` and `seconds_per_frame` list each other.
- **`video2image.convert`** derives the frame count from the video duration (`round(duration / seconds_per_frame)`) when seconds-per-frame is set, then reuses the existing even-spacing midpoint sampling.
- **`MediaConverter.normalize_params`** now treats an empty string as "unset" for *optional* fields (not only those with a declared default), so a blank optional `number` field (e.g. `seconds_per_frame` left blank in favor of `n_clips`) no longer trips marshmallow's number validator.

## Tests

- Added converter tests: field mutual-exclusivity/`clears` metadata, duration-scaled frame counts, seconds-precedence-over-frames, and blank-seconds fallback through `convert_normalized`.
- `converters` (178), `io` (748), and `core`+`api` (1132) Python suites pass; frontend `build:prod` is clean (no errors/warnings).

> Note: `./run-tests.sh core` is currently blocked by a pre-existing `npm audit` gate flagging Angular 19 CVEs (fix requires a breaking upgrade to Angular 21) — unrelated to this change. Verified the frontend TypeScript build and Python suites independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqu7LAJkLcRZp5SRuyh6iY)_