### PR TITLE
Fix DINOv3/DINOv2 patch embedders crashing on empty attentions tuple

### DIFF
--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -627,6 +627,79 @@ class TestEmbedderCapabilities:
         assert e.patch_forward({"media_path": "/nonexistent.jpg"}) is None
 
 
+class TestDinoAttentionBackend:
+    """Patch-capable DINO loaders must request the eager attention backend.
+
+    The patch variants read CLS→patch attention out of the forward pass
+    (``output_attentions=True``).  The SDPA backend silently drops those
+    tensors, leaving an empty ``attentions`` tuple that ``attentions[-1]``
+    then indexes into and raises ``IndexError``.  The single-vector variants
+    never read attentions, so they must keep the faster default (no
+    ``attn_implementation`` override).
+    """
+
+    def _captured_load_kwargs(self, embedder, shared_module):
+        """Drive ``_load_models_impl`` with the network/weight load stubbed and
+        return the kwargs passed to the model ``from_pretrained`` call."""
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        @contextmanager
+        def _noop_cm(*args, **kwargs):
+            yield
+
+        calls = []
+
+        def fake_load(load_fn, *args, **kwargs):
+            kwargs.pop("on_progress", None)
+            calls.append(kwargs)
+            # First call loads the model, second loads the processor.  Return a
+            # lightweight stand-in that supports the chained .to(...).eval().
+            stub = MagicMock()
+            stub.to.return_value = stub
+            return stub
+
+        with (
+            patch.object(shared_module, "load_pretrained_local_first", side_effect=fake_load),
+            patch.object(shared_module, "embedder_load_setup", return_value=None),
+            patch.object(shared_module, "timed_progress", _noop_cm),
+            patch.object(shared_module, "intercept_tqdm_progress", _noop_cm),
+            patch.object(shared_module, "intercept_weight_loading_progress", _noop_cm),
+            patch.object(shared_module, "hf_token", return_value=None),
+        ):
+            embedder._load_models_impl()
+        # The model load is the first call; the processor load is the second.
+        return calls[0]
+
+    def test_dinov3_patch_requests_eager_attention(self):
+        from vtscore.media.image import _dinov3_shared
+        from vtscore.media.image.embedder_dinov3_patch import ImageDinov3PatchEmbedder
+
+        kwargs = self._captured_load_kwargs(ImageDinov3PatchEmbedder(), _dinov3_shared)
+        assert kwargs.get("attn_implementation") == "eager"
+
+    def test_dinov3_single_does_not_force_attention_backend(self):
+        from vtscore.media.image import _dinov3_shared
+        from vtscore.media.image.embedder_dinov3_single import ImageDinov3SingleEmbedder
+
+        kwargs = self._captured_load_kwargs(ImageDinov3SingleEmbedder(), _dinov3_shared)
+        assert "attn_implementation" not in kwargs
+
+    def test_dinov2_patch_requests_eager_attention(self):
+        from vtscore.media.image import _dinov2_shared
+        from vtscore.media.image.embedder_dinov2_patch import ImageDinov2PatchEmbedder
+
+        kwargs = self._captured_load_kwargs(ImageDinov2PatchEmbedder(), _dinov2_shared)
+        assert kwargs.get("attn_implementation") == "eager"
+
+    def test_dinov2_single_does_not_force_attention_backend(self):
+        from vtscore.media.image import _dinov2_shared
+        from vtscore.media.image.embedder_dinov2_single import ImageDinov2SingleEmbedder
+
+        kwargs = self._captured_load_kwargs(ImageDinov2SingleEmbedder(), _dinov2_shared)
+        assert "attn_implementation" not in kwargs
+
+
 # ---------------------------------------------------------------------------
 # Region-aware similarity scoring
 # ---------------------------------------------------------------------------

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -70,6 +70,15 @@ class _Dinov2Base(MediaEmbedder):
             from transformers import AutoImageProcessor, AutoModel  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading DINOv2 model weights…")
+        # The patch variant reads CLS→patch attention out of the forward pass,
+        # so it needs ``output_attentions=True`` to return real tensors.  The
+        # SDPA attention backend silently drops them (leaving an empty
+        # ``attentions`` tuple that ``attentions[-1]`` then indexes into and
+        # raises IndexError), so force the eager backend when we depend on
+        # attentions; the single-vector variant keeps faster SDPA.
+        extra_kwargs: dict[str, Any] = {}
+        if self.supports_patch_regions:
+            extra_kwargs["attn_implementation"] = "eager"
         with (
             intercept_tqdm_progress(self._on_progress),
             intercept_weight_loading_progress(self._on_progress, "Loading DINOv2 model weights…"),
@@ -81,6 +90,7 @@ class _Dinov2Base(MediaEmbedder):
                 cache_dir=cache_dir,
                 token=hf_token(),
                 on_progress=self._on_progress,
+                **extra_kwargs,
             )
         self._model = self._model.to("cpu")
         self._model.eval()

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -81,6 +81,16 @@ class _Dinov3Base(MediaEmbedder):
             from transformers import AutoImageProcessor, AutoModel  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading DINOv3 model weights…")
+        # The patch variant slices CLS→patch attention out of the forward pass
+        # to build its saliency map, so it needs ``output_attentions=True`` to
+        # return real tensors.  transformers defaults DINOv3 to the SDPA
+        # attention backend, which silently ignores ``output_attentions`` and
+        # yields an empty ``attentions`` tuple (then ``attentions[-1]`` raises
+        # IndexError).  Force the eager backend when we depend on attentions;
+        # the single-vector variant never reads them, so it keeps faster SDPA.
+        extra_kwargs: dict[str, Any] = {}
+        if self.supports_patch_regions:
+            extra_kwargs["attn_implementation"] = "eager"
         with (
             intercept_tqdm_progress(self._on_progress),
             intercept_weight_loading_progress(self._on_progress, "Loading DINOv3 model weights…"),
@@ -92,6 +102,7 @@ class _Dinov3Base(MediaEmbedder):
                 cache_dir=cache_dir,
                 token=hf_token(),
                 on_progress=self._on_progress,
+                **extra_kwargs,
             )
         self._model = self._model.to("cpu")
         self._model.eval()


### PR DESCRIPTION
## Problem

Loading an image dataset with the `dinov3_patch` embedder failed on every chunk with:

```
File ".../vtscore/media/patch_embed.py", line 181, in hf_vit_to_patch_output
    attn = outputs.attentions[-1][batch_index]  # (heads, T, T) - last block
           ~~~~~~~~~~~~~~~~~~^^^^
IndexError: tuple index out of range
```

The patch variants read the CLS→patch attention out of the forward pass (`output_attentions=True`) to build their per-patch saliency map. `transformers` defaults these ViT backbones to the **SDPA** attention backend, which silently ignores `output_attentions` and returns an **empty** `attentions` tuple — the warning logged at load time spells it out:

> `sdpa` attention does not support `output_attentions=True`. Please set your attention to `eager` ...

`hf_vit_to_patch_output` then indexes `attentions[-1]`, raising `IndexError`, so every bulk patch-forward chunk fails and the image gets no regions.

## Fix

Force `attn_implementation="eager"` at model-load time for the patch-capable variants, gated on `supports_patch_regions`, so attentions are actually returned. The single-vector variants (`dinov3_single`, `dinov2_single`) never read attentions, so they keep the faster default SDPA path with no override.

The same latent bug existed in the shared DINOv2 loader (identical `output_attentions=True` + shared adapter), so the fix is applied there too for consistency — it just hadn't surfaced because the active embedder in the report was DINOv3.

## Tests

Added `TestDinoAttentionBackend` to `tests/detectors/test_patch_embedder.py`, which stubs the weight load and asserts:
- `dinov3_patch` / `dinov2_patch` request `attn_implementation="eager"`
- `dinov3_single` / `dinov2_single` do **not** override the attention backend

Full `./run-tests.sh` suite passes (4848 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1QWPjKUgcz5axKqQaBrmj)_