### PR TITLE
Disable Autopilot/Text sort on no-text datasets instead of failing

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -179,6 +179,7 @@
 @if (newDetectorFlow.open) {
   <vt-new-detector-modal
     [defaultMediaType]="newDetectorFlow.defaultMediaType"
+    [datasetEmbedder]="newDetectorFlow.datasetEmbedder"
     [seedMediaId]="newDetectorFlow.seedMediaId ?? null"
     [seedCropParams]="newDetectorFlow.seedCropParams ?? null"
     (closed)="onNewDetectorClosed()"

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -97,6 +97,7 @@ export class AppComponent {
   newDetectorFlow: NewDetectorFlowState = {
     open: false,
     defaultMediaType: '',
+    datasetEmbedder: '',
   };
   recentSessions: RecentSession[] = [];
 

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -245,7 +245,10 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       const other = this.activeContext.intentDatasetId
         ? this.datasetState.datasets.find((d) => d.id === this.activeContext.intentDatasetId)
         : null;
-      this.newThingFlows.openNewDetector({ defaultMediaType: other?.media_type || '' });
+      this.newThingFlows.openNewDetector({
+        defaultMediaType: other?.media_type || '',
+        datasetEmbedder: other?.embedder || '',
+      });
     }
   }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1015,9 +1015,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return loadingTypes.size === 1 ? [...loadingTypes][0] : '';
   }
 
+  /** Embedder of the single active/selected dataset (mirrors
+   *  ``activeDatasetMediaType``). Empty when ambiguous or unrecorded; lets the
+   *  new-detector modal warn about text-only detectors on no-text datasets. */
+  get activeDatasetEmbedder(): string {
+    if (this.selectedDatasetIds.size === 1) {
+      const selId = [...this.selectedDatasetIds][0];
+      const sel = this.datasets.find((d) => d.id === selId);
+      if (sel?.embedder) return sel.embedder;
+    }
+    const loaded = this.datasets.find((d) => d.loaded);
+    return loaded?.embedder ?? '';
+  }
+
   openNewDetectorModal(): void {
     this.newDetectorClosing = false;
-    this.newThingFlows.openNewDetector({ defaultMediaType: this.activeDatasetMediaType });
+    this.newThingFlows.openNewDetector({
+      defaultMediaType: this.activeDatasetMediaType,
+      datasetEmbedder: this.activeDatasetEmbedder,
+    });
   }
 
   onNewDetectorAnimationEnd(): void {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -95,6 +95,13 @@
                   (keydown.enter)="$event.preventDefault(); submit()"
                 />
               </div>
+              @if (showNoTextWarning) {
+                <p class="warn-text">
+                  This dataset's embedder can't search by text. You can still create this
+                  detector, but you won't be able to start in Autopilot or use Text sort —
+                  label a few good and bad examples first to train it.
+                </p>
+              }
             </div>
             <div class="example-col">
               <label class="col-label">{{ exampleColumnLabel }}</label>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -68,6 +68,14 @@
 // `.form-group`, `.info-text`, `.error-text` come from `_components.scss`.
 .required { color: var(--color-bad); }
 
+// Inline caution copy (no shared `--text-warning` utility class yet; mirrors
+// the local `.warn-text` in the combine-datasets modal).
+.warn-text {
+  margin: 0;
+  font-size: var(--font-md);
+  color: var(--text-warning);
+}
+
 // Two-column layout for text vs media example input
 .example-columns {
   display: grid;

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -28,10 +28,12 @@ describe('NewDetectorModalComponent', () => {
     });
     // EmbedderCapabilityService.ensureLoaded() in ngOnInit fetches the
     // embedder registry (drives the no-text warning).
-    httpMock.expectOne('/api/embedders').flush([
-      { name: 'clap', supports_text: true },
-      { name: 'dinov3', supports_text: false },
-    ]);
+    httpMock.expectOne('/api/embedders').flush({
+      embedders: [
+        { name: 'clap', supports_text: true },
+        { name: 'dinov3', supports_text: false },
+      ],
+    });
     // settingsState.load() in ngOnInit fetches settings.
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});
@@ -240,7 +242,7 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
         { type_id: 'image', name: 'Image', icon: 'image' },
       ],
     });
-    httpMock.expectOne('/api/embedders').flush([]);
+    httpMock.expectOne('/api/embedders').flush({ embedders: [] });
     // settingsState.load() in ngOnInit fetches settings.
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -26,6 +26,12 @@ describe('NewDetectorModalComponent', () => {
         { type_id: 'image', name: 'Image', icon: 'image' },
       ],
     });
+    // EmbedderCapabilityService.ensureLoaded() in ngOnInit fetches the
+    // embedder registry (drives the no-text warning).
+    httpMock.expectOne('/api/embedders').flush([
+      { name: 'clap', supports_text: true },
+      { name: 'dinov3', supports_text: false },
+    ]);
     // settingsState.load() in ngOnInit fetches settings.
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});
@@ -168,6 +174,35 @@ describe('NewDetectorModalComponent', () => {
     expect(component.name).toBe('dog barking sounds');
   });
 
+  it('warns about no-text datasets only for a text-hint-only detector', () => {
+    // No warning before any text is entered.
+    component.datasetEmbedder = 'dinov3';
+    component.pendingText = '';
+    expect(component.showNoTextWarning).toBe(false);
+
+    // Text entered against a no-text embedder → warn.
+    component.pendingText = 'a red car';
+    expect(component.showNoTextWarning).toBe(true);
+
+    // A media example seed (not text-only) → no warning even on a no-text dataset.
+    component.exampleType = 'media';
+    component.exampleValue = 'file.jpg';
+    component.exampleDisplay = 'file.jpg';
+    expect(component.showNoTextWarning).toBe(false);
+  });
+
+  it('does not warn when the dataset embedder can search by text', () => {
+    component.datasetEmbedder = 'clap';
+    component.pendingText = 'dog barking';
+    expect(component.showNoTextWarning).toBe(false);
+  });
+
+  it('does not warn when the active dataset embedder is unknown', () => {
+    component.datasetEmbedder = '';
+    component.pendingText = 'dog barking';
+    expect(component.showNoTextWarning).toBe(false);
+  });
+
   it('stops mirroring once the user edits the name', () => {
     component.onPendingTextInput('dog');
     expect(component.name).toBe('dog');
@@ -205,6 +240,7 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
         { type_id: 'image', name: 'Image', icon: 'image' },
       ],
     });
+    httpMock.expectOne('/api/embedders').flush([]);
     // settingsState.load() in ngOnInit fetches settings.
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({});

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -12,6 +12,7 @@ import { DatasetsUiApiService } from '../../../services/datasets-ui-api.service'
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
+import { EmbedderCapabilityService } from '../../../services/embedder-capability.service';
 import {
   DemoDataset,
   ImporterField,
@@ -48,9 +49,16 @@ export class NewDetectorModalComponent implements OnInit {
   private sortingApi = inject(SortingApiService);
   private labelImportersApi = inject(LabelImportersApiService);
   private settingsState = inject(SettingsStateService);
+  private embedderCaps = inject(EmbedderCapabilityService);
 
   /** Media type of the currently active dataset, if any. */
   @Input() defaultMediaType = '';
+
+  /** Embedder of the active dataset, if one is in context. When it can't
+   *  search by text, a text-only detector won't be able to start in Autopilot
+   *  or use Text sort on that dataset; the form surfaces a warning. Empty when
+   *  unknown, which suppresses the warning. */
+  @Input() datasetEmbedder = '';
 
   /** When set, the modal opens with this loaded-media id materialised into
    *  example_media/ as the seed example. The picker is bypassed and the
@@ -201,6 +209,7 @@ export class NewDetectorModalComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.embedderCaps.ensureLoaded();
     this.datasetsListingsApi.getMediaTypes().subscribe({
       next: (res) => {
         this.mediaTypeInfos = res.media_types || [];
@@ -323,6 +332,20 @@ export class NewDetectorModalComponent implements OnInit {
 
   get hasExample(): boolean {
     return this.exampleType === 'media' || !!this.pendingText.trim();
+  }
+
+  /**
+   * True when the active dataset's embedder can't search by text and the user
+   * is creating a text-hint-only detector (text entered, no media example).
+   * Such a detector still works — but only after labeling enough to train it —
+   * so we warn that Autopilot and Text sort won't be available up front.
+   */
+  get showNoTextWarning(): boolean {
+    return (
+      !this.embedderCaps.supportsText(this.datasetEmbedder) &&
+      this.hasPendingText &&
+      !this.hasMediaExample
+    );
   }
 
   get hasMediaExample(): boolean {

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -39,6 +39,7 @@
       [datasetName]="datasetName"
       [autopilotCollapsed]="autopilotCollapsed"
       [autopilotEnabled]="autopilotEnabled"
+      [autopilotDisabled]="autopilotDisabled"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
       (autopilotRefocus)="onAutopilotRefocus()"

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -373,6 +373,66 @@ describe('LabelViewComponent', () => {
     httpMock.expectNone('/api/sort');
   });
 
+  describe('no-text dataset gating', () => {
+    // Load a dataset whose media were embedded by a vision-only encoder
+    // (DINOv3, supports_text=false) so the text-support checks resolve false.
+    function loadNoTextDataset(): void {
+      fixture.detectChanges();
+      TestBed.tick();
+      httpMock.match('/api/medias/ids').forEach(req =>
+        req.flush([{ id: 1, media_type: 'image', embedder: 'dinov3' }]),
+      );
+      httpMock.match('/api/votes').forEach(req =>
+        req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
+      );
+      httpMock.match('/api/settings').forEach(req => req.flush({ volume: 80 }));
+      httpMock.match('/api/dataset/status').forEach(req =>
+        req.flush({ display_name: 'DINOv3 dataset' }),
+      );
+      httpMock.match('/api/inclusion').forEach(req => req.flush({ inclusion: 0 }));
+      httpMock.match('/api/media-types').forEach(req => req.flush({ media_types: [] }));
+      httpMock.match('/api/embedders').forEach(req =>
+        req.flush([{ name: 'dinov3', supports_text: false }]),
+      );
+    }
+
+    it('reports text unsupported and disables autopilot for a text-hint-only detector', async () => {
+      const session = TestBed.inject(LabelSessionService);
+      session.textQuery = 'a red car';
+      session.mediaExample = '';
+      loadNoTextDataset();
+      await settleResource();
+
+      expect(component.textSupported).toBe(false);
+      expect(component.autopilotDisabled).toBe(true);
+    });
+
+    it('skips the doomed autopilot text sort on a no-text dataset', async () => {
+      const session = TestBed.inject(LabelSessionService);
+      session.textQuery = 'a red car';
+      session.mediaExample = '';
+      loadNoTextDataset();
+      await settleResource();
+
+      // The deferred autopilot text sort must be dropped, never sent.
+      httpMock.expectNone('/api/sort');
+    });
+
+    it('keeps autopilot available when the detector carries a media-example seed', async () => {
+      const session = TestBed.inject(LabelSessionService);
+      session.textQuery = '';
+      session.mediaExample = 'example.jpg';
+      // Keep the panel out of autopilot so we assert the gating getters
+      // without firing an example sort that auto-start would kick off.
+      component.autopilotEnabled = false;
+      loadNoTextDataset();
+      await settleResource();
+
+      expect(component.textSupported).toBe(false);
+      expect(component.autopilotDisabled).toBe(false);
+    });
+  });
+
   it('should trigger learned sort when autopilot transitions from bad to hard', fakeAsync(() => {
     flushInitialRequests();
 

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -392,7 +392,7 @@ describe('LabelViewComponent', () => {
       httpMock.match('/api/inclusion').forEach(req => req.flush({ inclusion: 0 }));
       httpMock.match('/api/media-types').forEach(req => req.flush({ media_types: [] }));
       httpMock.match('/api/embedders').forEach(req =>
-        req.flush([{ name: 'dinov3', supports_text: false }]),
+        req.flush({ embedders: [{ name: 'dinov3', supports_text: false }] }),
       );
     }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -26,6 +26,7 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
+import { EmbedderCapabilityService } from '../../services/embedder-capability.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
 import { DetectorRegistryEntry, ProgressEvent } from '../../models/api.models';
@@ -68,6 +69,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   sortState = inject(SortStateService);
   private settingsState = inject(SettingsStateService);
   private autopilotStateService = inject(AutopilotStateService);
+  private embedderCaps = inject(EmbedderCapabilityService);
   private activeContext = inject(ActiveContextService);
   private progressEvents = inject(ProgressEventsService);
   private newThingFlows = inject(NewThingFlowsService);
@@ -165,7 +167,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.applyPanelPx();
         }
       }
-      if (this.autopilotTextSortPending && medias.length > 0) {
+      // Wait for the embedder registry too, so the text-support check inside
+      // `triggerAutopilotTextSort` is reliable (and we never fire a doomed
+      // text sort on a no-text dataset). `infos()` is tracked so this effect
+      // re-runs once the registry resolves.
+      if (this.autopilotTextSortPending && medias.length > 0 && this.embedderCaps.infos() !== null) {
         this.autopilotTextSortPending = false;
         this.triggerAutopilotTextSort();
       }
@@ -178,6 +184,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     this.autopilotStateService.clear();
+    this.embedderCaps.ensureLoaded();
     this.voteState.clear();
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
@@ -700,6 +707,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const media = this.mediaState.mediasSignal().find((m) => m.id === mediaId);
     this.newThingFlows.openNewDetector({
       defaultMediaType: media?.media_type ?? '',
+      datasetEmbedder: media?.embedder ?? '',
       seedMediaId: mediaId,
       seedCropParams: cropParams,
     });
@@ -814,6 +822,31 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Autopilot ---
 
+  /**
+   * Whether the active dataset's embedder can embed text queries. Drives the
+   * Text-sort gate and the Autopilot availability check. Defaults to ``true``
+   * until medias / the embedder registry have loaded so we never hide a
+   * working feature on missing metadata.
+   */
+  get textSupported(): boolean {
+    const medias = this.mediaState.mediasSignal();
+    if (medias.length === 0) return true;
+    return this.embedderCaps.supportsText(medias[0].embedder ?? '');
+  }
+
+  /**
+   * True when Autopilot has no way to seed its first sort: the dataset's
+   * embedder can't search by text, the detector carries no media-example seed,
+   * and there aren't yet enough labels for Learn sort. Bound into the
+   * left-panel to disable the Autopilot tab; it re-enables automatically once
+   * the user labels a good and a bad (Learn sort becomes available).
+   */
+  get autopilotDisabled(): boolean {
+    if (this.textSupported) return false;
+    if (this.labelSession.mediaExample) return false;
+    return !this.voteState.learnedSortAvailable;
+  }
+
   onAutopilotStart(): void {
     // Initialize re-sort tracking
     this.resortVoteCount = 0;
@@ -842,7 +875,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       const textQuery = this.labelSession.textQuery;
       const mediaExample = this.labelSession.mediaExample;
       if (textQuery) {
-        if (this.mediaState.mediasSignal().length > 0) {
+        // Defer until both medias and the embedder registry are loaded so the
+        // no-text check in `triggerAutopilotTextSort` is reliable.
+        if (this.mediaState.mediasSignal().length > 0 && this.embedderCaps.infos() !== null) {
           this.triggerAutopilotTextSort();
         } else {
           this.autopilotTextSortPending = true;
@@ -862,9 +897,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private triggerAutopilotTextSort(): void {
     const textQuery = this.labelSession.textQuery;
-    if (textQuery) {
-      this.onTextSort(textQuery);
-    }
+    if (!textQuery) return;
+    // No-text dataset, text-hint-only detector: the dataset's embedder can't
+    // embed the query, so don't fire a sort that's guaranteed to fail. The
+    // left-panel disables the Autopilot tab (see `autopilotDisabled`) and the
+    // user labels manually until Learn sort re-enables Autopilot.
+    if (!this.textSupported) return;
+    this.onTextSort(textQuery);
   }
 
   private triggerAutopilotMediaSort(): void {
@@ -1008,6 +1047,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Deactivate autopilot state so resort prompt and phase logic stop firing.
     this.autopilotStateService.deactivate();
     this.showResortPrompt = false;
+    // Drop any deferred seed sort that hasn't fired yet (e.g. we stopped before
+    // medias finished loading) so it can't fire after autopilot is gone.
+    this.autopilotTextSortPending = false;
+    this.autopilotMediaSortPending = false;
   }
 
   // --- Panel width helpers ---

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -117,8 +117,11 @@
           role="tab"
           [class.active]="activeTab === 'autopilot'"
           [attr.aria-selected]="activeTab === 'autopilot'"
+          [disabled]="autopilotDisabled"
           (click)="setTab('autopilot')"
-          title="Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration."
+          [title]="autopilotDisabled
+            ? 'Autopilot needs a way to seed its first sort. This dataset\'s embedder can\'t search by text, so label a few good and bad examples in Manual mode to enable it.'
+            : 'Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration.'"
         ><span class="label-full">Autopilot</span><span class="label-short">Auto</span></button>
       </div>
     }

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -56,7 +56,7 @@
     outline: none;
   }
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-primary);
   }
@@ -65,6 +65,11 @@
     background: var(--bg-surface);
     color: var(--text-primary);
     border-bottom: 2px solid var(--accent);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 }
 

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -55,6 +55,46 @@ describe('LeftPanelComponent', () => {
     expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
   });
 
+  it('should default to manual and not start autopilot when autopilotDisabled', () => {
+    const fresh = TestBed.createComponent(LeftPanelComponent);
+    const comp = fresh.componentInstance;
+    comp.autopilotDisabled = true;
+    vi.spyOn(comp.autopilotStart, 'emit');
+    fresh.detectChanges();
+    expect(comp.activeTab).toBe('manual');
+    expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to manual when autopilot becomes disabled after starting', () => {
+    // Default init lands on the autopilot tab.
+    expect(component.activeTab).toBe('autopilot');
+    vi.spyOn(component.autopilotStop, 'emit');
+    component.autopilotDisabled = true;
+    component.ngOnChanges({
+      autopilotDisabled: new SimpleChange(false, true, false),
+    });
+    expect(component.activeTab).toBe('manual');
+    expect(component.autopilotStop.emit).toHaveBeenCalled();
+  });
+
+  it('should ignore clicks on the autopilot tab while it is disabled', () => {
+    component.setTab('manual');
+    component.autopilotDisabled = true;
+    vi.spyOn(component.autopilotStart, 'emit');
+    component.setTab('autopilot');
+    expect(component.activeTab).toBe('manual');
+    expect(component.autopilotStart.emit).not.toHaveBeenCalled();
+  });
+
+  it('should disable the autopilot tab button when autopilotDisabled', () => {
+    component.autopilotDisabled = true;
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const tabs = el.querySelectorAll<HTMLButtonElement>('.left-tab');
+    // Second tab is Autopilot.
+    expect(tabs[1].disabled).toBe(true);
+  });
+
   it('should render autopilot tab content by default', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.tab-panel-autopilot')).toBeTruthy();

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -22,9 +22,10 @@ import { StripeOverviewComponent } from './stripe-overview/stripe-overview.compo
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { IconComponent } from '../icon/icon.component';
-import { Media, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { Media, MediaTypeInfo } from '../../models/api.models';
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsListingsApiService } from '../../services/datasets-listings-api.service';
+import { EmbedderCapabilityService } from '../../services/embedder-capability.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 
 export type { SortMode, SelectMode, SortedItem };
@@ -79,6 +80,15 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   readonly textQuery = input('');
   readonly autopilotCollapsed = input(false);
   @Input() autopilotEnabled = true;
+  /**
+   * True when Autopilot cannot run on the active (dataset, detector) pair: the
+   * dataset's embedder can't search by text, the detector has no media-example
+   * seed, and there aren't yet enough labels for Learn sort. In that state
+   * Autopilot has no way to seed its first sort, so the tab is disabled and the
+   * panel falls back to Manual. It re-enables once Learn sort becomes available
+   * (the parent flips this back to ``false`` once both label classes exist).
+   */
+  @Input() autopilotDisabled = false;
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
   readonly panelMode = input<'label' | 'find'>('label');
   /** Disable all interaction (used during Find scoring). */
@@ -126,22 +136,18 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   textSortAvailable = true;
 
   private readonly datasetsListingsApi = inject(DatasetsListingsApiService);
+  private readonly embedderCaps = inject(EmbedderCapabilityService);
 
-  // Media-type / embedder metadata ride `rxResource`: both load once on
-  // creation (no request signal = eager), wrapping the existing generated-client
-  // reads so the interceptor chain still applies. The derived labels live in
-  // plain fields recomputed by the effects below + `ngOnChanges(medias)`.
+  // Media-type metadata rides `rxResource`: loads once on creation (no request
+  // signal = eager), wrapping the existing generated-client read so the
+  // interceptor chain still applies. Embedder capability metadata comes from
+  // the shared `EmbedderCapabilityService` cache instead. The derived labels
+  // live in plain fields recomputed by the effects below + `ngOnChanges`.
   private readonly mediaTypesResource = rxResource({
     stream: () => this.datasetsListingsApi.getMediaTypes(),
   });
-  private readonly embeddersResource = rxResource({
-    stream: () => this.datasetsListingsApi.getEmbedders(),
-  });
   private readonly mediaTypeInfos = computed<MediaTypeInfo[]>(
     () => this.mediaTypesResource.value()?.media_types ?? [],
-  );
-  private readonly embedderInfos = computed<EmbedderInfo[]>(
-    () => this.embeddersResource.value() ?? [],
   );
 
   constructor() {
@@ -153,18 +159,20 @@ export class LeftPanelComponent implements OnInit, OnChanges {
       this.updateMediaTypeName();
     });
     effect(() => {
-      this.embedderInfos();
+      this.embedderCaps.infos();
       this.updateTextSortAvailable();
     });
   }
 
   ngOnInit(): void {
+    this.embedderCaps.ensureLoaded();
     if (this.panelMode() === 'find') {
       // Find mode doesn't use tabs; keep manual as a no-op default
       this.activeTab = 'manual';
     } else {
-      this.activeTab = this.autopilotEnabled ? 'autopilot' : 'manual';
-      if (this.autopilotEnabled) {
+      const startAutopilot = this.autopilotEnabled && !this.autopilotDisabled;
+      this.activeTab = startAutopilot ? 'autopilot' : 'manual';
+      if (startAutopilot) {
         this.autopilotStart.emit();
       }
     }
@@ -174,6 +182,17 @@ export class LeftPanelComponent implements OnInit, OnChanges {
     if (changes['medias']) {
       this.updateMediaTypeName();
       this.updateTextSortAvailable();
+    }
+    if (changes['autopilotDisabled'] && !changes['autopilotDisabled'].firstChange) {
+      // Autopilot just became impossible (e.g. medias loaded and revealed a
+      // no-text embedder, after we optimistically started on entry). Fall back
+      // to Manual so the user can label by hand; the doomed text sort is also
+      // skipped upstream. When it flips back to available we leave the user
+      // where they are and just re-enable the tab.
+      if (this.autopilotDisabled && this.activeTab === 'autopilot') {
+        this.activeTab = 'manual';
+        this.autopilotStop.emit();
+      }
     }
   }
 
@@ -202,13 +221,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
    * hide a working feature.
    */
   private updateTextSortAvailable(): void {
-    const embedderName = this.medias.length > 0 ? this.medias[0].embedder : '';
-    if (!embedderName || this.embedderInfos().length === 0) {
-      this.textSortAvailable = true;
-      return;
-    }
-    const info = this.embedderInfos().find((e) => e.name === embedderName);
-    this.textSortAvailable = info ? info.supports_text !== false : true;
+    const embedderName = this.medias.length > 0 ? this.medias[0].embedder ?? '' : '';
+    this.textSortAvailable = this.embedderCaps.supportsText(embedderName);
   }
 
   /**
@@ -237,6 +251,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   setTab(tab: 'manual' | 'autopilot'): void {
+    // Autopilot can't be entered while it has no way to seed a first sort.
+    if (tab === 'autopilot' && this.autopilotDisabled) return;
     if (tab === this.activeTab) {
       if (tab === 'autopilot') {
         this.autopilotRefocus.emit();

--- a/frontend/src/app/services/embedder-capability.service.ts
+++ b/frontend/src/app/services/embedder-capability.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, inject, signal } from '@angular/core';
+
+import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import type { EmbedderInfo } from '../models/api.models';
+
+/**
+ * Process-wide cache of embedder capability metadata (the `GET /api/embedders`
+ * registry), so callers can answer "can this dataset's embedder search by
+ * text?" without each reimplementing the `supports_text` lookup.
+ *
+ * Vision-only / speech-only encoders (DINOv3, EUPE, AST, Whisper, VideoMAE)
+ * report `supports_text === false`; CLIP/SigLIP/CLAP/E5/X-CLIP report `true`.
+ * Text sort and Autopilot's text-seed phase only work on the latter.
+ *
+ * The default everywhere is **text supported** when we don't know (empty
+ * embedder name, registry not loaded yet, or an unrecognised name): we never
+ * want to hide a working feature on missing metadata.
+ */
+@Injectable({ providedIn: 'root' })
+export class EmbedderCapabilityService {
+  private readonly api = inject(DatasetsListingsApiService);
+
+  /** Loaded embedder metadata, or `null` until the registry resolves. */
+  readonly infos = signal<EmbedderInfo[] | null>(null);
+  private loading = false;
+
+  /** Kick off a one-time load of the embedder registry. Idempotent. */
+  ensureLoaded(): void {
+    if (this.infos() !== null || this.loading) return;
+    this.loading = true;
+    this.api.getEmbedders().subscribe({
+      next: (list) => {
+        this.infos.set(list ?? []);
+        this.loading = false;
+      },
+      error: () => {
+        this.infos.set([]);
+        this.loading = false;
+      },
+    });
+  }
+
+  /** True once the registry has resolved (success or failure). */
+  get loaded(): boolean {
+    return this.infos() !== null;
+  }
+
+  /**
+   * Whether *embedderName* can embed text queries. Defaults to `true` when the
+   * name is empty or the registry hasn't loaded / doesn't recognise it, so a
+   * working text feature is never hidden on missing metadata.
+   */
+  supportsText(embedderName: string): boolean {
+    if (!embedderName) return true;
+    const infos = this.infos();
+    if (!infos) return true;
+    const info = infos.find((e) => e.name === embedderName);
+    return info ? info.supports_text !== false : true;
+  }
+}

--- a/frontend/src/app/services/new-thing-flows.service.ts
+++ b/frontend/src/app/services/new-thing-flows.service.ts
@@ -12,6 +12,11 @@ export interface ImporterFlowState {
 export interface NewDetectorFlowState {
   open: boolean;
   defaultMediaType: string;
+  /** Embedder name of the active dataset, if one is in context. Lets the
+   *  modal warn when a text-only detector is being created against a dataset
+   *  whose embedder can't search by text (no Autopilot / Text sort). Empty
+   *  when unknown, which suppresses the warning. */
+  datasetEmbedder: string;
   /** ID of a loaded media to use as the new detector's seed example.
    *  When set, the modal materialises this media to ``example_media/``
    *  on open and pre-fills the example field, skipping the picker. */
@@ -56,6 +61,7 @@ export class NewThingFlowsService {
   private readonly newDetectorSubject = new BehaviorSubject<NewDetectorFlowState>({
     open: false,
     defaultMediaType: '',
+    datasetEmbedder: '',
     seedMediaId: undefined,
     seedCropParams: undefined,
   });
@@ -106,6 +112,7 @@ export class NewThingFlowsService {
     this.newDetectorSubject.next({
       open: true,
       defaultMediaType: opts.defaultMediaType ?? '',
+      datasetEmbedder: opts.datasetEmbedder ?? '',
       seedMediaId: opts.seedMediaId,
       seedCropParams: opts.seedCropParams,
     });
@@ -115,6 +122,7 @@ export class NewThingFlowsService {
     this.newDetectorSubject.next({
       open: false,
       defaultMediaType: '',
+      datasetEmbedder: '',
       seedMediaId: undefined,
       seedCropParams: undefined,
     });


### PR DESCRIPTION
## Problem

When a detector is created with **only a text hint** on a **no-text dataset** (one whose embedder can't search by text — e.g. DINOv3, EUPE, AST, Whisper, VideoMAE), entering Train mode used to leave the user stuck: Autopilot auto-fired a text sort that the backend rejects (clean 400), dead-ending in a "Sort failed" state with no path forward (Learn sort isn't available yet because there are no votes). There was also no warning at detector-creation time.

## What this does

1. **Warn at creation.** The New Detector modal now shows an inline caution under the Text Example field when the active dataset's embedder can't search by text and the user is creating a *text-hint-only* detector: it can still be created, but won't start in Autopilot or use Text sort until it's trained.

2. **Disable, don't break, in Train mode.** On a no-text dataset where the detector has only a text hint (no media-example seed, no labels yet), the **Autopilot tab is disabled** (greyed, with an explanatory tooltip) and the panel falls back to **Manual**. The doomed autopilot text sort is skipped rather than sent. Text sort itself was already gated in the sort bar.

3. **Re-enable when training is available.** Once the user labels enough for Learn sort (≥1 good + ≥1 bad), `autopilotDisabled` flips back to `false` and the Autopilot tab becomes clickable again. Per the chosen behavior, the user stays in Manual and opts back into Autopilot themselves (no surprise auto-switch). A media-example seed keeps Autopilot available throughout (media sort works on no-text encoders).

## How

- New `EmbedderCapabilityService` caches the `GET /api/embedders` registry and answers `supportsText(embedderName)` (defaults to `true` on unknown/missing metadata so a working feature is never hidden). The left-panel's existing text-sort gate now delegates to it, removing the duplicated `supports_text` rule.
- `LabelViewComponent` exposes `textSupported` / `autopilotDisabled` (factoring in the detector's media-example seed and Learn-sort readiness), threads `autopilotDisabled` into the left-panel, and skips the autopilot text-seed sort when text isn't supported. The deferred seed sort now also waits for the embedder registry so the check is reliable.
- The active dataset's embedder is threaded into the New Detector modal (`datasetEmbedder`) via `NewThingFlowsService` from the dashboard / context-pulldown / seed openers.

## Tests

- `EmbedderCapabilityService`-backed gating covered in `left-panel`, `label-view`, and `new-detector-modal` specs.
- Full frontend gate green: `./run-tests.sh frontend` → build OK, audit OK, **777 Vitest tests passing**, plus the ruff/pyright/pip-audit/OpenAPI preamble. No Python code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACtza96x1edSkfSJyw5rAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACtza96x1edSkfSJyw5rAt)_