### PR TITLE
Treat SSE heartbeat as backend-liveness signal

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -28,6 +28,7 @@ tracker, so clients do not need a separate REST bootstrap call.
 | `sort` | progress object | `sort_progress` (text sort) |
 | `find` | progress object | `find_progress` (multi-dataset Find) |
 | `eval` | progress object | `eval_progress` (train-and-score) |
+| `heartbeat` | `{ "ts": <unix seconds> }` | periodic liveness ping (every ~5s) |
 
 ### Progress object shape
 
@@ -75,10 +76,15 @@ data: {"status":"loading",...}
 
 ```
 
-Comment lines (`: heartbeat`) arrive every ~5 seconds so connections
-survive idle proxies. They also re-emit the `loading-tasks` and
-`detector-loading-tasks` channels so finished tasks vanish from the UI
-once they pass their stale-prune window without a server-side timer.
+A `heartbeat` event arrives every ~5 seconds so connections survive idle
+proxies **and** so the client has a continuous "backend is alive" signal: the
+Angular client treats every frame (heartbeat or real progress) as proof of
+life and only declares the backend offline when the stream goes silent. It is
+a real named event rather than an SSE comment (`: heartbeat`) precisely because
+comments are invisible to the browser's `EventSource` API. Each heartbeat tick
+also re-emits the `loading-tasks` and `detector-loading-tasks` channels so
+finished tasks vanish from the UI once they pass their stale-prune window
+without a server-side timer.
 
 ## Example
 

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { ProgressEventsService } from './progress-events.service';
+import { ConnectionStateService, ConnectionStatus } from './connection-state.service';
+
+/**
+ * Minimal stand-in for the browser `EventSource` (jsdom has none). Captures
+ * the named-event listeners the service registers so the test can synthesise
+ * server frames and assert how the service reacts.
+ */
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  static readonly CLOSED = 2;
+
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private readonly listeners = new Map<string, ((e: MessageEvent) => void)[]>();
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(name: string, fn: (e: MessageEvent) => void): void {
+    const list = this.listeners.get(name) ?? [];
+    list.push(fn);
+    this.listeners.set(name, list);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  /** Test helper: deliver a frame on a named channel. */
+  emit(name: string, data: unknown): void {
+    const event = { data: JSON.stringify(data) } as MessageEvent;
+    for (const fn of this.listeners.get(name) ?? []) fn(event);
+  }
+}
+
+describe('ProgressEventsService liveness wiring', () => {
+  let recordSuccess: ReturnType<typeof vi.fn>;
+  let status$: BehaviorSubject<ConnectionStatus>;
+  let originalEventSource: typeof EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+
+    recordSuccess = vi.fn();
+    status$ = new BehaviorSubject<ConnectionStatus>('online');
+    const connectionStub = {
+      status$,
+      recordSuccess,
+      recordNetworkFailure: vi.fn(),
+      get isOffline() {
+        return status$.value === 'offline';
+      },
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConnectionStateService, useValue: connectionStub as unknown as ConnectionStateService },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    globalThis.EventSource = originalEventSource;
+  });
+
+  function connectedSource(): FakeEventSource {
+    TestBed.inject(ProgressEventsService);
+    return FakeEventSource.instances[0];
+  }
+
+  it('connects to /api/events while online', () => {
+    const es = connectedSource();
+    expect(es.url).toBe('/api/events');
+  });
+
+  it('treats a heartbeat frame as proof the backend is alive', () => {
+    const es = connectedSource();
+    recordSuccess.mockClear();
+    es.emit('heartbeat', { ts: 123 });
+    expect(recordSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a real progress frame as proof of life too', () => {
+    const es = connectedSource();
+    recordSuccess.mockClear();
+    es.emit('dataset', { status: 'loading', current: 5, total: 10 });
+    expect(recordSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -125,27 +125,24 @@ export class ProgressEventsService implements OnDestroy {
     const es = new EventSource('/api/events');
     this.source = es;
 
-    es.addEventListener('server', (e) =>
-      this.zone.run(() => this.handleServerFrame(e)),
+    this.listen(es, 'server', (e) => this.handleServerFrame(e));
+    this.listen(es, 'dataset', (e) =>
+      this.datasetSubject.next(this.parse<ProgressEvent>(e, {})),
     );
-    es.addEventListener('dataset', (e) =>
-      this.zone.run(() => this.datasetSubject.next(this.parse<ProgressEvent>(e, {}))),
+    this.listen(es, 'loading-tasks', (e) =>
+      this.loadingTasksSubject.next(this.parse<LoadingTask[]>(e, [])),
     );
-    es.addEventListener('loading-tasks', (e) =>
-      this.zone.run(() => this.loadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
+    this.listen(es, 'detector-loading-tasks', (e) =>
+      this.detectorLoadingTasksSubject.next(this.parse<LoadingTask[]>(e, [])),
     );
-    es.addEventListener('detector-loading-tasks', (e) =>
-      this.zone.run(() => this.detectorLoadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
-    );
-    es.addEventListener('sort', (e) =>
-      this.zone.run(() => this.sortSubject.next(this.parse<ProgressEvent>(e, {}))),
-    );
-    es.addEventListener('find', (e) =>
-      this.zone.run(() => this.findSubject.next(this.parse<ProgressEvent>(e, {}))),
-    );
-    es.addEventListener('eval', (e) =>
-      this.zone.run(() => this.evalSubject.next(this.parse<ProgressEvent>(e, {}))),
-    );
+    this.listen(es, 'sort', (e) => this.sortSubject.next(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'find', (e) => this.findSubject.next(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'eval', (e) => this.evalSubject.next(this.parse<ProgressEvent>(e, {})));
+    // The periodic `heartbeat` frame carries no payload we render; its sole
+    // job is to keep the circuit breaker online (handled by `listen`'s
+    // recordSuccess) during long, busy operations that aren't emitting
+    // progress frames, so the backend never looks dead while it's merely busy.
+    this.listen(es, 'heartbeat', () => {});
 
     es.onopen = () => this.zone.run(() => this.connection.recordSuccess());
 
@@ -184,6 +181,23 @@ export class ProgressEventsService implements OnDestroy {
       this.reconnectTimer = null;
       this.connect();
     }, 2000);
+  }
+
+  /**
+   * Register a named-event listener that (a) re-enters Angular's zone so
+   * bound templates update, and (b) records the frame as proof the backend
+   * is alive. Every frame that arrives over the stream — progress data or a
+   * bare `heartbeat` — resets the connection circuit breaker, so it only
+   * trips offline when the stream genuinely goes silent (a dead backend),
+   * not when a busy backend is slow to answer unrelated background pollers.
+   */
+  private listen(es: EventSource, name: string, handler: (e: Event) => void): void {
+    es.addEventListener(name, (e) =>
+      this.zone.run(() => {
+        this.connection.recordSuccess();
+        handler(e);
+      }),
+    );
   }
 
   private parse<T>(e: Event, fallback: T): T {

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -289,6 +289,31 @@ class TestEventsRoute:
         finally:
             gen.close()
 
+    def test_heartbeat_is_a_real_named_event(self):
+        """An idle stream emits a named ``heartbeat`` event (not an SSE
+        comment) so the browser's EventSource fires a listener and the client
+        can use it as a liveness signal."""
+        gen = stream_progress_events(heartbeat_seconds=0.01)
+        try:
+            # Drain the connect comment + initial snapshot, then keep pulling
+            # until the idle branch fires a heartbeat (no updates published, so
+            # the queue.get() times out almost immediately).
+            heartbeat = None
+            deadline = time.monotonic() + 2.0
+            while heartbeat is None and time.monotonic() < deadline:
+                chunk = next(gen)
+                if chunk.startswith("event: heartbeat\n"):
+                    heartbeat = chunk
+            assert heartbeat is not None, "no heartbeat frame arrived"
+            # It is a real event with a JSON data line, never a `: heartbeat`
+            # comment.
+            assert not heartbeat.startswith(": ")
+            data_line = [ln for ln in heartbeat.splitlines() if ln.startswith("data: ")][0]
+            payload = json.loads(data_line.removeprefix("data: "))
+            assert "ts" in payload
+        finally:
+            gen.close()
+
     def test_initial_dataset_snapshot_reflects_current_state(self):
         dataset_progress.update("loading", "snap", 7, 8)
         try:

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -31,6 +31,14 @@ from vtscore.concurrency.progress import (
 #: channels so finished tasks vanish from clients once they pass the
 #: ``LoadingTasksTracker`` stale-prune window without us having to
 #: schedule a background timer for every finish.
+#:
+#: The heartbeat is the frontend's authoritative "backend is alive" signal
+#: (see ``ConnectionStateService``): as long as a frame — heartbeat or real
+#: progress — keeps arriving, the client's offline circuit breaker stays
+#: online even while a long, busy operation (dataset ingest, training) makes
+#: the backend slow to answer unrelated background pollers. So the cadence
+#: must stay comfortably below the breaker's tolerance for consecutive poller
+#: misses; 5s is well under that.
 HEARTBEAT_SECONDS = 5.0
 
 #: Per-process identifier emitted as the first SSE frame on every new
@@ -132,7 +140,14 @@ def stream_progress_events(  # noqa: C901
                 name, snapshot = q.get(timeout=timeout)
                 yield _format_sse(name, snapshot)
             except queue.Empty:
-                yield ": heartbeat\n\n"
+                # Emit the heartbeat as a real, named ``heartbeat`` event
+                # rather than an SSE comment (``: heartbeat``). Comments are
+                # invisible to the browser's EventSource API, so the client
+                # could not use them as a liveness signal; a named event fires
+                # a listener, letting the frontend treat every heartbeat as
+                # proof the backend is still alive (and keeping idle proxies
+                # open just as a comment would).
+                yield _format_sse("heartbeat", {"ts": time.time()})
                 # Re-emit task channels so clients see finished tasks
                 # disappear once their stale-prune window elapses.
                 for name, tasks_tracker in _TASK_CHANNELS.items():

--- a/vtsearch/routes/events.py
+++ b/vtsearch/routes/events.py
@@ -19,10 +19,10 @@ def progress_events() -> Response:
 
     The client connects with ``new EventSource('/api/events')`` and listens
     for ``server`` (per-connect identity frame carrying ``boot_id``),
-    ``dataset``, ``sort``, ``find``, ``eval``, ``loading-tasks``, and
-    ``detector-loading-tasks`` events. The first frame on every channel is
-    the current snapshot; clients do not need a separate REST call to
-    bootstrap state.
+    ``dataset``, ``sort``, ``find``, ``eval``, ``loading-tasks``,
+    ``detector-loading-tasks``, and ``heartbeat`` (periodic liveness ping)
+    events. The first frame on every channel is the current snapshot; clients
+    do not need a separate REST call to bootstrap state.
     """
     response = Response(
         stream_with_context(stream_progress_events()),


### PR DESCRIPTION
## Problem

The "inactive backend" offline banner fired too easily during long, busy operations like dataset ingest. The backend was alive and streaming progress frames the whole time — it was just slow to answer unrelated background pollers — but the app declared it dead anyway.

Two gaps in the frontend circuit breaker (`ConnectionStateService`) caused this:

1. **The heartbeat was invisible.** `vtscore/concurrency/events.py` emitted the "I'm still here!" heartbeat as an SSE *comment* (`: heartbeat`). SSE comments fire no listener in the browser's `EventSource` API, so the client could never use them as a liveness signal.
2. **Live progress frames didn't count as proof of life.** Only full HTTP responses and the one-time SSE `onopen` reset the breaker. The `dataset`/`loading-tasks`/etc. frames streaming during ingest did not, so a few slow/failed pollers could pile up to the offline threshold while ingest was clearly running.

## Fix

Make the SSE stream the authoritative liveness signal:

- **Backend** (`vtscore/concurrency/events.py`): emit the heartbeat as a real named `heartbeat` event carrying a `{ "ts": ... }` timestamp instead of an invisible comment. A named event keeps idle proxies alive just as a comment did, but is also visible to the client.
- **Frontend** (`progress-events.service.ts`): route every named-event listener through a `listen` helper that calls `recordSuccess()` on each frame — heartbeat or real progress. The breaker now only trips when the stream genuinely goes silent (a dead backend), not when a busy backend is slow to answer unrelated pollers.

## Tests

- New backend test asserts the idle stream emits a real named `heartbeat` event (not a comment) with a `ts` payload.
- New frontend spec stubs `EventSource` and verifies both a `heartbeat` frame and a real `dataset` progress frame call `recordSuccess()`.
- Full suite green (`./run-tests.sh`: 4842 passed; frontend Vitest: 763 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XurbavHuNK3rpo3VB2ukzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XurbavHuNK3rpo3VB2ukzE)_