### PR TITLE
Cache flattened region matrix to unblock per-vote DINOv3 region voting

### DIFF
--- a/tests_lib/detectors/test_region_score_pool.py
+++ b/tests_lib/detectors/test_region_score_pool.py
@@ -1,0 +1,119 @@
+"""Region (patch) scoring path of ``_score_all_media`` + its matrix cache.
+
+DINOv3-style patch datasets expose ``patch_regions`` (a list of
+:class:`RegionVector`s) per media.  Scoring flattens every (media, region)
+pair into one matrix, runs a single MLP forward pass, then max-pools back
+down to one score + winning-region index per media.
+
+The matrix used to be rebuilt from scratch on every vote - a
+hundreds-of-thousands-row Python loop plus a multi-GB ``np.stack`` - which,
+running in the background training thread, stalled the next vote's request.
+These tests pin (a) the max-pool / best-region correctness and (b) that the
+flattened matrix is cached on the dataset context and reused until the
+media-id set changes.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from vtscore.detectors.training import _score_all_media
+from vtscore.embedding.matrix import get_region_matrix_for_snap, invalidate_embedding_matrix
+from vtscore.media.patch_embed import RegionVector
+from vtscore.state.core import get_active_context
+
+DIM = 8
+
+
+def _region(rng: np.random.Generator, ri: int) -> RegionVector:
+    """A RegionVector with a deterministic L2-normalised vector."""
+    vec = rng.standard_normal(DIM).astype(np.float32)
+    vec /= np.linalg.norm(vec) + 1e-8
+    return RegionVector(box=(0.0, 0.0, ri / 10.0 + 0.1, 1.0), vec=vec)
+
+
+def _region_media(media_id: int, n_regions: int) -> dict:
+    rng = np.random.default_rng(media_id)
+    regions = [_region(rng, ri) for ri in range(n_regions)]
+    return {
+        "id": media_id,
+        "media_type": "image",
+        "embedder": "dinov3_patch",
+        # Image-level embedding is the fallback row for region-less media.
+        "embedding": rng.standard_normal(DIM).astype(np.float32),
+        "patch_regions": regions,
+    }
+
+
+def _linear_model() -> nn.Module:
+    torch.manual_seed(0)
+    return nn.Sequential(nn.Linear(DIM, 1)).eval()
+
+
+class TestRegionMaxPool:
+    def test_scores_and_best_region_match_manual_pool(self):
+        # Media 1 & 2 carry regions; media 3 has none -> image-level fallback.
+        clips = {
+            1: _region_media(1, 3),
+            2: _region_media(2, 4),
+            3: {**_region_media(3, 0), "patch_regions": []},
+        }
+        model = _linear_model()
+
+        all_ids, scores, best_region = _score_all_media(cast(nn.Sequential, model), clips)
+
+        assert all_ids == [1, 2, 3]
+
+        # Recompute the expected per-media max-pool independently.
+        for idx, cid in enumerate(all_ids):
+            regions = clips[cid]["patch_regions"]
+            if regions:
+                vecs = np.stack([r.vec for r in regions]).astype(np.float32)
+            else:
+                vecs = clips[cid]["embedding"][None, :].astype(np.float32)
+            with torch.no_grad():
+                logits = model(torch.from_numpy(vecs)).squeeze(-1)
+                row_scores = torch.sigmoid(logits).numpy()
+            expected_best = int(np.argmax(row_scores))
+            assert abs(scores[idx] - float(row_scores.max())) < 1e-6
+            assert best_region[idx] == expected_best
+
+        # The region-less media's winning region is always 0 (its single row).
+        assert best_region[2] == 0
+
+
+class TestRegionMatrixCache:
+    def test_matrix_cached_and_invalidated(self):
+        ctx = get_active_context()
+        # Replace the active dataset's medias with region media so the snap
+        # key set matches the context (the condition for caching).
+        ctx.medias.clear()
+        ctx.medias[1] = _region_media(1, 3)
+        ctx.medias[2] = _region_media(2, 2)
+        invalidate_embedding_matrix(ctx)
+
+        snap = dict(ctx.medias)
+        ids1, matrix1, media_idx1, region_idx1 = get_region_matrix_for_snap(snap)
+
+        # 3 + 2 = 5 flattened rows, mapped back to media indices 0/1.
+        assert ids1 == [1, 2]
+        assert matrix1.shape == (5, DIM)
+        assert media_idx1.tolist() == [0, 0, 0, 1, 1]
+        assert region_idx1.tolist() == [0, 1, 2, 0, 1]
+
+        # Second call reuses the very same cached arrays (no rebuild).
+        _ids2, matrix2, media_idx2, _region_idx2 = get_region_matrix_for_snap(dict(ctx.medias))
+        assert matrix2 is matrix1
+        assert media_idx2 is media_idx1
+        assert ctx._region_matrix is matrix1
+
+        # Invalidation drops the cache; the next call rebuilds a fresh array.
+        invalidate_embedding_matrix(ctx)
+        assert ctx._region_matrix is None
+        _ids3, matrix3, _media_idx3, _region_idx3 = get_region_matrix_for_snap(dict(ctx.medias))
+        assert matrix3 is not matrix1
+        np.testing.assert_array_equal(matrix3, matrix1)

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -241,9 +241,7 @@ def _score_all_media(
         # any real score (in ``[0, 1]``) for the same media.
         flat_scores = np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)
 
-    scores, best_region = _segmented_max_pool(
-        flat_scores, media_index_per_row, region_index_per_row, len(all_ids)
-    )
+    scores, best_region = _segmented_max_pool(flat_scores, media_index_per_row, region_index_per_row, len(all_ids))
     return all_ids, scores, best_region
 
 

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -211,51 +211,77 @@ def _score_all_media(
     """
     import torch  # noqa: PLC0415
 
+    from vtscore.embedding.matrix import (  # noqa: PLC0415
+        get_embedding_matrix_for_snap,
+        get_region_matrix_for_snap,
+    )
+
     has_regions = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
     if has_regions:
-        all_ids = sorted(clips_dict.keys())
-        flat_vecs: list[np.ndarray] = []
-        media_index_per_row: list[int] = []
-        region_index_per_row: list[int] = []
-        for mi, cid in enumerate(all_ids):
-            media = clips_dict[cid]
-            regions = media.get("patch_regions")
-            if regions:
-                for ri, r in enumerate(regions):
-                    flat_vecs.append(np.asarray(r.vec, dtype=np.float32))
-                    media_index_per_row.append(mi)
-                    region_index_per_row.append(ri)
-            else:
-                flat_vecs.append(np.asarray(media["embedding"], dtype=np.float32))
-                media_index_per_row.append(mi)
-                region_index_per_row.append(0)
-        X_all = torch.from_numpy(np.stack(flat_vecs).astype(np.float32, copy=False))
+        # One row per (media, region) pair, built once and cached on the
+        # dataset context (the region vectors never change between votes -
+        # only the MLP weights do), so online retraining no longer rebuilds
+        # a multi-hundred-thousand-row matrix on every vote.
+        all_ids, X_np, media_index_per_row, region_index_per_row = get_region_matrix_for_snap(clips_dict)
     else:
-        from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
-
-        all_ids, all_embs = get_embedding_matrix_for_snap(clips_dict)
-        X_all = torch.from_numpy(all_embs)
+        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict)
         n = len(all_ids)
-        media_index_per_row = list(range(n))
-        region_index_per_row = [0] * n
+        media_index_per_row = np.arange(n, dtype=np.int64)
+        region_index_per_row = np.zeros(n, dtype=np.int64)
+
+    if not all_ids:
+        return [], [], []
 
     with torch.no_grad():
-        X_all = X_all.to(next(model.parameters()).device)
+        X_all = torch.from_numpy(X_np).to(next(model.parameters()).device)
         # ``sigmoid_to_finite_scores`` replaces NaN/±Inf with the
         # ``NON_FINITE_SCORE_SENTINEL`` (-1.0) so a destabilised MLP cannot
         # leak non-finite floats into the JSON response. The downstream
-        # ``s > scores[mi]`` max-pool then incidentally drops sentinels in
-        # favour of any real score for the same media.
-        flat_scores = sigmoid_to_finite_scores(model(X_all))
+        # segmented max-pool then incidentally drops sentinels in favour of
+        # any real score (in ``[0, 1]``) for the same media.
+        flat_scores = np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)
 
-    scores: list[float] = [-1.0] * len(all_ids)
-    best_region: list[int] = [0] * len(all_ids)
-    for s, mi, ri in zip(flat_scores, media_index_per_row, region_index_per_row, strict=True):
-        if s > scores[mi]:
-            scores[mi] = float(s)
-            best_region[mi] = ri
-
+    scores, best_region = _segmented_max_pool(
+        flat_scores, media_index_per_row, region_index_per_row, len(all_ids)
+    )
     return all_ids, scores, best_region
+
+
+def _segmented_max_pool(
+    flat_scores: np.ndarray,
+    media_index_per_row: np.ndarray,
+    region_index_per_row: np.ndarray,
+    n_media: int,
+) -> tuple[list[float], list[int]]:
+    """Max-pool per-row scores down to one score + winning region per media.
+
+    *media_index_per_row* is non-decreasing and contiguous (every media owns
+    a single run of rows), and every media has at least one row, so each
+    media's rows form one ``reduceat`` segment.  Returns ``(scores,
+    best_region)`` as plain Python lists, where ``best_region[m]`` is the
+    region index of the *first* row achieving media ``m``'s max - matching
+    the strict-``>`` "first wins" tie-break of the original scalar loop.
+
+    Fully vectorised so the per-vote scoring tail holds the GIL for
+    microseconds rather than iterating hundreds of thousands of rows in
+    Python (which, in the background training thread, would stall the
+    ``gthread`` pool serving the next vote).
+    """
+    # Start of each media's contiguous run of rows.
+    seg_starts = np.searchsorted(media_index_per_row, np.arange(n_media))
+    seg_max = np.maximum.reduceat(flat_scores, seg_starts)
+
+    # First row per media that reaches its segment max (region 0 - the
+    # CLS/full-image node - is always row 0 of a segment, so an all-sentinel
+    # media resolves to region 0, exactly as the old -1.0-seeded loop did).
+    is_max = flat_scores >= seg_max[media_index_per_row]
+    cand_rows = np.flatnonzero(is_max)
+    cand_media = media_index_per_row[cand_rows]
+    first_cand = np.searchsorted(cand_media, np.arange(n_media))
+    winning_rows = cand_rows[first_cand]
+    best_region = region_index_per_row[winning_rows]
+
+    return seg_max.tolist(), best_region.tolist()
 
 
 def _format_results(

--- a/vtscore/embedding/__init__.py
+++ b/vtscore/embedding/__init__.py
@@ -29,6 +29,7 @@ from vtscore.embedding.loader import (
 from vtscore.embedding.matrix import (
     get_embedding_matrix,
     get_embedding_matrix_for_snap,
+    get_region_matrix_for_snap,
     invalidate_embedding_matrix,
 )
 
@@ -52,4 +53,5 @@ __all__ = [
     "get_embedding_matrix",
     "invalidate_embedding_matrix",
     "get_embedding_matrix_for_snap",
+    "get_region_matrix_for_snap",
 ]

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -106,10 +106,116 @@ def get_embedding_submatrix(ctx: "DatasetContext", ids: list[int]) -> tuple[list
 
 
 def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
-    """Drop the cached matrix on *ctx*; next access rebuilds it."""
+    """Drop the cached matrices on *ctx*; next access rebuilds them.
+
+    Clears both the per-media embedding matrix and the flattened
+    per-region matrix (used by patch-region scoring), since both are keyed
+    on the media-id set and become stale together when the dataset's media
+    change.
+    """
     with _state_lock:
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
+        ctx._region_matrix_ids = None
+        ctx._region_matrix = None
+        ctx._region_media_index = None
+        ctx._region_index_per_row = None
+
+
+def _build_region_arrays(
+    snap: dict,
+    sorted_ids: list[int],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Flatten every media's ``patch_regions`` into one ``(R, D)`` matrix.
+
+    Returns ``(region_matrix, media_index_per_row, region_index_per_row)``:
+
+    * ``region_matrix`` - ``(R, D)`` float32, one row per (media, region) pair.
+    * ``media_index_per_row`` - ``int64 (R,)``, the index into *sorted_ids*
+      that each row belongs to.  Non-decreasing and contiguous per media.
+    * ``region_index_per_row`` - ``int64 (R,)``, the region's index within its
+      media's ``patch_regions`` list (the winning value surfaces as the UI's
+      best-match overlay).
+
+    Media that expose no ``patch_regions`` contribute a single row from their
+    image-level ``embedding`` (region index 0), so every media has at least
+    one row - keeping the downstream segmented max-pool free of empty groups.
+    """
+    flat_vecs: list[np.ndarray] = []
+    media_index_per_row: list[int] = []
+    region_index_per_row: list[int] = []
+    for mi, cid in enumerate(sorted_ids):
+        media = snap[cid]
+        regions = media.get("patch_regions")
+        if regions:
+            for ri, r in enumerate(regions):
+                flat_vecs.append(np.asarray(r.vec, dtype=np.float32))
+                media_index_per_row.append(mi)
+                region_index_per_row.append(ri)
+        else:
+            flat_vecs.append(np.asarray(_require_embedding(cid, media), dtype=np.float32))
+            media_index_per_row.append(mi)
+            region_index_per_row.append(0)
+    region_matrix = np.stack(flat_vecs).astype(np.float32, copy=False)
+    return (
+        region_matrix,
+        np.asarray(media_index_per_row, dtype=np.int64),
+        np.asarray(region_index_per_row, dtype=np.int64),
+    )
+
+
+def get_region_matrix_for_snap(
+    snap: dict,
+) -> tuple[list[int], np.ndarray, np.ndarray, np.ndarray]:
+    """Return the cached flattened region matrix for *snap*.
+
+    Returns ``(sorted_ids, region_matrix, media_index_per_row,
+    region_index_per_row)`` - see :func:`_build_region_arrays` for the
+    array shapes.  When *snap*'s key set matches the active
+    :class:`DatasetContext`'s medias (the common per-vote case), the matrix
+    is built once and cached on the context, then reused across subsequent
+    votes; only the MLP weights change between votes, never the region
+    vectors, so the cache is valid until the media-id set changes.  A
+    cross-dataset / subset *snap* builds fresh without populating the cache.
+
+    Returns empty arrays when *snap* is empty.  Raises ``ValueError`` if a
+    region-less media has ``embedding=None``.
+    """
+    from vtscore.state.core import get_active_context
+
+    sorted_ids = sorted(snap.keys())
+    if not sorted_ids:
+        empty_vecs = np.empty((0, 0), dtype=np.float32)
+        empty_idx = np.empty((0,), dtype=np.int64)
+        return [], empty_vecs, empty_idx, empty_idx
+
+    ctx = get_active_context()
+    with _state_lock:
+        if (
+            ctx._region_matrix is not None
+            and ctx._region_matrix_ids == sorted_ids
+            and ctx._region_media_index is not None
+            and ctx._region_index_per_row is not None
+        ):
+            return (
+                list(sorted_ids),
+                ctx._region_matrix,
+                ctx._region_media_index,
+                ctx._region_index_per_row,
+            )
+
+    region_matrix, media_index, region_index = _build_region_arrays(snap, sorted_ids)
+
+    # Populate the cache only when *snap* matches the active dataset's medias
+    # (the common case: ``snap = snapshot_medias()``).  Subset / cross-dataset
+    # dicts are ephemeral and must not clobber the active cache.
+    if sorted_ids == sorted(ctx.medias.keys()):
+        with _state_lock:
+            ctx._region_matrix_ids = sorted_ids
+            ctx._region_matrix = region_matrix
+            ctx._region_media_index = media_index
+            ctx._region_index_per_row = region_index
+    return list(sorted_ids), region_matrix, media_index, region_index
 
 
 def get_embedding_matrix_for_snap(

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -143,6 +143,10 @@ def clear_medias() -> None:
         ctx.medias.clear()
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
+        ctx._region_matrix_ids = None
+        ctx._region_matrix = None
+        ctx._region_media_index = None
+        ctx._region_index_per_row = None
         ctx._projection = None
         ctx._pyramids = {}
         ctx.diversity_tree = None

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -278,6 +278,20 @@ class DatasetContext:
         # we don't rebuild a 10k-row matrix per call.
         "_emb_matrix_ids",
         "_emb_matrix",
+        # Cached *flattened region matrix* for patch-region (e.g. DINOv3)
+        # datasets, mirroring ``_emb_matrix`` but expanded to one row per
+        # (media, region) pair.  ``_region_matrix`` is the ``(R, D)`` float32
+        # matrix; ``_region_media_index`` / ``_region_index_per_row`` are the
+        # parallel ``int64`` arrays mapping each row back to its media index
+        # (into the sorted id list) and its region index within that media.
+        # Built lazily by ``vtscore.embedding.matrix.get_region_matrix_for_snap``
+        # and reused across votes so online retraining never rebuilds the
+        # multi-hundred-thousand-row matrix per vote.  Keyed, like
+        # ``_emb_matrix``, on the sorted media-id list in ``_region_matrix_ids``.
+        "_region_matrix_ids",
+        "_region_matrix",
+        "_region_media_index",
+        "_region_index_per_row",
         # VTSBrowse: cached projection (frozen at ingest) + per-bin-shape
         # pyramids derived from it. The projection (UMAP coords) is shared
         # across bin shapes; ``_pyramids`` maps "hex"/"square" -> Pyramid so the
@@ -305,6 +319,10 @@ class DatasetContext:
         self.dataset_display_name: str | None = None
         self._emb_matrix_ids: list[int] | None = None
         self._emb_matrix: Any = None  # np.ndarray | None
+        self._region_matrix_ids: list[int] | None = None
+        self._region_matrix: Any = None  # np.ndarray | None, shape (R, D)
+        self._region_media_index: Any = None  # np.ndarray | None, int64 (R,)
+        self._region_index_per_row: Any = None  # np.ndarray | None, int64 (R,)
         self._projection: Any = None  # Projection | None
         self._pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid
         self._subset_projection: Any = None  # Projection | None (ephemeral subset UMAP)
@@ -508,6 +526,10 @@ class _RequestMissingDatasetContext(DatasetContext):
         object.__setattr__(self, "dataset_display_name", None)
         object.__setattr__(self, "_emb_matrix_ids", None)
         object.__setattr__(self, "_emb_matrix", None)
+        object.__setattr__(self, "_region_matrix_ids", None)
+        object.__setattr__(self, "_region_matrix", None)
+        object.__setattr__(self, "_region_media_index", None)
+        object.__setattr__(self, "_region_index_per_row", None)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise _frozen_mutation_error("dataset")


### PR DESCRIPTION
## Problem

Region voting (DINOv3 patch embedder) on a medium-large dataset (smallest Places365) had a ~5s pause after **every** vote: the current image stayed put, then finally animated away and the next item appeared. That violates VTSearch's "vote → next question immediately, retrain in the background" model.

## Root cause

The vote POST itself is cheap and returns fast, but the swipe animation and next-item selection wait on its response. Each vote schedules a background learned-sort, whose `_score_all_media` (in `vtscore/detectors/training.py`) rebuilt the per-region scoring matrix **from scratch on every vote**:

- a pure-Python loop over every `(media, region)` pair — on Places365-small that's ~36k images × ~23 regions ≈ **840k iterations**, each doing an `np.asarray`, and
- a `np.stack` allocating a **multi-GB** `(R, D)` float32 matrix.

Both are GIL-bound. Running in the background training thread, they starved the `gthread` worker pool, so the **next** vote's POST stalled several seconds. The region vectors never change between votes — only the MLP weights do — so all that rebuild work was pure waste.

## Fix

- **Cache the flattened region matrix** + the `row → media` / `row → region` index arrays on `DatasetContext`, mirroring the existing `_emb_matrix` cache and keyed on the sorted media-id set (`vtscore/embedding/matrix.py::get_region_matrix_for_snap`). It's built once and reused across votes; `invalidate_embedding_matrix` now clears it alongside the embedding matrix so it can't go stale when the media set changes. (Process-scoped in-memory only — no persistence, per the repo rule.)
- **Vectorize the max-pool** in `_score_all_media` into a numpy segmented reduce (`_segmented_max_pool`), so the per-vote scoring tail no longer iterates hundreds of thousands of rows in Python. Behavior (per-media max score, first-row-wins best-region, sentinel handling) is preserved — covered by the existing NaN-safety test and the new ones.

After the first scoring pass populates the cache, subsequent votes only run the (GIL-releasing) MLP forward pass, so the next item shows immediately.

## Tests

- New `tests_lib/detectors/test_region_score_pool.py`: pins region max-pool / best-region correctness against an independent recompute, and the cache populate/reuse/invalidate lifecycle.
- Full `./run-tests.sh` green (4850 passed), including the ruff/format/codespell/deptry/pyright/frontend gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9HEBPUaqP3hAUxxXB3See)_