### PR TITLE
Zoneless Phase 1.1: signalize ProgressEventsService SSE pump

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -1,8 +1,8 @@
 # Zoneless change detection — detailed migration plan
 
-Status: **Phase 0 shipped (test harness); Phase 1.3 + 1.4 shipped
-(ConnectionStateService + BrowseSelectionService signalized); Phase 1.1–1.2 and
-Phases 2–5 not started.** This document
+Status: **Phase 0 shipped (test harness); Phase 1.1 + 1.3 + 1.4 shipped
+(ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
+signalized); Phase 1.2 and Phases 2–5 not started.** This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
 supersedes the earlier stub. Every count and file:line reference was checked
@@ -399,16 +399,24 @@ These three services are read across the whole app and contain the NgZone CD
 re-entries; converting them neutralizes the largest blast radius. Each lands with
 its consumers and specs updated, under zone-based prod (behavior-neutral).
 
-1.1 **`ProgressEventsService` (SSE pump) — the single most important rewrite.**
-Drop the `this.zone.run(...)` wrappers in `listen()` and `onopen`. Replace the
-six `BehaviorSubject` channels (`dataset`, `loadingTasks`,
-`detectorLoadingTasks`, `sort`, `find`, `eval`) with `signal`s exposed
-read-only; keep the synchronous getters as signal reads; keep `serverReset$` as a
-`Subject` only if all its consumers are imperative (otherwise a signal). A signal
-write inside the EventSource callback schedules CD with no zone. Migrate
-consumers: prefer `| async`→signal reads in templates (progress bars, modals);
-the `votingIterations$` derived Observable can become a `computed`. `NgZone` can
-then be removed from the service.
+1.1 **`ProgressEventsService` (SSE pump) — the single most important rewrite.
+✅ DONE.** Dropped the `this.zone.run(...)` wrappers in `listen()` and `onopen`
+and removed `NgZone` from the service. The six `BehaviorSubject` channels
+(`dataset`, `loadingTasks`, `detectorLoadingTasks`, `sort`, `find`, `eval`) are
+now `signal`s exposed read-only; a signal write inside the EventSource callback
+notifies the scheduler with no zone. The synchronous latest-value getters became
+signal reads (callable — `loadingTasks()`/`detectorLoadingTasks()`; the unused
+`find` getter was dropped). `votingIterations` is now a `computed`. `serverReset$`
+stays a `Subject` (its only consumer, `dashboard-loading-tasks`, is imperative).
+The many consumers that compose channels with RxJS operators
+(takeUntil/filter/take — `dashboard-loading-tasks`, `toast`, `context-switch`,
+`find-view`, `label-view`, `dashboard`, `progress-modal`) keep their `$`
+observables, now `toObservable` bridges over the backing signals, so a signal
+write still drives them; this is behavior-neutral under the still-zoned prod app.
+Per-component `| async`→signal template reads are deferred to those components'
+Phase 2 conversions. New zoneless staleness canary in
+`progress-events.service.spec.ts` drives an SSE frame through the fake EventSource
+and asserts the rendered DOM repaints with no manual `detectChanges`.
 
 1.2 **`KeyboardService`.** Keep the `runOutsideAngular` keydown listener (it is a
 harmless no-op under zoneless and still avoids per-keystroke churn under zone).
@@ -566,13 +574,15 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1.1–1.2 and Phases 2–5 remain.** Shipped so far: Phase 0 (harness) and
-  Phase 1.3 + 1.4 (ConnectionStateService + BrowseSelectionService signalized,
-  with their consumers and zoneless canary specs). Still owed in Phase 1:
-  **1.1 `ProgressEventsService`** (the SSE pump — six channels + the `NgZone`
-  re-entries) and **1.2 `KeyboardService`** (couples with `center-panel`). Then
-  the component conversions (Phase 2), the prod flip (Phase 3), human browser QA
-  (Phase 4), and cleanup (Phase 5).
+- **Phase 1.2 and Phases 2–5 remain.** Shipped so far: Phase 0 (harness) and
+  Phase 1.1 + 1.3 + 1.4 (ProgressEventsService SSE pump + ConnectionStateService
+  + BrowseSelectionService signalized, with their consumers and zoneless canary
+  specs). Still owed in Phase 1: **1.2 `KeyboardService`** (drop the 10
+  `zone.run(() => action$.next(...))` re-entries; the CD trigger moves to the
+  consumer `center-panel`, whose shortcut-driven state must be signalized — this
+  couples with the Phase 2.3 center-panel conversion). Then the component
+  conversions (Phase 2), the prod flip (Phase 3), human browser QA (Phase 4), and
+  cleanup (Phase 5).
 - **Full consumer specs for the browse cluster.** Phase 1.4 added a service unit
   spec + a signal-driven canary, but `browse-canvas`, `browse-bin-popup`, and
   `browse-selection-panel` still have **no** component specs (they are heavy to

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -887,7 +887,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             takeUntil(this.destroy$),
           )
           .subscribe(() => {
-            const failed = this.progressEvents.detectorLoadingTasks.some(
+            const failed = this.progressEvents.detectorLoadingTasks().some(
               (t) => t.task_id === resp.task_id && !!t.error,
             );
             if (failed) return; // ToastService surfaces the build error from the SSE task

--- a/frontend/src/app/services/browse-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-prep.service.spec.ts
@@ -67,9 +67,7 @@ describe('BrowsePrepService', () => {
     };
     const activeContextStub = { modelId: '' };
     const progressEventsStub = {
-      get loadingTasks(): LoadingTask[] {
-        return loadingTasks;
-      },
+      loadingTasks: (): LoadingTask[] => loadingTasks,
     };
     const projectionApiStub = {
       getMeta: (): Observable<ProjectionMeta> => metaProvider(),

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -97,7 +97,7 @@ export class BrowsePrepService {
           // A failed load leaves an errored task on the SSE row, which the
           // dashboard already shows; bail out silently rather than stacking a
           // second (projection) error on top of it.
-          const loadFailed = this.progressEvents.loadingTasks.some(
+          const loadFailed = this.progressEvents.loadingTasks().some(
             (t) => t.dataset_id === datasetId && !!t.error,
           );
           if (loadFailed) {
@@ -152,7 +152,7 @@ export class BrowsePrepService {
     if (s.phase === 'loading') {
       // Defer to the real SSE task once it shows; until then, a placeholder
       // so the row gives immediate feedback instead of flashing blank.
-      const hasReal = this.progressEvents.loadingTasks.some(
+      const hasReal = this.progressEvents.loadingTasks().some(
         (t) => t.dataset_id === datasetId && t.status !== 'idle',
       );
       if (hasReal) return null;

--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -121,12 +121,8 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
     const progressEventsStub = {
       loadingTasks$: loadingTasks$.asObservable(),
       detectorLoadingTasks$: detectorLoadingTasks$.asObservable(),
-      get loadingTasks(): LoadingTask[] {
-        return loadingTasks$.value;
-      },
-      get detectorLoadingTasks(): LoadingTask[] {
-        return detectorLoadingTasks$.value;
-      },
+      loadingTasks: (): LoadingTask[] => loadingTasks$.value,
+      detectorLoadingTasks: (): LoadingTask[] => detectorLoadingTasks$.value,
     };
 
     TestBed.configureTestingModule({

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -309,7 +309,7 @@ export class ContextSwitchService {
     // Best-effort: cancel any active dataset/detector loading tasks so
     // we don't waste CPU on a load whose result will be discarded. The
     // request-id check is the actual correctness guarantee.
-    const datasetTasks = this.progressEvents.loadingTasks.filter((t) => t.status !== 'idle');
+    const datasetTasks = this.progressEvents.loadingTasks().filter((t) => t.status !== 'idle');
     for (const t of datasetTasks) {
       this.datasetsRegistryApi.cancelTask(t.task_id).subscribe({
         error: () => {
@@ -317,7 +317,7 @@ export class ContextSwitchService {
         },
       });
     }
-    const detectorTasks = this.progressEvents.detectorLoadingTasks.filter((t) => t.status !== 'idle');
+    const detectorTasks = this.progressEvents.detectorLoadingTasks().filter((t) => t.status !== 'idle');
     for (const t of detectorTasks) {
       this.detectorsRegistryApi.cancelDetectorLoadingTask(t.task_id).subscribe({
         error: () => {

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -1,7 +1,9 @@
-import { WritableSignal, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { Component, WritableSignal, inject, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProgressEventsService } from './progress-events.service';
 import { ConnectionStateService, ConnectionStatus } from './connection-state.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import { settleZoneless } from '../testing/settle-resource';
 
 /**
  * Minimal stand-in for the browser `EventSource` (jsdom has none). Captures
@@ -95,5 +97,82 @@ describe('ProgressEventsService liveness wiring', () => {
     recordSuccess.mockClear();
     es.emit('dataset', { status: 'loading', current: 5, total: 10 });
     expect(recordSuccess).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Zoneless staleness canary (docs/plans/zoneless-migration.md, Phases 0.3/0.4 +
+ * 1.1). As of Phase 1.1 the six SSE channels are signals, so a frame arriving on
+ * the EventSource (which fires *outside* Angular's NgZone) schedules change
+ * detection via the signal write — no `zone.run` re-entry. This component reads
+ * the `dataset` channel signal in its template; driving a frame through the fake
+ * EventSource and asserting the rendered DOM after `settleZoneless()`, with no
+ * manual `detectChanges()`, proves the SSE pump repaints bound views under
+ * zoneless. (Before Phase 1.1 the channel was a `BehaviorSubject.next()` from a
+ * raw listener, which would leave this view stale.)
+ */
+@Component({
+  selector: 'app-progress-canary',
+  standalone: true,
+  template: `<span class="status">{{ progress.dataset().status ?? 'none' }}</span>`,
+})
+class ProgressCanaryComponent {
+  readonly progress = inject(ProgressEventsService);
+}
+
+describe('ProgressEventsService (zoneless view canary)', () => {
+  let fixture: ComponentFixture<ProgressCanaryComponent>;
+  let originalEventSource: typeof EventSource;
+  let status: WritableSignal<ConnectionStatus>;
+
+  beforeEach(async () => {
+    FakeEventSource.instances = [];
+    originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+
+    status = signal<ConnectionStatus>('online');
+    const connectionStub = {
+      status,
+      recordSuccess: vi.fn(),
+      recordNetworkFailure: vi.fn(),
+      get isOffline() {
+        return status() === 'offline';
+      },
+    };
+
+    configureZoneless({
+      imports: [ProgressCanaryComponent],
+      providers: [
+        ProgressEventsService,
+        { provide: ConnectionStateService, useValue: connectionStub as unknown as ConnectionStateService },
+      ],
+    });
+    fixture = TestBed.createComponent(ProgressCanaryComponent);
+    // Constructing the component injects the service; its status-signal effect
+    // opens the EventSource on settle.
+    await settleZoneless(fixture);
+  });
+
+  afterEach(() => {
+    globalThis.EventSource = originalEventSource;
+  });
+
+  function statusText(): string | null {
+    return fixture.nativeElement.querySelector('.status')?.textContent?.trim() ?? null;
+  }
+
+  it('renders the empty initial channel state', () => {
+    expect(statusText()).toBe('none');
+  });
+
+  it('repaints when an SSE frame lands, with no manual detectChanges', async () => {
+    const es = FakeEventSource.instances[0];
+    es.emit('dataset', { status: 'loading', current: 5, total: 10 });
+    await settleZoneless(fixture);
+    expect(statusText()).toBe('loading');
+
+    es.emit('dataset', { status: 'idle' });
+    await settleZoneless(fixture);
+    expect(statusText()).toBe('idle');
   });
 });

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, OnDestroy, NgZone, effect, inject } from '@angular/core';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { Injectable, OnDestroy, computed, effect, inject, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
 import {
   LoadingTask,
   ProgressEvent,
@@ -31,22 +32,36 @@ import { ConnectionStateService } from './connection-state.service';
  */
 @Injectable({ providedIn: 'root' })
 export class ProgressEventsService implements OnDestroy {
-  private zone = inject(NgZone);
   private connection = inject(ConnectionStateService);
 
-  private readonly datasetSubject = new BehaviorSubject<ProgressEvent>({});
-  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
-  private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
-  private readonly sortSubject = new BehaviorSubject<ProgressEvent>({});
-  private readonly findSubject = new BehaviorSubject<ProgressEvent>({});
-  private readonly evalSubject = new BehaviorSubject<ProgressEvent>({});
+  // Canonical channel state as signals. A signal write inside the EventSource
+  // callback notifies Angular's scheduler directly, so the SSE pump triggers
+  // change detection on bound templates with no NgZone re-entry — correct under
+  // both zone-based and zoneless change detection.
+  private readonly _dataset = signal<ProgressEvent>({});
+  private readonly _loadingTasks = signal<LoadingTask[]>([]);
+  private readonly _detectorLoadingTasks = signal<LoadingTask[]>([]);
+  private readonly _sort = signal<ProgressEvent>({});
+  private readonly _find = signal<ProgressEvent>({});
+  private readonly _eval = signal<ProgressEvent>({});
 
-  readonly dataset$ = this.datasetSubject.asObservable();
-  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
-  readonly detectorLoadingTasks$ = this.detectorLoadingTasksSubject.asObservable();
-  readonly sort$ = this.sortSubject.asObservable();
-  readonly find$ = this.findSubject.asObservable();
-  readonly eval$ = this.evalSubject.asObservable();
+  // Read-only signal views: the canonical reads (also the synchronous
+  // latest-value accessors — call them, e.g. `loadingTasks()`).
+  readonly dataset = this._dataset.asReadonly();
+  readonly loadingTasks = this._loadingTasks.asReadonly();
+  readonly detectorLoadingTasks = this._detectorLoadingTasks.asReadonly();
+  readonly sort = this._sort.asReadonly();
+  readonly find = this._find.asReadonly();
+
+  // Observable bridges for the consumers that compose channel updates with
+  // RxJS operators (takeUntil/filter/take/…). Each is a `toObservable` view of
+  // the backing signal, so a signal write still drives them.
+  readonly dataset$ = toObservable(this._dataset);
+  readonly loadingTasks$ = toObservable(this._loadingTasks);
+  readonly detectorLoadingTasks$ = toObservable(this._detectorLoadingTasks);
+  readonly sort$ = toObservable(this._sort);
+  readonly find$ = toObservable(this._find);
+  readonly eval$ = toObservable(this._eval);
 
   /**
    * Fires whenever the backend's `boot_id` changes between successive
@@ -80,37 +95,21 @@ export class ProgressEventsService implements OnDestroy {
   }
 
   // -------------------------------------------------------------------------
-  // Latest-value accessors. Components that briefly need a value outside an
-  // RxJS pipeline (e.g. inside an imperative callback after a POST) use
-  // these instead of re-subscribing.
+  // Derived eval progress. Components that briefly need a value outside an
+  // RxJS pipeline read the signals/computeds directly (e.g. `loadingTasks()`).
   // -------------------------------------------------------------------------
 
-  get loadingTasks(): LoadingTask[] {
-    return this.loadingTasksSubject.value;
-  }
-
-  get detectorLoadingTasks(): LoadingTask[] {
-    return this.detectorLoadingTasksSubject.value;
-  }
-
-  get find(): ProgressEvent {
-    return this.findSubject.value;
-  }
-
   /** Derive the {progress,total,done} shape the eval modal cares about. */
-  get votingIterations(): VotingIterationsResponse {
-    const prog = this.evalSubject.value;
+  readonly votingIterations = computed<VotingIterationsResponse>(() => {
+    const prog = this._eval();
     const current = Number(prog.current ?? 0);
     const total = Number(prog.total ?? 0);
     const status = String(prog.status ?? 'idle');
     const done = status === 'idle' && total > 0 && current >= total;
     return { progress: current, total, done };
-  }
-
-  readonly votingIterations$ = new Observable<VotingIterationsResponse>((sub) => {
-    const inner = this.eval$.subscribe(() => sub.next(this.votingIterations));
-    return () => inner.unsubscribe();
   });
+
+  readonly votingIterations$ = toObservable(this.votingIterations);
 
   // -------------------------------------------------------------------------
   // EventSource lifecycle.
@@ -118,32 +117,32 @@ export class ProgressEventsService implements OnDestroy {
 
   private connect(): void {
     if (this.source) return;
-    // EventSource fires events outside Angular's NgZone, so manually
-    // re-enter the zone for every subject.next() to trigger change
-    // detection on bound templates.
+    // EventSource fires events outside Angular's NgZone, but each handler
+    // writes a signal (or calls a signalized service), which notifies the
+    // change-detection scheduler directly — no zone re-entry needed.
     const es = new EventSource('/api/events');
     this.source = es;
 
     this.listen(es, 'server', (e) => this.handleServerFrame(e));
     this.listen(es, 'dataset', (e) =>
-      this.datasetSubject.next(this.parse<ProgressEvent>(e, {})),
+      this._dataset.set(this.parse<ProgressEvent>(e, {})),
     );
     this.listen(es, 'loading-tasks', (e) =>
-      this.loadingTasksSubject.next(this.parse<LoadingTask[]>(e, [])),
+      this._loadingTasks.set(this.parse<LoadingTask[]>(e, [])),
     );
     this.listen(es, 'detector-loading-tasks', (e) =>
-      this.detectorLoadingTasksSubject.next(this.parse<LoadingTask[]>(e, [])),
+      this._detectorLoadingTasks.set(this.parse<LoadingTask[]>(e, [])),
     );
-    this.listen(es, 'sort', (e) => this.sortSubject.next(this.parse<ProgressEvent>(e, {})));
-    this.listen(es, 'find', (e) => this.findSubject.next(this.parse<ProgressEvent>(e, {})));
-    this.listen(es, 'eval', (e) => this.evalSubject.next(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'sort', (e) => this._sort.set(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'find', (e) => this._find.set(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'eval', (e) => this._eval.set(this.parse<ProgressEvent>(e, {})));
     // The periodic `heartbeat` frame carries no payload we render; its sole
     // job is to keep the circuit breaker online (handled by `listen`'s
     // recordSuccess) during long, busy operations that aren't emitting
     // progress frames, so the backend never looks dead while it's merely busy.
     this.listen(es, 'heartbeat', () => {});
 
-    es.onopen = () => this.zone.run(() => this.connection.recordSuccess());
+    es.onopen = () => this.connection.recordSuccess();
 
     es.onerror = () => {
       // Feed the circuit breaker: an SSE error is a connectivity signal too,
@@ -183,20 +182,18 @@ export class ProgressEventsService implements OnDestroy {
   }
 
   /**
-   * Register a named-event listener that (a) re-enters Angular's zone so
-   * bound templates update, and (b) records the frame as proof the backend
-   * is alive. Every frame that arrives over the stream — progress data or a
-   * bare `heartbeat` — resets the connection circuit breaker, so it only
-   * trips offline when the stream genuinely goes silent (a dead backend),
-   * not when a busy backend is slow to answer unrelated background pollers.
+   * Register a named-event listener that records the frame as proof the
+   * backend is alive and then dispatches it. Every frame that arrives over the
+   * stream — progress data or a bare `heartbeat` — resets the connection
+   * circuit breaker (a signal write), so it only trips offline when the stream
+   * genuinely goes silent (a dead backend), not when a busy backend is slow to
+   * answer unrelated background pollers.
    */
   private listen(es: EventSource, name: string, handler: (e: Event) => void): void {
-    es.addEventListener(name, (e) =>
-      this.zone.run(() => {
-        this.connection.recordSuccess();
-        handler(e);
-      }),
-    );
+    es.addEventListener(name, (e) => {
+      this.connection.recordSuccess();
+      handler(e);
+    });
   }
 
   private parse<T>(e: Event, fallback: T): T {


### PR DESCRIPTION
## What

Continues the zoneless migration (`docs/plans/zoneless-migration.md`). Ships **Phase 1.1** — the single most important service rewrite — converting `ProgressEventsService` (the SSE pump) off NgZone re-entry.

- The six SSE channels (`dataset`, `loading-tasks`, `detector-loading-tasks`, `sort`, `find`, `eval`) go from `BehaviorSubject`s to **signals** exposed read-only. A signal write inside the EventSource callback notifies Angular's scheduler directly, so the pump triggers change detection with **no `zone.run` re-entry**; `NgZone` is removed from the service.
- The synchronous latest-value getters become signal reads (callable: `loadingTasks()` / `detectorLoadingTasks()`). The unused `find` getter is dropped.
- `votingIterations` becomes a `computed`; `votingIterations$` a `toObservable` of it.
- `serverReset$` stays a `Subject` (its only consumer, `dashboard-loading-tasks`, is imperative).
- Consumers that compose channels with RxJS operators (`takeUntil`/`filter`/`take` — `dashboard-loading-tasks`, `toast`, `context-switch`, `find-view`, `label-view`, `dashboard`, `progress-modal`) keep their `$` observables, now **`toObservable` bridges** over the backing signals, so a signal write still drives them. This is behavior-neutral under the still-zoned production app; per-component `| async`→signal template reads are deferred to those components' Phase 2 conversions.
- Sync-getter call sites (`context-switch`, `browse-prep`, `dashboard`) updated to call the signals; the two consumer spec stubs updated to the callable shape.

## Tests

- New **zoneless staleness canary** in `progress-events.service.spec.ts`: drives an SSE frame through the fake `EventSource` and asserts the rendered DOM repaints after `settleZoneless()` with **no manual `detectChanges`** — proving the signal write schedules CD under zoneless (it would have left the view stale under the old `BehaviorSubject.next()` from a raw listener).
- `./run-tests.sh` full pass (4875 passed, 1 skipped); frontend gate green (794 Vitest tests, `build:prod` clean, audit clean).

## Notes

Production is still zone-based — the flip is Phase 3. This change is correct under both zone and zoneless. Next in Phase 1 is **1.2 `KeyboardService`** (couples with the `center-panel` conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGY8MJDADDqYkpZ8snnQaA)_