### PR TITLE
Restore region crop on undo/redo of good votes

### DIFF
--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -527,6 +527,48 @@ describe('VoteStateService', () => {
       expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
       req.flush({ ok: true, state: 'good', click_time: 1 });
     });
+
+    it('redo of a region good vote re-applies the click crop', () => {
+      service
+        .submitToggleVoteAndRecord(5, 'good', 'foo.wav', [0.1, 0.2, 0.3, 0.4])
+        .subscribe();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'good', click_time: 1 });
+
+      service.undo();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
+
+      // Redo must restore the original crop, not POST a box-less good vote.
+      service.redo();
+      const redoReq = httpMock.expectOne('/api/medias/5/vote');
+      expect(redoReq.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      redoReq.flush({ ok: true, state: 'good', click_time: 2 });
+      expect(service.goodRegionBoxes['5']).toEqual([0.1, 0.2, 0.3, 0.4]);
+    });
+
+    it('undo restores the crop of the previous good vote', () => {
+      // Media 5 already has a region good vote with a known crop.
+      service.applyOptimisticState(5, 'good');
+      service['goodRegionBoxesSubject'].next({ '5': [0.5, 0.6, 0.7, 0.8] });
+
+      // User re-crops the same good vote with a new box.
+      service
+        .submitToggleVoteAndRecord(5, 'good', 'foo.wav', [0.1, 0.2, 0.3, 0.4])
+        .subscribe();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'good', click_time: 1 });
+
+      // Undo must restore the prior crop, not drop it.
+      service.undo();
+      const undoReq = httpMock.expectOne('/api/medias/5/vote');
+      expect(undoReq.request.body).toEqual({ target: 'good', region_box: [0.5, 0.6, 0.7, 0.8] });
+      undoReq.flush({ ok: true, state: 'good', click_time: 2 });
+      expect(service.goodRegionBoxes['5']).toEqual([0.5, 0.6, 0.7, 0.8]);
+    });
   });
 
   it('goodVotes$ should emit on load', () => new Promise<void>((done) => {

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -15,6 +15,20 @@ export interface UndoEntry {
   mediaId: number;
   clickedDirection: 'good' | 'bad';
   previousPolarity: 'good' | 'bad' | null;
+  /**
+   * Region box the media's good vote carried *before* the click, or ``null``
+   * when it had none (was un-voted / bad / a box-less good).  Replayed on
+   * undo so restoring back to a good vote also restores its crop instead of
+   * silently dropping it (a box-less good POST).
+   */
+  previousRegionBox: number[] | null;
+  /**
+   * Region box the click itself applied (the box drawn for the good vote that
+   * produced this entry), or ``null`` when the click set bad / un-voted / a
+   * box-less good.  Replayed on redo so re-applying a good vote restores its
+   * crop.
+   */
+  clickedRegionBox: number[] | null;
   mediaName: string;
 }
 
@@ -270,9 +284,24 @@ export class VoteStateService implements OnDestroy {
       : this.badVotesSubject.value.has(id)
         ? 'bad'
         : null;
+    // Snapshot the crop the good vote carried before the click (for undo) and
+    // the crop this click applies (for redo).  Both captured synchronously,
+    // before the optimistic flip clears/overwrites the region-box map.
+    const prevBox = this.goodRegionBoxesSubject.value[String(id)];
+    const previousRegionBox = previousPolarity === 'good' && prevBox ? [...prevBox] : null;
+    const target = this.toggleTargetFor(id, clickedDirection);
+    const clickedRegionBox =
+      target === 'good' && regionBox && regionBox.length === 4 ? [...regionBox] : null;
     return this.submitToggleVote(id, clickedDirection, regionBox).pipe(
       tap(() => {
-        this.past.push({ mediaId: id, clickedDirection, previousPolarity, mediaName });
+        this.past.push({
+          mediaId: id,
+          clickedDirection,
+          previousPolarity,
+          previousRegionBox,
+          clickedRegionBox,
+          mediaName,
+        });
         if (this.past.length > UNDO_STACK_MAX) this.past.shift();
         this.future = [];
       }),
@@ -423,7 +452,19 @@ export class VoteStateService implements OnDestroy {
       : this.badVotesSubject.value.has(mediaId)
         ? 'bad'
         : null;
-    this.past.push({ mediaId, clickedDirection, previousPolarity, mediaName });
+    const prevBox = this.goodRegionBoxesSubject.value[String(mediaId)];
+    const previousRegionBox = previousPolarity === 'good' && prevBox ? [...prevBox] : null;
+    this.past.push({
+      mediaId,
+      clickedDirection,
+      previousPolarity,
+      previousRegionBox,
+      // This low-level primitive isn't told the click's region box; redo of a
+      // good vote recorded this way restores no crop.  Production callers use
+      // submitToggleVoteAndRecord, which captures it.
+      clickedRegionBox: null,
+      mediaName,
+    });
     if (this.past.length > UNDO_STACK_MAX) this.past.shift();
     this.future = [];
   }
@@ -451,8 +492,10 @@ export class VoteStateService implements OnDestroy {
     if (!entry) return;
     this.future.push(entry);
     const target: VoteState = entry.previousPolarity ?? 'none';
+    const box = target === 'good' ? entry.previousRegionBox : null;
     this.applyOptimisticState(entry.mediaId, target);
-    this.mediasApi.vote(entry.mediaId, target).subscribe({
+    this.applyOptimisticRegionBox(entry.mediaId, box);
+    this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       error: () => this.loadVotes(),
     });
@@ -470,8 +513,10 @@ export class VoteStateService implements OnDestroy {
     // click was an un-vote).
     const target: VoteState =
       entry.previousPolarity === entry.clickedDirection ? 'none' : entry.clickedDirection;
+    const box = target === 'good' ? entry.clickedRegionBox : null;
     this.applyOptimisticState(entry.mediaId, target);
-    this.mediasApi.vote(entry.mediaId, target).subscribe({
+    this.applyOptimisticRegionBox(entry.mediaId, box);
+    this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       error: () => this.loadVotes(),
     });


### PR DESCRIPTION
## Problem

The undo/redo path re-POSTed votes without the region box, so undoing back to a good vote silently dropped its crop (a box-less good vote), and redoing a region good vote did the same.

## Cause

`UndoEntry` only stored the polarity to restore, not any region box. `undo()` and `redo()` called `mediasApi.vote(id, target)` with no box, so the server received a box-less good vote and the Good-pile thumbnail lost its crop.

## Fix

- `UndoEntry` now carries two crops, both captured synchronously at record time (before the optimistic flip overwrites the region-box map):
  - `previousRegionBox` — the crop the good vote had *before* the click, replayed on **undo**.
  - `clickedRegionBox` — the crop the click itself applied, replayed on **redo**.
- `submitToggleVoteAndRecord` captures both; the low-level `recordVote` primitive captures `previousRegionBox` (it isn't told the click's box, so its redo restores no crop — production callers use `submitToggleVoteAndRecord`).
- `undo()` / `redo()` now pass the appropriate box to `mediasApi.vote(...)` and apply it optimistically via `applyOptimisticRegionBox` so the Good-pile thumbnail re-crops immediately.

## Tests

Added Vitest coverage: redo re-applies the click crop, and undo restores the prior good vote's crop. Full frontend gate green (767 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrRCyXJEU93iZEBXmjPMAt)_