### PR TITLE
Zoneless Phase 1.2: de-zone KeyboardService + signalize center-panel

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -1,8 +1,10 @@
 # Zoneless change detection — detailed migration plan
 
-Status: **Phase 0 shipped (test harness); Phase 1.1 + 1.3 + 1.4 shipped
+Status: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
 (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
-signalized); Phase 1.2 and Phases 2–5 not started.** This document
+signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
+signalized, i.e. the center-panel slice of Phase 2.3); the rest of Phase 2 and
+Phases 3–5 not started.** This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
 supersedes the earlier stub. Every count and file:line reference was checked
@@ -418,14 +420,23 @@ Phase 2 conversions. New zoneless staleness canary in
 `progress-events.service.spec.ts` drives an SSE frame through the fake EventSource
 and asserts the rendered DOM repaints with no manual `detectChanges`.
 
-1.2 **`KeyboardService`.** Keep the `runOutsideAngular` keydown listener (it is a
-harmless no-op under zoneless and still avoids per-keystroke churn under zone).
-Drop the 10 `this.zone.run(() => this.action$.next(...))` re-entries — emit
-plainly. The CD trigger moves to the **consumer** (`center-panel`): the
-shortcut-driven state (`isVoting`, `spinningVote`, `swipeClass`, `undoToastText`,
-volume) must be **signals** (this also fixes the Phase-2 center-panel timer
-resets and the Recipe-F effect in one stroke). Optionally expose the latest
-action as a signal instead of a `Subject`.
+1.2 **`KeyboardService`. ✅ DONE.** Kept the `runOutsideAngular` keydown listener
+(harmless no-op under zoneless, still avoids per-keystroke churn under zone) and
+the injected `NgZone` it needs. Dropped all 10
+`this.zone.run(() => this.action$.next(...))` re-entries — `action$` now emits
+plainly (it stays a `Subject`; the consumer composes it, so a signal would have
+bought nothing). The CD trigger moved to the **consumer** (`center-panel`),
+whose shortcut/timer/HTTP-driven template-bound state was signalized:
+`isVoting`, `volume`, `audioPlaying`, `showAnimations`, `showMetadata`,
+`swipeClass`, `spinningVote`, `undoToastText`, `pendingBadConfirm`, and the
+private `labelHintDismissed`. The Recipe-F settings-mirror `effect()` now writes
+those signals (`.set()`) instead of plain fields, fixing the latent
+plain-field-write trap in one stroke. This is the center-panel slice of Phase
+2.3; `image-viewer`/`video-player` remain for the rest of 2.3. New zoneless DOM
+canary `center-panel.zoneless.spec.ts` drives a real `keydown` through the live
+`KeyboardService` listener (an un-bound document callback) and asserts the vote
+renders + the undo toast appears with no manual `detectChanges`; the existing
+contract spec was updated to the signal accessors.
 
 1.3 **`ConnectionStateService`. ✅ DONE.** Converted `statusSubject`/
 `retryingSubject` to signals exposed read-only (`status`/`retrying`, backed by
@@ -574,15 +585,16 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1.2 and Phases 2–5 remain.** Shipped so far: Phase 0 (harness) and
-  Phase 1.1 + 1.3 + 1.4 (ProgressEventsService SSE pump + ConnectionStateService
-  + BrowseSelectionService signalized, with their consumers and zoneless canary
-  specs). Still owed in Phase 1: **1.2 `KeyboardService`** (drop the 10
-  `zone.run(() => action$.next(...))` re-entries; the CD trigger moves to the
-  consumer `center-panel`, whose shortcut-driven state must be signalized — this
-  couples with the Phase 2.3 center-panel conversion). Then the component
-  conversions (Phase 2), the prod flip (Phase 3), human browser QA (Phase 4), and
-  cleanup (Phase 5).
+- **Phase 1 complete; Phases 2–5 remain.** Shipped so far: Phase 0 (harness) and
+  all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService SSE pump +
+  ConnectionStateService + BrowseSelectionService signalized) and 1.2
+  (KeyboardService de-zoned + the coupled center-panel state signalized), each
+  with its consumers and a zoneless canary spec. Remaining in **Phase 2**: the
+  rest of the component clusters in the suggested order. Note 2.3's center-panel
+  *state* shipped with 1.2, but 2.3 still owes `image-viewer` (window drag/key
+  handlers + shake + its `ResizeObserver` rendered-size writes) and a check that
+  `video-player` is DOM-only. Then the prod flip (Phase 3), human browser QA
+  (Phase 4), and cleanup (Phase 5).
 - **Full consumer specs for the browse cluster.** Phase 1.4 added a service unit
   spec + a signal-driven canary, but `browse-canvas`, `browse-bin-popup`, and
   `browse-selection-panel` still have **no** component specs (they are heavy to

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -2,22 +2,22 @@
   @if (!media) {
     <p class="placeholder-text">Select a media item to view</p>
   } @else {
-    <div class="media-swipe-wrapper" [class]="mediaType === 'audio' ? '' : swipeClass">
+    <div class="media-swipe-wrapper" [class]="mediaType === 'audio' ? '' : swipeClass()">
       @switch (mediaType) {
         @case ('audio') {
-          <vt-audio-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" [swipeClass]="swipeClass" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
+          <vt-audio-player [media]="media" [volume]="volume()" [audioPlaying]="audioPlaying()" [swipeClass]="swipeClass()" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
         }
         @case ('image') {
           <vt-image-viewer
             [media]="media"
-            [pendingBadConfirm]="pendingBadConfirm"
+            [pendingBadConfirm]="pendingBadConfirm()"
             [highlightBox]="highlightBox"
             (regionBoxChange)="onRegionBoxChange($event)"
             (armedConfirmCanceled)="onArmedConfirmCanceled()"
           ></vt-image-viewer>
         }
         @case ('video') {
-          <vt-video-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
+          <vt-video-player [media]="media" [volume]="volume()" [audioPlaying]="audioPlaying()" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
         }
         @case ('text') {
           <vt-text-viewer [media]="media"></vt-text-viewer>
@@ -78,12 +78,12 @@
       </div>
     }
 
-    <div class="metadata-tray" [class.collapsed]="!showMetadata">
-      <button class="metadata-toggle" (click)="toggleMetadata()" [title]="showMetadata ? 'Hide metadata' : 'Show metadata'" [attr.aria-label]="showMetadata ? 'Hide metadata' : 'Show metadata'">
-        <span class="metadata-toggle-icon">{{ showMetadata ? '&#x25BC;' : '&#x25B2;' }}</span>
+    <div class="metadata-tray" [class.collapsed]="!showMetadata()">
+      <button class="metadata-toggle" (click)="toggleMetadata()" [title]="showMetadata() ? 'Hide metadata' : 'Show metadata'" [attr.aria-label]="showMetadata() ? 'Hide metadata' : 'Show metadata'">
+        <span class="metadata-toggle-icon">{{ showMetadata() ? '&#x25BC;' : '&#x25B2;' }}</span>
         <span class="metadata-toggle-label">Metadata</span>
       </button>
-      @if (showMetadata) {
+      @if (showMetadata()) {
         <div class="metadata-grid">
           <div class="metadata-item">
             <span class="metadata-label">Name</span>
@@ -107,21 +107,21 @@
       }
     </div>
 
-    @if (pendingBadConfirm) {
+    @if (pendingBadConfirm()) {
       <div class="bad-confirm-hint" role="status" aria-live="polite">
         Press &larr; again to vote no and discard the box, or Esc to keep the box.
       </div>
     }
 
-    @if (undoToastText) {
-      <div class="undo-toast" role="status" aria-live="polite">{{ undoToastText }}</div>
+    @if (undoToastText()) {
+      <div class="undo-toast" role="status" aria-live="polite">{{ undoToastText() }}</div>
     }
 
     <vt-voting-overlay
       [isGood]="isGood"
       [isBad]="isBad"
-      [disabled]="isVoting || disabled()"
-      [spinningVote]="spinningVote"
+      [disabled]="isVoting() || disabled()"
+      [spinningVote]="spinningVote()"
       [showHint]="showFirstVoteHint"
       (voted)="castVote($event)"
     ></vt-voting-overlay>

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -97,7 +97,7 @@ describe('CenterPanelComponent', () => {
 
   it('should send vote request on castVote', () => {
     component.media = mockMedia;
-    component.showAnimations = false;
+    component.showAnimations.set(false);
     fixture.detectChanges();
 
     let emitted: { id: number; vote: string } | undefined;
@@ -118,9 +118,9 @@ describe('CenterPanelComponent', () => {
 
   it('should prevent double voting', () => {
     component.media = mockMedia;
-    component.showAnimations = false;
+    component.showAnimations.set(false);
     fixture.detectChanges();
-    component.isVoting = true;
+    component.isVoting.set(true);
     component.castVote('good');
     httpMock.expectNone('/api/medias/1/vote');
   });
@@ -138,7 +138,7 @@ describe('CenterPanelComponent', () => {
     component.media = mockMedia;
     fixture.detectChanges();
     // Simulate swipe ending
-    component.swipeClass = 'swipe-right';
+    component.swipeClass.set('swipe-right');
 
     // Change to new media (triggers ngOnChanges)
     component.media = { ...mockMedia, id: 2, filename: 'next.wav' };
@@ -146,7 +146,7 @@ describe('CenterPanelComponent', () => {
       media: { currentValue: component.media, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
     });
 
-    expect(component.swipeClass).toBe('');
+    expect(component.swipeClass()).toBe('');
   });
 
   it('should format metadata values', () => {
@@ -168,7 +168,7 @@ describe('CenterPanelComponent', () => {
 
     function setup(): void {
       component.media = imageMedia;
-      component.showAnimations = false;
+      component.showAnimations.set(false);
       // Skip dev-mode check-no-changes: rendering the image-view-controls (gated
       // on the `imageViewer` ViewChild) settles the zoom-slider bindings within
       // the first CD pass, which the guard would otherwise flag as NG0100. This
@@ -199,7 +199,7 @@ describe('CenterPanelComponent', () => {
       // First ← arms the discard-confirm; no request yet.
       component.castVote('bad');
       httpMock.expectNone('/api/medias/1/vote');
-      expect(component.pendingBadConfirm).toBe(true);
+      expect(component.pendingBadConfirm()).toBe(true);
       // Second ← throws the box away and votes no.
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
@@ -212,7 +212,7 @@ describe('CenterPanelComponent', () => {
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
       expect(req.request.body).toEqual({ target: 'bad' });
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
   });
@@ -228,7 +228,7 @@ describe('CenterPanelComponent', () => {
 
     function setup(): void {
       component.media = imageMedia;
-      component.showAnimations = false;
+      component.showAnimations.set(false);
       // Skip dev-mode check-no-changes: rendering the image-view-controls (gated
       // on the `imageViewer` ViewChild) settles the zoom-slider bindings within
       // the first CD pass, which the guard would otherwise flag as NG0100. This
@@ -241,13 +241,13 @@ describe('CenterPanelComponent', () => {
       component.onRegionBoxChange(box);
       component.castVote('bad');
       httpMock.expectNone('/api/medias/1/vote');
-      expect(component.pendingBadConfirm).toBe(true);
+      expect(component.pendingBadConfirm()).toBe(true);
       expect(component.currentRegionBox).toEqual(box);
 
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
       expect(req.request.body).toEqual({ target: 'bad' });
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
 
@@ -255,12 +255,12 @@ describe('CenterPanelComponent', () => {
       setup();
       component.onRegionBoxChange(box);
       component.castVote('bad');
-      expect(component.pendingBadConfirm).toBe(true);
+      expect(component.pendingBadConfirm()).toBe(true);
 
       // Esc-while-armed (or mousedown-on-box) routes through this handler from
       // the image viewer.
       component.onArmedConfirmCanceled();
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       expect(component.currentRegionBox).toEqual(box);
       httpMock.expectNone('/api/medias/1/vote');
     });
@@ -269,10 +269,10 @@ describe('CenterPanelComponent', () => {
       setup();
       component.onRegionBoxChange(box);
       component.castVote('bad');
-      expect(component.pendingBadConfirm).toBe(true);
+      expect(component.pendingBadConfirm()).toBe(true);
 
       component.onRegionBoxChange(null);
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       expect(component.currentRegionBox).toBeNull();
     });
 
@@ -280,7 +280,7 @@ describe('CenterPanelComponent', () => {
       setup();
       component.onRegionBoxChange(box);
       component.castVote('bad');
-      expect(component.pendingBadConfirm).toBe(true);
+      expect(component.pendingBadConfirm()).toBe(true);
 
       const next: Media = { ...imageMedia, id: 2, filename: 'next.png' };
       component.media = next;
@@ -292,7 +292,7 @@ describe('CenterPanelComponent', () => {
           isFirstChange: () => false,
         },
       });
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       expect(component.currentRegionBox).toBeNull();
     });
 
@@ -301,7 +301,7 @@ describe('CenterPanelComponent', () => {
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
       expect(req.request.body).toEqual({ target: 'bad' });
-      expect(component.pendingBadConfirm).toBe(false);
+      expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
 

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output, signal } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
@@ -50,22 +50,27 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   @ViewChild(ImageViewerComponent) imageViewer?: ImageViewerComponent;
   @ViewChild(VideoPlayerComponent) videoPlayer?: VideoPlayerComponent;
 
-  isVoting = false;
-  volume = 1;
-  audioPlaying = true;
-  showAnimations = true;
-  showMetadata = true;
-  swipeClass = '';
-  spinningVote: 'good' | 'bad' | null = null;
+  // These fields are written from non-bound callbacks — the keyboard-shortcut
+  // dispatch (`KeyboardService.action$`), HTTP/vote subscriptions, and timers —
+  // and read in the template, so under zoneless CD they must be signals: a plain
+  // field write from those callbacks would not notify the scheduler and the view
+  // would silently go stale. (zoneless-migration.md, Phase 1.2 / Recipe B & F.)
+  readonly isVoting = signal(false);
+  readonly volume = signal(1);
+  readonly audioPlaying = signal(true);
+  readonly showAnimations = signal(true);
+  readonly showMetadata = signal(true);
+  readonly swipeClass = signal('');
+  readonly spinningVote = signal<'good' | 'bad' | null>(null);
 
   /** Persisted dismissal of the zero-votes first-vote hint. Initialised
    *  to ``true`` so the hint never flashes before settings load resolves;
    *  loadSettings() flips it to ``false`` only when the server confirms
    *  the user has never dismissed it. */
-  private labelHintDismissed = true;
+  private readonly labelHintDismissed = signal(true);
 
   /** Transient text shown after Cmd/Ctrl-Z; auto-cleared after a short delay. */
-  undoToastText: string | null = null;
+  readonly undoToastText = signal<string | null>(null);
   private undoToastTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Bad-vote-with-box state: drawing a box is real work, so a stray ← shouldn't
@@ -75,7 +80,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   // state without voting and without discarding the box.
   // Public so the template can bind it into the image viewer.
   currentRegionBox: RegionBox | null = null;
-  pendingBadConfirm = false;
+  readonly pendingBadConfirm = signal(false);
 
   /** Embedder capability listings, loaded once in init(). Used to decide
    *  whether the active dataset's embedder is patch-region-aware, which gates
@@ -91,21 +96,21 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
-      this.volume = settings.volume ?? 1;
-      this.audioPlaying = settings.audio_playing !== false;
-      this.showAnimations = settings.show_animations !== false;
-      this.showMetadata = settings.show_metadata !== false;
-      this.labelHintDismissed = settings.label_hint_dismissed === true;
+      this.volume.set(settings.volume ?? 1);
+      this.audioPlaying.set(settings.audio_playing !== false);
+      this.showAnimations.set(settings.show_animations !== false);
+      this.showMetadata.set(settings.show_metadata !== false);
+      this.labelHintDismissed.set(settings.label_hint_dismissed === true);
     });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media']) {
-      this.swipeClass = '';
+      this.swipeClass.set('');
       // Navigating to another item clears the armed bad-vote-confirm state.
       // ImageViewer also clears its own regionBox on media change and will emit null;
       // resetting eagerly here keeps state coherent across the swap.
-      this.pendingBadConfirm = false;
+      this.pendingBadConfirm.set(false);
       this.currentRegionBox = null;
     }
   }
@@ -172,10 +177,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
             }
             break;
           case 'undo':
-            if (!this.disabled() && !this.isVoting) this.voteState.undo();
+            if (!this.disabled() && !this.isVoting()) this.voteState.undo();
             break;
           case 'redo':
-            if (!this.disabled() && !this.isVoting) this.voteState.redo();
+            if (!this.disabled() && !this.isVoting()) this.voteState.redo();
             break;
         }
       }),
@@ -190,18 +195,18 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   /** Persist the first-vote hint as dismissed once the first vote lands. */
   private maybeDismissLabelHint(): void {
-    if (this.labelHintDismissed) return;
+    if (this.labelHintDismissed()) return;
     if (this.voteState.goodVotes.size === 0 && this.voteState.badVotes.size === 0) return;
-    this.labelHintDismissed = true;
+    this.labelHintDismissed.set(true);
     this.settingsState.update({ label_hint_dismissed: true }).subscribe();
   }
 
   private showUndoToast(action: 'undo' | 'redo', mediaName: string): void {
     const verb = action === 'undo' ? 'Undid vote on' : 'Redid vote on';
-    this.undoToastText = `${verb} ${mediaName}`;
+    this.undoToastText.set(`${verb} ${mediaName}`);
     if (this.undoToastTimer) clearTimeout(this.undoToastTimer);
     this.undoToastTimer = setTimeout(() => {
-      this.undoToastText = null;
+      this.undoToastText.set(null);
       this.undoToastTimer = null;
     }, 2000);
   }
@@ -246,7 +251,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
    *  polarity) and the user has not previously dismissed the hint. The
    *  hint dismisses on the first vote in this session and persists. */
   get showFirstVoteHint(): boolean {
-    if (this.labelHintDismissed) return false;
+    if (this.labelHintDismissed()) return false;
     return this.voteState.goodVotes.size === 0 && this.voteState.badVotes.size === 0;
   }
 
@@ -275,12 +280,12 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   toggleMetadata(): void {
-    this.showMetadata = !this.showMetadata;
-    this.settingsState.update({ show_metadata: this.showMetadata }).subscribe();
+    this.showMetadata.set(!this.showMetadata());
+    this.settingsState.update({ show_metadata: this.showMetadata() }).subscribe();
   }
 
   castVote(vote: 'good' | 'bad'): void {
-    if (!this.media || this.isVoting) return;
+    if (!this.media || this.isVoting()) return;
 
     // Region annotations only attach to yes-votes (salient-area semantics).
     // A no-vote with a box drawn arms a sticky discard-confirm state; the first
@@ -288,37 +293,37 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     // throws the box away and votes no. The state has no timeout: a time-based
     // modal would expire silently and surprise the user. Esc, mouse-on-box, a
     // fresh Shift-drag, or item navigation clear armed without voting.
-    if (vote === 'bad' && this.currentRegionBox && !this.pendingBadConfirm) {
-      this.pendingBadConfirm = true;
+    if (vote === 'bad' && this.currentRegionBox && !this.pendingBadConfirm()) {
+      this.pendingBadConfirm.set(true);
       this.imageViewer?.pulseRegionBox();
       return;
     }
 
     const regionBox = vote === 'good' ? this.currentRegionBox : null;
-    this.pendingBadConfirm = false;
-    this.isVoting = true;
+    this.pendingBadConfirm.set(false);
+    this.isVoting.set(true);
 
     this.voteState
       .submitToggleVoteAndRecord(this.media.id, vote, this.mediaDisplayName(this.media), regionBox)
       .subscribe({
         next: () => {
-          const animate = this.showAnimations && !!this.media && !prefersReducedMotion();
+          const animate = this.showAnimations() && !!this.media && !prefersReducedMotion();
           if (animate) {
-            this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
-            this.spinningVote = vote;
+            this.swipeClass.set(vote === 'good' ? 'swipe-right' : 'swipe-left');
+            this.spinningVote.set(vote);
             if (this.spinTimer) clearTimeout(this.spinTimer);
-            this.spinTimer = setTimeout(() => (this.spinningVote = null), 300);
+            this.spinTimer = setTimeout(() => this.spinningVote.set(null), 300);
             setTimeout(() => {
               this.mediaVoted.emit({ id: this.media!.id, vote });
-              this.isVoting = false;
+              this.isVoting.set(false);
             }, 180);
           } else {
             this.mediaVoted.emit({ id: this.media!.id, vote });
-            this.isVoting = false;
+            this.isVoting.set(false);
           }
         },
         error: () => {
-          this.isVoting = false;
+          this.isVoting.set(false);
         },
       });
   }
@@ -327,12 +332,12 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.currentRegionBox = box;
     // Clearing the box also clears any pending bad-vote confirmation;
     // there's nothing left to confirm against.
-    if (!box) this.pendingBadConfirm = false;
+    if (!box) this.pendingBadConfirm.set(false);
   }
 
   /** Esc-while-armed or mouse interaction with the box: cancel armed, keep the box. */
   onArmedConfirmCanceled(): void {
-    this.pendingBadConfirm = false;
+    this.pendingBadConfirm.set(false);
   }
 
   private loadSettings(): void {
@@ -340,25 +345,25 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   private adjustVolume(delta: number): void {
-    this.volume = Math.max(0, Math.min(1, this.volume + delta));
+    this.volume.set(Math.max(0, Math.min(1, this.volume() + delta)));
     if (this.audioPlayer) {
       this.audioPlayer.adjustVolume(delta);
     }
     if (this.videoPlayer) {
       this.videoPlayer.adjustVolume(delta);
     }
-    this.settingsState.update({ volume: this.volume }).subscribe();
+    this.settingsState.update({ volume: this.volume() }).subscribe();
   }
 
   onPlayingChanged(playing: boolean): void {
     if (this._pausedByVisibility) return;
-    this.audioPlaying = playing;
-    this.settingsState.update({ audio_playing: this.audioPlaying }).subscribe();
+    this.audioPlaying.set(playing);
+    this.settingsState.update({ audio_playing: this.audioPlaying() }).subscribe();
   }
 
   private onVisibilityChange = (): void => {
     if (document.hidden) {
-      if (this.audioPlaying) {
+      if (this.audioPlaying()) {
         this._pausedByVisibility = true;
         this.stopPlayback();
       }
@@ -382,13 +387,13 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   private togglePlayback(): void {
-    this.audioPlaying = !this.audioPlaying;
+    this.audioPlaying.set(!this.audioPlaying());
     if (this.audioPlayer) {
       this.audioPlayer.togglePlayback();
     }
     if (this.videoPlayer) {
       this.videoPlayer.togglePlayback();
     }
-    this.settingsState.update({ audio_playing: this.audioPlaying }).subscribe();
+    this.settingsState.update({ audio_playing: this.audioPlaying() }).subscribe();
   }
 }

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -1,0 +1,123 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CenterPanelComponent } from './center-panel.component';
+import { Media } from '../../models/api.models';
+import { ANIMATIONS_OFF_CLASS } from '../../utils/reduced-motion';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+/**
+ * Zoneless staleness canary for the center panel (docs/plans/zoneless-migration.md,
+ * Phases 0.3/0.4 + 1.2). Phase 1.2 dropped the `zone.run(...)` re-entries from
+ * `KeyboardService`, moving the change-detection trigger to this consumer, whose
+ * shortcut-driven state (`isVoting`/`spinningVote`/`swipeClass`/`undoToastText`/
+ * `volume`/`pendingBadConfirm` + the settings mirror) is now signalized.
+ *
+ * This spec runs under a zoneless `TestBed` and drives the component through the
+ * *production channel* — a real `keydown` dispatched on `document` (handled by the
+ * live `KeyboardService` listener, NOT a bound template event) — then asserts on
+ * the rendered DOM after `settleZoneless()` with NO manual `detectChanges()`. The
+ * keyboard callback and the vote/undo HTTP `.subscribe()` callbacks are all
+ * un-bound, so if any of those state writes were a plain field instead of a signal
+ * the scheduler would never be notified and the DOM would stay stale — failing
+ * these assertions.
+ */
+describe('CenterPanelComponent (zoneless keyboard canary)', () => {
+  let fixture: ComponentFixture<CenterPanelComponent>;
+  let component: CenterPanelComponent;
+  let httpMock: HttpTestingController;
+
+  // Audio media keeps the swipe wrapper class empty (so the DOM stays simple) and
+  // avoids the image-viewer ViewChild's NG0100 settling quirk.
+  const mockMedia: Media = {
+    id: 1,
+    media_type: 'audio',
+    filename: 'test.wav',
+    md5: 'abc123',
+    custom_metadata: {},
+  };
+
+  beforeEach(async () => {
+    configureZoneless({
+      imports: [CenterPanelComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    fixture = TestBed.createComponent(CenterPanelComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+
+    // `media` is a decorator @Input; set it through `setInput` (the same channel
+    // the parent's binding uses) so the write schedules CD.
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
+
+    // init() wires the keyboard subscription + starts the document listener and
+    // kicks the settings/embedders loads. Flush those so afterEach's verify()
+    // is clean. show_animations:false takes the non-animated vote branch (no
+    // dangling timers) and is the production path for "reduce motion".
+    component.init();
+    await settleZoneless(fixture);
+    for (const req of httpMock.match((r) => r.url.includes('settings'))) {
+      req.flush({ show_animations: false });
+    }
+    for (const req of httpMock.match((r) => r.url.includes('embedders'))) {
+      req.flush({ embedders: [] });
+    }
+    await settleZoneless(fixture);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    httpMock.verify();
+    // The settings effect mirrors show_animations:false onto <html>; undo it so
+    // the class does not leak into other specs in the same jsdom document.
+    document.documentElement.classList.remove(ANIMATIONS_OFF_CLASS);
+  });
+
+  function votingOverlay(): HTMLElement {
+    return fixture.nativeElement.querySelector('vt-voting-overlay');
+  }
+
+  it('renders the vote as cast after a keyboard ArrowRight, with no manual detectChanges', async () => {
+    expect(votingOverlay().querySelector('.btn-good.voted')).toBeNull();
+
+    // Production channel: a real → keypress, handled by the live KeyboardService
+    // listener (un-bound document callback), dispatches a 'vote' action that the
+    // component's subscription turns into castVote('good').
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await settleZoneless(fixture);
+
+    // The optimistic vote POST; its response callback flips `isVoting` (a signal)
+    // back, which is the only thing that can schedule CD for the un-bound chain.
+    httpMock.expectOne('/api/medias/1/vote').flush({ state: 'good', click_time: 1 });
+    await settleZoneless(fixture);
+
+    expect(component.voteState.goodVotes.has(1)).toBe(true);
+    // If `isVoting`/the vote state weren't signalized, this would still be null.
+    expect(votingOverlay().querySelector('.btn-good.voted')).not.toBeNull();
+  });
+
+  it('shows the undo toast after a keyboard Cmd/Ctrl-Z, with no manual detectChanges', async () => {
+    // Land a vote first so the undo stack has an entry to pop.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await settleZoneless(fixture);
+    httpMock.expectOne('/api/medias/1/vote').flush({ state: 'good', click_time: 1 });
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.undo-toast')).toBeNull();
+
+    // Ctrl-Z → KeyboardService emits {type:'undo'} → voteState.undo() emits on
+    // toast$, whose un-bound subscription writes the `undoToastText` signal.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }));
+    await settleZoneless(fixture);
+    // undo() re-POSTs the reverted target ('none'); flush it.
+    httpMock.expectOne('/api/medias/1/vote').flush({ state: 'none', click_time: 2 });
+    await settleZoneless(fixture);
+
+    const toast = fixture.nativeElement.querySelector('.undo-toast');
+    expect(toast).not.toBeNull();
+    expect(toast!.textContent).toContain('Undid vote on test.wav');
+  });
+});

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -29,12 +29,15 @@ describe('CenterPanelComponent (zoneless keyboard canary)', () => {
   let component: CenterPanelComponent;
   let httpMock: HttpTestingController;
 
-  // Audio media keeps the swipe wrapper class empty (so the DOM stays simple) and
-  // avoids the image-viewer ViewChild's NG0100 settling quirk.
+  // Document media keeps the viewer fully inert in jsdom: it only sets a
+  // sanitized iframe URL — no HTTP, no Loading placeholder (text viewer's
+  // NG0100), no native `fetch()` of a relative URL (audio/video) and no
+  // ViewChild settling quirk (image). The viewer is incidental here — the
+  // assertions are on the always-rendered voting overlay / undo toast.
   const mockMedia: Media = {
     id: 1,
-    media_type: 'audio',
-    filename: 'test.wav',
+    media_type: 'document',
+    filename: 'test.pdf',
     md5: 'abc123',
     custom_metadata: {},
   };
@@ -54,13 +57,19 @@ describe('CenterPanelComponent (zoneless keyboard canary)', () => {
     await settleZoneless(fixture);
 
     // init() wires the keyboard subscription + starts the document listener and
-    // kicks the settings/embedders loads. Flush those so afterEach's verify()
-    // is clean. show_animations:false takes the non-animated vote branch (no
-    // dangling timers) and is the production path for "reduce motion".
+    // kicks the settings/embedders loads. The settings GET is driven by an
+    // `rxResource`; while it is loading the zoneless app stays unstable, so we
+    // must NOT `whenStable()` until it is flushed. Drain a macrotask + tick to
+    // let the GETs be issued, flush them, THEN settle. show_animations:false
+    // takes the non-animated vote branch (no dangling timers) and is the
+    // production path for "reduce motion".
     component.init();
-    await settleZoneless(fixture);
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    TestBed.tick();
+    // label_hint_dismissed:true so the first vote's hint-dismissal does not fire
+    // a settings PUT we'd have to flush.
     for (const req of httpMock.match((r) => r.url.includes('settings'))) {
-      req.flush({ show_animations: false });
+      req.flush({ show_animations: false, label_hint_dismissed: true });
     }
     for (const req of httpMock.match((r) => r.url.includes('embedders'))) {
       req.flush({ embedders: [] });
@@ -118,6 +127,6 @@ describe('CenterPanelComponent (zoneless keyboard canary)', () => {
 
     const toast = fixture.nativeElement.querySelector('.undo-toast');
     expect(toast).not.toBeNull();
-    expect(toast!.textContent).toContain('Undid vote on test.wav');
+    expect(toast!.textContent).toContain('Undid vote on test.pdf');
   });
 });

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -17,6 +17,12 @@ export interface KeyboardAction {
 export class KeyboardService implements OnDestroy {
   private zone = inject(NgZone);
 
+  // Shortcuts are dispatched as a plain Subject emit. Under zoneless CD the
+  // re-entry that used to wrap every `.next()` in `zone.run(...)` is gone: the
+  // CD trigger now lives in the consumer (center-panel), whose shortcut-driven
+  // state is signalized so a write from this callback notifies the scheduler.
+  // The keydown listener still runs in `runOutsideAngular` (a harmless no-op
+  // under zoneless, and it still avoids per-keystroke churn while prod is zoned).
   readonly action$ = new Subject<KeyboardAction>();
 
   private listener: ((e: KeyboardEvent) => void) | null = null;
@@ -56,7 +62,7 @@ export class KeyboardService implements OnDestroy {
       e.preventDefault();
       (document.activeElement as HTMLElement)?.blur();
       const type = e.shiftKey ? 'redo' : 'undo';
-      this.zone.run(() => this.action$.next({ type }));
+      this.action$.next({ type });
       return;
     }
 
@@ -67,49 +73,49 @@ export class KeyboardService implements OnDestroy {
       case 'ArrowRight':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'vote', direction: 'good' }));
+        this.action$.next({ type: 'vote', direction: 'good' });
         break;
       case 'ArrowLeft':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'vote', direction: 'bad' }));
+        this.action$.next({ type: 'vote', direction: 'bad' });
         break;
       case 'ArrowUp':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'volume', volumeDelta: 0.05 }));
+        this.action$.next({ type: 'volume', volumeDelta: 0.05 });
         break;
       case 'ArrowDown':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'volume', volumeDelta: -0.05 }));
+        this.action$.next({ type: 'volume', volumeDelta: -0.05 });
         break;
       case ' ':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'playback' }));
+        this.action$.next({ type: 'playback' });
         break;
       case '+':
       case '=':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'zoom', zoomDirection: 'in' }));
+        this.action$.next({ type: 'zoom', zoomDirection: 'in' });
         break;
       case '-':
       case '_':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'zoom', zoomDirection: 'out' }));
+        this.action$.next({ type: 'zoom', zoomDirection: 'out' });
         break;
       case '[':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'rotate', rotateDirection: 'left' }));
+        this.action$.next({ type: 'rotate', rotateDirection: 'left' });
         break;
       case ']':
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
-        this.zone.run(() => this.action$.next({ type: 'rotate', rotateDirection: 'right' }));
+        this.action$.next({ type: 'rotate', rotateDirection: 'right' });
         break;
     }
   }


### PR DESCRIPTION
## Summary

Continues the zoneless change-detection migration (`docs/plans/zoneless-migration.md`). This lands **Phase 1.2** — the last remaining Phase 1 item — and the coupled center-panel slice of Phase 2.3. With it, **Phase 1 is complete**.

Behavior-neutral under the still-zoned production app; nothing flips prod to zoneless yet (that's Phase 3).

### `KeyboardService` (de-zoned)
- Dropped all 10 `this.zone.run(() => this.action$.next(...))` re-entries — `action$` now emits plainly.
- Kept the `runOutsideAngular` keydown listener and the injected `NgZone` it needs (a harmless no-op under zoneless; still avoids per-keystroke churn while prod is zoned).
- `action$` stays a `Subject` — its sole consumer (`center-panel`) composes it, so a signal would have bought nothing.

### `center-panel` (signalized — the CD trigger moves to the consumer)
- The shortcut/timer/HTTP-driven template-bound state is now signals: `isVoting`, `volume`, `audioPlaying`, `showAnimations`, `showMetadata`, `swipeClass`, `spinningVote`, `undoToastText`, `pendingBadConfirm`, and the private `labelHintDismissed`. A write from the (now un-zoned) keyboard callback or a vote/undo HTTP `.subscribe()` callback notifies the scheduler instead of silently going stale.
- The Recipe-F settings-mirror `effect()` now writes those signals via `.set()` instead of plain fields, closing the latent plain-field-write trap.
- Template + the existing contract spec updated to the signal accessors.

### Tests
- New zoneless DOM canary `center-panel.zoneless.spec.ts`: drives a real `keydown` through the live `KeyboardService` listener (an **un-bound document callback**) and asserts the vote renders (`.btn-good.voted`) and the undo toast appears — with **no manual `detectChanges()`**. If any of those writes were a plain field, the DOM would stay stale and the canary would fail.
- `./run-tests.sh frontend` green: `build:prod` clean (0 warnings), audit OK, **796 Vitest tests pass**.

### Plan doc
- Status header, §1.2, and Open follow-ups updated: Phase 1 complete; Phase 2.3 still owes `image-viewer`/`video-player`; Phases 2 (rest), 3 (flip), 4 (human QA), 5 (cleanup) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lapwx2N2Gg8qBMq6LBVRSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lapwx2N2Gg8qBMq6LBVRSk)_