### PR TITLE
Make DINO best-match box visually distinct from the user marquee

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -447,8 +447,9 @@ regions per vote; region votes on non-image media types.
 Extends the v1 gallery-card `best_region` outline into the center/focus viewer.
 A **Highlight** toggle sits next to the Marquee button in the image-view controls
 (image media only) and is **hidden unless the active dataset's embedder reports
-`supports_patch_regions`**. When on, the focused image overlays a yellow **dashed**
-box (distinct from the solid yellow voting box) around the region the detector
+`supports_patch_regions`**. When on, the focused image overlays a neutral
+white/black **dashed** "marching ants" box (distinct from the user's solid yellow
+voting box, which keeps the attention color) around the region the detector
 matched best at inference.
 
 No new bookkeeping: reuses the `best_region` the backend already returns on every

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -71,16 +71,19 @@
 }
 
 // Read-only overlay marking the region the detector matched best at inference.
-// Dashed (vs the voting box's solid stroke) so the two are never confused, and
-// pointer-events: none so it never intercepts a pan/draw on the image beneath.
+// Deliberately neutral: a white dashed stroke over a black backing (the classic
+// "marching ants" crop look) so it recedes behind the user's solid YELLOW voting
+// box and reads as a machine-generated annotation rather than a selection. The
+// monochrome stroke stays legible on any image, light or dark. pointer-events:
+// none so it never intercepts a pan/draw on the image beneath.
 .highlight-box {
   position: absolute;
   box-sizing: border-box;
-  border: 1.5px dashed rgba(255, 224, 102, 0.95);
-  background: rgba(255, 224, 102, 0.06);
+  border: 1.5px dashed rgba(255, 255, 255, 0.95);
+  background: transparent;
   box-shadow:
-    0 0 0 1px rgba(0, 0, 0, 0.45) inset,
-    0 0 0 1px rgba(0, 0, 0, 0.35);
+    0 0 0 1px rgba(0, 0, 0, 0.7) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.7);
   pointer-events: none;
 }
 

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -43,9 +43,10 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    * The region the detector/embedder matched best at inference, as a normalised
    * ``[x0, y0, x1, y1]`` box (the argmax over patch regions that produced this
    * media's score).  ``null`` when the active dataset isn't patch-region-aware
-   * or the focused media hasn't been scored.  Rendered as a yellow dashed
-   * overlay only while the Highlight toggle (``highlightMode``) is on; purely
-   * informational, never interactive (no drag/resize, no vote semantics).
+   * or the focused media hasn't been scored.  Rendered as a neutral white/black
+   * dashed overlay (distinct from the user's solid yellow voting box) only while
+   * the Highlight toggle (``highlightMode``) is on; purely informational, never
+   * interactive (no drag/resize, no vote semantics).
    */
   @Input() highlightBox: RegionBox | null = null;
   @Output() regionBoxChange = new EventEmitter<RegionBox | null>();
@@ -82,8 +83,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   // the toggle is off; toggling the button just turns the gesture on without a modifier.
   marqueeMode = false;
   // Sticky toggle exposed by the Highlight button in .image-view-controls. While
-  // true the viewer overlays a yellow dashed box (`highlightBox`) around the
-  // region the detector matched best at inference. Independent of marqueeMode -
+  // true the viewer overlays a neutral white/black dashed box (`highlightBox`)
+  // around the region the detector matched best at inference. Independent of marqueeMode -
   // both can be on at once (the highlight is read-only and sits behind the
   // interactive voting box).
   highlightMode = false;

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -215,8 +215,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   /** Percent-position style for the best-match highlight overlay.  Returns null
    *  when the box is missing, malformed, degenerate, or covers (effectively) the
-   *  whole image - mirrors the gallery thumbnail's `bestRegionStyle` so the
-   *  near-full single-vector fallback box never paints a frame round everything. */
+   *  whole image, so the near-full single-vector fallback box never paints a
+   *  frame round everything.  (This overlay is the only place a best-match region
+   *  is drawn - thumbnails never render a best-region outline.) */
   get highlightBoxStyle(): { [k: string]: string } | null {
     const box = this.highlightBox;
     if (!box || box.length !== 4) return null;


### PR DESCRIPTION
## Problem

In the image viewer, the user's interactive **marquee** box and the read-only **DINO best-match** highlight box were both yellow, differing only by solid vs dashed stroke. Since color dominates perception, the two were hard to tell apart at a glance.

## Change

Keep yellow reserved for the user's selection (the attention color), and render the DINO highlight as a neutral **white/black dashed "marching ants"** box so it recedes behind the user box and reads as a machine-generated annotation:

- `.highlight-box` now uses a white dashed stroke (`rgba(255,255,255,.95)`) over a stronger black backing (`box-shadow` inset/outset at `.7` alpha), with the yellow fill removed. Monochrome stays legible on any image, light or dark.
- The user marquee (`.region-box`) is unchanged — still solid yellow.
- Updated the stale "yellow dashed" doc comments in `image-viewer.component.ts` and the description in `docs/plans/patch-embedder.md`.

Frontend-only, no behavior change. `./run-tests.sh frontend` passes (build OK, 758 Vitest tests, no audit/budget warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV5k4q9mcTmvWK5ihTkKbi

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV5k4q9mcTmvWK5ihTkKbi)_