### PR TITLE
Structural embedders: Stage-2 geometric re-rank + verification classifier

### DIFF
--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -1,8 +1,11 @@
 # Structural Embedders — Design
 
-**Status:** v1 in progress — **foundation shipped**, Stage-2 sort wiring +
-verification classifier + frontend overlay deferred (see "What shipped" /
-"Open follow-ups" below). This is the living spec for a third embedder *type*
+**Status:** v1 in progress — **foundation + Stage-2 backend core shipped**
+(two-stage re-rank, RegionYes-as-template, match-statistic verification
+classifier, all wired into the vote-driven learned-sort path); **frontend
+overlay + example-sort/labelset-path re-rank + K/threshold spike-tuning
+deferred** (see "What shipped" / "Open follow-ups" below). This is the living
+spec for a third embedder *type*
 (alongside single-vector and patch) that searches for **specific instances**
 ("the Coca-Cola logo") rather than **semantic categories** ("a cola can"). The
 architecture below is the agreed direction; the work plan is a sketch to be
@@ -453,22 +456,58 @@ download):
   `package-data`), rebuilt by `scripts/build_vlad_codebook.py` (seeded
   placeholder now; `--images DIR` does the real corpus k-means fit).
 
+## What shipped (v1 Stage-2 backend core)
+
+The Stage-1→Stage-2 chokepoint and the verification learnable, wired into the
+vote-driven sort and fully CPU-tested
+(`tests_lib/detectors/test_structural_similarity.py`):
+
+- **Chokepoint** — `vtscore/training/structural_similarity.py` (library-tier,
+  import-clean): the one place that knows the two-stage rule. `structural_rerank`
+  takes the Stage-1-sorted list, geometrically verifies the top-`K`
+  (`DEFAULT_RERANK_TOP_K`) against the templates, and re-ranks by a verification
+  score in `[0, 1]`; candidates beyond the shortlist are kept in Stage-1 order
+  and scored 0 (the accepted K trade-off). The matched-region `inlier_box` rides
+  out on each verified result as `best_region` (the data side of the overlay).
+- **RegionYes-as-template** — `filter_features_to_box` keeps only the keypoints
+  inside a yes-vote's `region_box`; `build_templates` makes one template per Good
+  vote (whole-image yes keeps all keypoints) and `best_match_stats` scores
+  **max-over-templates**.
+- **Verification classifier** — `train_verification_classifier` stacks each
+  labelled item's `MatchStats` (verified against the templates, leave-one-out for
+  a Good vote's own template) into the `match_stats_to_features` vector and trains
+  a tiny MLP via `train_model`; its decision boundary is the calibrated threshold
+  (`STRUCTURAL_DECISION_THRESHOLD = 0.5`). `VerificationScorer` wraps it, falling
+  back below `MIN_VERIFICATION_VOTES` (3) to a cold-start inlier gate that crosses
+  0.5 exactly at `DEFAULT_MIN_INLIERS`, so the same threshold separates
+  match/non-match in both regimes. Carried on `DetectorContext.verification_classifier`
+  (in-memory, re-derived every retrain, never persisted) next to the retrieval MLP.
+- **Wiring** — `maybe_structural_rerank` is invoked from `train_and_score`
+  (`vtscore/detectors/training.py`), gated on media carrying `local_features`
+  (mirrors the patch path's `patch_regions` gate) so every non-structural dataset
+  is untouched and pays zero cost. The matcher is resolved backend-agnostically
+  via the embedder's new `structural_matcher` property.
+
 ## Open follow-ups
 
-- **Stage-2 sort wiring (next).** The geometric re-rank is not yet wired into the
-  similarity/sort path — `SiftMatcher.verify` works and is tested, but nothing
-  calls it during a sort yet. Add the Stage-1→Stage-2 chokepoint (shortlist by
-  VLAD cosine, RANSAC-rerank the top-K) in `region_similarity.py` / a sibling
-  `structural_similarity.py`. Pin K with the spike.
-- **Verification classifier.** Train the match-statistic classifier
-  (`match_stats_to_features` → `train_model`) from RegionYes/No votes; its
-  decision boundary is the calibrated threshold. Carry it on `DetectorContext`
-  alongside the retrieval MLP. Cold-start (<3 votes) falls back to
-  `MatchStats.is_match(DEFAULT_MIN_INLIERS)`.
-- **RegionYes-as-template.** Restrict the template keypoints to those inside the
-  vote's `region_box`; multiple RegionYes votes → max-over-templates.
-- **Frontend overlay.** Draw the `MatchStats.inlier_box` matched region on result
-  cards / focus pane, reusing patch's best-region machinery.
+- **Frontend overlay (next).** The backend already emits the matched-region
+  `best_region` box on verified results; draw it on result cards / focus pane,
+  reusing patch's best-region machinery. Optionally render the inlier
+  correspondences as a debug view.
+- **Re-rank in the other sort paths.** `maybe_structural_rerank` is wired into the
+  vote-driven `train_and_score` only. The **labelset** path
+  (`labelset_train_and_score`, used when a saved structural detector reloads
+  cross-dataset) and the **example-sort** path (seed-by-example, which would need
+  the uploaded example's local features) don't re-rank yet. Wire both, reusing the
+  same chokepoint.
+- **K / threshold / live-vs-on-demand spike.** `DEFAULT_RERANK_TOP_K = 50` and the
+  "tail scores 0 / threshold = 0.5" policy are reasonable defaults but unspiked.
+  Sweep K on a demo image dataset and confirm the live-on-every-sort latency is
+  acceptable (vs an on-demand "verify" action) before pinning.
+- **Find-path classifier reuse.** The verification classifier is carried on
+  `DetectorContext` but only the retrieval MLP is consumed by the Find scoring
+  path today; have Find re-rank with the stored classifier so a pre-trained
+  structural detector verifies without re-deriving.
 - **Double SIFT detection.** The embed pass (VLAD) and the local-features pass
   each run SIFT once per image. Acceptable for v1; a combined single-detect pass
   is a cheap later optimisation.

--- a/tests_lib/detectors/test_structural_similarity.py
+++ b/tests_lib/detectors/test_structural_similarity.py
@@ -1,0 +1,340 @@
+"""Tests for the Stage-2 geometric re-rank + verification classifier.
+
+Exercises ``vtscore.training.structural_similarity``: RegionYes-as-template
+filtering, max-over-templates verification, the match-statistic classifier
+(plus its cold-start fallback), and the Stage-1->Stage-2 re-rank chokepoint
+(the "two-stage flow" the design doc calls for - an item the VLAD coarse stage
+ranks mid-pack but that geometrically verifies is promoted above a high-VLAD
+item with no geometric support).
+
+No model weights are downloaded - SIFT (via ``SiftMatcher``) is all that's
+needed; the verification classifier trains on tiny synthetic match-stat vectors.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from vtscore.media.structural import (
+    DEFAULT_MIN_INLIERS,
+    SIFT_DESCRIPTOR_DIM,
+    MatchStats,
+    SiftMatcher,
+    StructuralFeatures,
+)
+from vtscore.training.structural_similarity import (
+    STRUCTURAL_DECISION_THRESHOLD,
+    VerificationScorer,
+    best_match_stats,
+    build_templates,
+    filter_features_to_box,
+    maybe_structural_rerank,
+    snapshot_is_structural,
+    structural_rerank,
+    train_verification_classifier,
+)
+
+
+# --------------------------------------------------------------------------
+# Synthetic image / feature helpers (shared shape with test_structural_embedder)
+# --------------------------------------------------------------------------
+
+
+def _textured_image(seed: int = 0, size: int = 200) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    img = (rng.random((size, size)) * 255).astype(np.uint8)
+    img = cv2.GaussianBlur(img, (3, 3), 0)
+    lo, hi = size // 6, size - size // 6
+    x0, y0, x1, y1 = sorted(rng.integers(lo, hi, size=2)) + sorted(rng.integers(lo, hi, size=2))
+    cv2.rectangle(img, (int(x0), int(x1)), (int(y0), int(y1)), 255, 3)
+    cx, cy = rng.integers(lo, hi, size=2)
+    cv2.circle(img, (int(cx), int(cy)), int(rng.integers(15, 35)), 0, 2)
+    p = rng.integers(10, size - 10, size=4)
+    cv2.line(img, (int(p[0]), int(p[1])), (int(p[2]), int(p[3])), 200, 2)
+    return img
+
+
+def _similarity_matrix(angle_deg: float, scale: float, tx: float, ty: float) -> np.ndarray:
+    theta = np.deg2rad(angle_deg)
+    return np.array(
+        [
+            [scale * np.cos(theta), -scale * np.sin(theta), tx],
+            [scale * np.sin(theta), scale * np.cos(theta), ty],
+        ],
+        dtype=np.float32,
+    )
+
+
+def _warp(img: np.ndarray, angle: float, scale: float, tx: float, ty: float) -> np.ndarray:
+    h, w = img.shape
+    return cv2.warpAffine(img, _similarity_matrix(angle, scale, tx, ty), (w, h))
+
+
+def _feats(img: np.ndarray, *, matcher: SiftMatcher, max_features: int = 400) -> StructuralFeatures:
+    return matcher.detect_and_describe(img, max_features=max_features)
+
+
+# --------------------------------------------------------------------------
+# RegionYes-as-template
+# --------------------------------------------------------------------------
+
+
+class TestFilterFeaturesToBox:
+    def _feat(self, n: int = 20) -> StructuralFeatures:
+        rng = np.random.default_rng(0)
+        kp = rng.random((n, 4)).astype(np.float32)  # x, y in [0, 1]
+        desc = (rng.random((n, SIFT_DESCRIPTOR_DIM)) * 255).astype(np.float32)
+        return StructuralFeatures(keypoints=kp, descriptors=desc)
+
+    def test_none_box_returns_unchanged(self):
+        feat = self._feat()
+        assert filter_features_to_box(feat, None) is feat
+
+    def test_box_keeps_only_inside_keypoints(self):
+        feat = self._feat(n=50)
+        box = (0.0, 0.0, 0.5, 0.5)
+        out = filter_features_to_box(feat, box)
+        assert out.count <= feat.count
+        # Every surviving keypoint is inside the box.
+        assert (out.keypoints[:, 0] <= 0.5).all()
+        assert (out.keypoints[:, 1] <= 0.5).all()
+        # Descriptors are filtered in lockstep with keypoints.
+        assert out.descriptors.shape[0] == out.count
+
+    def test_unordered_box_is_normalised(self):
+        feat = self._feat(n=40)
+        ordered = filter_features_to_box(feat, (0.1, 0.2, 0.6, 0.7))
+        flipped = filter_features_to_box(feat, (0.6, 0.7, 0.1, 0.2))
+        np.testing.assert_array_equal(ordered.keypoints, flipped.keypoints)
+
+    def test_empty_box_falls_back_to_full_features(self):
+        feat = self._feat(n=30)
+        # A box in a corner no keypoint lands in -> fall back to all features
+        # (an empty template can never verify, so the full set is more useful).
+        out = filter_features_to_box(feat, (0.999, 0.999, 1.0, 1.0))
+        assert out is feat
+
+
+class TestBuildTemplates:
+    def test_one_template_per_good_vote_with_features(self):
+        m = SiftMatcher()
+        snap = {
+            1: {"local_features": _feats(_textured_image(1), matcher=m)},
+            2: {"local_features": _feats(_textured_image(2), matcher=m)},
+            3: {},  # no features -> skipped
+        }
+        templates = build_templates({1: None, 2: None, 3: None}, snap, {})
+        ids = {cid for cid, _ in templates}
+        assert ids == {1, 2}
+
+    def test_region_box_restricts_template(self):
+        m = SiftMatcher()
+        feat = _feats(_textured_image(5), matcher=m)
+        snap = {1: {"local_features": feat}}
+        templates = build_templates({1: None}, snap, {1: (0.0, 0.0, 0.5, 0.5)})
+        (_, tpl) = templates[0]
+        assert tpl.count <= feat.count
+        assert (tpl.keypoints[:, 0] <= 0.5).all()
+
+
+# --------------------------------------------------------------------------
+# Max-over-templates verification
+# --------------------------------------------------------------------------
+
+
+class TestBestMatchStats:
+    def test_picks_the_matching_template(self):
+        m = SiftMatcher()
+        base = _textured_image(7)
+        t_match = _feats(base, matcher=m)
+        t_other = _feats(_textured_image(8), matcher=m)
+        candidate = _feats(_warp(base, 10.0, 1.1, 6.0, -4.0), matcher=m)
+
+        # Order shouldn't matter - the strongest fit wins either way.
+        s1 = best_match_stats([t_other, t_match], candidate, m)
+        s2 = best_match_stats([t_match, t_other], candidate, m)
+        assert s1.model_ok is True
+        assert s2.model_ok is True
+        assert s1.inlier_count == s2.inlier_count
+
+    def test_no_templates_returns_empty_stats(self):
+        m = SiftMatcher()
+        candidate = _feats(_textured_image(9), matcher=m)
+        stats = best_match_stats([], candidate, m)
+        assert stats.model_ok is False
+        assert stats.inlier_count == 0
+
+
+# --------------------------------------------------------------------------
+# Verification scorer (cold-start + classifier)
+# --------------------------------------------------------------------------
+
+
+class TestVerificationScorerColdStart:
+    def test_model_not_ok_scores_zero(self):
+        scorer = VerificationScorer(model=None)
+        assert scorer.score(MatchStats(inlier_count=50, model_ok=False)) == 0.0
+
+    def test_threshold_crossing_at_min_inliers(self):
+        scorer = VerificationScorer(model=None, min_inliers=DEFAULT_MIN_INLIERS)
+        at_gate = scorer.score(MatchStats(inlier_count=DEFAULT_MIN_INLIERS, model_ok=True))
+        assert at_gate == pytest.approx(0.5)
+        # Below the gate is below threshold; well above saturates at 1.0.
+        assert scorer.score(MatchStats(inlier_count=2, model_ok=True)) < STRUCTURAL_DECISION_THRESHOLD
+        assert scorer.score(MatchStats(inlier_count=100, model_ok=True)) == 1.0
+
+
+class TestVerificationClassifier:
+    def _shared_instance_snapshot(self):
+        """Good votes are warps of one base image (a shared instance);
+        bad votes are unrelated images."""
+        m = SiftMatcher()
+        base = _textured_image(101)
+        snap = {
+            1: {"local_features": _feats(base, matcher=m)},
+            2: {"local_features": _feats(_warp(base, 12.0, 1.1, 8.0, -5.0), matcher=m)},
+            3: {"local_features": _feats(_warp(base, -8.0, 0.9, -6.0, 4.0), matcher=m)},
+            4: {"local_features": _feats(_textured_image(202), matcher=m)},
+            5: {"local_features": _feats(_textured_image(303), matcher=m)},
+        }
+        good = {1: None, 2: None, 3: None}
+        bad = {4: None, 5: None}
+        return m, snap, good, bad
+
+    def test_cold_start_below_min_votes_returns_none(self):
+        m = SiftMatcher()
+        snap = {
+            1: {"local_features": _feats(_textured_image(1), matcher=m)},
+            2: {"local_features": _feats(_textured_image(2), matcher=m)},
+        }
+        templates = build_templates({1: None}, snap, {})
+        # Only 2 votes total (< MIN_VERIFICATION_VOTES) -> cold-start.
+        clf = train_verification_classifier(templates, {1: None}, {2: None}, snap, m)
+        assert clf is None
+
+    def test_classifier_separates_match_from_non_match(self):
+        m, snap, good, bad = self._shared_instance_snapshot()
+        templates = build_templates(good, snap, {})
+        clf = train_verification_classifier(templates, good, bad, snap, m)
+        assert clf is not None
+
+        scorer = VerificationScorer(model=clf)
+        tpl_feats = [tpl for _, tpl in templates]
+
+        # A held-out warp of the shared instance should score higher than an
+        # unrelated image.
+        base = _textured_image(101)
+        held_out = _feats(_warp(base, 5.0, 1.05, 3.0, 2.0), matcher=m)
+        unrelated = _feats(_textured_image(909), matcher=m)
+        match_score = scorer.score(best_match_stats(tpl_feats, held_out, m))
+        non_match_score = scorer.score(best_match_stats(tpl_feats, unrelated, m))
+        assert match_score > non_match_score
+
+
+# --------------------------------------------------------------------------
+# Stage-1 -> Stage-2 chokepoint
+# --------------------------------------------------------------------------
+
+
+class TestStructuralRerank:
+    def test_geometric_match_promoted_over_high_vlad_non_match(self):
+        """The two-stage invariant: an item VLAD ranks mid-pack but that
+        geometrically verifies is promoted above a high-VLAD non-match."""
+        m = SiftMatcher()
+        base = _textured_image(404)
+        template = _feats(base, matcher=m)
+        warped = _feats(_warp(base, -10.0, 0.95, -7.0, 5.0), matcher=m)
+        unrelated = _feats(_textured_image(808), matcher=m)
+
+        snap = {
+            10: {"local_features": unrelated},  # high VLAD, no geometric support
+            20: {"local_features": warped},  # mid VLAD, verifies strongly
+        }
+        # Stage-1 ranks the unrelated item first.
+        results = [
+            {"id": 10, "score": 0.91},
+            {"id": 20, "score": 0.42},
+        ]
+        scorer = VerificationScorer(model=None)
+        out = structural_rerank(results, snap, [template], scorer, m, top_k=50)
+
+        assert out[0]["id"] == 20, "geometrically-verified item must be promoted"
+        assert out[0]["score"] >= STRUCTURAL_DECISION_THRESHOLD
+        # The verified item carries an inlier-box overlay.
+        assert "best_region" in out[0]
+        assert len(out[0]["best_region"]) == 4
+        # The non-match falls below threshold and drops its (absent) overlay.
+        non_match = next(e for e in out if e["id"] == 10)
+        assert non_match["score"] < STRUCTURAL_DECISION_THRESHOLD
+        assert "best_region" not in non_match
+
+    def test_items_beyond_shortlist_are_zeroed_and_kept_in_order(self):
+        m = SiftMatcher()
+        base = _textured_image(11)
+        template = _feats(base, matcher=m)
+        snap = {
+            1: {"local_features": _feats(_warp(base, 6.0, 1.0, 4.0, 0.0), matcher=m)},
+            2: {"local_features": _feats(_textured_image(22), matcher=m)},
+            3: {"local_features": _feats(_textured_image(33), matcher=m)},
+        }
+        results = [
+            {"id": 1, "score": 0.9},
+            {"id": 2, "score": 0.8},
+            {"id": 3, "score": 0.7},
+        ]
+        scorer = VerificationScorer(model=None)
+        # top_k=1 -> only id 1 is verified; ids 2,3 are the tail.
+        out = structural_rerank(results, snap, [template], scorer, m, top_k=1)
+        tail = out[1:]
+        assert [e["id"] for e in tail] == [2, 3]  # Stage-1 order preserved
+        assert all(e["score"] == 0.0 for e in tail)
+
+    def test_no_templates_returns_input_unchanged(self):
+        m = SiftMatcher()
+        results = [{"id": 1, "score": 0.5}]
+        out = structural_rerank(results, {}, [], VerificationScorer(), m)
+        assert out == results
+
+
+# --------------------------------------------------------------------------
+# App-facing glue (gating)
+# --------------------------------------------------------------------------
+
+
+class TestMaybeStructuralRerank:
+    def test_noop_for_non_structural_snapshot(self):
+        snap = {1: {"embedding": np.zeros(8, dtype=np.float32)}}  # no local_features
+        results = [{"id": 1, "score": 0.7}]
+        out, thresh = maybe_structural_rerank(results, 0.33, snap, {1: None}, {}, {})
+        assert out == results
+        assert thresh == 0.33
+        assert snapshot_is_structural(snap) is False
+
+    def test_structural_snapshot_reranks_and_sets_threshold(self, monkeypatch):
+        m = SiftMatcher()
+        base = _textured_image(55)
+        snap = {
+            1: {"local_features": _feats(base, matcher=m), "embedder": "sift_vlad"},
+            2: {"local_features": _feats(_warp(base, 9.0, 1.05, 5.0, -3.0), matcher=m), "embedder": "sift_vlad"},
+            3: {"local_features": _feats(_textured_image(66), matcher=m), "embedder": "sift_vlad"},
+        }
+        # Resolve the matcher to our local SIFT instance (the registry embedder
+        # is stubbed in the library test tier).
+        monkeypatch.setattr(
+            "vtscore.training.structural_similarity._resolve_matcher",
+            lambda _snap: m,
+        )
+        results = [
+            {"id": 3, "score": 0.95},  # high VLAD, unrelated
+            {"id": 2, "score": 0.40},  # warp of the good-vote instance
+            {"id": 1, "score": 0.30},  # the good-vote instance itself
+        ]
+        good = {1: None}
+        bad = {3: None}
+        out, thresh = maybe_structural_rerank(results, 0.77, snap, good, bad, {})
+        assert thresh == STRUCTURAL_DECISION_THRESHOLD
+        # id 2 (warp of the template) is geometrically verified and leads.
+        assert out[0]["id"] == 2
+        assert out[0]["score"] >= STRUCTURAL_DECISION_THRESHOLD

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -457,7 +457,7 @@ def train_and_score(
     """
     region_boxes = vote_region_boxes or {}
     X_list, y_list = _build_vote_xy(clips_dict, good_votes, bad_votes, region_boxes)
-    return _train_and_score_xy(
+    results, threshold, model = _train_and_score_xy(
         X_list,
         y_list,
         clips_dict,
@@ -467,6 +467,19 @@ def train_and_score(
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
     )
+
+    # Stage-2 structural re-rank: a no-op for every non-structural dataset
+    # (gated on media carrying ``local_features``), so existing datasets are
+    # untouched.  For a structural (SIFT/VLAD) dataset it geometrically
+    # verifies the VLAD shortlist against the RegionYes templates and re-ranks
+    # by the match-statistic classifier (or the cold-start inlier gate).  See
+    # docs/plans/structural-embedder.md.
+    from vtscore.training.structural_similarity import maybe_structural_rerank  # noqa: PLC0415
+
+    results, threshold = maybe_structural_rerank(
+        results, threshold, clips_dict, good_votes, bad_votes, region_boxes, det_ctx
+    )
+    return results, threshold, model
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/media/image/_structural_shared.py
+++ b/vtscore/media/image/_structural_shared.py
@@ -83,6 +83,18 @@ class _StructuralImageBase(MediaEmbedder):
     def max_features(self) -> int:
         return DEFAULT_MAX_FEATURES
 
+    @property
+    def structural_matcher(self) -> Optional[StructuralMatcher]:
+        """The geometric-verification backend, loading it on first access.
+
+        The Stage-2 re-rank (``vtscore.training.structural_similarity``) asks
+        the embedder for its matcher rather than hard-coding SIFT, so a future
+        learned-feature backend slots in unchanged.
+        """
+        if self._matcher is None:
+            self.load_models()
+        return self._matcher
+
     # --- backend hook ------------------------------------------------------
 
     def _make_matcher(self) -> StructuralMatcher:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -397,6 +397,12 @@ class DetectorContext:
         # region.  See ``logical-bug-audit.md`` finding M4.
         "label_embedding_regions",
         "model",  # nn.Sequential | None (current trained MLP)
+        # Structural (SIFT/VLAD) detectors carry a *second* learned object next
+        # to the retrieval MLP: the match-statistic verification classifier
+        # (None until trained / for non-structural detectors).  In-memory only,
+        # re-derived from votes on every retrain, never persisted.  See
+        # docs/plans/structural-embedder.md.
+        "verification_classifier",  # nn.Sequential | None
         "threshold",  # decision threshold
         # Cross-dataset training-corpus counts (from on-disk labelset).  These
         # are independent of ``good_votes``/``bad_votes``, which only count
@@ -472,6 +478,9 @@ class DetectorContext:
         self.label_embeddings: dict[str, Any] = {}
         self.label_embedding_regions: dict[str, tuple[float, float, float, float] | None] = {}
         self.model: Any = None  # nn.Sequential | None
+        # Match-statistic verification classifier for structural detectors;
+        # None for non-structural detectors and until first trained.
+        self.verification_classifier: Any = None  # nn.Sequential | None
         self.threshold: float = 0.5
         self.labelset_good_count: int = 0
         self.labelset_bad_count: int = 0
@@ -696,6 +705,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))
         object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
         object.__setattr__(self, "model", None)
+        object.__setattr__(self, "verification_classifier", None)
         object.__setattr__(self, "threshold", 0.5)
         object.__setattr__(self, "labelset_good_count", 0)
         object.__setattr__(self, "labelset_bad_count", 0)

--- a/vtscore/training/structural_similarity.py
+++ b/vtscore/training/structural_similarity.py
@@ -1,0 +1,430 @@
+"""Stage-2 geometric re-rank + match-statistic verification classifier.
+
+This is the chokepoint the structural-embedder design
+(``docs/plans/structural-embedder.md``) calls for: the one place that knows
+the **two-stage** rule, the way :func:`score_against_query` is the one place
+that knows max-over-regions for patch embedders.
+
+* **Stage 1** is the ordinary VLAD retrieval - it rides
+  ``media["embedding"]`` through the MLP / cosine sort unchanged and produces a
+  ranked candidate list.
+* **Stage 2** (here) takes the top-*K* of that list and, for each candidate,
+  geometrically verifies it against the **templates** derived from the user's
+  RegionYes votes (RANSAC similarity fit via the dataset's
+  :class:`~vtscore.media.structural.StructuralMatcher`).  Candidates are
+  re-ranked by a verification score: either the learned **match-statistic
+  classifier** (when there are enough votes to train it) or, before then, the
+  cold-start inlier gate.
+
+The verification score is a probability in ``[0, 1]``; the classifier's
+decision boundary (and the cold-start gate's ``DEFAULT_MIN_INLIERS`` mapping)
+both sit at :data:`STRUCTURAL_DECISION_THRESHOLD`, so "score >= threshold"
+means "geometrically a match" in either regime.
+
+Library-tier and import-clean: no Flask, no app-tier imports.  ``torch`` and the
+embedder registry are imported lazily so the pure data helpers
+(:func:`filter_features_to_box`, :func:`build_templates`,
+:func:`best_match_stats`) import without them.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+from vtscore.media.structural import (
+    DEFAULT_MIN_INLIERS,
+    MatchStats,
+    StructuralFeatures,
+    StructuralMatcher,
+    match_stats_to_features,
+)
+
+_log = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------
+# Tunable constants (pinned by the pre-impl spike; see the design doc's open
+# questions on K, live-vs-on-demand, and the geometric model).
+# --------------------------------------------------------------------------
+
+DEFAULT_RERANK_TOP_K = 50
+"""Stage-1 shortlist size fed to the Stage-2 RANSAC re-rank.
+
+Too small misses true matches the coarse VLAD stage under-ranks; too large
+blows the re-rank latency budget (Stage 2 is O(K * match * RANSAC)).  Candidates
+beyond the shortlist are not geometrically verified and score 0 - the accepted
+K trade-off for an instance-search tool.
+"""
+
+MIN_VERIFICATION_VOTES = 3
+"""Vote count below which the match-statistic classifier is not trained.
+
+Mirrors the safe-threshold GMM fallback the detector MLP uses below 6 labels:
+with too few votes we fall back to :class:`VerificationScorer`'s cold-start
+inlier gate instead of a useless classifier.
+"""
+
+STRUCTURAL_DECISION_THRESHOLD = 0.5
+"""Decision boundary of the verification score.
+
+The match-statistic classifier emits a sigmoid probability whose boundary is
+0.5; the cold-start gate maps ``inlier_count == DEFAULT_MIN_INLIERS`` to 0.5
+too, so a single threshold separates match/non-match in both regimes.
+"""
+
+
+# --------------------------------------------------------------------------
+# RegionYes-as-template
+# --------------------------------------------------------------------------
+
+
+def filter_features_to_box(
+    features: StructuralFeatures,
+    box: Optional[tuple[float, float, float, float]],
+) -> StructuralFeatures:
+    """Keep only the keypoints whose location falls inside *box*.
+
+    This is RegionYes-as-template: "find the Coca-Cola logo" boxes the logo and
+    discards the surrounding clutter a whole-image template would drag in.  When
+    *box* is ``None`` (a whole-image Yes) the features are returned unchanged.
+    *box* is a normalised ``(x0, y0, x1, y1)`` and need not be ordered.
+
+    If the box contains no keypoints the unfiltered features are returned - an
+    empty template can never verify anything, so falling back to the full set is
+    the more useful behaviour than silently producing a dead template.
+    """
+    if box is None:
+        return features
+    kp = features.keypoints_f32()
+    if kp.shape[0] == 0:
+        return features
+    x0, x1 = sorted((float(box[0]), float(box[2])))
+    y0, y1 = sorted((float(box[1]), float(box[3])))
+    xs, ys = kp[:, 0], kp[:, 1]
+    inside = (xs >= x0) & (xs <= x1) & (ys >= y0) & (ys <= y1)
+    if not inside.any():
+        return features
+    return StructuralFeatures(keypoints=kp[inside], descriptors=features.descriptors_f32()[inside])
+
+
+def _local_features(media: Optional[dict]) -> Optional[StructuralFeatures]:
+    """Return *media*'s stored ``local_features`` as a :class:`StructuralFeatures`."""
+    if media is None:
+        return None
+    feats = media.get("local_features")
+    return feats if isinstance(feats, StructuralFeatures) else None
+
+
+def build_templates(
+    good_votes: Any,
+    snap: dict[Any, dict],
+    region_boxes: dict[Any, tuple[float, float, float, float]],
+) -> list[tuple[Any, StructuralFeatures]]:
+    """Build one ``(media_id, template)`` per Good vote that carries features.
+
+    RegionYes votes restrict the template to the boxed keypoints
+    (:func:`filter_features_to_box`); whole-image Yes votes keep every keypoint.
+    Good votes whose media has no ``local_features`` (or isn't in *snap*) are
+    skipped.  The media id is retained so the verification-classifier training
+    can hold the item's own template out (leave-one-out) and avoid a trivial
+    self-match positive.
+    """
+    templates: list[tuple[Any, StructuralFeatures]] = []
+    for cid in good_votes:
+        feats = _local_features(snap.get(cid))
+        if feats is None or feats.count == 0:
+            continue
+        templates.append((cid, filter_features_to_box(feats, region_boxes.get(cid))))
+    return templates
+
+
+# --------------------------------------------------------------------------
+# Max-over-templates verification
+# --------------------------------------------------------------------------
+
+
+def best_match_stats(
+    template_features: list[StructuralFeatures],
+    candidate: StructuralFeatures,
+    matcher: StructuralMatcher,
+) -> MatchStats:
+    """Verify *candidate* against every template; return the strongest fit.
+
+    Multiple RegionYes votes mean multiple templates; the score is the **max
+    over templates** (keep the best geometric fit), directly analogous to
+    patch's max-over-regions.  "Best" orders by ``(model_ok, inlier_count,
+    inlier_ratio)`` so a plausible model always beats a degenerate one.
+    """
+    best = MatchStats()
+    best_key = (False, -1, -1.0)
+    for tpl in template_features:
+        stats = matcher.verify(tpl, candidate)
+        key = (stats.model_ok, stats.inlier_count, stats.inlier_ratio)
+        if key > best_key:
+            best_key = key
+            best = stats
+    return best
+
+
+# --------------------------------------------------------------------------
+# Verification classifier (the genuinely-structural learnable)
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class VerificationScorer:
+    """Maps a :class:`MatchStats` to a match probability in ``[0, 1]``.
+
+    Wraps either the trained match-statistic classifier (*model*) or, before
+    there are enough votes to train one, the cold-start inlier gate.  Both put
+    their decision boundary at :data:`STRUCTURAL_DECISION_THRESHOLD`.
+    """
+
+    model: Optional[Any] = None  # nn.Sequential | None
+    min_inliers: int = DEFAULT_MIN_INLIERS
+
+    def score(self, stats: MatchStats) -> float:
+        """Probability that *stats* represents a genuine instance match."""
+        if self.model is None:
+            # Cold-start: a continuous gate that crosses 0.5 exactly at
+            # ``min_inliers`` (so ``MatchStats.is_match`` and "score >= 0.5"
+            # agree) and saturates at 1.0 by ``2 * min_inliers``.
+            if not stats.model_ok:
+                return 0.0
+            return float(min(1.0, stats.inlier_count / (2.0 * self.min_inliers)))
+
+        import torch  # noqa: PLC0415
+
+        from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
+
+        feat = match_stats_to_features(stats)
+        with torch.no_grad():
+            x = torch.from_numpy(feat).unsqueeze(0).to(next(self.model.parameters()).device)
+            prob = sigmoid_to_finite_scores(self.model(x))[0]
+        # ``sigmoid_to_finite_scores`` sentinels non-finite logits to -1.0;
+        # clamp that to 0.0 so a destabilised classifier never out-ranks a real
+        # match (and never reports a negative "probability").
+        return float(prob) if prob >= 0.0 else 0.0
+
+
+def train_verification_classifier(
+    templates: list[tuple[Any, StructuralFeatures]],
+    good_votes: Any,
+    bad_votes: Any,
+    snap: dict[Any, dict],
+    matcher: StructuralMatcher,
+) -> Optional[Any]:
+    """Train the match-statistic classifier from RegionYes / No votes.
+
+    Each labelled item is verified against the templates (max-over-templates),
+    its :class:`MatchStats` stacked into the fixed-D
+    :func:`~vtscore.media.structural.match_stats_to_features` vector, and a tiny
+    MLP trained over those vectors: RegionYes / Yes that verify are positives,
+    No are negatives.  The classifier's decision boundary **is** the calibrated
+    match threshold, so threshold calibration falls out for free.
+
+    A Good vote's own template is held out when computing its positive example
+    (leave-one-out) so a trivial self-match doesn't dominate training.  Returns
+    ``None`` (cold-start) when there are fewer than
+    :data:`MIN_VERIFICATION_VOTES` votes, when either class ends up empty, or
+    when training is otherwise impossible - the caller then uses the inlier
+    gate.
+    """
+    if len(good_votes) + len(bad_votes) < MIN_VERIFICATION_VOTES:
+        return None
+
+    feats: list[np.ndarray] = []
+    labels: list[float] = []
+    all_templates = [tpl for _, tpl in templates]
+
+    for cid in good_votes:
+        cand = _local_features(snap.get(cid))
+        if cand is None or cand.count == 0:
+            continue
+        # Hold out this item's own template (leave-one-out) to avoid a trivial
+        # self-match positive.  If it was the only template, there is nothing to
+        # verify against, so skip it as a training example.
+        loo = [tpl for tc, tpl in templates if tc != cid]
+        if not loo:
+            continue
+        feats.append(match_stats_to_features(best_match_stats(loo, cand, matcher)))
+        labels.append(1.0)
+
+    for cid in bad_votes:
+        cand = _local_features(snap.get(cid))
+        if cand is None or cand.count == 0:
+            continue
+        feats.append(match_stats_to_features(best_match_stats(all_templates, cand, matcher)))
+        labels.append(0.0)
+
+    num_pos = sum(1 for v in labels if v == 1.0)
+    num_neg = len(labels) - num_pos
+    if len(feats) < 2 or num_pos == 0 or num_neg == 0:
+        return None
+
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.mlp import train_model  # noqa: PLC0415
+
+    X = torch.from_numpy(np.stack(feats).astype(np.float32, copy=False))
+    y = torch.tensor(labels, dtype=torch.float32).unsqueeze(1)
+    try:
+        return train_model(X, y, X.shape[1])
+    except ValueError:
+        # train_model rejects single-class data; guarded above, but stay defensive.
+        return None
+
+
+# --------------------------------------------------------------------------
+# Stage-1 -> Stage-2 chokepoint
+# --------------------------------------------------------------------------
+
+
+def structural_rerank(
+    results: list[dict],
+    snap: dict[Any, dict],
+    template_features: list[StructuralFeatures],
+    scorer: VerificationScorer,
+    matcher: StructuralMatcher,
+    *,
+    top_k: int = DEFAULT_RERANK_TOP_K,
+    score_key: str = "score",
+) -> list[dict]:
+    """Re-rank Stage-1 *results* by geometric verification of the top-*K*.
+
+    *results* is the Stage-1-sorted list of ``{"id", score_key, ...}`` dicts.
+    The top-*K* are geometrically verified against *template_features*
+    (max-over-templates) and re-ordered by the resulting verification score;
+    each gets that score in *score_key* and the inlier bounding box in
+    ``best_region`` (reusing patch's overlay machinery).  Candidates beyond the
+    shortlist are left in Stage-1 order behind the re-ranked block and scored 0
+    - they were never geometrically checked, so for an instance search they are
+    "no confirmed match".
+
+    Order and score stay consistent (an item's position matches its reported
+    score within each block) so the existing threshold/colouring path needs no
+    special-casing.  When there are no templates the input is returned unchanged.
+    """
+    if not results or not template_features:
+        return list(results)
+
+    head = results[:top_k]
+    tail = results[top_k:]
+
+    scored: list[tuple[float, float, dict]] = []
+    for entry in head:
+        feats = _local_features(snap.get(entry.get("id")))
+        verification = 0.0
+        box: Optional[tuple[float, float, float, float]] = None
+        if feats is not None and feats.count > 0:
+            stats = best_match_stats(template_features, feats, matcher)
+            verification = scorer.score(stats)
+            box = stats.inlier_box
+        new = dict(entry)
+        stage1 = float(new.get(score_key, 0.0) or 0.0)
+        new[score_key] = round(verification, 4)
+        if box is not None:
+            new["best_region"] = [float(c) for c in box]
+        else:
+            new.pop("best_region", None)
+        scored.append((verification, stage1, new))
+
+    # Re-rank the shortlist by verification score, breaking ties by the Stage-1
+    # score so a strong VLAD candidate wins among equally-(un)verified items.
+    scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    out = [s[2] for s in scored]
+
+    for entry in tail:
+        new = dict(entry)
+        new[score_key] = 0.0
+        new.pop("best_region", None)
+        out.append(new)
+    return out
+
+
+# --------------------------------------------------------------------------
+# App-facing glue (gated, no-op for non-structural datasets)
+# --------------------------------------------------------------------------
+
+
+def snapshot_is_structural(snap: dict[Any, dict]) -> bool:
+    """True iff any media in *snap* carries populated ``local_features``."""
+    return any(_local_features(m) is not None for m in snap.values())
+
+
+def _resolve_matcher(snap: dict[Any, dict]) -> Optional[StructuralMatcher]:
+    """Resolve the dataset's structural matcher from its embedder, or ``None``.
+
+    Backend-agnostic: asks the embedder for its
+    :class:`~vtscore.media.structural.StructuralMatcher` rather than hard-coding
+    SIFT, so a learned-feature backend slots in unchanged.
+    """
+    name = ""
+    for m in snap.values():
+        name = m.get("embedder") or ""
+        if name:
+            break
+    if not name:
+        return None
+    from vtscore.media import get_embedder  # noqa: PLC0415
+
+    try:
+        emb = get_embedder(name)
+    except KeyError:
+        return None
+    return getattr(emb, "structural_matcher", None)
+
+
+def maybe_structural_rerank(
+    results: list[dict],
+    threshold: float,
+    snap: dict[Any, dict],
+    good_votes: Any,
+    bad_votes: Any,
+    region_boxes: dict[Any, tuple[float, float, float, float]],
+    det_ctx: Any = None,
+    *,
+    top_k: int = DEFAULT_RERANK_TOP_K,
+    score_key: str = "score",
+) -> tuple[list[dict], float]:
+    """Apply the Stage-2 re-rank when the active dataset is structural.
+
+    A no-op (returns ``(results, threshold)`` unchanged) for every non-
+    structural dataset - gated on ``local_features`` being present, exactly as
+    the patch path gates on ``patch_regions`` - so existing datasets pay zero
+    cost and see no behaviour change.  For a structural dataset it builds the
+    RegionYes templates, trains (or cold-starts) the verification classifier,
+    re-ranks the shortlist, and returns the classifier's decision boundary as
+    the threshold.  The trained classifier is carried on *det_ctx* (in-memory,
+    re-derived every retrain) alongside the retrieval MLP.
+    """
+    if not snapshot_is_structural(snap):
+        return results, threshold
+    matcher = _resolve_matcher(snap)
+    if matcher is None:
+        return results, threshold
+    templates = build_templates(good_votes, snap, region_boxes)
+    if not templates:
+        return results, threshold
+
+    classifier = train_verification_classifier(templates, good_votes, bad_votes, snap, matcher)
+    if det_ctx is not None:
+        try:
+            det_ctx.verification_classifier = classifier
+        except Exception:  # noqa: BLE001 - request-missing sentinel refuses writes
+            pass
+
+    scorer = VerificationScorer(model=classifier)
+    reranked = structural_rerank(
+        results,
+        snap,
+        [tpl for _, tpl in templates],
+        scorer,
+        matcher,
+        top_k=top_k,
+        score_key=score_key,
+    )
+    return reranked, STRUCTURAL_DECISION_THRESHOLD


### PR DESCRIPTION
Continues the structural-embedder v1 work (`docs/plans/structural-embedder.md`). The foundation (SIFT/VLAD matcher core, `sift_vlad` embedder, loader pass, codebook) already shipped; this lands the **Stage-2 backend core** — the geometric re-rank, RegionYes-as-template, and the match-statistic verification classifier — wired into the vote-driven learned-sort path.

## What's here

- **`vtscore/training/structural_similarity.py`** (library-tier, import-clean) — the Stage-1→Stage-2 chokepoint:
  - `structural_rerank` shortlists the top-`K` (`DEFAULT_RERANK_TOP_K = 50`) of the Stage-1-sorted list, geometrically verifies each against the templates (max-over-templates RANSAC via the dataset's `StructuralMatcher`), and re-ranks by a verification score in `[0, 1]`. Candidates beyond the shortlist stay in Stage-1 order and score 0 (the accepted K trade-off for instance search). The matched-region `inlier_box` rides out as `best_region` (the data side of the overlay).
  - **RegionYes-as-template**: `filter_features_to_box` restricts a yes-vote's template to the boxed keypoints; `build_templates` makes one template per Good vote; `best_match_stats` scores max-over-templates.
  - **Verification classifier**: `train_verification_classifier` trains a tiny MLP over `match_stats_to_features` vectors (RegionYes/Yes positives, No negatives; leave-one-out for a Good vote's own template). Its decision boundary is the calibrated threshold (`STRUCTURAL_DECISION_THRESHOLD = 0.5`). `VerificationScorer` falls back below `MIN_VERIFICATION_VOTES` (3) to a cold-start inlier gate that crosses 0.5 exactly at `DEFAULT_MIN_INLIERS`, so one threshold separates match/non-match in both regimes.
- **Wiring**: `maybe_structural_rerank` is invoked from `train_and_score`, **gated on media carrying `local_features`** (mirrors the patch path's `patch_regions` gate), so every non-structural dataset is untouched and pays zero cost. The matcher is resolved backend-agnostically via the embedder's new `structural_matcher` property.
- **State**: the classifier is carried on `DetectorContext.verification_classifier` (in-memory, re-derived every retrain, never persisted) alongside the retrieval MLP — consistent with the No-Persisted-Vectors rule.

## Tests

`tests_lib/detectors/test_structural_similarity.py` (17 tests): RegionYes box filtering, template building, max-over-templates, cold-start scorer thresholds, classifier match/non-match separation, the two-stage promotion invariant (a mid-VLAD item that geometrically verifies is promoted above a high-VLAD non-match), shortlist/tail handling, and the non-structural no-op gate.

Full `./run-tests.sh` is green (4892 passed, 1 skipped).

## Deferred (tracked in the plan's Open follow-ups)

Frontend overlay rendering; re-rank in the labelset-reload and example-sort paths; K/threshold/live-vs-on-demand spike; Find-path reuse of the stored classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012N4rTAqEsuWLsZoj2oiHUe)_