### PR TITLE
Fix best-match highlight: resolve stored embedder for patch back-fill

### DIFF
--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -590,3 +590,67 @@ class TestEmbedMissingRoutesToPatchForwardBulk:
         for m in medias.values():
             assert m.get("patch_regions") is not None
             assert m.get("patch_grid") is not None
+
+    def test_backfill_resolves_stored_embedder_over_single_vector_default(self):
+        """Reloading a patch dataset with no explicit embedder still back-fills.
+
+        Regression: ``embed_missing`` resolved the embedder from the requested
+        name or the *media-type default*, which for images is the single-vector
+        SigLIP embedder (``supports_patch_regions=False``).  A pre-embedded
+        patch dataset (cached pickle reload / content-vector importer) loaded
+        with ``embedder_name=""`` therefore resolved to SigLIP and skipped the
+        patch-region back-fill entirely - so region voting and the best-match
+        highlight had no region data, and nothing rendered.  The resolver now
+        falls back to the embedder the media were embedded with (stored on each
+        media dict) before the media-type default.
+        """
+        from vtscore.datasets.stages.embedding import embed_missing
+
+        # The patch embedder the media were originally embedded with...
+        patch_emb = mock.MagicMock()
+        patch_emb.name = "fake_patch"
+        patch_emb._model = True
+        patch_emb._on_progress = lambda *a, **kw: None
+        patch_emb.supports_patch_regions = True
+        patch_emb.patch_forward_bulk.return_value = [
+            mock.MagicMock(patch_grid=np.zeros((4, 4, 768), dtype=np.float32)) for _ in range(2)
+        ]
+
+        # ...and the single-vector embedder that is the media-type default.
+        default_single = mock.MagicMock()
+        default_single.name = "fake_single"
+        default_single.supports_patch_regions = False
+
+        medias = {
+            i: {
+                "media_type": "image",
+                "embedding": np.zeros(768, dtype=np.float32),
+                "embedder": "fake_patch",
+                "media_path": f"/tmp/img_{i}.png",
+            }
+            for i in range(1, 3)
+        }
+
+        def _get_embedder(name):
+            if name == "fake_patch":
+                return patch_emb
+            raise KeyError(name)
+
+        with (
+            mock.patch("vtscore.media.get_embedder", side_effect=_get_embedder),
+            mock.patch("vtscore.media.embedders_for_type", return_value=[default_single]),
+            mock.patch(
+                "vtscore.media.patch_embed.build_region_tree", return_value=np.zeros((23, 768), dtype=np.float32)
+            ),
+            mock.patch("vtscore.media.patch_embed.to_fp16", side_effect=lambda x: x.astype(np.float16)),
+        ):
+            # No explicit embedder: must resolve to the stored "fake_patch",
+            # not the single-vector default.
+            embed_missing(medias, embedder_name="")
+
+        # The single-vector default never got a look-in for the patch pass.
+        default_single.patch_forward_bulk.assert_not_called()
+        assert patch_emb.patch_forward_bulk.call_count == 1
+        for m in medias.values():
+            assert m.get("patch_regions") is not None
+            assert m.get("patch_grid") is not None

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -30,6 +30,23 @@ def _first_media_type(items: Iterable[tuple[int, dict[str, Any]]]) -> str:
     return ""
 
 
+def _first_stored_embedder(medias: dict[int, dict[str, Any]]) -> str:
+    """Return the first non-empty ``embedder`` recorded on a media, or ``""``.
+
+    Already-embedded media (a pickle reload or content-vector importer) carry
+    the name of the embedder that produced their vectors.  When no explicit
+    embedder was requested for this load, we resolve against that stored name
+    rather than the media-type default so a patch-embedded dataset re-binds to
+    its patch embedder - the single-vector default would otherwise report
+    ``supports_patch_regions=False`` and silently skip the region back-fill.
+    """
+    for m in medias.values():
+        name = m.get("embedder")
+        if name:
+            return name
+    return ""
+
+
 def embed_missing(  # noqa: C901
     medias: dict[int, dict[str, Any]],
     embedder_name: str = "",
@@ -69,6 +86,20 @@ def embed_missing(  # noqa: C901
             emb = get_embedder(embedder_name)
         except KeyError:
             emb = None
+    if emb is None and not embedder_name:
+        # No explicit embedder for this load: honour the one the media were
+        # already embedded with (set on a pickle reload / content-vector
+        # importer) before falling back to the media-type default.  Without
+        # this a patch-embedded dataset reloaded with no embedder pick would
+        # resolve to the single-vector default and skip the patch-region
+        # back-fill below, so the best-match highlight and region voting have
+        # no region data to work with.
+        stored = _first_stored_embedder(medias)
+        if stored:
+            try:
+                emb = get_embedder(stored)
+            except KeyError:
+                emb = None
     if emb is None:
         avail = embedders_for_type(media_type)
         emb = avail[0] if avail else None


### PR DESCRIPTION
## Problem

The best-match Highlight (yellow box) still didn't render for patch-embedder datasets when training a detector with region voting — no box on thumbnails or the main canvas.

The previous fix added a patch-region back-fill to `embed_missing` so already-embedded datasets (a cached pickle reload or a content-vector importer bound to a patch embedder) would re-derive their region trees on load. But that back-fill is gated on the **resolved** embedder reporting `supports_patch_regions`, and the resolver only considered the explicitly-requested embedder or the **media-type default**. For images the default is single-vector SigLIP (`supports_patch_regions=False`).

So when such a dataset is loaded with no explicit embedder pick (`embedder_name=""`), `embed_missing` resolved to SigLIP and skipped the patch pass entirely — even though every media's stored `embedder` field said it was a patch embedder. With no `patch_regions`/`patch_grid` on the media:

- region voting silently fell back to image-level (CLS) embeddings, and
- detector scoring produced no `best_region`, so the highlight had nothing to draw anywhere.

This is exactly the "pickle / content-vector importer bound to a patch embedder" case the previous fix's docstring claimed to cover.

## Fix

When no explicit embedder is requested, resolve the embedder from the name stored on the already-embedded media (added `_first_stored_embedder`) **before** falling back to the media-type default. A patch-embedded dataset then re-binds to its patch embedder and re-derives its region trees on reload, so `best_region` flows through to the gallery thumbnails and the focus-view Highlight overlay.

Verified end-to-end with a synthetic patch grid: `train_and_score` returns well-formed sub-region boxes (not the hidden full-image fallback).

## Tests

- New regression test `test_backfill_resolves_stored_embedder_over_single_vector_default` reproduces the real condition (single-vector default + patch-capable stored embedder + empty `embedder_name`). The pre-existing back-fill test passed only because it mocked the *default* to be patch-capable, masking this gap.
- `./run-tests.sh detectors io datasets` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y3rWbBTaSn394QadHChzk)_