### PR TITLE
Simplify robot icon: just eyes in the head

### DIFF
--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -61,7 +61,7 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   cloud:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>',
   robot:
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><line x1="12" y1="4.5" x2="12" y2="7"/><rect x="4" y="7" width="16" height="12" rx="2.5"/><path d="M4 11a2 2 0 0 0 0 4"/><path d="M20 11a2 2 0 0 1 0 4"/><circle cx="9.5" cy="12.5" r="1.2"/><circle cx="14.5" cy="12.5" r="1.2"/><line x1="10" y1="16" x2="14" y2="16"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><line x1="12" y1="4.5" x2="12" y2="7"/><rect x="4" y="7" width="16" height="12" rx="2.5"/><path d="M4 11a2 2 0 0 0 0 4"/><path d="M20 11a2 2 0 0 1 0 4"/><circle cx="9.5" cy="12.5" r="1.2"/><circle cx="14.5" cy="12.5" r="1.2"/></svg>',
   list:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>',
   grid:


### PR DESCRIPTION
The robot icon was too busy for the small space it renders in. This drops the mouth line so only the two eyes remain in the existing head (there was no separate nose path; the mouth was the only extra facial feature).

The icon is defined once in the shared `vt-icon` SVG registry (`icon-svgs-extended.ts`), so this single change applies everywhere the icon appears (e.g. the dashboard "Detectors" section title).

## Testing
- `./run-tests.sh frontend` — build OK, audit OK, 765 unit tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxhAu85LXmy9C6u7NTMB3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxhAu85LXmy9C6u7NTMB3n)_