### PR TITLE
Zoneless migration Phase 0: make the Vitest suite a zoneless-staleness oracle

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -1,6 +1,6 @@
 # Zoneless change detection — detailed migration plan
 
-Status: **Not started (planning complete; audited + red-teamed).** This document
+Status: **Phase 0 shipped (test harness); Phases 1–5 not started.** This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
 supersedes the earlier stub. Every count and file:line reference was checked
@@ -8,6 +8,36 @@ against the code; every Angular API claim was verified against angular.dev / the
 angular source (Appendix C); and the plan itself was adversarially reviewed for
 accuracy, feasibility, and completeness (which added the dialog-service,
 CDK-virtual-scroll, observer-callback, and test-autoDetect items below).
+
+**What shipped (Phase 0).** The Vitest suite can now run any spec under a
+zoneless `TestBed` and catch staleness:
+- `frontend/src/app/testing/zoneless-testbed.ts` — `provideZoneless()` /
+  `configureZoneless()` helpers (per-component opt-in; not enabled globally).
+- `settleZoneless(fixture)` added next to `settleResource()` in
+  `frontend/src/app/testing/settle-resource.ts` (macrotask drain +
+  `whenStable()`, no `detectChanges()`).
+- `frontend/src/app/testing/zoneless-testbed.spec.ts` — reference/canary spec for
+  the 0.3/0.4 pattern; verified to **fail** on a plain-field-write staleness bug
+  and pass on the signal path (the suite is a genuine oracle).
+- Test polyfills decoupled from the prod build via a dedicated
+  `frontend:build:test` configuration in `angular.json` (see the 0.1 correction
+  below). The hand-rolled ProxyZone shim in `test-setup.ts` was replaced by the
+  Angular-maintained `zone.js/plugins/vitest-patch`; all 69 spec files / 767
+  tests pass.
+
+**Correction discovered while implementing 0.1** (the plan as written assumed
+facts that the pinned toolchain did not match):
+- `zone.js/plugins/vitest-patch` ships only in **zone.js ≥ 0.16**, not the pinned
+  `~0.15.0`. Phase 0 bumped `zone.js` to `~0.16.0` (Angular 21.2 peer-depends on
+  `~0.15.0 || ~0.16.0`, so this is in-range).
+- The `@angular/build:unit-test` builder (21.2) has **no `polyfills` option**, so
+  0.1's "give the test target its own `polyfills`" is not literally possible.
+  Equivalent decoupling: a dedicated `build:test` configuration that pins the
+  test polyfills, with the unit-test `buildTarget` pointed at it.
+- `vitest-patch` needs `ProxyZoneSpec`/`SyncTestZoneSpec` (from
+  `zone.js/testing`) to exist at load time, and the builder appends
+  `zone.js/testing` *last*; so the polyfills array lists `zone.js/testing`
+  **before** `vitest-patch`. See Open follow-ups for the Phase-3 implication.
 
 No production code has changed yet; the only thing that shipped alongside the
 original stub was the 540 kB initial-bundle budget bump and the one-component
@@ -278,17 +308,29 @@ Today every component spec calls `fixture.detectChanges()` manually, which
 We fix the harness so it exercises real zoneless scheduling, **before** touching
 production.
 
-0.1 **Decouple the test target's polyfills from the prod build.** Today the
-`test` target inherits `polyfills: ["zone.js"]` from `buildTarget:
-frontend:build:development`. Give the **test target its own** `polyfills` so a
-later removal of zone.js from the build path cannot silently break fakeAsync:
+0.1 **Decouple the test target's polyfills from the prod build.** ✅ **DONE.**
+Today the `test` target inherited `polyfills: ["zone.js"]` from `buildTarget:
+frontend:build:development`. The `@angular/build:unit-test` builder has no
+`polyfills` option of its own (its schema rejects it), so the decoupling is done
+with a dedicated **`build:test` configuration** that pins its own polyfills,
+pointed at by the unit-test `buildTarget`. A later removal of zone.js from the
+base production polyfills then cannot silently break fakeAsync:
 ```jsonc
+// architect.build.configurations.test
+"test": {
+  "optimization": false,
+  "extractLicenses": false,
+  "sourceMap": true,
+  // testing BEFORE vitest-patch: the patch needs ProxyZoneSpec at load time,
+  // and the builder appends zone.js/testing last, so list it explicitly first.
+  "polyfills": ["zone.js", "zone.js/testing", "zone.js/plugins/vitest-patch"]
+},
+// architect.test.options
 "test": {
   "builder": "@angular/build:unit-test",
   "options": {
-    "polyfills": ["zone.js", "zone.js/plugins/vitest-patch"],
     "tsConfig": "tsconfig.spec.json",
-    "buildTarget": "frontend:build:development",
+    "buildTarget": "frontend:build:test",
     "runner": "vitest",
     "runnerConfig": "vitest.config.ts",
     "setupFiles": ["src/test-setup.ts"]
@@ -297,12 +339,12 @@ later removal of zone.js from the build path cannot silently break fakeAsync:
 ```
 `zone.js/plugins/vitest-patch` is the documented bridge that keeps
 `fakeAsync`/`tick`/`waitForAsync` working under the Vitest builder (Appendix C
-#7). It is explicitly a **transitional** mechanism — Angular recommends migrating
-to native `async` + Vitest fake timers long-term (deferred; Open follow-ups). If
-`vitest-patch` fully subsumes the hand-rolled ProxyZone shim in `test-setup.ts`,
-delete the shim **only after** confirming all 43 fakeAsync occurrences (11 files)
-still pass; do not delete it first (the shim's guard fails *silently* if zone.js
-is absent, throwing "Expected to be running in 'ProxyZone'" with no clear cause).
+#7), but it ships only in **zone.js ≥ 0.16**, so Phase 0 bumped `zone.js` to
+`~0.16.0` (in Angular 21.2's `~0.15.0 || ~0.16.0` peer range). It is explicitly a
+**transitional** mechanism — Angular recommends migrating to native `async` +
+Vitest fake timers long-term (deferred; Open follow-ups). The hand-rolled
+ProxyZone shim in `test-setup.ts` was fully subsumed by `vitest-patch` and
+removed **after** confirming all 43 fakeAsync occurrences (11 files) still pass.
 
 0.2 **Add a zoneless `TestBed` helper.** Create
 `frontend/src/app/testing/zoneless-testbed.ts` exporting a providers fragment
@@ -451,9 +493,11 @@ flip preserves/improves it. Still, re-verify the high-frequency drag handlers
 (`find-view`, `browse-view`, `image-viewer`, `browse-minimap`) in Phase 4, since
 they previously leaned on coalesced single-CD-per-frame.
 
-3.2 In `frontend/angular.json`, remove `"zone.js"` from the **build** target's
-`polyfills` (the production array). Leave the **test** target's polyfills
-(set in 0.1) untouched — tests still need zone.js for fakeAsync.
+3.2 In `frontend/angular.json`, remove `"zone.js"` from the **base** `build`
+options `polyfills` (the production array). Leave the **`build:test`
+configuration's** polyfills (set in 0.1) untouched — tests still need zone.js +
+`zone.js/testing` + `vitest-patch` for fakeAsync. Because `build:test` pins its
+own array, it is already decoupled and needs no change at the flip.
 
 3.3 Keep `zone.js` in `package.json` (the test run imports it). It is no longer
 bundled into prod because it is out of the build polyfills; no `npm audit`
@@ -505,6 +549,22 @@ A checklist version of the above goes in the PR description for the QA pass.
 - Adopt `ChangeDetectionStrategy.OnPush` explicitly on components for clarity
   (under zoneless they already behave OnPush-like; this is documentation/intent,
   not a functional change).
+
+### Open follow-ups
+
+- **Phases 1–5 unstarted.** Phase 0 (harness) is the only shipped phase. The
+  reactivity conversion (Phases 1–2), the prod flip (Phase 3), human browser QA
+  (Phase 4), and cleanup (Phase 5) all remain.
+- **Drop the `vitest-patch` bridge (Phase 5).** Migrate the 43 fakeAsync
+  occurrences (11 files) to native `async` + Vitest fake timers, then remove
+  `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
+  polyfills and finally `zone.js` from `package.json`. Angular's recommended
+  long-term direction; separable, no prod impact.
+- **Adopt the zoneless `TestBed` per component.** `provideZoneless()` /
+  `configureZoneless()` and `settleZoneless()` exist but are used only by the
+  reference spec. Each migrated component (Phases 1–2) must switch its spec to
+  them, delete the manual `fixture.detectChanges()` pumps, and add a canary
+  (0.4). 188 `detectChanges()` calls across 39 files still to convert.
 
 ---
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -105,6 +105,16 @@
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
+            // The test target carries its OWN polyfills, decoupled from the
+            // build target above, so dropping "zone.js" from the production
+            // build (zoneless flip, Phase 3 of docs/plans/zoneless-migration.md)
+            // cannot silently break fakeAsync here. "zone.js/plugins/vitest-patch"
+            // is the Angular-maintained bridge that keeps fakeAsync/tick/
+            // waitForAsync working under the @angular/build:unit-test Vitest
+            // runner (zone.js's jest patch bails outside jest). It is explicitly
+            // transitional; the long-term direction is native async + Vitest
+            // fake timers (plan Phase 5).
+            "polyfills": ["zone.js", "zone.js/plugins/vitest-patch"],
             "tsConfig": "tsconfig.spec.json",
             "buildTarget": "frontend:build:development",
             "runner": "vitest",

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -80,6 +80,27 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "test": {
+              // Build configuration used only by the unit-test target. Mirrors
+              // `development` but pins its OWN polyfills so the fakeAsync bridge
+              // survives the Phase 3 removal of zone.js from the base production
+              // polyfills (see docs/plans/zoneless-migration.md, Phase 0.1).
+              // "zone.js/plugins/vitest-patch" is the Angular-maintained bridge
+              // that keeps fakeAsync/tick/waitForAsync working under the Vitest
+              // runner (zone.js's jest patch bails outside jest). It is
+              // explicitly transitional — the long-term direction is native
+              // async + Vitest fake timers (plan Phase 5).
+              //
+              // Order matters: vitest-patch needs ProxyZoneSpec/SyncTestZoneSpec
+              // (from "zone.js/testing") to exist at its load time, so testing
+              // is listed BEFORE it. The builder also auto-appends another
+              // "zone.js/testing" at the end, but that re-import is a no-op (ES
+              // modules execute once).
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "polyfills": ["zone.js", "zone.js/testing", "zone.js/plugins/vitest-patch"]
             }
           },
           "defaultConfiguration": "production"
@@ -105,18 +126,15 @@
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
-            // The test target carries its OWN polyfills, decoupled from the
-            // build target above, so dropping "zone.js" from the production
-            // build (zoneless flip, Phase 3 of docs/plans/zoneless-migration.md)
-            // cannot silently break fakeAsync here. "zone.js/plugins/vitest-patch"
-            // is the Angular-maintained bridge that keeps fakeAsync/tick/
-            // waitForAsync working under the @angular/build:unit-test Vitest
-            // runner (zone.js's jest patch bails outside jest). It is explicitly
-            // transitional; the long-term direction is native async + Vitest
-            // fake timers (plan Phase 5).
-            "polyfills": ["zone.js", "zone.js/plugins/vitest-patch"],
             "tsConfig": "tsconfig.spec.json",
-            "buildTarget": "frontend:build:development",
+            // Point at a dedicated `test` build configuration (below) instead of
+            // `development`, so the test polyfills are decoupled from the
+            // production build. The @angular/build:unit-test builder has no
+            // `polyfills` option of its own; it inherits them from this
+            // buildTarget. Dropping "zone.js" from the base production polyfills
+            // (zoneless flip, Phase 3 of docs/plans/zoneless-migration.md) then
+            // cannot silently break fakeAsync, because build:test pins its own.
+            "buildTarget": "frontend:build:test",
             "runner": "vitest",
             "runnerConfig": "vitest.config.ts",
             "setupFiles": ["src/test-setup.ts"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "marked": "^14.1.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "zone.js": "~0.15.0"
+        "zone.js": "~0.16.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.2.16",
@@ -15042,9 +15042,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
       "license": "MIT"
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "marked": "^14.1.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.2.16",

--- a/frontend/src/app/testing/settle-resource.ts
+++ b/frontend/src/app/testing/settle-resource.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 
 /**
  * Drain the asynchrony an `rxResource` introduces in Vitest specs.
@@ -15,4 +15,24 @@ import { TestBed } from '@angular/core/testing';
 export async function settleResource(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve));
   TestBed.tick();
+}
+
+/**
+ * Drain scheduled change detection in a zoneless spec (see
+ * `docs/plans/zoneless-migration.md`, Phase 0.3 and `zoneless-testbed.ts`).
+ *
+ * After driving a component's state through the production channel (a service
+ * signal/subject write, a dispatched bound event), `await settleZoneless(fixture)`
+ * runs a macrotask — letting promise microtasks and `setTimeout`-based resource
+ * resolution land — then awaits `fixture.whenStable()`, which flushes only the CD
+ * that was actually *scheduled*. Crucially it does NOT call `detectChanges()`, so
+ * a missing notification (a forgotten signal write / `markForCheck`) shows up as
+ * stale DOM rather than being papered over by a forced render.
+ *
+ * Assert on the rendered DOM (`fixture.nativeElement.querySelector(...)`) after
+ * this resolves, not on component fields.
+ */
+export async function settleZoneless(fixture: ComponentFixture<unknown>): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve));
+  await fixture.whenStable();
 }

--- a/frontend/src/app/testing/zoneless-testbed.spec.ts
+++ b/frontend/src/app/testing/zoneless-testbed.spec.ts
@@ -1,0 +1,76 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureZoneless, provideZoneless } from './zoneless-testbed';
+import { settleZoneless } from './settle-resource';
+
+/**
+ * Reference spec for the zoneless test harness (docs/plans/zoneless-migration.md,
+ * Phase 0.3 / 0.4). It is NOT testing app code — it proves the harness itself
+ * works, and serves as the copy-me pattern for per-component canary specs in
+ * Phases 1–2:
+ *
+ *   - run the TestBed under `provideZonelessChangeDetection()` (via
+ *     `configureZoneless` / `provideZoneless`),
+ *   - drive state through the production channel (here, a signal write) with NO
+ *     manual `fixture.detectChanges()`,
+ *   - `await settleZoneless(fixture)`,
+ *   - assert on the rendered DOM.
+ *
+ * Because the fixture refreshes only what change detection actually *schedules*,
+ * a forgotten notification surfaces as a stale-DOM assertion failure rather than
+ * being masked by a forced render.
+ */
+@Component({
+  selector: 'app-zoneless-canary',
+  standalone: true,
+  template: `<span class="value">{{ count() }}</span>`,
+})
+class ZonelessCanaryComponent {
+  readonly count = signal(0);
+}
+
+describe('zoneless test harness', () => {
+  function valueText(fixture: ComponentFixture<ZonelessCanaryComponent>): string | null {
+    return fixture.nativeElement.querySelector('.value')?.textContent?.trim() ?? null;
+  }
+
+  it('renders the initial signal value under a zoneless TestBed', async () => {
+    configureZoneless({ imports: [ZonelessCanaryComponent] });
+    const fixture = TestBed.createComponent(ZonelessCanaryComponent);
+
+    await settleZoneless(fixture);
+
+    expect(valueText(fixture)).toBe('0');
+  });
+
+  it('repaints when a template-read signal changes, with no manual detectChanges', async () => {
+    configureZoneless({ imports: [ZonelessCanaryComponent] });
+    const fixture = TestBed.createComponent(ZonelessCanaryComponent);
+    await settleZoneless(fixture);
+
+    // Drive state the way the app would: write the signal the template reads.
+    // A signal write read in a template schedules CD with no zone involved.
+    fixture.componentInstance.count.set(42);
+    await settleZoneless(fixture);
+
+    // Assert on the DOM, not the field. If the write failed to schedule CD this
+    // would still read "0" and fail — which is exactly the staleness we want to
+    // catch.
+    expect(valueText(fixture)).toBe('42');
+  });
+
+  it('exposes the same provider via provideZoneless() for manual module config', async () => {
+    TestBed.configureTestingModule({
+      imports: [ZonelessCanaryComponent],
+      providers: [...provideZoneless()],
+    });
+    const fixture = TestBed.createComponent(ZonelessCanaryComponent);
+    await settleZoneless(fixture);
+
+    fixture.componentInstance.count.set(7);
+    await settleZoneless(fixture);
+
+    expect(valueText(fixture)).toBe('7');
+  });
+});

--- a/frontend/src/app/testing/zoneless-testbed.ts
+++ b/frontend/src/app/testing/zoneless-testbed.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+/**
+ * Zoneless `TestBed` helpers for the zoneless-migration effort.
+ *
+ * See `docs/plans/zoneless-migration.md` (Phase 0). The migration converts
+ * VTSearch's frontend off zone.js. The failure mode it introduces — "a value
+ * changed but the view silently went stale" — does NOT surface in a normal spec
+ * today, because every component spec drives `fixture.detectChanges()` by hand,
+ * which force-renders and therefore masks the staleness. These helpers let a
+ * spec run its `TestBed` under `provideZonelessChangeDetection()` so the fixture
+ * refreshes only what change detection actually *schedules* — turning the
+ * headless suite into a real zoneless-staleness oracle, component by component.
+ *
+ * How to use, as a component migrates (Phase 1–2):
+ *  1. Add `provideZonelessChangeDetection()` to the spec's providers — either via
+ *     `provideZoneless()` spread into `configureTestingModule({ providers: [...] })`
+ *     or by calling `configureZoneless({ ... })` instead of `configureTestingModule`.
+ *  2. **Remove** the manual `fixture.detectChanges()` pumps (do not supplement
+ *     them — a leftover manual pump both re-masks staleness and can race
+ *     auto-detect into `ExpressionChangedAfterItHasBeenChecked`/NG0100). Adding
+ *     `provideZonelessChangeDetection()` flips `ComponentFixtureAutoDetect` on by
+ *     default, so the fixture refreshes itself on scheduled CD.
+ *  3. Drive updates through the *same channel the app uses* (push to the service
+ *     subject/signal, dispatch a bound event), then `await settleZoneless()` (or
+ *     `await fixture.whenStable()`) — NOT `fixture.detectChanges()`.
+ *  4. Assert on `fixture.nativeElement.querySelector(...)` (rendered DOM), not on
+ *     `component.someField`. A missing notification ⇒ stale DOM ⇒ failing
+ *     assertion.
+ *
+ * Enabling zoneless **globally** is intentionally NOT done here: none of the
+ * ~221 subscribe sites are ready yet, so a global flip would turn the suite red
+ * en masse. It is adopted per component, in lockstep with the conversions.
+ */
+
+/**
+ * Providers fragment that puts a `TestBed` under zoneless change detection.
+ * Spread it into a spec's `configureTestingModule({ providers: [...] })`.
+ */
+export function provideZoneless(): unknown[] {
+  return [provideZonelessChangeDetection()];
+}
+
+/**
+ * Convenience wrapper around `TestBed.configureTestingModule` that prepends the
+ * zoneless provider to the supplied module definition. Returns the `TestBed` so
+ * callers can chain (mirrors `configureTestingModule`'s return).
+ */
+export function configureZoneless(
+  moduleDef: Parameters<typeof TestBed.configureTestingModule>[0] = {},
+): typeof TestBed {
+  return TestBed.configureTestingModule({
+    ...moduleDef,
+    providers: [...provideZoneless(), ...(moduleDef.providers ?? [])],
+  });
+}

--- a/frontend/src/app/testing/zoneless-testbed.ts
+++ b/frontend/src/app/testing/zoneless-testbed.ts
@@ -49,7 +49,7 @@ export function provideZoneless(): unknown[] {
  */
 export function configureZoneless(
   moduleDef: Parameters<typeof TestBed.configureTestingModule>[0] = {},
-): typeof TestBed {
+) {
   return TestBed.configureTestingModule({
     ...moduleDef,
     providers: [...provideZoneless(), ...(moduleDef.providers ?? [])],

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -89,65 +89,16 @@ const canvasContextStub = new Proxy(
 HTMLCanvasElement.prototype.getContext = (() =>
   canvasContextStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
-// --- fakeAsync / ProxyZone bootstrap ---------------------------------------
+// --- fakeAsync / ProxyZone bridge ------------------------------------------
 // Angular's fakeAsync()/tick() require each test to run inside a Zone forked
 // with a ProxyZoneSpec. zone.js/testing only auto-wires that for Jasmine,
-// Mocha and Jest runners — its jest patch bails with `typeof jest ===
-// 'undefined'`, and Vitest is none of those — so without help every
-// fakeAsync() spec throws "Expected to be running in 'ProxyZone'".
+// Mocha and Jest — its jest patch bails with `typeof jest === 'undefined'`,
+// and Vitest is none of those — so without help every fakeAsync() spec throws
+// "Expected to be running in 'ProxyZone'".
 //
-// zone.js/testing is already loaded (it ships in the builder's test polyfills,
-// which run before this setup file), so Zone.ProxyZoneSpec is available. We
-// replicate zone.js's jest patch against Vitest's global describe/it/hooks
-// (which share the same names): describe bodies run in a sync-only zone and
-// it/beforeEach/afterEach bodies run in the proxy zone, exactly as the jest
-// patch does. The specs use no it.only/skip/each modifiers, so wrapping the
-// bare globals is sufficient.
-{
-  type ZoneLike = {
-    current: { fork(spec: unknown): { run(fn: unknown, ctx: unknown, args: unknown): unknown } };
-    ProxyZoneSpec?: new () => unknown;
-    SyncTestZoneSpec?: new (name: string) => unknown;
-  };
-  const g = globalThis as unknown as Record<string, unknown> & { Zone?: ZoneLike };
-  const Zone = g.Zone;
-  const PATCHED = '__vtsearchProxyZonePatched__';
-  if (Zone?.ProxyZoneSpec && Zone.SyncTestZoneSpec && !g[PATCHED]) {
-    g[PATCHED] = true;
-    const rootZone = Zone.current;
-    const syncZone = rootZone.fork(new Zone.SyncTestZoneSpec('vitest.describe'));
-    const proxyZone = rootZone.fork(new Zone.ProxyZoneSpec());
-
-    const runIn =
-      (zone: { run(fn: unknown, ctx: unknown, args: unknown): unknown }, body: unknown) =>
-      function (this: unknown, ...args: unknown[]): unknown {
-        return zone.run(body, this, args);
-      };
-
-    const wrap = (name: string, bodyArgIndex: number, zone: typeof syncZone) => {
-      const original = g[name] as ((...a: unknown[]) => unknown) | undefined;
-      if (typeof original !== 'function') {
-        return;
-      }
-      const wrapped = function (this: unknown, ...args: unknown[]): unknown {
-        if (typeof args[bodyArgIndex] === 'function') {
-          args[bodyArgIndex] = runIn(zone, args[bodyArgIndex]);
-        }
-        return original.apply(this, args);
-      };
-      // Preserve modifiers/helpers (.only, .skip, .each, …) as-is.
-      Object.assign(wrapped, original);
-      g[name] = wrapped;
-    };
-
-    for (const name of ['describe', 'fdescribe', 'xdescribe']) {
-      wrap(name, 1, syncZone);
-    }
-    for (const name of ['it', 'fit', 'xit', 'test', 'xtest']) {
-      wrap(name, 1, proxyZone);
-    }
-    for (const name of ['beforeEach', 'afterEach', 'beforeAll', 'afterAll']) {
-      wrap(name, 0, proxyZone);
-    }
-  }
-}
+// `zone.js/plugins/vitest-patch` (loaded ahead of this file via the test
+// target's polyfills in angular.json) is the Angular-maintained bridge that
+// wires Vitest's describe/it/hooks into the sync/proxy zones, replacing the
+// hand-rolled replica that used to live here. It is explicitly transitional;
+// the long-term direction is native async + Vitest fake timers (zoneless
+// migration Phase 5). Nothing further is needed here.


### PR DESCRIPTION
Implements **Phase 0** of `docs/plans/zoneless-migration.md` — the test-harness phase that must land before any reactivity conversion. No production change-detection behavior changes; this only equips the headless suite to *catch* zoneless staleness ("a value changed but the view silently went stale") before the prod flip in a later phase.

## What landed

- **Decoupled test polyfills from the prod build** (`angular.json`). The `@angular/build:unit-test` builder (21.2) has **no `polyfills` option**, so instead of giving the test target its own array (as the plan's 0.1 sketch assumed), a dedicated `build:test` configuration pins the test polyfills and the unit-test `buildTarget` points at it. A later removal of `zone.js` from the production polyfills (Phase 3) therefore cannot silently break `fakeAsync`.
- **Replaced the hand-rolled ProxyZone shim** in `test-setup.ts` with the Angular-maintained **`zone.js/plugins/vitest-patch`**. The shim fell back *silently* if zone.js went missing (a top risk in the plan's §7); the official bridge is maintained and explicit. The jsdom stubs and the TestBed cascade guard are retained.
- **Bumped `zone.js` `~0.15.0` → `~0.16.0`** — `vitest-patch` only ships in 0.16+, and Angular 21.2 peer-depends on `~0.15.0 || ~0.16.0`, so this is in-range. (Polyfills list `zone.js/testing` *before* `vitest-patch` so `ProxyZoneSpec` exists at the patch's load time.)
- **Zoneless `TestBed` helpers** (`frontend/src/app/testing/zoneless-testbed.ts`): `provideZoneless()` / `configureZoneless()`. Per-component opt-in — **not** enabled globally (that would turn the suite red en masse before any component is migrated).
- **`settleZoneless(fixture)`** added next to `settleResource()`: macrotask drain + `await fixture.whenStable()`, deliberately **no** `detectChanges()`, so a missing notification surfaces as stale DOM.
- **Reference/canary spec** (`zoneless-testbed.spec.ts`) establishing the 0.3/0.4 pattern (drive state through the production channel → `settleZoneless` → assert rendered DOM).

## Verification

- All **69 → 70 spec files / 770 tests pass** under `vitest-patch` with the shim removed (the 43 fakeAsync occurrences across 11 files included).
- **The harness is a genuine oracle**, not always-green: a throwaway spec that writes a *plain* field from a timer callback (no signal / `markForCheck`) was confirmed to **fail** with stale DOM (`expected 'before' to be 'after'`), while the signal path repaints. (Throwaway spec removed; the committed reference spec covers the passing signal path.)
- `./run-tests.sh frontend` green end-to-end (ruff/build/audit/Vitest).

## Notes

- The plan doc is updated: Phase 0 marked shipped, the 0.1 config corrected to what the pinned toolchain actually supports, and an **Open follow-ups** section added (drop the `vitest-patch` bridge in Phase 5; adopt the zoneless TestBed per component — 188 `detectChanges()` calls across 39 files still to convert).
- **Backwards-compat note:** the `zone.js` minor bump (0.15→0.16) is the only dependency change; production bundling is unchanged (still `["zone.js"]` in the base build polyfills until Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Trkz4fyQQkp54vNwExR1qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Trkz4fyQQkp54vNwExR1qA)_