### PR TITLE
Run Angular 21 modernization schematics (control-flow, inject, signal I/O)

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, effect } from '@angular/core';
+import { Component, HostListener, effect, inject } from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { combineLatest } from 'rxjs';
@@ -60,6 +60,17 @@ import { isPairCompatible } from './utils/context-compat';
   styleUrl: './app.component.scss',
 })
 export class AppComponent {
+  private router = inject(Router);
+  private mediaState = inject(MediaStateService);
+  private datasetState = inject(DatasetStateService);
+  private activeContext = inject(ActiveContextService);
+  private recent = inject(RecentSessionsService);
+  auth = inject(AuthService);
+  achievements = inject(AchievementsService);
+  private settingsState = inject(SettingsStateService);
+  private themeService = inject(ThemeService);
+  private newThingFlows = inject(NewThingFlowsService);
+
   title = 'VTSearch';
   menuOpen = false;
   showSettings = false;
@@ -89,20 +100,9 @@ export class AppComponent {
   };
   recentSessions: RecentSession[] = [];
 
-  constructor(
-    private router: Router,
-    private mediaState: MediaStateService,
-    private datasetState: DatasetStateService,
-    private activeContext: ActiveContextService,
-    private recent: RecentSessionsService,
-    public auth: AuthService,
-    public achievements: AchievementsService,
-    private settingsState: SettingsStateService,
-    private themeService: ThemeService,
-    private newThingFlows: NewThingFlowsService,
-    _toast: ToastService,
-    activeContextWatcher: ActiveContextWatcherService,
-  ) {
+  constructor() {
+    const activeContextWatcher = inject(ActiveContextWatcherService);
+
     this.auth.checkStatus();
     this.settingsState.load();
     effect(() => {

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.html
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.html
@@ -1,14 +1,14 @@
 <div
   class="achievement-badge"
   [ngClass]="tierClass"
-  [style.width.px]="size"
-  [style.height.px]="size"
-  [attr.aria-label]="iconType + ' badge'">
+  [style.width.px]="size()"
+  [style.height.px]="size()"
+  [attr.aria-label]="iconType() + ' badge'">
   @if (showOuterRing || tierIdx === -1) {
     <svg
       class="achievement-decoration"
-      [attr.width]="size"
-      [attr.height]="size"
+      [attr.width]="size()"
+      [attr.height]="size()"
       viewBox="0 0 100 100"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
@@ -43,6 +43,6 @@
     </svg>
   }
   <span class="achievement-symbol">
-    <vt-icon [type]="iconType" [size]="innerIconSize"></vt-icon>
+    <vt-icon [type]="iconType()" [size]="innerIconSize"></vt-icon>
   </span>
 </div>

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IconComponent } from '../icon/icon.component';
 
@@ -20,10 +20,10 @@ import { IconComponent } from '../icon/icon.component';
   styleUrl: './achievement-badge.component.scss',
 })
 export class AchievementBadgeComponent {
-  @Input() iconType = 'trophy';
+  readonly iconType = input('trophy');
   @Input() tierIdx = -1;
   /** Outer badge size in pixels (the inner icon is auto-scaled). */
-  @Input() size = 56;
+  readonly size = input(56);
 
   get tierClass(): string {
     switch (this.tierIdx) {
@@ -41,7 +41,7 @@ export class AchievementBadgeComponent {
   }
 
   get innerIconSize(): number {
-    return Math.max(12, Math.round(this.size * 0.55));
+    return Math.max(12, Math.round(this.size() * 0.55));
   }
 
   get showOuterRing(): boolean {

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementsService } from '../../services/achievements.service';
@@ -11,12 +11,10 @@ import { ToastService } from '../../services/toast.service';
   template: '',
 })
 export class AchievementUnlockHostComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+  private achievements = inject(AchievementsService);
+  private toast = inject(ToastService);
 
-  constructor(
-    private achievements: AchievementsService,
-    private toast: ToastService,
-  ) {}
+  private destroy$ = new Subject<void>();
 
   ngOnInit(): void {
     this.achievements.unlocks.pipe(takeUntil(this.destroy$)).subscribe((p) => {

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, effect } from '@angular/core';
+import { Component, OnDestroy, OnInit, effect, inject } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -33,6 +33,9 @@ interface AchievementRow extends AchievementEntry {
   styleUrl: './achievements-tab.component.scss',
 })
 export class AchievementsTabComponent implements OnInit, OnDestroy {
+  private achievements = inject(AchievementsService);
+  private settingsState = inject(SettingsStateService);
+
   rows: AchievementRow[] = [];
   docs: DocEntry[] = [];
   mediaTypes: MediaTypeEntry[] = [];
@@ -53,10 +56,7 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   private disableAchievements = false;
   private lastState: AchievementState | null = null;
 
-  constructor(
-    private achievements: AchievementsService,
-    private settingsState: SettingsStateService,
-  ) {
+  constructor() {
     effect(() => {
       const s = this.settingsState.settingsSignal();
       this.disableAchievements = s?.enable_achievements === false;

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -18,7 +18,7 @@
     </span>
     <vt-view-controls
       side="popup"
-      [currentMediaType]="mediaType"
+      [currentMediaType]="mediaType()"
       [showFocus]="false"
       [showViewMode]="false"
       [allowSizeInList]="true"
@@ -89,7 +89,7 @@
     }
   </div>
 
-  @if (mediaType === 'audio') {
+  @if (mediaType() === 'audio') {
     <audio #audioEl class="sr-only" [src]="audioSrc"></audio>
   }
 </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,18 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostListener,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-  ViewChild,
-  effect,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostListener, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
@@ -102,24 +88,31 @@ const HOVER_EXTENT_PER_RADIUS = 3;
   styleUrl: './browse-bin-popup.component.scss',
 })
 export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDestroy {
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private selection = inject(BrowseSelectionService);
+  private metadataCache = inject(MediaMetadataCacheService);
+  private activeContext = inject(ActiveContextService);
+  private settingsState = inject(SettingsStateService);
+  private cdr = inject(ChangeDetectorRef);
+
   /** Member media ids of the bin the popup was summoned over. */
-  @Input() memberIds: number[] = [];
+  readonly memberIds = input<number[]>([]);
   /** Active dataset media type, used for the view prefs, hover-to-hear, and placeholders. */
-  @Input() mediaType = '';
+  readonly mediaType = input('');
   /** Viewport anchor (clientX/clientY) the popup opens at, then clamps inward. */
-  @Input() x = 0;
-  @Input() y = 0;
+  readonly x = input(0);
+  readonly y = input(0);
   /** The canvas's bounding rect (viewport coords); the popup is clamped to the
    *  on-screen part of it so it stays fully visible. Null falls back to the
    *  full viewport. */
-  @Input() bounds: DOMRect | null = null;
+  readonly bounds = input<DOMRect | null>(null);
   /** Current on-screen bin radius (CSS px) of the main canvas, i.e. the radius
    *  the hovered thumbnail breaks out from. The preview pane is sized relative
    *  to this so it tracks the main-canvas thumbnail-size setting. */
-  @Input() hoverThumbRadius = 28;
+  readonly hoverThumbRadius = input(28);
 
   /** Emitted when the popup should close (outside click, Escape, or the X). */
-  @Output() dismissed = new EventEmitter<void>();
+  readonly dismissed = output<void>();
 
   @ViewChild('panel') private panelRef?: ElementRef<HTMLElement>;
   @ViewChild('header') private headerRef?: ElementRef<HTMLElement>;
@@ -177,14 +170,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   private readonly subs: Subscription[] = [];
   private scrollSub: Subscription | null = null;
 
-  constructor(
-    private host: ElementRef<HTMLElement>,
-    private selection: BrowseSelectionService,
-    private metadataCache: MediaMetadataCacheService,
-    private activeContext: ActiveContextService,
-    private settingsState: SettingsStateService,
-    private cdr: ChangeDetectorRef,
-  ) {
+  constructor() {
     // Re-read the popup's thumbnail size whenever settings change (this is how
     // the in-header size buttons take effect, and how a change on one popup
     // becomes the default for every future popup of this media type).
@@ -198,7 +184,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['memberIds']) {
-      this.ids = this.memberIds ?? [];
+      this.ids = this.memberIds() ?? [];
       this.stopAudio();
       // Open on the bin's representative so the pane is never blank (a singleton
       // therefore lands straight on a large high-res view).
@@ -225,8 +211,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       // Re-anchor to the summon point, unless the user has dragged the popup —
       // then keep their spot (``place`` re-clamps it back on-screen if needed).
       if (!this.dragged) {
-        this.left = this.x;
-        this.top = this.y;
+        this.left = this.x();
+        this.top = this.y();
       }
       // Measure + clamp after the new content lays out.
       setTimeout(() => this.place());
@@ -258,15 +244,16 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
   get showPreview(): boolean {
-    return usesThumbnails(this.mediaType);
+    return usesThumbnails(this.mediaType());
   }
 
   /** Pull the remembered thumbnail size for the active media type, rechunk the
    *  rows, and re-clamp (the body height may have changed). */
   private applyViewPrefs(): void {
     const prevGoal = this.gridGoalWidth;
+    const mediaType = this.mediaType();
     this.gridGoalWidth = iconSizeToGoalWidth(
-      (this.mediaType && this.gridSizeDict[this.mediaType]) || 'M',
+      (mediaType && this.gridSizeDict[mediaType]) || 'M',
     );
     if (this.gridGoalWidth !== prevGoal) {
       this.rebuildRows();
@@ -311,7 +298,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  taller. Zero when there is no preview. */
   get previewSize(): number {
     if (!this.showPreview) return 0;
-    const desired = this.hoverThumbRadius * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
+    const desired = this.hoverThumbRadius() * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
     // Keep it within the vertical room the region leaves (which already folds in
     // the absolute MAX_PREVIEW_PX cap via ``previewCapPx``).
     return Math.round(Math.max(MIN_PREVIEW_PX, Math.min(desired, this.previewCapPx)));
@@ -415,7 +402,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   onEntryEnter(id: number): void {
     // Thumbnail media: paint the hovered item's full-res original into the pane.
     if (this.showPreview) this.previewId = id;
-    if (this.mediaType !== 'audio') return;
+    if (this.mediaType() !== 'audio') return;
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
     this.audioSrc = src;
@@ -511,7 +498,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Re-clamp the popup, anchoring at the summon point unless the user has
    *  dragged it (then keep their spot, just nudged back on-screen if needed). */
   private place(): void {
-    this.clampInto(this.dragged ? this.left : this.x, this.dragged ? this.top : this.y);
+    this.clampInto(this.dragged ? this.left : this.x(), this.dragged ? this.top : this.y());
   }
 
   /** Clamp ``(desiredLeft, desiredTop)`` so the *whole* popup sits inside the
@@ -525,7 +512,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   private clampInto(desiredLeft: number, desiredTop: number): void {
     const panel = this.panelRef?.nativeElement;
     if (!panel) return;
-    const b = this.bounds;
+    const b = this.bounds();
     // Visible region = canvas rect clipped to the viewport. Clipping to the
     // window is what keeps the popup fully on-screen when the canvas extends
     // past the bottom/right edges of the window.

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.html
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.html
@@ -1,3 +1,3 @@
-<div class="canvas-container" [class.marquee-active]="marqueeMode">
+<div class="canvas-container" [class.marquee-active]="marqueeMode()">
   <canvas #canvas></canvas>
 </div>

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1,16 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -66,14 +54,20 @@ const HOVER_RADIUS_SCALE = 1.38;
   styleUrl: './browse-canvas.component.scss',
 })
 export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
+  private ngZone = inject(NgZone);
+  private tileCache = inject(TileCacheService);
+  private activeContext = inject(ActiveContextService);
+  private viewport = inject(BrowseViewportService);
+  private selection = inject(BrowseSelectionService);
+
   @ViewChild('canvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
-  @Input() meta: ProjectionMeta | null = null;
+  readonly meta = input<ProjectionMeta | null>(null);
   /**
    * Active dataset media type. For ``image`` and ``video`` the representative
    * item's thumbnail is painted directly onto each hex; other types keep the
    * flat density (darkred→yellow) shading.
    */
-  @Input() mediaType = '';
+  readonly mediaType = input('');
   /** On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
    * default before any saved size is applied. See {@link targetRadius}. */
   static readonly DEFAULT_TARGET_RADIUS = 28;
@@ -97,7 +91,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * a specific map. Resolved to concrete colours against the live theme at
    * draw time, so a theme switch repaints with the right ramp.
    */
-  @Input() colormap: BrowseColormapId = 'auto';
+  readonly colormap = input<BrowseColormapId>('auto');
   /**
    * Width (CSS px) of the colormap-coloured border painted around multi-item
    * ("pile") thumbnails. The band's colour is the density colour for the cell's
@@ -105,24 +99,24 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * disables it (cells fall back to the faint dark separator). Only takes effect
    * in {@link thumbnailMode} (image/video); singletons never get the band.
    */
-  @Input() thumbnailBorder = 0;
+  readonly thumbnailBorder = input(0);
   /**
    * GUI parallel to the Shift modifier: when on, a plain left-drag rubber-bands
    * a selection marquee instead of panning, so the region-select gesture is
    * discoverable without knowing the Shift+drag hotkey. Shift+drag keeps working
    * regardless. Toggled by the region-select button in the browse toolbar.
    */
-  @Input() marqueeMode = false;
-  @Output() hexHover = new EventEmitter<HexHoverEvent | null>();
+  readonly marqueeMode = input(false);
+  readonly hexHover = output<HexHoverEvent | null>();
   /** A right-click on the canvas; the view opens the bin popup in response. */
-  @Output() contextMenu = new EventEmitter<BrowseContextMenuEvent>();
+  readonly contextMenu = output<BrowseContextMenuEvent>();
   /**
    * The densest visible cell's item count, emitted whenever it changes. Density
    * shading is renormalized to this per frame (yellow = this many items, the
    * darkest red = 1), so the legend reads it to label the ramp with live
    * numbers that track pan/zoom.
    */
-  @Output() densityMaxChanged = new EventEmitter<number>();
+  readonly densityMaxChanged = output<number>();
 
   /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
   private thumbCache = new Map<number, HTMLImageElement>();
@@ -288,17 +282,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private recenterSub: Subscription | null = null;
   private selectionSub: Subscription | null = null;
 
-  constructor(
-    private ngZone: NgZone,
-    private tileCache: TileCacheService,
-    private activeContext: ActiveContextService,
-    private viewport: BrowseViewportService,
-    private selection: BrowseSelectionService,
-  ) {}
-
   /** True when cells should be painted with the central item's thumbnail. */
   private get thumbnailMode(): boolean {
-    return usesThumbnails(this.mediaType);
+    return usesThumbnails(this.mediaType());
   }
 
   /** At the largest zoom levels a cell is drawn wider (in device px) than the
@@ -322,7 +308,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   /** Geometry (hex or square) for the active projection's bin shape. */
   private get geom(): BinGeometry {
-    return binGeometry(this.meta?.bin_shape);
+    return binGeometry(this.meta()?.bin_shape);
   }
 
   /** On-screen scale (projection units → CSS px). Used for all projection↔screen
@@ -383,20 +369,21 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['meta'] && this.meta) {
+    const meta = this.meta();
+    if (changes['meta'] && meta) {
       // Fresh meta re-bins (new projection, bin-shape toggle, cull). Any zoom
       // transition was easing the *old* data, so abandon it; the redraw below
       // paints the new state. A boundary settle would spring toward the old
       // bounds, so stop it too.
       this.cancelZoomAnim();
       this.cancelSettle();
-      this.tileCache.setProjectionId(this.meta.projection_id);
+      this.tileCache.setProjectionId(meta.projection_id);
       // A bin-shape toggle delivers fresh meta for the *same* projection id
       // (hex and square share one UMAP layout). In that case keep the current
       // pan/zoom and just re-bin visually; only a genuinely new projection
       // re-frames to data and drops stale representative thumbnails.
-      if (this.meta.projection_id !== this.lastProjectionId) {
-        this.lastProjectionId = this.meta.projection_id;
+      if (meta.projection_id !== this.lastProjectionId) {
+        this.lastProjectionId = meta.projection_id;
         // A brand-new projection opens auto-fit: clear the user-framed flag so a
         // saved cell size applied right after load re-fits to keep it all in view.
         this.framedByUser = false;
@@ -419,7 +406,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     }
     // Entering region-select mode: drop any hover preview/highlight that was
     // showing, since hover is suppressed while the mode is on.
-    if (changes['marqueeMode'] && this.marqueeMode) {
+    if (changes['marqueeMode'] && this.marqueeMode()) {
       this.clearHover();
     }
     // A colormap change only affects flat (non-thumbnail) shading; repaint.
@@ -491,7 +478,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // framing and the viewport bounds published to the minimap match the actual
     // canvas. Only on the first real measurement — a later window resize keeps
     // the user's pan/zoom.
-    if (!this.fittedAgainstRealSize && this.meta && this.width > 0 && this.height > 0) {
+    if (!this.fittedAgainstRealSize && this.meta() && this.width > 0 && this.height > 0) {
       this.fitToData();
     } else {
       // The viewport changed size: a shrunk canvas raises the fit floor and a
@@ -503,8 +490,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private fitToData(): void {
-    if (!this.meta || this.meta.point_count === 0) return;
-    const [xmin, ymin, xmax, ymax] = this.meta.bounds;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return;
+    const [xmin, ymin, xmax, ymax] = meta.bounds;
     this.transform.zoom = this.computeFitZoom();
     this.transform.centerX = (xmin + xmax) / 2;
     this.transform.centerY = (ymin + ymax) / 2;
@@ -527,8 +515,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * at 0, so this settles immediately).
    */
   private computeFitZoom(): number {
-    if (!this.meta) return this.transform.zoom;
-    const [xmin, ymin, xmax, ymax] = this.meta.bounds;
+    const meta = this.meta();
+    if (!meta) return this.transform.zoom;
+    const [xmin, ymin, xmax, ymax] = meta.bounds;
     const dataW = xmax - xmin || 1;
     const dataH = ymax - ymin || 1;
     // Small breathing room beyond the bins themselves.
@@ -541,7 +530,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     );
     for (let i = 0; i < 3; i++) {
       const level = this.levelForEffZoom(zoom);
-      const r = this.meta.base_radius / Math.pow(2, level);
+      const r = meta.base_radius / Math.pow(2, level);
       const padW = dataW + 2 * (r + dataW * padding);
       const padH = dataH + 2 * (r + dataH * padding);
       zoom = Math.min(w / padW, h / padH);
@@ -567,9 +556,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   private computeMaxZoom(): number {
     const minZoom = this.computeFitZoom();
-    if (!this.meta || this.meta.levels.length === 0) return minZoom;
-    const maxLevel = this.meta.levels.length - 1;
-    const maxZoom = (this.targetRadius * Math.pow(2, maxLevel + 0.5)) / this.meta.base_radius;
+    const meta = this.meta();
+    if (!meta || meta.levels.length === 0) return minZoom;
+    const maxLevel = meta.levels.length - 1;
+    const maxZoom = (this.targetRadius * Math.pow(2, maxLevel + 0.5)) / meta.base_radius;
     // A tiny projection can fit whole at a zoom already past its finest-level
     // size; never let the ceiling drop below the floor (that would invert the
     // clamp and trap the view between two crossed limits).
@@ -595,7 +585,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * clamp no longer force-recentres on zoom-out.)
    */
   private clampView(): void {
-    if (!this.meta || this.meta.point_count === 0) return;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return;
     if (this.width <= 0 || this.height <= 0) return;
     const c = this.clampedTransform(this.transform);
     this.transform.zoom = c.zoom;
@@ -633,9 +624,10 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private panLimits(
     z: number,
   ): { loX: number; hiX: number; loY: number; hiY: number; viewX: number; viewY: number } | null {
-    if (!this.meta || this.meta.point_count === 0) return null;
-    const [xmin, ymin, xmax, ymax] = this.meta.bounds;
-    const r = this.meta.base_radius / Math.pow(2, this.levelForEffZoom(z));
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return null;
+    const [xmin, ymin, xmax, ymax] = meta.bounds;
+    const r = meta.base_radius / Math.pow(2, this.levelForEffZoom(z));
     return { loX: xmin - r, hiX: xmax + r, loY: ymin - r, hiY: ymax + r, viewX: this.width / z, viewY: this.height / z };
   }
 
@@ -744,18 +736,20 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * ({@link targetRadius}) at the given on-screen zoom. Shared by live level
    * selection and fit framing. */
   private levelForEffZoom(effZoom: number): number {
-    if (!this.meta || this.meta.levels.length === 0) return 0;
+    const meta = this.meta();
+    if (!meta || meta.levels.length === 0) return 0;
     const idealLevel = Math.log2(
-      (this.meta.base_radius * effZoom) / this.targetRadius,
+      (meta.base_radius * effZoom) / this.targetRadius,
     );
     return Math.max(
       0,
-      Math.min(this.meta.levels.length - 1, Math.round(idealLevel)),
+      Math.min(meta.levels.length - 1, Math.round(idealLevel)),
     );
   }
 
   private updateActiveLevel(): void {
-    if (!this.meta || this.meta.levels.length === 0) return;
+    const meta = this.meta();
+    if (!meta || meta.levels.length === 0) return;
     // Floor the level at the coarsest one reachable in "normal space" (the
     // level the fit zoom lands on). Zooming out past the whole-projection fit
     // only happens in the rubber-band overshoot zone, and that overshoot is
@@ -793,11 +787,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getVisibleTiles(): { tx: number; ty: number }[] {
-    if (!this.meta) return [];
+    const meta = this.meta();
+    if (!meta) return [];
     const level = this.activeLevel;
-    const radius = this.meta.base_radius / Math.pow(2, level);
+    const radius = meta.base_radius / Math.pow(2, level);
     const geom = this.geom;
-    const tileSpan = this.meta.tile_span;
+    const tileSpan = meta.tile_span;
     const tileW = tileSpan * geom.dx(radius);
     const tileH = tileSpan * geom.dy(radius);
 
@@ -976,7 +971,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       clearTimeout(this.settleTimer);
       this.settleTimer = null;
     }
-    if (!this.meta || this.meta.point_count === 0) return;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return;
     if (this.width <= 0 || this.height <= 0) return;
     const dest = this.clampedTransform(this.transform);
     const cur = this.transform;
@@ -1065,7 +1061,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.fillStyle = this.themeColor('--bg-body');
     ctx.fillRect(0, 0, this.width, this.height);
 
-    if (!this.meta || this.meta.point_count === 0) {
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) {
       ctx.fillStyle = this.themeColor('--text-muted');
       ctx.font = '16px sans-serif';
       ctx.textAlign = 'center';
@@ -1074,7 +1071,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     const level = this.activeLevel;
-    const radius = this.meta.base_radius / Math.pow(2, level);
+    const radius = meta.base_radius / Math.pow(2, level);
     const screenRadius = radius * this.effZoom;
 
     const visibleTiles = this.getVisibleTiles();
@@ -1099,7 +1096,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     // Resolve the colormap against the live theme once per frame, not per cell.
-    const cmap = resolveColormap(this.colormap, this.effectiveTheme());
+    const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
     // Accent for selection rings + marquee, also resolved once per frame.
     this.selAccent = this.themeColor('--accent-color') || '#4f9dff';
     const selectionActive = this.selection.size > 0;
@@ -1253,7 +1250,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       if (selState === 1) ctx.setLineDash([6, 4]);
       ctx.stroke();
       ctx.restore();
-    } else if (thumb && !single && this.thumbnailBorder > 0) {
+    } else if (thumb && !single && this.thumbnailBorder() > 0) {
       // Pile thumbnail: a band whose colormap colour encodes how many items are
       // stacked under this tile. Clipped to the cell so the full width sits just
       // inside the thumbnail edge rather than bleeding onto neighbours (a
@@ -1262,7 +1259,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       ctx.save();
       ctx.clip();
       ctx.strokeStyle = densityColor(Math.max(0, Math.min(1, t)), cmap.ramp);
-      ctx.lineWidth = this.thumbnailBorder * 2;
+      ctx.lineWidth = this.thumbnailBorder() * 2;
       ctx.stroke();
       ctx.restore();
     } else {
@@ -1439,7 +1436,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private prefetchNeighbors(visibleTiles: { tx: number; ty: number }[]): void {
-    if (!this.meta) return;
+    const meta = this.meta();
+    if (!meta) return;
     const level = this.activeLevel;
     const seen = new Set(visibleTiles.map((t) => `${t.tx}:${t.ty}`));
     for (const { tx, ty } of visibleTiles) {
@@ -1455,15 +1453,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     if (level > 0) {
       this.prefetchLevel(level - 1, visibleTiles);
     }
-    if (this.meta.levels.length > level + 1) {
+    if (meta.levels.length > level + 1) {
       this.prefetchLevel(level + 1, visibleTiles);
     }
   }
 
   private prefetchLevel(targetLevel: number, sourceTiles: { tx: number; ty: number }[]): void {
-    if (!this.meta) return;
-    const sourceRadius = this.meta.base_radius / Math.pow(2, this.activeLevel);
-    const targetRadius = this.meta.base_radius / Math.pow(2, targetLevel);
+    const meta = this.meta();
+    if (!meta) return;
+    const sourceRadius = meta.base_radius / Math.pow(2, this.activeLevel);
+    const targetRadius = meta.base_radius / Math.pow(2, targetLevel);
     const ratio = sourceRadius / targetRadius;
     const seen = new Set<string>();
     for (const { tx, ty } of sourceTiles) {
@@ -1500,7 +1499,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.panStartY = event.clientY;
     this.dragMoved = false;
 
-    if (event.shiftKey || this.marqueeMode) {
+    if (event.shiftKey || this.marqueeMode()) {
       // Shift+drag (or the region-select toggle): rubber-band a region to add to
       // the selection. Suppress any hover preview while marqueeing so it doesn't
       // flicker over the rectangle.
@@ -1614,7 +1613,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   /** Double-click zooms in about the cursor (map idiom). Shift/region-select are
    *  reserved for the marquee, so they don't zoom. */
   private onDblClick(event: MouseEvent): void {
-    if (event.shiftKey || this.marqueeMode) return;
+    if (event.shiftKey || this.marqueeMode()) return;
     this.cancelPendingToggle();
     const [mx, my] = this.canvasXY(event);
     this.zoomBy(BrowseCanvasComponent.DOUBLE_CLICK_ZOOM, mx, my);
@@ -1664,7 +1663,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   /** Add every bin whose centre falls inside the marquee rectangle. */
   private commitMarquee(): void {
-    if (!this.marquee || !this.meta) return;
+    if (!this.marquee || !this.meta()) return;
     const [px0, py0] = this.screenToProj(this.marquee.x0, this.marquee.y0);
     const [px1, py1] = this.screenToProj(this.marquee.x1, this.marquee.y1);
     const minX = Math.min(px0, px1);
@@ -1759,7 +1758,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   setThumbnailRadius(radius: number, reframe: boolean): void {
     if (radius <= 0 || radius === this.targetRadius) return;
     this.cancelSettle();
-    if (reframe && this.meta && this.fittedAgainstRealSize) {
+    const meta = this.meta();
+    if (reframe && meta && this.fittedAgainstRealSize) {
       this.framedByUser = true;
       this.transform.zoom *= radius / this.targetRadius;
     }
@@ -1772,7 +1772,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // letting the now-larger edge bins spill past the default-radius framing.
     // Once the user has panned/zoomed, only re-select the level so their view is
     // preserved.
-    if (!reframe && !this.framedByUser && this.meta && this.fittedAgainstRealSize) {
+    if (!reframe && !this.framedByUser && meta && this.fittedAgainstRealSize) {
       this.fitToData();
     } else {
       // A reframe scales the zoom in lock-step with the size, which can push it
@@ -1797,7 +1797,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // No hover while panning or marqueeing (mid-drag), and none at all in
     // region-select mode: the cursor is a crosshair for drawing a box, so a
     // hover preview/highlight popping up under it would just be noise.
-    if (this.isPanning || this.isMarquee || this.marqueeMode) return;
+    if (this.isPanning || this.isMarquee || this.marqueeMode()) return;
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
@@ -1872,13 +1872,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private hitTest(sx: number, sy: number): HexCellPayload | null {
-    if (!this.meta) return null;
+    const meta = this.meta();
+    if (!meta) return null;
     const [px, py] = this.screenToProj(sx, sy);
     const level = this.activeLevel;
-    const radius = this.meta.base_radius / Math.pow(2, level);
+    const radius = meta.base_radius / Math.pow(2, level);
     const geom = this.geom;
-    const tileW = this.meta.tile_span * geom.dx(radius);
-    const tileH = this.meta.tile_span * geom.dy(radius);
+    const tileW = meta.tile_span * geom.dx(radius);
+    const tileH = meta.tile_span * geom.dy(radius);
 
     const txEst = Math.floor(px / tileW);
     const tyEst = Math.floor(py / tileH);

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  Input,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, input } from '@angular/core';
 
 import { ActiveContextService } from '../../services/active-context.service';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
@@ -19,8 +11,10 @@ import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
   styleUrl: './browse-hover-preview.component.scss',
 })
 export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
-  @Input() hover: HexHoverEvent | null = null;
-  @Input() mediaType = '';
+  private activeContext = inject(ActiveContextService);
+
+  readonly hover = input<HexHoverEvent | null>(null);
+  readonly mediaType = input('');
   @ViewChild('audioEl') audioRef?: ElementRef<HTMLAudioElement>;
 
   visible = false;
@@ -31,12 +25,11 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   count = 0;
   private textLoadAbort: AbortController | null = null;
 
-  constructor(private activeContext: ActiveContextService) {}
-
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['hover']) {
-      if (this.hover) {
-        this.show(this.hover);
+      const hover = this.hover();
+      if (hover) {
+        this.show(hover);
       } else {
         this.hide();
       }
@@ -53,7 +46,8 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
 
     // Image and video paint their thumbnail directly onto the hex (see
     // browse-canvas); nothing happens on hover, so suppress the pop-up.
-    if (this.mediaType === 'image' || this.mediaType === 'video') {
+    const mediaType = this.mediaType();
+    if (mediaType === 'image' || mediaType === 'video') {
       this.hide();
       return;
     }
@@ -63,7 +57,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
     this.top = event.screenY - 8;
     this.count = event.cell.count;
 
-    switch (this.mediaType) {
+    switch (mediaType) {
       case 'audio':
         this.textContent = '';
         this.playAudio(representativeId);
@@ -120,14 +114,14 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
     fetch(url, { signal: abort.signal })
       .then((r) => r.json())
       .then((data) => {
-        if (this.hover?.cell.rep_id === mediaId) {
+        if (this.hover()?.cell.rep_id === mediaId) {
           const text: string = data.content || '';
           this.textContent = text.length > 300 ? text.slice(0, 300) + '...' : text;
         }
       })
       .catch((err) => {
         if (err?.name === 'AbortError') return;
-        if (this.hover?.cell.rep_id === mediaId) {
+        if (this.hover()?.cell.rep_id === mediaId) {
           this.textContent = `Item #${mediaId}`;
         }
       });

--- a/frontend/src/app/components/browse-legend/browse-legend.component.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input } from '@angular/core';
 import {
   gradientStops,
   resolveColormap,
@@ -32,7 +32,7 @@ interface LegendTick {
   standalone: true,
   template: `
     <div class="browse-legend" role="img" [attr.aria-label]="ariaLabel">
-      <span class="browse-legend-title">{{ title }}</span>
+      <span class="browse-legend-title">{{ title() }}</span>
       <div class="browse-legend-row">
         <div class="browse-legend-single">
           <span class="browse-legend-dot" [style.background]="singleColor"></span>
@@ -57,11 +57,11 @@ interface LegendTick {
 })
 export class BrowseLegendComponent implements OnInit, OnDestroy {
   /** Heading above the swatch — what the color encodes. */
-  @Input() title = 'Items per cell';
+  readonly title = input('Items per cell');
   /** Item count the top of the ramp currently maps to. */
-  @Input() maxCount = 1;
+  readonly maxCount = input(1);
   /** Active density colormap preset; resolved against the live theme. */
-  @Input() colormap: BrowseColormapId = 'auto';
+  readonly colormap = input<BrowseColormapId>('auto');
 
   private readonly numberFormat = new Intl.NumberFormat();
   /** Live theme, refreshed by a ``data-theme`` observer so the key repaints. */
@@ -89,7 +89,7 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
 
   /** Colormap resolved for the current preset + theme (same as the canvas). */
   private get resolved() {
-    return resolveColormap(this.colormap, this.theme);
+    return resolveColormap(this.colormap(), this.theme);
   }
 
   /** Horizontal gradient with the dense (last ramp stop) end at the right. */
@@ -111,7 +111,7 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
    * shown by the dot instead).
    */
   get ticks(): LegendTick[] {
-    const max = Math.max(Math.round(this.maxCount), 1);
+    const max = Math.max(Math.round(this.maxCount()), 1);
     if (max < 2) return [];
     const seen = new Set<number>();
     const out: LegendTick[] = [];
@@ -125,10 +125,10 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
   }
 
   get ariaLabel(): string {
-    const max = Math.max(Math.round(this.maxCount), 1);
+    const max = Math.max(Math.round(this.maxCount()), 1);
     return max < 2
-      ? `${this.title}: every cell in view holds 1 item`
-      : `${this.title}: a dot is 1 item; the ramp runs up to ${this.numberFormat.format(
+      ? `${this.title()}: every cell in view holds 1 item`
+      : `${this.title()}: a dot is 1 item; the ramp runs up to ${this.numberFormat.format(
           max,
         )} items at its brightest`;
   }

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -1,17 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, HostBinding, Input, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { BrowseViewportService, ViewportBounds } from '../../services/browse-viewport.service';
@@ -52,12 +39,17 @@ export const MINIMAP_MAX_HEIGHT = 450;
   styleUrl: './browse-minimap.component.scss',
 })
 export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
+  private ngZone = inject(NgZone);
+  private tileCache = inject(TileCacheService);
+  private viewport = inject(BrowseViewportService);
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+
   @ViewChild('canvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
-  @Input() meta: ProjectionMeta | null = null;
+  readonly meta = input<ProjectionMeta | null>(null);
   @Input() width = 200;
   @Input() height = 150;
   /** Density colormap preset; mirrors the main canvas so the overview matches. */
-  @Input() colormap: BrowseColormapId = 'auto';
+  readonly colormap = input<BrowseColormapId>('auto');
   /**
    * Docked mode: the minimap fills its container (the browse side panel's
    * meta-row) and sizes its canvas to fit via a {@link ResizeObserver},
@@ -67,9 +59,12 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input() @HostBinding('class.dock') dock = false;
   /** Hide request from the close button (floating mode only). */
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
   /** Final size after a resize drag, for persistence (floating mode only). */
-  @Output() resized = new EventEmitter<{ width: number; height: number }>();
+  readonly resized = output<{
+    width: number;
+    height: number;
+}>();
 
   private resizeObserver: ResizeObserver | null = null;
 
@@ -96,13 +91,6 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   private boundResizeUp = this.onResizeUp.bind(this);
   private boundNavMove = this.onNavMove.bind(this);
   private boundNavUp = this.onNavUp.bind(this);
-
-  constructor(
-    private ngZone: NgZone,
-    private tileCache: TileCacheService,
-    private viewport: BrowseViewportService,
-    private host: ElementRef<HTMLElement>,
-  ) {}
 
   ngOnInit(): void {
     this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
@@ -202,15 +190,17 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
    * level 0 (so the map is finer-grained), clamped to the available levels.
    */
   private overviewLevel(f: { scale: number }): number {
-    if (!this.meta || this.meta.levels.length === 0) return 0;
-    const basePx = this.meta.base_radius * f.scale; // level-0 hex radius in px
+    const meta = this.meta();
+    if (!meta || meta.levels.length === 0) return 0;
+    const basePx = meta.base_radius * f.scale; // level-0 hex radius in px
     const ideal = Math.log2(basePx / BrowseMinimapComponent.OVERVIEW_TARGET_HEX_PX);
-    return Math.max(0, Math.min(this.meta.levels.length - 1, Math.round(ideal)));
+    return Math.max(0, Math.min(meta.levels.length - 1, Math.round(ideal)));
   }
 
   /** Fetch every tile of the overview level spanning the bounds (idempotent). */
   private requestOverviewTiles(): void {
-    if (!this.meta || this.meta.point_count === 0) return;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return;
     const f = this.fit();
     if (!f) return;
     const level = this.overviewLevel(f);
@@ -220,12 +210,13 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private overviewTiles(level: number): { tx: number; ty: number }[] {
-    if (!this.meta) return [];
-    const radius = this.meta.base_radius / Math.pow(2, level);
-    const geom = binGeometry(this.meta.bin_shape);
-    const tileW = this.meta.tile_span * geom.dx(radius);
-    const tileH = this.meta.tile_span * geom.dy(radius);
-    const [xmin, ymin, xmax, ymax] = this.meta.bounds;
+    const meta = this.meta();
+    if (!meta) return [];
+    const radius = meta.base_radius / Math.pow(2, level);
+    const geom = binGeometry(meta.bin_shape);
+    const tileW = meta.tile_span * geom.dx(radius);
+    const tileH = meta.tile_span * geom.dy(radius);
+    const [xmin, ymin, xmax, ymax] = meta.bounds;
     const txMin = Math.floor(xmin / tileW) - 1;
     const txMax = Math.ceil(xmax / tileW) + 1;
     const tyMin = Math.floor(ymin / tileH) - 1;
@@ -263,8 +254,9 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
    * settles immediately.
    */
   private fit(): { scale: number; cx: number; cy: number; margin: number } | null {
-    if (!this.meta || this.meta.point_count === 0) return null;
-    const [xmin, ymin, xmax, ymax] = this.meta.bounds;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return null;
+    const [xmin, ymin, xmax, ymax] = meta.bounds;
     const dataW = xmax - xmin || 1;
     const dataH = ymax - ymin || 1;
     const margin = 4;
@@ -273,7 +265,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     let scale = Math.min(availW / dataW, availH / dataH);
     for (let i = 0; i < 3; i++) {
       const level = this.overviewLevel({ scale });
-      const r = this.meta.base_radius / Math.pow(2, level);
+      const r = meta.base_radius / Math.pow(2, level);
       scale = Math.min(availW / (dataW + 2 * r), availH / (dataH + 2 * r));
     }
     return { scale, cx: (xmin + xmax) / 2, cy: (ymin + ymax) / 2, margin };
@@ -300,9 +292,9 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
       const cells = this.overviewCells(level);
       let maxCount = 1;
       for (const c of cells) if (c.count > maxCount) maxCount = c.count;
-      const geom = binGeometry(this.meta!.bin_shape);
-      const cellR = (this.meta!.base_radius / Math.pow(2, level)) * f.scale;
-      const cmap = resolveColormap(this.colormap, this.effectiveTheme());
+      const geom = binGeometry(this.meta()!.bin_shape);
+      const cellR = (this.meta()!.base_radius / Math.pow(2, level)) * f.scale;
+      const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
       for (const cell of cells) {
         const [sx, sy] = this.projToMap(cell.cx, cell.cy, f);
         const single = cell.count === 1;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -13,7 +13,7 @@
     </button>
   </div>
 
-  @if (canVerify) {
+  @if (canVerify()) {
     <div class="bsp-actions">
       <button
         type="button"
@@ -51,7 +51,7 @@
     </select>
     <vt-view-controls
       side="right"
-      [currentMediaType]="mediaType"
+      [currentMediaType]="mediaType()"
       [showFocus]="false"
       class="bsp-view-controls" />
   </div>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, effect } from '@angular/core';
+import { Component, OnDestroy, OnInit, effect, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -42,8 +42,13 @@ interface SelectionEntry {
   styleUrl: './browse-selection-panel.component.scss',
 })
 export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
+  private selection = inject(BrowseSelectionService);
+  private metadataCache = inject(MediaMetadataCacheService);
+  private activeContext = inject(ActiveContextService);
+  private settingsState = inject(SettingsStateService);
+
   /** Active media type, used to resolve the per-type view-mode + size prefs. */
-  @Input() mediaType = '';
+  readonly mediaType = input('');
 
   /**
    * Whether to offer the verify actions. Only meaningful when browsing a Find
@@ -52,13 +57,13 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
    * leave the unverified set and drop from the browse. The browse view owns the
    * actual mutation + re-projection.
    */
-  @Input() canVerify = false;
+  readonly canVerify = input(false);
 
   /** Emitted when the user marks the selection Verified Good. */
-  @Output() verifyGood = new EventEmitter<void>();
+  readonly verifyGood = output<void>();
 
   /** Emitted when the user marks the selection Verified Bad. */
-  @Output() verifyBad = new EventEmitter<void>();
+  readonly verifyBad = output<void>();
 
   count = 0;
   sortMode: SelectionSortMode = 'time-desc';
@@ -72,12 +77,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private readonly thumbnailFailedUrls = new Set<string>();
   private readonly subs: Subscription[] = [];
 
-  constructor(
-    private selection: BrowseSelectionService,
-    private metadataCache: MediaMetadataCacheService,
-    private activeContext: ActiveContextService,
-    private settingsState: SettingsStateService,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -116,9 +116,10 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   }
 
   private applyViewPrefs(): void {
-    if (!this.mediaType) return;
-    this.viewMode = this.viewModeRightDict[this.mediaType] ?? 'grid';
-    this.gridGoalWidth = iconSizeToGoalWidth(this.gridIconSizeRightDict[this.mediaType] ?? 'M');
+    const mediaType = this.mediaType();
+    if (!mediaType) return;
+    this.viewMode = this.viewModeRightDict[mediaType] ?? 'grid';
+    this.gridGoalWidth = iconSizeToGoalWidth(this.gridIconSizeRightDict[mediaType] ?? 'M');
   }
 
   private buildSortedEntries(): SelectionEntry[] {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild, effect } from '@angular/core';
+import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -60,6 +60,21 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
   styleUrl: './browse-view.component.scss',
 })
 export class BrowseViewComponent implements OnInit, OnDestroy {
+  private projectionApi = inject(ProjectionApiService);
+  private tileCache = inject(TileCacheService);
+  private activeContext = inject(ActiveContextService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private settingsState = inject(SettingsStateService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private browseSubset = inject(BrowseSubsetService);
+  private selection = inject(BrowseSelectionService);
+  private mediasApi = inject(MediasApiService);
+  private dialog = inject(VtDialogService);
+  private toast = inject(ToastService);
+  private ngZone = inject(NgZone);
+
   @ViewChild(BrowseCanvasComponent) private canvas?: BrowseCanvasComponent;
   /** The 3-column grid (canvas | divider | side panel); the divider drag
    *  measures against its box. Only present in the ``ready`` state. */
@@ -183,22 +198,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private pollErrors = 0;
   private static readonly MAX_POLL_ERRORS = 5;
 
-  constructor(
-    private projectionApi: ProjectionApiService,
-    private tileCache: TileCacheService,
-    private activeContext: ActiveContextService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private settingsState: SettingsStateService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private browseSubset: BrowseSubsetService,
-    private selection: BrowseSelectionService,
-    private mediasApi: MediasApiService,
-    private dialog: VtDialogService,
-    private toast: ToastService,
-    private ngZone: NgZone,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -1,4 +1,4 @@
-<div class="waveform-swipe-wrapper" [class]="swipeClass">
+<div class="waveform-swipe-wrapper" [class]="swipeClass()">
   <canvas
     #waveformCanvas
     class="waveform-canvas"

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -1,15 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-  ViewChild,
-  AfterViewInit,
-} from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, AfterViewInit, inject, input, output } from '@angular/core';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
@@ -20,11 +9,13 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './audio-player.component.scss',
 })
 export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit {
+  private activeContext = inject(ActiveContextService);
+
   @Input() media!: Media;
   @Input() volume = 1;
-  @Input() audioPlaying = true;
-  @Input() swipeClass = '';
-  @Output() playingChanged = new EventEmitter<boolean>();
+  readonly audioPlaying = input(true);
+  readonly swipeClass = input('');
+  readonly playingChanged = output<boolean>();
 
   @ViewChild('waveformCanvas') canvasRef!: ElementRef<HTMLCanvasElement>;
   @ViewChild('audioEl') audioRef!: ElementRef<HTMLAudioElement>;
@@ -38,8 +29,6 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   // whenever the metadata cache hydrates; without this guard, every cache
   // refresh would re-`loadAudio()` and snap playback back to t=0.
   private lastMediaId: number | null = null;
-
-  constructor(private activeContext: ActiveContextService) {}
 
   ngAfterViewInit(): void {
     this.viewReady = true;
@@ -84,13 +73,13 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   onPlay(): void {
-    if (!this.audioPlaying) {
+    if (!this.audioPlaying()) {
       this.playingChanged.emit(true);
     }
   }
 
   onPause(): void {
-    if (this.audioPlaying) {
+    if (this.audioPlaying()) {
       this.playingChanged.emit(false);
     }
   }
@@ -124,9 +113,10 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   private syncPlaybackState(): void {
     const audio = this.audioRef?.nativeElement;
     if (!audio) return;
-    if (this.audioPlaying && audio.paused) {
+    const audioPlaying = this.audioPlaying();
+    if (audioPlaying && audio.paused) {
       audio.play().catch(() => {});
-    } else if (!this.audioPlaying && !audio.paused) {
+    } else if (!audioPlaying && !audio.paused) {
       audio.pause();
     }
   }

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -120,7 +120,7 @@
     <vt-voting-overlay
       [isGood]="isGood"
       [isBad]="isBad"
-      [disabled]="isVoting || disabled"
+      [disabled]="isVoting || disabled()"
       [spinningVote]="spinningVote"
       [showHint]="showFirstVoteHint"
       (voted)="castVote($event)"

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild, effect } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
@@ -32,9 +32,19 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
   styleUrl: './center-panel.component.scss',
 })
 export class CenterPanelComponent implements OnChanges, OnDestroy {
+  private mediasApi = inject(MediasApiService);
+  private keyboard = inject(KeyboardService);
+  voteState = inject(VoteStateService);
+  private settingsState = inject(SettingsStateService);
+  private sortState = inject(SortStateService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+
   @Input() media: Media | null = null;
-  @Input() disabled = false;
-  @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  readonly disabled = input(false);
+  readonly mediaVoted = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
 
   @ViewChild(AudioPlayerComponent) audioPlayer?: AudioPlayerComponent;
   @ViewChild(ImageViewerComponent) imageViewer?: ImageViewerComponent;
@@ -77,14 +87,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   private _pausedByVisibility = false;
   private subs: Subscription[] = [];
 
-  constructor(
-    private mediasApi: MediasApiService,
-    private keyboard: KeyboardService,
-    public voteState: VoteStateService,
-    private settingsState: SettingsStateService,
-    private sortState: SortStateService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -146,7 +149,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
       this.keyboard.action$.subscribe((action) => {
         switch (action.type) {
           case 'vote':
-            if (this.media && action.direction && !this.disabled) {
+            if (this.media && action.direction && !this.disabled()) {
               this.castVote(action.direction);
             }
             break;
@@ -169,10 +172,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
             }
             break;
           case 'undo':
-            if (!this.disabled && !this.isVoting) this.voteState.undo();
+            if (!this.disabled() && !this.isVoting) this.voteState.undo();
             break;
           case 'redo':
-            if (!this.disabled && !this.isVoting) this.voteState.redo();
+            if (!this.disabled() && !this.isVoting) this.voteState.redo();
             break;
         }
       }),

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -10,6 +10,9 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './document-viewer.component.scss',
 })
 export class DocumentViewerComponent implements OnChanges {
+  private activeContext = inject(ActiveContextService);
+  private sanitizer = inject(DomSanitizer);
+
   @Input() media!: Media;
 
   // `<object [data]>` is a RESOURCE_URL sink, so Angular rejects a plain
@@ -19,11 +22,6 @@ export class DocumentViewerComponent implements OnChanges {
   // See ImageViewerComponent.lastMediaId; keep the iframe stable across
   // metadata-enrichment ngOnChanges cycles for the same id.
   private lastMediaId: number | null = null;
-
-  constructor(
-    private activeContext: ActiveContextService,
-    private sanitizer: DomSanitizer,
-  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -1,14 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, output } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -32,6 +22,8 @@ const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a s
   styleUrl: './image-viewer.component.scss',
 })
 export class ImageViewerComponent implements OnChanges, OnDestroy {
+  private activeContext = inject(ActiveContextService);
+
   @Input() media!: Media;
   /**
    * True while the parent is in the v2 "bad-vote-with-box discard confirm" armed state.
@@ -49,13 +41,13 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    * interactive (no drag/resize, no vote semantics).
    */
   @Input() highlightBox: RegionBox | null = null;
-  @Output() regionBoxChange = new EventEmitter<RegionBox | null>();
+  readonly regionBoxChange = output<RegionBox | null>();
   /**
    * Fired when the user does something that cancels the armed bad-vote-confirm without
    * voting (Esc while armed, or any mousedown on the box body/handles, or starting a
    * fresh Shift-drag). The parent clears its armed state but keeps the box.
    */
-  @Output() armedConfirmCanceled = new EventEmitter<void>();
+  readonly armedConfirmCanceled = output<void>();
 
   @ViewChild('imageWrap') wrapRef!: ElementRef<HTMLDivElement>;
   @ViewChild('imageEl') imageRef!: ElementRef<HTMLImageElement>;
@@ -109,7 +101,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   readonly maxZoom = 5;
   readonly zoomStep = 0.05;
 
-  constructor(private activeContext: ActiveContextService) {
+  constructor() {
     this.setupWindowKeyListeners();
   }
 

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { Media } from '../../../models/api.models';
@@ -10,6 +10,8 @@ import { Media } from '../../../models/api.models';
   styleUrl: './text-viewer.component.scss',
 })
 export class TextViewerComponent implements OnChanges, OnDestroy {
+  private mediasApi = inject(MediasApiService);
+
   @Input() media!: Media;
 
   text = 'Loading...';
@@ -17,8 +19,6 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
   // See ImageViewerComponent.lastMediaId; avoid re-fetching the text payload
   // every time the metadata cache hydrates a new reference for the same id.
   private lastMediaId: number | null = null;
-
-  constructor(private mediasApi: MediasApiService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
 
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -11,10 +11,12 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './video-player.component.scss',
 })
 export class VideoPlayerComponent implements OnChanges, OnDestroy {
+  private activeContext = inject(ActiveContextService);
+
   @Input() media!: Media;
-  @Input() volume = 1;
-  @Input() audioPlaying = true;
-  @Output() playingChanged = new EventEmitter<boolean>();
+  readonly volume = input(1);
+  readonly audioPlaying = input(true);
+  readonly playingChanged = output<boolean>();
 
   @ViewChild('videoEl') videoRef!: ElementRef<HTMLVideoElement>;
 
@@ -32,8 +34,6 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   // case (loadedmetadata) does not fire again, so we (re)apply the bounds here.
   private metadataLoaded = false;
 
-  constructor(private activeContext: ActiveContextService) {}
-
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
       if (this.media.id !== this.lastMediaId) {
@@ -50,7 +50,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
       }
     }
     if (changes['volume'] && this.videoRef?.nativeElement) {
-      this.videoRef.nativeElement.volume = this.volume;
+      this.videoRef.nativeElement.volume = this.volume();
     }
     if (changes['audioPlaying'] && !changes['media'] && this.videoRef?.nativeElement) {
       this.syncPlaybackState();
@@ -68,7 +68,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   onPlay(): void {
-    if (!this.audioPlaying) {
+    if (!this.audioPlaying()) {
       this.playingChanged.emit(true);
     }
   }
@@ -78,7 +78,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   onPause(): void {
-    if (this.audioPlaying) {
+    if (this.audioPlaying()) {
       this.playingChanged.emit(false);
     }
   }
@@ -103,7 +103,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
     const video = this.videoRef?.nativeElement;
     if (!video) return;
     this.metadataLoaded = true;
-    video.volume = this.volume;
+    video.volume = this.volume();
     this.applyClipBounds();
     this.syncPlaybackState();
   }
@@ -159,9 +159,10 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   private syncPlaybackState(): void {
     const video = this.videoRef?.nativeElement;
     if (!video) return;
-    if (this.audioPlaying && video.paused) {
+    const audioPlaying = this.audioPlaying();
+    if (audioPlaying && video.paused) {
       video.play().catch(() => {});
-    } else if (!this.audioPlaying && !video.paused) {
+    } else if (!audioPlaying && !video.paused) {
       video.pause();
     }
   }

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -11,7 +11,7 @@
     (click)="onVoteBad($event)"
     title="Mark this media as a Bad example."
   >
-    <vt-icon type="thumbs-down" [size]="18" [class.icon-spinning]="spinningVote === 'bad'"></vt-icon>
+    <vt-icon type="thumbs-down" [size]="18" [class.icon-spinning]="spinningVote() === 'bad'"></vt-icon>
     Bad
   </button>
   <button
@@ -21,7 +21,7 @@
     (click)="onVoteGood($event)"
     title="Mark this media as a Good example."
   >
-    <vt-icon type="thumbs-up" [size]="18" [class.icon-spinning]="spinningVote === 'good'"></vt-icon>
+    <vt-icon type="thumbs-up" [size]="18" [class.icon-spinning]="spinningVote() === 'good'"></vt-icon>
     Good
   </button>
 </div>

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { Component, Input, OnDestroy, input, output } from '@angular/core';
 import { IconComponent } from '../../icon/icon.component';
 
 @Component({
@@ -12,12 +12,12 @@ export class VotingOverlayComponent implements OnDestroy {
   @Input() isGood = false;
   @Input() isBad = false;
   @Input() disabled = false;
-  @Input() spinningVote: 'good' | 'bad' | null = null;
+  readonly spinningVote = input<'good' | 'bad' | null>(null);
   /** When true, renders the faint first-vote hint above the buttons. The
    *  parent decides when to show this (zero votes + not previously dismissed)
    *  and dismisses it on first vote. */
   @Input() showHint = false;
-  @Output() voted = new EventEmitter<'good' | 'bad'>();
+  readonly voted = output<'good' | 'bad'>();
 
   goodFlash = false;
   badFlash = false;

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
@@ -1,7 +1,7 @@
 <div class="clipboard-copy">
-  @if (mode === 'list') {
+  @if (mode() === 'list') {
     <select class="form-select" [(ngModel)]="selectedColumnKey" title="Column to copy to clipboard">
-      @for (col of columns; track col.key) {
+      @for (col of columns(); track col.key) {
         <option [value]="col.key">{{ col.label }}</option>
       }
     </select>
@@ -9,7 +9,7 @@
   <select
     class="form-select"
     [(ngModel)]="delimiter"
-    [title]="mode === 'list' ? 'Separator between copied values' : 'Delimiter between columns'"
+    [title]="mode() === 'list' ? 'Separator between copied values' : 'Delimiter between columns'"
   >
     @for (opt of delimiterOptions; track opt.value) {
       <option [value]="opt.value">{{ opt.label }}</option>
@@ -17,12 +17,12 @@
   </select>
   <button
     class="btn"
-    [class.btn--primary]="buttonVariant === 'primary'"
-    [class.btn--secondary]="buttonVariant === 'secondary'"
+    [class.btn--primary]="buttonVariant() === 'primary'"
+    [class.btn--secondary]="buttonVariant() === 'secondary'"
     (click)="copy()"
     [disabled]="isDisabled"
     title="Copy to clipboard"
   >
-    {{ buttonText || copyLabel }}
+    {{ buttonText || copyLabel() }}
   </button>
 </div>

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnDestroy, SimpleChanges, input } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -34,13 +34,13 @@ interface DelimiterOption {
   styleUrl: './clipboard-copy.component.scss',
 })
 export class ClipboardCopyComponent implements OnChanges, OnDestroy {
-  @Input() mode: 'table' | 'list' = 'table';
-  @Input() rows: Record<string, unknown>[] = [];
-  @Input() columns: ClipboardColumn[] = [];
+  readonly mode = input<'table' | 'list'>('table');
+  readonly rows = input<Record<string, unknown>[]>([]);
+  readonly columns = input<ClipboardColumn[]>([]);
   /** Extra disable condition layered on top of the empty-data guards. */
-  @Input() disabled = false;
-  @Input() copyLabel = 'Copy';
-  @Input() buttonVariant: 'primary' | 'secondary' = 'primary';
+  readonly disabled = input(false);
+  readonly copyLabel = input('Copy');
+  readonly buttonVariant = input<'primary' | 'secondary'>('primary');
 
   /** Unified delimiter vocabulary, shared across both modes. */
   static readonly DELIMITERS: DelimiterOption[] = [
@@ -60,27 +60,28 @@ export class ClipboardCopyComponent implements OnChanges, OnDestroy {
   private feedbackTimer: ReturnType<typeof setTimeout> | null = null;
 
   get delimiterOptions(): DelimiterOption[] {
-    return this.mode === 'list'
+    return this.mode() === 'list'
       ? ClipboardCopyComponent.DELIMITERS
       : ClipboardCopyComponent.DELIMITERS.filter((d) => !d.listOnly);
   }
 
   get isDisabled(): boolean {
-    if (this.disabled) return true;
-    if (this.rows.length === 0) return true;
-    if (this.mode === 'table') return this.columns.length === 0;
+    if (this.disabled()) return true;
+    if (this.rows().length === 0) return true;
+    if (this.mode() === 'table') return this.columns().length === 0;
     return !this.selectedColumnKey;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['mode']) {
       // Default delimiter per mode: list → newline, table → comma.
-      this.delimiter = this.mode === 'list' ? '\n' : ',';
+      this.delimiter = this.mode() === 'list' ? '\n' : ',';
     }
-    if (changes['columns'] && this.mode === 'list') {
+    if (changes['columns'] && this.mode() === 'list') {
       // Keep the single-column selector pointed at a valid column.
-      if (!this.columns.some((c) => c.key === this.selectedColumnKey)) {
-        this.selectedColumnKey = this.columns[0]?.key ?? '';
+      const columns = this.columns();
+      if (!columns.some((c) => c.key === this.selectedColumnKey)) {
+        this.selectedColumnKey = columns[0]?.key ?? '';
       }
     }
   }
@@ -99,14 +100,15 @@ export class ClipboardCopyComponent implements OnChanges, OnDestroy {
   }
 
   private buildText(): string {
-    if (this.mode === 'list') {
+    if (this.mode() === 'list') {
       const key = this.selectedColumnKey;
-      return this.rows.map((r) => this.cell(r, key)).join(this.delimiter);
+      return this.rows().map((r) => this.cell(r, key)).join(this.delimiter);
     }
-    if (this.columns.length === 0) return '';
-    const header = this.columns.map((c) => c.label).join(this.delimiter);
-    const body = this.rows.map((r) =>
-      this.columns.map((c) => this.cell(r, c.key)).join(this.delimiter),
+    const columns = this.columns();
+    if (columns.length === 0) return '';
+    const header = columns.map((c) => c.label).join(this.delimiter);
+    const body = this.rows().map((r) =>
+      this.columns().map((c) => this.cell(r, c.key)).join(this.delimiter),
     );
     return [header, ...body].join('\n');
   }

--- a/frontend/src/app/components/context-menu/context-menu.component.html
+++ b/frontend/src/app/components/context-menu/context-menu.component.html
@@ -1,11 +1,11 @@
 <div
   class="context-menu"
   role="menu"
-  [style.left.px]="x"
-  [style.top.px]="y"
+  [style.left.px]="x()"
+  [style.top.px]="y()"
   (contextmenu)="onMenuContextMenu($event)"
 >
-  @for (item of items; track item.id) {
+  @for (item of items(); track item.id) {
     <button
       type="button"
       class="menu-item"

--- a/frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/frontend/src/app/components/context-menu/context-menu.component.ts
@@ -1,12 +1,5 @@
 
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostListener,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, ElementRef, HostListener, inject, input, output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 export interface ContextMenuItem {
@@ -34,19 +27,17 @@ export interface ContextMenuItem {
   styleUrl: './context-menu.component.scss',
 })
 export class ContextMenuComponent {
-  @Input({ required: true }) x = 0;
-  @Input({ required: true }) y = 0;
-  @Input() items: ContextMenuItem[] = [];
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private sanitizer = inject(DomSanitizer);
 
-  @Output() actionSelected = new EventEmitter<string>();
-  @Output() dismissed = new EventEmitter<void>();
+  readonly x = input.required<number>();
+  readonly y = input.required<number>();
+  readonly items = input<ContextMenuItem[]>([]);
+
+  readonly actionSelected = output<string>();
+  readonly dismissed = output<void>();
 
   private iconCache = new Map<string, SafeHtml>();
-
-  constructor(
-    private host: ElementRef<HTMLElement>,
-    private sanitizer: DomSanitizer,
-  ) {}
 
   /** Sanitise (once per distinct SVG string) the item icon for `[innerHTML]`. */
   safeIcon(svg: string): SafeHtml {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, inject, input } from '@angular/core';
 
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -49,7 +49,16 @@ interface PulldownRow {
   styleUrl: './context-pulldown.component.scss',
 })
 export class ContextPulldownComponent implements OnInit, OnDestroy {
-  @Input() kind: PulldownKind = 'dataset';
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private datasetState = inject(DatasetStateService);
+  private activeContext = inject(ActiveContextService);
+  private contextSwitch = inject(ContextSwitchService);
+  private newThingFlows = inject(NewThingFlowsService);
+  private pulldownControl = inject(PulldownControlService);
+  private dashboardColumns = inject(DashboardColumnsService);
+  private runningJobs = inject(RunningJobsService);
+
+  readonly kind = input<PulldownKind>('dataset');
 
   @ViewChild('menuRef') menuRef?: ElementRef<HTMLDivElement>;
 
@@ -86,17 +95,6 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
    *  needing a separate per-row subscription. */
   private busyPairs: Map<string, string[]> = new Map();
 
-  constructor(
-    private host: ElementRef<HTMLElement>,
-    private datasetState: DatasetStateService,
-    private activeContext: ActiveContextService,
-    private contextSwitch: ContextSwitchService,
-    private newThingFlows: NewThingFlowsService,
-    private pulldownControl: PulldownControlService,
-    private dashboardColumns: DashboardColumnsService,
-    private runningJobs: RunningJobsService,
-  ) {}
-
   ngOnInit(): void {
     this.datasetState.datasets$.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.rebuildRows();
@@ -114,7 +112,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     });
 
     this.newThingFlows.created$.pipe(takeUntil(this.destroy$)).subscribe(({ kind, id }) => {
-      if (kind !== this.kind || !id || !this.awaitingNew) return;
+      if (kind !== this.kind() || !id || !this.awaitingNew) return;
       this.sawSuccessSignal = true;
       this.awaitingNew = false;
       this.switchToNewItem(id);
@@ -143,7 +141,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     });
 
     this.pulldownControl
-      .openSignal$(this.kind)
+      .openSignal$(this.kind())
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.openMenu());
 
@@ -175,7 +173,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   get isDataset(): boolean {
-    return this.kind === 'dataset';
+    return this.kind() === 'dataset';
   }
 
   get placeholderLabel(): string {

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { Router } from '@angular/router';
 import { Subject, combineLatest } from 'rxjs';
@@ -25,17 +25,15 @@ import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.mo
   styleUrl: './incompatible-pair-explainer.component.scss',
 })
 export class IncompatiblePairExplainerComponent implements OnInit, OnDestroy {
+  private router = inject(Router);
+  private activeContext = inject(ActiveContextService);
+  private datasetState = inject(DatasetStateService);
+  private pulldownControl = inject(PulldownControlService);
+
   dataset: DatasetRegistryEntry | null = null;
   detector: DetectorRegistryEntry | null = null;
 
   private destroy$ = new Subject<void>();
-
-  constructor(
-    private router: Router,
-    private activeContext: ActiveContextService,
-    private datasetState: DatasetStateService,
-    private pulldownControl: PulldownControlService,
-  ) {}
 
   ngOnInit(): void {
     combineLatest([

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
@@ -1,11 +1,11 @@
-<vt-modal title="Choose MediaClipper" [open]="open" [showCloseButton]="false" (closed)="cancel()">
+<vt-modal title="Choose MediaClipper" [open]="open()" [showCloseButton]="false" (closed)="cancel()">
   <button class="btn btn--secondary btn--sm back-btn" (click)="cancel()" title="Return to the importer without changing the clipper">&larr; Back</button>
-  @if (clippers.length === 0) {
+  @if (clippers().length === 0) {
     <p class="empty-state">No clippers available for this media type.</p>
   } @else {
     <div class="clipper-chooser">
       <div class="clipper-tab-bar">
-        @for (clipper of clippers; track clipper.name) {
+        @for (clipper of clippers(); track clipper.name) {
           <button
             class="clipper-tab"
             [class.active]="activeTab === clipper.name"
@@ -55,6 +55,6 @@
   }
 
   <div class="form-actions" modal-footer>
-    <button class="btn btn--primary" (click)="confirm()" [disabled]="clippers.length === 0">OK</button>
+    <button class="btn btn--primary" (click)="confirm()" [disabled]="clippers().length === 0">OK</button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,25 +17,25 @@ export interface ClipperSelection {
   styleUrl: './clipper-chooser.component.scss',
 })
 export class ClipperChooserComponent implements OnChanges {
-  @Input() open = false;
-  @Input() clippers: ClipperInfo[] = [];
+  readonly open = input(false);
+  readonly clippers = input<ClipperInfo[]>([]);
 
-  @Output() selected = new EventEmitter<ClipperSelection>();
-  @Output() cancelled = new EventEmitter<void>();
+  readonly selected = output<ClipperSelection>();
+  readonly cancelled = output<void>();
 
   activeTab = '';
   /** Per-clipper parameter values, keyed by clipper name then param key. */
   paramValues: Record<string, Record<string, number | string>> = {};
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['open'] && this.open) {
+    if (changes['open'] && this.open()) {
       this.initTabs();
     }
   }
 
   private initTabs(): void {
     this.paramValues = {};
-    for (const clipper of this.clippers) {
+    for (const clipper of this.clippers()) {
       const questions = clipper.creation_questions || clipper.parameters || [];
       const vals: Record<string, number | string> = {};
       for (const q of questions) {
@@ -44,14 +44,14 @@ export class ClipperChooserComponent implements OnChanges {
       this.paramValues[clipper.name] = vals;
     }
     // Default to first non-default clipper tab if available, else first clipper
-    if (this.clippers.length > 0) {
-      const nonDefault = this.clippers.find((c) => !c.name.endsWith('_default'));
-      this.activeTab = nonDefault ? nonDefault.name : this.clippers[0].name;
+    if (this.clippers().length > 0) {
+      const nonDefault = this.clippers().find((c) => !c.name.endsWith('_default'));
+      this.activeTab = nonDefault ? nonDefault.name : this.clippers()[0].name;
     }
   }
 
   get activeClipper(): ClipperInfo | undefined {
-    return this.clippers.find((c) => c.name === this.activeTab);
+    return this.clippers().find((c) => c.name === this.activeTab);
   }
 
   get activeQuestions(): ClipperParameter[] {

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit, inject, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -23,22 +23,20 @@ interface CombineRow {
   styleUrl: './combine-datasets-modal.component.scss',
 })
 export class CombineDatasetsModalComponent implements OnInit {
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+
   /** Datasets pre-selected on the dashboard when the modal was opened. */
   @Input() datasets: DatasetRegistryEntry[] = [];
 
-  @Output() closed = new EventEmitter<void>();
-  @Output() combineStarted = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly combineStarted = output<void>();
 
   rows: CombineRow[] = [];
   mediaTypes: MediaTypeInfo[] = [];
   submitting = false;
   error = '';
   name = '';
-
-  constructor(
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-  ) {}
 
   ngOnInit(): void {
     this.rows = this.datasets

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, OnInit, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -20,13 +20,15 @@ interface SourceRow {
   styleUrl: './combine-detectors-modal.component.scss',
 })
 export class CombineDetectorsModalComponent implements OnInit {
-  /** Trainable models the user has selected on the dashboard. */
-  @Input() sources: DetectorRegistryEntry[] = [];
-  /** All registered model names; used for inline name-collision check. */
-  @Input() existingNames: string[] = [];
+  private detectorsCrudApi = inject(DetectorsCrudApiService);
 
-  @Output() closed = new EventEmitter<void>();
-  @Output() created = new EventEmitter<string>();
+  /** Trainable models the user has selected on the dashboard. */
+  readonly sources = input<DetectorRegistryEntry[]>([]);
+  /** All registered model names; used for inline name-collision check. */
+  readonly existingNames = input<string[]>([]);
+
+  readonly closed = output<void>();
+  readonly created = output<string>();
 
   newName = '';
   conflictPolicy: 'drop' = 'drop';
@@ -37,16 +39,14 @@ export class CombineDetectorsModalComponent implements OnInit {
   totalLabels = 0;
   mediaType = '';
 
-  constructor(private detectorsCrudApi: DetectorsCrudApiService) {}
-
   ngOnInit(): void {
-    this.rows = this.sources.map((m) => ({
+    this.rows = this.sources().map((m) => ({
       name: this.trainableNameOf(m),
       numLabels: (m.num_training as number) ?? 0,
       textQuery: (m.text_query as string) ?? '',
     }));
     this.totalLabels = this.rows.reduce((sum, r) => sum + r.numLabels, 0);
-    this.mediaType = this.sources[0]?.media_type ?? '';
+    this.mediaType = this.sources()[0]?.media_type ?? '';
   }
 
   /** The combine API operates on the registry name (= labelset filename). */
@@ -57,7 +57,7 @@ export class CombineDetectorsModalComponent implements OnInit {
   get nameCollision(): boolean {
     const trimmed = this.newName.trim();
     if (!trimmed) return false;
-    return this.existingNames.some((n) => n === trimmed);
+    return this.existingNames().some((n) => n === trimmed);
   }
 
   get nameValidationMessage(): string {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, OnDestroy, effect } from '@angular/core';
+import { Component, HostListener, OnInit, OnDestroy, effect, inject } from '@angular/core';
 
 import { NavigationCancel, NavigationEnd, NavigationError, Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
@@ -70,6 +70,27 @@ import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
   styleUrl: './dashboard.component.scss',
 })
 export class DashboardComponent implements OnInit, OnDestroy {
+  private router = inject(Router);
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private datasetsUiApi = inject(DatasetsUiApiService);
+  private detectorsFindApi = inject(DetectorsFindApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private toast = inject(ToastService);
+  private dialog = inject(VtDialogService);
+  private labelSession = inject(LabelSessionService);
+  datasetState = inject(DatasetStateService);
+  private activeContext = inject(ActiveContextService);
+  private contextSwitch = inject(ContextSwitchService);
+  private authService = inject(AuthService);
+  private topBarState = inject(TopBarStateService);
+  private newThingFlows = inject(NewThingFlowsService);
+  modals = inject(DashboardModalsService);
+  loadingTasksSvc = inject(DashboardLoadingTasksService);
+  browsePrep = inject(BrowsePrepService);
+  private progressEvents = inject(ProgressEventsService);
+  private settingsState = inject(SettingsStateService);
+
   selectedDatasetIds: Set<string> = new Set();
   selectedDetectorIds: Set<string> = new Set();
 
@@ -159,29 +180,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   diskUsage: UsageBytes | null = null;
   ramUsage: UsageBytes | null = null;
 
-  constructor(
-    private router: Router,
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private datasetsUiApi: DatasetsUiApiService,
-    private detectorsFindApi: DetectorsFindApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private toast: ToastService,
-    private dialog: VtDialogService,
-    private labelSession: LabelSessionService,
-    public datasetState: DatasetStateService,
-    private activeContext: ActiveContextService,
-    private contextSwitch: ContextSwitchService,
-    private authService: AuthService,
-    private topBarState: TopBarStateService,
-    private newThingFlows: NewThingFlowsService,
-    public modals: DashboardModalsService,
-    public loadingTasksSvc: DashboardLoadingTasksService,
-    public browsePrep: BrowsePrepService,
-    private progressEvents: ProgressEventsService,
-    private settingsState: SettingsStateService,
-    columnsService: DashboardColumnsService,
-  ) {
+  constructor() {
+    const columnsService = inject(DashboardColumnsService);
+
     this.datasetCols = columnsService.datasetCols;
     this.detectorCols = columnsService.detectorCols;
     // Mirror the server's age-off setting so the Age-Off column appears

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -37,7 +37,7 @@
        column so the Browse eye stays put and waggles, mirroring how Find/Train
        waggle while their job runs; a plain dataset load replaces the actions
        column too. -->
-  <td [attr.colspan]="taskKind === 'projection' ? columnOrder.length : columnOrder.length + 1">
+  <td [attr.colspan]="taskKind() === 'projection' ? columnOrder.length : columnOrder.length + 1">
     <div class="inline-loading-progress">
       <div class="progress-context">
         <div class="progress-header">{{ taskProgressInfo.header }}</div>
@@ -57,11 +57,11 @@
         @if (taskProgressInfo.eta) {
           <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
         }
-        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" [title]="taskKind === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'">Cancel</button>
+        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" [title]="taskKind() === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'">Cancel</button>
       </div>
     </div>
   </td>
-  @if (taskKind === 'projection') {
+  @if (taskKind() === 'projection') {
     <td class="actions-col">
       <div class="actions-cell">
         <button class="browse-btn" type="button" disabled aria-label="Building projection for browse" title="Building projection…">
@@ -142,7 +142,7 @@
         <circle cx="12" cy="12" r="3"></circle>
       </svg>
     </button>
-    @if (!isDefaultLogin) {
+    @if (!isDefaultLogin()) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
@@ -157,7 +157,7 @@
       </svg>
     </button>
     <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
-      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen()" [class.pie-inactive]="!statsOpen() && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <path d="M12 2a10 10 0 0 1 0 20"/>
         <line x1="12" y1="12" x2="12" y2="2"/>
@@ -166,7 +166,7 @@
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen()" [class.trash-inactive]="!deleteConfirmOpen() && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges, ViewChild, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -22,21 +22,21 @@ import { buildDatasetCardMenuItems } from '../card-context-menu-items';
 })
 export class DatasetCardComponent implements OnChanges {
   @Input() dataset: any;
-  @Input() currentUser = '';
-  @Input() isDefaultLogin = true;
+  readonly currentUser = input('');
+  readonly isDefaultLogin = input(true);
   @Input() columnOrder: string[] = [];
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;
   /** Which progress vocabulary to render the inline row with. ``projection``
    *  is used while the Browse button pre-builds the dataset's projection. */
-  @Input() taskKind: ProgressKind = 'dataset';
+  readonly taskKind = input<ProgressKind>('dataset');
 
   @HostBinding('class.loading-error')
   get hasLoadingError(): boolean {
     return !!this.loadingTask?.error;
   }
-  @Output() rowClick = new EventEmitter<MouseEvent>();
+  readonly rowClick = output<MouseEvent>();
 
   @HostListener('click', ['$event'])
   onClick(event: MouseEvent): void {
@@ -52,31 +52,31 @@ export class DatasetCardComponent implements OnChanges {
     if (this.loadingTask) return;
     event.preventDefault();
     this.contextMenuItems = buildDatasetCardMenuItems(this.dataset, {
-      isDefaultLogin: this.isDefaultLogin,
+      isDefaultLogin: this.isDefaultLogin(),
       isOwner: this.isOwner,
     });
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
     this.contextMenuOpen = true;
   }
-  @Output() rename = new EventEmitter<string>();
-  @Output() stats = new EventEmitter<void>();
-  @Output() delete = new EventEmitter<void>();
-  @Output() load = new EventEmitter<void>();
-  @Output() browse = new EventEmitter<void>();
-  @Output() security = new EventEmitter<void>();
-  @Output() cancelTask = new EventEmitter<string>();
-  @Output() dismissTask = new EventEmitter<string>();
-  @Output() checkboxToggle = new EventEmitter<void>();
+  readonly rename = output<string>();
+  readonly stats = output<void>();
+  readonly delete = output<void>();
+  readonly load = output<void>();
+  readonly browse = output<void>();
+  readonly security = output<void>();
+  readonly cancelTask = output<string>();
+  readonly dismissTask = output<string>();
+  readonly checkboxToggle = output<void>();
 
   get isOwner(): boolean {
-    return this.dataset?.created_by === this.currentUser;
+    return this.dataset?.created_by === this.currentUser();
   }
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
-  @Input() statsOpen = false;
-  @Input() deleteConfirmOpen = false;
+  readonly statsOpen = input(false);
+  readonly deleteConfirmOpen = input(false);
 
   editing = false;
   wasEditing = false;
@@ -158,13 +158,13 @@ export class DatasetCardComponent implements OnChanges {
   }
 
   onPieAnimationEnd(): void {
-    if (!this.statsOpen) {
+    if (!this.statsOpen()) {
       this.wasStatsOpen = false;
     }
   }
 
   onTrashAnimationEnd(): void {
-    if (!this.deleteConfirmOpen) {
+    if (!this.deleteConfirmOpen()) {
       this.wasDeleteOpen = false;
     }
   }
@@ -219,7 +219,7 @@ export class DatasetCardComponent implements OnChanges {
   get taskProgressInfo(): ProgressHeader {
     const task = this.loadingTask;
     if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
-    return formatProgressHeader(task, this.taskKind, task.embedder);
+    return formatProgressHeader(task, this.taskKind(), task.embedder);
   }
 
   get taskIsIndeterminate(): boolean {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
+import { Component, HostListener, Input, OnInit, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -26,18 +26,24 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
   styleUrl: './dataset-importer-modal.component.scss',
 })
 export class DatasetImporterModalComponent implements OnInit {
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private settingsState = inject(SettingsStateService);
+  private toastService = inject(ToastService);
+  private datasetsUiApi = inject(DatasetsUiApiService);
+
   /** Media type_id guessed from existing datasets/models (e.g. "image"). */
   @Input() guessedMediaType = '';
   /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
-  @Input() guessedMediaEmbedder = '';
+  readonly guessedMediaEmbedder = input('');
   /** Picker tab id to pre-select when the modal opens (e.g. "server" from
    *  the dashboard's first-run welcome banner CTA).  Empty leaves the
    *  picker in the default "no tab selected" state. */
   @Input() initialTab = '';
 
-  @Output() closed = new EventEmitter<void>();
-  @Output() importStarted = new EventEmitter<void>();
-  @Output() demoSelected = new EventEmitter<DemoDataset>();
+  readonly closed = output<void>();
+  readonly importStarted = output<void>();
+  readonly demoSelected = output<DemoDataset>();
 
   importers: ImporterInfo[] = [];
   selectedImporter: ImporterInfo | null = null;
@@ -187,14 +193,6 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Which context opened the chooser: 'form' | 'demo' | 'sf' | 'lf' */
   clipperChooserContext: 'form' | 'demo' | 'sf' | 'lf' = 'form';
   clipperChooserClippers: ClipperInfo[] = [];
-
-  constructor(
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-    private settingsState: SettingsStateService,
-    private toastService: ToastService,
-    private datasetsUiApi: DatasetsUiApiService,
-  ) {}
 
   /** Whether the inline server-filesystem folder browser is expanded under
    *  the server_folder path input. */
@@ -513,8 +511,8 @@ export class DatasetImporterModalComponent implements OnInit {
     if (embedders.length === 0) return '';
     const locked = this.lockedEmbedderFor(mediaTypeFolderOrTypeId, embedders);
     if (locked) return locked;
-    const guessedMatch = this.guessedMediaEmbedder
-      ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
+    const guessedMatch = this.guessedMediaEmbedder()
+      ? embedders.find((e) => e.name === this.guessedMediaEmbedder())
       : null;
     if (guessedMatch) return guessedMatch.name;
     const typeId = this.toTypeId(mediaTypeFolderOrTypeId) || mediaTypeFolderOrTypeId;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -10,27 +10,27 @@
   </button>
 }
 
-@if (advancedOpen && showSourceSpecs) {
+@if (advancedOpen && showSourceSpecs()) {
   <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
   <vt-source-specs-picker
-    [availableConverters]="availableConverters"
-    [nativeType]="nativeType"
-    [typeLabels]="typeLabels"
-    [specs]="sourceSpecs"
-    [clippers]="clippers"
-    [selectedClipperName]="selectedClipper"
-    [selectedClipperParams]="selectedClipperParams"
+    [availableConverters]="availableConverters()"
+    [nativeType]="nativeType()"
+    [typeLabels]="typeLabels()"
+    [specs]="sourceSpecs()"
+    [clippers]="clippers()"
+    [selectedClipperName]="selectedClipper()"
+    [selectedClipperParams]="selectedClipperParams()"
     (specsChange)="onSourceSpecsChange($event)"
     (clipperChooserRequested)="onClipperClick()"
   ></vt-source-specs-picker>
 }
 
-@if (embedders.length > 1 && showEmbedderPicker) {
+@if (embedders().length > 1 && showEmbedderPicker) {
   <label class="form-label" for="import-advanced-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
   <select
     id="import-advanced-embedder"
     class="form-select"
-    [ngModel]="selectedEmbedder"
+    [ngModel]="selectedEmbedder()"
     (ngModelChange)="onEmbedderChange($event)"
   >
     @if (recommendedEmbedders.length > 0) {
@@ -69,7 +69,7 @@
     <input
       id="import-advanced-projection"
       type="checkbox"
-      [ngModel]="buildProjection"
+      [ngModel]="buildProjection()"
       (ngModelChange)="onBuildProjectionChange($event)"
     />
     Build 2-D Browse projection now

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -34,31 +34,31 @@ export class ImportAdvancedComponent {
   /** Converters available for the current native type; feeds the
    *  source-specs picker.  Computed by the parent from the importer's
    *  ``available_converters_by_media_type``. */
-  @Input() availableConverters: ConverterInfo[] = [];
+  readonly availableConverters = input<ConverterInfo[]>([]);
   /** Native (output) type id of the dataset (e.g. ``"image"``). Drives
    *  the "include directly" row inside the source-specs picker. */
-  @Input() nativeType = '';
+  readonly nativeType = input('');
   /** Map of ``type_id`` → human label for the source-specs picker. */
-  @Input() typeLabels: Record<string, string> = {};
+  readonly typeLabels = input<Record<string, string>>({});
   /** Embedders available for the current media type.  When fewer than
    *  two are available the picker stays hidden; there is nothing to
    *  choose between. */
-  @Input() embedders: EmbedderInfo[] = [];
+  readonly embedders = input<EmbedderInfo[]>([]);
   /** Clippers available for the current media type.  Same single-option
    *  hide rule as :prop:`embedders`. */
-  @Input() clippers: ClipperInfo[] = [];
+  readonly clippers = input<ClipperInfo[]>([]);
   /** Whether the Include-media (source-specs) block should be offered
    *  at all.  True for every importer that participates in the dataset
    *  modal's form / server-folder / local-folder/files flows. */
-  @Input() showSourceSpecs = false;
+  readonly showSourceSpecs = input(false);
 
   /** Two-way bound source-spec list. */
-  @Input() sourceSpecs: SourceSpec[] = [];
-  @Output() sourceSpecsChange = new EventEmitter<SourceSpec[]>();
+  readonly sourceSpecs = input<SourceSpec[]>([]);
+  readonly sourceSpecsChange = output<SourceSpec[]>();
 
   /** Two-way bound embedder selection. */
-  @Input() selectedEmbedder = '';
-  @Output() selectedEmbedderChange = new EventEmitter<string>();
+  readonly selectedEmbedder = input('');
+  readonly selectedEmbedderChange = output<string>();
 
   /** When non-empty, the embedder picker is hidden because the user has
    *  set a Solo mediaEmbedder for the current mediaType in settings (or
@@ -66,34 +66,34 @@ export class ImportAdvancedComponent {
    *  the lock against the live embedder list and only passing a value
    *  here when the locked embedder actually exists for the type; a
    *  stale or removed embedder falls back to the normal picker. */
-  @Input() lockedEmbedder = '';
+  readonly lockedEmbedder = input('');
 
   /** Current clipper selection (one-way).  Changes flow through the
    *  parent's clipper chooser modal; clicking either the native row's
    *  Details button or the standalone fallback Details button emits
    *  :prop:`clipperChooserRequested` and the parent updates this input
    *  after the chooser settles. */
-  @Input() selectedClipper = '';
+  readonly selectedClipper = input('');
 
   /** Current parameter values for the selected clipper, keyed by the
    *  clipper's parameter ``key``.  Forwarded to the source-specs
    *  picker so the native row can render a live preview of the active
    *  settings. */
-  @Input() selectedClipperParams: Record<string, string | number> = {};
+  readonly selectedClipperParams = input<Record<string, string | number>>({});
 
   /** Fired when the user clicks either the native row's Details
    *  button (inside the source-specs column) or the standalone
    *  Details fallback below the Advanced block and the parent opens its
    *  shared clipper chooser modal. */
-  @Output() clipperChooserRequested = new EventEmitter<void>();
+  readonly clipperChooserRequested = output<void>();
 
   /** Two-way bound "compute the 2-D Browse projection at ingest" toggle.
    *  Defaults off: building the UMAP layout + hex-tile pyramid up front
    *  costs compute the user may not want to spend (Browse builds it lazily
    *  on first visit otherwise).  Lives in the Advanced block because it is
    *  a cost/latency tradeoff, not a routine import setting. */
-  @Input() buildProjection = false;
-  @Output() buildProjectionChange = new EventEmitter<boolean>();
+  readonly buildProjection = input(false);
+  readonly buildProjectionChange = output<boolean>();
 
   /** Whether the Advanced section is currently expanded.  Local state
    *  per instance; opening Advanced in one flow does not carry over
@@ -107,14 +107,14 @@ export class ImportAdvancedComponent {
   /** True when the user has not overridden the embedder, or when the
    *  current selection is one the registry marks ``is_default``. */
   get isDefaultEmbedderSelected(): boolean {
-    if (!this.selectedEmbedder) return true;
-    return !!this.embedders.find((e) => e.name === this.selectedEmbedder)?.is_default;
+    if (!this.selectedEmbedder()) return true;
+    return !!this.embedders().find((e) => e.name === this.selectedEmbedder())?.is_default;
   }
 
   /** True when the first clipper (the registry's recommended default
    *  for this media type) is currently selected. */
   get isDefaultClipperSelected(): boolean {
-    return this.clippers.length > 0 && this.clippers[0].name === this.selectedClipper;
+    return this.clippers().length > 0 && this.clippers()[0].name === this.selectedClipper();
   }
 
   /** The Advanced toggle is shown either when the Include-media block
@@ -123,7 +123,7 @@ export class ImportAdvancedComponent {
    *  overridden (otherwise their pickers stay visible anyway and the
    *  toggle would be redundant). */
   get showAdvancedToggle(): boolean {
-    if (this.showSourceSpecs) return true;
+    if (this.showSourceSpecs()) return true;
     return this.isDefaultEmbedderSelected && this.isDefaultClipperSelected;
   }
 
@@ -132,7 +132,7 @@ export class ImportAdvancedComponent {
    *  mediaEmbedder is locked for the current mediaType (then the user
    *  has explicitly opted out of seeing the picker for this type). */
   get showEmbedderPicker(): boolean {
-    if (this.lockedEmbedder) return false;
+    if (this.lockedEmbedder()) return false;
     return this.advancedOpen || !this.isDefaultEmbedderSelected;
   }
 
@@ -153,21 +153,21 @@ export class ImportAdvancedComponent {
    *  fall back to this standalone button so the override stays visible
    *  and the chooser stays reachable. */
   get showStandaloneClipperButton(): boolean {
-    if (this.clippers.length <= 1) return false;
+    if (this.clippers().length <= 1) return false;
     if (!this.showClipperPicker) return false;
-    return !(this.advancedOpen && this.showSourceSpecs);
+    return !(this.advancedOpen && this.showSourceSpecs());
   }
 
   /** Embedders flagged ``is_default`` for the active media type; shown
    *  in the Recommended optgroup. */
   get recommendedEmbedders(): EmbedderInfo[] {
-    return this.embedders.filter((e) => e.is_default);
+    return this.embedders().filter((e) => e.is_default);
   }
 
   /** Non-default embedders; shown in the Advanced optgroup inside the
    *  embedder select. */
   get advancedEmbedderOptions(): EmbedderInfo[] {
-    return this.embedders.filter((e) => !e.is_default);
+    return this.embedders().filter((e) => !e.is_default);
   }
 
   /** Human label for an embedder's option element. */
@@ -178,8 +178,8 @@ export class ImportAdvancedComponent {
   /** License-warning string for the current embedder, or null when the
    *  embedder has no special licensing concerns. */
   get licenseNotice(): string | null {
-    if (!this.selectedEmbedder) return null;
-    const found = this.embedders.find((e) => e.name === this.selectedEmbedder);
+    if (!this.selectedEmbedder()) return null;
+    const found = this.embedders().find((e) => e.name === this.selectedEmbedder());
     return found?.license_notice ?? null;
   }
 
@@ -187,7 +187,7 @@ export class ImportAdvancedComponent {
    *  ``"None"`` for unset or ``*_default`` clippers (which mean "no
    *  pre-processing"). */
   get clipperDisplayName(): string {
-    const clipper = this.clippers.find((c) => c.name === this.selectedClipper);
+    const clipper = this.clippers().find((c) => c.name === this.selectedClipper());
     if (!clipper) return 'None';
     if (clipper.name.endsWith('_default')) return 'None';
     return clipper.display_name || clipper.name;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
@@ -1,13 +1,13 @@
 <div class="form-group">
   <label
     class="form-label"
-    [for]="mediaTypeFieldId"
+    [for]="mediaTypeFieldId()"
     title="The native media type of the dataset. Other types listed below can be pulled in and converted to this type."
   >Dataset MediaType</label>
   <div class="media-type-dropdown" [class.open]="open">
     <button
       type="button"
-      [id]="mediaTypeFieldId"
+      [id]="mediaTypeFieldId()"
       class="form-select media-type-trigger"
       role="combobox"
       [attr.aria-haspopup]="'listbox'"
@@ -32,7 +32,7 @@
         [id]="listboxId"
         aria-label="Dataset MediaType"
       >
-        @for (opt of mediaTypeOptions; track opt; let i = $index) {
+        @for (opt of mediaTypeOptions(); track opt; let i = $index) {
           <li
             class="media-type-option"
             role="option"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { Component, ElementRef, HostListener, Input, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -30,29 +30,31 @@ import { IconComponent } from '../../../icon/icon.component';
   styleUrl: './import-config.component.scss',
 })
 export class ImportConfigComponent {
+  private hostEl = inject<ElementRef<HTMLElement>>(ElementRef);
+
   /** ``id`` value for the rendered media-type trigger button.  Each
    *  call site supplies a unique value so the modal does not contain
    *  duplicate ids when multiple flows are present in the DOM. */
-  @Input() mediaTypeFieldId = 'import-config-media-type';
+  readonly mediaTypeFieldId = input('import-config-media-type');
 
   /** Two-way bound output media type (folder_import_name, e.g.
    *  ``"images"``).  Parent reloads embedders/clippers/source-specs on
    *  every change. */
   @Input() mediaType = '';
-  @Output() mediaTypeChange = new EventEmitter<string>();
+  readonly mediaTypeChange = output<string>();
 
   /** ``folder_import_name`` values to show in the dropdown (same list
    *  the importer's ``media_type`` field declares as ``options``). */
-  @Input() mediaTypeOptions: string[] = [];
+  readonly mediaTypeOptions = input<string[]>([]);
 
   /** Map of ``folder_import_name`` → human label.  Parent computes this
    *  once from the ``/api/media-types`` response. */
-  @Input() mediaTypeOptionLabels: Record<string, string> = {};
+  readonly mediaTypeOptionLabels = input<Record<string, string>>({});
 
   /** Map of ``folder_import_name`` → icon string (emoji or named SVG
    *  type from :class:`MediaTypeInfo.icon`).  When empty for a given
    *  option, the row renders label-only. */
-  @Input() mediaTypeOptionIcons: Record<string, string> = {};
+  readonly mediaTypeOptionIcons = input<Record<string, string>>({});
 
   /** Pre-formatted hint string from
    *  :meth:`DatasetImporterModalComponent.detectionHint`.  Empty hides
@@ -67,19 +69,17 @@ export class ImportConfigComponent {
    *  closed or no option is highlighted. */
   activeIndex = -1;
 
-  constructor(private hostEl: ElementRef<HTMLElement>) {}
-
   /** ``id`` for the popup ``role="listbox"`` element, derived from the
    *  trigger's id so it stays unique across the multiple flows the modal
    *  may render at once. */
   get listboxId(): string {
-    return `${this.mediaTypeFieldId}-listbox`;
+    return `${this.mediaTypeFieldId()}-listbox`;
   }
 
   /** ``id`` for the option at ``index`` so the combobox trigger can
    *  point ``aria-activedescendant`` at the highlighted row. */
   optionId(index: number): string {
-    return `${this.mediaTypeFieldId}-option-${index}`;
+    return `${this.mediaTypeFieldId()}-option-${index}`;
   }
 
   /** ``id`` of the currently active option, or ``null`` when the popup
@@ -93,13 +93,13 @@ export class ImportConfigComponent {
    *  option value when no label is supplied (e.g. the parent's
    *  ``mediaTypes`` list has not loaded yet). */
   optionLabel(opt: string): string {
-    return this.mediaTypeOptionLabels[opt] || opt;
+    return this.mediaTypeOptionLabels()[opt] || opt;
   }
 
   /** Icon string for an option (emoji or :class:`IconComponent` type
    *  name).  Empty hides the icon for that row. */
   iconFor(opt: string): string {
-    return this.mediaTypeOptionIcons[opt] || '';
+    return this.mediaTypeOptionIcons()[opt] || '';
   }
 
   toggle(): void {
@@ -115,7 +115,7 @@ export class ImportConfigComponent {
    *  point. */
   private openPopup(): void {
     this.open = true;
-    const selected = this.mediaTypeOptions.indexOf(this.mediaType);
+    const selected = this.mediaTypeOptions().indexOf(this.mediaType);
     this.activeIndex = selected >= 0 ? selected : 0;
   }
 
@@ -134,7 +134,7 @@ export class ImportConfigComponent {
   /** Move the keyboard highlight to ``index`` (clamped) and scroll it
    *  into view within the popup. */
   private setActiveIndex(index: number): void {
-    const last = this.mediaTypeOptions.length - 1;
+    const last = this.mediaTypeOptions().length - 1;
     if (last < 0) return;
     this.activeIndex = Math.max(0, Math.min(last, index));
     // Defer until the ``[id]`` binding has flushed so the lookup hits the
@@ -173,14 +173,14 @@ export class ImportConfigComponent {
         break;
       case 'End':
         event.preventDefault();
-        this.setActiveIndex(this.mediaTypeOptions.length - 1);
+        this.setActiveIndex(this.mediaTypeOptions().length - 1);
         break;
       case 'Enter':
       case ' ':
       case 'Spacebar':
         event.preventDefault();
         if (this.activeIndex >= 0) {
-          this.select(this.mediaTypeOptions[this.activeIndex]);
+          this.select(this.mediaTypeOptions()[this.activeIndex]);
         }
         break;
       case 'Escape':

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -1,29 +1,29 @@
 <div class="importer-picker">
   <div class="importer-tab-bar">
-    @for (tab of visibleImporterTabs; track tab.id) {
+    @for (tab of visibleImporterTabs(); track tab.id) {
       <button
         class="importer-tab"
-        [class.active]="activeTab === tab.id"
+        [class.active]="activeTab() === tab.id"
         (click)="activeTabChange.emit(tab.id)"
         [title]="tabTitle(tab.label)"
       >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
     }
   </div>
-  @if (!activeTab) {
-    <p class="tab-bar-hint">{{ noTabHint }}</p>
+  @if (!activeTab()) {
+    <p class="tab-bar-hint">{{ noTabHint() }}</p>
   }
 
-  @if (activeTab) {
+  @if (activeTab()) {
     @if (importersForActiveTab.length === 0) {
       <div class="importer-subtab-bar">
-        <span class="empty-state empty-state--inline">{{ emptyCategoryText }}</span>
+        <span class="empty-state empty-state--inline">{{ emptyCategoryText() }}</span>
       </div>
-    } @else if (importersForActiveTab.length > 1 || alwaysShowSubtabBar) {
+    } @else if (importersForActiveTab.length > 1 || alwaysShowSubtabBar()) {
       <div class="importer-subtab-bar">
         @for (imp of importersForActiveTab; track imp.name) {
           <button
             class="importer-subtab"
-            [class.active]="selectedImporter?.name === imp.name"
+            [class.active]="selectedImporter()?.name === imp.name"
             [class.disabled]="imp['enabled'] === false"
             [disabled]="imp['enabled'] === false"
             (click)="importerSelected.emit(imp)"
@@ -31,39 +31,39 @@
           >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
         }
       </div>
-      @if (!selectedImporter) {
+      @if (!selectedImporter()) {
         <p class="tab-bar-hint">{{ noImporterHint }}</p>
       }
     }
   }
 </div>
 
-@if (activePickerView === 'demo' && selectedImporter) {
+@if (activePickerView() === 'demo' && selectedImporter()) {
   <div class="demo-picker">
-    @if (demoLoading) {
-      <p class="empty-state">{{ demoLoadingText }}</p>
-    } @else if (demos.length === 0) {
-      <p class="empty-state">{{ demoEmptyText }}</p>
+    @if (demoLoading()) {
+      <p class="empty-state">{{ demoLoadingText() }}</p>
+    } @else if (demos().length === 0) {
+      <p class="empty-state">{{ demoEmptyText() }}</p>
     } @else {
-      @if (showDemoMediaTypeTabs) {
+      @if (showDemoMediaTypeTabs()) {
         <div class="demo-tab-bar">
-          @for (tab of demoTabs; track tab) {
+          @for (tab of demoTabs(); track tab) {
             <button
               class="demo-tab"
-              [class.active]="activeDemoTab === tab"
+              [class.active]="activeDemoTab() === tab"
               (click)="activeDemoTabChange.emit(tab)"
               [title]="'Filter demos by media type: ' + getDemoTabText(tab)"
             >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabText(tab) }}</button>
           }
         </div>
-        @if (!activeDemoTab) {
-          <p class="tab-bar-hint">{{ demoNoTabHint }}</p>
+        @if (!activeDemoTab()) {
+          <p class="tab-bar-hint">{{ demoNoTabHint() }}</p>
         }
       }
 
       <ng-content select="[demoBefore]"></ng-content>
 
-      @if (activeDemoTab && demoCols) {
+      @if (activeDemoTab() && demoCols) {
         <div class="demo-content-area">
           <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
             <thead>
@@ -89,11 +89,11 @@
               </tr>
             </thead>
             <tbody>
-              @for (demo of filteredDemos; track demo.name) {
+              @for (demo of filteredDemos(); track demo.name) {
                 <tr
                   class="demo-row"
                   [class.ready]="demo.status === 'ready'"
-                  [class.selected]="selectedDemoName === demo.name"
+                  [class.selected]="selectedDemoName() === demo.name"
                   [class.disabled]="demoRowDisabled(demo)"
                   role="button"
                   tabindex="0"
@@ -131,21 +131,21 @@
   </div>
 }
 
-@if (activePickerView === 'server_folder' && selectedImporter) {
+@if (activePickerView() === 'server_folder' && selectedImporter()) {
   <div class="server-folder-browser">
     <ng-content select="[sfBefore]"></ng-content>
 
     <div class="sf-browse-section">
-      <label class="form-label" [for]="sfPathFieldId">{{ sfPathLabel }}</label>
+      <label class="form-label" [for]="sfPathFieldId()">{{ sfPathLabel() }}</label>
       <input
-        [id]="sfPathFieldId"
+        [id]="sfPathFieldId()"
         type="text"
         class="form-input"
-        [placeholder]="sfPathPlaceholder"
+        [placeholder]="sfPathPlaceholder()"
         [(ngModel)]="sfPathInputValue"
         (ngModelChange)="sfPathInputValueChange.emit($event)"
         (keydown.enter)="sfPathApplied.emit(); $event.preventDefault()"
-        (blur)="sfApplyOnBlur && sfPathApplied.emit()"
+        (blur)="sfApplyOnBlur() && sfPathApplied.emit()"
       />
     </div>
 
@@ -153,39 +153,39 @@
   </div>
 }
 
-@if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
+@if ((activePickerView() === 'local_folder' || activePickerView() === 'local_files') && selectedImporter()) {
   <div class="local-folder-uploader">
     <ng-content select="[lfInfo]"></ng-content>
 
     <ng-content select="[lfBefore]"></ng-content>
 
     <div class="form-group form-group--section">
-      @if (lfShowFieldLabel) {
-        @if (lfPickerKind === 'folder') {
-          <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">{{ lfFolderFieldLabel }}<span class="required">*</span></label>
+      @if (lfShowFieldLabel()) {
+        @if (lfPickerKind() === 'folder') {
+          <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">{{ lfFolderFieldLabel() }}<span class="required">*</span></label>
         } @else {
-          <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">{{ lfFilesFieldLabel }}<span class="required">*</span></label>
+          <label class="form-label" title="Choose a single file: a .txt/.list of paths, or a .npz archive of paths + pre-computed embedding vectors.">{{ lfFilesFieldLabel() }}<span class="required">*</span></label>
         }
       }
-      @if (lfPickerKind === 'folder') {
+      @if (lfPickerKind() === 'folder') {
         <vt-drop-zone
-          [label]="lfFolderDropLabel"
-          [sublabel]="lfFolderDropSublabel"
+          [label]="lfFolderDropLabel()"
+          [sublabel]="lfFolderDropSublabel()"
           [directory]="true"
           [multiple]="true"
           (filesSelected)="lfFilesDropped.emit($event)"
         ></vt-drop-zone>
       } @else {
         <vt-drop-zone
-          [label]="lfFilesDropLabel"
-          [sublabel]="lfFilesDropSublabel"
-          [accept]="lfFilesAcceptAttr"
+          [label]="lfFilesDropLabel()"
+          [sublabel]="lfFilesDropSublabel()"
+          [accept]="lfFilesAcceptAttr()"
           (filesSelected)="lfFilesDropped.emit($event)"
         ></vt-drop-zone>
       }
-      @if (lfShowFileCount && lfFiles.length > 0) {
+      @if (lfShowFileCount() && lfFiles.length > 0) {
         <p class="info-text">
-          @if (lfPickerKind === 'folder') {
+          @if (lfPickerKind() === 'folder') {
             Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
             @if (lfFolderName) { from <code>{{ lfFolderName }}</code> }
           } @else {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -57,33 +57,33 @@ export class SourcePickerComponent {
   /** Tabs to render in the top-level category bar, in display order.
    *  Parent computes this from the importer registry; see
    *  ``DatasetImporterModalComponent.visibleImporterTabs``. */
-  @Input() visibleImporterTabs: ImporterPickerTab[] = [];
+  readonly visibleImporterTabs = input<ImporterPickerTab[]>([]);
 
   /** Importers whose ``category`` matches ``activeTab`` (i.e. the
    *  sub-tabs to render). */
   @Input() importersForActiveTab: ImporterInfo[] = [];
 
-  @Input() activeTab = '';
-  @Input() selectedImporter: ImporterInfo | null = null;
-  @Input() activeImporterTabLabel = '';
+  readonly activeTab = input('');
+  readonly selectedImporter = input<ImporterInfo | null>(null);
+  readonly activeImporterTabLabel = input('');
 
   /** Fired when the user clicks a top-level category tab. */
-  @Output() activeTabChange = new EventEmitter<string>();
+  readonly activeTabChange = output<string>();
   /** Fired when the user clicks a sub-tab (importer card). */
-  @Output() importerSelected = new EventEmitter<ImporterInfo>();
+  readonly importerSelected = output<ImporterInfo>();
 
   // --- Chrome customization ---
 
   /** Hint shown above the sub-tab area when no top tab is selected. */
-  @Input() noTabHint = 'Select what type of dataset to add.';
+  readonly noTabHint = input('Select what type of dataset to add.');
   /** Hint shown when a tab with multiple importers has none picked yet.
    *  ``{label}`` is replaced with the active tab's label. */
-  @Input() noImporterHintTemplate = 'Select how to add a {label} dataset.';
+  readonly noImporterHintTemplate = input('Select how to add a {label} dataset.');
   /** ``title`` attribute on top-level tab buttons.  ``{label}`` is
    *  replaced with the tab label. */
-  @Input() tabTitleTemplate = 'Show {label} dataset importers';
+  readonly tabTitleTemplate = input('Show {label} dataset importers');
   /** Message shown when the active tab has zero importers. */
-  @Input() emptyCategoryText = 'No importers in this category.';
+  readonly emptyCategoryText = input('No importers in this category.');
 
   /** When ``false`` (default), the sub-tab row is suppressed when the
    *  active category has exactly one importer - the parent is expected
@@ -92,121 +92,121 @@ export class SourcePickerComponent {
    *  (e.g. the New Detector media picker, where every category is a
    *  distinct kind of source the user should see labelled) set this to
    *  ``true``. */
-  @Input() alwaysShowSubtabBar = false;
+  readonly alwaysShowSubtabBar = input(false);
 
   // === Demo source view ===
 
-  @Input() demos: DemoDataset[] = [];
-  @Input() filteredDemos: DemoDataset[] = [];
-  @Input() demoLoading = false;
-  @Input() demoTabs: string[] = [];
-  @Input() activeDemoTab = '';
+  readonly demos = input<DemoDataset[]>([]);
+  readonly filteredDemos = input<DemoDataset[]>([]);
+  readonly demoLoading = input(false);
+  readonly demoTabs = input<string[]>([]);
+  readonly activeDemoTab = input('');
   @Input() demoCols: ManagedColumns | null = null;
-  @Input() mediaTypes: MediaTypeInfo[] = [];
+  readonly mediaTypes = input<MediaTypeInfo[]>([]);
 
-  @Output() activeDemoTabChange = new EventEmitter<string>();
-  @Output() demoSelected = new EventEmitter<DemoDataset>();
+  readonly activeDemoTabChange = output<string>();
+  readonly demoSelected = output<DemoDataset>();
 
-  @Input() demoLoadingText = 'Loading demo datasets...';
-  @Input() demoEmptyText = 'No demo datasets available.';
-  @Input() demoNoTabHint = 'Select the media type to demonstrate.';
+  readonly demoLoadingText = input('Loading demo datasets...');
+  readonly demoEmptyText = input('No demo datasets available.');
+  readonly demoNoTabHint = input('Select the media type to demonstrate.');
 
   /** Optional predicate run on every demo row.  When provided and it
    *  returns ``true``, the row gets a ``disabled`` class for visual
    *  styling.  Source picker still emits ``demoSelected`` for clicks
    *  - the parent is responsible for treating disabled rows as
    *  no-ops. */
-  @Input() demoRowDisabledFn: ((demo: DemoDataset) => boolean) | null = null;
+  readonly demoRowDisabledFn = input<((demo: DemoDataset) => boolean) | null>(null);
   /** Optional formatter for the ``title`` attribute on each demo row. */
-  @Input() demoRowTitleFn: ((demo: DemoDataset) => string) | null = null;
+  readonly demoRowTitleFn = input<((demo: DemoDataset) => string) | null>(null);
 
   /** When ``true`` (default) the inner media-type tab bar renders above
    *  the demo table.  Callers that want to render their own media-type
    *  picker (e.g. the Add Dataset modal, which uses a dropdown to match
    *  the other importer flows) set this to ``false`` and project their
    *  widget into the ``[demoBefore]`` slot. */
-  @Input() showDemoMediaTypeTabs = true;
+  readonly showDemoMediaTypeTabs = input(true);
 
   /** Name of the currently-selected demo row.  Used to highlight the
    *  selected row when the parent treats row clicks as a selection (not
    *  an immediate submit).  Empty string disables the highlight. */
-  @Input() selectedDemoName = '';
+  readonly selectedDemoName = input('');
 
   // === Server folder source view ===
 
   @Input() sfPathInputValue = '';
-  @Output() sfPathInputValueChange = new EventEmitter<string>();
+  readonly sfPathInputValueChange = output<string>();
   /** Fired when the user finalises the typed path (Enter or blur). */
-  @Output() sfPathApplied = new EventEmitter<void>();
+  readonly sfPathApplied = output<void>();
 
-  @Input() sfPathLabel = 'Folder to import';
-  @Input() sfPathPlaceholder = '/absolute/server/path/to/folder';
-  @Input() sfPathFieldId = 'sf-path-input';
+  readonly sfPathLabel = input('Folder to import');
+  readonly sfPathPlaceholder = input('/absolute/server/path/to/folder');
+  readonly sfPathFieldId = input('sf-path-input');
   /** Whether to fire ``sfPathApplied`` on the path input's ``blur``
    *  event in addition to Enter.  The Add Dataset modal wants
    *  blur-to-detect; the New Detector modal explicitly drives loading
    *  through a Load button and disables blur to avoid double-firing. */
-  @Input() sfApplyOnBlur = true;
+  readonly sfApplyOnBlur = input(true);
 
   // === Local folder/files source view ===
 
-  @Input() lfPickerKind: 'folder' | 'files' = 'folder';
+  readonly lfPickerKind = input<'folder' | 'files'>('folder');
   @Input() lfFiles: File[] = [];
   @Input() lfFolderName = '';
-  @Output() lfFilesDropped = new EventEmitter<File[]>();
+  readonly lfFilesDropped = output<File[]>();
 
   /** ``vt-drop-zone`` label rendered when ``lfPickerKind === 'folder'``. */
-  @Input() lfFolderDropLabel = 'Drop a folder here to import';
+  readonly lfFolderDropLabel = input('Drop a folder here to import');
   /** ``vt-drop-zone`` sublabel rendered when ``lfPickerKind === 'folder'``. */
-  @Input() lfFolderDropSublabel = 'or click to browse';
+  readonly lfFolderDropSublabel = input('or click to browse');
   /** ``vt-drop-zone`` label rendered when ``lfPickerKind === 'files'``. */
-  @Input() lfFilesDropLabel = 'Drop a paths file (.txt, .list, or .npz)';
+  readonly lfFilesDropLabel = input('Drop a paths file (.txt, .list, or .npz)');
   /** ``vt-drop-zone`` sublabel rendered when ``lfPickerKind === 'files'``. */
-  @Input() lfFilesDropSublabel = 'or click to browse';
+  readonly lfFilesDropSublabel = input('or click to browse');
   /** ``accept`` attribute for the ``files`` kind dropzone (comma-separated
    *  extensions / MIME types).  Empty string accepts anything. */
-  @Input() lfFilesAcceptAttr = '.txt,.list,.npz';
+  readonly lfFilesAcceptAttr = input('.txt,.list,.npz');
 
   /** Whether to render the "Folder*" / "Paths file*" form-label above the
    *  dropzone.  Disabled by callers (e.g. the New Detector modal) that
    *  bake the affordance entirely into the dropzone's own label. */
-  @Input() lfShowFieldLabel = true;
+  readonly lfShowFieldLabel = input(true);
   /** Label for the dropzone form-label, when ``lfShowFieldLabel`` is on. */
-  @Input() lfFolderFieldLabel = 'Folder';
+  readonly lfFolderFieldLabel = input('Folder');
   /** Label for the dropzone form-label in ``files`` mode. */
-  @Input() lfFilesFieldLabel = 'Paths file';
+  readonly lfFilesFieldLabel = input('Paths file');
 
   /** Whether to render the "Selected N files" / "Using paths from …" info
    *  text below the dropzone.  Disabled by callers that only use the
    *  first picked file (e.g. the New Detector modal) and have no
    *  meaningful count to show. */
-  @Input() lfShowFileCount = true;
+  readonly lfShowFileCount = input(true);
 
   // === View dispatch ===
 
   /** ``picker_view`` of the currently selected importer.  Drives which
    *  source widget is rendered below the chrome. */
-  @Input() activePickerView = '';
+  readonly activePickerView = input('');
 
   // -------------------------------------------------------------------
 
   get noImporterHint(): string {
-    return this.noImporterHintTemplate.replace('{label}', this.activeImporterTabLabel);
+    return this.noImporterHintTemplate().replace('{label}', this.activeImporterTabLabel());
   }
 
   tabTitle(label: string): string {
-    return this.tabTitleTemplate.replace('{label}', label);
+    return this.tabTitleTemplate().replace('{label}', label);
   }
 
   // === Demo helpers ===
 
   getDemoTabIcon(mediaType: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
+    const mt = this.mediaTypes().find((m) => m.type_id === mediaType);
     return mt?.icon || '';
   }
 
   getDemoTabText(mediaType: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
+    const mt = this.mediaTypes().find((m) => m.type_id === mediaType);
     return mt ? mt.name : mediaType;
   }
 
@@ -215,11 +215,13 @@ export class SourcePickerComponent {
   }
 
   demoRowDisabled(demo: DemoDataset): boolean {
-    return this.demoRowDisabledFn ? this.demoRowDisabledFn(demo) : false;
+    const demoRowDisabledFn = this.demoRowDisabledFn();
+    return demoRowDisabledFn ? demoRowDisabledFn(demo) : false;
   }
 
   demoRowTitle(demo: DemoDataset): string {
-    return this.demoRowTitleFn ? this.demoRowTitleFn(demo) : '';
+    const demoRowTitleFn = this.demoRowTitleFn();
+    return demoRowTitleFn ? demoRowTitleFn(demo) : '';
   }
 
   statusBadgeClass(status: string): string {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.html
@@ -11,7 +11,7 @@
         [disabled]="true"
       />
       <span class="ssp-row-label">
-        <strong>{{ labelFor(nativeType) }}</strong>
+        <strong>{{ labelFor(nativeType()) }}</strong>
       </span>
     </label>
 
@@ -35,7 +35,7 @@
     <div class="ssp-row">
       <label
         class="ssp-row-main"
-        [title]="'Pull in ' + labelFor(st) + ' files and convert them to ' + labelFor(nativeType) + '.'"
+        [title]="'Pull in ' + labelFor(st) + ' files and convert them to ' + labelFor(nativeType()) + '.'"
       >
         <input
           type="checkbox"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -25,34 +25,34 @@ import { ClipperInfo, ConverterInfo, SourceSpec } from '../../../../models/api.m
 export class SourceSpecsPickerComponent implements OnChanges {
   /** All converters whose ``target_type`` matches the current native
    *  type.  Comes from the importer's ``to_dict()`` payload. */
-  @Input() availableConverters: ConverterInfo[] = [];
+  readonly availableConverters = input<ConverterInfo[]>([]);
   /** Native media type id (e.g. ``"image"``) - the dataset's output
    *  type.  The native checkbox represents "include direct files of
    *  this type, no conversion". */
-  @Input() nativeType = '';
+  readonly nativeType = input('');
   /** Two-way bound source-spec list submitted to the importer. */
-  @Input() specs: SourceSpec[] = [];
+  readonly specs = input<SourceSpec[]>([]);
   /** Map of type_id → human-readable label.  Falls back to the type_id
    *  when a label is missing. */
-  @Input() typeLabels: Record<string, string> = {};
+  readonly typeLabels = input<Record<string, string>>({});
   /** Clippers available for the native media type.  Drives the native
    *  row's "Details" button - shown only when there is more than one
    *  clipper to pick between (same gate as the legacy standalone
    *  Clipper section).  An empty list means "no clipper choice", and
    *  the Details button is suppressed. */
-  @Input() clippers: ClipperInfo[] = [];
+  readonly clippers = input<ClipperInfo[]>([]);
   /** Name of the clipper currently selected by the parent for the
    *  native row.  Used to look up the matching :class:`ClipperInfo`
    *  for the inline summary preview. */
-  @Input() selectedClipperName = '';
+  readonly selectedClipperName = input('');
   /** Current parameter values for the selected native clipper, keyed by
    *  the clipper's parameter ``key``.  Substituted into the clipper's
    *  ``summary_template`` to render the inline preview. */
-  @Input() selectedClipperParams: Record<string, string | number> = {};
-  @Output() specsChange = new EventEmitter<SourceSpec[]>();
+  readonly selectedClipperParams = input<Record<string, string | number>>({});
+  readonly specsChange = output<SourceSpec[]>();
   /** Fired when the user clicks the native row's "Details" button.
    *  The parent opens the shared clipper-chooser modal in response. */
-  @Output() clipperChooserRequested = new EventEmitter<void>();
+  readonly clipperChooserRequested = output<void>();
 
   /** Per-source-type draft so the user can configure a converter via
    *  the Details panel *before* checking the box.  Edits made while
@@ -65,29 +65,29 @@ export class SourceSpecsPickerComponent implements OnChanges {
       this.drafts.clear();
       this.detailsOpenSet.clear();
     }
-    for (const s of this.specs) {
+    for (const s of this.specs()) {
       if (s.converter !== null) this.drafts.set(s.source_type, s);
     }
   }
 
   get nonNativeSourceTypes(): string[] {
     const set = new Set<string>();
-    for (const c of this.availableConverters) {
-      if (c.source_type !== this.nativeType) set.add(c.source_type);
+    for (const c of this.availableConverters()) {
+      if (c.source_type !== this.nativeType()) set.add(c.source_type);
     }
     return Array.from(set).sort();
   }
 
   labelFor(sourceType: string): string {
-    return this.typeLabels[sourceType] || sourceType;
+    return this.typeLabels()[sourceType] || sourceType;
   }
 
   isNonNativeChecked(sourceType: string): boolean {
-    return this.specs.some((s) => s.source_type === sourceType && s.converter !== null);
+    return this.specs().some((s) => s.source_type === sourceType && s.converter !== null);
   }
 
   convertersFor(sourceType: string): ConverterInfo[] {
-    return this.availableConverters.filter((c) => c.source_type === sourceType);
+    return this.availableConverters().filter((c) => c.source_type === sourceType);
   }
 
   /** True iff the Details opener should be rendered for *sourceType*:
@@ -112,7 +112,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
    *  there has to be more than one clipper for the user to pick
    *  between.  Same gate as the legacy standalone Clipper section. */
   hasNativeDetails(): boolean {
-    return this.clippers.length > 1;
+    return this.clippers().length > 1;
   }
 
   /** Click handler for the native row's Details button - bubbles up to
@@ -126,9 +126,10 @@ export class SourceSpecsPickerComponent implements OnChanges {
    *  first available clipper so the summary still renders when the
    *  parent hasn't picked one yet. */
   private currentClipper(): ClipperInfo | null {
-    if (!this.clippers.length) return null;
-    const byName = this.clippers.find((c) => c.name === this.selectedClipperName);
-    return byName || this.clippers[0];
+    const clippers = this.clippers();
+    if (!clippers.length) return null;
+    const byName = clippers.find((c) => c.name === this.selectedClipperName());
+    return byName || clippers[0];
   }
 
   /** Live one-line summary of the native row's clipper, with current
@@ -144,8 +145,8 @@ export class SourceSpecsPickerComponent implements OnChanges {
     for (const p of c.parameters || []) {
       params[p.key] = p.default;
     }
-    for (const k of Object.keys(this.selectedClipperParams)) {
-      const v = this.selectedClipperParams[k];
+    for (const k of Object.keys(this.selectedClipperParams())) {
+      const v = this.selectedClipperParams()[k];
       if (v !== undefined && v !== null && v !== '') params[k] = v;
     }
     return formatSummary(c.summary_template || c.description || '', params);
@@ -165,7 +166,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
 
   currentConverter(sourceType: string): ConverterInfo | null {
     const name = this.currentConverterName(sourceType);
-    return this.availableConverters.find((c) => c.name === name) || null;
+    return this.availableConverters().find((c) => c.name === name) || null;
   }
 
   paramValue(sourceType: string, key: string): string | number | null {
@@ -174,7 +175,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
   }
 
   toggleNonNative(sourceType: string, checked: boolean): void {
-    const others = this.specs.filter((s) => !(s.source_type === sourceType && s.converter !== null));
+    const others = this.specs().filter((s) => !(s.source_type === sourceType && s.converter !== null));
     if (checked) {
       this.specsChange.emit([...others, { ...this.getDraft(sourceType) }]);
     } else {
@@ -183,7 +184,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
   }
 
   setConverter(sourceType: string, converterName: string): void {
-    const c = this.availableConverters.find((x) => x.name === converterName);
+    const c = this.availableConverters().find((x) => x.name === converterName);
     if (!c) return;
     const draft: SourceSpec = {
       source_type: sourceType,
@@ -192,7 +193,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
     };
     this.drafts.set(sourceType, draft);
     if (this.isNonNativeChecked(sourceType)) {
-      this.specsChange.emit(this.specs.map((s) =>
+      this.specsChange.emit(this.specs().map((s) =>
         (s.source_type === sourceType && s.converter !== null) ? { ...draft } : s
       ));
     }
@@ -212,7 +213,7 @@ export class SourceSpecsPickerComponent implements OnChanges {
     const updated: SourceSpec = { ...draft, params };
     this.drafts.set(sourceType, updated);
     if (this.isNonNativeChecked(sourceType)) {
-      this.specsChange.emit(this.specs.map((s) =>
+      this.specsChange.emit(this.specs().map((s) =>
         (s.source_type === sourceType && s.converter !== null) ? { ...updated } : s
       ));
     }

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -123,7 +123,7 @@
         <circle cx="12" cy="12" r="3"></circle>
       </svg>
     </button>
-    @if (!isDefaultLogin) {
+    @if (!isDefaultLogin()) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
@@ -138,17 +138,17 @@
       </svg>
     </button>
     <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Import Labels" title="Import Labels">
-      <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+      <svg aria-hidden="true" [class.cap-active]="addLabelsOpen()" [class.cap-inactive]="!addLabelsOpen() && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
     </button>
     <button class="export-btn" (click)="onExport($event)" aria-label="Export detector" title="Export">
-      <svg aria-hidden="true" [class.export-active]="exportOpen" [class.export-inactive]="!exportOpen && wasExportOpen" (animationend)="onExportAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.export-active]="exportOpen()" [class.export-inactive]="!exportOpen() && wasExportOpen" (animationend)="onExportAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
         <polyline points="15 3 21 3 21 9"></polyline>
         <line x1="12" y1="12" x2="21" y2="3"></line>
       </svg>
     </button>
     <button class="stats-btn" (click)="onStats($event)" aria-label="Detector stats" title="Stats">
-      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen()" [class.pie-inactive]="!statsOpen() && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <path d="M12 2a10 10 0 0 1 0 20"/>
         <line x1="12" y1="12" x2="12" y2="2"/>
@@ -157,7 +157,7 @@
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete">
-      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen()" [class.trash-inactive]="!deleteConfirmOpen() && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges, ViewChild, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -21,8 +21,8 @@ import { buildDetectorCardMenuItems } from '../card-context-menu-items';
 })
 export class DetectorCardComponent implements OnChanges {
   @Input() detector: any;
-  @Input() currentUser = '';
-  @Input() isDefaultLogin = true;
+  readonly currentUser = input('');
+  readonly isDefaultLogin = input(true);
   @Input() columnOrder: string[] = [];
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
@@ -33,7 +33,7 @@ export class DetectorCardComponent implements OnChanges {
     return !!this.loadingTask?.error;
   }
 
-  @Output() rowClick = new EventEmitter<MouseEvent>();
+  readonly rowClick = output<MouseEvent>();
 
   @HostListener('click', ['$event'])
   onClick(event: MouseEvent): void {
@@ -49,30 +49,30 @@ export class DetectorCardComponent implements OnChanges {
     if (this.loadingTask) return;
     event.preventDefault();
     this.contextMenuItems = buildDetectorCardMenuItems(this.detector, {
-      isDefaultLogin: this.isDefaultLogin,
+      isDefaultLogin: this.isDefaultLogin(),
       isOwner: this.isOwner,
     });
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
     this.contextMenuOpen = true;
   }
-  @Output() rename = new EventEmitter<string>();
-  @Output() delete = new EventEmitter<void>();
-  @Output() export = new EventEmitter<void>();
-  @Output() addLabels = new EventEmitter<void>();
-  @Output() load = new EventEmitter<void>();
-  @Output() unload = new EventEmitter<void>();
-  @Output() browse = new EventEmitter<void>();
-  @Output() stats = new EventEmitter<void>();
-  @Output() cancelTask = new EventEmitter<string>();
-  @Output() dismissTask = new EventEmitter<string>();
-  @Output() checkboxToggle = new EventEmitter<void>();
-  @Output() security = new EventEmitter<void>();
+  readonly rename = output<string>();
+  readonly delete = output<void>();
+  readonly export = output<void>();
+  readonly addLabels = output<void>();
+  readonly load = output<void>();
+  readonly unload = output<void>();
+  readonly browse = output<void>();
+  readonly stats = output<void>();
+  readonly cancelTask = output<string>();
+  readonly dismissTask = output<string>();
+  readonly checkboxToggle = output<void>();
+  readonly security = output<void>();
 
   /** True when the current user created this detector (only the creator may
    *  rename/delete it or edit its access list). */
   get isOwner(): boolean {
-    return this.detector?.created_by === this.currentUser;
+    return this.detector?.created_by === this.currentUser();
   }
 
   onSecurity(event: MouseEvent): void {
@@ -82,10 +82,10 @@ export class DetectorCardComponent implements OnChanges {
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
-  @Input() deleteConfirmOpen = false;
-  @Input() addLabelsOpen = false;
-  @Input() exportOpen = false;
-  @Input() statsOpen = false;
+  readonly deleteConfirmOpen = input(false);
+  readonly addLabelsOpen = input(false);
+  readonly exportOpen = input(false);
+  readonly statsOpen = input(false);
 
   editing = false;
   wasEditing = false;
@@ -181,25 +181,25 @@ export class DetectorCardComponent implements OnChanges {
   }
 
   onTrashAnimationEnd(): void {
-    if (!this.deleteConfirmOpen) {
+    if (!this.deleteConfirmOpen()) {
       this.wasDeleteOpen = false;
     }
   }
 
   onCapAnimationEnd(): void {
-    if (!this.addLabelsOpen) {
+    if (!this.addLabelsOpen()) {
       this.wasAddLabelsOpen = false;
     }
   }
 
   onExportAnimationEnd(): void {
-    if (!this.exportOpen) {
+    if (!this.exportOpen()) {
       this.wasExportOpen = false;
     }
   }
 
   onPieAnimationEnd(): void {
-    if (!this.statsOpen) {
+    if (!this.statsOpen()) {
       this.wasStatsOpen = false;
     }
   }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
+import { Component, HostListener, Input, OnInit, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -40,6 +40,15 @@ type TrainedSubView = 'picker' | 'form';
   styleUrl: './new-detector-modal.component.scss',
 })
 export class NewDetectorModalComponent implements OnInit {
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private datasetsUiApi = inject(DatasetsUiApiService);
+  private sortingApi = inject(SortingApiService);
+  private labelImportersApi = inject(LabelImportersApiService);
+  private settingsState = inject(SettingsStateService);
+
   /** Media type of the currently active dataset, if any. */
   @Input() defaultMediaType = '';
 
@@ -50,10 +59,10 @@ export class NewDetectorModalComponent implements OnInit {
   @Input() seedMediaId: number | null = null;
 
   /** Optional crop bounds applied when materialising ``seedMediaId``. */
-  @Input() seedCropParams: Record<string, unknown> | null = null;
+  readonly seedCropParams = input<Record<string, unknown> | null>(null);
 
-  @Output() closed = new EventEmitter<void>();
-  @Output() created = new EventEmitter<string>();
+  readonly closed = output<void>();
+  readonly created = output<string>();
 
   view: ModalView = 'main';
   tab: ModalTab = 'blank';
@@ -165,17 +174,6 @@ export class NewDetectorModalComponent implements OnInit {
   labelImporterFile: File | null = null;
   labelImporterFileFieldKey: string | null = null;
 
-  constructor(
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private datasetsUiApi: DatasetsUiApiService,
-    private sortingApi: SortingApiService,
-    private labelImportersApi: LabelImportersApiService,
-    private settingsState: SettingsStateService,
-  ) {}
-
   /** Type_id of the active solo-mediaType streamlining, or ``null`` when
    *  off. When non-null, the mediaType form-group is hidden in the
    *  template and ``mediaType`` is locked to this value on init. */
@@ -239,7 +237,7 @@ export class NewDetectorModalComponent implements OnInit {
     }
 
     if (this.seedMediaId != null) {
-      this.materializeSeedFromMediaId(this.seedMediaId, this.seedCropParams ?? undefined);
+      this.materializeSeedFromMediaId(this.seedMediaId, this.seedCropParams() ?? undefined);
     }
   }
 

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.html
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.html
@@ -1,6 +1,6 @@
-@if (usage) {
+@if (usage()) {
   <div class="usage-bar" [title]="title">
-    <div class="usage-bar-label">{{ label }}: {{ freeText }}</div>
+    <div class="usage-bar-label">{{ label() }}: {{ freeText }}</div>
     <div class="usage-bar-track" [class.warn]="usedPct >= 80" [class.critical]="usedPct >= 95">
       <div class="usage-bar-fill" [style.width.%]="usedPct"></div>
     </div>

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 
 export interface UsageBytes {
   total: number;
@@ -13,28 +13,30 @@ export interface UsageBytes {
   templateUrl: './usage-bar.component.html',
   styleUrl: './usage-bar.component.scss',
   host: {
-    '[class.side-left]': "side === 'left'",
-    '[class.side-right]': "side === 'right'",
+    '[class.side-left]': "side() === 'left'",
+    '[class.side-right]': "side() === 'right'",
   },
 })
 export class UsageBarComponent {
-  @Input() usage: UsageBytes | null = null;
-  @Input() label = '';
-  @Input() side: 'left' | 'right' = 'right';
-  @Input() titlePrefix = '';
+  readonly usage = input<UsageBytes | null>(null);
+  readonly label = input('');
+  readonly side = input<'left' | 'right'>('right');
+  readonly titlePrefix = input('');
 
   get usedPct(): number {
-    if (!this.usage || this.usage.total <= 0) return 0;
-    return (this.usage.used / this.usage.total) * 100;
+    const usage = this.usage();
+    if (!usage || usage.total <= 0) return 0;
+    return (usage.used / usage.total) * 100;
   }
 
   get freeText(): string {
-    if (!this.usage) return '';
-    return `${this.formatBytes(this.usage.free)} free of ${this.formatBytes(this.usage.total)}`;
+    const usage = this.usage();
+    if (!usage) return '';
+    return `${this.formatBytes(usage.free)} free of ${this.formatBytes(usage.total)}`;
   }
 
   get title(): string {
-    const prefix = this.titlePrefix || this.label;
+    const prefix = this.titlePrefix() || this.label();
     return prefix ? `${prefix}: ${this.freeText}` : this.freeText;
   }
 

--- a/frontend/src/app/components/dialog-host/dialog-host.component.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../modal/modal.component';
@@ -13,7 +13,8 @@ import { VtDialogService } from '../../services/dialog.service';
   styleUrl: './dialog-host.component.scss',
 })
 export class DialogHostComponent {
-  constructor(public dialog: VtDialogService) {}
+  dialog = inject(VtDialogService);
+
 
   onButtonClick(value: unknown): void {
     this.dialog.resolve(value);

--- a/frontend/src/app/components/drop-zone/drop-zone.component.html
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.html
@@ -1,11 +1,11 @@
 <div
   class="drop-zone"
   [class.drop-zone--active]="isDragging"
-  [class.drop-zone--disabled]="disabled"
+  [class.drop-zone--disabled]="disabled()"
   role="button"
   tabindex="0"
-  [attr.aria-disabled]="disabled ? 'true' : null"
-  [attr.aria-label]="label"
+  [attr.aria-disabled]="disabled() ? 'true' : null"
+  [attr.aria-label]="label()"
   (click)="openPicker()"
   (keydown.enter)="openPicker()"
   (keydown.space)="$event.preventDefault(); openPicker()"
@@ -19,7 +19,7 @@
     <polyline points="17 8 12 3 7 8" />
     <line x1="12" y1="3" x2="12" y2="15" />
   </svg>
-  <p class="drop-zone-label">{{ label }}</p>
+  <p class="drop-zone-label">{{ label() }}</p>
   @if (sublabel) {
     <p class="drop-zone-sublabel">{{ sublabel }}</p>
   }
@@ -27,10 +27,10 @@
     #fileInput
     type="file"
     class="drop-zone-input"
-    [attr.accept]="accept || null"
-    [attr.multiple]="multiple ? '' : null"
-    [attr.webkitdirectory]="directory ? '' : null"
-    [attr.directory]="directory ? '' : null"
+    [attr.accept]="accept() || null"
+    [attr.multiple]="multiple() ? '' : null"
+    [attr.webkitdirectory]="directory() ? '' : null"
+    [attr.directory]="directory() ? '' : null"
     (change)="onInputChange($event)"
   />
 </div>

--- a/frontend/src/app/components/drop-zone/drop-zone.component.ts
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild, input, output } from '@angular/core';
 
 
 @Component({
@@ -9,13 +9,13 @@ import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@
   styleUrl: './drop-zone.component.scss',
 })
 export class DropZoneComponent {
-  @Input() label = 'Drop files here, or click to browse';
+  readonly label = input('Drop files here, or click to browse');
   @Input() sublabel = '';
-  @Input() accept = '';
-  @Input() multiple = false;
-  @Input() directory = false;
-  @Input() disabled = false;
-  @Output() filesSelected = new EventEmitter<File[]>();
+  readonly accept = input('');
+  readonly multiple = input(false);
+  readonly directory = input(false);
+  readonly disabled = input(false);
+  readonly filesSelected = output<File[]>();
 
   @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
 
@@ -23,7 +23,7 @@ export class DropZoneComponent {
   private dragDepth = 0;
 
   openPicker(): void {
-    if (this.disabled) return;
+    if (this.disabled()) return;
     this.fileInput?.nativeElement.click();
   }
 
@@ -38,7 +38,7 @@ export class DropZoneComponent {
     if (!this.hasFiles(event)) return;
     event.preventDefault();
     event.stopPropagation();
-    if (this.disabled) return;
+    if (this.disabled()) return;
     this.dragDepth++;
     this.isDragging = true;
   }
@@ -47,7 +47,7 @@ export class DropZoneComponent {
     if (!this.hasFiles(event)) return;
     event.preventDefault();
     event.stopPropagation();
-    if (this.disabled) return;
+    if (this.disabled()) return;
     if (event.dataTransfer) {
       event.dataTransfer.dropEffect = 'copy';
     }
@@ -65,7 +65,7 @@ export class DropZoneComponent {
     event.stopPropagation();
     this.dragDepth = 0;
     this.isDragging = false;
-    if (this.disabled) return;
+    if (this.disabled()) return;
     const dt = event.dataTransfer;
     if (!dt) return;
 
@@ -90,7 +90,7 @@ export class DropZoneComponent {
 
     if (files.length === 0) return;
     // For single-file pickers, only emit the first dropped file.
-    if (!this.directory && !this.multiple) {
+    if (!this.directory() && !this.multiple()) {
       this.filesSelected.emit([files[0]]);
     } else {
       this.filesSelected.emit(files);

--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, ElementRef, HostListener, Input, signal } from '@angular/core';
+import { Component, ElementRef, HostListener, signal, inject, input } from '@angular/core';
 
 const HOVER_DELAY_MS = 500;
 
@@ -12,7 +12,7 @@ const HOVER_DELAY_MS = 500;
       class="field-hint-icon"
       tabindex="0"
       role="img"
-      [attr.aria-label]="ariaLabel || hint"
+      [attr.aria-label]="ariaLabel() || hint()"
       (mouseenter)="onMouseEnter()"
       (mouseleave)="onMouseLeave()"
       (focus)="onMouseEnter()"
@@ -32,7 +32,7 @@ const HOVER_DELAY_MS = 500;
         >?</text>
       </svg>
       @if (visible()) {
-        <span class="field-hint-tooltip" role="tooltip">{{ hint }}</span>
+        <span class="field-hint-tooltip" role="tooltip">{{ hint() }}</span>
       }
     </span>
     `,
@@ -80,13 +80,13 @@ const HOVER_DELAY_MS = 500;
   ],
 })
 export class FieldHintIconComponent {
-  @Input() hint = '';
-  @Input() ariaLabel = '';
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  readonly hint = input('');
+  readonly ariaLabel = input('');
 
   readonly visible = signal(false);
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(private readonly elementRef: ElementRef<HTMLElement>) {}
 
   onMouseEnter(): void {
     if (this.visible()) return;

--- a/frontend/src/app/components/file-browser/file-browser.component.html
+++ b/frontend/src/app/components/file-browser/file-browser.component.html
@@ -5,7 +5,7 @@
       class="form-input file-browser-input"
       [(ngModel)]="inputValue"
       (ngModelChange)="onInputChange()"
-      [placeholder]="placeholder"
+      [placeholder]="placeholder()"
       aria-label="File path"
     />
     <button

--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { map } from 'rxjs/operators';
@@ -24,17 +24,19 @@ import {
   styleUrl: './file-browser.component.scss',
 })
 export class FileBrowserComponent implements OnInit, OnChanges {
+  private fileBrowserApi = inject(FileBrowserApiService);
+
   /** Comma-separated extensions to filter files, e.g. ".csv,.json" */
-  @Input() extensions = '';
+  readonly extensions = input('');
 
   /** Current value (path): pre-populates the filename input. */
-  @Input() value = '';
+  readonly value = input('');
 
   /** Placeholder text for the manual input. */
-  @Input() placeholder = '';
+  readonly placeholder = input('');
 
   /** Emits the selected file path (relative to root). */
-  @Output() pathSelected = new EventEmitter<string>();
+  readonly pathSelected = output<string>();
 
   browserOpen = false;
 
@@ -44,7 +46,7 @@ export class FileBrowserComponent implements OnInit, OnChanges {
   /** Bound to the inner ``<vt-folder-browser>``.  Arrow function so
    *  ``this`` resolves correctly when the child component invokes it. */
   readonly browseFn: FolderBrowserBrowseFn = (path: string) =>
-    this.fileBrowserApi.browse(path, this.extensions).pipe(
+    this.fileBrowserApi.browse(path, this.extensions()).pipe(
       map((res) => ({
         directories: res.directories,
         files: res.files,
@@ -52,15 +54,13 @@ export class FileBrowserComponent implements OnInit, OnChanges {
       })),
     );
 
-  constructor(private fileBrowserApi: FileBrowserApiService) {}
-
   ngOnInit(): void {
-    this.inputValue = this.value;
+    this.inputValue = this.value();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['value']) {
-      this.inputValue = this.value;
+      this.inputValue = this.value();
     }
   }
 

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { combineLatest, Subject, Subscription } from 'rxjs';
@@ -45,6 +45,24 @@ import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/gr
   styleUrl: './find-view.component.scss',
 })
 export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
+  private mediasApi = inject(MediasApiService);
+  private detectorsFindApi = inject(DetectorsFindApiService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private toast = inject(ToastService);
+  private dialog = inject(VtDialogService);
+  private ngZone = inject(NgZone);
+  private activeContext = inject(ActiveContextService);
+  private datasetState = inject(DatasetStateService);
+  mediaState = inject(MediaStateService);
+  voteState = inject(VoteStateService);
+  sortState = inject(SortStateService);
+  private sortingApi = inject(SortingApiService);
+  private settingsState = inject(SettingsStateService);
+  private progressEvents = inject(ProgressEventsService);
+  private browseSubset = inject(BrowseSubsetService);
+  private router = inject(Router);
+
   @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
   @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
 
@@ -100,25 +118,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private boundRightMouseMove = this.onRightMouseMove.bind(this);
   private boundRightMouseUp = this.onRightMouseUp.bind(this);
 
-  constructor(
-    private mediasApi: MediasApiService,
-    private detectorsFindApi: DetectorsFindApiService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private toast: ToastService,
-    private dialog: VtDialogService,
-    private ngZone: NgZone,
-    private activeContext: ActiveContextService,
-    private datasetState: DatasetStateService,
-    public mediaState: MediaStateService,
-    public voteState: VoteStateService,
-    public sortState: SortStateService,
-    private sortingApi: SortingApiService,
-    private settingsState: SettingsStateService,
-    private progressEvents: ProgressEventsService,
-    private browseSubset: BrowseSubsetService,
-    private router: Router,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;

--- a/frontend/src/app/components/folder-browser/folder-browser.component.html
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.html
@@ -5,7 +5,7 @@
       class="vfb-crumb"
       [class.active]="!currentPath"
       (click)="navigateRoot()"
-    >{{ rootLabel }}</button>
+    >{{ rootLabel() }}</button>
     @for (crumb of breadcrumbs; track $index) {
       <span class="vfb-crumb-sep">/</span>
       <button
@@ -31,7 +31,7 @@
         (click)="setSort('name')"
         title="Sort by name"
       >Name <span class="vfb-sort-ind">{{ sortIndicator('name') }}</span></button>
-      @if (showDate) {
+      @if (showDate()) {
         <button
           type="button"
           class="vfb-col vfb-col-date"
@@ -39,7 +39,7 @@
           title="Sort by modified date"
         >Modified <span class="vfb-sort-ind">{{ sortIndicator('modified') }}</span></button>
       }
-      @if (showFiles && showSize) {
+      @if (showFiles() && showSize()) {
         <button
           type="button"
           class="vfb-col vfb-col-size"
@@ -66,7 +66,7 @@
         </button>
       }
       @if (rows.length === 0) {
-        <p class="vfb-empty">{{ emptyMessage || (showFiles ? 'Empty folder.' : 'No subdirectories.') }}</p>
+        <p class="vfb-empty">{{ emptyMessage() || (showFiles() ? 'Empty folder.' : 'No subdirectories.') }}</p>
       }
       @for (row of rows; track trackRow($index, row); let i = $index) {
         <button
@@ -75,7 +75,7 @@
           [class.vfb-row--dir]="row.kind === 'dir'"
           [class.vfb-row--file]="row.kind === 'file'"
           [class.vfb-row--selected]="i === selectedIndex"
-          [disabled]="busy && row.kind === 'file'"
+          [disabled]="busy() && row.kind === 'file'"
           (click)="selectRow(i)"
           (dblclick)="onRowDblClick(row)"
           [title]="row.path"
@@ -88,10 +88,10 @@
             }
           </span>
           <span class="vfb-name">{{ row.name }}</span>
-          @if (showDate) {
+          @if (showDate()) {
             <span class="vfb-date">{{ row.modified_at }}</span>
           }
-          @if (showFiles && showSize) {
+          @if (showFiles() && showSize()) {
             <span class="vfb-size">{{ row.kind === 'file' ? formatSize(row.size_bytes) : '' }}</span>
           }
         </button>
@@ -99,7 +99,7 @@
     }
   </div>
 
-  @if (showPathFooter && rootPath) {
+  @if (showPathFooter() && rootPath) {
     <div class="vfb-path-footer">
       <span class="vfb-path-label">Path:</span>
       <code class="vfb-path-value">{{ absolutePath }}</code>

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -3,15 +3,14 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
-  EventEmitter,
   HostListener,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
   ViewChild,
+  input,
+  output
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
@@ -80,52 +79,55 @@ const TYPEAHEAD_RESET_MS = 800;
 })
 export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
   /** Required: returns the listing for a given relative path. */
-  @Input({ required: true }) browse!: FolderBrowserBrowseFn;
+  readonly browse = input.required<FolderBrowserBrowseFn>();
 
   /** When false, only directories are rendered (the user is picking a
    *  folder, not a file inside it). */
-  @Input() showFiles = true;
+  readonly showFiles = input(true);
 
   /** Initial relative path to load.  Changes to this re-load the list. */
-  @Input() initialPath = '';
+  readonly initialPath = input('');
 
   /** Label for the root crumb.  Defaults to "Root". */
-  @Input() rootLabel = 'Root';
+  readonly rootLabel = input('Root');
 
   /** Show the absolute-path footer (only meaningful when the browse fn
    *  returns ``rootPath``). */
-  @Input() showPathFooter = false;
+  readonly showPathFooter = input(false);
 
   /** Show the modified-at column.  Defaults to true. */
-  @Input() showDate = true;
+  readonly showDate = input(true);
 
   /** Show the size column for files.  Defaults to true. */
-  @Input() showSize = true;
+  readonly showSize = input(true);
 
   /** When true, file rows show a wait cursor and ignore clicks (e.g. the
    *  caller is processing a previous confirm). */
-  @Input() busy = false;
+  readonly busy = input(false);
 
   /** Empty-state message shown when the listing is empty. */
-  @Input() emptyMessage = '';
+  readonly emptyMessage = input('');
 
   /** Whether to auto-focus the list on init so keyboard navigation works
    *  without an extra click.  Defaults to true. */
-  @Input() autoFocus = true;
+  readonly autoFocus = input(true);
 
   /** Fired whenever the displayed directory changes.  ``path`` is
    *  relative to the browse root; ``rootPath`` is the absolute server
    *  path if the backend exposes one (empty string otherwise). */
-  @Output() pathChange = new EventEmitter<{ path: string; rootPath: string }>();
+  readonly pathChange = output<{
+    path: string;
+    rootPath: string;
+}>();
 
   /** Fired when the user confirms a file (Enter on selected file, or
    *  double-click on a file).  Folders are never emitted; they
    *  navigate. */
-  @Output() confirm = new EventEmitter<FolderBrowserFileEntry>();
+  readonly confirm = output<FolderBrowserFileEntry>();
 
   /** Fired on browse() errors so the parent can surface them in its own
    *  way.  The component also shows an inline error message. */
-  @Output() loadError = new EventEmitter<unknown>();
+  readonly loadError = output<unknown>();
 
   rows: Row[] = [];
   currentPath = '';
@@ -143,11 +145,11 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
   @ViewChild('listEl') listEl?: ElementRef<HTMLDivElement>;
 
   ngOnInit(): void {
-    this.loadDirectory(this.initialPath || '');
+    this.loadDirectory(this.initialPath() || '');
   }
 
   ngAfterViewInit(): void {
-    if (this.autoFocus) {
+    if (this.autoFocus()) {
       // Defer one tick so the list element is in the DOM.
       setTimeout(() => this.listEl?.nativeElement.focus(), 0);
     }
@@ -155,7 +157,7 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
 
   ngOnChanges(changes: SimpleChanges): void {
     if ('initialPath' in changes && !changes['initialPath'].firstChange) {
-      this.loadDirectory(this.initialPath || '');
+      this.loadDirectory(this.initialPath() || '');
     }
   }
 
@@ -172,10 +174,10 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
     this.loading = true;
     this.error = '';
     this.currentSub?.unsubscribe();
-    this.currentSub = this.browse(path).subscribe({
+    this.currentSub = this.browse()(path).subscribe({
       next: (res) => {
         const dirs = res.directories || [];
-        const files = this.showFiles ? res.files || [] : [];
+        const files = this.showFiles() ? res.files || [] : [];
         const rows: Row[] = [];
         for (const d of dirs) {
           rows.push({ kind: 'dir', name: d.name, path: d.path, modified_at: d.modified_at });
@@ -230,7 +232,7 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
   }
 
   enter(row: Row): void {
-    if (this.busy) return;
+    if (this.busy()) return;
     if (row.kind === 'dir') {
       this.loadDirectory(row.path);
     } else if (row.kind === 'file') {

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, OnChanges } from '@angular/core';
+import { ChangeDetectorRef, Component, OnChanges, inject, input } from '@angular/core';
 
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
@@ -79,7 +79,7 @@ const sanitizedCache = new Map<string, SafeHtml>();
   imports: [],
   template: `
     @if (svgHtml) {
-      <span class="vt-icon__svg" [style.width.px]="size" [style.height.px]="size" [innerHTML]="svgHtml"></span>
+      <span class="vt-icon__svg" [style.width.px]="size()" [style.height.px]="size()" [innerHTML]="svgHtml"></span>
     }
   `,
   styles: [`
@@ -103,22 +103,24 @@ const sanitizedCache = new Map<string, SafeHtml>();
   `],
 })
 export class IconComponent implements OnChanges {
-  @Input() icon = '';
-  @Input() size = 16;
+  private sanitizer = inject(DomSanitizer);
+  private cdr = inject(ChangeDetectorRef);
+
+  readonly icon = input('');
+  readonly size = input(16);
   /** Directly set the icon type, bypassing emoji mapping. */
-  @Input() type = '';
+  readonly type = input('');
 
   protected svgHtml: SafeHtml | null = null;
-
-  constructor(private sanitizer: DomSanitizer, private cdr: ChangeDetectorRef) {}
 
   ngOnChanges(): void {
     this.renderIcon();
   }
 
   get iconType(): string {
-    if (this.type) return this.type;
-    return emojiToType(this.icon);
+    const type = this.type();
+    if (type) return type;
+    return emojiToType(this.icon());
   }
 
   /** Non-empty if iconType is a single capital letter (A–Z). */

--- a/frontend/src/app/components/label-view/label-view-panel-state.service.ts
+++ b/frontend/src/app/components/label-view/label-view-panel-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
@@ -22,6 +22,8 @@ type FocusMode = 'click' | 'hover';
  */
 @Injectable()
 export class LabelViewPanelStateService {
+  private settingsState = inject(SettingsStateService);
+
   private viewModeLeftDict: Record<string, ViewMode> = {};
   private gridIconSizeLeftDict: Record<string, string> = {};
   private focusModeLeftDict: Record<string, FocusMode> = {};
@@ -30,8 +32,6 @@ export class LabelViewPanelStateService {
   private panelPxRightDict: Record<string, number> = {};
 
   private _currentMediaType = '';
-
-  constructor(private settingsState: SettingsStateService) {}
 
   setMediaType(mediaType: string): void {
     this._currentMediaType = mediaType;

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, effect, inject } from '@angular/core';
 
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -57,6 +57,23 @@ import { buildMediaContextMenuItems } from './media-context-menu-items';
   styleUrl: './label-view.component.scss',
 })
 export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
+  private sortingApi = inject(SortingApiService);
+  private detectorsFindApi = inject(DetectorsFindApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private mediasApi = inject(MediasApiService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private labelSession = inject(LabelSessionService);
+  mediaState = inject(MediaStateService);
+  voteState = inject(VoteStateService);
+  sortState = inject(SortStateService);
+  private settingsState = inject(SettingsStateService);
+  private autopilotStateService = inject(AutopilotStateService);
+  private activeContext = inject(ActiveContextService);
+  private progressEvents = inject(ProgressEventsService);
+  private newThingFlows = inject(NewThingFlowsService);
+  private toast = inject(ToastService);
+  panelState = inject(LabelViewPanelStateService);
+
   @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
   @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
 
@@ -114,24 +131,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private autopilotTextSortPending = false;
   private autopilotMediaSortPending = false;
 
-  constructor(
-    private sortingApi: SortingApiService,
-    private detectorsFindApi: DetectorsFindApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private mediasApi: MediasApiService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private labelSession: LabelSessionService,
-    public mediaState: MediaStateService,
-    public voteState: VoteStateService,
-    public sortState: SortStateService,
-    private settingsState: SettingsStateService,
-    private autopilotStateService: AutopilotStateService,
-    private activeContext: ActiveContextService,
-    private progressEvents: ProgressEventsService,
-    private newThingFlows: NewThingFlowsService,
-    private toast: ToastService,
-    public panelState: LabelViewPanelStateService,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;

--- a/frontend/src/app/components/label-view/panel-resize.directive.ts
+++ b/frontend/src/app/components/label-view/panel-resize.directive.ts
@@ -1,14 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  HostListener,
-  Input,
-  NgZone,
-  OnDestroy,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, HostBinding, HostListener, NgZone, OnDestroy, inject, input, output } from '@angular/core';
 
 /**
  * Handles a vertical-divider drag for a flanking panel inside `vt-label-view`.
@@ -39,23 +29,24 @@ import {
   standalone: true,
 })
 export class PanelResizeDirective implements OnDestroy {
-  @Input('vtPanelResize') side: 'left' | 'right' = 'left';
-  @Input({ required: true }) layoutEl!: HTMLElement;
-  @Input() minWidth = 100;
-  @Input() opposingWidth = 0;
-  @Input() centerMin = 100;
-  @Input() dividerTotal = 16;
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private ngZone = inject(NgZone);
 
-  @Output() widthChange = new EventEmitter<number>();
-  @Output() resizeEnd = new EventEmitter<number>();
+  readonly side = input<'left' | 'right'>('left', { alias: "vtPanelResize" });
+  readonly layoutEl = input.required<HTMLElement>();
+  readonly minWidth = input(100);
+  readonly opposingWidth = input(0);
+  readonly centerMin = input(100);
+  readonly dividerTotal = input(16);
+
+  readonly widthChange = output<number>();
+  readonly resizeEnd = output<number>();
 
   @HostBinding('class.dragging') dragging = false;
 
   private boundMove = this.onMouseMove.bind(this);
   private boundUp = this.onMouseUp.bind(this);
   private lastWidth = 0;
-
-  constructor(private host: ElementRef<HTMLElement>, private ngZone: NgZone) {}
 
   @HostListener('mousedown', ['$event'])
   onMouseDown(event: MouseEvent): void {
@@ -74,10 +65,10 @@ export class PanelResizeDirective implements OnDestroy {
 
   private onMouseMove(event: MouseEvent): void {
     if (!this.dragging) return;
-    const rect = this.layoutEl.getBoundingClientRect();
-    const raw = this.side === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
-    const max = rect.width - this.dividerTotal - this.centerMin - this.opposingWidth;
-    const width = Math.max(this.minWidth, Math.min(max, raw));
+    const rect = this.layoutEl().getBoundingClientRect();
+    const raw = this.side() === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
+    const max = rect.width - this.dividerTotal() - this.centerMin() - this.opposingWidth();
+    const width = Math.max(this.minWidth(), Math.min(max, raw));
     this.lastWidth = width;
     this.ngZone.run(() => this.widthChange.emit(width));
   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -1,5 +1,5 @@
-<div class="autopilot-panel" [class.collapsed]="collapsed">
-  @if (collapsed) {
+<div class="autopilot-panel" [class.collapsed]="collapsed()">
+  @if (collapsed()) {
     <div class="collapsed-steps">
       <button class="collapse-toggle" (click)="toggleCollapse.emit()" title="Show autopilot panel" aria-label="Show autopilot panel">&#9654;</button>
       @for (step of steps; track step.phase) {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
 
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
@@ -37,6 +37,9 @@ export interface StepDisplay {
   styleUrl: './autopilot-panel.component.scss',
 })
 export class AutopilotPanelComponent implements OnInit, OnChanges {
+  autopilotState = inject(AutopilotStateService);
+  private toastService = inject(ToastService);
+
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   /**
@@ -48,19 +51,14 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Input() labelsetGoodCount = 0;
   @Input() labelsetBadCount = 0;
   @Input() labelingStatus: LabelingStatusResponse | null = null;
-  @Input() collapsed = false;
+  readonly collapsed = input(false);
 
-  @Output() started = new EventEmitter<void>();
-  @Output() stopped = new EventEmitter<void>();
-  @Output() toggleCollapse = new EventEmitter<void>();
-  @Output() refocus = new EventEmitter<void>();
+  readonly started = output<void>();
+  readonly stopped = output<void>();
+  readonly toggleCollapse = output<void>();
+  readonly refocus = output<void>();
 
   private completionAlerted = false;
-
-  constructor(
-    public autopilotState: AutopilotStateService,
-    private toastService: ToastService,
-  ) {}
 
   get state(): AutopilotState {
     return this.autopilotState.state;

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
@@ -8,7 +8,7 @@
     min="-10"
     max="10"
     step="1"
-    [value]="value"
+    [value]="value()"
     (input)="onInput($event)"
     title="Adjust inclusion bias. Positive favors recall, negative favors precision."
     aria-label="Inclusion"

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.spec.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.spec.ts
@@ -20,7 +20,7 @@ describe('InclusionSliderComponent', () => {
   });
 
   it('should default to 0', () => {
-    expect(component.value).toBe(0);
+    expect(component.value()).toBe(0);
   });
 
   it('should emit valueChange on input', () => {

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 
 
 @Component({
@@ -9,9 +9,9 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
   styleUrl: './inclusion-slider.component.scss',
 })
 export class InclusionSliderComponent {
-  @Input() value = 0;
+  readonly value = input(0);
 
-  @Output() valueChange = new EventEmitter<number>();
+  readonly valueChange = output<number>();
 
   onInput(event: Event): void {
     const target = event.target as HTMLInputElement;

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,8 +1,8 @@
-<div class="left-panel" [class.collapsed-autopilot]="panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed" [class.disabled]="disabled">
-  @if (datasetName && !(panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed)) {
+<div class="left-panel" [class.collapsed-autopilot]="panelMode() === 'label' && activeTab === 'autopilot' && autopilotCollapsed()" [class.disabled]="disabled()">
+  @if (datasetName && !(panelMode() === 'label' && activeTab === 'autopilot' && autopilotCollapsed())) {
     <div class="dataset-name" [title]="datasetName">{{ datasetName }}</div>
   }
-  @if (panelMode === 'find') {
+  @if (panelMode() === 'find') {
     <!-- Find mode: simplified view (inclusion control, media list header, media items, and stripe). -->
     <div class="tab-panel-manual" role="region" aria-label="Find results">
       <!-- Inclusion cutoff plus the unverified-positives work-queue actions
@@ -11,13 +11,13 @@
            acted on yet. -->
       <div class="find-inclusion-row">
         <vt-inclusion-slider
-          [value]="inclusion"
+          [value]="inclusion()"
           (valueChange)="inclusionChange.emit($event)"
         />
         <div class="goods-actions find-queue-actions">
           <button
             class="goods-action-btn"
-            [disabled]="disabled || unverifiedGoodCount === 0"
+            [disabled]="disabled() || unverifiedGoodCount === 0"
             (click)="browse.emit()"
             aria-label="Browse unverified positives"
             title="Browse the unverified positives (above-threshold items you haven't acted on) as their own 2-D UMAP projection"
@@ -29,7 +29,7 @@
           </button>
           <button
             class="goods-action-btn"
-            [disabled]="disabled || unverifiedGoodCount === 0"
+            [disabled]="disabled() || unverifiedGoodCount === 0"
             (click)="toDataset.emit()"
             aria-label="Unverified positives to dataset"
             title="Promote the unverified positives (above-threshold items you haven't acted on) into their own dataset"
@@ -38,7 +38,7 @@
           </button>
           <button
             class="goods-action-btn"
-            [disabled]="disabled || unverifiedGoodCount === 0"
+            [disabled]="disabled() || unverifiedGoodCount === 0"
             (click)="unverifiedExport.emit()"
             aria-label="Export unverified positives"
             title="Export the unverified positives (above-threshold items you haven't acted on) — e.g. to re-import as a dataset"
@@ -54,7 +54,7 @@
 
       <div class="images-header">
         <h3 class="images-header-title">
-          {{ mediaTypeName }}s ({{ (sortOrder?.length ?? medias.length) | number }})
+          {{ mediaTypeName }}s ({{ (sortOrder()?.length ?? medias.length) | number }})
         </h3>
         <vt-view-controls
           side="left"
@@ -67,9 +67,9 @@
         <vt-progress-indicators
           [labelingStatus]="null"
           [sortBusy]="sortBusy"
-          [sortStatus]="sortStatus"
-          [sortProgress]="sortProgress"
-          [sortProgressTotal]="sortProgressTotal"
+          [sortStatus]="sortStatus()"
+          [sortProgress]="sortProgress()"
+          [sortProgressTotal]="sortProgressTotal()"
           (cancel)="sortCancel.emit()"
         />
       }
@@ -77,24 +77,24 @@
       <div class="media-list-container">
         <vt-media-list
           [medias]="medias"
-          [sortOrder]="sortOrder"
-          [threshold]="threshold"
-          [selectedId]="selectedId"
-          [goodVotes]="goodVotes"
-          [badVotes]="badVotes"
-          [viewMode]="viewMode"
-          [gridGoalWidth]="gridGoalWidth"
-          [focusMode]="focusMode"
+          [sortOrder]="sortOrder()"
+          [threshold]="threshold()"
+          [selectedId]="selectedId()"
+          [goodVotes]="goodVotes()"
+          [badVotes]="badVotes()"
+          [viewMode]="viewMode()"
+          [gridGoalWidth]="gridGoalWidth()"
+          [focusMode]="focusMode()"
           [showScores]="false"
           (mediaSelect)="mediaSelect.emit($event)"
           (mediaVote)="mediaVote.emit($event)"
         />
         <vt-stripe-overview
-          [sortOrder]="sortOrder"
-          [threshold]="threshold"
-          [selectedId]="selectedId"
-          [goodVotes]="goodVotes"
-          [badVotes]="badVotes"
+          [sortOrder]="sortOrder()"
+          [threshold]="threshold()"
+          [selectedId]="selectedId()"
+          [goodVotes]="goodVotes()"
+          [badVotes]="badVotes()"
           [totalCount]="medias.length"
           (stripeClick)="onStripeClick($event)"
         />
@@ -102,7 +102,7 @@
     </div>
   } @else {
     <!-- Label mode: full labeling UI with tabs -->
-    @if (!(activeTab === 'autopilot' && autopilotCollapsed)) {
+    @if (!(activeTab === 'autopilot' && autopilotCollapsed())) {
       <div class="left-tabs" role="tablist" aria-label="Panel mode">
         <button
           class="left-tab"
@@ -126,10 +126,10 @@
     @if (activeTab === 'manual') {
       <div class="tab-panel-manual" role="tabpanel" aria-label="Manual mode">
         <vt-sort-bar
-          [sortMode]="sortMode"
-          [loadSortLabel]="loadSortLabel"
-          [initialTextQuery]="textQuery"
-          [learnedSortAvailable]="learnedSortAvailable"
+          [sortMode]="sortMode()"
+          [loadSortLabel]="loadSortLabel()"
+          [initialTextQuery]="textQuery()"
+          [learnedSortAvailable]="learnedSortAvailable()"
           [textSortAvailable]="textSortAvailable"
           (sortModeChange)="sortModeChange.emit($event)"
           (textSort)="textSort.emit($event)"
@@ -140,22 +140,22 @@
         />
 
         <vt-select-mode
-          [selectMode]="selectMode"
+          [selectMode]="selectMode()"
           (selectModeChange)="selectModeChange.emit($event)"
         />
 
         <vt-progress-indicators
-          [labelingStatus]="labelingStatus"
+          [labelingStatus]="labelingStatus()"
           [sortBusy]="sortBusy"
-          [sortStatus]="sortStatus"
-          [sortProgress]="sortProgress"
-          [sortProgressTotal]="sortProgressTotal"
+          [sortStatus]="sortStatus()"
+          [sortProgress]="sortProgress()"
+          [sortProgressTotal]="sortProgressTotal()"
           (indicatorClick)="indicatorClick.emit($event)"
           (cancel)="sortCancel.emit()"
         />
 
         <vt-inclusion-slider
-          [value]="inclusion"
+          [value]="inclusion()"
           (valueChange)="inclusionChange.emit($event)"
         />
 
@@ -174,39 +174,39 @@
         <div class="media-list-container">
           <vt-media-list
             [medias]="medias"
-            [sortOrder]="sortOrder"
-            [threshold]="threshold"
-            [selectedId]="selectedId"
-            [goodVotes]="goodVotes"
-            [badVotes]="badVotes"
-            [viewMode]="viewMode"
-            [gridGoalWidth]="gridGoalWidth"
-            [focusMode]="focusMode"
+            [sortOrder]="sortOrder()"
+            [threshold]="threshold()"
+            [selectedId]="selectedId()"
+            [goodVotes]="goodVotes()"
+            [badVotes]="badVotes()"
+            [viewMode]="viewMode()"
+            [gridGoalWidth]="gridGoalWidth()"
+            [focusMode]="focusMode()"
             [showScores]="false"
             (mediaSelect)="mediaSelect.emit($event)"
             (mediaVote)="mediaVote.emit($event)"
             (mediaContextRequest)="mediaContextRequest.emit($event)"
           />
           <vt-stripe-overview
-            [sortOrder]="sortOrder"
-            [threshold]="threshold"
-            [selectedId]="selectedId"
-            [goodVotes]="goodVotes"
-            [badVotes]="badVotes"
+            [sortOrder]="sortOrder()"
+            [threshold]="threshold()"
+            [selectedId]="selectedId()"
+            [goodVotes]="goodVotes()"
+            [badVotes]="badVotes()"
             [totalCount]="medias.length"
             (stripeClick)="onStripeClick($event)"
           />
         </div>
       </div>
     } @else {
-      <div class="tab-panel-autopilot" [class.collapsed]="autopilotCollapsed" role="tabpanel" aria-label="Autopilot mode">
+      <div class="tab-panel-autopilot" [class.collapsed]="autopilotCollapsed()" role="tabpanel" aria-label="Autopilot mode">
         <vt-autopilot-panel
-          [goodVotes]="goodVotes"
-          [badVotes]="badVotes"
-          [labelsetGoodCount]="labelsetGoodCount"
-          [labelsetBadCount]="labelsetBadCount"
-          [labelingStatus]="labelingStatus"
-          [collapsed]="autopilotCollapsed"
+          [goodVotes]="goodVotes()"
+          [badVotes]="badVotes()"
+          [labelsetGoodCount]="labelsetGoodCount()"
+          [labelsetBadCount]="labelsetBadCount()"
+          [labelingStatus]="labelingStatus()"
+          [collapsed]="autopilotCollapsed()"
           (started)="autopilotStart.emit()"
           (stopped)="autopilotStop.emit()"
           (toggleCollapse)="autopilotToggleCollapse.emit()"

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,8 +1,6 @@
 import {
   Component,
   Input,
-  Output,
-  EventEmitter,
   OnInit,
   OnChanges,
   SimpleChanges,
@@ -10,6 +8,8 @@ import {
   computed,
   effect,
   inject,
+  input,
+  output
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -49,68 +49,75 @@ export type { SortMode, SelectMode, SortedItem };
 })
 export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() medias: Media[] = [];
-  @Input() sortOrder: SortedItem[] | null = null;
-  @Input() threshold: number | null = null;
-  @Input() selectedId: number | null = null;
-  @Input() goodVotes: Set<number> = new Set();
-  @Input() badVotes: Set<number> = new Set();
+  readonly sortOrder = input<SortedItem[] | null>(null);
+  readonly threshold = input<number | null>(null);
+  readonly selectedId = input<number | null>(null);
+  readonly goodVotes = input<Set<number>>(new Set());
+  readonly badVotes = input<Set<number>>(new Set());
   /**
    * True when the active detector (or active votes, when no detector is
    * loaded) has at least one good and one bad label.  Used to gate "Sort by
    * Learned"; distinct from ``goodVotes`` / ``badVotes`` because those Sets
    * only contain media IDs in the *currently loaded* dataset.
    */
-  @Input() learnedSortAvailable = false;
+  readonly learnedSortAvailable = input(false);
   /** Active detector's saved labelset counts (across all datasets). */
-  @Input() labelsetGoodCount = 0;
-  @Input() labelsetBadCount = 0;
-  @Input() sortMode: SortMode = 'text';
-  @Input() selectMode: SelectMode = 'top';
-  @Input() inclusion: number = 0;
+  readonly labelsetGoodCount = input(0);
+  readonly labelsetBadCount = input(0);
+  readonly sortMode = input<SortMode>('text');
+  readonly selectMode = input<SelectMode>('top');
+  readonly inclusion = input<number>(0);
   @Input() sortBusy = false;
-  @Input() sortStatus = '';
-  @Input() sortProgress = 0;
-  @Input() sortProgressTotal = 0;
-  @Input() labelingStatus: LabelingStatusResponse | null = null;
-  @Input() viewMode: 'grid' | 'list' = 'list';
-  @Input() gridGoalWidth: number = 80;
-  @Input() focusMode: 'click' | 'hover' = 'click';
-  @Input() loadSortLabel = '';
-  @Input() textQuery = '';
-  @Input() autopilotCollapsed = false;
+  readonly sortStatus = input('');
+  readonly sortProgress = input(0);
+  readonly sortProgressTotal = input(0);
+  readonly labelingStatus = input<LabelingStatusResponse | null>(null);
+  readonly viewMode = input<'grid' | 'list'>('list');
+  readonly gridGoalWidth = input<number>(80);
+  readonly focusMode = input<'click' | 'hover'>('click');
+  readonly loadSortLabel = input('');
+  readonly textQuery = input('');
+  readonly autopilotCollapsed = input(false);
   @Input() autopilotEnabled = true;
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
-  @Input() panelMode: 'label' | 'find' = 'label';
+  readonly panelMode = input<'label' | 'find'>('label');
   /** Disable all interaction (used during Find scoring). */
-  @Input() disabled = false;
+  readonly disabled = input(false);
   /** Display name of the current dataset. */
   @Input() datasetName = '';
 
-  @Output() sortModeChange = new EventEmitter<SortMode>();
-  @Output() selectModeChange = new EventEmitter<SelectMode>();
-  @Output() inclusionChange = new EventEmitter<number>();
-  @Output() textSort = new EventEmitter<string>();
-  @Output() learnedSort = new EventEmitter<void>();
-  @Output() loadSort = new EventEmitter<void>();
-  @Output() modelSelected = new EventEmitter<string>();
-  @Output() exampleSortStarted = new EventEmitter<unknown>();
-  @Output() mediaSelect = new EventEmitter<number>();
-  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
-  @Output() mediaContextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
-  @Output() indicatorClick = new EventEmitter<string>();
+  readonly sortModeChange = output<SortMode>();
+  readonly selectModeChange = output<SelectMode>();
+  readonly inclusionChange = output<number>();
+  readonly textSort = output<string>();
+  readonly learnedSort = output<void>();
+  readonly loadSort = output<void>();
+  readonly modelSelected = output<string>();
+  readonly exampleSortStarted = output<unknown>();
+  readonly mediaSelect = output<number>();
+  readonly mediaVote = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
+  readonly mediaContextRequest = output<{
+    id: number;
+    x: number;
+    y: number;
+}>();
+  readonly indicatorClick = output<string>();
   /** User clicked the Cancel button on the running sort progress bar. */
-  @Output() sortCancel = new EventEmitter<void>();
+  readonly sortCancel = output<void>();
   /** Find mode: browse the unverified positives as their own UMAP projection. */
-  @Output() browse = new EventEmitter<void>();
+  readonly browse = output<void>();
   /** Find mode: promote the unverified positives into their own dataset. */
-  @Output() toDataset = new EventEmitter<void>();
+  readonly toDataset = output<void>();
   /** Find mode: export the unverified positives (above-threshold work queue). */
-  @Output() unverifiedExport = new EventEmitter<void>();
-  @Output() autopilotStart = new EventEmitter<void>();
-  @Output() autopilotStop = new EventEmitter<void>();
-  @Output() autopilotRefocus = new EventEmitter<void>();
-  @Output() autopilotToggleCollapse = new EventEmitter<void>();
-  @Output() autopilotEnabledChange = new EventEmitter<boolean>();
+  readonly unverifiedExport = output<void>();
+  readonly autopilotStart = output<void>();
+  readonly autopilotStop = output<void>();
+  readonly autopilotRefocus = output<void>();
+  readonly autopilotToggleCollapse = output<void>();
+  readonly autopilotEnabledChange = output<boolean>();
 
   @ViewChild(MediaListComponent) mediaListComponent!: MediaListComponent;
 
@@ -152,7 +159,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   ngOnInit(): void {
-    if (this.panelMode === 'find') {
+    if (this.panelMode() === 'find') {
       // Find mode doesn't use tabs; keep manual as a no-op default
       this.activeTab = 'manual';
     } else {
@@ -212,9 +219,10 @@ export class LeftPanelComponent implements OnInit, OnChanges {
    * Browse / To Dataset / Export all operate on exactly this set.
    */
   get unverifiedGoodCount(): number {
-    const order = this.sortOrder;
-    if (!order || this.threshold == null) return 0;
-    const cutoff = this.threshold;
+    const order = this.sortOrder();
+    const threshold = this.threshold();
+    if (!order || threshold == null) return 0;
+    const cutoff = threshold;
     let n = 0;
     for (const item of order) {
       if (item.score >= cutoff) n++;

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -11,21 +11,28 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './media-item.component.scss',
 })
 export class MediaItemComponent implements OnChanges {
+  private activeContext = inject(ActiveContextService);
+
   @Input({ required: true }) media!: Media;
   @Input() active = false;
   @Input() voteLabel: 'good' | 'bad' | null = null;
   @Input() score: number | null = null;
   @Input() viewMode: 'grid' | 'list' = 'list';
-  @Input() focusMode: 'click' | 'hover' = 'click';
+  readonly focusMode = input<'click' | 'hover'>('click');
 
-  @Output() select = new EventEmitter<number>();
-  @Output() vote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
-  @Output() contextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
+  readonly select = output<number>();
+  readonly vote = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
+  readonly contextRequest = output<{
+    id: number;
+    x: number;
+    y: number;
+}>();
 
   thumbnailFailed = false;
   private lastMediaId: number | null = null;
-
-  constructor(private activeContext: ActiveContextService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media.id !== this.lastMediaId) {
@@ -67,7 +74,7 @@ export class MediaItemComponent implements OnChanges {
   }
 
   onClick(): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.vote.emit({ id: this.media.id, vote: 'bad' });
     } else {
       this.select.emit(this.media.id);
@@ -75,7 +82,7 @@ export class MediaItemComponent implements OnChanges {
   }
 
   onContextMenu(event: MouseEvent): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       // Hover mode keeps the existing right-click = vote-good shortcut; the
       // context menu is intentionally not available so speed-labeling stays
       // fast. Users can still seed a detector via the dashboard.
@@ -88,7 +95,7 @@ export class MediaItemComponent implements OnChanges {
   }
 
   onMouseEnter(): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.select.emit(this.media.id);
     }
   }

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -1,13 +1,13 @@
 @if (showSkeletons) {
   <div
     class="media-list media-list-skeleton"
-    [class.grid-layout]="viewMode === 'grid'"
-    [style.--grid-goal-width]="gridGoalWidth + 'px'"
+    [class.grid-layout]="viewMode() === 'grid'"
+    [style.--grid-goal-width]="gridGoalWidth() + 'px'"
     aria-busy="true"
     aria-label="Loading media"
   >
     @for (_ of skeletonPlaceholders; track $index) {
-      @if (viewMode === 'grid') {
+      @if (viewMode() === 'grid') {
         <div class="media-skeleton-card">
           <vt-skeleton width="100%" height="100%" />
         </div>
@@ -30,11 +30,11 @@
       }
       <vt-media-item
         [media]="item.media"
-        [active]="selectedId === item.media.id"
+        [active]="selectedId() === item.media.id"
         [voteLabel]="getVoteLabel(item.media.id)"
         [score]="item.score"
-        [viewMode]="viewMode"
-        [focusMode]="focusMode"
+        [viewMode]="viewMode()"
+        [focusMode]="focusMode()"
         (select)="onMediaSelect($event)"
         (vote)="onMediaVote($event)"
         (contextRequest)="onMediaContextRequest($event)"
@@ -44,12 +44,12 @@
 } @else if (useGridVirtual) {
   <!-- Virtual scrolling for large galleries: cards are chunked into rows so
        only the visible rows are mounted, instead of every thumbnail at once. -->
-  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual" [style.--grid-goal-width]="gridGoalWidth + 'px'">
+  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual" [style.--grid-goal-width]="gridGoalWidth() + 'px'">
     <div
       class="grid-virtual-row"
       *cdkVirtualFor="let row of gridRows; trackBy: trackByGridRow"
       [style.height.px]="gridRowHeight"
-      [style.--grid-goal-width]="gridGoalWidth + 'px'"
+      [style.--grid-goal-width]="gridGoalWidth() + 'px'"
       [style.grid-template-columns]="row.kind === 'threshold' ? null : 'repeat(' + gridColumns + ', var(--grid-goal-width, 80px))'"
     >
       @if (row.kind === 'threshold') {
@@ -60,11 +60,11 @@
         @for (item of row.items; track trackByMediaId($index, item)) {
           <vt-media-item
             [media]="item.media"
-            [active]="selectedId === item.media.id"
+            [active]="selectedId() === item.media.id"
             [voteLabel]="getVoteLabel(item.media.id)"
             [score]="item.score"
-            [viewMode]="viewMode"
-            [focusMode]="focusMode"
+            [viewMode]="viewMode()"
+            [focusMode]="focusMode()"
             (select)="onMediaSelect($event)"
             (vote)="onMediaVote($event)"
             (contextRequest)="onMediaContextRequest($event)"
@@ -75,7 +75,7 @@
   </cdk-virtual-scroll-viewport>
 } @else {
   <!-- Plain DOM rendering for small datasets or grid mode -->
-  <div class="media-list" [class.grid-layout]="viewMode === 'grid'" [style.--grid-goal-width]="gridGoalWidth + 'px'" role="listbox" aria-label="Media items" #listContainer>
+  <div class="media-list" [class.grid-layout]="viewMode() === 'grid'" [style.--grid-goal-width]="gridGoalWidth() + 'px'" role="listbox" aria-label="Media items" #listContainer>
     @for (item of cachedOrderedItems; track trackByMediaId($index, item)) {
       @if (item.showThreshold) {
         <div class="media-threshold-line" title="Decision boundary between predicted good and bad items" aria-label="Good/Bad threshold">
@@ -84,11 +84,11 @@
       }
       <vt-media-item
         [media]="item.media"
-        [active]="selectedId === item.media.id"
+        [active]="selectedId() === item.media.id"
         [voteLabel]="getVoteLabel(item.media.id)"
         [score]="item.score"
-        [viewMode]="viewMode"
-        [focusMode]="focusMode"
+        [viewMode]="viewMode()"
+        [focusMode]="focusMode()"
         (select)="onMediaSelect($event)"
         (vote)="onMediaVote($event)"
         (contextRequest)="onMediaContextRequest($event)"

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -1,19 +1,4 @@
-import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  ElementRef,
-  ViewChild,
-  AfterViewChecked,
-  ChangeDetectorRef,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  SimpleChanges,
-  effect,
-} from '@angular/core';
+import { Component, Input, ElementRef, ViewChild, AfterViewChecked, ChangeDetectorRef, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, effect, inject, input, output } from '@angular/core';
 
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subject } from 'rxjs';
@@ -77,20 +62,32 @@ type GridRow = { kind: 'items'; items: OrderedItem[] } | { kind: 'threshold' };
   styleUrl: './media-list.component.scss',
 })
 export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
+  private metadataCache = inject(MediaMetadataCacheService);
+  private mediaState = inject(MediaStateService);
+  private cdr = inject(ChangeDetectorRef);
+  private zone = inject(NgZone);
+
   @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
-  @Input() selectedId: number | null = null;
+  readonly selectedId = input<number | null>(null);
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
-  @Input() viewMode: 'grid' | 'list' = 'list';
-  @Input() gridGoalWidth: number = 80;
-  @Input() focusMode: 'click' | 'hover' = 'click';
-  @Input() showScores = true;
+  readonly viewMode = input<'grid' | 'list'>('list');
+  readonly gridGoalWidth = input<number>(80);
+  readonly focusMode = input<'click' | 'hover'>('click');
+  readonly showScores = input(true);
 
-  @Output() mediaSelect = new EventEmitter<number>();
-  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
-  @Output() mediaContextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
+  readonly mediaSelect = output<number>();
+  readonly mediaVote = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
+  readonly mediaContextRequest = output<{
+    id: number;
+    x: number;
+    y: number;
+}>();
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
   @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
 
@@ -120,12 +117,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   loadingMedias = false;
   readonly skeletonPlaceholders = Array.from({ length: 12 });
 
-  constructor(
-    private metadataCache: MediaMetadataCacheService,
-    private mediaState: MediaStateService,
-    private cdr: ChangeDetectorRef,
-    private zone: NgZone,
-  ) {
+  constructor() {
     effect(() => {
       this.loadingMedias = this.mediaState.isLoading();
     });
@@ -151,12 +143,12 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   /** Whether list mode is virtualizing (many lightweight rows). */
   get useListVirtual(): boolean {
-    return this.viewMode === 'list' && this.cachedOrderedItems.length > VIRTUAL_SCROLL_THRESHOLD;
+    return this.viewMode() === 'list' && this.cachedOrderedItems.length > VIRTUAL_SCROLL_THRESHOLD;
   }
 
   /** Whether grid mode is virtualizing (many heavy thumbnail cards). */
   get useGridVirtual(): boolean {
-    return this.viewMode === 'grid' && this.cachedOrderedItems.length > GRID_VIRTUAL_THRESHOLD;
+    return this.viewMode() === 'grid' && this.cachedOrderedItems.length > GRID_VIRTUAL_THRESHOLD;
   }
 
   /**
@@ -225,7 +217,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
         items.push({
           media,
-          score: this.showScores ? sorted.score : null,
+          score: this.showScores() ? sorted.score : null,
           showThreshold,
         });
       }
@@ -250,7 +242,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
    * same stride so CDK's fixed-size strategy scrolls accurately.
    */
   private rebuildGridRows(): void {
-    if (this.viewMode !== 'grid') {
+    if (this.viewMode() !== 'grid') {
       this.gridRows = [];
       return;
     }
@@ -284,7 +276,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     if (!el) return false;
     const inner = el.clientWidth - 2 * GRID_GAP_PX;
     if (inner <= 0) return false;
-    const cols = Math.max(1, Math.floor((inner + GRID_GAP_PX) / (this.gridGoalWidth + GRID_GAP_PX)));
+    const cols = Math.max(1, Math.floor((inner + GRID_GAP_PX) / (this.gridGoalWidth() + GRID_GAP_PX)));
     if (cols === this.gridColumns) return false;
     this.gridColumns = cols;
     return true;
@@ -336,7 +328,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
       if (this.useVirtualScroll && this.virtualViewport) {
         // In virtual-scroll mode, find the index and scroll to it.  Grid items
         // are chunked into rows, so map the item index to its row first.
-        const idx = this.cachedOrderedItems.findIndex((i) => i.media.id === this.selectedId);
+        const idx = this.cachedOrderedItems.findIndex((i) => i.media.id === this.selectedId());
         if (idx >= 0) {
           const target = this.useGridVirtual ? this.itemIndexToRow(idx) : idx;
           this.virtualViewport.scrollToIndex(target, behavior);

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -6,8 +6,8 @@
       }
       <vt-progress-bar
         [indeterminate]="isIndeterminate"
-        [value]="sortProgress"
-        [max]="sortProgressTotal"
+        [value]="sortProgress()"
+        [max]="sortProgressTotal()"
       />
       <button
         class="btn btn--cancel btn--sm"

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, input, output } from '@angular/core';
 
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
@@ -14,18 +14,18 @@ export class ProgressIndicatorsComponent {
   @Input() labelingStatus: LabelingStatusResponse | null = null;
   @Input() sortBusy = false;
   @Input() sortStatus = '';
-  @Input() sortProgress = 0;
-  @Input() sortProgressTotal = 0;
+  readonly sortProgress = input(0);
+  readonly sortProgressTotal = input(0);
 
-  @Output() indicatorClick = new EventEmitter<string>();
-  @Output() cancel = new EventEmitter<void>();
+  readonly indicatorClick = output<string>();
+  readonly cancel = output<void>();
 
   onCancel(): void {
     this.cancel.emit();
   }
 
   get isIndeterminate(): boolean {
-    return this.sortProgressTotal <= 0;
+    return this.sortProgressTotal() <= 0;
   }
 
   get smartStatus(): string {

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, output } from '@angular/core';
 
 import { SelectMode } from '../left-panel.component';
 
@@ -12,7 +12,7 @@ import { SelectMode } from '../left-panel.component';
 export class SelectModeComponent {
   @Input() selectMode: SelectMode = 'top';
 
-  @Output() selectModeChange = new EventEmitter<SelectMode>();
+  readonly selectModeChange = output<SelectMode>();
 
   onChange(mode: SelectMode): void {
     this.selectModeChange.emit(mode);

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, OnInit, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { SortMode } from '../left-panel.component';
@@ -14,7 +14,7 @@ import { LoadSortModalComponent } from '../../modals/load-sort-modal/load-sort-m
 export class SortBarComponent implements OnInit {
   @Input() sortMode: SortMode = 'text';
   @Input() loadSortLabel = '';
-  @Input() initialTextQuery = '';
+  readonly initialTextQuery = input('');
   /**
    * True when the active detector (or active votes, when no detector is
    * loaded) has at least one good and one bad label available for training.
@@ -26,21 +26,22 @@ export class SortBarComponent implements OnInit {
    * for vision-only encoders (DINOv3, Perception Encoder); disables the
    * "Text" sort radio so users can't try a search that will always fail.
    */
-  @Input() textSortAvailable = true;
+  readonly textSortAvailable = input(true);
 
-  @Output() sortModeChange = new EventEmitter<SortMode>();
-  @Output() textSort = new EventEmitter<string>();
-  @Output() learnedSort = new EventEmitter<void>();
-  @Output() loadSort = new EventEmitter<void>();
-  @Output() modelSelected = new EventEmitter<string>();
-  @Output() exampleSortStarted = new EventEmitter<unknown>();
+  readonly sortModeChange = output<SortMode>();
+  readonly textSort = output<string>();
+  readonly learnedSort = output<void>();
+  readonly loadSort = output<void>();
+  readonly modelSelected = output<string>();
+  readonly exampleSortStarted = output<unknown>();
 
   textQuery = '';
   showLoadSortModal = false;
 
   ngOnInit(): void {
-    if (this.initialTextQuery) {
-      this.textQuery = this.initialTextQuery;
+    const initialTextQuery = this.initialTextQuery();
+    if (initialTextQuery) {
+      this.textQuery = initialTextQuery;
     }
   }
 
@@ -69,7 +70,7 @@ export class SortBarComponent implements OnInit {
   }
 
   get textDisabled(): boolean {
-    return !this.textSortAvailable;
+    return !this.textSortAvailable();
   }
 
   get searchDisabled(): boolean {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, input, output } from '@angular/core';
 
 import { SortedItem } from '../left-panel.component';
 
@@ -15,8 +15,8 @@ export class StripeOverviewComponent implements OnChanges {
   @Input() selectedId: number | null = null;
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
-  @Input() totalCount = 0;
-  @Output() stripeClick = new EventEmitter<number>();
+  readonly totalCount = input(0);
+  readonly stripeClick = output<number>();
 
   /** Cached dots, rebuilt only when inputs change. */
   cachedDots: { top: number; type: 'good' | 'bad' | 'selected' }[] = [];

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, inject, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
@@ -11,13 +11,13 @@ import { AuthService } from '../../services/auth.service';
   styleUrl: './login.component.scss',
 })
 export class LoginComponent {
-  @Output() loggedIn = new EventEmitter<void>();
+  private auth = inject(AuthService);
+
+  readonly loggedIn = output<void>();
 
   username = '';
   error = '';
   busy = false;
-
-  constructor(private auth: AuthService) {}
 
   submit(): void {
     const name = this.username.trim();

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -1,16 +1,16 @@
-@if (open) {
+@if (open()) {
 <div
   class="modal-backdrop"
   (click)="onBackdropClick($event)"
   (keydown)="onKeydown($event)"
   role="dialog"
   aria-modal="true"
-  [attr.aria-label]="title"
+  [attr.aria-label]="title()"
   tabindex="-1"
 >
   <div class="modal-content">
     <div class="modal-header">
-      <h2>{{ title }}</h2>
+      <h2>{{ title() }}</h2>
       @if (showCloseButton) {
         <button class="modal-close" (click)="close()" title="Close" aria-label="Close">&times;</button>
       }

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input, input, output } from '@angular/core';
 
 @Component({
   selector: 'vt-modal',
@@ -7,10 +7,10 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   styleUrl: './modal.component.scss',
 })
 export class ModalComponent {
-  @Input() title = '';
-  @Input() open = false;
+  readonly title = input('');
+  readonly open = input(false);
   @Input() showCloseButton = true;
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   onBackdropClick(event: MouseEvent): void {
     if (event.target === event.currentTarget) {

--- a/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
+++ b/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { AchievementsTabComponent } from '../../achievements-tab/achievements-tab.component';
 
@@ -9,7 +9,7 @@ import { AchievementsTabComponent } from '../../achievements-tab/achievements-ta
   templateUrl: './achievements-modal.component.html',
 })
 export class AchievementsModalComponent {
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   close(): void {
     this.closed.emit();

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
@@ -1,20 +1,19 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, Input, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 
 @Component({
   selector: 'vt-autodetect-progress-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent, ProgressBarComponent],
+  imports: [ModalComponent, ProgressBarComponent],
   templateUrl: './autodetect-progress-modal.component.html',
   styleUrl: './autodetect-progress-modal.component.scss',
 })
 export class AutoDetectProgressModalComponent {
   @Input() progress = 0;
   @Input() statusText = 'Initializing...';
-  @Output() closed = new EventEmitter<void>();
-  @Output() cancelled = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly cancelled = output<void>();
 
   onCancel(): void {
     this.cancelled.emit();

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, inject, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -24,8 +24,10 @@ import type { ExporterEntry } from '../../../generated/api-client/models/exporte
   styleUrl: './autodetect-results-modal.component.scss',
 })
 export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
+  private exportersApi = inject(ExportersApiService);
+
   @Input() data: AutoDetectResultsData = { results: {} };
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   exportSides: 'good' | 'bad' | 'both' = 'good';
   exporters: ExporterEntry[] = [];
@@ -43,8 +45,6 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   ];
 
   private destroy$ = new Subject<void>();
-
-  constructor(private exportersApi: ExportersApiService) {}
 
   ngOnInit(): void {
     this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -1,4 +1,4 @@
-<vt-modal [open]="true" [title]="'Stats: ' + datasetName" (closed)="close()">
+<vt-modal [open]="true" [title]="'Stats: ' + datasetName()" (closed)="close()">
   @if (loading) {
     <p class="loading-text">Loading stats...</p>
   } @else if (error) {

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, OnInit, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
@@ -13,18 +13,18 @@ import { formatTimestamp as formatTs } from '../../../utils/format-date';
   styleUrl: './dataset-stats-modal.component.scss',
 })
 export class DatasetStatsModalComponent implements OnInit {
-  @Input() datasetId = '';
-  @Input() datasetName = '';
-  @Output() closed = new EventEmitter<void>();
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+
+  readonly datasetId = input('');
+  readonly datasetName = input('');
+  readonly closed = output<void>();
 
   loading = true;
   error = '';
   stats: DatasetRegistryStatsResponse | null = null;
 
-  constructor(private datasetsRegistryApi: DatasetsRegistryApiService) {}
-
   ngOnInit(): void {
-    this.datasetsRegistryApi.getDatasetStats(this.datasetId).subscribe({
+    this.datasetsRegistryApi.getDatasetStats(this.datasetId()).subscribe({
       next: (data) => {
         this.stats = data;
         this.loading = false;

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
@@ -1,4 +1,4 @@
-<vt-modal [open]="true" [title]="'Stats: ' + detectorName" (closed)="close()">
+<vt-modal [open]="true" [title]="'Stats: ' + detectorName()" (closed)="close()">
   @if (loading) {
     <p class="loading-text">Loading stats...</p>
   } @else if (error) {

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, OnInit, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsRegistryApiService } from '../../../services/detectors-registry-api.service';
@@ -18,18 +18,18 @@ import { formatTimestamp as formatTs } from '../../../utils/format-date';
   styleUrl: './detector-stats-modal.component.scss',
 })
 export class DetectorStatsModalComponent implements OnInit {
-  @Input() detectorId = '';
-  @Input() detectorName = '';
-  @Output() closed = new EventEmitter<void>();
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+
+  readonly detectorId = input('');
+  readonly detectorName = input('');
+  readonly closed = output<void>();
 
   loading = true;
   error = '';
   stats: DetectorRegistryStatsResponse | null = null;
 
-  constructor(private detectorsRegistryApi: DetectorsRegistryApiService) {}
-
   ngOnInit(): void {
-    this.detectorsRegistryApi.getDetectorStats(this.detectorId).subscribe({
+    this.detectorsRegistryApi.getDetectorStats(this.detectorId()).subscribe({
       next: (data) => {
         this.stats = data;
         this.loading = false;

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -1,5 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, Input, OnDestroy, OnInit, inject, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
 
@@ -13,14 +12,16 @@ interface Example {
 @Component({
   selector: 'vt-examples-editor-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent],
+  imports: [ModalComponent],
   templateUrl: './examples-editor-modal.component.html',
   styleUrl: './examples-editor-modal.component.scss',
 })
 export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
+  private detectorsCrudApi = inject(DetectorsCrudApiService);
+
   @Input() modelName = '';
-  @Output() closed = new EventEmitter<void>();
-  @Output() saved = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly saved = output<void>();
 
   examples: Example[] = [];
   loading = true;
@@ -28,8 +29,6 @@ export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
   error = '';
   status = '';
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(private detectorsCrudApi: DetectorsCrudApiService) {}
 
   ngOnInit(): void {
     if (!this.modelName) {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -1,13 +1,12 @@
 import {
   Component,
-  EventEmitter,
-  Input,
   OnInit,
-  Output,
   computed,
   effect,
   inject,
   signal,
+  input,
+  output
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -50,16 +49,16 @@ export interface ColumnDef {
   styleUrl: './export-modal.component.scss',
 })
 export class ExportModalComponent implements OnInit {
-  @Input() detectorName = '';
+  readonly detectorName = input('');
   /**
    * The filter the modal opens on. ``unverified`` / ``verified`` are
    * server-side partitions (by Find ``verified_ids``) that can't be derived
    * client-side, so the modal fetches them with that ``label_filter``; the
    * other values are client-side category filters over the full fetched set.
    */
-  @Input() initialFilter: LabelFilter = 'good';
-  @Output() closed = new EventEmitter<void>();
-  @Output() exported = new EventEmitter<void>();
+  readonly initialFilter = input<LabelFilter>('good');
+  readonly closed = output<void>();
+  readonly exported = output<void>();
 
   private readonly datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private readonly exportersApi = inject(ExportersApiService);
@@ -164,7 +163,8 @@ export class ExportModalComponent implements OnInit {
    *  parent-supplied name and `labelSession.modelName` are both
    *  empty (typical when this modal opens from the Find view). */
   private get effectiveDetectorName(): string {
-    if (this.detectorName) return this.detectorName;
+    const detectorName = this.detectorName();
+    if (detectorName) return detectorName;
     if (this.labelSession.modelName) return this.labelSession.modelName;
     const modelId = this.activeContext.modelId;
     if (!modelId) return '';
@@ -174,17 +174,18 @@ export class ExportModalComponent implements OnInit {
   ngOnInit(): void {
     // Split the requested filter into a server-side partition (unverified /
     // verified are fetched with that label_filter) and a client-side category.
-    if (this.initialFilter === 'unverified' || this.initialFilter === 'verified') {
-      this.serverFilter = this.initialFilter;
+    const initialFilter = this.initialFilter();
+    if (initialFilter === 'unverified' || initialFilter === 'verified') {
+      this.serverFilter = initialFilter;
       this.labelFilter = 'both';
-    } else if (this.initialFilter === 'unverified_good') {
+    } else if (initialFilter === 'unverified_good') {
       // The left work-queue export: the unverified partition (server-side),
       // sliced to the above-threshold good category (client-side).
       this.serverFilter = 'unverified';
       this.labelFilter = 'good';
     } else {
       this.serverFilter = 'both';
-      this.labelFilter = this.initialFilter;
+      this.labelFilter = initialFilter;
     }
 
     // Now that the input-derived `serverFilter` is set, release the labels read

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, OnInit, inject, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsFindApiService } from '../../../services/detectors-find-api.service';
@@ -27,7 +27,9 @@ interface ChartPoint {
   styleUrl: './find-stats-modal.component.scss',
 })
 export class FindStatsModalComponent implements OnInit {
-  @Output() closed = new EventEmitter<void>();
+  private findApi = inject(DetectorsFindApiService);
+
+  readonly closed = output<void>();
 
   loading = true;
   error = '';
@@ -40,8 +42,6 @@ export class FindStatsModalComponent implements OnInit {
   private readonly padRight = 10;
   private readonly padTop = 10;
   private readonly padBottom = 22;
-
-  constructor(private findApi: DetectorsFindApiService) {}
 
   ngOnInit(): void {
     this.findApi.getFindStats().subscribe({

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, inject, signal, OnInit, SecurityContext } from '@angular/core';
+import { Component, inject, signal, OnInit, SecurityContext, output } from '@angular/core';
 
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -48,7 +48,7 @@ const ABSOLUTE_SRC_RE = /^([a-z]+:)?\/\//i;
   styleUrl: './keyboard-help-modal.component.scss',
 })
 export class KeyboardHelpModalComponent implements OnInit {
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   private readonly http = inject(HttpClient);
   private readonly sanitizer = inject(DomSanitizer);

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
+import { Component, Input, computed, inject, signal, input, output } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
@@ -15,9 +15,9 @@ import type { ExporterEntry } from '../../../generated/api-client/models/exporte
 })
 export class LabelExporterModalComponent {
   @Input() goodsOnly = false;
-  @Input() customTitle = '';
-  @Output() closed = new EventEmitter<void>();
-  @Output() exportComplete = new EventEmitter<void>();
+  readonly customTitle = input('');
+  readonly closed = output<void>();
+  readonly exportComplete = output<void>();
 
   private readonly exportersApi = inject(ExportersApiService);
   private readonly sortingApi = inject(SortingApiService);
@@ -41,7 +41,8 @@ export class LabelExporterModalComponent {
   );
 
   get title(): string {
-    if (this.customTitle) return this.customTitle;
+    const customTitle = this.customTitle();
+    if (customTitle) return customTitle;
     return this.goodsOnly ? 'Export Labels (Goods)' : 'Export Labels';
   }
 

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -17,7 +17,7 @@
       }
     </div>
 
-    @if (!targetModelName) {
+    @if (!targetModelName()) {
     <div class="add-media-section">
       <p class="add-media-heading">Add media directly</p>
       <div class="add-media-buttons">

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -1,13 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -29,12 +20,16 @@ type ModalView = 'picker' | 'form';
   styleUrl: './label-importer-modal.component.scss',
 })
 export class LabelImporterModalComponent implements OnInit, OnDestroy {
+  private labelImportersApi = inject(LabelImportersApiService);
+  private mediasApi = inject(MediasApiService);
+  private voteState = inject(VoteStateService);
+
   /** When set, labels are imported directly into this trainable model
    *  instead of into the active dataset's vote state. */
-  @Input() targetModelName: string | null = null;
+  readonly targetModelName = input<string | null>(null);
 
-  @Output() closed = new EventEmitter<void>();
-  @Output() imported = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly imported = output<void>();
 
   @ViewChild('addGoodInput') addGoodInput!: ElementRef<HTMLInputElement>;
   @ViewChild('addBadInput') addBadInput!: ElementRef<HTMLInputElement>;
@@ -56,17 +51,12 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
   addingBad = false;
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(
-    private labelImportersApi: LabelImportersApiService,
-    private mediasApi: MediasApiService,
-    private voteState: VoteStateService,
-  ) {}
-
   get modalTitle(): string {
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
-    return this.targetModelName ? `Import Labels into ${this.targetModelName}` : 'Import Labels';
+    const targetModelName = this.targetModelName();
+    return targetModelName ? `Import Labels into ${targetModelName}` : 'Import Labels';
   }
 
   /** Typed view of the selected importer's plugin fields for the template
@@ -187,9 +177,10 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
     this.error = '';
     this.successMessage = '';
 
-    const request$ = this.targetModelName
+    const targetModelName = this.targetModelName();
+    const request$ = targetModelName
       ? this.labelImportersApi.runModelImport(
-          this.targetModelName,
+          targetModelName,
           this.selectedImporter.name,
           this.formValues,
           this.selectedFile ?? undefined,

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, OnInit, inject, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -30,9 +30,15 @@ type MediaPickerView = 'sources' | 'browse-items' | 'file-browser';
   styleUrl: './load-sort-modal.component.scss',
 })
 export class LoadSortModalComponent implements OnInit {
-  @Output() closed = new EventEmitter<void>();
-  @Output() modelSelected = new EventEmitter<string>();
-  @Output() exampleSortStarted = new EventEmitter<unknown>();
+  private sortingApi = inject(SortingApiService);
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private datasetsUiApi = inject(DatasetsUiApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+
+  readonly closed = output<void>();
+  readonly modelSelected = output<string>();
+  readonly exampleSortStarted = output<unknown>();
 
   serverMediaFiles: ServerMediaFileEntry[] = [];
   registryModels: DetectorRegistryEntry[] = [];
@@ -62,14 +68,6 @@ export class LoadSortModalComponent implements OnInit {
   pendingFileMediaType = '';
   pendingServerFilename = '';
   pendingOrigin: { origin: Record<string, unknown>; key: string } | null = null;
-
-  constructor(
-    private sortingApi: SortingApiService,
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-    private datasetsUiApi: DatasetsUiApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-  ) {}
 
   ngOnInit(): void {
     this.sortingApi.getServerMediaFiles().subscribe({

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
@@ -2,11 +2,11 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnDestroy,
-  Output,
   ViewChild,
+  input,
+  output
 } from '@angular/core';
 
 
@@ -29,9 +29,9 @@ const HANDLE_HIT_PX = 12;
 export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
   @Input() audioUrl = '';
   /** Original audio file, used to decode the waveform. */
-  @Input() audioFile?: File;
-  @Output() applied = new EventEmitter<AudioCropResult>();
-  @Output() cancelled = new EventEmitter<void>();
+  readonly audioFile = input<File>();
+  readonly applied = output<AudioCropResult>();
+  readonly cancelled = output<void>();
 
   @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
@@ -46,12 +46,13 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
   private peaks: number[] = [];
 
   async ngAfterViewInit(): Promise<void> {
-    if (!this.audioFile) {
+    const audioFile = this.audioFile();
+    if (!audioFile) {
       this.loading = false;
       return;
     }
     try {
-      const arrayBuffer = await this.audioFile.arrayBuffer();
+      const arrayBuffer = await audioFile.arrayBuffer();
       const AudioCtx = (window.AudioContext ||
         (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext);
       const ctx = new AudioCtx();

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.html
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.html
@@ -8,7 +8,7 @@
   (pointermove)="onPointerMove($event)"
   (pointerup)="onPointerUp($event)"
   (pointercancel)="onPointerUp($event)">
-  <img #img [src]="imageUrl" (load)="onImageLoaded()" alt="Crop target" />
+  <img #img [src]="imageUrl()" (load)="onImageLoaded()" alt="Crop target" />
   <div
     class="crop-mask top"
     [style.height.px]="cropY">

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
@@ -2,10 +2,9 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
-  EventEmitter,
-  Input,
-  Output,
   ViewChild,
+  input,
+  output
 } from '@angular/core';
 
 
@@ -26,9 +25,9 @@ const HANDLE_HIT_RADIUS = 12;
   styleUrl: './image-crop-overlay.component.scss',
 })
 export class ImageCropOverlayComponent implements AfterViewInit {
-  @Input() imageUrl = '';
-  @Output() applied = new EventEmitter<ImageCropResult>();
-  @Output() cancelled = new EventEmitter<void>();
+  readonly imageUrl = input('');
+  readonly applied = output<ImageCropResult>();
+  readonly cancelled = output<void>();
 
   @ViewChild('img') imgRef!: ElementRef<HTMLImageElement>;
 

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
@@ -4,7 +4,7 @@
   (closed)="onCancel()">
   @if (view === 'confirm') {
     <div class="preview">
-      @switch (mediaType) {
+      @switch (mediaType()) {
         @case ('image') {
           <img [src]="fileUrl" alt="Example preview" />
         }
@@ -16,12 +16,12 @@
         }
         @default {
           <div class="generic-preview">
-            {{ file.name }}
+            {{ file().name }}
           </div>
         }
       }
     </div>
-    <div class="filename">{{ file.name }}</div>
+    <div class="filename">{{ file().name }}</div>
     <div class="actions">
       <button type="button" class="primary" (click)="onOk()">OK</button>
       <button
@@ -37,17 +37,17 @@
   }
 
   @if (view === 'cropping') {
-    @if (mediaType === 'image') {
+    @if (mediaType() === 'image') {
       <vt-image-crop-overlay
         [imageUrl]="fileUrl"
         (applied)="onImageCropApplied($event)"
         (cancelled)="onCropOverlayCancelled()">
       </vt-image-crop-overlay>
     }
-    @if (mediaType === 'audio') {
+    @if (mediaType() === 'audio') {
       <vt-audio-crop-overlay
         [audioUrl]="fileUrl"
-        [audioFile]="file"
+        [audioFile]="file()"
         (applied)="onAudioCropApplied($event)"
         (cancelled)="onCropOverlayCancelled()">
       </vt-audio-crop-overlay>

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output } from '@angular/core';
 
 import { ModalComponent } from '../../modal/modal.component';
 import { ImageCropOverlayComponent, ImageCropResult } from './image-crop-overlay.component';
@@ -21,17 +21,18 @@ type View = 'confirm' | 'cropping';
   styleUrl: './media-crop-modal.component.scss',
 })
 export class MediaCropModalComponent implements OnInit, OnDestroy {
-  @Input() file!: File;
-  @Input() mediaType = '';
-  @Output() confirmed = new EventEmitter<MediaCropResult>();
-  @Output() cancelled = new EventEmitter<void>();
+  readonly file = input.required<File>();
+  readonly mediaType = input('');
+  readonly confirmed = output<MediaCropResult>();
+  readonly cancelled = output<void>();
 
   view: View = 'confirm';
   fileUrl = '';
 
   ngOnInit(): void {
-    if (this.file) {
-      this.fileUrl = URL.createObjectURL(this.file);
+    const file = this.file();
+    if (file) {
+      this.fileUrl = URL.createObjectURL(file);
     }
   }
 
@@ -42,11 +43,12 @@ export class MediaCropModalComponent implements OnInit, OnDestroy {
   }
 
   get cropSupported(): boolean {
-    return this.mediaType === 'image' || this.mediaType === 'audio';
+    const mediaType = this.mediaType();
+    return mediaType === 'image' || mediaType === 'audio';
   }
 
   onOk(): void {
-    this.confirmed.emit({ file: this.file });
+    this.confirmed.emit({ file: this.file() });
   }
 
   onOkButCrop(): void {
@@ -63,14 +65,14 @@ export class MediaCropModalComponent implements OnInit, OnDestroy {
 
   onImageCropApplied(result: ImageCropResult): void {
     this.confirmed.emit({
-      file: this.file,
+      file: this.file(),
       cropParams: { box: result.box },
     });
   }
 
   onAudioCropApplied(result: AudioCropResult): void {
     this.confirmed.emit({
-      file: this.file,
+      file: this.file(),
       cropParams: { start: result.start, end: result.end },
     });
   }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,7 +1,7 @@
 <vt-modal [title]="title" [open]="true" (closed)="close()">
   @if (analyzing) {
     <div class="analysis-loading">
-      @if (useCachedHistory) {
+      @if (useCachedHistory()) {
         <p aria-live="polite">Loading indicator history...</p>
       } @else {
         <p aria-live="polite">Training detectors over label history...</p>

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, inject, input, output } from '@angular/core';
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
@@ -24,9 +24,14 @@ export type ProgressMetric = 'smart' | 'stable' | 'diverse';
   styleUrl: './progress-modal.component.scss',
 })
 export class ProgressModalComponent implements OnInit, OnDestroy {
+  private sortingApi = inject(SortingApiService);
+  private chartsService = inject(ChartsService);
+  private settingsState = inject(SettingsStateService);
+  private progressEvents = inject(ProgressEventsService);
+
   @Input() metric: ProgressMetric = 'smart';
-  @Input() useCachedHistory = false;
-  @Output() closed = new EventEmitter<void>();
+  readonly useCachedHistory = input(false);
+  readonly closed = output<void>();
 
   @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
 
@@ -40,13 +45,6 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(
-    private sortingApi: SortingApiService,
-    private chartsService: ChartsService,
-    private settingsState: SettingsStateService,
-    private progressEvents: ProgressEventsService,
-  ) {}
-
   get title(): string {
     switch (this.metric) {
       case 'smart':
@@ -59,7 +57,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    if (this.useCachedHistory) {
+    if (this.useCachedHistory()) {
       this.loadCachedHistory();
     } else {
       this.runAnalysis();

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -3,7 +3,7 @@
     <div class="resort-prompt">
       <p class="prompt-text">
         Your current example:
-        <strong>{{ currentExampleDisplay }}</strong>
+        <strong>{{ currentExampleDisplay() }}</strong>
       </p>
       <p class="prompt-text">Would you like to supply a different example to sort by, or keep your current one?</p>
 

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -30,12 +30,17 @@ type ModalView = 'prompt' | 'media-picker';
   styleUrl: './resort-prompt-modal.component.scss',
 })
 export class ResortPromptModalComponent {
-  @Input() currentExampleType: 'text' | 'media' = 'text';
-  @Input() currentExampleDisplay = '';
+  private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private datasetsUiApi = inject(DatasetsUiApiService);
+  private sortingApi = inject(SortingApiService);
+
+  readonly currentExampleType = input<'text' | 'media'>('text');
+  readonly currentExampleDisplay = input('');
   @Input() keepLabelsCount = 0;
-  @Output() closed = new EventEmitter<void>();
-  @Output() keepExample = new EventEmitter<void>();
-  @Output() newExample = new EventEmitter<ResortResult>();
+  readonly closed = output<void>();
+  readonly keepExample = output<void>();
+  readonly newExample = output<ResortResult>();
 
   view: ModalView = 'prompt';
   pendingText = '';
@@ -52,13 +57,6 @@ export class ResortPromptModalComponent {
   fileLoading = false;
   typedPath = '';
   typedPathError = '';
-
-  constructor(
-    private datasetsCrudApi: DatasetsCrudApiService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-    private datasetsUiApi: DatasetsUiApiService,
-    private sortingApi: SortingApiService,
-  ) {}
 
   onKeep(): void {
     this.keepExample.emit();

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnDestroy, Output, computed, inject, signal } from '@angular/core';
+import { Component, OnDestroy, computed, inject, signal, output } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
@@ -20,8 +20,8 @@ type ModalView = 'picker' | 'form';
   styleUrl: './settings-exporter-modal.component.scss',
 })
 export class SettingsExporterModalComponent implements OnDestroy {
-  @Output() closed = new EventEmitter<void>();
-  @Output() exported = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly exported = output<void>();
 
   private readonly settingsIoApi = inject(SettingsIoApiService);
 

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnDestroy, Output, computed, inject, signal } from '@angular/core';
+import { Component, OnDestroy, computed, inject, signal, output } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
@@ -19,8 +19,8 @@ type ModalView = 'picker' | 'form';
   styleUrl: './settings-importer-modal.component.scss',
 })
 export class SettingsImporterModalComponent implements OnDestroy {
-  @Output() closed = new EventEmitter<void>();
-  @Output() imported = new EventEmitter<void>();
+  readonly closed = output<void>();
+  readonly imported = output<void>();
 
   private readonly settingsIoApi = inject(SettingsIoApiService);
 

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,13 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -58,14 +49,17 @@ export interface AutoFindExporterChange {
   styleUrl: './auto-find-settings.component.scss',
 })
 export class AutoFindSettingsComponent implements OnInit, OnChanges, OnDestroy {
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private exportersApi = inject(ExportersApiService);
+
   /** Currently configured results-exporter name ('' = no auto-export). */
-  @Input() autofindExporter = '';
+  readonly autofindExporter = input('');
   /** Per-exporter saved field values: `{exporter_name: {field_key: value}}`. */
-  @Input() autofindExporterFieldValues: Record<string, Record<string, string>> = {};
+  readonly autofindExporterFieldValues = input<Record<string, Record<string, string>>>({});
 
   /** Emits the new exporter selection + field-value map for the parent to
    *  persist whenever the user changes the exporter or any of its fields. */
-  @Output() exporterChange = new EventEmitter<AutoFindExporterChange>();
+  readonly exporterChange = output<AutoFindExporterChange>();
 
   detectors: AutofindDetectorEntry[] = [];
   exporters: ExporterEntry[] = [];
@@ -82,23 +76,18 @@ export class AutoFindSettingsComponent implements OnInit, OnChanges, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private exportersApi: ExportersApiService,
-  ) {}
-
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['autofindExporter']) {
-      this.activeExporter = this.autofindExporter || '';
+      this.activeExporter = this.autofindExporter() || '';
     }
     if (changes['autofindExporterFieldValues']) {
-      this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues);
+      this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
     }
   }
 
   ngOnInit(): void {
-    this.activeExporter = this.autofindExporter || '';
-    this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues);
+    this.activeExporter = this.autofindExporter() || '';
+    this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
 
     this.detectorsRegistryApi
       .getRegistry()

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -46,18 +38,20 @@ import {
   styleUrl: './import-defaults-settings.component.scss',
 })
 export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+
   /** All registered media types; drives the per-mediaType tab strip. */
-  @Input() mediaTypes: MediaTypeInfo[] = [];
+  readonly mediaTypes = input<MediaTypeInfo[]>([]);
   /** Current per-mediaType defaults map (the saved value). */
-  @Input() defaults: ImportDefaultsByMediaType = {};
+  readonly defaults = input<ImportDefaultsByMediaType>({});
   /** When set (solo-mediaType streamlining), the tab strip collapses to
    *  just that one mediaType so the user only configures what they'll
    *  actually use. */
-  @Input() effectiveSoloMediaType: string | null = null;
+  readonly effectiveSoloMediaType = input<string | null>(null);
   /** Emits a full updated defaults map whenever the user changes any
    *  per-mediaType setting.  The parent merges it back into its
    *  ``settings`` object and persists. */
-  @Output() defaultsChange = new EventEmitter<ImportDefaultsByMediaType>();
+  readonly defaultsChange = output<ImportDefaultsByMediaType>();
 
   activeType = '';
   clipperChooserOpen = false;
@@ -67,8 +61,6 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   clippersByType: Record<string, ClipperInfo[]> = {};
   convertersByType: Record<string, ConverterInfo[]> = {};
   loadingByType: Record<string, boolean> = {};
-
-  constructor(private datasetsListingsApi: DatasetsListingsApiService) {}
 
   ngOnInit(): void {
     this.pickInitialTab();
@@ -87,22 +79,22 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
       this.loadForType(this.activeType);
       return;
     }
-    const soloMatch = this.effectiveSoloMediaType
-      ? visible.find((mt) => mt.type_id === this.effectiveSoloMediaType)
+    const soloMatch = this.effectiveSoloMediaType()
+      ? visible.find((mt) => mt.type_id === this.effectiveSoloMediaType())
       : null;
     this.selectTab((soloMatch || visible[0]).type_id);
   }
 
   get visibleTypes(): MediaTypeInfo[] {
-    if (this.effectiveSoloMediaType) {
-      return this.mediaTypes.filter((mt) => mt.type_id === this.effectiveSoloMediaType);
+    if (this.effectiveSoloMediaType()) {
+      return this.mediaTypes().filter((mt) => mt.type_id === this.effectiveSoloMediaType());
     }
-    return this.mediaTypes;
+    return this.mediaTypes();
   }
 
   get typeLabels(): Record<string, string> {
     const out: Record<string, string> = {};
-    for (const mt of this.mediaTypes) out[mt.type_id] = mt.name;
+    for (const mt of this.mediaTypes()) out[mt.type_id] = mt.name;
     return out;
   }
 
@@ -184,7 +176,7 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   }
 
   get currentDefaults(): ImportDefaultsForMediaType {
-    return this.defaults[this.activeType] || {};
+    return this.defaults()[this.activeType] || {};
   }
 
   get currentEmbedder(): string {
@@ -249,7 +241,7 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
    *  mediaType, used to gate the "Reset" button so it doesn't appear
    *  when there's nothing to reset. */
   get hasOverridesForActiveType(): boolean {
-    const d = this.defaults[this.activeType];
+    const d = this.defaults()[this.activeType];
     if (!d) return false;
     if (d.embedder) return true;
     if (d.clipper) return true;
@@ -267,7 +259,7 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   // -----------------------------------------------------------------
 
   private updateActive(patch: Partial<ImportDefaultsForMediaType>): void {
-    const next: ImportDefaultsByMediaType = { ...this.defaults };
+    const next: ImportDefaultsByMediaType = { ...this.defaults() };
     const merged: ImportDefaultsForMediaType = { ...this.currentDefaults, ...patch };
     // Strip empty values so the persisted dict stays compact.
     for (const k of Object.keys(merged) as (keyof ImportDefaultsForMediaType)[]) {
@@ -320,7 +312,7 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   }
 
   resetActiveType(): void {
-    const next: ImportDefaultsByMediaType = { ...this.defaults };
+    const next: ImportDefaultsByMediaType = { ...this.defaults() };
     delete next[this.activeType];
     this.defaultsChange.emit(next);
   }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, inject, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { forkJoin, Subject } from 'rxjs';
@@ -36,8 +36,14 @@ import {
   styleUrl: './settings-modal.component.scss',
 })
 export class SettingsModalComponent implements OnInit, OnDestroy {
+  private settingsApi = inject(SettingsApiService);
+  private settingsState = inject(SettingsStateService);
+  private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private themeService = inject(ThemeService);
+  private dialog = inject(VtDialogService);
+
   @Input() preselectedViewTab = '';
-  @Output() closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   settings: AppSettings = { volume: 50 };
   mediaTypes: MediaTypeInfo[] = [];
@@ -59,14 +65,6 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   private savedTimer: ReturnType<typeof setTimeout> | null = null;
 
   private destroy$ = new Subject<void>();
-
-  constructor(
-    private settingsApi: SettingsApiService,
-    private settingsState: SettingsStateService,
-    private datasetsListingsApi: DatasetsListingsApiService,
-    private themeService: ThemeService,
-    private dialog: VtDialogService,
-  ) {}
 
   ngOnDestroy(): void {
     if (this.savedTimer !== null) clearTimeout(this.savedTimer);

--- a/frontend/src/app/components/offline-banner/offline-banner.component.ts
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ConnectionStateService } from '../../services/connection-state.service';
 
 /**
@@ -18,5 +18,5 @@ import { ConnectionStateService } from '../../services/connection-state.service'
   styleUrl: './offline-banner.component.scss',
 })
 export class OfflineBannerComponent {
-  constructor(public connection: ConnectionStateService) {}
+  connection = inject(ConnectionStateService);
 }

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -12,7 +12,7 @@ import { FormsModule } from '@angular/forms';
 export class DetectorContextBarComponent {
   @Input() detectorName = '';
   @Input() visible = false;
-  @Output() renamed = new EventEmitter<string>();
+  readonly renamed = output<string>();
 
   editing = false;
   editValue = '';

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -2,7 +2,7 @@
   <div class="vote-section-header">
     <div class="vote-section-heading">
       <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
-        {{ headingLabel ?? (label === 'good' ? 'Goods' : 'Bads') }} ({{ ids.length | number }})
+        {{ headingLabel() ?? (label === 'good' ? 'Goods' : 'Bads') }} ({{ ids.length | number }})
       </h3>
       @if (foldedNote) {
         <span class="folded-note" [title]="'These items live on the left work queue; the bucket actions still include them.'">{{ foldedNote }}</span>
@@ -10,7 +10,7 @@
     </div>
     <ng-content select="[list-actions]"></ng-content>
   </div>
-  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>
+  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth() + 'px'" #voteListContainer>
     @for (entry of sortedEntries; track trackById($index, entry)) {
       <div
         class="vote-entry"

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -23,13 +23,16 @@ export interface LabelEntry {
   styleUrl: './label-list.component.scss',
 })
 export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
+  private activeContext = inject(ActiveContextService);
+  private metadataCache = inject(MediaMetadataCacheService);
+
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
   /**
    * Overrides the bucket heading word ("Goods"/"Bads"). Find mode passes
    * "Verified Good" / "Verified Bad" so the bucket reads as the confirmed pile.
    */
-  @Input() headingLabel: string | null = null;
+  readonly headingLabel = input<string | null>(null);
   /**
    * Find mode: a small "[N] Unverified Good/Bad" line folded under the heading,
    * counting the items still on the left work queue that the bucket's actions
@@ -44,13 +47,16 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
    * a box (a region vote drawn on an image), its thumbnail is cropped to that
    * region rather than showing the whole frame.
    */
-  @Input() regionBoxes: Record<string, number[]> = {};
+  readonly regionBoxes = input<Record<string, number[]>>({});
   @Input() sortMode: LabelSortMode = 'time-desc';
   @Input() viewMode: 'grid' | 'list' = 'grid';
-  @Input() gridGoalWidth: number = 80;
-  @Input() focusMode: 'click' | 'hover' = 'click';
-  @Output() mediaSelected = new EventEmitter<number>();
-  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  readonly gridGoalWidth = input<number>(80);
+  readonly focusMode = input<'click' | 'hover'>('click');
+  readonly mediaSelected = output<number>();
+  readonly mediaVote = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
 
   @ViewChild('voteListContainer') voteListContainer?: ElementRef<HTMLDivElement>;
 
@@ -59,11 +65,6 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
   private mediaMap = new Map<number, Media>();
   private readonly destroy$ = new Subject<void>();
-
-  constructor(
-    private activeContext: ActiveContextService,
-    private metadataCache: MediaMetadataCacheService,
-  ) {}
 
   ngOnInit(): void {
     this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
@@ -180,7 +181,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     // A region-voted item shows a thumbnail of just the voted crop. The box
     // coordinates ride in the query string so a re-vote with a different box
     // is a distinct URL (and cache entry) rather than a stale tile.
-    const box = this.regionBoxes[String(id)];
+    const box = this.regionBoxes()[String(id)];
     if (box && box.length === 4) {
       const sep = url.includes('?') ? '&' : '?';
       url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
@@ -206,7 +207,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   }
 
   onEntryClick(id: number): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.mediaVote.emit({ id, vote: 'bad' });
     } else {
       this.mediaSelected.emit(id);
@@ -214,14 +215,14 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   }
 
   onEntryContextMenu(event: MouseEvent, id: number): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       event.preventDefault();
       this.mediaVote.emit({ id, vote: 'good' });
     }
   }
 
   onEntryMouseEnter(id: number): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.mediaSelected.emit(id);
     }
   }

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 export type LabelSortMode =
@@ -19,7 +19,7 @@ export type LabelSortMode =
 })
 export class LabelSortComponent {
   @Input() mode: LabelSortMode = 'time-desc';
-  @Output() modeChange = new EventEmitter<LabelSortMode>();
+  readonly modeChange = output<LabelSortMode>();
 
   onSortChange(value: LabelSortMode): void {
     this.mode = value;

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -1,8 +1,8 @@
 <div class="vote-section">
-  <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + elements.length + ')' : 'Items you have marked as negative examples (' + elements.length + ')'">
-    {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ elements.length | number }})
+  <h3 [class]="label()" [title]="label() === 'good' ? 'Items you have marked as positive examples (' + elements().length + ')' : 'Items you have marked as negative examples (' + elements().length + ')'">
+    {{ label() === 'good' ? 'Goods' : 'Bads' }} ({{ elements().length | number }})
   </h3>
-  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>
+  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth() + 'px'" #voteListContainer>
     @for (entry of sortedEntries; track trackById($index, entry)) {
       <div
         class="vote-entry"
@@ -11,7 +11,7 @@
         [attr.title]="isMissing(entry) ? entry.name + ' (not in the current dataset)' : null"
         role="button"
         tabindex="0"
-        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry) ? ' (not in current dataset)' : '')"
+        [attr.aria-label]="(label() === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry) ? ' (not in current dataset)' : '')"
         (click)="onEntryClick(entry)"
         (contextmenu)="onEntryContextMenu($event, entry)"
         (mouseenter)="onEntryMouseEnter(entry)"

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -1,14 +1,4 @@
-import {
-  AfterViewChecked,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, OnChanges, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
@@ -26,23 +16,26 @@ interface SortedElement extends DetectorLabelView {
   styleUrls: ['../label-list/label-list.component.scss'],
 })
 export class LabelsetListComponent implements OnChanges, AfterViewChecked {
-  @Input() label: 'good' | 'bad' = 'good';
-  @Input() elements: DetectorLabelView[] = [];
-  @Input() modelName: string = '';
-  @Input() sortMode: LabelSortMode = 'time-desc';
-  @Input() viewMode: 'grid' | 'list' = 'grid';
-  @Input() gridGoalWidth: number = 80;
-  @Input() focusMode: 'click' | 'hover' = 'click';
-  @Output() elementSelected = new EventEmitter<DetectorLabelView>();
-  @Output() elementVote = new EventEmitter<{ id: string; vote: 'good' | 'bad' }>();
+  private detectorsCrudApi = inject(DetectorsCrudApiService);
+
+  readonly label = input<'good' | 'bad'>('good');
+  readonly elements = input<DetectorLabelView[]>([]);
+  readonly modelName = input<string>('');
+  readonly sortMode = input<LabelSortMode>('time-desc');
+  readonly viewMode = input<'grid' | 'list'>('grid');
+  readonly gridGoalWidth = input<number>(80);
+  readonly focusMode = input<'click' | 'hover'>('click');
+  readonly elementSelected = output<DetectorLabelView>();
+  readonly elementVote = output<{
+    id: string;
+    vote: 'good' | 'bad';
+}>();
 
   @ViewChild('voteListContainer') voteListContainer?: ElementRef<HTMLDivElement>;
 
   sortedEntries: SortedElement[] = [];
   private pendingScrollPct: number | null = null;
   private thumbnailFailedUrls = new Set<string>();
-
-  constructor(private detectorsCrudApi: DetectorsCrudApiService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['viewMode'] && !changes['viewMode'].firstChange && this.voteListContainer) {
@@ -64,16 +57,16 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   private buildSorted(): SortedElement[] {
-    const entries: SortedElement[] = this.elements.map((e) => ({
+    const entries: SortedElement[] = this.elements().map((e) => ({
       ...e,
-      confidence: e.score >= 0 ? (this.label === 'good' ? e.score : 1 - e.score) : -1,
+      confidence: e.score >= 0 ? (this.label() === 'good' ? e.score : 1 - e.score) : -1,
     }));
     return this.sortEntries(entries);
   }
 
   private sortEntries(entries: SortedElement[]): SortedElement[] {
     const sorted = [...entries];
-    switch (this.sortMode) {
+    switch (this.sortMode()) {
       case 'time-desc':
         sorted.sort((a, b) => b.time - a.time);
         break;
@@ -101,7 +94,7 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   get isGrid(): boolean {
-    return this.viewMode === 'grid';
+    return this.viewMode() === 'grid';
   }
 
   hasThumbnailUrl(entry: DetectorLabelView): boolean {
@@ -116,8 +109,9 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   thumbnailUrl(entry: DetectorLabelView): string {
-    if (!this.modelName) return '';
-    let url = this.detectorsCrudApi.labelThumbnailUrl(this.modelName, entry.id);
+    const modelName = this.modelName();
+    if (!modelName) return '';
+    let url = this.detectorsCrudApi.labelThumbnailUrl(modelName, entry.id);
     // The route crops to the element's stored region box server-side; fold the
     // box into the URL so a re-vote with a different box busts the cached tile
     // (the box coords aren't otherwise part of the URL).
@@ -145,7 +139,7 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   onEntryClick(entry: DetectorLabelView): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.elementVote.emit({ id: entry.id, vote: 'bad' });
     } else {
       this.elementSelected.emit(entry);
@@ -153,14 +147,14 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   onEntryContextMenu(event: MouseEvent, entry: DetectorLabelView): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       event.preventDefault();
       this.elementVote.emit({ id: entry.id, vote: 'good' });
     }
   }
 
   onEntryMouseEnter(entry: DetectorLabelView): void {
-    if (this.focusMode === 'hover') {
+    if (this.focusMode() === 'hover') {
       this.elementSelected.emit(entry);
     }
   }

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -5,9 +5,9 @@
     (renamed)="onDetectorRenamed($event)"
   />
 
-  @if (mode !== 'find') {
+  @if (mode() !== 'find') {
     <div class="import-row">
-      <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()" title="Import good/bad labels from a file or add media directly to the good or bad pile">Import Labels</button>
+      <button class="panel-btn import-btn" [disabled]="disabled()" (click)="onImportLabels()" title="Import good/bad labels from a file or add media directly to the good or bad pile">Import Labels</button>
     </div>
   }
 
@@ -29,11 +29,11 @@
     <vt-labelset-list
       label="good"
       [elements]="goodElements"
-      [modelName]="trainableModelName ?? ''"
+      [modelName]="trainableModelName() ?? ''"
       [sortMode]="sortMode"
       [viewMode]="viewMode"
       [gridGoalWidth]="gridGoalWidth"
-      [focusMode]="focusMode"
+      [focusMode]="focusMode()"
       (elementSelected)="onLabelsetElementSelected($event)"
       (elementVote)="onLabelsetElementVote($event)"
     />
@@ -43,11 +43,11 @@
     <vt-labelset-list
       label="bad"
       [elements]="badElements"
-      [modelName]="trainableModelName ?? ''"
+      [modelName]="trainableModelName() ?? ''"
       [sortMode]="sortMode"
       [viewMode]="viewMode"
       [gridGoalWidth]="gridGoalWidth"
-      [focusMode]="focusMode"
+      [focusMode]="focusMode()"
       (elementSelected)="onLabelsetElementSelected($event)"
       (elementVote)="onLabelsetElementVote($event)"
     />
@@ -55,8 +55,8 @@
     <vt-label-list
       label="good"
       [ids]="goodDisplayIds"
-      [headingLabel]="mode === 'find' ? 'Verified Good' : null"
-      [foldedNote]="mode === 'find' ? ((unverifiedGoodCount | number) + ' Unverified Good') : null"
+      [headingLabel]="mode() === 'find' ? 'Verified Good' : null"
+      [foldedNote]="mode() === 'find' ? ((unverifiedGoodCount | number) + ' Unverified Good') : null"
       [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
@@ -64,29 +64,29 @@
       [sortMode]="sortMode"
       [viewMode]="viewMode"
       [gridGoalWidth]="gridGoalWidth"
-      [focusMode]="focusMode"
+      [focusMode]="focusMode()"
       (mediaSelected)="onMediaSelected($event)"
       (mediaVote)="onMediaVote($event)"
     >
-      @if (mode === 'find') {
+      @if (mode() === 'find') {
         <div list-actions class="goods-actions">
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse positive items (verified and unverified).">
+          <button class="goods-action-btn" [disabled]="disabled() || goodIds.length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse positive items (verified and unverified).">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
               <circle cx="12" cy="12" r="3"></circle>
             </svg>
           </button>
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the full good set (verified + unverified) into their own dataset">
+          <button class="goods-action-btn" [disabled]="disabled() || goodIds.length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the full good set (verified + unverified) into their own dataset">
             <vt-icon type="cubes" [size]="14"></vt-icon>
           </button>
-          <button class="goods-action-btn" [disabled]="disabled || goodIds.length === 0" (click)="onExportGood()" aria-label="Export" title="Export the full good set (verified + unverified) to clipboard, file, email, or webhook">
+          <button class="goods-action-btn" [disabled]="disabled() || goodIds.length === 0" (click)="onExportGood()" aria-label="Export" title="Export the full good set (verified + unverified) to clipboard, file, email, or webhook">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
               <polyline points="15 3 21 3 21 9"></polyline>
               <line x1="12" y1="12" x2="21" y2="3"></line>
             </svg>
           </button>
-          <button class="goods-action-btn" [disabled]="disabled" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
+          <button class="goods-action-btn" [disabled]="disabled()" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="10"/>
               <path d="M12 2a10 10 0 0 1 0 20"/>
@@ -104,21 +104,21 @@
     <vt-label-list
       label="bad"
       [ids]="badDisplayIds"
-      [headingLabel]="mode === 'find' ? 'Verified Bad' : null"
-      [foldedNote]="mode === 'find' ? ((unverifiedBadCount | number) + ' Unverified Bad') : null"
+      [headingLabel]="mode() === 'find' ? 'Verified Bad' : null"
+      [foldedNote]="mode() === 'find' ? ((unverifiedBadCount | number) + ' Unverified Bad') : null"
       [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
       [sortMode]="sortMode"
       [viewMode]="viewMode"
       [gridGoalWidth]="gridGoalWidth"
-      [focusMode]="focusMode"
+      [focusMode]="focusMode()"
       (mediaSelected)="onMediaSelected($event)"
       (mediaVote)="onMediaVote($event)"
     >
-      @if (mode === 'find') {
+      @if (mode() === 'find') {
         <div list-actions class="goods-actions">
-          <button class="goods-action-btn" [disabled]="disabled || badIds.length === 0" (click)="onExportBad()" aria-label="Export" title="Export the full bad set (verified + unverified) to clipboard, file, email, or webhook">
+          <button class="goods-action-btn" [disabled]="disabled() || badIds.length === 0" (click)="onExportBad()" aria-label="Export" title="Export the full bad set (verified + unverified) to clipboard, file, email, or webhook">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
               <polyline points="15 3 21 3 21 9"></polyline>
@@ -130,11 +130,11 @@
     </vt-label-list>
   }
 
-  @if (mode === 'find') {
+  @if (mode() === 'find') {
     <div class="corrections-row">
       <button
         class="panel-btn corrections-btn"
-        [disabled]="disabled"
+        [disabled]="disabled()"
         (click)="onAddCorrections()"
         title="Add the corrections you've made (items you changed from the detector's call) into this detector's labelset and retrain it. This changes the detector, so the current evaluation no longer applies."
       >
@@ -144,9 +144,9 @@
     </div>
   }
 
-  @if (mode !== 'find') {
+  @if (mode() !== 'find') {
     <div class="export-row">
-      <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
+      <button class="panel-btn export-btn" [disabled]="disabled()" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
           <polyline points="15 3 21 3 21 9"></polyline>

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, effect } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, effect, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,32 +42,41 @@ export interface TrainModeContext {
   styleUrl: './right-panel.component.scss',
 })
 export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  voteState = inject(VoteStateService);
+  labelsetState = inject(LabelsetStateService);
+  private settingsState = inject(SettingsStateService);
+  private dialog = inject(VtDialogService);
+
   @Input() medias: Media[] = [];
   @Input() trainMode: TrainModeContext | null = null;
-  @Input() focusMode: 'click' | 'hover' = 'click';
+  readonly focusMode = input<'click' | 'hover'>('click');
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */
-  @Input() mode: 'label' | 'find' = 'label';
+  readonly mode = input<'label' | 'find'>('label');
   /**
    * Trainable model name that owns the labels shown in the right pane.
    * When set in label mode, the pane is sourced from the on-disk labelset
    * (so detector labels survive across dataset switches).  When empty, the
    * pane falls back to cid-based vote display.
    */
-  @Input() trainableModelName: string | null = null;
+  readonly trainableModelName = input<string | null>(null);
   /** Disable interactive buttons (used during Find scoring). */
-  @Input() disabled = false;
-  @Output() mediaSelected = new EventEmitter<number>();
-  @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  readonly disabled = input(false);
+  readonly mediaSelected = output<number>();
+  readonly mediaVoted = output<{
+    id: number;
+    vote: 'good' | 'bad';
+}>();
   /** Find mode: browse the positive results as their own UMAP projection. */
-  @Output() browse = new EventEmitter<void>();
+  readonly browse = output<void>();
   /** Find mode: promote the goods into their own dataset. */
-  @Output() toDataset = new EventEmitter<void>();
+  readonly toDataset = output<void>();
   /** Find mode: export a label partition (good / bad). */
-  @Output() exportLabels = new EventEmitter<'good' | 'bad'>();
+  readonly exportLabels = output<'good' | 'bad'>();
   /** Find mode: open the detector-evaluation Stats modal. */
-  @Output() stats = new EventEmitter<void>();
+  readonly stats = output<void>();
   /** Find mode: fold the corrections into the detector's labelset and retrain. */
-  @Output() addCorrections = new EventEmitter<void>();
+  readonly addCorrections = output<void>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
@@ -90,13 +99,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   protected currentMediaType = '';
   private destroy$ = new Subject<void>();
 
-  constructor(
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    public voteState: VoteStateService,
-    public labelsetState: LabelsetStateService,
-    private settingsState: SettingsStateService,
-    private dialog: VtDialogService,
-  ) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -121,7 +124,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   /** True when the right pane should be sourced from the labelset (not /api/votes). */
   get useLabelset(): boolean {
-    return this.mode === 'label' && !!this.trainableModelName;
+    return this.mode() === 'label' && !!this.trainableModelName();
   }
 
   /**
@@ -130,13 +133,13 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
    * just ``good ∩ verified``. In Label mode it shows every good vote.
    */
   get goodDisplayIds(): number[] {
-    if (this.mode !== 'find') return this.goodIds;
+    if (this.mode() !== 'find') return this.goodIds;
     return this.goodIds.filter((id) => this.verifiedIds.has(id));
   }
 
   /** Bad-bucket counterpart of {@link goodDisplayIds}. */
   get badDisplayIds(): number[] {
-    if (this.mode !== 'find') return this.badIds;
+    if (this.mode() !== 'find') return this.badIds;
     return this.badIds.filter((id) => this.verifiedIds.has(id));
   }
 
@@ -155,7 +158,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.voteState.startPolling();
     this.subscribeToVotes();
     if (this.useLabelset) {
-      this.labelsetState.setModel(this.trainableModelName);
+      this.labelsetState.setModel(this.trainableModelName());
       this.labelsetState.startPolling();
     }
     this.subscribeToLabelset();
@@ -172,7 +175,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     }
     if (changes['trainableModelName'] || changes['mode']) {
       if (this.useLabelset) {
-        this.labelsetState.setModel(this.trainableModelName);
+        this.labelsetState.setModel(this.trainableModelName());
         this.labelsetState.startPolling();
       } else {
         this.labelsetState.stopPolling();

--- a/frontend/src/app/components/skeleton/skeleton.component.ts
+++ b/frontend/src/app/components/skeleton/skeleton.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { NgStyle } from '@angular/common';
 
 @Component({
@@ -9,15 +9,15 @@ import { NgStyle } from '@angular/common';
   styleUrl: './skeleton.component.scss',
 })
 export class SkeletonComponent {
-  @Input() width = '100%';
-  @Input() height = '12px';
-  @Input() borderRadius = 'var(--radius-sm)';
+  readonly width = input('100%');
+  readonly height = input('12px');
+  readonly borderRadius = input('var(--radius-sm)');
 
   get boxStyle(): Record<string, string> {
     return {
-      width: this.width,
-      height: this.height,
-      'border-radius': this.borderRadius,
+      width: this.width(),
+      height: this.height(),
+      'border-radius': this.borderRadius(),
     };
   }
 }

--- a/frontend/src/app/components/toast-container/toast-container.component.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { Subscription } from 'rxjs';
 import { Toast, ToastService } from '../../services/toast.service';
@@ -17,14 +17,14 @@ import { Toast, ToastService } from '../../services/toast.service';
   styleUrl: './toast-container.component.scss',
 })
 export class ToastContainerComponent implements OnInit, OnDestroy {
+  private toastService = inject(ToastService);
+
   toasts: Toast[] = [];
   expandedId: number | null = null;
   copiedId: number | null = null;
 
   private sub?: Subscription;
   private copiedTimer?: ReturnType<typeof setTimeout>;
-
-  constructor(private toastService: ToastService) {}
 
   ngOnInit(): void {
     this.sub = this.toastService.toasts$.subscribe((toasts) => {

--- a/frontend/src/app/components/view-controls/view-controls.component.html
+++ b/frontend/src/app/components/view-controls/view-controls.component.html
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMinSize || !currentMediaType || (viewMode === 'list' && !allowSizeInList)"
+      [disabled]="atMinSize || !currentMediaType() || (viewMode === 'list' && !allowSizeInList())"
       (click)="bumpSize(-1)"
       title="Smaller thumbnails"
       aria-label="Smaller thumbnails">
@@ -12,7 +12,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMaxSize || !currentMediaType || (viewMode === 'list' && !allowSizeInList)"
+      [disabled]="atMaxSize || !currentMediaType() || (viewMode === 'list' && !allowSizeInList())"
       (click)="bumpSize(1)"
       title="Bigger thumbnails"
       aria-label="Bigger thumbnails">
@@ -20,7 +20,7 @@
     </button>
   </div>
 
-  @if (showViewMode) {
+  @if (showViewMode()) {
   <div class="vc-group">
     <button
       type="button"
@@ -45,7 +45,7 @@
   </div>
   }
 
-  @if (showFocus) {
+  @if (showFocus()) {
   <div class="vc-group">
     <button
       type="button"

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, effect } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, effect, inject, input } from '@angular/core';
 
 import { SettingsStateService } from '../../services/settings-state.service';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
@@ -16,14 +16,16 @@ type IconSize = (typeof ICON_SIZES)[number];
   styleUrl: './view-controls.component.scss',
 })
 export class ViewControlsComponent implements OnInit, OnChanges {
-  @Input() side: 'left' | 'right' | 'popup' = 'left';
-  @Input() currentMediaType = '';
+  private settingsState = inject(SettingsStateService);
+
+  readonly side = input<'left' | 'right' | 'popup'>('left');
+  readonly currentMediaType = input('');
   /**
    * Whether to show the click/hover focus toggle. The VTSBrowse selection
    * panel reuses this control for its Grid/List + size buttons but has no
    * good/bad voting, so it hides the focus group with ``[showFocus]="false"``.
    */
-  @Input() showFocus = true;
+  readonly showFocus = input(true);
   /**
    * Whether the thumbnail-size buttons stay active in list mode. The
    * left/right Find panels keep the historic behavior (size applies to grid
@@ -31,13 +33,13 @@ export class ViewControlsComponent implements OnInit, OnChanges {
    * scales its list-mode thumbnails too, so it opts in with
    * ``[allowSizeInList]="true"``.
    */
-  @Input() allowSizeInList = false;
+  readonly allowSizeInList = input(false);
   /**
    * Whether to show the Grid/List toggle. The VTSBrowse bin popup is grid-only
    * (it pairs the grid with a large hover preview), so it hides the toggle with
    * ``[showViewMode]="false"`` while keeping the thumbnail-size buttons.
    */
-  @Input() showViewMode = true;
+  readonly showViewMode = input(true);
 
   viewMode: 'grid' | 'list' = 'list';
   focusMode: 'click' | 'hover' = 'click';
@@ -45,7 +47,7 @@ export class ViewControlsComponent implements OnInit, OnChanges {
 
   private settings: AppSettings = { volume: 50 };
 
-  constructor(private settingsState: SettingsStateService) {
+  constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -65,7 +67,7 @@ export class ViewControlsComponent implements OnInit, OnChanges {
   }
 
   private refresh(): void {
-    const type = this.currentMediaType;
+    const type = this.currentMediaType();
     this.viewMode = (this.getDict('view_mode')[type] as 'grid' | 'list') ?? this.defaultViewMode();
     this.focusMode = (this.getDict('focus_mode')[type] as 'click' | 'hover') ?? 'click';
     const size = this.getDict('grid_icon_size')[type] as IconSize | undefined;
@@ -75,11 +77,11 @@ export class ViewControlsComponent implements OnInit, OnChanges {
   private defaultViewMode(): 'grid' | 'list' {
     // Left panel reads as a list by default; the right panel and the
     // VTSBrowse bin popup default to a thumbnail grid.
-    return this.side === 'left' ? 'list' : 'grid';
+    return this.side() === 'left' ? 'list' : 'grid';
   }
 
   private key(prefix: 'view_mode' | 'focus_mode' | 'grid_icon_size'): keyof AppSettings {
-    return `${prefix}_${this.side}` as keyof AppSettings;
+    return `${prefix}_${this.side()}` as keyof AppSettings;
   }
 
   private getDict(prefix: 'view_mode' | 'focus_mode' | 'grid_icon_size'): Record<string, string> {
@@ -88,17 +90,17 @@ export class ViewControlsComponent implements OnInit, OnChanges {
   }
 
   setViewMode(mode: 'grid' | 'list'): void {
-    if (!this.currentMediaType || this.viewMode === mode) return;
+    if (!this.currentMediaType() || this.viewMode === mode) return;
     this.save('view_mode', mode);
   }
 
   setFocusMode(mode: 'click' | 'hover'): void {
-    if (!this.currentMediaType || this.focusMode === mode) return;
+    if (!this.currentMediaType() || this.focusMode === mode) return;
     this.save('focus_mode', mode);
   }
 
   bumpSize(delta: 1 | -1): void {
-    if (!this.currentMediaType || (this.viewMode === 'list' && !this.allowSizeInList)) return;
+    if (!this.currentMediaType() || (this.viewMode === 'list' && !this.allowSizeInList())) return;
     const idx = ICON_SIZES.indexOf(this.gridIconSize);
     const next = ICON_SIZES[Math.max(0, Math.min(ICON_SIZES.length - 1, idx + delta))];
     if (next === this.gridIconSize) return;
@@ -115,7 +117,7 @@ export class ViewControlsComponent implements OnInit, OnChanges {
 
   private save(prefix: 'view_mode' | 'focus_mode' | 'grid_icon_size', value: string): void {
     const key = this.key(prefix);
-    const updated = { ...this.getDict(prefix), [this.currentMediaType]: value };
+    const updated = { ...this.getDict(prefix), [this.currentMediaType()]: value };
     this.settingsState.update({ [key]: updated } as SettingsUpdate).subscribe();
   }
 }

--- a/frontend/src/app/services/active-context-watcher.service.ts
+++ b/frontend/src/app/services/active-context-watcher.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { combineLatest } from 'rxjs';
 import { ActiveContextService } from './active-context.service';
@@ -21,16 +21,14 @@ import { ToastService } from './toast.service';
  */
 @Injectable({ providedIn: 'root' })
 export class ActiveContextWatcherService {
+  private activeContext = inject(ActiveContextService);
+  private datasetState = inject(DatasetStateService);
+  private toast = inject(ToastService);
+  private router = inject(Router);
+
   private lastSeenDatasetName: { id: string; name: string } | null = null;
   private lastSeenDetectorName: { id: string; name: string } | null = null;
   private started = false;
-
-  constructor(
-    private activeContext: ActiveContextService,
-    private datasetState: DatasetStateService,
-    private toast: ToastService,
-    private router: Router,
-  ) {}
 
   /** Navigate to /dashboard when an active half is cleared from under
    *  us. Phase 2 makes the URL the source of truth, so a half-set pair

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Router } from '@angular/router';
@@ -50,19 +50,17 @@ const MAX_POLL_ERRORS = 5;
  */
 @Injectable({ providedIn: 'root' })
 export class BrowsePrepService {
+  private router = inject(Router);
+  private activeContext = inject(ActiveContextService);
+  private contextSwitch = inject(ContextSwitchService);
+  private progressEvents = inject(ProgressEventsService);
+  private projectionApi = inject(ProjectionApiService);
+
   private readonly stateSubject = new BehaviorSubject<BrowsePrepState | null>(null);
   readonly state$ = this.stateSubject.asObservable();
 
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private pollErrors = 0;
-
-  constructor(
-    private router: Router,
-    private activeContext: ActiveContextService,
-    private contextSwitch: ContextSwitchService,
-    private progressEvents: ProgressEventsService,
-    private projectionApi: ProjectionApiService,
-  ) {}
 
   /** True while a browse preparation is in flight (not counting the
    *  terminal error state, which waits for the user to dismiss). */

--- a/frontend/src/app/services/connection-state.service.ts
+++ b/frontend/src/app/services/connection-state.service.ts
@@ -3,7 +3,7 @@ import {
   HttpContext,
   HttpContextToken,
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 /**
@@ -52,6 +52,8 @@ export type ConnectionStatus = 'online' | 'offline';
  */
 @Injectable({ providedIn: 'root' })
 export class ConnectionStateService {
+  private http = inject(HttpClient);
+
   /**
    * Consecutive network failures needed to declare the backend offline. A
    * threshold above 1 keeps a single transient blip (one dropped request
@@ -71,7 +73,7 @@ export class ConnectionStateService {
 
   private consecutiveFailures = 0;
 
-  constructor(private http: HttpClient) {
+  constructor() {
     // A browser-level `offline` event (the OS lost its network interface) is
     // an unambiguous, immediate signal — trip the breaker at once rather
     // than waiting for the failure threshold. The matching `online` event is

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, EMPTY, Observable, ReplaySubject, Subject } from 'rxjs';
 import { catchError, filter, take, takeUntil } from 'rxjs/operators';
 import { Router } from '@angular/router';
@@ -53,19 +53,17 @@ interface ActiveSwitch {
  */
 @Injectable({ providedIn: 'root' })
 export class ContextSwitchService {
+  private activeContext = inject(ActiveContextService);
+  private datasetState = inject(DatasetStateService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private progressEvents = inject(ProgressEventsService);
+  private router = inject(Router);
+
   private readonly switchingSubject = new BehaviorSubject<boolean>(false);
   readonly switching$ = this.switchingSubject.asObservable();
 
   private active: ActiveSwitch | null = null;
-
-  constructor(
-    private activeContext: ActiveContextService,
-    private datasetState: DatasetStateService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private progressEvents: ProgressEventsService,
-    private router: Router,
-  ) {}
 
   get switching(): boolean {
     return this.switchingSubject.value;

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { LoadingTask } from '../models/api.models';
@@ -31,6 +31,12 @@ import { ProgressEventsService } from './progress-events.service';
  */
 @Injectable({ providedIn: 'root' })
 export class DashboardLoadingTasksService {
+  private progressEvents = inject(ProgressEventsService);
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+  private datasetState = inject(DatasetStateService);
+  private achievements = inject(AchievementsService);
+
   private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
   private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
 
@@ -46,13 +52,7 @@ export class DashboardLoadingTasksService {
   private datasetPollingActive = false;
   private detectorPollingActive = false;
 
-  constructor(
-    private progressEvents: ProgressEventsService,
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-    private datasetState: DatasetStateService,
-    private achievements: AchievementsService,
-  ) {
+  constructor() {
     // SSE pushes the initial snapshot on connect, so the first event on
     // each channel tells us whether there's anything in flight; auto-
     // resume polling without the dashboard having to coordinate it.

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, Subject, forkJoin, of } from 'rxjs';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
@@ -7,6 +7,9 @@ import { DetectorsRegistryApiService } from './detectors-registry-api.service';
 
 @Injectable({ providedIn: 'root' })
 export class DatasetStateService implements OnDestroy {
+  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private detectorsRegistryApi = inject(DetectorsRegistryApiService);
+
   private readonly datasetsSubject = new BehaviorSubject<DatasetRegistryEntry[]>([]);
   private readonly detectorsSubject = new BehaviorSubject<DetectorRegistryEntry[]>([]);
   private readonly loadingSubject = new BehaviorSubject<boolean>(false);
@@ -32,10 +35,7 @@ export class DatasetStateService implements OnDestroy {
   readonly error$ = this.errorSubject.asObservable();
   readonly loaded$ = this.loadedSubject.asObservable();
 
-  constructor(
-    private datasetsRegistryApi: DatasetsRegistryApiService,
-    private detectorsRegistryApi: DetectorsRegistryApiService,
-  ) {
+  constructor() {
     // Single subscription that uses switchMap to cancel in-flight requests
     // when a new refresh is triggered, preventing stale responses from
     // overwriting fresh data. `catchError` keeps the outer pipeline alive

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import { Injectable, NgZone, OnDestroy, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 
 export type VoteDirection = 'good' | 'bad';
@@ -15,11 +15,11 @@ export interface KeyboardAction {
 
 @Injectable({ providedIn: 'root' })
 export class KeyboardService implements OnDestroy {
+  private zone = inject(NgZone);
+
   readonly action$ = new Subject<KeyboardAction>();
 
   private listener: ((e: KeyboardEvent) => void) | null = null;
-
-  constructor(private zone: NgZone) {}
 
   /** Start listening for keyboard shortcuts on the document. */
   start(): void {

--- a/frontend/src/app/services/labelset-state.service.ts
+++ b/frontend/src/app/services/labelset-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, EMPTY, Observable, Subject, timer } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import type { DetectorLabelView } from '../generated/api-client/models/detector-label-view';
@@ -7,6 +7,8 @@ import { DetectorsCrudApiService } from './detectors-crud-api.service';
 
 @Injectable({ providedIn: 'root' })
 export class LabelsetStateService implements OnDestroy {
+  private api = inject(DetectorsCrudApiService);
+
   private readonly goodSubject = new BehaviorSubject<DetectorLabelView[]>([]);
   private readonly badSubject = new BehaviorSubject<DetectorLabelView[]>([]);
   private readonly mediaTypeSubject = new BehaviorSubject<string>('');
@@ -18,8 +20,6 @@ export class LabelsetStateService implements OnDestroy {
   readonly good$ = this.goodSubject.asObservable();
   readonly bad$ = this.badSubject.asObservable();
   readonly mediaType$ = this.mediaTypeSubject.asObservable();
-
-  constructor(private api: DetectorsCrudApiService) {}
 
   ngOnDestroy(): void {
     this.stopPolling();

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
@@ -34,6 +34,9 @@ const BATCH_SIZE = 200;
  */
 @Injectable({ providedIn: 'root' })
 export class MediaMetadataCacheService implements OnDestroy {
+  private mediasApi = inject(MediasApiService);
+  private activeContext = inject(ActiveContextService);
+
   private readonly cache = new Map<string, MediaBatchResponse>();
   private readonly pendingByDataset = new Map<string, Set<number>>();
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -42,11 +45,6 @@ export class MediaMetadataCacheService implements OnDestroy {
   /** Emits the current cache version (increments on every batch arrival). */
   private readonly versionSubject = new BehaviorSubject<number>(0);
   readonly version$ = this.versionSubject.asObservable();
-
-  constructor(
-    private mediasApi: MediasApiService,
-    private activeContext: ActiveContextService,
-  ) {}
 
   ngOnDestroy(): void {
     this.destroy$.next();

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy, NgZone } from '@angular/core';
+import { Injectable, OnDestroy, NgZone, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 import {
@@ -32,6 +32,9 @@ import { ConnectionStateService } from './connection-state.service';
  */
 @Injectable({ providedIn: 'root' })
 export class ProgressEventsService implements OnDestroy {
+  private zone = inject(NgZone);
+  private connection = inject(ConnectionStateService);
+
   private readonly datasetSubject = new BehaviorSubject<ProgressEvent>({});
   private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
   private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
@@ -60,10 +63,7 @@ export class ProgressEventsService implements OnDestroy {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private lastBootId: string | null = null;
 
-  constructor(
-    private zone: NgZone,
-    private connection: ConnectionStateService,
-  ) {
+  constructor() {
     // Track the circuit breaker: stay connected while online, and tear the
     // EventSource down when the breaker trips so its native auto-reconnect
     // stops hammering a dead backend. The BehaviorSubject replays the current

--- a/frontend/src/app/services/running-jobs.service.ts
+++ b/frontend/src/app/services/running-jobs.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
 import { catchError, distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs/operators';
@@ -40,14 +40,14 @@ export function pairKey(datasetId: string, detectorId: string): string {
  */
 @Injectable({ providedIn: 'root' })
 export class RunningJobsService implements OnDestroy {
+  private http = inject(HttpClient);
+
   private readonly intervalMs = 3000;
   private readonly busyPairsSubject = new BehaviorSubject<Map<string, string[]>>(new Map());
   private readonly stopPolling$ = new Subject<void>();
   private readonly destroy$ = new Subject<void>();
   private observerCount = 0;
   private polling = false;
-
-  constructor(private http: HttpClient) {}
 
   ngOnDestroy(): void {
     this.destroy$.next();

--- a/frontend/src/app/services/theme.service.ts
+++ b/frontend/src/app/services/theme.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { SettingsApiService } from './settings-api.service';
 
@@ -12,13 +12,13 @@ const OS_MEDIA_QUERY = '(prefers-color-scheme: light)';
 
 @Injectable({ providedIn: 'root' })
 export class ThemeService implements OnDestroy {
+  private settingsApi = inject(SettingsApiService);
+
   private themeSubject = new BehaviorSubject<Theme>('system');
   theme$: Observable<Theme> = this.themeSubject.asObservable();
 
   private osMedia: MediaQueryList | null = null;
   private osListener: ((e: MediaQueryListEvent) => void) | null = null;
-
-  constructor(private settingsApi: SettingsApiService) {}
 
   ngOnDestroy(): void {
     this.unsubscribeOs();

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LoadingTask } from '../models/api.models';
 import { ProgressEventsService } from './progress-events.service';
@@ -88,7 +88,9 @@ export class ToastService {
   private readonly seenTaskKeys = new Set<string>();
   private readonly autoDismissTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
-  constructor(progressEvents: ProgressEventsService) {
+  constructor() {
+    const progressEvents = inject(ProgressEventsService);
+
     progressEvents.loadingTasks$.subscribe((tasks) => this.routeTaskErrors(tasks, 'dataset'));
     progressEvents.detectorLoadingTasks$.subscribe((tasks) => this.routeTaskErrors(tasks, 'detector'));
   }

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, EMPTY, Observable, Subject, timer } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
@@ -29,6 +29,9 @@ const UNDO_STACK_MAX = 20;
 
 @Injectable({ providedIn: 'root' })
 export class VoteStateService implements OnDestroy {
+  private sortingApi = inject(SortingApiService);
+  private mediasApi = inject(MediasApiService);
+
   private readonly goodVotesSubject = new BehaviorSubject<Set<number>>(new Set());
   private readonly badVotesSubject = new BehaviorSubject<Set<number>>(new Set());
   private readonly verifiedIdsSubject = new BehaviorSubject<Set<number>>(new Set());
@@ -97,11 +100,6 @@ export class VoteStateService implements OnDestroy {
   readonly goodRegionBoxes$ = this.goodRegionBoxesSubject.asObservable();
   /** Emits a short message every time an undo or redo executes. */
   readonly toast$ = this.toastSubject.asObservable();
-
-  constructor(
-    private sortingApi: SortingApiService,
-    private mediasApi: MediasApiService,
-  ) {}
 
   ngOnDestroy(): void {
     this.destroy$.next();


### PR DESCRIPTION
## What & why

After the Angular 21 upgrade, the frontend infrastructure was already modern (100% standalone components, modern `@angular/build:application` builder, lazy routes, `@defer`-ed modals, Vitest), but component **idioms** were still on Angular pre-16 patterns. This PR runs Angular's official automated migration schematics to adopt modern Angular 21 idioms. **No behavior change** — purely mechanical, schematic-driven refactors.

## What landed

| Schematic | Effect |
|-----------|--------|
| `@angular/core:control-flow` | Templates were already on `@if`/`@for`; removed two now-unused `CommonModule` imports. |
| `@angular/core:inject` | Converted constructor parameter injection → `inject()` across ~50 files. 1 site left that the schematic couldn't safely convert. |
| `@angular/core:signal-input-migration` | `@Input()` → signal `input()` (~241 inputs). 39 `@Input` sites left where safety couldn't be proven (e.g. inputs reassigned internally). |
| `@angular/core:output-migration` | All `@Output()`/`EventEmitter` pairs → `output()` (164 sites). |

139 files changed.

## Verification

All checks green via `./run-tests.sh frontend`:
- `build:prod` — no errors or warnings
- Vitest — 765 passed (69 files)
- `npm audit` — 0 production vulnerabilities
- ruff / ruff format / codespell / deptry / pip-audit / pyright / OpenAPI snapshot — all pass

## Follow-ups (deferred)

This was scoped to the mechanical schematics only. The natural next steps toward the zoneless bundle-size win remain:
1. Convert hot-path service state (`BehaviorSubject`/`Subject`) → `signal`/`computed`.
2. Flip components to `ChangeDetectionStrategy.OnPush`.
3. Go zoneless (`provideZonelessChangeDetection`, drop zone.js for ~35 kB).

`OnPush` depends on the signal-state conversion, and zoneless depends on `OnPush` — so they need to land in that order in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TvQ5J5qdvTfJJfDFqFVu8)_