### PR TITLE
Add structural-embedder design doc

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -29,6 +29,7 @@ it can't drift far. (Point-in-time UI review/audit reports live in
 ## Detectors / embedders / clippers
 
 - [patch-embedder.md](patch-embedder.md): patch-based image embedder (V1+V2 shipped; V3 design)
+- [structural-embedder.md](structural-embedder.md): structural (instance-matching) embedder — SIFT/VLAD + RANSAC re-rank (design only — not started)
 - [clipper-chain.md](clipper-chain.md): ordered converter/clipper chains (Phase 1 shipped)
 - [cli-detector-converter.md](cli-detector-converter.md): CLI autodetect with converters + clippers (Phase 1 shipped)
 

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -14,7 +14,8 @@ the example/region similarity flow and the match-statistic verification classifi
 just like patch); **planar-only** matching; **image-only v1 with audio as the next
 media target**; **dual-embedder coexistence deferred** to patch v3 (one structural
 embedder per dataset for now); **a fixed, shipped VLAD vocabulary** for v1 (no
-per-dataset codebook fit); **affine-only** geometric matching (no homography).
+per-dataset codebook fit); **similarity-transform** geometric matching (4 DoF:
+translation, rotation, uniform scale — no shear, no perspective).
 
 ## Motivation — structural vs semantic search
 
@@ -26,7 +27,7 @@ Coke can, because they mean almost the same thing.
 
 A **structural** search asks a different question: *does this specific visual
 pattern appear in the haystack item, allowing for translation, rotation, scale,
-and mild perspective?* This is **instance retrieval** / object-instance matching,
+and uniform scale?* This is **instance retrieval** / object-instance matching,
 the classic local-feature + geometric-verification problem (SIFT/SURF/ORB
 keypoints, descriptor matching, RANSAC geometric verification). The canonical
 pipeline is
@@ -49,7 +50,7 @@ two assumptions at once:
    128-D SIFT descriptors), not a single fixed-D vector. There is no canonical
    "image vector."
 2. **Comparison operator.** Two images are compared by **geometric verification**
-   — match descriptors, then RANSAC-fit an affine transform and count inliers —
+   — match descriptors, then RANSAC-fit a similarity transform and count inliers —
    not by a dot product.
 
 Meanwhile *every* downstream consumer in VTSearch wants exactly the thing
@@ -93,9 +94,12 @@ product, same as today) and is what makes Stage 2 tractable.
 ### Stage 2 — geometric verification (the new structural part)
 
 For the top-K candidates from Stage 1, match the query/template keypoints against
-each candidate's keypoints and RANSAC-fit an **affine** transform (a 6-DoF model:
-translation, rotation, scale, shear — chosen over homography because it's more
-stable with few inliers and sufficient for planar targets). This yields an
+each candidate's keypoints and RANSAC-fit a **similarity** transform (a 4-DoF
+model: translation, rotation, uniform scale — *no* shear or perspective). This is
+the exact transform a digitally-overlaid logo undergoes; dropping the affine
+shear/anisotropic-scale DoF and the homography perspective DoF means RANSAC needs
+only 2 correspondences to fit, constrains the fit harder, and yields fewer false
+positives than a looser model. This yields an
 inlier set and a geometric model per candidate, and **re-ranks** the shortlist by
 geometric consistency.
 
@@ -131,8 +135,9 @@ spaces that are both fixed-D and metric, so both reuse `train_model` verbatim:
    - inlier count and inlier ratio (inliers / tentative matches),
    - number of tentative (pre-RANSAC) descriptor matches,
    - mean / median reprojection error of inliers,
-   - geometric plausibility of the fitted affine model: determinant sign, condition
-     number, scale and shear within sane bounds (rejects degenerate fits),
+   - geometric plausibility of the fitted similarity model: scale within sane
+     bounds and reflection check (shear and anisotropic scale are zero by
+     construction, so there are no degenerate-affine fits to reject),
    - spatial extent / spread of the inliers in the candidate image.
 
    Stack those into a fixed-D feature vector **per (template, candidate) pair** and
@@ -304,11 +309,14 @@ field collapses cleanly into the v3 dict-keyed schema, just as the patch fields 
 ## Non-goals
 
 - **No new media type.** Structural-embedded images are still `image` media.
-- **No 3D / non-planar matching, and affine-only (no homography).** Confirmed
-  planar-only for now: the affine model assumes a roughly planar target (logos,
-  packaging, flat artwork, building façades), which covers the motivating use
-  cases. Full perspective homography and fundamental-matrix / 3D-aware matching are
-  out of scope.
+- **Similarity transform only — no shear, no perspective.** v1 models the
+  template→appearance transform as a 4-DoF similarity (translation, rotation,
+  uniform scale), which is exactly what a digitally-composited logo undergoes.
+  Affine shear / anisotropic scale (the affine approximation to oblique viewing)
+  and full perspective homography are both out of scope: if we ever needed to model
+  a logo seen on a tilted real-world surface, the right move is to jump straight to
+  homography, not to stop at affine's middle ground. Fundamental-matrix / 3D-aware
+  matching is also out of scope.
 - **No persisted vectors outside the dataset pickle.** Local features live in the
   pickle and RAM only (see Storage). Templates and both classifiers re-derive from
   origins on load.
@@ -354,10 +362,13 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 4. **Live re-rank vs on-demand.** Does Stage 2 run on every sort, or only when the
    user asks (a "verify" action)? Latency vs immediacy. Probably live on the
    shortlist (K small) but measure.
-5. **Geometric model — DECIDED: affine only.** A 6-DoF affine (translation,
-   rotation, scale, shear) for both the RANSAC inlier gate and the matched-region
-   overlay. More stable than homography with few inliers and sufficient for planar
-   targets. Perspective homography is not used in v1.
+5. **Geometric model — DECIDED: similarity transform only.** A 4-DoF similarity
+   (translation, rotation, uniform scale) for both the RANSAC inlier gate and the
+   matched-region overlay. Matches the digital-overlay use case exactly; needs only
+   2 correspondences to fit, so it constrains harder and false-positives less than
+   affine or homography. Neither affine shear nor perspective homography is used in
+   v1 — the conscious call is "no shear at all, and if shear is ever needed, go all
+   the way to homography rather than stop at affine."
 6. **VLAD vs alternatives for Stage 1.** VLAD is the recommended default, but a
    learned global descriptor (e.g. reusing a DINOv2 CLS vector purely for the
    coarse shortlist) could outperform VLAD while the local features do the
@@ -386,8 +397,8 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 ## Tests
 
 - **Matcher unit tests** with synthetic correspondences (no model weights): a
-  known affine transform applied to a planted keypoint set → `verify` recovers it
-  with
+  known similarity transform applied to a planted keypoint set → `verify` recovers
+  it with
   the expected inlier count; degenerate/no-match inputs return low/zero inliers and
   a rejected geometric model.
 - **VLAD aggregation:** descriptor set → fixed-D L2-normalised vector of the right

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -14,7 +14,7 @@ the example/region similarity flow and the match-statistic verification classifi
 just like patch); **planar-only** matching; **image-only v1 with audio as the next
 media target**; **dual-embedder coexistence deferred** to patch v3 (one structural
 embedder per dataset for now); **a fixed, shipped VLAD vocabulary** for v1 (no
-per-dataset codebook fit).
+per-dataset codebook fit); **affine-only** geometric matching (no homography).
 
 ## Motivation — structural vs semantic search
 
@@ -28,7 +28,8 @@ A **structural** search asks a different question: *does this specific visual
 pattern appear in the haystack item, allowing for translation, rotation, scale,
 and mild perspective?* This is **instance retrieval** / object-instance matching,
 the classic local-feature + geometric-verification problem (SIFT/SURF/ORB
-keypoints, descriptor matching, RANSAC homography). The canonical pipeline is
+keypoints, descriptor matching, RANSAC geometric verification). The canonical
+pipeline is
 Sivic & Zisserman's "Video Google" and Philbin et al.'s Oxford-Buildings work.
 
 Use cases this unlocks that no semantic embedder can: brand/logo detection,
@@ -48,7 +49,7 @@ two assumptions at once:
    128-D SIFT descriptors), not a single fixed-D vector. There is no canonical
    "image vector."
 2. **Comparison operator.** Two images are compared by **geometric verification**
-   — match descriptors, then RANSAC-fit a homography/affine and count inliers —
+   — match descriptors, then RANSAC-fit an affine transform and count inliers —
    not by a dot product.
 
 Meanwhile *every* downstream consumer in VTSearch wants exactly the thing
@@ -92,7 +93,9 @@ product, same as today) and is what makes Stage 2 tractable.
 ### Stage 2 — geometric verification (the new structural part)
 
 For the top-K candidates from Stage 1, match the query/template keypoints against
-each candidate's keypoints and RANSAC-fit a homography (or affine). This yields an
+each candidate's keypoints and RANSAC-fit an **affine** transform (a 6-DoF model:
+translation, rotation, scale, shear — chosen over homography because it's more
+stable with few inliers and sufficient for planar targets). This yields an
 inlier set and a geometric model per candidate, and **re-ranks** the shortlist by
 geometric consistency.
 
@@ -128,8 +131,8 @@ spaces that are both fixed-D and metric, so both reuse `train_model` verbatim:
    - inlier count and inlier ratio (inliers / tentative matches),
    - number of tentative (pre-RANSAC) descriptor matches,
    - mean / median reprojection error of inliers,
-   - geometric plausibility of the fitted model: determinant sign, condition
-     number, scale and shear within sane bounds (rejects degenerate homographies),
+   - geometric plausibility of the fitted affine model: determinant sign, condition
+     number, scale and shear within sane bounds (rejects degenerate fits),
    - spatial extent / spread of the inliers in the candidate image.
 
    Stack those into a fixed-D feature vector **per (template, candidate) pair** and
@@ -301,10 +304,11 @@ field collapses cleanly into the v3 dict-keyed schema, just as the patch fields 
 ## Non-goals
 
 - **No new media type.** Structural-embedded images are still `image` media.
-- **No 3D / non-planar matching.** Confirmed planar-only for now: homography/affine
-  assumes a roughly planar target (logos, packaging, flat artwork, building
-  façades), which covers the motivating use cases. Fundamental-matrix / 3D-aware
-  matching is out of scope.
+- **No 3D / non-planar matching, and affine-only (no homography).** Confirmed
+  planar-only for now: the affine model assumes a roughly planar target (logos,
+  packaging, flat artwork, building façades), which covers the motivating use
+  cases. Full perspective homography and fundamental-matrix / 3D-aware matching are
+  out of scope.
 - **No persisted vectors outside the dataset pickle.** Local features live in the
   pickle and RAM only (see Storage). Templates and both classifiers re-derive from
   origins on load.
@@ -350,9 +354,10 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 4. **Live re-rank vs on-demand.** Does Stage 2 run on every sort, or only when the
    user asks (a "verify" action)? Latency vs immediacy. Probably live on the
    shortlist (K small) but measure.
-5. **Geometric model: homography vs affine.** Affine is more stable with few
-   inliers; homography handles perspective. Possibly affine for the inlier
-   gate, homography for the final overlay. Decide empirically.
+5. **Geometric model — DECIDED: affine only.** A 6-DoF affine (translation,
+   rotation, scale, shear) for both the RANSAC inlier gate and the matched-region
+   overlay. More stable than homography with few inliers and sufficient for planar
+   targets. Perspective homography is not used in v1.
 6. **VLAD vs alternatives for Stage 1.** VLAD is the recommended default, but a
    learned global descriptor (e.g. reusing a DINOv2 CLS vector purely for the
    coarse shortlist) could outperform VLAD while the local features do the
@@ -381,7 +386,8 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 ## Tests
 
 - **Matcher unit tests** with synthetic correspondences (no model weights): a
-  known homography applied to a planted keypoint set → `verify` recovers it with
+  known affine transform applied to a planted keypoint set → `verify` recovers it
+  with
   the expected inlier count; degenerate/no-match inputs return low/zero inliers and
   a rejected geometric model.
 - **VLAD aggregation:** descriptor set → fixed-D L2-normalised vector of the right

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -8,8 +8,12 @@ to be filled in when implementation starts (the way `patch-embedder.md`'s v2/v3
 punchlists were filled in during impl).
 
 Decisions locked in design: **two-stage architecture** (global vector retrieval +
-geometric re-rank), **SIFT for v1 with a pluggable matching backend** so learned
-local features drop in later.
+geometric re-rank); **SIFT for v1 with a pluggable matching backend** so learned
+local features drop in later; **the full vote-trained detector ships in v1** (both
+the example/region similarity flow and the match-statistic verification classifier,
+just like patch); **planar-only** matching; **image-only v1 with audio as the next
+media target**; **dual-embedder coexistence deferred** to patch v3 (one structural
+embedder per dataset for now).
 
 ## Motivation — structural vs semantic search
 
@@ -271,39 +275,53 @@ Structural embedders set `supports_text = False`, `is_default = False`
   structural datasets the copy nudges "box the pattern you want to match."
 - **No new region-vote affordance** beyond what patch v2 already ships.
 
-## Relationship to patch v3 (dual-embedder)
+## Single embedder per dataset (dual-embedder deferred)
 
-`supports_text = False` means a structural-only dataset can be seeded *only* by
-example/region, never by a text query — which forecloses the "text query seeds the
-flow" entry point. The natural fix is patch-embedder.md's **v3 dual-embedder**
-design: a dataset binds *both* a text-capable embedder (SigLIP — for text-seeded
-discovery and diversity) *and* a structural embedder (for the instance-matching
-detector). The v3 schema (`media["embeddings"]` keyed by embedder name) already
-accommodates this; a structural embedder would be a third role-type alongside
-`text_embedder` and `patch_embedder` — e.g. `structural_embedder: str | None`.
-This is the right long-term home for structural search and the reason to land v3
-first (or concurrently).
+For now a structural embedder is **one embedder per dataset**, exactly like patch:
+the dataset is bound to it at creation, and both the example/region similarity
+flow and the vote-trained detector run against that single embedder. This is the
+whole v1/v2 scope — no coexistence with a text embedder.
+
+`supports_text = False` does mean a structural dataset can be seeded *only* by
+example/region, never by a text query. That's an accepted limitation for now, the
+same way a `dinov*_patch` dataset has no text sort today. The longer-term fix —
+binding a text-capable embedder (SigLIP) *and* a structural embedder on the same
+dataset so text-seeded discovery and instance matching coexist — is patch
+v3's **dual-embedder** territory (a structural embedder would slot in as a third
+role-type alongside `text_embedder` / `patch_embedder`). **Deferred; we'll take it
+up when patch v3 lands.** Nothing in v1/v2 forecloses it: the per-media `embedding`
+field collapses cleanly into the v3 dict-keyed schema, just as the patch fields do.
 
 ## Non-goals
 
 - **No new media type.** Structural-embedded images are still `image` media.
-- **No 3D / non-planar matching in v1.** Homography/affine assumes a roughly
-  planar target (logos, packaging, flat artwork, building façades). Fundamental-
-  matrix / 3D-aware matching is out of scope.
+- **No 3D / non-planar matching.** Confirmed planar-only for now: homography/affine
+  assumes a roughly planar target (logos, packaging, flat artwork, building
+  façades), which covers the motivating use cases. Fundamental-matrix / 3D-aware
+  matching is out of scope.
 - **No persisted vectors outside the dataset pickle.** Local features live in the
   pickle and RAM only (see Storage). Templates and both classifiers re-derive from
   origins on load.
-- **No audio/text/document structural matching in v1.** Audio has a real
-  structural analog (Shazam-style constellation fingerprinting) and documents have
-  layout/template matching — both are future backends under the same abstraction,
-  not v1.
+- **Image only in v1, but audio is the next media target (soon).** Audio has a
+  direct structural analog — Shazam-style constellation fingerprinting (spectrogram
+  peak pairs → hashed landmarks → geometric/temporal consistency), which is the
+  same detect-features → match → verify-by-geometry shape as SIFT+RANSAC. The
+  `StructuralMatcher` protocol and the `supports_geometric_verification` flag are
+  therefore kept **media-agnostic** from the start so an audio backend drops in
+  without reshaping the interface (the "local features" become spectrogram
+  landmarks, the geometric model becomes a time-frequency offset histogram). Text
+  and document structural matching (layout/template) are further out.
 - **No swap-backend-on-an-existing-dataset flow.** Like patch, the embedder is
   fixed at dataset creation; changing it means re-import.
 
 ## Media scope
 
-v1: **image only** (+ video frames later, reusing the image path per-frame).
-Matches the patch-embedder scope decision.
+v1: **image only** (+ video frames later, reusing the image path per-frame),
+matching the patch-embedder scope decision. **Audio is the next media target and
+expected soon** — see Non-goals for why the matcher abstraction is kept
+media-agnostic now so the audio (constellation-fingerprint) backend lands without
+an interface rewrite. The capability flag is `supports_geometric_verification`
+(deliberately not `supports_*_image_*`) for exactly this reason.
 
 ## Open questions
 
@@ -342,10 +360,15 @@ Matches the patch-embedder scope decision.
   greyed via the existing `supports_text` gate. Pre-impl spike on a demo image
   dataset to lock vocabulary source, K, and the geometric model.
 - **v2:** learned-local-feature backend (SuperPoint + LightGlue or similar) as a
-  drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes.
-- **v3:** structural embedder as a third role in the patch-v3 dual-embedder schema
-  (text + patch + structural slots per dataset), so a dataset can offer text-seeded
-  discovery *and* instance-matching detectors simultaneously.
+  drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes. **Plus
+  the audio backend** (constellation fingerprinting) under the same media-agnostic
+  `StructuralMatcher` protocol + `supports_geometric_verification` flag — the
+  next media target, sequenced here because the image work proves out the
+  abstraction it reuses.
+- **Later (deferred):** structural embedder as a third role in the patch-v3
+  dual-embedder schema (text + patch + structural slots per dataset), so a dataset
+  can offer text-seeded discovery *and* instance-matching detectors simultaneously.
+  Picked up when patch v3 lands; not scheduled here.
 
 ## Tests
 
@@ -379,5 +402,8 @@ Matches the patch-embedder scope decision.
 - VLAD-vocabulary persistence decision (Open Question 1) blocks impl start.
 - Spike (Stage-1 backbone choice, K, geometric model) precedes v1 build, like the
   caltech101_s sweep preceded patch v1.
-- Landing or coordinating with patch v3 (dual-embedder) is what makes structural +
-  text-seeded discovery coexist on one dataset.
+- Keep the `StructuralMatcher` protocol media-agnostic from day one so the audio
+  (constellation-fingerprint) backend — the next media target — lands in v2 without
+  reshaping the interface.
+- Dual-embedder coexistence (structural + text on one dataset) is deferred to patch
+  v3; not scheduled here.

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -1,0 +1,383 @@
+# Structural Embedders — Design
+
+**Status:** Design only — not started. This is the living spec for a third
+embedder *type* (alongside single-vector and patch) that searches for **specific
+instances** ("the Coca-Cola logo") rather than **semantic categories** ("a cola
+can"). The architecture below is the agreed direction; the work plan is a sketch
+to be filled in when implementation starts (the way `patch-embedder.md`'s v2/v3
+punchlists were filled in during impl).
+
+Decisions locked in design: **two-stage architecture** (global vector retrieval +
+geometric re-rank), **SIFT for v1 with a pluggable matching backend** so learned
+local features drop in later.
+
+## Motivation — structural vs semantic search
+
+Today every embedder is *semantic*: SigLIP/CLAP/DINO map a media item to a point
+in a learned feature space where nearness ≈ "means the same kind of thing." That
+answers "find me cola cans." It does **not** answer "find me images containing
+*this exact logo*" — a semantic embedder will happily rank a Pepsi can next to a
+Coke can, because they mean almost the same thing.
+
+A **structural** search asks a different question: *does this specific visual
+pattern appear in the haystack item, allowing for translation, rotation, scale,
+and mild perspective?* This is **instance retrieval** / object-instance matching,
+the classic local-feature + geometric-verification problem (SIFT/SURF/ORB
+keypoints, descriptor matching, RANSAC homography). The canonical pipeline is
+Sivic & Zisserman's "Video Google" and Philbin et al.'s Oxford-Buildings work.
+
+Use cases this unlocks that no semantic embedder can: brand/logo detection,
+finding reproductions or crops of a specific artwork, locating a particular
+landmark building, near-duplicate and tampering detection, matching a product's
+packaging.
+
+## The core mismatch (why this is a new *type*, not a new embedder)
+
+Patch embedders were a relatively cheap addition because they still produce
+vectors that live in a metric space — `score_against_query` just took a `max` of
+cosine over a region set instead of a single cosine. Structural matching breaks
+two assumptions at once:
+
+1. **Representation.** A structural feature extractor produces a *variable-size
+   set* of `(keypoint, descriptor)` pairs per image (hundreds to thousands of
+   128-D SIFT descriptors), not a single fixed-D vector. There is no canonical
+   "image vector."
+2. **Comparison operator.** Two images are compared by **geometric verification**
+   — match descriptors, then RANSAC-fit a homography/affine and count inliers —
+   not by a dot product.
+
+Meanwhile *every* downstream consumer in VTSearch wants exactly the thing
+structural matching doesn't natively provide — a fixed-D L2-normalised vector and
+a cosine comparison:
+
+- `train_model(X, y, input_dim)` (`vtscore/training/mlp.py`) needs an `(N, D)`
+  matrix.
+- the diversity tree, the pre-vote random/diversity sorts, and cosine/example
+  sort all consume `media["embedding"]`.
+- `_score_all_media` (`vtscore/detectors/training.py`) runs the MLP over a
+  stacked vector matrix.
+
+So the design problem is not "add a new embedder," it's "reconcile a
+set-of-descriptors + geometric-fit world with VTSearch's vector + cosine world
+without rewriting the downstream." The two-stage architecture below is how.
+
+## Architecture — two-stage instance retrieval
+
+The reconciliation that has worked in the literature for two decades: **aggregate
+the descriptor set into a fixed-D vector for retrieval, and keep the raw
+keypoints for a geometric re-rank.**
+
+### Stage 1 — retrieval (rides the existing pipeline unchanged)
+
+Aggregate each image's local descriptors into a single fixed-D vector via **VLAD**
+(Vector of Locally Aggregated Descriptors) — or BoVW / Fisher vector; VLAD is the
+recommended default for its size/quality balance. That aggregated vector *is* a
+metric-space embedding, so:
+
+- it populates `media["embedding"]` exactly like any single-vector embedder;
+- the diversity tree, cosine/example sort, the pre-vote sorts, and `train_model`
+  all work with **zero new machinery**;
+- `supports_text` is `False` (no text encoder maps into VLAD space), so the text
+  sort greys out via the already-shipped `supports_text` gate.
+
+Stage 1 alone is "coarse instance retrieval": it shortlists images whose overall
+local-feature population resembles the query. It is fast (one matrix–vector
+product, same as today) and is what makes Stage 2 tractable.
+
+### Stage 2 — geometric verification (the new structural part)
+
+For the top-K candidates from Stage 1, match the query/template keypoints against
+each candidate's keypoints and RANSAC-fit a homography (or affine). This yields an
+inlier set and a geometric model per candidate, and **re-ranks** the shortlist by
+geometric consistency.
+
+Stage 2 is a *re-rank layered after sorting*, never a replacement for it. Running
+RANSAC against the whole haystack would be O(N·match·RANSAC) and far too slow, so
+restricting it to the Stage-1 shortlist is both the elegant and the *necessary*
+design — it's what keeps structural search within the existing scalability
+budget.
+
+```
+query/template ─┐
+                ├─► Stage 1: VLAD cosine over all media  ──► top-K shortlist
+haystack VLAD ──┘                                              │
+                                                               ▼
+template keypoints ──► Stage 2: descriptor match + RANSAC ──► re-ranked results
+haystack keypoints ──►        per shortlisted candidate         + inlier overlay
+```
+
+## The "MLP equivalent" — a classifier over *match statistics*, not descriptors
+
+The hardest open question in the original brainstorm was *"what's the MLP
+equivalent, and how do we learn the Good space in SIFT-space?"* The answer:
+**you don't learn in raw SIFT-descriptor space at all.** You learn in two derived
+spaces that are both fixed-D and metric, so both reuse `train_model` verbatim:
+
+1. **Retrieval MLP (already exists).** Trains on the VLAD vectors. Learns coarsely
+   "what does the good instance's local-feature population look like." This is the
+   ordinary detector MLP; no changes.
+
+2. **Verification classifier (the genuinely-structural learnable).** Every RANSAC
+   fit against a template emits a small bundle of *match statistics*:
+
+   - inlier count and inlier ratio (inliers / tentative matches),
+   - number of tentative (pre-RANSAC) descriptor matches,
+   - mean / median reprojection error of inliers,
+   - geometric plausibility of the fitted model: determinant sign, condition
+     number, scale and shear within sane bounds (rejects degenerate homographies),
+   - spatial extent / spread of the inliers in the candidate image.
+
+   Stack those into a fixed-D feature vector **per (template, candidate) pair** and
+   train a logistic-regression / tiny MLP → P(match). The user's votes supply the
+   labels directly: **RegionYes** items that geometrically verify against a
+   template are positive match-stat examples; **No** items are negatives. This is
+   exactly the "tune the RANSAC comparer + calibrate the threshold" intuition —
+   and the classifier's decision boundary **is** the calibrated threshold, so
+   threshold calibration falls out for free instead of being a separate hand-tuned
+   knob.
+
+So the conceptual map is: **VLAD-space MLP for retrieval, match-statistic-space
+classifier for verification.** Neither lives in descriptor space, and both reuse
+`train_model(X, y)` with no shape change — `X` is just VLAD vectors in one case
+and match-statistics in the other.
+
+## Voting model — RegionYes is *constitutive*, not advisory
+
+Patch v2 treats a region box as a "salient-area hint" attached to a yes-vote. For
+structural detectors the box is **stronger**: it *defines the template*.
+
+- **RegionYes** (box-on-yes, the existing `LabeledElement.region_box`): we keep
+  only the keypoints whose location falls inside the box as the query template.
+  "Find the Coca-Cola logo" boxes the logo and discards the surrounding clutter
+  that a whole-image template would drag in. This is the primary positive signal.
+- **Whole-image Yes** (no box): allowed, but produces a noisy template (matches
+  background texture). The UI should nudge toward boxing for structural detectors;
+  unboxed yes still works as a coarse template.
+- **No**: feeds the verification classifier's negatives, and can additionally
+  drive a TF-IDF / stop-list down-weighting of non-discriminative visual words (a
+  logo printed over busy background texture; generic edges that match everything).
+- **Multiple RegionYes votes → multiple templates.** Score = **max over
+  templates** (verify the candidate against each template, keep the best fit),
+  directly analogous to patch's max-over-regions.
+
+`LabeledElement.region_box` already exists (shipped in patch v2), so the persisted
+form of a structural detector is just `origin + region_box` per labelled example —
+no new schema. Templates re-derive on load by re-embedding the boxed source
+region, exactly the way `DetectorContext.label_embeddings` re-derives today.
+
+## Feature backend — SIFT for v1, pluggable for learned features
+
+Same interchangeable-backbone story that DINOv2 / DINOv3 / EUPE have for patch:
+the *matching backend* is pluggable behind the structural-embedder interface.
+
+| Backend | Pros | Cons |
+|---|---|---|
+| **Classic SIFT + RANSAC** (OpenCV) | CPU-friendly, deterministic, ungated, light deps, patent expired (in mainline OpenCV since 4.4). Good enough for clean planar logos. | Weaker than learned features under strong viewpoint/illumination change. |
+| **Learned local features** (SuperPoint + LightGlue/SuperGlue, DISK, ALIKED, DeDoDe) | Markedly better instance matching, especially under viewpoint/illumination change. | Needs GPU, heavier deps, some gating. |
+
+**v1 ships classic SIFT** (zero-ceremony proof, runs in the CPU test suite), but
+the matching backend is an abstraction (`StructuralMatcher`-style protocol:
+`detect_and_describe(image) -> (keypoints, descriptors)` +
+`verify(template, candidate) -> MatchStats`) so SuperPoint+LightGlue is a drop-in
+v2 backend without touching Stage 1, the classifier, or the UI.
+
+## Storage — keypoints in the dataset pickle, nothing new on disk
+
+Following the patch precedent (`patch_grid` / `patch_regions` live in the pickle),
+a structural embedder stores per media:
+
+```python
+media["embedding"]      = np.ndarray   # (D,) fp32, L2-normalised VLAD vector — Stage 1
+media["local_features"] = StructuralFeatures(
+    keypoints  = np.ndarray,           # (M, 4) fp16: x, y, scale, orientation (normalised coords)
+    descriptors= np.ndarray,           # (M, d) — uint8 for SIFT (128), fp16 for learned
+)
+```
+
+Size: a typical image yields ~1–2k SIFT keypoints × 128 bytes ≈ 128–256 KB/image —
+the same order as patch's `patch_grid`. Stored fp16/uint8 in the pickle, cast on
+read. Capped per image (keep the top-M by response) to bound worst-case size.
+
+**No-Persisted-Vectors compliance.** Local features live *only* in the dataset
+pickle (the sanctioned snapshot store) and in RAM. They are never written to
+detector JSON or `settings.json`. The detector persists `origin + region_box` per
+labelled example and re-derives templates + the match-stat classifier on load —
+fully consistent with the rule. The VLAD **visual vocabulary** (see Open
+Questions) is the one new artifact whose persistence needs a decision.
+
+## Capability flag & embedder surface
+
+A new flag on `MediaEmbedder` (next to `supports_text` /
+`supports_patch_regions` in `vtscore/media/embedder.py`):
+
+```python
+@property
+def supports_geometric_verification(self) -> bool:
+    """Whether this embedder produces local features for instance matching.
+
+    Structural embedders (SIFT/VLAD, learned-local-feature variants) return
+    True; the loader then stores media["local_features"] alongside the VLAD
+    media["embedding"], and the geometric re-rank + match-stat classifier
+    paths activate.  All other embedders return False and the structural
+    pipeline is skipped entirely.
+    """
+    return False
+```
+
+`to_dict()` surfaces it (like `supports_text` / `supports_patch_regions`).
+Structural embedders set `supports_text = False`, `is_default = False`
+(specialist tool, not a per-media-type default).
+
+## Integration points (backend)
+
+- **New embedder(s):** `vtscore/media/image/embedder_sift_vlad.py` (slug
+  `sift_vlad`), `supports_geometric_verification = True`, `supports_text = False`.
+  Built on a shared `_structural_shared.py` base so a future
+  `embedder_superpoint_lightglue.py` reuses the VLAD aggregation + storage and
+  only swaps the detector/matcher.
+- **Matcher abstraction:** new module `vtscore/media/structural.py` — pure
+  protocol + SIFT implementation: `detect_and_describe`, `aggregate_vlad`,
+  `verify(template, candidate) -> MatchStats`, `match_stats_to_features(stats) ->
+  np.ndarray`. No Flask, library-tier (lives under `vtscore`, import-clean).
+- **VLAD vocabulary:** k-means codebook fit (see Open Questions for where it comes
+  from). A pure-numpy/`faiss`-optional helper.
+- **Loader hook:** `vtscore/datasets/loader_pickle.py` / `loader_folder.py`
+  already call `embed_media` / `embed_media_bulk`. Add a sibling pass, gated on
+  `embedder.supports_geometric_verification`, that runs `detect_and_describe`,
+  `aggregate_vlad`, and stores `media["local_features"]`.
+- **Similarity / re-rank chokepoint:** extend `vtscore/training/region_similarity.py`
+  (or a sibling `structural_similarity.py`) with the Stage-1→Stage-2 flow:
+  Stage-1 cosine produces the shortlist, Stage-2 RANSAC re-ranks. One place knows
+  the two-stage rule, the way `score_against_query` is the one place that knows
+  max-over-regions today.
+- **Verification classifier:** trains via the existing `train_model` on
+  match-statistic feature vectors; threshold = its decision boundary. Lives next
+  to the detector MLP in `vtscore/detectors/training.py`. The detector therefore
+  carries *two* learned objects (retrieval MLP on VLAD, verification classifier on
+  match-stats), both in-memory, both re-derived from votes.
+- **Vote recording:** unchanged — `region_box` on yes-votes already round-trips
+  (patch v2). For structural detectors the box defines the template instead of a
+  salient-area hint; the schema is identical.
+
+## Integration points (frontend)
+
+- **Sort bar:** text input greys out via the existing `supports_text = false`
+  path. No new component.
+- **Result overlay:** reuse the patch `best_region`/highlight machinery to draw
+  the matched-region outline (the inlier bounding box from the RANSAC fit) on
+  result cards and the focus pane — informational, like patch's best-region
+  outline. Optionally render the inlier correspondences as a debug view.
+- **Region voting:** the v2 Shift-drag box-draw UX is reused verbatim; for
+  structural datasets the copy nudges "box the pattern you want to match."
+- **No new region-vote affordance** beyond what patch v2 already ships.
+
+## Relationship to patch v3 (dual-embedder)
+
+`supports_text = False` means a structural-only dataset can be seeded *only* by
+example/region, never by a text query — which forecloses the "text query seeds the
+flow" entry point. The natural fix is patch-embedder.md's **v3 dual-embedder**
+design: a dataset binds *both* a text-capable embedder (SigLIP — for text-seeded
+discovery and diversity) *and* a structural embedder (for the instance-matching
+detector). The v3 schema (`media["embeddings"]` keyed by embedder name) already
+accommodates this; a structural embedder would be a third role-type alongside
+`text_embedder` and `patch_embedder` — e.g. `structural_embedder: str | None`.
+This is the right long-term home for structural search and the reason to land v3
+first (or concurrently).
+
+## Non-goals
+
+- **No new media type.** Structural-embedded images are still `image` media.
+- **No 3D / non-planar matching in v1.** Homography/affine assumes a roughly
+  planar target (logos, packaging, flat artwork, building façades). Fundamental-
+  matrix / 3D-aware matching is out of scope.
+- **No persisted vectors outside the dataset pickle.** Local features live in the
+  pickle and RAM only (see Storage). Templates and both classifiers re-derive from
+  origins on load.
+- **No audio/text/document structural matching in v1.** Audio has a real
+  structural analog (Shazam-style constellation fingerprinting) and documents have
+  layout/template matching — both are future backends under the same abstraction,
+  not v1.
+- **No swap-backend-on-an-existing-dataset flow.** Like patch, the embedder is
+  fixed at dataset creation; changing it means re-import.
+
+## Media scope
+
+v1: **image only** (+ video frames later, reusing the image path per-frame).
+Matches the patch-embedder scope decision.
+
+## Open questions
+
+1. **VLAD visual vocabulary — where does the codebook come from?** Options:
+   (a) fit a k-means codebook per-dataset at ingest (adds a fit pass, vocabulary
+   tuned to the data, but the codebook becomes a per-dataset artifact that must
+   live in the pickle); (b) ship a fixed pre-trained vocabulary (no fit step,
+   smaller pickle, but generic). Leaning (a) stored in the pickle header, since
+   instance retrieval benefits from a data-specific vocabulary and the pickle is
+   already the sanctioned store. **Needs a decision before impl.**
+2. **Stage-1 shortlist size K.** How many candidates feed the RANSAC re-rank?
+   Too small misses true matches the VLAD coarse stage under-ranks; too large
+   blows the re-rank latency budget. Sweep on a demo dataset.
+3. **Cold-start with <3 votes.** The verification classifier has nothing to train
+   on until there are both yes and no votes. Need a sensible default inlier-count
+   threshold for the zero/one-vote case, mirroring the safe-threshold GMM blend
+   the detector MLP uses below 6 labels.
+4. **Live re-rank vs on-demand.** Does Stage 2 run on every sort, or only when the
+   user asks (a "verify" action)? Latency vs immediacy. Probably live on the
+   shortlist (K small) but measure.
+5. **Geometric model: homography vs affine.** Affine is more stable with few
+   inliers; homography handles perspective. Possibly affine for the inlier
+   gate, homography for the final overlay. Decide empirically.
+6. **VLAD vs alternatives for Stage 1.** VLAD is the recommended default, but a
+   learned global descriptor (e.g. reusing a DINOv2 CLS vector purely for the
+   coarse shortlist) could outperform VLAD while the local features do the
+   verification. Worth a spike comparison.
+
+## Phasing
+
+- **v1:** SIFT + VLAD + RANSAC, image-only, single structural embedder
+  (`sift_vlad`). `supports_geometric_verification` flag; `media["local_features"]`
+  storage; two-stage retrieval+rerank; match-statistic verification classifier;
+  RegionYes-as-template voting (reusing the v2 `region_box` schema and Shift-drag
+  UX); matched-region overlay (reusing patch's best-region machinery). Text sort
+  greyed via the existing `supports_text` gate. Pre-impl spike on a demo image
+  dataset to lock vocabulary source, K, and the geometric model.
+- **v2:** learned-local-feature backend (SuperPoint + LightGlue or similar) as a
+  drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes.
+- **v3:** structural embedder as a third role in the patch-v3 dual-embedder schema
+  (text + patch + structural slots per dataset), so a dataset can offer text-seeded
+  discovery *and* instance-matching detectors simultaneously.
+
+## Tests
+
+- **Matcher unit tests** with synthetic correspondences (no model weights): a
+  known homography applied to a planted keypoint set → `verify` recovers it with
+  the expected inlier count; degenerate/no-match inputs return low/zero inliers and
+  a rejected geometric model.
+- **VLAD aggregation:** descriptor set → fixed-D L2-normalised vector of the right
+  shape; deterministic under a seeded codebook; round-trips through the pickle as
+  fp16/uint8 and casts back correctly.
+- **Two-stage flow:** Stage-1 cosine shortlists, Stage-2 re-ranks; an item that
+  VLAD ranks mid-pack but geometrically verifies strongly is promoted above an
+  item with a high VLAD score but no geometric support.
+- **Match-stat classifier:** `train_model` over hand-crafted match-statistic
+  vectors separates verifying (RegionYes) from non-verifying (No) examples; its
+  decision boundary acts as the calibrated threshold. Single-vote / cold-start
+  falls back to the default inlier threshold.
+- **Capability flag:** `sift_vlad` registers with `supports_text = False`,
+  `supports_geometric_verification = True`; `/api/embedders` surfaces the new
+  field; existing embedders unchanged.
+- **Voting:** a RegionYes box on a structural dataset defines the template
+  keypoint subset; whole-image yes uses all keypoints; multiple RegionYes votes
+  score by max-over-templates.
+- **No-persist:** detector JSON for a structural detector contains origins +
+  `region_box` only — no keypoints, no descriptors, no classifier weights.
+- **GPU (v2):** a real learned-feature backend integration, marked
+  `@pytest.mark.gpu`.
+
+## Open follow-ups
+
+- VLAD-vocabulary persistence decision (Open Question 1) blocks impl start.
+- Spike (Stage-1 backbone choice, K, geometric model) precedes v1 build, like the
+  caltech101_s sweep preceded patch v1.
+- Landing or coordinating with patch v3 (dual-embedder) is what makes structural +
+  text-seeded discovery coexist on one dataset.

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -13,7 +13,8 @@ local features drop in later; **the full vote-trained detector ships in v1** (bo
 the example/region similarity flow and the match-statistic verification classifier,
 just like patch); **planar-only** matching; **image-only v1 with audio as the next
 media target**; **dual-embedder coexistence deferred** to patch v3 (one structural
-embedder per dataset for now).
+embedder per dataset for now); **a fixed, shipped VLAD vocabulary** for v1 (no
+per-dataset codebook fit).
 
 ## Motivation — structural vs semantic search
 
@@ -206,8 +207,11 @@ read. Capped per image (keep the top-M by response) to bound worst-case size.
 pickle (the sanctioned snapshot store) and in RAM. They are never written to
 detector JSON or `settings.json`. The detector persists `origin + region_box` per
 labelled example and re-derives templates + the match-stat classifier on load —
-fully consistent with the rule. The VLAD **visual vocabulary** (see Open
-Questions) is the one new artifact whose persistence needs a decision.
+fully consistent with the rule. The VLAD **visual vocabulary** is a **fixed,
+pre-trained codebook shipped with the code** (like the embedder's model weights),
+not a per-dataset artifact — so it introduces no new persisted state and no
+per-dataset fit pass. (A data-tuned per-dataset codebook is a possible v2
+optimisation; see Open Questions.)
 
 ## Capability flag & embedder surface
 
@@ -243,8 +247,10 @@ Structural embedders set `supports_text = False`, `is_default = False`
   protocol + SIFT implementation: `detect_and_describe`, `aggregate_vlad`,
   `verify(template, candidate) -> MatchStats`, `match_stats_to_features(stats) ->
   np.ndarray`. No Flask, library-tier (lives under `vtscore`, import-clean).
-- **VLAD vocabulary:** k-means codebook fit (see Open Questions for where it comes
-  from). A pure-numpy/`faiss`-optional helper.
+- **VLAD vocabulary:** a **fixed pre-trained codebook** trained offline on a
+  generic descriptor corpus and shipped as a small asset (downloaded/cached like
+  model weights, not fit per dataset). The aggregation is a pure-numpy helper that
+  loads the shipped centroids and assigns descriptors to them. No ingest-time fit.
 - **Loader hook:** `vtscore/datasets/loader_pickle.py` / `loader_folder.py`
   already call `embed_media` / `embed_media_bulk`. Add a sibling pass, gated on
   `embedder.supports_geometric_verification`, that runs `detect_and_describe`,
@@ -325,13 +331,15 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 
 ## Open questions
 
-1. **VLAD visual vocabulary — where does the codebook come from?** Options:
-   (a) fit a k-means codebook per-dataset at ingest (adds a fit pass, vocabulary
-   tuned to the data, but the codebook becomes a per-dataset artifact that must
-   live in the pickle); (b) ship a fixed pre-trained vocabulary (no fit step,
-   smaller pickle, but generic). Leaning (a) stored in the pickle header, since
-   instance retrieval benefits from a data-specific vocabulary and the pickle is
-   already the sanctioned store. **Needs a decision before impl.**
+1. **VLAD visual vocabulary — DECIDED for v1: fixed, shipped codebook.** v1 uses a
+   single pre-trained k-means codebook trained offline on a generic descriptor
+   corpus and shipped as a small asset (cached like model weights). No per-dataset
+   fit, no codebook in the pickle, no new persisted state. The remaining sub-
+   decisions are just the codebook *size* (e.g. 128/256 centroids — bigger = more
+   discriminative VLAD, larger vectors) and the *training corpus*, both pinned by
+   the pre-impl spike. A data-tuned per-dataset codebook (better instance recall on
+   a narrow domain, at the cost of an ingest fit pass and a per-dataset artifact)
+   is a possible **v2** optimisation, not v1.
 2. **Stage-1 shortlist size K.** How many candidates feed the RANSAC re-rank?
    Too small misses true matches the VLAD coarse stage under-ranks; too large
    blows the re-rank latency budget. Sweep on a demo dataset.
@@ -358,7 +366,7 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
   RegionYes-as-template voting (reusing the v2 `region_box` schema and Shift-drag
   UX); matched-region overlay (reusing patch's best-region machinery). Text sort
   greyed via the existing `supports_text` gate. Pre-impl spike on a demo image
-  dataset to lock vocabulary source, K, and the geometric model.
+  dataset to lock the codebook size + training corpus, K, and the geometric model.
 - **v2:** learned-local-feature backend (SuperPoint + LightGlue or similar) as a
   drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes. **Plus
   the audio backend** (constellation fingerprinting) under the same media-agnostic
@@ -399,9 +407,10 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
 
 ## Open follow-ups
 
-- VLAD-vocabulary persistence decision (Open Question 1) blocks impl start.
-- Spike (Stage-1 backbone choice, K, geometric model) precedes v1 build, like the
-  caltech101_s sweep preceded patch v1.
+- VLAD vocabulary is settled for v1 (fixed shipped codebook); the spike only pins
+  its size + training corpus, so impl is no longer blocked on a design decision.
+- Spike (codebook size/corpus, Stage-1 backbone choice, K, geometric model)
+  precedes v1 build, like the caltech101_s sweep preceded patch v1.
 - Keep the `StructuralMatcher` protocol media-agnostic from day one so the audio
   (constellation-fingerprint) backend — the next media target — lands in v2 without
   reshaping the interface.


### PR DESCRIPTION
Adds `docs/plans/structural-embedder.md`, a design spec for a third embedder *type* (alongside single-vector and patch) that searches for **specific instances** ("the Coca-Cola logo") rather than **semantic categories** ("a cola can").

Design-only; no code. Decisions captured per discussion:

- **Two-stage architecture.** VLAD global vector for retrieval (rides the existing diversity-tree / cosine-sort / `train_model` pipeline unchanged) + RANSAC geometric verification as a re-rank on the Stage-1 top-K. Restricting RANSAC to the shortlist is both elegant and a scalability necessity.
- **The "MLP equivalent."** Nothing learns in raw SIFT-descriptor space. Two derived, fixed-D, metric spaces each reuse `train_model`: a VLAD-space *retrieval* MLP and a *verification* classifier over **match statistics** (inlier count/ratio, reprojection error, homography plausibility, …). The verification classifier's decision boundary **is** the calibrated threshold.
- **Voting.** A **RegionYes** box is *constitutive* here — it defines the template keypoint subset (reusing the existing `LabeledElement.region_box` + Shift-drag UX from patch v2). Multiple RegionYes votes → max-over-templates. No-votes feed the verification negatives.
- **Backend.** Classic SIFT for v1 (CPU, ungated, deterministic, runs in the test suite), behind a pluggable `StructuralMatcher` so learned local features (SuperPoint+LightGlue, etc.) drop in as a v2 backend.
- **Persistence.** Local features live only in the dataset pickle (sanctioned store) + RAM; detector JSON keeps origins + `region_box` and re-derives templates and both classifiers on load — compliant with the No-Persisted-Vectors rule. The one new persisted artifact under discussion is the VLAD vocabulary.

New capability flag `MediaEmbedder.supports_geometric_verification`; `supports_text = False`; relationship to patch-v3 dual-embedder (so a dataset can offer text-seeded discovery *and* instance-matching detectors) is spelled out. Open questions (VLAD vocabulary source, shortlist size K, cold-start threshold, live-vs-on-demand re-rank, geometric model) and a v1/v2/v3 phasing are listed. Indexed in `docs/plans/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Lq489bZ7yKm5aYAgA973)_