### PR TITLE
Structural embedders: wire Stage-2 re-rank into the Find path

### DIFF
--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -3,10 +3,10 @@
 **Status:** v1 in progress — **foundation + Stage-2 backend core + re-rank
 across all sort paths shipped** (two-stage re-rank, RegionYes-as-template,
 match-statistic verification classifier, wired into the vote-driven learned-sort
-path **plus** the example-sort and labelset/saved-detector paths); **find-path
-classifier reuse + K/threshold spike-tuning deferred** (the matched-region
-overlay already rides patch's `best_region` machinery; see "What shipped" /
-"Open follow-ups" below). This is the living spec for a third embedder *type*
+path **plus** the example-sort, labelset/saved-detector, **and Find
+(`find-label`) paths** — so every scoring entry point now verifies); **K/threshold
+spike-tuning deferred** (the matched-region overlay already rides patch's
+`best_region` machinery; see "What shipped" / "Open follow-ups" below). This is the living spec for a third embedder *type*
 (alongside single-vector and patch) that searches for **specific instances**
 ("the Coca-Cola logo") rather than **semantic categories** ("a cola can"). The
 architecture below is the agreed direction; the work plan is a sketch to be
@@ -518,6 +518,31 @@ vote-driven sort (CPU-tested in
   (`vtscore/detectors/labelset_training.py`). A no-op for non-structural
   datasets (gated on the active snapshot carrying `local_features`).
 
+## What shipped (v1 Find-path re-rank)
+
+The Stage-2 re-rank now also reaches the **Find** scoring path, the last scoring
+entry point that stopped at coarse VLAD retrieval (CPU-tested in
+`tests/detectors/test_find_label.py` +
+`tests_lib/detectors/test_structural_labelset.py`):
+
+- **`find-label` wiring.** `find_label` (`vtsearch/routes/detectors/scoring.py`)
+  scores every media with the retrieval MLP (`score_media_with_model`) and then
+  hands the result list to `maybe_labelset_structural_rerank` — the same
+  chokepoint the learned-sort labelset path uses — before applying the
+  threshold labels and freezing `find_scores`. The detector's stored labelset is
+  parsed once (`LabelSet.from_dict(det_data["labelset"])`) and the re-rank builds
+  the RegionYes templates + verification classifier from the cross-dataset
+  `label_local_features` cache (re-derived from origins, then reused), so a
+  pre-trained structural detector verifies in Find without re-detecting features
+  on every pass. The classifier lands on `DetectorContext.verification_classifier`
+  exactly as on the vote/labelset paths.
+- **No-op for non-structural detectors.** Gated on the active snapshot carrying
+  `local_features` (via `snapshot_is_structural`), so the audio/image
+  single-vector and patch detectors are untouched and pay only one O(N) snapshot
+  scan. The frozen `find_scores` then hold the verification probabilities and the
+  cutoff is the classifier's `STRUCTURAL_DECISION_THRESHOLD` (0.5), so the
+  Inclusion slider re-thresholds over verification scores like any other Find run.
+
 ## Open follow-ups
 
 - **Frontend overlay — basics done, debug view deferred.** The backend emits the
@@ -532,10 +557,18 @@ vote-driven sort (CPU-tested in
   "tail scores 0 / threshold = 0.5" policy are reasonable defaults but unspiked.
   Sweep K on a demo image dataset and confirm the live-on-every-sort latency is
   acceptable (vs an on-demand "verify" action) before pinning.
-- **Find-path classifier reuse.** The verification classifier is carried on
-  `DetectorContext` but only the retrieval MLP is consumed by the Find scoring
-  path today; have Find re-rank with the stored classifier so a pre-trained
-  structural detector verifies without re-deriving.
+- **Find-path classifier reuse — SHIPPED.** The Find scoring path
+  (`POST /api/find-label`) now routes a saved structural detector's Stage-1 VLAD
+  scores through the same Stage-2 re-rank as the learned-sort/labelset path
+  (`maybe_labelset_structural_rerank`, wired in
+  `vtsearch/routes/detectors/scoring.py`). The detector's on-disk labelset is
+  re-derived into templates + verification classifier (reusing the
+  `DetectorContext.label_local_features` cache so features aren't re-detected
+  across calls) and the active dataset's shortlist is geometrically re-ranked;
+  the classifier is stored on `DetectorContext.verification_classifier` as on
+  every other path. A no-op for non-structural detectors. So every scoring entry
+  point — vote-driven sort, example-sort, labelset sort, **and Find** — now
+  verifies. See "What shipped (v1 Find-path re-rank)".
 - **Double SIFT detection.** The embed pass (VLAD) and the local-features pass
   each run SIFT once per image. Acceptable for v1; a combined single-detect pass
   is a cheap later optimisation.

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -112,6 +112,55 @@ class TestFindLabel:
         assert "dataset_id" in resp.get_json()["errors"]["json"]
 
 
+class TestFindLabelStructuralRerank:
+    """find-label routes a saved detector's scores through the Stage-2
+    geometric re-rank, the Find counterpart to the learned-sort/labelset path.
+
+    A no-op for the audio (non-structural) test fixtures, so the hook is
+    exercised here by capturing what the route hands it: the detector's parsed
+    labelset and the active-dataset snapshot.  The re-rank itself is covered at
+    the library tier (``tests_lib/detectors/test_structural_labelset.py``).
+    """
+
+    def test_find_label_routes_scores_through_structural_rerank(self, client, monkeypatch):
+        from vtscore.detectors import labelset_training
+
+        detector_id = setup_trainable_model_in_registry(
+            "struct-rerank-find",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+
+        captured: dict = {}
+
+        def fake_rerank(det_ctx, labelset, results, threshold, snap):
+            # The detector's six on-disk labels must reach the re-rank as a
+            # parsed LabelSet, and the active dataset as the score snapshot.
+            captured["good_bad_labels"] = sum(1 for el in labelset.elements if el.label in ("good", "bad"))
+            captured["snap_len"] = len(snap)
+            captured["n_results"] = len(results)
+            # Mimic a structural outcome: collapse to a single verified hit at
+            # the classifier's 0.5 decision boundary.
+            top = max(results, key=lambda r: r["score"])
+            return [{"id": top["id"], "score": 1.0}], 0.5
+
+        monkeypatch.setattr(labelset_training, "maybe_labelset_structural_rerank", fake_rerank)
+
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+
+        assert captured["good_bad_labels"] == 6
+        assert captured["snap_len"] == app_module.NUM_MEDIAS
+        assert captured["n_results"] == app_module.NUM_MEDIAS
+        # The re-rank's threshold and re-ranked result set drive the labels.
+        assert data["threshold"] == 0.5
+        assert data["good_count"] == 1
+        assert data["bad_count"] == 0
+        assert len(data["results"]) == 1
+
+
 class TestFindModeIsPerDetector:
     """Find mode is per-detector state, not a process-wide global.
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -172,6 +172,24 @@ def find_label(body: dict):  # noqa: C901
         total_steps=_FIND_LABEL_STEPS,
     )
 
+    # Stage-2 structural re-rank for a saved structural (SIFT/VLAD) detector:
+    # geometrically verify the VLAD shortlist against the detector's RegionYes
+    # templates and re-rank by the match-statistic verification classifier.
+    # This is the Find counterpart to the re-rank already wired into the
+    # vote-driven (``train_and_score``) and learned-sort (``labelset_train_and_score``)
+    # paths, so a pre-trained structural detector verifies in Find too instead of
+    # stopping at the coarse VLAD retrieval.  A no-op for every non-structural
+    # detector (gated on the active snapshot carrying ``local_features``).  See
+    # docs/plans/structural-embedder.md.
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.labelset_training import maybe_labelset_structural_rerank
+    from vtscore.state.core import get_active_detector_context
+
+    labelset = LabelSet.from_dict((det_data or {}).get("labelset") or {})
+    results, threshold = maybe_labelset_structural_rerank(
+        get_active_detector_context(), labelset, results, threshold, snap
+    )
+
     update_find_progress(
         "running",
         f"Applying labels to {n_total} items…",


### PR DESCRIPTION
## What

Wires the structural Stage-2 geometric re-rank into the **Find** scoring path (`POST /api/find-label`) — the last scoring entry point that stopped at coarse VLAD retrieval. This closes the "Find-path classifier reuse" follow-up in `docs/plans/structural-embedder.md`.

Before this change, a saved structural (SIFT/VLAD) detector scored only its Stage-1 retrieval MLP in Find; the match-statistic verification classifier never ran there, even though it already runs on the vote-driven learned-sort, example-sort, and labelset paths.

## How

`find_label` (`vtsearch/routes/detectors/scoring.py`) now scores every media with the retrieval MLP (`score_media_with_model`) and then routes the result list through `maybe_labelset_structural_rerank` — the same chokepoint the learned-sort labelset path already uses — **before** applying the threshold labels and freezing `find_scores`.

- The detector's on-disk labelset is parsed once (`LabelSet.from_dict(det_data["labelset"])`) and the re-rank builds the RegionYes templates + verification classifier from the cross-dataset `DetectorContext.label_local_features` cache (re-derived from origins, then reused), so a pre-trained structural detector verifies without re-detecting features on every pass. The classifier lands on `DetectorContext.verification_classifier` exactly as on the vote/labelset paths.
- **No-op for non-structural detectors** — gated on the active snapshot carrying `local_features` (`snapshot_is_structural`), so single-vector and patch detectors are untouched and pay only one O(N) snapshot scan. For a structural detector the frozen `find_scores` then hold the verification probabilities and the cutoff is the classifier's `STRUCTURAL_DECISION_THRESHOLD` (0.5).

Every scoring entry point — vote-driven sort, example-sort, labelset sort, and now Find — verifies.

## Tests

- New `tests/detectors/test_find_label.py::TestFindLabelStructuralRerank` confirms the route hands the detector's parsed labelset and the active-dataset snapshot to the re-rank, and that the re-rank's threshold + re-ranked results drive the labels. The re-rank internals stay covered at the library tier (`tests_lib/detectors/test_structural_labelset.py`).
- Full `./run-tests.sh` green (4901 passed, 1 skipped) — includes ruff, codespell, deptry, and the frontend build.

Plan doc (`docs/plans/structural-embedder.md`) updated: status header + new "What shipped (v1 Find-path re-rank)" section; the follow-up bullet marked SHIPPED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BFvgiDS5R1xyB7yZ2MCEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015BFvgiDS5R1xyB7yZ2MCEJ)_