### PR TITLE
Fix best-match highlight on patch datasets; new highlighter icon

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -52,7 +52,7 @@
             aria-label="Highlight: outline best-matched region"
             [attr.aria-pressed]="imageViewer.highlightMode"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5" stroke-dasharray="3 2.5"/><circle cx="12" cy="12" r="2.5" fill="currentColor" stroke="none"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4l6 6-8 8-6-6z"/><path d="M6 12l-2.5 6.5L10 16z" fill="currentColor"/></svg>
           </button>
         }
         <span class="ivc-sep" aria-hidden="true"></span>

--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -538,3 +538,55 @@ class TestEmbedMissingRoutesToPatchForwardBulk:
         for m in medias.values():
             assert m.get("patch_regions") is not None
             assert m.get("patch_grid") is not None
+
+    def test_embed_missing_backfills_patch_regions_for_preembedded(self):
+        """Already-embedded images that lack a region tree still get the patch
+        pass.
+
+        Regression: the patch-region pass used to be gated on the image-level
+        ``missing`` set, so a dataset that arrived already-embedded (pickle /
+        content-vector importer) but without ``patch_regions`` never ran the
+        patch pass.  The best-match highlight then had no region to draw even
+        though the embedder reported ``supports_patch_regions``.
+        """
+        from vtscore.datasets.stages.embedding import embed_missing
+
+        emb = mock.MagicMock()
+        emb.name = "fake_patch"
+        emb._model = True
+        emb._on_progress = lambda *a, **kw: None
+        emb.supports_patch_regions = True
+
+        patch_outputs = [mock.MagicMock(patch_grid=np.zeros((4, 4, 768), dtype=np.float32)) for _ in range(2)]
+        emb.patch_forward_bulk.return_value = patch_outputs
+
+        # Every media already carries an embedding (nothing in the "missing"
+        # set) but no patch_regions yet.
+        medias = {
+            i: {
+                "media_type": "image",
+                "embedding": np.zeros(768, dtype=np.float32),
+                "embedder": "fake_patch",
+                "media_path": f"/tmp/img_{i}.png",
+            }
+            for i in range(1, 3)
+        }
+
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+            mock.patch(
+                "vtscore.media.patch_embed.build_region_tree", return_value=np.zeros((23, 768), dtype=np.float32)
+            ),
+            mock.patch("vtscore.media.patch_embed.to_fp16", side_effect=lambda x: x.astype(np.float16)),
+        ):
+            embed_missing(medias)
+
+        # No image-level embedding work (all were embedded already)...
+        emb.embed_media_bulk.assert_not_called()
+        # ...but the patch pass still ran over the region-less images.
+        assert emb.patch_forward_bulk.call_count == 1
+        sent = emb.patch_forward_bulk.call_args.args[0]
+        assert len(sent) == 2
+        for m in medias.values():
+            assert m.get("patch_regions") is not None
+            assert m.get("patch_grid") is not None

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -10,6 +10,7 @@ that report ``supports_patch_regions``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
 from vtscore.embedding.matrix import invalidate_embedding_matrix
@@ -18,6 +19,15 @@ from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
 
 if TYPE_CHECKING:
     from vtscore.state import DatasetContext
+
+
+def _first_media_type(items: Iterable[tuple[int, dict[str, Any]]]) -> str:
+    """Return the first non-empty ``media_type`` among *items*, or ``""``."""
+    for _, m in items:
+        mt = m.get("media_type")
+        if mt:
+            return mt
+    return ""
 
 
 def embed_missing(  # noqa: C901
@@ -41,15 +51,13 @@ def embed_missing(  # noqa: C901
     report ``supports_patch_regions``.
     """
     missing = [(mid, m) for mid, m in medias.items() if m.get("embedding") is None]
-    if not missing:
-        return
 
-    media_type = ""
-    for _, m in missing:
-        mt = m.get("media_type")
-        if mt:
-            media_type = mt
-            break
+    # Resolve the media type from the items that need work.  Prefer the
+    # unembedded items, but fall back to any media so the patch-region
+    # back-fill below can run even when every image already carries an
+    # embedding (e.g. a pre-embedded pickle or content-vector importer bound
+    # to a patch embedder).
+    media_type = _first_media_type(missing) or _first_media_type(medias.items())
     if not media_type:
         return
 
@@ -67,6 +75,32 @@ def embed_missing(  # noqa: C901
     if emb is None:
         return
 
+    # Patch-capable embedders attach a per-image HAC region tree + patch grid
+    # alongside the CLS ``embedding``.  That side-channel must exist for any
+    # image *this* embedder produced but that lacks ``patch_regions`` - not
+    # only the images we embed in this call.  Without it the best-match
+    # highlight, region voting, and region-aware scoring have no region data,
+    # which is exactly what happens to an already-embedded dataset (pickle /
+    # content-vector importer) that never ran the patch pass: the Highlight
+    # toggle shows (the embedder reports the capability) but draws nothing.
+    # Re-deriving from the source file at load keeps ``patch_regions`` an
+    # in-memory artifact, consistent with the no-persisted-vectors rule.
+    patch_capable = getattr(emb, "supports_patch_regions", False) is True
+
+    def _needs_patch(m: dict[str, Any]) -> bool:
+        # Match the embedder so we never re-pool regions for an image whose
+        # CLS embedding came from a different model.
+        return (
+            m.get("embedding") is not None
+            and m.get("patch_regions") is None
+            and m.get("embedder") in (None, "", emb.name)
+        )
+
+    has_patch_backfill = patch_capable and any(_needs_patch(m) for m in medias.values())
+
+    if not missing and not has_patch_backfill:
+        return
+
     if on_progress is None:
 
         def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
@@ -78,36 +112,41 @@ def embed_missing(  # noqa: C901
         on_progress("loading", "Loading embedding model…", 0, 0)
         emb.load_models()
 
-    total = len(missing)
-    on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
-
-    inputs = [m for _, m in missing]
     original_cb = emb._on_progress
-    emb._on_progress = on_progress
-    try:
-        vectors = emb.embed_media_bulk(inputs)
-    except Exception:
-        logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
+
+    if missing:
+        total = len(missing)
+        on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
+
+        inputs = [m for _, m in missing]
+        emb._on_progress = on_progress
+        try:
+            vectors = emb.embed_media_bulk(inputs)
+        except Exception:
+            logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
+            vectors = None
+        finally:
+            emb._on_progress = original_cb
+
+        if vectors is not None:
+            embedder_id = emb.name
+            for (mid, _), vec in zip(missing, vectors):
+                if vec is None:
+                    continue
+                media = medias.get(mid)
+                if media is None:
+                    continue
+                media["embedding"] = vec
+                if not media.get("embedder"):
+                    media["embedder"] = embedder_id
+
+    # Patch-region pass for embedders that support it (DINOv2/v3/EUPE).  Runs
+    # over every patch-capable image still lacking a region tree, including
+    # ones that arrived already-embedded - not just the items embedded above.
+    if not patch_capable:
         return
-    finally:
-        emb._on_progress = original_cb
 
-    embedder_id = emb.name
-    for (mid, _), vec in zip(missing, vectors):
-        if vec is None:
-            continue
-        media = medias.get(mid)
-        if media is None:
-            continue
-        media["embedding"] = vec
-        if not media.get("embedder"):
-            media["embedder"] = embedder_id
-
-    # Patch-region pass for embedders that support it (DINOv2/v3/EUPE).
-    if getattr(emb, "supports_patch_regions", False) is not True:
-        return
-
-    patch_inputs = [m for _, m in missing if m.get("patch_regions") is None]
+    patch_inputs = [m for m in medias.values() if _needs_patch(m)]
     if not patch_inputs:
         return
 


### PR DESCRIPTION
## Summary

The focus-view **Highlight** toggle drew nothing on patch-embedder datasets — no yellow dashed box on the canvas and no region outlines on the gallery thumbnails — even with a patch-capable embedder and region votes. This fixes the root cause and refreshes the button glyph.

## The bug

The patch-region pass (which attaches `media["patch_regions"]` + `media["patch_grid"]`, the side-channel the best-match highlight, region voting, and region-aware scoring all depend on) lived **inside `embed_missing` and was gated entirely on the image-level `missing` set** (`embedding is None`).

So any dataset that arrived **already-embedded but without a region tree** — a pickle, or a content-vector importer, bound to a patch embedder — hit the early `return` and never ran the patch pass. The result:

- The Highlight toggle still **showed** (it keys off `supports_patch_regions`, which is a property of the embedder), but there was no `best_region` to draw.
- Region voting silently fell back to image-level embeddings (no `patch_grid`), though the cropped vote *thumbnails* still rendered (pure UI).
- So nothing appeared **anywhere** — canvas or left-panel thumbnails — which is the reported symptom.

A standalone repro confirmed the scoring pipeline produces correct **sub-region** `best_region` values when `patch_regions` are present, isolating the gap to the attach step.

## The fix

`embed_missing` now runs the patch pass over **every patch-capable image still lacking a region tree**, not just images embedded in the current call — matched on the stored `embedder` so we never re-pool regions against a different model.

- Fresh folder loads: unchanged.
- Properly-loaded patch datasets (regions already present) and non-patch datasets: still a no-op.
- Re-deriving from the source file at load keeps `patch_regions` an in-memory artifact, consistent with the no-persisted-vectors rule.

Caveat: re-derivation needs the source image to be reachable; a pure-vector dataset with no recoverable files can't have its regions rebuilt (it degrades gracefully — no crash, just no highlight).

## Also

- Swapped the Highlight button glyph (was a dashed rectangle + dot) for a chisel-tip highlighter that matches the sibling line-art controls.

## Tests

- New `tests_lib` regression: `test_embed_missing_backfills_patch_regions_for_preembedded` — already-embedded, region-less, patch-capable media get the patch pass with no image-level embed work.
- Full `./run-tests.sh` green (4843 passed, 1 skipped), including the frontend build that validates the new icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011GJG9ShS3kP3hgSPUFKXPz)_