### PR TITLE
httpResource migration: plan + Phase 1 pilot (SettingsStateService on rxResource)

### DIFF
--- a/docs/plans/angular-21-upgrade.md
+++ b/docs/plans/angular-21-upgrade.md
@@ -218,7 +218,9 @@ its own effort:
   requires adopting signals broadly first — VTSearch barely uses them today.
 - **`httpResource` / `resource`.** Could trim `switchMap`/manual-subscription
   boilerplate across the ~67 RxJS API services, adoptable incrementally. Worth
-  a focused pass later if the data layer is being touched anyway.
+  a focused pass later if the data layer is being touched anyway. **Scoped in
+  its own plan: `httpresource-migration.md`** (recommends `rxResource` wrapping
+  the existing generated client; not started).
 - **Signal Forms.** Low value here — VTSearch uses no forms — and experimental
   in 21 (not stable until ~22/23).
 - **ARIA directives, CLI MCP server.** Marginal for this app.

--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -1,9 +1,61 @@
 # `httpResource` / reactive-resource migration for the data layer
 
-Status: **Plan only — not started.** Scoped after the Angular 21 + Vitest work
-landed (see `angular-21-upgrade.md`, which lists this as a deferred carrot).
-This doc decides *how* VTSearch should adopt Angular's resource primitives and
-in what order; it does not change code yet.
+Status: **Phase 1 (pilot) shipped.** The `SettingsStateService` read path now
+runs on `rxResource`; the pattern and its test story are proven (see "What
+shipped" below). Remaining read services are deferred — see "Open follow-ups".
+Scoped after the Angular 21 + Vitest work landed (see `angular-21-upgrade.md`,
+which lists this as a deferred carrot). This doc decides *how* VTSearch should
+adopt Angular's resource primitives and in what order.
+
+## What shipped (Phase 1 pilot)
+
+`SettingsStateService` (`frontend/src/app/services/settings-state.service.ts`)
+was reimplemented on `rxResource` while keeping its public surface
+(`settings`, `settings$`, `load`, `update`, `clear`) intact, so none of its ~16
+consumers changed. The concrete, repeatable pattern:
+
+- **Wrap the existing generated-client read in `rxResource`.** The loader's
+  `stream` calls the existing typed method (`SettingsApiService.getSettings()`),
+  so the generated client and the interceptor chain are untouched.
+- **A monotonic counter signal is the request.** `params: () => count === 0 ?
+  undefined : count` keeps the resource idle until the first `load()`
+  (`undefined` request = no fetch); each `load()` bumps the counter to refetch.
+  This maps an imperative "load/refresh on demand" trigger onto a reactive
+  resource.
+- **Signals are the new canonical API** (`settingsSignal`, `isLoading`,
+  `error`), exposed from the resource. Backwards-compat shims bridge to existing
+  consumers: the sync getter reads the signal; `settings$` is
+  `toObservable(settingsSignal)` (replays latest like the old `BehaviorSubject`,
+  but emits asynchronously).
+- **Mutations stay imperative.** `update()` is still a `HttpClient` PUT; it
+  writes the server's response back into the resource via `resource.set(...)`.
+  `clear()` is `resource.set(undefined)`.
+- **Document side-effects move to an `effect()`** (here, the `animations-off`
+  class) that watches the settings signal, replacing the old manual `emit()`.
+
+### Testing `rxResource` (important — this is the real cost)
+
+The resource's loader is **effect-scheduled and promise-based**, which changes
+test timing. Concretely, for the Vitest + `HttpTestingController` suite:
+
+- The loader runs in a **root effect**, so `fixture.detectChanges()` does *not*
+  issue the GET. Call **`TestBed.tick()`** after the action that triggers
+  `load()` and before `httpMock.expectOne(...)`. (This is the bulk of the
+  consumer-spec churn: ~40 call sites across the settings consumers each needed
+  one `TestBed.tick()`.)
+- The value **commits on a microtask** (the loader is promise-based), so reading
+  `resource.value()` synchronously after `flush()` misses it. In a normal
+  (non-fakeAsync) test, drain with `await new Promise(r => setTimeout(r))` then
+  `TestBed.tick()`.
+- **`rxResource` values do not commit under `fakeAsync` at all** — the virtual
+  clock doesn't drive the resource's resolution (looping `tick()/TestBed.tick()`
+  does not help). A fakeAsync spec can still *flush* the request to satisfy
+  `verify()`, but any spec that asserts a **settings-derived value** must be
+  converted to a real-async (`async`/`await`) test. Only one right-panel test
+  needed this; the rest only flush the request.
+- At **runtime** none of this matters: zone change detection flushes the loader
+  effect immediately after `load()`, so the GET fires as before. The timing
+  change is test-only.
 
 ## Goal
 
@@ -102,13 +154,10 @@ way — verified against the current functional-interceptor setup.)
 
 ## Suggested sequencing (incremental, reversible)
 
-1. **Pilot one read** end-to-end: pick a simple, context-keyed GET with a clear
-   consumer (candidate: media-types list, or settings load) and convert it to
-   `rxResource` wrapping the existing api-service method, keyed off a
-   `toSignal` of the active context. Render via `value()` (signal / `@if`), not
-   `.subscribe()`. Establish the spec pattern. One PR.
-2. **Write the pattern down** (a short `docs/` note + a tiny shared helper if a
-   helper earns its keep) so the next conversions are mechanical.
+1. **Pilot one read** end-to-end — **done** (`SettingsStateService`, see "What
+   shipped"). The pattern and its test story are proven.
+2. **Write the pattern down** — **done** (the "What shipped" + "Testing
+   `rxResource`" sections above are the reference for the next conversions).
 3. **Expand by area**, one PR per service/feature, only where it removes real
    boilerplate. Leave pollers, `forkJoin` aggregates, and mutations alone unless
    a conversion is clearly a win.
@@ -117,6 +166,21 @@ way — verified against the current functional-interceptor setup.)
 
 Each step is independently shippable and revertible; there is no point where the
 app must be half-migrated.
+
+## Open follow-ups
+
+- **Expand to more read services** (step 3). The settings pilot kept the old
+  public API for zero consumer churn; future conversions can go further and
+  expose the resource signals directly to consumers (then drop the
+  `settings$`/getter shims) where it removes real boilerplate. Natural next
+  candidates: context-keyed list reads (media-types, embedders) where a
+  `toSignal(activeContext)` request key earns the reactivity.
+- **Pollers and `forkJoin` aggregates** (`VoteStateService`, labeling status,
+  `DatasetStateService.refresh()`) are still imperative by design; revisit only
+  if a resource clearly wins.
+- **A shared test helper** for the `TestBed.tick()` / real-async drain dance was
+  not extracted yet (the settings specs inline it). Extract one once a second
+  service is converted and the shape is confirmed to repeat.
 
 ## Decision points needing the user
 

--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -1,0 +1,136 @@
+# `httpResource` / reactive-resource migration for the data layer
+
+Status: **Plan only — not started.** Scoped after the Angular 21 + Vitest work
+landed (see `angular-21-upgrade.md`, which lists this as a deferred carrot).
+This doc decides *how* VTSearch should adopt Angular's resource primitives and
+in what order; it does not change code yet.
+
+## Goal
+
+Trim the `switchMap` / manual-subscription / `BehaviorSubject` boilerplate in
+the **read** path of the data layer by moving GET-style fetches onto Angular's
+reactive resource primitives (`rxResource` / `httpResource`). Reads become
+signal-driven: a resource re-fetches when its request signals change, exposes
+`value()`/`status()`/`error()`/`isLoading()`, and drops the hand-rolled
+"subscribe in `ngOnInit`, store in a field, unsubscribe in `ngOnDestroy`"
+ceremony.
+
+**Explicitly NOT in scope:** mutations (POST/PUT/DELETE — votes, sort kicks,
+imports, renames, deletes) stay imperative `HttpClient` calls. Resources are
+for reads. Server-Sent Events (`ProgressEventsService`) stay as-is. This is a
+*read-path* refactor, adoptable incrementally — never a big-bang rewrite.
+
+## Current state (as of this plan)
+
+- **Generated client**: `ng-openapi-gen` (config `apiService: false`) emits
+  standalone **Observable-returning functions** under
+  `src/app/generated/api-client/fn/**`, e.g.
+  `getVotes(http, rootUrl, params, ctx): Observable<StrictHttpResponse<T>>`.
+- **~26 hand-written `*-api.service.ts`** wrap those functions into typed,
+  `Observable`-returning methods (e.g. `SortingApiService.getLabelingStatus()`).
+  ~60 GET-style read methods across them.
+- **~29 state services** (`*-state.service.ts`) hold UI state in
+  `BehaviorSubject`s and orchestrate fetches/polling (e.g. `VoteStateService`
+  polls `/api/votes` via `timer(0, ms)`; `DatasetStateService` `forkJoin`s the
+  registries).
+- **Consumption is imperative, not reactive**: **66** `.subscribe()` call sites
+  in non-spec code vs **2** `| async` pipes. Components subscribe in `ngOnInit`
+  and write to plain fields. So this migration is as much about *consumption*
+  (template-level signal reads) as about the services.
+- **HTTP wiring**: `provideHttpClient(withInterceptors([activeContext,
+  achievementsRefresh, error]))`. The `activeContext` interceptor injects
+  `X-Dataset-Id` / `X-Detector-Id` on every request from
+  `ActiveContextService`; `error` is the circuit-breaker/connection-state
+  chokepoint. **`ActiveContextService` is `BehaviorSubject`-based** (no signals).
+- **Signals today**: essentially unused (1 component). Zone-based change
+  detection is still on.
+
+## Key design decision: `rxResource` over raw `httpResource`
+
+Angular 21 ships two relevant primitives:
+
+- **`httpResource(() => url | request)`** — issues the GET itself given a URL
+  (or request object). It **bypasses the generated client**: you'd hand-build
+  URLs/params that `ng-openapi-gen` already generates, duplicating the typed
+  param/response contracts and losing the OpenAPI-snapshot guarantee.
+- **`rxResource({ params, stream })`** (from `@angular/core/rxjs-interop`) —
+  wraps an **Observable loader**. The loader can call the existing typed
+  `*-api.service.ts` methods unchanged, so we **keep the generated client** and
+  its types, and just gain signal-driven reactivity + `value()/status()/error()`.
+
+**Recommendation: lead with `rxResource`** wrapping existing api-service
+methods. It is the incremental-friendly choice — no generated-client churn, no
+URL duplication, interceptors still apply (same `HttpClient`). Reserve
+`httpResource` only for genuinely new raw reads where no generated function
+exists. (Both share `provideHttpClient` + the interceptor chain, so headers,
+achievements-refresh, and the error/circuit-breaker all keep working either
+way — verified against the current functional-interceptor setup.)
+
+## Obstacles to resolve before/during rollout
+
+1. **Signal adoption is a prerequisite.** Resources are signal-driven, but the
+   reactivity sources (`ActiveContextService`, sort/vote/settings state) are
+   `BehaviorSubject`s, and consumers `.subscribe()` rather than read signals.
+   Two sub-decisions:
+   - Bridge the existing `Observable`s to signals with `toSignal(...)` at the
+     edges (cheap, non-invasive, lets resources key off
+     `toSignal(activeContext.datasetId$)`), **or** convert the hot state
+     services to `signal()`-backed (larger, cleaner long-term). Start with
+     `toSignal` bridges; convert services opportunistically.
+   - Resources must be created in an **injection context** (field initializer
+     or `inject()`-time). Polling/orchestration that lives in services needs the
+     resource owned by the right scope.
+2. **Polling endpoints don't map to resources.** `VoteStateService` /
+   labeling-status poll on a timer. Resources fetch-on-request-change, not on an
+   interval. Options: keep pollers imperative, or drive a resource's reload from
+   a timer signal. Recommend leaving pollers alone in phase 1.
+3. **`forkJoin` aggregates** (e.g. `DatasetStateService.refresh()`) — a resource
+   per call composed via `computed`, or keep the aggregate imperative. Decide
+   per call site; don't force it.
+4. **Experimental API.** `httpResource`/`rxResource` are still marked
+   experimental in 21; the signature may shift in 22/23. Keep the surface small
+   and centralized (a thin helper) so an API change is a one-file fix.
+5. **Error semantics.** Today errors flow through `errorInterceptor` (toasts,
+   circuit breaker, connection state). Resources surface errors via `error()`
+   instead of an Observable `error` callback — confirm the interceptor-driven
+   side effects still fire (they do, since the request still goes through the
+   chain) and decide how components render `error()` vs the current toasts.
+6. **Test story.** The Vitest suite drives `HttpTestingController` +
+   `fakeAsync`. Resources resolve on microtasks/effects; spec patterns will need
+   a small, documented helper (flush + `await`/`tick` + read `value()`), since
+   the current specs assert on imperative subscribe results.
+
+## Suggested sequencing (incremental, reversible)
+
+1. **Pilot one read** end-to-end: pick a simple, context-keyed GET with a clear
+   consumer (candidate: media-types list, or settings load) and convert it to
+   `rxResource` wrapping the existing api-service method, keyed off a
+   `toSignal` of the active context. Render via `value()` (signal / `@if`), not
+   `.subscribe()`. Establish the spec pattern. One PR.
+2. **Write the pattern down** (a short `docs/` note + a tiny shared helper if a
+   helper earns its keep) so the next conversions are mechanical.
+3. **Expand by area**, one PR per service/feature, only where it removes real
+   boilerplate. Leave pollers, `forkJoin` aggregates, and mutations alone unless
+   a conversion is clearly a win.
+4. **Revisit consumption**: as reads become resources, prefer template signal
+   reads / `@if (resource.value(); as x)` over `.subscribe()`-into-field.
+
+Each step is independently shippable and revertible; there is no point where the
+app must be half-migrated.
+
+## Decision points needing the user
+
+- **Depth**: thin `toSignal` bridges (minimal, keep `BehaviorSubject` services)
+  vs converting hot state services to signal-backed (bigger, cleaner). Recommend
+  starting thin.
+- **Relationship to zoneless.** Going zoneless (the other deferred carrot)
+  wants broad signal adoption too; this migration is a natural on-ramp. Decide
+  whether to treat them as one track or keep separate.
+- **Pilot target** — which first read to convert (media-types vs settings vs an
+  active-context-keyed list).
+
+## Out of scope (record only)
+
+- Mutations, SSE, polling intervals (above).
+- Replacing `ng-openapi-gen` — the generated client stays; `rxResource` wraps it.
+- Going zoneless — its own effort (`angular-21-upgrade.md` → Deferred).

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -156,6 +156,7 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.expectOne(req => req.url === '/api/embedders' && !req.params.get('media_type'))
       .flush({ embedders: [] });
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});
   }
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -27,6 +27,7 @@ describe('NewDetectorModalComponent', () => {
       ],
     });
     // settingsState.load() in ngOnInit fetches settings.
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
   });
@@ -205,6 +206,7 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
       ],
     });
     // settingsState.load() in ngOnInit fetches settings.
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});
     // No /api/datasets/registry call when defaultMediaType is provided.
   });

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -59,6 +59,10 @@ describe('RightPanelComponent', () => {
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+    // rxResource commits its value on a microtask; drain it then flush effects
+    // so the settings$ bridge emits and viewModeRightDict is populated.
+    tick();
+    TestBed.tick();
     // Trigger ngOnChanges by setting medias via input
     component.ngOnChanges({ medias: { currentValue: component.medias, previousValue: [], firstChange: true, isFirstChange: () => true } });
     expect(component.viewMode).toBe('list');

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -52,22 +52,25 @@ describe('RightPanelComponent', () => {
     cleanup();
   }));
 
-  it('should load view mode from settings on init', fakeAsync(() => {
+  // Real-async (not fakeAsync): the SettingsStateService rxResource has a
+  // promise-based loader whose value does not commit under fakeAsync's virtual
+  // clock, so a test that asserts a *settings-derived* value must drain real
+  // microtasks. See docs/plans/httpresource-migration.md.
+  it('should load view mode from settings on init', async () => {
     component.medias = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
     fixture.detectChanges();
-    tick();
-    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
+    TestBed.tick(); // run the rxResource loader effect so the GET is issued
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
-    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
-    // rxResource commits its value on a microtask; drain it then flush effects
-    // so the settings$ bridge emits and viewModeRightDict is populated.
-    tick();
+    // Drain the resource's promise-based value commit, then flush effects so the
+    // settings$ bridge emits and viewModeRightDict is populated. The votes poll
+    // request that the macrotask lets fire is discarded by cleanup().
+    await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick();
     // Trigger ngOnChanges by setting medias via input
     component.ngOnChanges({ medias: { currentValue: component.medias, previousValue: [], firstChange: true, isFirstChange: () => true } });
     expect(component.viewMode).toBe('list');
     cleanup();
-  }));
+  });
 
   it('should default viewMode to grid when not in settings', fakeAsync(() => {
     fixture.detectChanges();

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -32,6 +32,7 @@ describe('RightPanelComponent', () => {
     fixture.detectChanges();
     tick(); // Allow timer(0, ...) to fire
     // Settings request
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({
       volume: 1,
       view_mode_right: { audio: 'grid', image: 'grid' },
@@ -55,6 +56,7 @@ describe('RightPanelComponent', () => {
     component.medias = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
     fixture.detectChanges();
     tick();
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
     // Trigger ngOnChanges by setting medias via input
@@ -66,6 +68,7 @@ describe('RightPanelComponent', () => {
   it('should default viewMode to grid when not in settings', fakeAsync(() => {
     fixture.detectChanges();
     tick();
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
     expect(component.viewMode).toBe('grid');
@@ -75,6 +78,7 @@ describe('RightPanelComponent', () => {
   it('should poll for votes on init', fakeAsync(() => {
     fixture.detectChanges();
     tick();
+    TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
     httpMock.expectOne('/api/votes').flush({
       good: [1, 2],

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -16,6 +16,17 @@ describe('SettingsStateService', () => {
     inclusion: 0.5,
   };
 
+  // `load()` drives an `rxResource`, whose loader runs in an effect rather than
+  // synchronously. `TestBed.tick()` flushes pending effects so the resource
+  // issues its request / propagates its value; we tick after `load()` to make
+  // the HTTP request observable, and again after `flush()` to settle the value.
+  function load() {
+    service.load();
+    TestBed.tick();
+    httpMock.expectOne('/api/settings').flush(mockSettings);
+    TestBed.tick();
+  }
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideHttpClient(), provideHttpClientTesting()],
@@ -30,43 +41,42 @@ describe('SettingsStateService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should start with null settings', () => {
+  it('should start with null settings and not fetch until load()', () => {
+    TestBed.tick();
     expect(service.settings).toBeNull();
+    httpMock.expectNone('/api/settings');
   });
 
   it('load should fetch and store settings', () => {
-    service.load();
-    const req = httpMock.expectOne('/api/settings');
-    req.flush(mockSettings);
+    load();
     expect(service.settings).toEqual(mockSettings);
   });
 
   it('update should PUT and update cached settings', () => {
-    service.load();
-    httpMock.expectOne('/api/settings').flush(mockSettings);
+    load();
 
     const updated = { ...mockSettings, volume: 0.5 };
     service.update({ volume: 0.5 }).subscribe();
     const req = httpMock.expectOne('/api/settings');
     expect(req.request.method).toBe('PUT');
     req.flush(updated);
+    TestBed.tick();
     expect(service.settings?.volume).toBe(0.5);
   });
 
   it('clear should reset settings to null', () => {
-    service.load();
-    httpMock.expectOne('/api/settings').flush(mockSettings);
+    load();
 
     service.clear();
+    TestBed.tick();
     expect(service.settings).toBeNull();
   });
 
   it('settings$ should emit on load', () => new Promise<void>((done) => {
-    const emissions: any[] = [];
+    const emissions: (typeof mockSettings | null)[] = [];
     service.settings$.subscribe((s) => emissions.push(s));
 
-    service.load();
-    httpMock.expectOne('/api/settings').flush(mockSettings);
+    load();
 
     setTimeout(() => {
       expect(emissions.length).toBeGreaterThanOrEqual(2);

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -16,15 +16,22 @@ describe('SettingsStateService', () => {
     inclusion: 0.5,
   };
 
-  // `load()` drives an `rxResource`, whose loader runs in an effect rather than
-  // synchronously. `TestBed.tick()` flushes pending effects so the resource
-  // issues its request / propagates its value; we tick after `load()` to make
-  // the HTTP request observable, and again after `flush()` to settle the value.
-  function load() {
+  // Drain the asynchrony rxResource introduces: its loader is promise-based, so
+  // the stream value commits on a microtask; we then flush effects so the
+  // computed settings signal and the settings$ bridge update.
+  async function settle() {
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    TestBed.tick();
+  }
+
+  // `load()` drives the `rxResource`, whose loader runs in an effect rather than
+  // synchronously. `TestBed.tick()` runs the loader effect so the request is
+  // issued; `settle()` then lets the flushed response propagate to the value.
+  async function load() {
     service.load();
     TestBed.tick();
     httpMock.expectOne('/api/settings').flush(mockSettings);
-    TestBed.tick();
+    await settle();
   }
 
   beforeEach(() => {
@@ -47,13 +54,13 @@ describe('SettingsStateService', () => {
     httpMock.expectNone('/api/settings');
   });
 
-  it('load should fetch and store settings', () => {
-    load();
+  it('load should fetch and store settings', async () => {
+    await load();
     expect(service.settings).toEqual(mockSettings);
   });
 
-  it('update should PUT and update cached settings', () => {
-    load();
+  it('update should PUT and update cached settings', async () => {
+    await load();
 
     const updated = { ...mockSettings, volume: 0.5 };
     service.update({ volume: 0.5 }).subscribe();
@@ -64,20 +71,19 @@ describe('SettingsStateService', () => {
     expect(service.settings?.volume).toBe(0.5);
   });
 
-  it('clear should reset settings to null', () => {
-    load();
+  it('clear should reset settings to null', async () => {
+    await load();
 
     service.clear();
     TestBed.tick();
     expect(service.settings).toBeNull();
   });
 
-  it('settings$ should replay the loaded settings to subscribers', () => {
+  it('settings$ should replay the loaded settings to subscribers', async () => {
     const emissions: unknown[] = [];
     const sub = service.settings$.subscribe((s) => emissions.push(s));
 
-    load();
-    TestBed.tick(); // let the toObservable bridge emit the new value
+    await load();
 
     sub.unsubscribe();
     expect(emissions.length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -72,16 +72,15 @@ describe('SettingsStateService', () => {
     expect(service.settings).toBeNull();
   });
 
-  it('settings$ should emit on load', () => new Promise<void>((done) => {
+  it('settings$ should replay the loaded settings to subscribers', () => {
     const emissions: unknown[] = [];
-    service.settings$.subscribe((s) => emissions.push(s));
+    const sub = service.settings$.subscribe((s) => emissions.push(s));
 
     load();
+    TestBed.tick(); // let the toObservable bridge emit the new value
 
-    setTimeout(() => {
-      expect(emissions.length).toBeGreaterThanOrEqual(2);
-      expect(emissions[emissions.length - 1]).toEqual(mockSettings);
-      done();
-    });
-  }));
+    sub.unsubscribe();
+    expect(emissions.length).toBeGreaterThanOrEqual(1);
+    expect(emissions[emissions.length - 1]).toEqual(mockSettings);
+  });
 });

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -73,7 +73,7 @@ describe('SettingsStateService', () => {
   });
 
   it('settings$ should emit on load', () => new Promise<void>((done) => {
-    const emissions: (typeof mockSettings | null)[] = [];
+    const emissions: unknown[] = [];
     service.settings$.subscribe((s) => emissions.push(s));
 
     load();

--- a/frontend/src/app/services/settings-state.service.ts
+++ b/frontend/src/app/services/settings-state.service.ts
@@ -1,70 +1,85 @@
-import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject, Observable } from 'rxjs';
-import { takeUntil, tap } from 'rxjs/operators';
+import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { rxResource, toObservable } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import type { AppSettings } from '../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../generated/api-client/models/settings-update';
 import { SettingsApiService } from './settings-api.service';
 import { ANIMATIONS_OFF_CLASS } from '../utils/reduced-motion';
 
+/**
+ * App-settings store, and the first read path migrated onto Angular's reactive
+ * resource primitives (see `docs/plans/httpresource-migration.md`). The GET is
+ * driven by an `rxResource` wrapping the existing generated-client method
+ * (`SettingsApiService.getSettings()`), so it keeps the typed client and the
+ * interceptor chain while dropping the hand-rolled subscribe/`BehaviorSubject`
+ * bookkeeping. The public surface (`settings`, `settings$`, `load`, `update`,
+ * `clear`) is unchanged for existing consumers; new code should prefer the
+ * signal API (`settingsSignal`, `isLoading`, `error`).
+ */
 @Injectable({ providedIn: 'root' })
-export class SettingsStateService implements OnDestroy {
-  private readonly settingsSubject = new BehaviorSubject<AppSettings | null>(null);
-  private readonly destroy$ = new Subject<void>();
-  private loading = false;
+export class SettingsStateService {
+  private readonly settingsApi = inject(SettingsApiService);
 
-  readonly settings$ = this.settingsSubject.asObservable();
+  // A monotonic load counter doubles as the resource request. `0` means
+  // "not requested yet" -> `params()` returns `undefined` -> the resource stays
+  // idle (no fetch). Each `load()` bumps the counter, which changes the request
+  // and so re-runs the loader.
+  private readonly loadCount = signal(0);
 
-  constructor(private settingsApi: SettingsApiService) {}
+  private readonly resource = rxResource({
+    params: () => (this.loadCount() === 0 ? undefined : this.loadCount()),
+    stream: () => this.settingsApi.getSettings(),
+  });
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+  /** Canonical settings signal: `null` until first successful load (or after `clear()`). */
+  readonly settingsSignal = computed<AppSettings | null>(() => this.resource.value() ?? null);
+
+  /** True while a settings fetch is in flight. */
+  readonly isLoading = this.resource.isLoading;
+
+  /** The error from the last failed fetch, if any. */
+  readonly error = this.resource.error;
+
+  /**
+   * Backwards-compatible Observable view for existing subscribers. Backed by
+   * the settings signal, so it replays the latest value to late subscribers
+   * (like the old `BehaviorSubject`) but emits asynchronously.
+   */
+  readonly settings$: Observable<AppSettings | null> = toObservable(this.settingsSignal);
+
+  constructor() {
+    // Reflect document-level effects of settings whenever the resolved value
+    // changes (load, update, or clear). Currently this mirrors the "Show
+    // Animations" toggle onto `<html>` as the `animations-off` class, which the
+    // global stylesheet and `prefersReducedMotion()` both honor so the one
+    // setting silences every decorative animation at once.
+    effect(() => {
+      const settings = this.settingsSignal();
+      if (typeof document !== 'undefined') {
+        const animationsOff = settings?.show_animations === false;
+        document.documentElement.classList.toggle(ANIMATIONS_OFF_CLASS, animationsOff);
+      }
+    });
   }
 
   get settings(): AppSettings | null {
-    return this.settingsSubject.value;
+    return this.settingsSignal();
   }
 
+  /** Fetch (or refetch) settings from the server. No-op while a fetch is in flight. */
   load(): void {
-    if (this.loading) return;
-    this.loading = true;
-    this.settingsApi
-      .getSettings()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (settings) => {
-          this.emit(settings);
-          this.loading = false;
-        },
-        error: () => {
-          this.loading = false;
-        },
-      });
+    if (this.resource.isLoading()) return;
+    this.loadCount.update((n) => n + 1);
   }
 
   update(changes: SettingsUpdate): Observable<AppSettings> {
-    return this.settingsApi.updateSettings(changes).pipe(
-      takeUntil(this.destroy$),
-      tap((updated) => this.emit(updated)),
-    );
+    return this.settingsApi
+      .updateSettings(changes)
+      .pipe(tap((updated) => this.resource.set(updated)));
   }
 
   clear(): void {
-    this.emit(null);
-  }
-
-  /**
-   * Publish new settings and reflect document-level effects. Currently this
-   * mirrors the "Show Animations" toggle onto `<html>` as the
-   * `animations-off` class, which the global stylesheet and the
-   * `prefersReducedMotion()` util both honor so the one setting silences every
-   * decorative animation at once.
-   */
-  private emit(settings: AppSettings | null): void {
-    this.settingsSubject.next(settings);
-    if (typeof document !== 'undefined') {
-      const animationsOff = settings?.show_animations === false;
-      document.documentElement.classList.toggle(ANIMATIONS_OFF_CLASS, animationsOff);
-    }
+    this.resource.set(undefined);
   }
 }


### PR DESCRIPTION
## What

Scopes the deferred reactive-resource migration of the data layer's read path **and ships its Phase 1 pilot.**

### Plan
`docs/plans/httpresource-migration.md` — grounded in VTSearch's actual data layer (ng-openapi-gen Observable functions wrapped by `*-api.service.ts`; ~29 `BehaviorSubject` state services; 66 `.subscribe()` sites vs 2 `| async`). Headline recommendation: **lead with `rxResource`** (wraps the existing typed client + interceptors) rather than raw `httpResource` (which bypasses the client). Documents obstacles, an incremental rollout, and decision points.

### Pilot (Phase 1)
`SettingsStateService` reimplemented on `rxResource` wrapping the existing `getSettings()`, **keeping its public API** (`settings`/`settings$`/`load`/`update`/`clear`) so all ~16 consumers are unchanged:
- Monotonic counter signal as the resource request (idle until first `load()`; bump to refetch).
- New forward signal API (`settingsSignal`/`isLoading`/`error`); `settings$` is a `toObservable` bridge; document side-effects (`animations-off`) move to an `effect()`.
- Mutations stay imperative (`update()` writes back via `resource.set()`).

### Test story (the real cost, now documented in the plan)
The loader is effect-scheduled + promise-based, so specs needed: `TestBed.tick()` to issue the GET (~40 consumer call sites), a real-async drain (`await setTimeout` + `TestBed.tick()`) for value assertions, and **one** right-panel value test moved off `fakeAsync` (rxResource values don't commit under the virtual clock). Runtime behavior is unchanged — zone CD flushes the loader immediately.

## Verification
`./run-tests.sh frontend` green: TypeScript build OK, audit OK, **760 Vitest tests pass**, no budget warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDsh3KYWH6prr4BkUvPUxz