### PR TITLE
Structural embedders: wire Stage-2 re-rank into labelset + example-sort paths

### DIFF
--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -1,11 +1,12 @@
 # Structural Embedders — Design
 
-**Status:** v1 in progress — **foundation + Stage-2 backend core shipped**
-(two-stage re-rank, RegionYes-as-template, match-statistic verification
-classifier, all wired into the vote-driven learned-sort path); **frontend
-overlay + example-sort/labelset-path re-rank + K/threshold spike-tuning
-deferred** (see "What shipped" / "Open follow-ups" below). This is the living
-spec for a third embedder *type*
+**Status:** v1 in progress — **foundation + Stage-2 backend core + re-rank
+across all sort paths shipped** (two-stage re-rank, RegionYes-as-template,
+match-statistic verification classifier, wired into the vote-driven learned-sort
+path **plus** the example-sort and labelset/saved-detector paths); **find-path
+classifier reuse + K/threshold spike-tuning deferred** (the matched-region
+overlay already rides patch's `best_region` machinery; see "What shipped" /
+"Open follow-ups" below). This is the living spec for a third embedder *type*
 (alongside single-vector and patch) that searches for **specific instances**
 ("the Coca-Cola logo") rather than **semantic categories** ("a cola can"). The
 architecture below is the agreed direction; the work plan is a sketch to be
@@ -488,18 +489,45 @@ vote-driven sort and fully CPU-tested
   is untouched and pays zero cost. The matcher is resolved backend-agnostically
   via the embedder's new `structural_matcher` property.
 
+## What shipped (v1 Stage-2 re-rank across all sort paths)
+
+The Stage-2 re-rank now reaches every scoring entry point, not just the
+vote-driven sort (CPU-tested in
+`tests_lib/detectors/test_structural_similarity.py` +
+`test_structural_labelset.py`):
+
+- **`feature_snap` decoupling.** `maybe_structural_rerank` takes an optional
+  `feature_snap` so the templates + verification classifier can be sourced from a
+  snapshot distinct from the re-rank target. The vote path leaves it `None`
+  (voted media are in the active dataset); the labelset path passes a synthetic
+  snapshot of re-derived cross-dataset features. The re-rank itself always runs
+  over the active dataset's `snap`.
+- **Example-sort (seed-by-example).** `maybe_structural_rerank_example` uses the
+  uploaded example's own local features as the single template (any crop is
+  applied to the file before feature detection, so it already restricts the
+  template) and the cold-start inlier gate to score (example-sort carries no
+  votes). Wired into `_example_sort_from_path` (`vtsearch/routes/sorting.py`);
+  the matched-region `best_region` rides out on `similarity`-keyed results, which
+  the frontend already renders.
+- **Labelset (saved-detector reload).** New
+  `DetectorContext.label_local_features` cache (in-memory, re-derived from each
+  element's origin via `populate_label_local_features`, invalidated on embedder
+  switch alongside `label_embeddings`). `maybe_labelset_structural_rerank`
+  projects the cache into the chokepoint's vote/snap shape and re-ranks the
+  active dataset; wired into `labelset_train_and_score`
+  (`vtscore/detectors/labelset_training.py`). A no-op for non-structural
+  datasets (gated on the active snapshot carrying `local_features`).
+
 ## Open follow-ups
 
-- **Frontend overlay (next).** The backend already emits the matched-region
-  `best_region` box on verified results; draw it on result cards / focus pane,
-  reusing patch's best-region machinery. Optionally render the inlier
-  correspondences as a debug view.
-- **Re-rank in the other sort paths.** `maybe_structural_rerank` is wired into the
-  vote-driven `train_and_score` only. The **labelset** path
-  (`labelset_train_and_score`, used when a saved structural detector reloads
-  cross-dataset) and the **example-sort** path (seed-by-example, which would need
-  the uploaded example's local features) don't re-rank yet. Wire both, reusing the
-  same chokepoint.
+- **Frontend overlay — basics done, debug view deferred.** The backend emits the
+  matched-region `best_region` box on verified results across all three sort
+  paths, and the frontend already renders `best_region` (the focus-pane
+  highlight box in `center-panel` / `image-viewer`, fed via `bestRegion` from the
+  learned-sort / example-sort responses) — so the structural overlay rides
+  patch's existing machinery with no new component. Still optional: a debug view
+  that draws the inlier *correspondences* (the matched keypoint lines), which
+  would need the backend to emit per-match point pairs.
 - **K / threshold / live-vs-on-demand spike.** `DEFAULT_RERANK_TOP_K = 50` and the
   "tail scores 0 / threshold = 0.5" policy are reasonable defaults but unspiked.
   Sweep K on a demo image dataset and confirm the live-on-every-sort latency is

--- a/tests_lib/detectors/test_structural_labelset.py
+++ b/tests_lib/detectors/test_structural_labelset.py
@@ -1,0 +1,154 @@
+"""Tests for the structural Stage-2 re-rank on the saved-detector (labelset) path.
+
+Exercises ``vtscore.detectors.labelset_training``'s structural helpers: the
+cross-dataset local-feature cache projection (:func:`_labelset_feature_snapshot`),
+the no-op gating of :func:`populate_label_local_features`, and the end-to-end
+:func:`maybe_labelset_structural_rerank` that lets a saved structural detector
+geometrically verify against a freshly loaded dataset.
+
+No model weights are downloaded - ``SiftMatcher`` supplies the geometry and the
+labelset's features are pre-seeded into the cache so the resolver/registry/disk
+path stays out of these unit tests (the same isolation
+``test_score_sanitization`` uses for the embedding cache).
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from vtscore.datasets.labelset import LabeledElement, LabelSet
+from vtscore.detectors import labelset_training
+from vtscore.detectors.labelset_elements import stable_element_id
+from vtscore.media.structural import SiftMatcher, StructuralFeatures
+from vtscore.state.core import DetectorContext
+from vtscore.training.structural_similarity import STRUCTURAL_DECISION_THRESHOLD
+
+
+def _textured_image(seed: int = 0, size: int = 200) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    img = (rng.random((size, size)) * 255).astype(np.uint8)
+    img = cv2.GaussianBlur(img, (3, 3), 0)
+    lo, hi = size // 6, size - size // 6
+    x0, y0, x1, y1 = sorted(rng.integers(lo, hi, size=2)) + sorted(rng.integers(lo, hi, size=2))
+    cv2.rectangle(img, (int(x0), int(x1)), (int(y0), int(y1)), 255, 3)
+    cx, cy = rng.integers(lo, hi, size=2)
+    cv2.circle(img, (int(cx), int(cy)), int(rng.integers(15, 35)), 0, 2)
+    p = rng.integers(10, size - 10, size=4)
+    cv2.line(img, (int(p[0]), int(p[1])), (int(p[2]), int(p[3])), 200, 2)
+    return img
+
+
+def _similarity_matrix(angle_deg: float, scale: float, tx: float, ty: float) -> np.ndarray:
+    theta = np.deg2rad(angle_deg)
+    return np.array(
+        [
+            [scale * np.cos(theta), -scale * np.sin(theta), tx],
+            [scale * np.sin(theta), scale * np.cos(theta), ty],
+        ],
+        dtype=np.float32,
+    )
+
+
+def _warp(img: np.ndarray, angle: float, scale: float, tx: float, ty: float) -> np.ndarray:
+    h, w = img.shape
+    return cv2.warpAffine(img, _similarity_matrix(angle, scale, tx, ty), (w, h))
+
+
+def _feats(img: np.ndarray, *, matcher: SiftMatcher, max_features: int = 400) -> StructuralFeatures:
+    return matcher.detect_and_describe(img, max_features=max_features)
+
+
+def _element(name: str, label: str, *, region_box=None) -> LabeledElement:
+    return LabeledElement(
+        origin={"importer": "test", "params": {}},
+        origin_name=name,
+        label=label,
+        md5=(name * 32)[:32],
+        region_box=region_box,
+    )
+
+
+class TestLabelsetFeatureSnapshot:
+    def test_splits_good_bad_and_carries_region_boxes(self):
+        m = SiftMatcher()
+        det_ctx = DetectorContext(detector_id="d", media_type="image")
+        good = _element("g", "good", region_box=(0.1, 0.1, 0.5, 0.5))
+        good_no_box = _element("h", "good")
+        bad = _element("b", "bad")
+        unresolved = _element("u", "good")  # no cached features -> dropped
+        skipped = _element("s", "")  # not a good/bad vote -> ignored
+        labelset = LabelSet(elements=[good, good_no_box, bad, unresolved, skipped])
+
+        det_ctx.label_local_features[stable_element_id(good)] = _feats(_textured_image(1), matcher=m)
+        det_ctx.label_local_features[stable_element_id(good_no_box)] = _feats(_textured_image(2), matcher=m)
+        det_ctx.label_local_features[stable_element_id(bad)] = _feats(_textured_image(3), matcher=m)
+
+        feat_snap, good_votes, bad_votes, region_boxes = labelset_training._labelset_feature_snapshot(det_ctx, labelset)
+
+        assert set(good_votes) == {stable_element_id(good), stable_element_id(good_no_box)}
+        assert set(bad_votes) == {stable_element_id(bad)}
+        # The region box rides through only for the element that had one.
+        assert region_boxes == {stable_element_id(good): (0.1, 0.1, 0.5, 0.5)}
+        # Every voted+cached element appears in the synthetic snapshot.
+        assert set(feat_snap) == set(good_votes) | set(bad_votes)
+        for entry in feat_snap.values():
+            assert isinstance(entry["local_features"], StructuralFeatures)
+
+
+class TestPopulateLabelLocalFeatures:
+    def test_noop_without_active_embedder(self):
+        """No active dataset (empty snap) -> no embedder -> nothing cached."""
+        det_ctx = DetectorContext(detector_id="d", media_type="image")
+        labelset = LabelSet(elements=[_element("g", "good")])
+        cached = labelset_training.populate_label_local_features(det_ctx, labelset, snap={})
+        assert cached == 0
+        assert dict(det_ctx.label_local_features) == {}
+
+
+class TestMaybeLabelsetStructuralRerank:
+    def test_noop_for_non_structural_dataset(self):
+        det_ctx = DetectorContext(detector_id="d", media_type="image")
+        labelset = LabelSet(elements=[_element("g", "good")])
+        snap = {1: {"embedding": np.zeros(8, dtype=np.float32)}}  # no local_features
+        results = [{"id": 1, "score": 0.7}]
+        out, thresh = labelset_training.maybe_labelset_structural_rerank(det_ctx, labelset, results, 0.33, snap)
+        assert out == results
+        assert thresh == 0.33
+
+    def test_reranks_active_dataset_against_cross_dataset_template(self, monkeypatch):
+        """A saved structural detector verifies the freshly loaded dataset
+        against templates re-derived from its (cross-dataset) labelset."""
+        m = SiftMatcher()
+        base = _textured_image(40)
+
+        det_ctx = DetectorContext(detector_id="d", media_type="image")
+        good = _element("g", "good")
+        bad = _element("b", "bad")
+        labelset = LabelSet(elements=[good, bad])
+        # Pre-seed the cross-dataset feature cache (the labelset's media are NOT
+        # in the loaded dataset) and skip the resolver-driven population pass.
+        det_ctx.label_local_features[stable_element_id(good)] = _feats(base, matcher=m)
+        det_ctx.label_local_features[stable_element_id(bad)] = _feats(_textured_image(41), matcher=m)
+        monkeypatch.setattr(labelset_training, "populate_label_local_features", lambda *a, **kw: 0)
+        monkeypatch.setattr(
+            "vtscore.training.structural_similarity._resolve_matcher",
+            lambda _snap: m,
+        )
+
+        # Active dataset: a high-VLAD unrelated item and a mid-VLAD warp of the
+        # good template.
+        snap = {
+            10: {"local_features": _feats(_textured_image(42), matcher=m), "embedder": "sift_vlad"},
+            20: {"local_features": _feats(_warp(base, 9.0, 1.05, 6.0, -4.0), matcher=m), "embedder": "sift_vlad"},
+        }
+        results = [
+            {"id": 10, "score": 0.94},  # high VLAD, unrelated
+            {"id": 20, "score": 0.35},  # warp of the cross-dataset template
+        ]
+        out, thresh = labelset_training.maybe_labelset_structural_rerank(det_ctx, labelset, results, 0.5, snap)
+
+        assert thresh == STRUCTURAL_DECISION_THRESHOLD
+        assert out[0]["id"] == 20, "geometrically-verified item must lead"
+        assert out[0]["score"] >= STRUCTURAL_DECISION_THRESHOLD
+        assert "best_region" in out[0]

--- a/tests_lib/detectors/test_structural_similarity.py
+++ b/tests_lib/detectors/test_structural_similarity.py
@@ -31,6 +31,7 @@ from vtscore.training.structural_similarity import (
     build_templates,
     filter_features_to_box,
     maybe_structural_rerank,
+    maybe_structural_rerank_example,
     snapshot_is_structural,
     structural_rerank,
     train_verification_classifier,
@@ -338,3 +339,81 @@ class TestMaybeStructuralRerank:
         # id 2 (warp of the template) is geometrically verified and leads.
         assert out[0]["id"] == 2
         assert out[0]["score"] >= STRUCTURAL_DECISION_THRESHOLD
+
+    def test_feature_snap_sources_templates_from_a_separate_snapshot(self, monkeypatch):
+        """The labelset path supplies templates/classifier features from a
+        synthetic ``feature_snap`` (re-derived cross-dataset features) while the
+        re-rank runs over the active dataset's own ``snap``."""
+        m = SiftMatcher()
+        base = _textured_image(71)
+        # Active dataset: an unrelated high-VLAD item and a warp of the template.
+        snap = {
+            10: {"local_features": _feats(_textured_image(72), matcher=m), "embedder": "sift_vlad"},
+            20: {"local_features": _feats(_warp(base, 8.0, 1.05, 5.0, -3.0), matcher=m), "embedder": "sift_vlad"},
+        }
+        # The good vote lives only in the (cross-dataset) feature snapshot, NOT
+        # in the active ``snap``: its id doesn't index into ``snap`` at all.
+        feature_snap = {"good-elem": {"local_features": _feats(base, matcher=m)}}
+        monkeypatch.setattr(
+            "vtscore.training.structural_similarity._resolve_matcher",
+            lambda _snap: m,
+        )
+        results = [
+            {"id": 10, "score": 0.93},  # high VLAD, unrelated
+            {"id": 20, "score": 0.31},  # warp of the cross-dataset template
+        ]
+        out, thresh = maybe_structural_rerank(
+            results, 0.5, snap, {"good-elem": None}, {}, {}, feature_snap=feature_snap
+        )
+        assert thresh == STRUCTURAL_DECISION_THRESHOLD
+        assert out[0]["id"] == 20, "the item matching the cross-dataset template must lead"
+        assert out[0]["score"] >= STRUCTURAL_DECISION_THRESHOLD
+
+
+class TestMaybeStructuralRerankExample:
+    def test_noop_for_non_structural_snapshot(self):
+        m = SiftMatcher()
+        snap = {1: {"embedding": np.zeros(8, dtype=np.float32)}}  # no local_features
+        results = [{"id": 1, "similarity": 0.7}]
+        example = _feats(_textured_image(1), matcher=m)
+        out, thresh = maybe_structural_rerank_example(results, 0.33, snap, example, score_key="similarity")
+        assert out == results
+        assert thresh == 0.33
+
+    def test_noop_when_example_has_no_features(self):
+        m = SiftMatcher()
+        snap = {1: {"local_features": _feats(_textured_image(1), matcher=m), "embedder": "sift_vlad"}}
+        results = [{"id": 1, "similarity": 0.7}]
+        empty = StructuralFeatures(
+            keypoints=np.zeros((0, 4), dtype=np.float32),
+            descriptors=np.zeros((0, SIFT_DESCRIPTOR_DIM), dtype=np.float32),
+        )
+        out, thresh = maybe_structural_rerank_example(results, 0.33, snap, empty, score_key="similarity")
+        assert out == results
+        assert thresh == 0.33
+
+    def test_example_template_promotes_geometric_match(self, monkeypatch):
+        """The uploaded example is the template; an item that geometrically
+        verifies against it is promoted above a high-cosine non-match, scored by
+        the cold-start gate (example-sort has no votes)."""
+        m = SiftMatcher()
+        base = _textured_image(81)
+        snap = {
+            10: {"local_features": _feats(_textured_image(82), matcher=m), "embedder": "sift_vlad"},
+            20: {"local_features": _feats(_warp(base, -9.0, 0.95, -6.0, 4.0), matcher=m), "embedder": "sift_vlad"},
+        }
+        monkeypatch.setattr(
+            "vtscore.training.structural_similarity._resolve_matcher",
+            lambda _snap: m,
+        )
+        example = _feats(base, matcher=m)
+        results = [
+            {"id": 10, "similarity": 0.95},  # high cosine, unrelated
+            {"id": 20, "similarity": 0.40},  # warp of the example
+        ]
+        out, thresh = maybe_structural_rerank_example(results, 0.9, snap, example, score_key="similarity")
+        assert thresh == STRUCTURAL_DECISION_THRESHOLD
+        assert out[0]["id"] == 20
+        assert out[0]["similarity"] >= STRUCTURAL_DECISION_THRESHOLD
+        assert "best_region" in out[0]
+        assert len(out[0]["best_region"]) == 4

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -160,6 +160,10 @@ def _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name: str) -> None:
     if det_ctx.embedder and embedder_name and det_ctx.embedder != embedder_name:
         det_ctx.label_embeddings.clear()
         det_ctx.label_embedding_regions.clear()
+        # Local features are descriptor sets in the old embedder's feature space;
+        # a switch invalidates them too (a SIFT template can't verify against a
+        # learned-feature candidate, nor vice versa).
+        det_ctx.label_local_features.clear()
 
 
 def _resolve_uncached_embedding(
@@ -290,6 +294,178 @@ def build_xy_from_labelset(
     return X_list, y_list
 
 
+# ---------------------------------------------------------------------------
+# Cross-dataset local features (structural / SIFT-VLAD detectors)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_uncached_local_features(
+    elem: LabeledElement,
+    snap: dict[int, dict[str, Any]] | None,
+    *,
+    embedder,
+) -> Any | None:
+    """Re-derive *elem*'s :class:`StructuralFeatures`, not consulting the cache.
+
+    Tries the in-dataset path first: when *elem* resolves to a cid in the
+    active *snap* that already carries ``local_features``, reuse them (no I/O).
+    Otherwise resolve the origin to a file via its importer and run the
+    embedder's ``local_features_forward`` to detect features freshly.  The
+    **full** (unfiltered) feature set is returned; any ``region_box`` is applied
+    downstream at template-build time.  Returns ``None`` when neither path
+    yields features.
+    """
+    from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
+    from vtscore.detectors.resolver import resolve_file_context
+    from vtscore.media.embedder import media_from_path
+    from vtscore.media.structural import StructuralFeatures
+
+    if snap:
+        cid = resolve_current_dataset_cid(elem)
+        if cid is not None and cid in snap:
+            feats = snap[cid].get("local_features")
+            if isinstance(feats, StructuralFeatures) and feats.count > 0:
+                return feats
+
+    with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
+        if file_path is None:
+            return None
+        try:
+            feats = embedder.local_features_forward(media_from_path(file_path))
+        except Exception:
+            log.warning(
+                "labelset_training: local_features_forward(%s) raised; "
+                "this label won't contribute a structural template",
+                elem.origin_name or elem.filename or "<unknown>",
+                exc_info=True,
+            )
+            return None
+    if feats is None or getattr(feats, "count", 0) == 0:
+        return None
+    return feats
+
+
+def populate_label_local_features(
+    det_ctx,
+    labelset: LabelSet,
+    *,
+    snap: dict[int, dict[str, Any]] | None,
+) -> int:
+    """Ensure every labelled element has cached local features on *det_ctx*.
+
+    A no-op (returns 0) unless the active dataset's embedder is structural
+    (``supports_geometric_verification``) - non-structural detectors never need
+    local features.  For a structural detector it re-derives the
+    :class:`~vtscore.media.structural.StructuralFeatures` for each good/bad
+    element (reusing the active dataset's stored features when the element is
+    loaded, resolving the origin file otherwise) and caches them on
+    ``det_ctx.label_local_features`` keyed by ``stable_element_id``.  The
+    embedder-switch invalidation in :func:`_maybe_clear_cache_on_embedder_switch`
+    clears this cache alongside the embedding cache.
+
+    Returns the number of elements that have cached features after this pass.
+    """
+    from vtscore.detectors.labelset_elements import stable_element_id
+
+    embedder_name = _embedder_for_active_dataset(snap)
+    embedder = None
+    if embedder_name:
+        from vtscore.media import get_embedder
+
+        try:
+            embedder = get_embedder(embedder_name)
+        except (KeyError, ValueError):
+            embedder = None
+    if embedder is None or not getattr(embedder, "supports_geometric_verification", False):
+        return 0
+
+    cache: dict[str, Any] = det_ctx.label_local_features
+    for elem in labelset.elements:
+        if elem.label not in ("good", "bad"):
+            continue
+        eid = stable_element_id(elem)
+        if eid in cache:
+            continue
+        feats = _resolve_uncached_local_features(elem, snap, embedder=embedder)
+        if feats is not None:
+            cache[eid] = feats
+    return len(cache)
+
+
+def _labelset_feature_snapshot(
+    det_ctx,
+    labelset: LabelSet,
+) -> tuple[dict[str, dict[str, Any]], dict[str, None], dict[str, None], dict[str, tuple[float, float, float, float]]]:
+    """Project the cached local features into the chokepoint's vote/snap shape.
+
+    Builds a synthetic ``feature_snap`` (``element_id -> {"local_features": ...}``)
+    plus ``good_votes`` / ``bad_votes`` / ``region_boxes`` keyed by the same
+    ``stable_element_id`` so :func:`maybe_structural_rerank` can build templates
+    and train the verification classifier against the cross-dataset labelset
+    exactly as it does against in-dataset votes.
+    """
+    from vtscore.detectors.labelset_elements import stable_element_id
+
+    cache: dict[str, Any] = det_ctx.label_local_features
+    feature_snap: dict[str, dict[str, Any]] = {}
+    good_votes: dict[str, None] = {}
+    bad_votes: dict[str, None] = {}
+    region_boxes: dict[str, tuple[float, float, float, float]] = {}
+    for elem in labelset.elements:
+        if elem.label not in ("good", "bad"):
+            continue
+        eid = stable_element_id(elem)
+        feats = cache.get(eid)
+        if feats is None:
+            continue
+        feature_snap[eid] = {"local_features": feats}
+        if elem.label == "good":
+            good_votes[eid] = None
+            if elem.region_box is not None:
+                region_boxes[eid] = elem.region_box
+        else:
+            bad_votes[eid] = None
+    return feature_snap, good_votes, bad_votes, region_boxes
+
+
+def maybe_labelset_structural_rerank(
+    det_ctx,
+    labelset: LabelSet,
+    results: list[dict[str, Any]],
+    threshold: float,
+    snap: dict[int, dict[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], float]:
+    """Stage-2 structural re-rank for the saved-detector (labelset) sort path.
+
+    The counterpart to the vote-driven re-rank wired into
+    :func:`~vtscore.detectors.training.train_and_score`: when a saved structural
+    detector is sorted against a (possibly different) loaded dataset, this
+    re-derives the labelset's local features, builds the RegionYes templates and
+    verification classifier from them, and geometrically re-ranks the active
+    dataset's Stage-1 shortlist.  A no-op for non-structural datasets (gated on
+    the active snapshot carrying ``local_features``) and when no labelled element
+    yields a usable template.
+    """
+    from vtscore.training.structural_similarity import maybe_structural_rerank, snapshot_is_structural
+
+    if not snap or not snapshot_is_structural(snap):
+        return results, threshold
+    populate_label_local_features(det_ctx, labelset, snap=snap)
+    feature_snap, good_votes, bad_votes, region_boxes = _labelset_feature_snapshot(det_ctx, labelset)
+    if not good_votes:
+        return results, threshold
+    return maybe_structural_rerank(
+        results,
+        threshold,
+        snap,
+        good_votes,
+        bad_votes,
+        region_boxes,
+        det_ctx,
+        feature_snap=feature_snap,
+    )
+
+
 def train_from_labelset(
     det_ctx,
     labelset: LabelSet,
@@ -350,7 +526,7 @@ def labelset_train_and_score(
 
     populate_label_embeddings(det_ctx, labelset, media_type=media_type, snap=clips_dict)
     X_list, y_list = build_xy_from_labelset(det_ctx, labelset)
-    return _train_and_score_xy(
+    results, threshold, model = _train_and_score_xy(
         X_list,
         y_list,
         clips_dict,
@@ -360,6 +536,12 @@ def labelset_train_and_score(
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
     )
+
+    # Stage-2 structural re-rank for a saved structural detector reloaded
+    # cross-dataset (the labelset counterpart to the vote-driven re-rank in
+    # ``train_and_score``).  A no-op for every non-structural dataset.
+    results, threshold = maybe_labelset_structural_rerank(det_ctx, labelset, results, threshold, clips_dict)
+    return results, threshold, model
 
 
 def update_cache_for_cid(

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -396,6 +396,14 @@ class DetectorContext:
         # region-pooled vector keyed to an element that no longer has a
         # region.  See ``logical-bug-audit.md`` finding M4.
         "label_embedding_regions",
+        # Cross-dataset local features (StructuralFeatures) for the labelset's
+        # elements, keyed by stable_element_id.  Re-derived from each element's
+        # origin so a saved structural detector can build templates + train its
+        # verification classifier against datasets that aren't currently loaded;
+        # the full (unfiltered) features are cached and the region_box is applied
+        # downstream at template-build time.  In-memory only, never persisted.
+        # See docs/plans/structural-embedder.md.
+        "label_local_features",  # str → StructuralFeatures
         "model",  # nn.Sequential | None (current trained MLP)
         # Structural (SIFT/VLAD) detectors carry a *second* learned object next
         # to the retrieval MLP: the match-statistic verification classifier
@@ -477,6 +485,7 @@ class DetectorContext:
         # those whose underlying media isn't part of the active dataset.
         self.label_embeddings: dict[str, Any] = {}
         self.label_embedding_regions: dict[str, tuple[float, float, float, float] | None] = {}
+        self.label_local_features: dict[str, Any] = {}
         self.model: Any = None  # nn.Sequential | None
         # Match-statistic verification classifier for structural detectors;
         # None for non-structural detectors and until first trained.
@@ -704,6 +713,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "training_medias", _FrozenDict("detector"))
         object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))
         object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
+        object.__setattr__(self, "label_local_features", _FrozenDict("detector"))
         object.__setattr__(self, "model", None)
         object.__setattr__(self, "verification_classifier", None)
         object.__setattr__(self, "threshold", 0.5)

--- a/vtscore/training/structural_similarity.py
+++ b/vtscore/training/structural_similarity.py
@@ -389,6 +389,7 @@ def maybe_structural_rerank(
     *,
     top_k: int = DEFAULT_RERANK_TOP_K,
     score_key: str = "score",
+    feature_snap: Optional[dict[Any, dict]] = None,
 ) -> tuple[list[dict], float]:
     """Apply the Stage-2 re-rank when the active dataset is structural.
 
@@ -400,17 +401,27 @@ def maybe_structural_rerank(
     re-ranks the shortlist, and returns the classifier's decision boundary as
     the threshold.  The trained classifier is carried on *det_ctx* (in-memory,
     re-derived every retrain) alongside the retrieval MLP.
+
+    *feature_snap* is the source of the template / classifier-candidate
+    ``local_features`` (keyed the same way as *good_votes* / *bad_votes*),
+    defaulting to *snap*.  The vote-driven path leaves it ``None`` because the
+    voted media live in the active dataset; the **labelset** path passes a
+    synthetic snapshot of re-derived cross-dataset features so a saved
+    structural detector can verify against templates from datasets that aren't
+    currently loaded.  The re-rank itself always runs over *snap* (the media the
+    user is actually sorting).
     """
     if not snapshot_is_structural(snap):
         return results, threshold
     matcher = _resolve_matcher(snap)
     if matcher is None:
         return results, threshold
-    templates = build_templates(good_votes, snap, region_boxes)
+    feat_snap = feature_snap if feature_snap is not None else snap
+    templates = build_templates(good_votes, feat_snap, region_boxes)
     if not templates:
         return results, threshold
 
-    classifier = train_verification_classifier(templates, good_votes, bad_votes, snap, matcher)
+    classifier = train_verification_classifier(templates, good_votes, bad_votes, feat_snap, matcher)
     if det_ctx is not None:
         try:
             det_ctx.verification_classifier = classifier
@@ -422,6 +433,49 @@ def maybe_structural_rerank(
         results,
         snap,
         [tpl for _, tpl in templates],
+        scorer,
+        matcher,
+        top_k=top_k,
+        score_key=score_key,
+    )
+    return reranked, STRUCTURAL_DECISION_THRESHOLD
+
+
+def maybe_structural_rerank_example(
+    results: list[dict],
+    threshold: float,
+    snap: dict[Any, dict],
+    example_features: Optional[StructuralFeatures],
+    *,
+    top_k: int = DEFAULT_RERANK_TOP_K,
+    score_key: str = "score",
+) -> tuple[list[dict], float]:
+    """Stage-2 re-rank for the example-sort (seed-by-example) path.
+
+    The template is the **uploaded example's own** local features rather than a
+    vote-derived one: the user can crop the upload to the pattern they want to
+    match before it is embedded, so the crop already restricts the template (no
+    ``region_box`` filtering needed here).  There are no votes, so there is no
+    match-statistic classifier to train - the cold-start inlier gate
+    (:class:`VerificationScorer` with no model) scores the fits, with its
+    boundary at :data:`STRUCTURAL_DECISION_THRESHOLD` like every other regime.
+
+    A no-op for non-structural datasets and when the example yielded no
+    features (an empty template can never verify anything, so the Stage-1
+    cosine order is left intact).
+    """
+    if not snapshot_is_structural(snap):
+        return results, threshold
+    if example_features is None or example_features.count == 0:
+        return results, threshold
+    matcher = _resolve_matcher(snap)
+    if matcher is None:
+        return results, threshold
+    scorer = VerificationScorer()  # cold-start: example-sort carries no votes
+    reranked = structural_rerank(
+        results,
+        snap,
+        [example_features],
         scorer,
         matcher,
         top_k=top_k,

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -591,12 +591,27 @@ def _example_sort_from_path(file_path: Path) -> tuple:
         raise ValueError("No embedder available for loaded dataset")
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
-    example_embedding = emb.embed_media(media_from_path(file_path))
+    media = media_from_path(file_path)
+    example_embedding = emb.embed_media(media)
 
     if example_embedding is None:
         raise ValueError("Failed to embed media file")
 
-    return _cosine_sort(example_embedding)
+    results, threshold = _cosine_sort(example_embedding)
+
+    # Stage-2 structural re-rank (a no-op for non-structural datasets): for a
+    # SIFT/VLAD dataset, geometrically verify the VLAD shortlist against the
+    # uploaded example's own local features.  The example is the template; any
+    # crop was already applied to the file above, so it restricts the template.
+    if getattr(emb, "supports_geometric_verification", False):
+        from vtscore.training.structural_similarity import maybe_structural_rerank_example  # noqa: PLC0415
+
+        example_features = emb.local_features_forward(media)
+        results, threshold = maybe_structural_rerank_example(
+            results, threshold, snap, example_features, score_key="similarity"
+        )
+
+    return results, threshold
 
 
 def _parse_crop_params(raw: str | None) -> dict | None:


### PR DESCRIPTION
## Summary

Continues the structural-embedder work (`docs/plans/structural-embedder.md`). The Stage-2 geometric re-rank was previously wired only into the vote-driven `train_and_score`. This PR extends its reach to the **other two scoring entry points** so structural (SIFT/VLAD) instance search verifies geometrically no matter how the sort was kicked off.

### Chokepoint decoupling
- `maybe_structural_rerank` gains an optional `feature_snap` parameter. Templates + the match-statistic verification classifier are built from `feature_snap` (defaulting to `snap`), while the re-rank itself always runs over the active dataset's `snap`. This lets the labelset path supply re-derived cross-dataset features without disturbing the vote path (which passes nothing and is unchanged).

### Example-sort (seed-by-example)
- New `maybe_structural_rerank_example`: the uploaded example is the single template (any crop is applied to the file before feature detection, so it already restricts the template), scored by the cold-start inlier gate (example-sort has no votes).
- Wired into `_example_sort_from_path` (`vtsearch/routes/sorting.py`). The matched-region `best_region` rides out on the `similarity`-keyed results, which the frontend already renders — no frontend change needed.

### Labelset (saved-detector reload, cross-dataset)
- New `DetectorContext.label_local_features` cache: per-element `StructuralFeatures`, re-derived from each element's origin (`populate_label_local_features`), full/unfiltered (the `region_box` is applied downstream at template-build time). In-memory only, never persisted; invalidated on embedder switch alongside `label_embeddings`.
- `maybe_labelset_structural_rerank` projects the cache into the chokepoint's vote/snap shape and re-ranks the active dataset; wired into `labelset_train_and_score`.

Both new paths are **no-ops for non-structural datasets** (gated on the active snapshot carrying `local_features`), so existing datasets pay zero cost.

## Tests
- `tests_lib/detectors/test_structural_similarity.py`: `feature_snap` sourcing + the example-sort entry point (cold-start promotion of a geometric match over a high-cosine non-match; no-op gates).
- `tests_lib/detectors/test_structural_labelset.py` (new): cache→vote/snap projection, `populate_label_local_features` gating, and end-to-end labelset re-rank.
- Full `./run-tests.sh` green (4900 passed; ruff / codespell / deptry / frontend build all pass).

## Notes
- No persisted vectors/MLPs: `label_local_features` is process-scoped on `DetectorContext`, re-derived from origins — consistent with the No-Persisted-Vectors rule.
- Plan doc updated (status header + What shipped + trimmed follow-ups). The frontend overlay already rides patch's `best_region` machinery; remaining follow-ups are the find-path classifier reuse, the inlier-correspondence debug view, and the K/threshold spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULgF3885sxYVzbyQy82yYF)_