### PR TITLE
Migrate picker-modal reads to rxResource (Phase 4)

### DIFF
--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -1,9 +1,10 @@
 # `httpResource` / reactive-resource migration for the data layer
 
-Status: **Phase 1 (pilot) + Phase 2 + Phase 3 shipped.** The
+Status: **Phase 1 (pilot) + Phase 2 + Phase 3 + Phase 4 shipped.** The
 `SettingsStateService` and `MediaStateService` read paths both run on
-`rxResource`, and Phase 3 converted the left-panel's media-type / embedder reads
-too. Phase 2 also **dropped the pilot's compatibility shims**: the services now
+`rxResource`, Phase 3 converted the left-panel's media-type / embedder reads,
+and Phase 4 converted the importer/exporter **picker-modal** list reads. Phase 2
+also **dropped the pilot's compatibility shims**: the services now
 expose their signals directly and all consumers were migrated, so there are no
 Observable bridges or sync getters left to bridge old callers (per the repo's
 "no shims, just make the clean change" rule). Phase 3 also extracted the shared
@@ -13,6 +14,56 @@ see "Open follow-ups". Scoped after the Angular 21 + Vitest work landed (see
 `angular-21-upgrade.md`, which lists this as a deferred carrot). This doc
 decides *how* VTSearch should adopt Angular's resource primitives and in what
 order.
+
+## What shipped (Phase 4 — picker-modal reads)
+
+The four importer/exporter picker modals each did an eager `ngOnInit` GET to
+populate their plugin list. All four moved to `rxResource`, following the
+Phase 3 eager pattern (no request signal = load once on creation):
+
+- **`LabelExporterModalComponent`** — `getExporters()` → eager `rxResource`.
+  This one carried a pure `destroy$`/`OnDestroy` (its export *mutation* was
+  already a bare subscribe), so the conversion **dropped the lifecycle plumbing
+  entirely** (`Subject`, `takeUntil`, `OnDestroy`, `OnInit`).
+- **`SettingsImporterModalComponent` / `SettingsExporterModalComponent`** —
+  `listImporters()` / `listExporters()` → eager `rxResource`. `OnDestroy` stays
+  in both because it clears the success-message close timer, not a `destroy$`.
+- **`ExportModalComponent`** (the involved one) — all **three** init reads moved
+  to resources. Dataset status (`getStatus()`) and the exporter list
+  (`getExporters()`) are eager; the **labels** read (`exportLabels(...)`) is
+  input-derived (its `label_filter` comes from the `initialFilter` `@Input`, set
+  in `ngOnInit`), so it uses a **trigger signal** (`labelsReady`, flipped at the
+  end of `ngOnInit`) as its request — the same "monotonic counter / gate" shape
+  the settings + media phases used. `buildColumns(...)` (which depends on the
+  resolved `available_columns`) moved to a **constructor `effect()`** that fires
+  when the labels resource settles (with the no-arg fallback on error). The
+  `destroy$`/`OnDestroy` is gone; the lone export *mutation* is now a bare
+  subscribe (matching `label-exporter`'s precedent).
+
+Repeatable details worth keeping:
+
+- **Picker list + its loading/error state are signal-driven.** Each modal
+  exposes `exporters()` / `importers()` (a `computed` that filters
+  `hidden_from_picker`) and `loading()` (`= resource.isLoading()`); templates
+  read the signals. The `loading = true` initial field is gone — an eager
+  resource reports `isLoading()` true until its first settle, matching the old
+  default.
+- **Error merging.** Each modal's `error` was set by *both* a list-load failure
+  and an action (export/import) failure. The migration keeps a writable
+  `signal` for the action error and exposes `error` as a `computed` that ORs in
+  the resource's load error (`resource.error() ? '<load msg>' : ''`). Imperative
+  `this.error = '…'` sites became `…Error.set('…')`.
+- **`inject()` over constructor params.** Resource field initializers reference
+  the api services, and a field initializer can't safely read a constructor
+  parameter property, so the services are `inject()`ed (same gotcha Phase 3 hit).
+- **Specs.** Added an `export-modal` spec (the component was previously
+  untested) and updated the `label-exporter` spec for the loader timing:
+  `TestBed.tick()` after `detectChanges()` to issue the eager GET, then
+  `settleResource()` before reading resolved values. The export-modal spec also
+  has to **settle once before flushing** so the trigger-gated labels GET (which
+  fires a microtask after `ngOnInit`) is pending alongside the two eager GETs,
+  and it matches the labels request by `r.url` predicate because the GET carries
+  an `?enrich=true` query string that a plain-string `expectOne` would miss.
 
 ## What shipped (Phase 3 — left-panel reads + housekeeping)
 
@@ -239,13 +290,20 @@ app must be half-migrated.
 ## Open follow-ups
 
 - **Expand to more read services** (step 3). Done for `SettingsStateService`
-  (Phase 1, shims removed in Phase 2), `MediaStateService` (Phase 2), and the
-  left-panel media-type / embedder reads (Phase 3). Those last two were
-  component-local `ngOnInit` fetches, so the conversion was eager (no request
-  signal). A still-open refinement: if media-types / embedders ever need to
-  **re-fetch on dataset switch**, give the resource a
+  (Phase 1, shims removed in Phase 2), `MediaStateService` (Phase 2), the
+  left-panel media-type / embedder reads (Phase 3), and the importer/exporter
+  picker-modal list reads (Phase 4). The component-local `ngOnInit` fetches
+  converted eagerly (no request signal); export-modal's input-derived labels
+  read used a trigger signal instead. A still-open refinement: if media-types /
+  embedders ever need to **re-fetch on dataset switch**, give the resource a
   `toSignal(activeContext.datasetId$)` request key instead of the eager load —
   today the component is recreated on switch, so eager-once suffices.
+- **Remaining component-local read subscribes** (not yet converted). The next
+  candidates after the picker modals are heavier: `dataset-importer-modal`
+  (interdependent clipper/embedder/demo loads + dynamic field-option fetches)
+  and `label-importer-modal` (importer list is a clean read, but field-options
+  and imports are mutations). Convert the clean list reads when those modals are
+  next touched; leave the dynamic field-option fetches imperative.
 - **`DetectorStateService` deleted (Phase 3).** It had no consumers outside its
   own file + spec. Done.
 - **Pollers and `forkJoin` aggregates** (`VoteStateService`, labeling status,

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -39,11 +39,11 @@
   <div class="export-section">
     <h3>
       Preview
-      @if (labelsLoaded) {
+      @if (labelsLoaded()) {
         <span class="preview-count">({{ filteredLabels.length | number }} rows)</span>
       }
     </h3>
-    @if (!labelsLoaded) {
+    @if (!labelsLoaded()) {
       <p class="empty-state">Loading labels...</p>
     } @else if (filteredLabels.length === 0) {
       <p class="empty-state">No labeled items to export.</p>
@@ -95,7 +95,7 @@
       </button>
 
       <!-- Exporter tabs -->
-      @for (exp of exporters; track exp.name) {
+      @for (exp of exporters(); track exp.name) {
         <button
           class="export-tab"
           [class.active]="activeTab === exp.name"
@@ -237,7 +237,7 @@
   @if (status) {
     <p class="status-text">{{ status }}</p>
   }
-  @if (error) {
-    <p class="error-text">{{ error }}</p>
+  @if (error()) {
+    <p class="error-text">{{ error() }}</p>
   }
 </vt-modal>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ExportModalComponent } from './export-modal.component';
+import { settleResource } from '../../../testing/settle-resource';
+
+describe('ExportModalComponent', () => {
+  let component: ExportModalComponent;
+  let fixture: ComponentFixture<ExportModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockExporters = [
+    { name: 'server_json_file', display_name: 'Server JSON', fields: [] },
+    { name: 'hidden', display_name: 'Hidden', hidden_from_picker: true, fields: [] },
+  ];
+  const mockLabels = {
+    labels: [
+      { md5: 'a', label: 'good', filename: 'a.wav' },
+      { md5: 'b', label: 'bad', filename: 'b.wav' },
+      { md5: 'c', label: 'good', filename: 'c.wav', is_correction: true },
+    ],
+    available_columns: ['label', 'md5', 'filename', 'category', 'extra'],
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExportModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExportModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  // The three init reads (dataset status, exporter list, labels) ride
+  // `rxResource`, whose loaders run in a root effect rather than during
+  // `detectChanges()`; tick to issue the GETs (the labels read also waits for
+  // `ngOnInit` to set the input-derived filter), then settle before asserting.
+  async function flushInit(): Promise<void> {
+    fixture.detectChanges();
+    TestBed.tick();
+    // The eager status/exporter GETs fire on the tick; the labels GET is
+    // released by `ngOnInit`'s signal flip a microtask later, so settle first
+    // to let all three become pending before flushing.
+    await settleResource();
+    httpMock.expectOne('/api/dataset/status').flush({ display_name: 'My Dataset' });
+    httpMock.expectOne('/api/exporters').flush(mockExporters);
+    httpMock.expectOne((r) => r.url === '/api/labels/export').flush(mockLabels);
+    await settleResource();
+  }
+
+  it('should create', async () => {
+    await flushInit();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads the exporter list, filtering hidden entries', async () => {
+    await flushInit();
+    expect(component.exporters().length).toBe(1);
+    expect(component.exporters()[0].name).toBe('server_json_file');
+  });
+
+  it('builds columns from available_columns once labels resolve', async () => {
+    await flushInit();
+    expect(component.labelsLoaded()).toBe(true);
+    const keys = component.columns.map((c) => c.key);
+    expect(keys).toContain('extra'); // discovered metadata column
+    expect(keys).not.toContain('origin'); // always-export keys stay out of the checkboxes
+  });
+
+  it('slices the fetched labels by the active category', async () => {
+    await flushInit();
+    component.labelFilter = 'good';
+    expect(component.filteredLabels.length).toBe(2);
+    component.labelFilter = 'bad';
+    expect(component.filteredLabels.length).toBe(1);
+    component.labelFilter = 'corrections';
+    expect(component.filteredLabels.length).toBe(1);
+  });
+
+  it('reports correction availability', async () => {
+    await flushInit();
+    expect(component.hasCorrections).toBe(true);
+  });
+
+  it('emits exported after a successful export run', async () => {
+    await flushInit();
+    vi.spyOn(component.exported, 'emit');
+    // A fieldless exporter exports immediately.
+    component.startExporter(mockExporters[0] as never);
+    httpMock.expectOne('/api/exporters/export').flush({ success: true });
+    expect(component.exported.emit).toHaveBeenCalled();
+  });
+
+  it('emits closed on close', async () => {
+    await flushInit();
+    vi.spyOn(component.closed, 'emit');
+    component.close();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -1,8 +1,17 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
 import {
@@ -40,7 +49,7 @@ export interface ColumnDef {
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',
 })
-export class ExportModalComponent implements OnInit, OnDestroy {
+export class ExportModalComponent implements OnInit {
   @Input() detectorName = '';
   /**
    * The filter the modal opens on. ``unverified`` / ``verified`` are
@@ -52,14 +61,54 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() exported = new EventEmitter<void>();
 
-  exporters: ExporterEntry[] = [];
-  loading = true;
-  error = '';
-  status = '';
+  private readonly datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private readonly exportersApi = inject(ExportersApiService);
+  private readonly labelSession = inject(LabelSessionService);
+  private readonly sortingApi = inject(SortingApiService);
+  private readonly activeContext = inject(ActiveContextService);
+  private readonly datasetState = inject(DatasetStateService);
+
+  // Two eager reads (dataset status + exporter list) load on creation; the
+  // labels read is input-derived, so it waits for `ngOnInit` to set
+  // `serverFilter` and flip `labelsReady`. All three wrap the generated-client
+  // methods so the interceptor chain still applies, replacing the old
+  // `ngOnInit` subscribes + `destroy$` plumbing.
+  private readonly statusResource = rxResource({
+    stream: () => this.datasetsRegistryApi.getStatus(),
+  });
+  private readonly exportersResource = rxResource({
+    stream: () => this.exportersApi.getExporters(),
+  });
+  private readonly labelsReady = signal(false);
+  private readonly labelsResource = rxResource({
+    params: () => (this.labelsReady() ? this.serverFilter : undefined),
+    stream: () => {
+      const labelFilter = this.serverFilter === 'both' ? undefined : this.serverFilter;
+      return this.sortingApi.exportLabels(false, { enrich: true, labelFilter });
+    },
+  });
+
+  readonly exporters = computed<ExporterEntry[]>(() =>
+    (this.exportersResource.value() ?? []).filter((e) => !e.hidden_from_picker),
+  );
 
   /** Labels fetched from the server. */
-  labels: LabeledElement[] = [];
-  labelsLoaded = false;
+  private readonly labelsList = computed<LabeledElement[]>(
+    () => this.labelsResource.value()?.labels ?? [],
+  );
+  readonly labelsLoaded = computed(
+    () => this.labelsResource.hasValue() || this.labelsResource.error() !== undefined,
+  );
+
+  /** Error from a failed export action; the read failures are merged in below. */
+  private readonly actionError = signal('');
+  readonly error = computed(
+    () =>
+      this.actionError() ||
+      (this.exportersResource.error() ? 'Failed to load exporters' : '') ||
+      (this.labelsResource.error() ? 'Failed to load labels' : ''),
+  );
+  status = '';
 
   /** Column definitions with selection state, built dynamically from API response. */
   columns: ColumnDef[] = [];
@@ -83,9 +132,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   submitting = false;
 
   /** Dataset display name for default filenames. */
-  private datasetName = '';
-
-  private destroy$ = new Subject<void>();
+  private readonly datasetName = computed(() => this.statusResource.value()?.display_name || '');
 
   /** Base columns that are always present. */
   private static readonly BASE_COLUMNS: { key: string; label: string }[] = [
@@ -98,14 +145,19 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   /** Columns excluded from checkboxes/preview but always appended to exports. */
   private static readonly ALWAYS_EXPORT_KEYS = ['origin', 'origin_name'];
 
-  constructor(
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private exportersApi: ExportersApiService,
-    private labelSession: LabelSessionService,
-    private sortingApi: SortingApiService,
-    private activeContext: ActiveContextService,
-    private datasetState: DatasetStateService,
-  ) {}
+  constructor() {
+    // Rebuild the column set when the labels read settles. The checkbox
+    // `enabled` state lives on `columns`, so it stays a mutable field rather
+    // than a pure computed; the effect mirrors the old subscribe's
+    // `buildColumns(...)` call (with the no-arg fallback on error).
+    effect(() => {
+      if (this.labelsResource.hasValue()) {
+        this.buildColumns(this.labelsResource.value()?.available_columns);
+      } else if (this.labelsResource.error()) {
+        this.buildColumns();
+      }
+    });
+  }
 
   /** Detector/model name from any available source. Falls back to the
    *  registry entry for the active detector id when the
@@ -135,36 +187,10 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       this.labelFilter = this.initialFilter;
     }
 
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (status) => {
-        this.datasetName = status.display_name || '';
-      },
-    });
-
-    this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (list) => {
-        this.exporters = list.filter((e) => !e.hidden_from_picker);
-        this.loading = false;
-      },
-      error: () => {
-        this.loading = false;
-        this.error = 'Failed to load exporters';
-      },
-    });
-
-    const labelFilter = this.serverFilter === 'both' ? undefined : this.serverFilter;
-    this.sortingApi.exportLabels(false, { enrich: true, labelFilter }).pipe(takeUntil(this.destroy$)).subscribe({
-      next: (data) => {
-        this.labels = data.labels || [];
-        this.labelsLoaded = true;
-        this.buildColumns(data.available_columns);
-      },
-      error: () => {
-        this.labelsLoaded = true;
-        this.error = 'Failed to load labels';
-        this.buildColumns();
-      },
-    });
+    // Now that the input-derived `serverFilter` is set, release the labels read
+    // (the dataset-status and exporter-list reads are eager and already in
+    // flight). `buildColumns` rides the constructor effect on resolution.
+    this.labelsReady.set(true);
   }
 
   /** Build column definitions from available_columns or fall back to defaults. */
@@ -197,21 +223,22 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   get filteredLabels(): LabeledElement[] {
+    const labels = this.labelsList();
     if (this.labelFilter === 'good') {
-      return this.labels.filter((e) => e.label === 'good');
+      return labels.filter((e) => e.label === 'good');
     }
     if (this.labelFilter === 'bad') {
-      return this.labels.filter((e) => e.label === 'bad');
+      return labels.filter((e) => e.label === 'bad');
     }
     if (this.labelFilter === 'corrections') {
-      return this.labels.filter((e) => e.is_correction === true);
+      return labels.filter((e) => e.is_correction === true);
     }
-    return this.labels;
+    return labels;
   }
 
   /** Whether any labels are corrections (detector label was changed by user). */
   get hasCorrections(): boolean {
-    return this.labels.some((e) => e.is_correction === true);
+    return this.labelsList().some((e) => e.is_correction === true);
   }
 
   get previewLabels(): LabeledElement[] {
@@ -272,7 +299,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     else if (this.labelFilter === 'corrections') parts.push('Corrections');
     const detName = this.effectiveDetectorName;
     if (detName) parts.push(detName);
-    if (this.datasetName) parts.push(this.datasetName);
+    const datasetName = this.datasetName();
+    if (datasetName) parts.push(datasetName);
     if (parts.length === 0) parts.push('labels');
     // Sanitise: replace characters unsafe for filenames with hyphens
     const stem = parts.join('-').replace(/[\\/:*?"<>|]+/g, '-');
@@ -326,7 +354,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       this.formValues[f.key] = this.defaultFor(f);
     }
     this.applyDefaultFilename(exporter);
-    this.error = '';
+    this.actionError.set('');
     this.status = '';
   }
 
@@ -339,7 +367,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       this.formValues[f.key] = this.defaultFor(f);
     }
     this.applyDefaultFilename(exporter);
-    this.error = '';
+    this.actionError.set('');
     this.status = '';
   }
 
@@ -385,7 +413,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
 
   cancelExporterForm(): void {
     this.selectedExporter = null;
-    this.error = '';
+    this.actionError.set('');
     this.status = '';
   }
 
@@ -397,7 +425,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   exportLabelsWith(exporter: ExporterEntry, fieldValues: Record<string, string>): void {
     const exporterLabel = exporter.display_name || exporter.name;
     this.status = `Exporting ${this.filteredLabels.length.toLocaleString()} labels to ${exporterLabel}…`;
-    this.error = '';
+    this.actionError.set('');
     this.submitting = true;
 
     const labelsData = {
@@ -410,7 +438,6 @@ export class ExportModalComponent implements OnInit, OnDestroy {
         field_values: fieldValues,
         results: labelsData,
       })
-      .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {
           this.status = 'Labels exported.';
@@ -420,7 +447,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.status = '';
-          this.error = 'Label export failed';
+          this.actionError.set('Label export failed');
           this.submitting = false;
         },
       });
@@ -452,10 +479,5 @@ export class ExportModalComponent implements OnInit, OnDestroy {
 
   close(): void {
     this.closed.emit();
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -382,7 +382,7 @@ export class ExportModalComponent implements OnInit {
   /** The exporter object for the currently active tab (null if clipboard). */
   get activeTabExporter(): ExporterEntry | null {
     if (this.activeTab === 'clipboard') return null;
-    return this.exporters.find((e) => e.name === this.activeTab) || null;
+    return this.exporters().find((e) => e.name === this.activeTab) || null;
   }
 
   /** Typed view of the active tab's plugin fields for the template (the

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
@@ -1,11 +1,11 @@
 <vt-modal [title]="title" [open]="true" (closed)="close()">
-  @if (loading) {
+  @if (loading()) {
     <p class="empty-state">Loading exporters...</p>
-  } @else if (exporters.length === 0) {
+  } @else if (exporters().length === 0) {
     <p class="empty-state">No exporters available.</p>
   } @else {
     <div class="exporter-picker">
-      @for (exp of exporters; track exp.name) {
+      @for (exp of exporters(); track exp.name) {
         <button class="exporter-card" (click)="selectExporter(exp)">
           <span class="exporter-name">@if (exp.icon) {<span class="exporter-icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
           @if (exp.description) {
@@ -16,7 +16,7 @@
     </div>
   }
 
-  @if (error) {
-    <p class="error-text">{{ error }}</p>
+  @if (error()) {
+    <p class="error-text">{{ error() }}</p>
   }
 </vt-modal>

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LabelExporterModalComponent } from './label-exporter-modal.component';
+import { settleResource } from '../../../testing/settle-resource';
 
 describe('LabelExporterModalComponent', () => {
   let component: LabelExporterModalComponent;
@@ -28,35 +29,40 @@ describe('LabelExporterModalComponent', () => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
+  // The exporter list now rides an eager `rxResource`, whose loader runs in a
+  // root effect rather than during `detectChanges()`; tick to issue the GET,
+  // then settle so the resolved value commits before assertions.
+  async function flushInit(): Promise<void> {
     fixture.detectChanges();
+    TestBed.tick();
     httpMock.expectOne('/api/exporters').flush(mockExporters);
+    await settleResource();
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should load exporters on init', () => {
-    flushInit();
-    expect(component.exporters.length).toBe(2);
-    expect(component.loading).toBe(false);
+  it('should load exporters on init', async () => {
+    await flushInit();
+    expect(component.exporters().length).toBe(2);
+    expect(component.loading()).toBe(false);
   });
 
-  it('should show correct title for goods only', () => {
+  it('should show correct title for goods only', async () => {
     component.goodsOnly = true;
-    flushInit();
+    await flushInit();
     expect(component.title).toContain('Goods');
   });
 
-  it('should show default title', () => {
-    flushInit();
+  it('should show default title', async () => {
+    await flushInit();
     expect(component.title).toBe('Export Labels');
   });
 
-  it('should export labels when exporter selected', () => {
-    flushInit();
+  it('should export labels when exporter selected', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     vi.spyOn(component.exportComplete, 'emit');
 
@@ -74,16 +80,16 @@ describe('LabelExporterModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render exporter cards', () => {
-    flushInit();
+  it('should render exporter cards', async () => {
+    await flushInit();
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
     const cards = el.querySelectorAll('.exporter-card');
     expect(cards.length).toBe(2);
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
@@ -1,7 +1,5 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ExportersApiService } from '../../../services/exporters-api.service';
@@ -15,44 +13,36 @@ import type { ExporterEntry } from '../../../generated/api-client/models/exporte
   templateUrl: './label-exporter-modal.component.html',
   styleUrl: './label-exporter-modal.component.scss',
 })
-export class LabelExporterModalComponent implements OnInit, OnDestroy {
+export class LabelExporterModalComponent {
   @Input() goodsOnly = false;
   @Input() customTitle = '';
   @Output() closed = new EventEmitter<void>();
   @Output() exportComplete = new EventEmitter<void>();
 
-  exporters: ExporterEntry[] = [];
-  loading = true;
-  error = '';
+  private readonly exportersApi = inject(ExportersApiService);
+  private readonly sortingApi = inject(SortingApiService);
 
-  private destroy$ = new Subject<void>();
+  // Eager `rxResource`: loads the exporter list once on creation (no request
+  // signal), wrapping the generated-client read so the interceptor chain still
+  // applies. Replaces the old `ngOnInit` subscribe + `destroy$` plumbing.
+  private readonly exportersResource = rxResource({
+    stream: () => this.exportersApi.getExporters(),
+  });
+  readonly exporters = computed<ExporterEntry[]>(() =>
+    (this.exportersResource.value() ?? []).filter((exp) => !exp.hidden_from_picker),
+  );
+  readonly loading = computed(() => this.exportersResource.isLoading());
 
-  constructor(
-    private exportersApi: ExportersApiService,
-    private sortingApi: SortingApiService,
-  ) {}
+  /** Error from a failed export action; the list-load failure is merged in. */
+  private readonly exportError = signal('');
+  readonly error = computed(
+    () =>
+      this.exportError() || (this.exportersResource.error() ? 'Failed to load exporters' : ''),
+  );
 
   get title(): string {
     if (this.customTitle) return this.customTitle;
     return this.goodsOnly ? 'Export Labels (Goods)' : 'Export Labels';
-  }
-
-  ngOnInit(): void {
-    this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (list) => {
-        this.exporters = list.filter((exp) => !exp.hidden_from_picker);
-        this.loading = false;
-      },
-      error: () => {
-        this.loading = false;
-        this.error = 'Failed to load exporters';
-      },
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   selectExporter(exporter: ExporterEntry): void {
@@ -69,12 +59,12 @@ export class LabelExporterModalComponent implements OnInit, OnDestroy {
               this.closed.emit();
             },
             error: () => {
-              this.error = 'Export failed';
+              this.exportError.set('Export failed');
             },
           });
       },
       error: () => {
-        this.error = 'Failed to fetch labels';
+        this.exportError.set('Failed to fetch labels');
       },
     });
   }

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -1,12 +1,12 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="exporter-picker">
-      @if (loading) {
+      @if (loading()) {
         <p class="empty-state">Loading exporters...</p>
-      } @else if (exporters.length === 0) {
+      } @else if (exporters().length === 0) {
         <p class="empty-state">No settings exporters available.</p>
       } @else {
-        @for (exp of exporters; track exp.name) {
+        @for (exp of exporters(); track exp.name) {
           <button class="exporter-card" (click)="selectExporter(exp)">
             <span class="exporter-name">@if (exp.icon) {<span class="exporter-icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
             @if (exp.description) {
@@ -17,8 +17,8 @@
       }
     </div>
 
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
+    @if (error()) {
+      <p class="error-text">{{ error() }}</p>
     }
     @if (successMessage) {
       <p class="success-text">{{ successMessage }}</p>
@@ -89,8 +89,8 @@
         }
       }
 
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
+      @if (error()) {
+        <p class="error-text">{{ error() }}</p>
       }
       @if (successMessage) {
         <p class="success-text">{{ successMessage }}</p>

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, Output, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -18,21 +19,37 @@ type ModalView = 'picker' | 'form';
   templateUrl: './settings-exporter-modal.component.html',
   styleUrl: './settings-exporter-modal.component.scss',
 })
-export class SettingsExporterModalComponent implements OnInit, OnDestroy {
+export class SettingsExporterModalComponent implements OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() exported = new EventEmitter<void>();
 
+  private readonly settingsIoApi = inject(SettingsIoApiService);
+
   view: ModalView = 'picker';
-  exporters: SettingsExporterEntry[] = [];
-  loading = true;
+
+  // Eager `rxResource`: loads the settings-exporter list once on creation,
+  // wrapping the generated-client read so the interceptor chain still applies.
+  private readonly exportersResource = rxResource({
+    stream: () => this.settingsIoApi.listExporters(),
+  });
+  readonly exporters = computed<SettingsExporterEntry[]>(() =>
+    (this.exportersResource.value() ?? []).filter((exp) => !exp.hidden_from_picker),
+  );
+  readonly loading = computed(() => this.exportersResource.isLoading());
+
   selectedExporter: SettingsExporterEntry | null = null;
   formValues: Record<string, string> = {};
   submitting = false;
-  error = '';
+
+  /** Error from a failed export action; the list-load failure is merged in. */
+  private readonly exportError = signal('');
+  readonly error = computed(
+    () =>
+      this.exportError() ||
+      (this.exportersResource.error() ? 'Failed to load settings exporters' : ''),
+  );
   successMessage = '';
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(private settingsIoApi: SettingsIoApiService) {}
 
   get modalTitle(): string {
     if (this.view === 'form' && this.selectedExporter) {
@@ -48,23 +65,10 @@ export class SettingsExporterModalComponent implements OnInit, OnDestroy {
     return (this.selectedExporter?.fields ?? []) as ImporterField[];
   }
 
-  ngOnInit(): void {
-    this.settingsIoApi.listExporters().subscribe({
-      next: (list) => {
-        this.exporters = list.filter((exp) => !exp.hidden_from_picker);
-        this.loading = false;
-      },
-      error: () => {
-        this.loading = false;
-        this.error = 'Failed to load settings exporters';
-      },
-    });
-  }
-
   selectExporter(exporter: SettingsExporterEntry): void {
     this.selectedExporter = exporter;
     this.formValues = {};
-    this.error = '';
+    this.exportError.set('');
     this.successMessage = '';
     const fields = (exporter.fields ?? []) as ImporterField[];
     for (const field of fields) {
@@ -90,14 +94,14 @@ export class SettingsExporterModalComponent implements OnInit, OnDestroy {
   back(): void {
     this.view = 'picker';
     this.selectedExporter = null;
-    this.error = '';
+    this.exportError.set('');
     this.successMessage = '';
   }
 
   submit(): void {
     if (!this.selectedExporter) return;
     this.submitting = true;
-    this.error = '';
+    this.exportError.set('');
     this.successMessage = '';
 
     this.settingsIoApi.runExport(this.selectedExporter.name, this.formValues).subscribe({
@@ -121,7 +125,7 @@ export class SettingsExporterModalComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.submitting = false;
-        this.error = err.error?.error || 'Export failed';
+        this.exportError.set(err.error?.error || 'Export failed');
       },
     });
   }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -1,12 +1,12 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="importer-picker">
-      @if (loading) {
+      @if (loading()) {
         <p class="empty-state">Loading importers...</p>
-      } @else if (importers.length === 0) {
+      } @else if (importers().length === 0) {
         <p class="empty-state">No settings importers available.</p>
       } @else {
-        @for (imp of importers; track imp.name) {
+        @for (imp of importers(); track imp.name) {
           <button class="importer-card" (click)="selectImporter(imp)">
             <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
             @if (imp.description) {
@@ -17,8 +17,8 @@
       }
     </div>
 
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
+    @if (error()) {
+      <p class="error-text">{{ error() }}</p>
     }
     @if (successMessage) {
       <p class="success-text">{{ successMessage }}</p>
@@ -95,8 +95,8 @@
         <p class="info-text">This importer requires no additional configuration.</p>
       }
 
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
+      @if (error()) {
+        <p class="error-text">{{ error() }}</p>
       }
       @if (successMessage) {
         <p class="success-text">{{ successMessage }}</p>

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, Output, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,23 +18,39 @@ type ModalView = 'picker' | 'form';
   templateUrl: './settings-importer-modal.component.html',
   styleUrl: './settings-importer-modal.component.scss',
 })
-export class SettingsImporterModalComponent implements OnInit, OnDestroy {
+export class SettingsImporterModalComponent implements OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() imported = new EventEmitter<void>();
 
+  private readonly settingsIoApi = inject(SettingsIoApiService);
+
   view: ModalView = 'picker';
-  importers: SettingsImporterEntry[] = [];
-  loading = true;
+
+  // Eager `rxResource`: loads the settings-importer list once on creation,
+  // wrapping the generated-client read so the interceptor chain still applies.
+  private readonly importersResource = rxResource({
+    stream: () => this.settingsIoApi.listImporters(),
+  });
+  readonly importers = computed<SettingsImporterEntry[]>(() =>
+    (this.importersResource.value() ?? []).filter((imp) => !imp.hidden_from_picker),
+  );
+  readonly loading = computed(() => this.importersResource.isLoading());
+
   selectedImporter: SettingsImporterEntry | null = null;
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
   selectedFileFieldKey: string | null = null;
   submitting = false;
-  error = '';
+
+  /** Error from a failed import action; the list-load failure is merged in. */
+  private readonly importError = signal('');
+  readonly error = computed(
+    () =>
+      this.importError() ||
+      (this.importersResource.error() ? 'Failed to load settings importers' : ''),
+  );
   successMessage = '';
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(private settingsIoApi: SettingsIoApiService) {}
 
   get modalTitle(): string {
     if (this.view === 'form' && this.selectedImporter) {
@@ -49,25 +66,12 @@ export class SettingsImporterModalComponent implements OnInit, OnDestroy {
     return (this.selectedImporter?.fields ?? []) as ImporterField[];
   }
 
-  ngOnInit(): void {
-    this.settingsIoApi.listImporters().subscribe({
-      next: (list) => {
-        this.importers = list.filter((imp) => !imp.hidden_from_picker);
-        this.loading = false;
-      },
-      error: () => {
-        this.loading = false;
-        this.error = 'Failed to load settings importers';
-      },
-    });
-  }
-
   selectImporter(importer: SettingsImporterEntry): void {
     this.selectedImporter = importer;
     this.formValues = {};
     this.selectedFile = null;
     this.selectedFileFieldKey = null;
-    this.error = '';
+    this.importError.set('');
     this.successMessage = '';
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
@@ -87,7 +91,7 @@ export class SettingsImporterModalComponent implements OnInit, OnDestroy {
   back(): void {
     this.view = 'picker';
     this.selectedImporter = null;
-    this.error = '';
+    this.importError.set('');
     this.successMessage = '';
   }
 
@@ -103,7 +107,7 @@ export class SettingsImporterModalComponent implements OnInit, OnDestroy {
   submit(): void {
     if (!this.selectedImporter) return;
     this.submitting = true;
-    this.error = '';
+    this.importError.set('');
     this.successMessage = '';
 
     this.settingsIoApi
@@ -122,7 +126,7 @@ export class SettingsImporterModalComponent implements OnInit, OnDestroy {
         },
         error: (err) => {
           this.submitting = false;
-          this.error = err.error?.error || 'Import failed';
+          this.importError.set(err.error?.error || 'Import failed');
         },
       });
   }


### PR DESCRIPTION
Continues the read-path migration onto Angular's `rxResource` (see `docs/plans/httpresource-migration.md`). Phases 1–3 covered `SettingsStateService`, `MediaStateService`, and the left-panel media-type/embedder reads; **Phase 4** converts the importer/exporter **picker-modal** list reads.

## What changed

- **`label-exporter-modal`** — `getExporters()` → eager `rxResource`. This modal's only lifecycle plumbing was a pure `destroy$`/`OnDestroy` (its export action was already a bare subscribe), so the conversion **drops `Subject`/`takeUntil`/`OnDestroy`/`OnInit` entirely**.
- **`settings-importer-modal` / `settings-exporter-modal`** — `listImporters()` / `listExporters()` → eager `rxResource`. `OnDestroy` stays in both (it clears the success-message close timer, not a `destroy$`).
- **`export-modal`** (the involved one) — all **three** init reads move to resources. Dataset status and the exporter list are eager; the input-derived **labels** read uses a trigger signal (`labelsReady`, flipped in `ngOnInit`) as its request, mirroring the settings/media "gate" pattern. `buildColumns(...)` rides a constructor `effect()` that fires when the labels resource settles. `destroy$`/`OnDestroy` removed; the export mutation is now a bare subscribe.

Each picker list and its `loading`/`error` state are now **signal-driven** (`computed`), and templates read the signals. A single `error()` computed merges the list-load failure with action (export/import) errors. API services are `inject()`ed because resource field initializers can't safely read constructor parameter properties.

## Tests

- Added an **`export-modal` spec** (the component was previously untested): covers list loading (filtering `hidden_from_picker`), column-building from `available_columns`, category slicing, corrections availability, a successful export run, and close.
- Updated the **`label-exporter` spec** for the `rxResource` loader timing (`TestBed.tick()` before `expectOne`, `settleResource()` before assertions).
- `./run-tests.sh` full suite green: **ALL 4848 TESTS PASSED**; frontend gate clean (build, `npm audit` 0 vulns, **Vitest 765 passed**).

No backend changes. No persisted vectors/MLPs touched. Plan doc updated with the Phase 4 "What shipped" section and refreshed Open follow-ups (next candidates: `dataset-importer-modal`, `label-importer-modal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvhPSFKXmGY7x3r9vS5xUg)_