### PR TITLE
httpResource migration Phase 2: MediaStateService + drop settings shims

### DIFF
--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -1,11 +1,57 @@
 # `httpResource` / reactive-resource migration for the data layer
 
-Status: **Phase 1 (pilot) shipped.** The `SettingsStateService` read path now
-runs on `rxResource`; the pattern and its test story are proven (see "What
-shipped" below). Remaining read services are deferred — see "Open follow-ups".
-Scoped after the Angular 21 + Vitest work landed (see `angular-21-upgrade.md`,
-which lists this as a deferred carrot). This doc decides *how* VTSearch should
-adopt Angular's resource primitives and in what order.
+Status: **Phase 1 (pilot) + Phase 2 (first expansion) shipped.** The
+`SettingsStateService` and `MediaStateService` read paths both run on
+`rxResource`. Phase 2 also **dropped the pilot's compatibility shims**: the
+services now expose their signals directly and all consumers were migrated, so
+there are no Observable bridges or sync getters left to bridge old callers (per
+the repo's "no shims, just make the clean change" rule). Remaining read
+services (pollers, `forkJoin` aggregates) are still deferred — see "Open
+follow-ups". Scoped after the Angular 21 + Vitest work landed (see
+`angular-21-upgrade.md`, which lists this as a deferred carrot). This doc
+decides *how* VTSearch should adopt Angular's resource primitives and in what
+order.
+
+## What shipped (Phase 2 — MediaStateService + shim removal)
+
+The user's call here was that preserving the old per-service public surface is
+not worth it: VTSearch's frontend is the only caller of its own services (and
+its backend), and a migration upgrades caller and callee together, so the
+shims the pilot left behind were pure dead weight. So Phase 2 went the full
+distance instead of bridging.
+
+- **`MediaStateService` read path migrated to `rxResource`.** The dataset-wide
+  media-stub list (`GET /api/medias/ids`) is now an `rxResource` wrapping the
+  generated `MediasApiService.getMediaIds()`, using the same monotonic-counter
+  request trigger as the settings pilot (`loadMedias()` bumps the counter;
+  `clear()` is `resource.set([])`). It exposes `mediasSignal()` /
+  `isLoading()`; `selectedId` is now a plain `signal`; `selectedMedia` /
+  `getMedia()` stay synchronous accessors over the signal + metadata cache. The
+  `medias$` / `loading$` / `selectedId$` Observables, the `BehaviorSubject`s,
+  and `OnDestroy`/`destroy$` are gone.
+- **`SettingsStateService` shims removed.** `settings$` (the `toObservable`
+  bridge) and the sync `settings` getter are deleted; the canonical surface is
+  `settingsSignal()` / `isLoading()` / `error()`.
+- **Consumer migration pattern (the repeatable part).** Every
+  `settings$.subscribe(s => …)` / `medias$.subscribe(m => …)` became a
+  **constructor `effect()`** that reads the signal (`settingsState
+  .settingsSignal()` / `mediaState.mediasSignal()`). Effects auto-dispose with
+  their component, so the matching `takeUntil(destroy$)` plumbing was dropped
+  (and `destroy$`/`OnDestroy` removed where it was the last user). Synchronous
+  getter reads (`settingsState.settings?.x`, `mediaState.medias`) became signal
+  calls (`settingsSignal()?.x`, `mediasSignal()`), including in templates
+  (`[medias]="mediaState.mediasSignal()"`, `[selectedId]="mediaState
+  .selectedId()"`). ~18 consumer files across both services.
+- **Test timing (reinforces the pilot's notes).** Because the `rxResource`
+  loader runs in a **root effect**, `fixture.detectChanges()` alone does *not*
+  issue the GET — component specs that previously relied on the old synchronous
+  `loadMedias()` subscribe needed a `TestBed.tick()` after `detectChanges()` to
+  actually fire `/api/medias/ids` (e.g. `label-view`'s `flushInitialRequests`).
+  The value still commits on a microtask, so any assertion on resolved medias
+  drains with the `settle()` helper (`await macrotask` + `TestBed.tick()`).
+  Effect-driven side effects (the medias→media-type sync, the deferred
+  autopilot text/media sort) are now microtask-scheduled rather than
+  synchronous, so the specs exercising them `await settle()` before asserting.
 
 ## What shipped (Phase 1 pilot)
 
@@ -169,18 +215,24 @@ app must be half-migrated.
 
 ## Open follow-ups
 
-- **Expand to more read services** (step 3). The settings pilot kept the old
-  public API for zero consumer churn; future conversions can go further and
-  expose the resource signals directly to consumers (then drop the
-  `settings$`/getter shims) where it removes real boilerplate. Natural next
-  candidates: context-keyed list reads (media-types, embedders) where a
-  `toSignal(activeContext)` request key earns the reactivity.
+- **Expand to more read services** (step 3). Done for `SettingsStateService`
+  (Phase 1, shims removed in Phase 2) and `MediaStateService` (Phase 2).
+  Remaining single-read candidates worth a look: context-keyed list reads
+  (media-types, embedders) where a `toSignal(activeContext)` request key would
+  earn the reactivity — these currently live inside the active-context /
+  datasets-listings services rather than a dedicated read service, so there's
+  plumbing to untangle first.
+- **`DetectorStateService` looks dead.** As of Phase 2 it has **no consumers**
+  outside its own file + spec (its `extractors$`/`localizers$` are unread).
+  Confirm and delete it (or wire it up) rather than converting it; converting a
+  service nobody reads demonstrates nothing.
 - **Pollers and `forkJoin` aggregates** (`VoteStateService`, labeling status,
   `DatasetStateService.refresh()`) are still imperative by design; revisit only
   if a resource clearly wins.
-- **A shared test helper** for the `TestBed.tick()` / real-async drain dance was
-  not extracted yet (the settings specs inline it). Extract one once a second
-  service is converted and the shape is confirmed to repeat.
+- **A shared test helper** for the `TestBed.tick()` / `settle()` drain dance is
+  still not extracted — the settings, media, and label-view specs each inline
+  their own `settle()`. The shape has now repeated across three specs, so this
+  is ripe to extract (a `settleResource(fixture)` test util).
 
 ## Decision points needing the user
 

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -162,7 +162,7 @@ describe('AppComponent', () => {
   it('should set settingsViewTab from labeling media type', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const mediaState = TestBed.inject(MediaStateService);
-    vi.spyOn(mediaState, 'medias', 'get').mockReturnValue([
+    vi.spyOn(mediaState, 'mediasSignal').mockReturnValue([
       { id: 1, media_type: 'image' },
     ]);
     fixture.componentInstance.isOnLabelView = true;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, effect } from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { combineLatest } from 'rxjs';
@@ -105,8 +105,9 @@ export class AppComponent {
   ) {
     this.auth.checkStatus();
     this.settingsState.load();
-    this.settingsState.settings$.subscribe((s) => {
-      this.achievementsDisabled = s?.enable_achievements === false;
+    effect(() => {
+      this.achievementsDisabled =
+        this.settingsState.settingsSignal()?.enable_achievements === false;
     });
     this.achievements.refresh();
     this.achievements.openPanelRequest$.subscribe(() => {
@@ -337,7 +338,7 @@ export class AppComponent {
   private inferMediaType(): string {
     // From labeling view: use the media type of loaded medias
     if (this.isOnLabelView) {
-      const medias = this.mediaState.medias;
+      const medias = this.mediaState.mediasSignal();
       if (medias.length > 0) {
         return medias[0].media_type;
       }

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, effect } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -56,16 +56,18 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   constructor(
     private achievements: AchievementsService,
     private settingsState: SettingsStateService,
-  ) {}
+  ) {
+    effect(() => {
+      const s = this.settingsState.settingsSignal();
+      this.disableAchievements = s?.enable_achievements === false;
+      if (this.lastState) this.applyState(this.lastState);
+    });
+  }
 
   ngOnInit(): void {
     this.achievements.state.pipe(takeUntil(this.destroy$)).subscribe((state) => {
       this.lastState = state;
       this.applyState(state);
-    });
-    this.settingsState.settings$.pipe(takeUntil(this.destroy$)).subscribe((s) => {
-      this.disableAchievements = s?.enable_achievements === false;
-      if (this.lastState) this.applyState(this.lastState);
     });
     this.achievements.refresh();
   }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -11,6 +11,7 @@ import {
   Output,
   SimpleChanges,
   ViewChild,
+  effect,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
@@ -183,7 +184,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     private activeContext: ActiveContextService,
     private settingsState: SettingsStateService,
     private cdr: ChangeDetectorRef,
-  ) {}
+  ) {
+    // Re-read the popup's thumbnail size whenever settings change (this is how
+    // the in-header size buttons take effect, and how a change on one popup
+    // becomes the default for every future popup of this media type).
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
+      this.applyViewPrefs();
+    });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['memberIds']) {
@@ -228,14 +239,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
       // A selection change anywhere (here, the canvas, the panel) re-highlights.
       this.selection.changed$.subscribe(() => this.cdr.markForCheck()),
-      // Re-read the popup's thumbnail size whenever settings change (this is how
-      // the in-header size buttons take effect, and how a change on one popup
-      // becomes the default for every future popup of this media type).
-      this.settingsState.settings$.subscribe((settings) => {
-        if (!settings) return;
-        this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
-        this.applyViewPrefs();
-      }),
     );
     this.settingsState.load();
     this.scrollSub =

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -77,7 +77,21 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
     private metadataCache: MediaMetadataCacheService,
     private activeContext: ActiveContextService,
     private settingsState: SettingsStateService,
-  ) {}
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      const viewDict = settings.view_mode_right;
+      if (viewDict && typeof viewDict === 'object') {
+        this.viewModeRightDict = viewDict as Record<string, 'grid' | 'list'>;
+      }
+      const sizeDict = settings.grid_icon_size_right;
+      if (sizeDict && typeof sizeDict === 'object') {
+        this.gridIconSizeRightDict = sizeDict as Record<string, string>;
+      }
+      this.applyViewPrefs();
+    });
+  }
 
   ngOnInit(): void {
     this.refreshSelection();
@@ -85,18 +99,6 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
       this.selection.changed$.subscribe(() => this.refreshSelection()),
       this.metadataCache.version$.subscribe(() => {
         this.sortedEntries = this.buildSortedEntries();
-      }),
-      this.settingsState.settings$.subscribe((settings) => {
-        if (!settings) return;
-        const viewDict = settings.view_mode_right;
-        if (viewDict && typeof viewDict === 'object') {
-          this.viewModeRightDict = viewDict as Record<string, 'grid' | 'list'>;
-        }
-        const sizeDict = settings.grid_icon_size_right;
-        if (sizeDict && typeof sizeDict === 'object') {
-          this.gridIconSizeRightDict = sizeDict as Record<string, string>;
-        }
-        this.applyViewPrefs();
       }),
     );
     this.settingsState.load();

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -198,10 +198,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     private dialog: VtDialogService,
     private toast: ToastService,
     private ngZone: NgZone,
-  ) {}
-
-  ngOnInit(): void {
-    this.settingsState.settings$.pipe(takeUntil(this.destroy$)).subscribe((settings) => {
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
       if (!settings) return;
       this.lastSettings = settings;
       if (settings.browse_panel_width != null) {
@@ -213,6 +212,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       }
       this.applyBrowsePrefsForMediaType();
     });
+  }
+
+  ngOnInit(): void {
     this.settingsState.load();
 
     // Subset mode: the Find view handed off a set of positive ids to project

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild, effect } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
@@ -84,7 +84,17 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     private settingsState: SettingsStateService,
     private sortState: SortStateService,
     private datasetsListingsApi: DatasetsListingsApiService,
-  ) {}
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      this.volume = settings.volume ?? 1;
+      this.audioPlaying = settings.audio_playing !== false;
+      this.showAnimations = settings.show_animations !== false;
+      this.showMetadata = settings.show_metadata !== false;
+      this.labelHintDismissed = settings.label_hint_dismissed === true;
+    });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media']) {
@@ -324,16 +334,6 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   private loadSettings(): void {
     this.settingsState.load();
-    this.subs.push(
-      this.settingsState.settings$.subscribe((settings) => {
-        if (!settings) return;
-        this.volume = settings.volume ?? 1;
-        this.audioPlaying = settings.audio_playing !== false;
-        this.showAnimations = settings.show_animations !== false;
-        this.showMetadata = settings.show_metadata !== false;
-        this.labelHintDismissed = settings.label_hint_dismissed === true;
-      }),
-    );
   }
 
   private adjustVolume(delta: number): void {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, OnDestroy } from '@angular/core';
+import { Component, HostListener, OnInit, OnDestroy, effect } from '@angular/core';
 
 import { NavigationCancel, NavigationEnd, NavigationError, Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
@@ -184,6 +184,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ) {
     this.datasetCols = columnsService.datasetCols;
     this.detectorCols = columnsService.detectorCols;
+    // Mirror the server's age-off setting so the Age-Off column appears
+    // only when the server actually stamps datasets with an expiry.
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      this.serverSetsAgeOff = settings?.dataset_max_age_days != null;
+    });
   }
 
   ngOnInit(): void {
@@ -192,15 +198,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .subscribe((status) => {
         this.currentUser = status?.user || '';
         this.isDefaultLogin = status?.provider === 'default';
-      });
-    // Mirror the server's age-off setting so the Age-Off column appears
-    // only when the server actually stamps datasets with an expiry. The
-    // settings are loaded once at app startup (AppComponent); subscribing
-    // to the BehaviorSubject replays the latest value immediately.
-    this.settingsState.settings$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((settings) => {
-        this.serverSetsAgeOff = settings?.dataset_max_age_days != null;
       });
     // Auto-select newly added items whenever the dataset/model lists change
     this.datasetState.datasets$

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -241,7 +241,7 @@ export class DatasetImporterModalComponent implements OnInit {
   private importDefaultsForFolderOrTypeId(folderOrTypeId: string): ImportDefaultsForMediaType | null {
     if (!folderOrTypeId) return null;
     const typeId = this.toTypeId(folderOrTypeId) || folderOrTypeId;
-    const map = ((this.settingsState.settings as Record<string, unknown> | undefined)?.[
+    const map = ((this.settingsState.settingsSignal() as Record<string, unknown> | undefined)?.[
       'import_defaults_by_media_type'
     ] || {}) as Record<string, ImportDefaultsForMediaType>;
     return map[typeId] || null;
@@ -404,7 +404,7 @@ export class DatasetImporterModalComponent implements OnInit {
    *  map and push it through ``SettingsStateService`` so the next
    *  importer open picks it up. */
   private persistImportDefaults(typeId: string, cfg: ImportDefaultsForMediaType): void {
-    const current = (this.settingsState.settings as Record<string, unknown> | undefined)?.[
+    const current = (this.settingsState.settingsSignal() as Record<string, unknown> | undefined)?.[
       'import_defaults_by_media_type'
     ] as Record<string, ImportDefaultsForMediaType> | undefined;
     const next: Record<string, ImportDefaultsForMediaType> = { ...(current || {}) };
@@ -454,7 +454,7 @@ export class DatasetImporterModalComponent implements OnInit {
    *  When non-null, the importer hides every mediaType picker and forces
    *  each flow's media_type field to this value. */
   get effectiveSoloMediaType(): string | null {
-    const v = this.settingsState.settings?.effective_solo_media_type;
+    const v = this.settingsState.settingsSignal()?.effective_solo_media_type;
     return v ? v : null;
   }
 
@@ -518,7 +518,7 @@ export class DatasetImporterModalComponent implements OnInit {
       : null;
     if (guessedMatch) return guessedMatch.name;
     const typeId = this.toTypeId(mediaTypeFolderOrTypeId) || mediaTypeFolderOrTypeId;
-    const savedMap = this.settingsState.settings?.last_embedder_per_media_type || {};
+    const savedMap = this.settingsState.settingsSignal()?.last_embedder_per_media_type || {};
     const saved = savedMap[typeId];
     if (saved) {
       const savedMatch = embedders.find((e) => e.name === saved);
@@ -537,7 +537,7 @@ export class DatasetImporterModalComponent implements OnInit {
     if (!mediaTypeFolderOrTypeId) return '';
     const typeId = this.toTypeId(mediaTypeFolderOrTypeId) || mediaTypeFolderOrTypeId;
     const effectiveMap =
-      this.settingsState.settings?.effective_solo_embedder_per_media_type || {};
+      this.settingsState.settingsSignal()?.effective_solo_embedder_per_media_type || {};
     const locked = effectiveMap[typeId];
     if (!locked) return '';
     const list = embedders ?? this.allEmbedders.filter((e) => e.media_type_id === typeId);

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -180,7 +180,7 @@ export class NewDetectorModalComponent implements OnInit {
    *  off. When non-null, the mediaType form-group is hidden in the
    *  template and ``mediaType`` is locked to this value on init. */
   get effectiveSoloMediaType(): string | null {
-    const v = this.settingsState.settings?.effective_solo_media_type;
+    const v = this.settingsState.settingsSignal()?.effective_solo_media_type;
     return v ? v : null;
   }
 

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -1,10 +1,10 @@
 <div class="layout" #layout>
   <div class="panel-left">
     <vt-left-panel
-      [medias]="mediaState.medias"
+      [medias]="mediaState.mediasSignal()"
       [sortOrder]="unverifiedSortOrder"
       [threshold]="sortState.threshold"
-      [selectedId]="mediaState.selectedId"
+      [selectedId]="mediaState.selectedId()"
       [goodVotes]="noVotes"
       [badVotes]="noVotes"
       [sortMode]="sortState.sortMode"
@@ -67,7 +67,7 @@
   ></div>
   <div class="panel-right">
     <vt-right-panel
-      [medias]="mediaState.medias"
+      [medias]="mediaState.mediasSignal()"
       [focusMode]="focusModeRight"
       [disabled]="sortState.sortBusy"
       mode="find"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { combineLatest, Subject, Subscription } from 'rxjs';
@@ -118,7 +118,71 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private progressEvents: ProgressEventsService,
     private browseSubset: BrowseSubsetService,
     private router: Router,
-  ) {}
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      const dict = settings.view_mode_left;
+      if (dict && typeof dict === 'object') {
+        this.viewModeLeftDict = dict as Record<string, 'grid' | 'list'>;
+        if (this.currentMediaType) {
+          this.viewModeLeft = this.viewModeLeftDict[this.currentMediaType] ?? 'list';
+        }
+      }
+      const sizeDict = settings.grid_icon_size_left;
+      if (sizeDict && typeof sizeDict === 'object') {
+        this.gridIconSizeLeftDict = sizeDict as Record<string, string>;
+        if (this.currentMediaType) {
+          this.gridGoalWidthLeft = iconSizeToGoalWidth(
+            this.gridIconSizeLeftDict[this.currentMediaType] ?? 'M',
+          );
+        }
+      }
+      const fmLeft = settings.focus_mode_left;
+      if (fmLeft && typeof fmLeft === 'object') {
+        this.focusModeLeftDict = fmLeft as Record<string, 'click' | 'hover'>;
+        if (this.currentMediaType) {
+          this.focusModeLeft = this.focusModeLeftDict[this.currentMediaType] ?? 'click';
+        }
+      }
+      const fmRight = settings.focus_mode_right;
+      if (fmRight && typeof fmRight === 'object') {
+        this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
+        if (this.currentMediaType) {
+          this.focusModeRight = this.focusModeRightDict[this.currentMediaType] ?? 'click';
+        }
+      }
+      const pplDict = settings.panel_pct_left;
+      if (pplDict && typeof pplDict === 'object') {
+        this.panelPxLeftDict = pplDict as Record<string, number>;
+        if (this.currentMediaType) {
+          this.applyPanelPx(this.currentMediaType);
+        }
+      }
+      const pprDict = settings.panel_pct_right;
+      if (pprDict && typeof pprDict === 'object') {
+        this.panelPxRightDict = pprDict as Record<string, number>;
+        if (this.currentMediaType) {
+          this.applyPanelPx(this.currentMediaType);
+        }
+      }
+    });
+
+    effect(() => {
+      const medias = this.mediaState.mediasSignal();
+      if (medias.length > 0) {
+        const newType = medias[0].media_type;
+        if (newType !== this.currentMediaType) {
+          this.currentMediaType = newType;
+          this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
+          this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
+          this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
+          this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
+          this.applyPanelPx(newType);
+        }
+      }
+    });
+  }
 
   ngOnInit(): void {
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
@@ -143,22 +207,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       next: (status) => { this.datasetName = status.display_name || ''; },
     });
 
-    // When medias arrive, run the find-label scoring
-    this.mediaState.medias$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        if (medias.length > 0) {
-          const newType = medias[0].media_type;
-          if (newType !== this.currentMediaType) {
-            this.currentMediaType = newType;
-            this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
-            this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
-            this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
-            this.applyPanelPx(newType);
-          }
-        }
-      });
+    // When medias arrive, the media-type sync runs from a constructor effect
+    // on `mediaState.mediasSignal()`.
 
     // Run find-label to score and label all medias — unless we're returning
     // from the Browser after verifying a selection there. In that case the
@@ -390,53 +440,6 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private loadSettings(): void {
     this.settingsState.load();
-    this.settingsState.settings$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((settings) => {
-        if (!settings) return;
-        const dict = settings.view_mode_left;
-        if (dict && typeof dict === 'object') {
-          this.viewModeLeftDict = dict as Record<string, 'grid' | 'list'>;
-          if (this.currentMediaType) {
-            this.viewModeLeft = this.viewModeLeftDict[this.currentMediaType] ?? 'list';
-          }
-        }
-        const sizeDict = settings.grid_icon_size_left;
-        if (sizeDict && typeof sizeDict === 'object') {
-          this.gridIconSizeLeftDict = sizeDict as Record<string, string>;
-          if (this.currentMediaType) {
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[this.currentMediaType] ?? 'M');
-          }
-        }
-        const fmLeft = settings.focus_mode_left;
-        if (fmLeft && typeof fmLeft === 'object') {
-          this.focusModeLeftDict = fmLeft as Record<string, 'click' | 'hover'>;
-          if (this.currentMediaType) {
-            this.focusModeLeft = this.focusModeLeftDict[this.currentMediaType] ?? 'click';
-          }
-        }
-        const fmRight = settings.focus_mode_right;
-        if (fmRight && typeof fmRight === 'object') {
-          this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
-          if (this.currentMediaType) {
-            this.focusModeRight = this.focusModeRightDict[this.currentMediaType] ?? 'click';
-          }
-        }
-        const pplDict = settings.panel_pct_left;
-        if (pplDict && typeof pplDict === 'object') {
-          this.panelPxLeftDict = pplDict as Record<string, number>;
-          if (this.currentMediaType) {
-            this.applyPanelPx(this.currentMediaType);
-          }
-        }
-        const pprDict = settings.panel_pct_right;
-        if (pprDict && typeof pprDict === 'object') {
-          this.panelPxRightDict = pprDict as Record<string, number>;
-          if (this.currentMediaType) {
-            this.applyPanelPx(this.currentMediaType);
-          }
-        }
-      });
   }
 
   // --- Media selection ---

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -1,10 +1,10 @@
 <div class="layout" #layout>
   <div class="panel-left">
     <vt-left-panel
-      [medias]="mediaState.medias"
+      [medias]="mediaState.mediasSignal()"
       [sortOrder]="sortState.sortOrder"
       [threshold]="sortState.threshold"
-      [selectedId]="mediaState.selectedId"
+      [selectedId]="mediaState.selectedId()"
       [goodVotes]="voteState.goodVotes"
       [badVotes]="voteState.badVotes"
       [learnedSortAvailable]="voteState.learnedSortAvailable"
@@ -76,7 +76,7 @@
   ></div>
   <div class="panel-right">
     <vt-right-panel
-      [medias]="mediaState.medias"
+      [medias]="mediaState.mediasSignal()"
       [focusMode]="focusModeRight"
       [trainableModelName]="trainableModelName"
       (mediaSelected)="onMediaSelect($event)"

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -38,6 +38,10 @@ describe('LabelViewComponent', () => {
   // by `afterEach`'s catch-all instead.
   function flushInitialRequests(): void {
     fixture.detectChanges();
+    // The medias and settings reads ride `rxResource`, whose loader runs in a
+    // root effect rather than synchronously during `detectChanges()`; tick so
+    // the GETs are actually issued before we match them.
+    TestBed.tick();
     // /api/medias/ids
     httpMock.match('/api/medias/ids').forEach(req =>
       req.flush([
@@ -283,10 +287,14 @@ describe('LabelViewComponent', () => {
     expect(component.mediaState.selectedId()).toBe(1);
   });
 
-  it('should trigger text sort on autopilot start when session has text query', () => {
+  it('should trigger text sort on autopilot start when session has text query', async () => {
     const session = TestBed.inject(LabelSessionService);
     session.textQuery = 'dog barking';
     flushInitialRequests();
+    // The medias list rides an rxResource: its value commits on a microtask and
+    // the media-type/autopilot effect runs on the next tick, so drain before the
+    // deferred initial sort fires.
+    await settle();
 
     // The left panel's ngOnInit already emits autopilotStart when autopilot is
     // enabled; with a text query and medias now loaded, that fires one initial
@@ -313,7 +321,7 @@ describe('LabelViewComponent', () => {
     expect(component.mediaState.selectedId()).toBe(1);
   });
 
-  it('should defer autopilot text sort until medias are loaded', () => {
+  it('should defer autopilot text sort until medias are loaded', async () => {
     const session = TestBed.inject(LabelSessionService);
     session.textQuery = 'cat meowing';
 
@@ -322,8 +330,10 @@ describe('LabelViewComponent', () => {
     // No sort request yet (no medias)
     httpMock.expectNone('/api/sort');
 
-    // Now trigger init which loads medias
+    // Now trigger init which loads medias. The medias GET rides an rxResource
+    // loader effect, so tick to issue it before flushing.
     fixture.detectChanges();
+    TestBed.tick();
     httpMock.match('/api/medias/ids').forEach(req =>
       req.flush([{ id: 1, media_type: 'audio' }]),
     );
@@ -345,6 +355,10 @@ describe('LabelViewComponent', () => {
     httpMock.match('/api/embedders').forEach(req =>
       req.flush([]),
     );
+
+    // Drain the rxResource value commit + media-type/autopilot effect so the
+    // deferred sort fires.
+    await settle();
 
     // Now the deferred sort should fire
     const req = httpMock.expectOne('/api/sort');

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -71,6 +71,14 @@ describe('LabelViewComponent', () => {
     );
   }
 
+  // The media stub list rides an `rxResource`, whose value commits on a
+  // microtask after the `/api/medias/ids` flush. Tests that read the resolved
+  // medias (`mediasSignal()` / `selectedMedia`) drain it with `settle()`.
+  async function settle(): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    TestBed.tick();
+  }
+
   afterEach(() => {
     component.ngOnDestroy();
     // Drain any outstanding polling requests from right-panel or label-view
@@ -90,9 +98,10 @@ describe('LabelViewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should load medias on init', () => {
+  it('should load medias on init', async () => {
     flushInitialRequests();
-    expect(component.mediaState.medias.length).toBe(2);
+    await settle();
+    expect(component.mediaState.mediasSignal().length).toBe(2);
   });
 
   it('should load votes on init', () => {
@@ -157,7 +166,7 @@ describe('LabelViewComponent', () => {
   it('should handle media selection', () => {
     flushInitialRequests();
     component.onMediaSelect(2);
-    expect(component.mediaState.selectedId).toBe(2);
+    expect(component.mediaState.selectedId()).toBe(2);
   });
 
   it('should handle sort mode change', () => {
@@ -180,7 +189,7 @@ describe('LabelViewComponent', () => {
     // With a sort order present the diversity fetch POSTs the scores.
     const req = httpMock.expectOne('/api/diversity-tree/next');
     req.flush({ id: 1, diversity_level: 2.0, exhausted: false });
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should reselect media when switching select mode to top', () => {
@@ -200,7 +209,7 @@ describe('LabelViewComponent', () => {
     component.onSelectModeChange('top');
     expect(component.sortState.selectMode).toBe('top');
     // Should auto-select id 1 (first unlabeled in sort order)
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should reselect media when switching select mode to hard', () => {
@@ -216,7 +225,7 @@ describe('LabelViewComponent', () => {
     component.onSelectModeChange('hard');
     expect(component.sortState.selectMode).toBe('hard');
     // id 1 (score 0.4) is closer to threshold 0.5 than id 2 (score 0.9)
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should handle inclusion change', fakeAsync(() => {
@@ -243,8 +252,9 @@ describe('LabelViewComponent', () => {
     expect(el.querySelector('vt-right-panel')).toBeTruthy();
   });
 
-  it('should resolve selectedMedia from selectedId', () => {
+  it('should resolve selectedMedia from selectedId', async () => {
     flushInitialRequests();
+    await settle();
     component.onMediaSelect(2);
     expect(component.mediaState.selectedMedia).toBeTruthy();
     expect(component.mediaState.selectedMedia!.id).toBe(2);
@@ -270,7 +280,7 @@ describe('LabelViewComponent', () => {
     });
 
     // Should auto-select id 1 (first unlabeled)
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should trigger text sort on autopilot start when session has text query', () => {
@@ -300,7 +310,7 @@ describe('LabelViewComponent', () => {
     });
 
     expect(component.sortState.sortOrder).toBeTruthy();
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should defer autopilot text sort until medias are loaded', () => {
@@ -344,7 +354,7 @@ describe('LabelViewComponent', () => {
       threshold: 0.5,
     });
 
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
   });
 
   it('should not trigger text sort on autopilot start when no text query', () => {
@@ -484,7 +494,7 @@ describe('LabelViewComponent', () => {
     httpMock.expectOne('/api/votes').flush({ good: [4], bad: [], click_times: {}, learned_scores: {} });
 
     component.onSelectModeChange('hard');
-    expect(component.mediaState.selectedId).toBe(5);
+    expect(component.mediaState.selectedId()).toBe(5);
   });
 
   it('should advance past just-voted item even when vote state is stale', () => {
@@ -506,7 +516,7 @@ describe('LabelViewComponent', () => {
 
     // Even with stale votes (id 1 not yet in badVotes), the selection should
     // have advanced to id 2 because onMediaVoted excludes the just-voted id.
-    expect(component.mediaState.selectedId).toBe(2);
+    expect(component.mediaState.selectedId()).toBe(2);
   });
 
   it('should deactivate autopilot state when switching to manual mode', () => {
@@ -584,11 +594,11 @@ describe('LabelViewComponent', () => {
 
     // Manually select a different media (simulating user clicking right panel)
     component.onMediaSelect(1);
-    expect(component.mediaState.selectedId).toBe(1);
+    expect(component.mediaState.selectedId()).toBe(1);
 
     // Refocus should re-select the autopilot suggestion (top unlabeled = id 2)
     component.onAutopilotRefocus();
-    expect(component.mediaState.selectedId).toBe(2);
+    expect(component.mediaState.selectedId()).toBe(2);
   });
 
   it('should clear stale autopilot state from previous session on init', () => {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, effect } from '@angular/core';
 
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -131,7 +131,50 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private newThingFlows: NewThingFlowsService,
     private toast: ToastService,
     public panelState: LabelViewPanelStateService,
-  ) {}
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      this.panelState.loadFromSettings(settings);
+      if (this.panelState.currentMediaType) {
+        this.applyPanelPx();
+      }
+      if (settings.autopilot_enabled != null) {
+        this.autopilotEnabled = settings.autopilot_enabled;
+      }
+      if (settings.hide_autopilot && !this.autopilotCollapsed) {
+        this.setAutopilotCollapsed(true);
+      } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {
+        this.setAutopilotCollapsed(false);
+      }
+      if (settings.autopilot_resort_interval != null) {
+        this.resortInterval = settings.autopilot_resort_interval;
+        // Initialize the threshold if not yet set
+        if (this.resortNextThreshold === 0) {
+          this.resortNextThreshold = this.resortInterval;
+        }
+      }
+    });
+
+    effect(() => {
+      const medias = this.mediaState.mediasSignal();
+      if (medias.length > 0) {
+        const newType = medias[0].media_type;
+        if (newType !== this.panelState.currentMediaType) {
+          this.panelState.setMediaType(newType);
+          this.applyPanelPx();
+        }
+      }
+      if (this.autopilotTextSortPending && medias.length > 0) {
+        this.autopilotTextSortPending = false;
+        this.triggerAutopilotTextSort();
+      }
+      if (this.autopilotMediaSortPending && medias.length > 0) {
+        this.autopilotMediaSortPending = false;
+        this.triggerAutopilotMediaSort();
+      }
+    });
+  }
 
   ngOnInit(): void {
     this.autopilotStateService.clear();
@@ -164,26 +207,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           return;
         }
         this.reloadForNewPair();
-      });
-
-    this.mediaState.medias$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        if (medias.length > 0) {
-          const newType = medias[0].media_type;
-          if (newType !== this.panelState.currentMediaType) {
-            this.panelState.setMediaType(newType);
-            this.applyPanelPx();
-          }
-        }
-        if (this.autopilotTextSortPending && medias.length > 0) {
-          this.autopilotTextSortPending = false;
-          this.triggerAutopilotTextSort();
-        }
-        if (this.autopilotMediaSortPending && medias.length > 0) {
-          this.autopilotMediaSortPending = false;
-          this.triggerAutopilotMediaSort();
-        }
       });
 
     this.autopilotStateService.state$
@@ -321,30 +344,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private loadSettings(): void {
     this.settingsState.load();
-    this.settingsState.settings$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((settings) => {
-        if (!settings) return;
-        this.panelState.loadFromSettings(settings);
-        if (this.panelState.currentMediaType) {
-          this.applyPanelPx();
-        }
-        if (settings.autopilot_enabled != null) {
-          this.autopilotEnabled = settings.autopilot_enabled;
-        }
-        if (settings.hide_autopilot && !this.autopilotCollapsed) {
-          this.setAutopilotCollapsed(true);
-        } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {
-          this.setAutopilotCollapsed(false);
-        }
-        if (settings.autopilot_resort_interval != null) {
-          this.resortInterval = settings.autopilot_resort_interval;
-          // Initialize the threshold if not yet set
-          if (this.resortNextThreshold === 0) {
-            this.resortNextThreshold = this.resortInterval;
-          }
-        }
-      });
   }
 
   private startStatusPolling(): void {
@@ -644,7 +643,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   } | null = null;
 
   onMediaContextRequest(event: { id: number; x: number; y: number }): void {
-    const media = this.mediaState.medias.find((m) => m.id === event.id);
+    const media = this.mediaState.mediasSignal().find((m) => m.id === event.id);
     this.contextMenuItems = buildMediaContextMenuItems(media?.media_type ?? '');
     this.contextMenuMediaId = event.id;
     this.contextMenuX = event.x;
@@ -698,7 +697,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private openSeedNewDetector(mediaId: number, cropParams?: Record<string, unknown>): void {
-    const media = this.mediaState.medias.find((m) => m.id === mediaId);
+    const media = this.mediaState.mediasSignal().find((m) => m.id === mediaId);
     this.newThingFlows.openNewDetector({
       defaultMediaType: media?.media_type ?? '',
       seedMediaId: mediaId,
@@ -843,13 +842,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       const textQuery = this.labelSession.textQuery;
       const mediaExample = this.labelSession.mediaExample;
       if (textQuery) {
-        if (this.mediaState.medias.length > 0) {
+        if (this.mediaState.mediasSignal().length > 0) {
           this.triggerAutopilotTextSort();
         } else {
           this.autopilotTextSortPending = true;
         }
       } else if (mediaExample) {
-        if (this.mediaState.medias.length > 0) {
+        if (this.mediaState.mediasSignal().length > 0) {
           this.triggerAutopilotMediaSort();
         } else {
           this.autopilotMediaSortPending = true;

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -12,6 +12,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  effect,
 } from '@angular/core';
 
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
@@ -115,8 +116,8 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   /** True once ``gridRowHeight`` has been measured from a real rendered card. */
   private gridHeightMeasured = false;
 
-  /** Mirror of ``MediaStateService.loading``; drives the skeleton rows when the
-   *  list is empty during the initial /api/medias/ids fetch. */
+  /** Mirror of ``MediaStateService.isLoading()``; drives the skeleton rows when
+   *  the list is empty during the initial /api/medias/ids fetch. */
   loadingMedias = false;
   readonly skeletonPlaceholders = Array.from({ length: 12 });
 
@@ -125,7 +126,11 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     private mediaState: MediaStateService,
     private cdr: ChangeDetectorRef,
     private zone: NgZone,
-  ) {}
+  ) {
+    effect(() => {
+      this.loadingMedias = this.mediaState.isLoading();
+    });
+  }
 
   ngOnInit(): void {
     // When the cache hydrates new items, re-enrich the displayed rows so
@@ -133,9 +138,6 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     this.metadataCache.version$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.rebuildOrderedItems());
-    this.mediaState.loading$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((loading) => (this.loadingMedias = loading));
   }
 
   get showSkeletons(): boolean {

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -186,7 +186,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
         this.chartsService.renderDiversityChart(
           canvas,
           this.chartData as DiversityDataPoint[],
-          this.settingsState.settings?.autopilot_goal_diversity ?? 40,
+          this.settingsState.settingsSignal()?.autopilot_goal_diversity ?? 40,
         );
         break;
     }

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -62,7 +62,7 @@ describe('RightPanelComponent', () => {
     TestBed.tick(); // run the rxResource loader effect so the GET is issued
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     // Drain the resource's promise-based value commit, then flush effects so the
-    // settings$ bridge emits and viewModeRightDict is populated. The votes poll
+    // settings effect runs and viewModeRightDict is populated. The votes poll
     // request that the macrotask lets fire is discarded by cleanup().
     await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick();

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -96,7 +96,28 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     public labelsetState: LabelsetStateService,
     private settingsState: SettingsStateService,
     private dialog: VtDialogService,
-  ) {}
+  ) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      const dict = settings.view_mode_right;
+      if (dict && typeof dict === 'object') {
+        this.viewModeRightDict = dict as Record<string, 'grid' | 'list'>;
+        if (this.currentMediaType) {
+          this.viewMode = this.viewModeRightDict[this.currentMediaType] ?? 'grid';
+        }
+      }
+      const sizeDict = settings.grid_icon_size_right;
+      if (sizeDict && typeof sizeDict === 'object') {
+        this.gridIconSizeRightDict = sizeDict as Record<string, string>;
+        if (this.currentMediaType) {
+          this.gridGoalWidth = iconSizeToGoalWidth(
+            this.gridIconSizeRightDict[this.currentMediaType] ?? 'M',
+          );
+        }
+      }
+    });
+  }
 
   /** True when the right pane should be sourced from the labelset (not /api/votes). */
   get useLabelset(): boolean {
@@ -131,7 +152,6 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnInit(): void {
     this.settingsState.load();
-    this.loadSettings();
     this.voteState.startPolling();
     this.subscribeToVotes();
     if (this.useLabelset) {
@@ -241,30 +261,6 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
         );
       },
     });
-  }
-
-  private loadSettings(): void {
-    this.settingsState.settings$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: settings => {
-          if (!settings) return;
-          const dict = settings.view_mode_right;
-          if (dict && typeof dict === 'object') {
-            this.viewModeRightDict = dict as Record<string, 'grid' | 'list'>;
-            if (this.currentMediaType) {
-              this.viewMode = this.viewModeRightDict[this.currentMediaType] ?? 'grid';
-            }
-          }
-          const sizeDict = settings.grid_icon_size_right;
-          if (sizeDict && typeof sizeDict === 'object') {
-            this.gridIconSizeRightDict = sizeDict as Record<string, string>;
-            if (this.currentMediaType) {
-              this.gridGoalWidth = iconSizeToGoalWidth(this.gridIconSizeRightDict[this.currentMediaType] ?? 'M');
-            }
-          }
-        },
-      });
   }
 
   private subscribeToVotes(): void {

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -1,7 +1,5 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, effect } from '@angular/core';
 
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { SettingsStateService } from '../../services/settings-state.service';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -17,7 +15,7 @@ type IconSize = (typeof ICON_SIZES)[number];
   templateUrl: './view-controls.component.html',
   styleUrl: './view-controls.component.scss',
 })
-export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
+export class ViewControlsComponent implements OnInit, OnChanges {
   @Input() side: 'left' | 'right' | 'popup' = 'left';
   @Input() currentMediaType = '';
   /**
@@ -46,24 +44,18 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
   gridIconSize: IconSize = 'M';
 
   private settings: AppSettings = { volume: 50 };
-  private destroy$ = new Subject<void>();
 
-  constructor(private settingsState: SettingsStateService) {}
+  constructor(private settingsState: SettingsStateService) {
+    effect(() => {
+      const settings = this.settingsState.settingsSignal();
+      if (!settings) return;
+      this.settings = settings;
+      this.refresh();
+    });
+  }
 
   ngOnInit(): void {
     this.settingsState.load();
-    this.settingsState.settings$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(settings => {
-        if (!settings) return;
-        this.settings = settings;
-        this.refresh();
-      });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, effect, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -61,7 +61,8 @@ export class AchievementsService {
   private readonly emittedUnlocks = new Set<string>();
 
   constructor() {
-    this.settingsState.settings$.subscribe((s) => {
+    effect(() => {
+      const s = this.settingsState.settingsSignal();
       const next = s?.enable_achievements === false;
       const flipped = next && !this.disabled;
       this.disabled = next;

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -13,6 +13,20 @@ describe('MediaStateService', () => {
     { id: 2, media_type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
   ];
 
+  // The media stub list rides an `rxResource`: its loader runs in an effect, so
+  // `TestBed.tick()` issues the request, and the value commits on a microtask,
+  // so `settle()` drains it before reading `mediasSignal()`.
+  async function settle() {
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    TestBed.tick();
+  }
+
+  function load() {
+    service.loadMedias();
+    TestBed.tick();
+    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
+  }
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideHttpClient(), provideHttpClientTesting()],
@@ -27,65 +41,59 @@ describe('MediaStateService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should start with empty medias', () => {
-    expect(service.medias).toEqual([]);
-    expect(service.selectedId).toBeNull();
+  it('should start with empty medias and not fetch until loadMedias()', () => {
+    TestBed.tick();
+    expect(service.mediasSignal()).toEqual([]);
+    expect(service.selectedId()).toBeNull();
     expect(service.selectedMedia).toBeNull();
+    httpMock.expectNone('/api/medias/ids');
   });
 
-  it('loadMedias should fetch and store medias', () => {
-    service.loadMedias();
-    const req = httpMock.expectOne('/api/medias/ids');
-    req.flush(mockMedias);
-    expect(service.medias).toEqual(mockMedias);
+  it('loadMedias should fetch and store medias', async () => {
+    load();
+    await settle();
+    expect(service.mediasSignal()).toEqual(mockMedias);
   });
 
-  it('selectMedia should update selectedId', () => {
-    service.loadMedias();
-    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
+  it('selectMedia should update selectedId', async () => {
+    load();
+    await settle();
 
     service.selectMedia(2);
-    expect(service.selectedId).toBe(2);
+    expect(service.selectedId()).toBe(2);
     expect(service.selectedMedia?.filename).toBe('b.png');
   });
 
-  it('selectedMedia should return null for unknown id', () => {
-    service.loadMedias();
-    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
+  it('selectedMedia should return null for unknown id', async () => {
+    load();
+    await settle();
 
     service.selectMedia(999);
     expect(service.selectedMedia).toBeNull();
   });
 
-  it('clear should reset all state', () => {
-    service.loadMedias();
-    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
+  it('clear should reset all state', async () => {
+    load();
+    await settle();
     service.selectMedia(1);
 
     service.clear();
-    expect(service.medias).toEqual([]);
-    expect(service.selectedId).toBeNull();
+    TestBed.tick();
+    expect(service.mediasSignal()).toEqual([]);
+    expect(service.selectedId()).toBeNull();
   });
 
-  it('medias$ should emit on load', () => new Promise<void>((done) => {
-    const emissions: Media[][] = [];
-    service.medias$.subscribe((m) => emissions.push(m));
+  it('mediasSignal should reflect the loaded medias', async () => {
+    expect(service.mediasSignal()).toEqual([]);
+    load();
+    await settle();
+    expect(service.mediasSignal()).toEqual(mockMedias);
+  });
 
-    service.loadMedias();
-    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
-
-    setTimeout(() => {
-      expect(emissions.length).toBeGreaterThanOrEqual(2); // initial [] + loaded
-      expect(emissions[emissions.length - 1]).toEqual(mockMedias);
-      done();
-    });
-  }));
-
-  it('selectedId$ should emit on select', () => new Promise<void>((done) => {
-    const ids: (number | null)[] = [];
-    service.selectedId$.subscribe((id) => ids.push(id));
-
+  it('selectedId signal should update on select', () => new Promise<void>((done) => {
+    expect(service.selectedId()).toBeNull();
     service.selectMedia(5);
+    expect(service.selectedId()).toBe(5);
 
     // selectMedia() also schedules a debounced metadata batch fetch
     // (POST /api/medias/batch) via the metadata cache; drain it so the
@@ -94,7 +102,6 @@ describe('MediaStateService', () => {
       for (const req of httpMock.match('/api/medias/batch')) {
         req.flush([]);
       }
-      expect(ids).toContain(5);
       done();
     });
   }));

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -1,6 +1,5 @@
-import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { finalize, takeUntil } from 'rxjs/operators';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import type { Media } from '../models/api.models';
 import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import { MediasApiService } from './medias-api.service';
@@ -10,6 +9,14 @@ import { MediaMetadataCacheService } from './media-metadata-cache.service';
  * Tracks the dataset-wide list of media stubs (``{id, type, embedder?}``)
  * and the current selection.
  *
+ * The stub list is a read path on Angular's reactive resource primitives (see
+ * `docs/plans/httpresource-migration.md`): an `rxResource` wraps the existing
+ * generated-client method (`MediasApiService.getMediaIds()`), so the typed
+ * client and interceptor chain are untouched while the hand-rolled
+ * subscribe/`BehaviorSubject` bookkeeping is gone. The public surface is
+ * signal-based: read `mediasSignal()` / `isLoading()` / `selectedId()`; call
+ * `loadMedias()` / `selectMedia()` / `clear()` to drive it.
+ *
  * Each stub is the minimum the UI needs to build the virtual scroller, the
  * stripe overview, and the media-type / embedder gates.  Full per-item
  * metadata (``filename``, ``md5``, ``custom_metadata``, …) is fetched on
@@ -17,44 +24,35 @@ import { MediaMetadataCacheService } from './media-metadata-cache.service';
  * {@link MediaMetadataCacheService}.
  */
 @Injectable({ providedIn: 'root' })
-export class MediaStateService implements OnDestroy {
-  private readonly mediasSubject = new BehaviorSubject<MediaIdsListResponse[]>([]);
-  private readonly selectedIdSubject = new BehaviorSubject<number | null>(null);
+export class MediaStateService {
+  private readonly mediasApi = inject(MediasApiService);
+  private readonly metadataCache = inject(MediaMetadataCacheService);
+
+  // A monotonic load counter doubles as the resource request. `0` means
+  // "not requested yet" -> `params()` returns `undefined` -> the resource stays
+  // idle (no fetch). Each `loadMedias()` bumps the counter, which changes the
+  // request and so re-runs the loader.
+  private readonly loadCount = signal(0);
+
+  private readonly resource = rxResource({
+    params: () => (this.loadCount() === 0 ? undefined : this.loadCount()),
+    stream: () => this.mediasApi.getMediaIds(),
+  });
+
+  /** The dataset-wide media stubs; empty until the first successful load (or after `clear()`). */
+  readonly mediasSignal = computed<MediaIdsListResponse[]>(() => this.resource.value() ?? []);
+
   /** True while ``/api/medias/ids`` is in flight. Drives skeleton loaders in
-   *  the media list/grid; flips back to ``false`` whether the request succeeds
-   *  or errors. */
-  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
-  private readonly destroy$ = new Subject<void>();
+   *  the media list/grid. */
+  readonly isLoading = this.resource.isLoading;
 
-  readonly medias$ = this.mediasSubject.asObservable();
-  readonly selectedId$ = this.selectedIdSubject.asObservable();
-  readonly loading$ = this.loadingSubject.asObservable();
+  private readonly selectedIdSignal = signal<number | null>(null);
 
-  constructor(
-    private mediasApi: MediasApiService,
-    private metadataCache: MediaMetadataCacheService,
-  ) {}
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  get medias(): MediaIdsListResponse[] {
-    return this.mediasSubject.value;
-  }
-
-  get selectedId(): number | null {
-    return this.selectedIdSubject.value;
-  }
-
-  get loading(): boolean {
-    return this.loadingSubject.value;
-  }
-
+  /** The currently-selected media id, or `null`. */
+  readonly selectedId = this.selectedIdSignal.asReadonly();
 
   get selectedMedia(): Media | null {
-    const id = this.selectedIdSubject.value;
+    const id = this.selectedIdSignal();
     if (id === null) return null;
     return this.getMedia(id);
   }
@@ -67,31 +65,23 @@ export class MediaStateService implements OnDestroy {
   getMedia(id: number): Media | null {
     const cached = this.metadataCache.get(id);
     if (cached) return cached;
-    return this.mediasSubject.value.find((m) => m.id === id) ?? null;
+    return this.mediasSignal().find((m) => m.id === id) ?? null;
   }
 
   selectMedia(id: number): void {
-    this.selectedIdSubject.next(id);
+    this.selectedIdSignal.set(id);
     this.metadataCache.ensureLoaded([id]);
   }
 
+  /** Fetch (or refetch) the dataset media stubs. No-op while a fetch is in flight. */
   loadMedias(): void {
-    this.loadingSubject.next(true);
-    this.mediasApi
-      .getMediaIds()
-      .pipe(
-        takeUntil(this.destroy$),
-        finalize(() => this.loadingSubject.next(false)),
-      )
-      .subscribe((stubs) => {
-        this.mediasSubject.next(stubs);
-      });
+    if (this.resource.isLoading()) return;
+    this.loadCount.update((n) => n + 1);
   }
 
   clear(): void {
-    this.mediasSubject.next([]);
-    this.selectedIdSubject.next(null);
-    this.loadingSubject.next(false);
+    this.resource.set([]);
+    this.selectedIdSignal.set(null);
     this.metadataCache.clear();
   }
 }

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -18,7 +18,7 @@ describe('SettingsStateService', () => {
 
   // Drain the asynchrony rxResource introduces: its loader is promise-based, so
   // the stream value commits on a microtask; we then flush effects so the
-  // computed settings signal and the settings$ bridge update.
+  // computed settings signal updates.
   async function settle() {
     await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick();
@@ -50,13 +50,13 @@ describe('SettingsStateService', () => {
 
   it('should start with null settings and not fetch until load()', () => {
     TestBed.tick();
-    expect(service.settings).toBeNull();
+    expect(service.settingsSignal()).toBeNull();
     httpMock.expectNone('/api/settings');
   });
 
   it('load should fetch and store settings', async () => {
     await load();
-    expect(service.settings).toEqual(mockSettings);
+    expect(service.settingsSignal()).toEqual(mockSettings);
   });
 
   it('update should PUT and update cached settings', async () => {
@@ -68,7 +68,7 @@ describe('SettingsStateService', () => {
     expect(req.request.method).toBe('PUT');
     req.flush(updated);
     TestBed.tick();
-    expect(service.settings?.volume).toBe(0.5);
+    expect(service.settingsSignal()?.volume).toBe(0.5);
   });
 
   it('clear should reset settings to null', async () => {
@@ -76,17 +76,11 @@ describe('SettingsStateService', () => {
 
     service.clear();
     TestBed.tick();
-    expect(service.settings).toBeNull();
+    expect(service.settingsSignal()).toBeNull();
   });
 
-  it('settings$ should replay the loaded settings to subscribers', async () => {
-    const emissions: unknown[] = [];
-    const sub = service.settings$.subscribe((s) => emissions.push(s));
-
+  it('settingsSignal should expose the loaded settings', async () => {
     await load();
-
-    sub.unsubscribe();
-    expect(emissions.length).toBeGreaterThanOrEqual(1);
-    expect(emissions[emissions.length - 1]).toEqual(mockSettings);
+    expect(service.settingsSignal()).toEqual(mockSettings);
   });
 });

--- a/frontend/src/app/services/settings-state.service.ts
+++ b/frontend/src/app/services/settings-state.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, computed, effect, inject, signal } from '@angular/core';
-import { rxResource, toObservable } from '@angular/core/rxjs-interop';
+import { rxResource } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import type { AppSettings } from '../generated/api-client/models/app-settings';
@@ -8,14 +8,14 @@ import { SettingsApiService } from './settings-api.service';
 import { ANIMATIONS_OFF_CLASS } from '../utils/reduced-motion';
 
 /**
- * App-settings store, and the first read path migrated onto Angular's reactive
- * resource primitives (see `docs/plans/httpresource-migration.md`). The GET is
- * driven by an `rxResource` wrapping the existing generated-client method
+ * App-settings store, migrated onto Angular's reactive resource primitives
+ * (see `docs/plans/httpresource-migration.md`). The GET is driven by an
+ * `rxResource` wrapping the existing generated-client method
  * (`SettingsApiService.getSettings()`), so it keeps the typed client and the
  * interceptor chain while dropping the hand-rolled subscribe/`BehaviorSubject`
- * bookkeeping. The public surface (`settings`, `settings$`, `load`, `update`,
- * `clear`) is unchanged for existing consumers; new code should prefer the
- * signal API (`settingsSignal`, `isLoading`, `error`).
+ * bookkeeping. The public surface is signal-based: read `settingsSignal()`
+ * (and `isLoading()` / `error()`); call `load()`/`update()`/`clear()` to drive
+ * it. Consumers react with `effect()` rather than subscribing to an Observable.
  */
 @Injectable({ providedIn: 'root' })
 export class SettingsStateService {
@@ -41,13 +41,6 @@ export class SettingsStateService {
   /** The error from the last failed fetch, if any. */
   readonly error = this.resource.error;
 
-  /**
-   * Backwards-compatible Observable view for existing subscribers. Backed by
-   * the settings signal, so it replays the latest value to late subscribers
-   * (like the old `BehaviorSubject`) but emits asynchronously.
-   */
-  readonly settings$: Observable<AppSettings | null> = toObservable(this.settingsSignal);
-
   constructor() {
     // Reflect document-level effects of settings whenever the resolved value
     // changes (load, update, or clear). Currently this mirrors the "Show
@@ -61,10 +54,6 @@ export class SettingsStateService {
         document.documentElement.classList.toggle(ANIMATIONS_OFF_CLASS, animationsOff);
       }
     });
-  }
-
-  get settings(): AppSettings | null {
-    return this.settingsSignal();
   }
 
   /** Fetch (or refetch) settings from the server. No-op while a fetch is in flight. */


### PR DESCRIPTION
## Summary

Phase 2 of the `httpResource`/`rxResource` data-layer migration (`docs/plans/httpresource-migration.md`). Phase 1 converted `SettingsStateService` but deliberately kept compatibility shims so consumers didn't change. Per the user's direction — VTSearch's frontend is the only caller of its own services, and a migration upgrades caller and callee together, so shims are dead weight — this PR goes the full distance: services expose signals directly, **all consumers were migrated, and the shims are gone** (matching the repo's "no shims, just make the clean change" rule).

## What changed

- **`MediaStateService` read path → `rxResource`.** `GET /api/medias/ids` now rides an `rxResource` wrapping the generated `getMediaIds()`, using the settings pilot's monotonic-counter request trigger. Exposes `mediasSignal()` / `isLoading()`; `selectedId` is a plain `signal`; `selectedMedia`/`getMedia()` stay synchronous accessors. The `medias$`/`loading$`/`selectedId$` Observables, `BehaviorSubject`s, and `OnDestroy`/`destroy$` are removed.
- **`SettingsStateService` shims removed.** `settings$` (the `toObservable` bridge) and the sync `settings` getter are deleted; canonical surface is `settingsSignal()` / `isLoading()` / `error()`.
- **Consumers migrated (~18 files).** Each `settings$`/`medias$` subscription became a constructor `effect()` reading the signal (effects auto-dispose, so the `takeUntil(destroy$)` plumbing went away). Sync getter reads and template bindings became signal calls (`settingsSignal()?.x`, `[medias]="mediaState.mediasSignal()"`, `[selectedId]="mediaState.selectedId()"`).
- **Specs updated.** The `rxResource` loader runs in a root effect, so `flushInitialRequests` now `TestBed.tick()`s to issue the GET; medias-derived assertions and the now-microtask-scheduled effects (media-type sync, deferred autopilot sort) drain via a `settle()` helper.

## Breaking change

The public surfaces of `SettingsStateService` and `MediaStateService` changed (Observables/getters → signals). All in-repo consumers are updated; there is no compatibility layer by design.

## Testing

`./run-tests.sh` green: 4843 Python tests pass, frontend gate passes (Angular `build:prod` clean, `npm audit` 0 vulns, 764 Vitest tests pass).

## Follow-ups (recorded in the plan)

- `DetectorStateService` appears dead (no consumers outside its file/spec) — confirm + delete rather than convert.
- Pollers / `forkJoin` aggregates remain imperative by design.
- A shared `settle()`/`TestBed.tick()` test helper is now ripe to extract (the shape repeated across three specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vex5kZJwg8RKbqMGuJF2vb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vex5kZJwg8RKbqMGuJF2vb)_