### PR TITLE
Stop vote buttons from gaining a focus ring when Shift is pressed

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -8,7 +8,7 @@
     class="btn-bad"
     [class.voted]="isBad"
     [class.vote-flash]="badFlash"
-    (click)="onVoteBad()"
+    (click)="onVoteBad($event)"
     title="Mark this media as a Bad example."
   >
     <vt-icon type="thumbs-down" [size]="18" [class.icon-spinning]="spinningVote === 'bad'"></vt-icon>
@@ -18,7 +18,7 @@
     class="btn-good"
     [class.voted]="isGood"
     [class.vote-flash]="goodFlash"
-    (click)="onVoteGood()"
+    (click)="onVoteGood($event)"
     title="Mark this media as a Good example."
   >
     <vt-icon type="thumbs-up" [size]="18" [class.icon-spinning]="spinningVote === 'good'"></vt-icon>

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.spec.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.spec.ts
@@ -60,6 +60,16 @@ describe('VotingOverlayComponent', () => {
     expect(emitted).toBe(false);
   });
 
+  it('should drop focus from the clicked button so Shift cannot re-ring it', () => {
+    // The button keeps DOM focus after a mouse click; pressing a modifier later
+    // would promote it to :focus-visible and paint a ring. Blurring on click
+    // prevents that, keeping Shift a pure cursor modifier during region voting.
+    const good = fixture.nativeElement.querySelector('.btn-good') as HTMLButtonElement;
+    good.focus();
+    good.click();
+    expect(document.activeElement).not.toBe(good);
+  });
+
   it('should hide the first-vote hint by default', () => {
     expect(fixture.nativeElement.querySelector('.vote-hint')).toBeNull();
   });

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -25,20 +25,35 @@ export class VotingOverlayComponent implements OnDestroy {
   private goodTimer: ReturnType<typeof setTimeout> | null = null;
   private badTimer: ReturnType<typeof setTimeout> | null = null;
 
-  onVoteGood(): void {
+  onVoteGood(event?: Event): void {
     if (this.disabled) return;
+    this.dropFocus(event);
     this.goodFlash = true;
     this.voted.emit('good');
     if (this.goodTimer) clearTimeout(this.goodTimer);
     this.goodTimer = setTimeout(() => (this.goodFlash = false), 300);
   }
 
-  onVoteBad(): void {
+  onVoteBad(event?: Event): void {
     if (this.disabled) return;
+    this.dropFocus(event);
     this.badFlash = true;
     this.voted.emit('bad');
     if (this.badTimer) clearTimeout(this.badTimer);
     this.badTimer = setTimeout(() => (this.badFlash = false), 300);
+  }
+
+  /**
+   * Blur the clicked button so it doesn't keep DOM focus. Without this, the
+   * button stays focused after a mouse click; the focus ring is suppressed by
+   * `:focus:not(:focus-visible)` only until the user presses a modifier (e.g.
+   * Shift to draw a region), at which point the browser promotes the focused
+   * element to `:focus-visible` and paints a ring around the last-voted button.
+   * Dropping focus on click keeps Shift purely a cursor modifier.
+   */
+  private dropFocus(event?: Event): void {
+    const target = event?.currentTarget;
+    if (target instanceof HTMLElement) target.blur();
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Problem

During region voting in the Train interface, pressing **Shift** (to switch the cursor into region-draw mode) painted a focus ring around whichever vote button was clicked last (e.g. a blue border around **Good**). Shift is meant to be a pure cursor modifier; it shouldn't draw attention to a previously-pressed button.

## Cause

This is the browser's `:focus-visible` modality heuristic. A mouse click leaves the button with DOM focus but no ring (mouse modality, suppressed by the existing `&:focus:not(:focus-visible)` rule). The moment a key like Shift is pressed, the browser re-evaluates focus as "keyboard modality" and promotes the still-focused button to genuine `:focus-visible`, so the ring appears. The CSS rule can't help once the state is truly `:focus-visible`.

## Fix

Blur the clicked vote button in `onVoteGood`/`onVoteBad` so no button retains focus after a click. With nothing focused, pressing Shift has nothing to ring. The keyboard `←`/`→` voting shortcuts are handled elsewhere and don't depend on button focus, so this doesn't affect keyboard voting.

Added a unit test asserting the clicked button loses focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei2cPZWKSeHDy6KMWacqJ3)_