### PR TITLE
Zoneless Phase 2.1: de-zone leaf utility components

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -3,7 +3,9 @@
 Status: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
 (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
 signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
-signalized, i.e. the center-panel slice of Phase 2.3); the rest of Phase 2 and
+signalized, i.e. the center-panel slice of Phase 2.3); Phase 2.1 shipped (leaf
+utility components — toast-container, clipboard-copy, voting-overlay,
+dialog-host + VtDialogService, browse-legend); the rest of Phase 2 (2.2–2.9) and
 Phases 3–5 not started.** This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
@@ -473,11 +475,22 @@ component: apply Recipe A/B/C/D/F as appropriate, switch its spec to the zoneles
 
 Suggested order (lightest/most-isolated first to build confidence):
 
-1. **Leaf utility components:** `toast-container` (A), `clipboard-copy` (C/signal),
-   `voting-overlay` (signal flashes), `field-hint-icon` (already signal),
-   `dialog-host` + **`VtDialogService`** (signalize dialog state, Recipe B/F —
-   see §2; canary: open a dialog from a non-event callback), `browse-legend`
-   (`MutationObserver` theme → signal).
+1. **Leaf utility components. ✅ DONE (Phase 2.1).** `toast-container` binds
+   `toasts$` via `| async` (Recipe A) and `copiedId` became a signal;
+   `clipboard-copy`'s `buttonText` flash became a signal (it is set from a
+   post-`await` continuation *and* a timer — the exact zoneless-sensitive path);
+   `voting-overlay`'s `goodFlash`/`badFlash` became signals and its `@Input()`
+   decorators were modernized to `input()`; `field-hint-icon` was already
+   signal-based (no change); `dialog-host` + **`VtDialogService`** had all dialog
+   state (`dialogOpen`/`dialogTitle`/`dialogMessage`/`dialogType`/
+   `dialogShowInput`/`dialogInputValue`/`dialogButtons`) signalized so a
+   `confirm`/`prompt` opened from a non-event callback still schedules CD, and the
+   dead `ApplicationRef`/`createComponent`/`EnvironmentInjector`/`modalRef` code
+   was dropped; `browse-legend`'s `theme` became a signal driven by the
+   `data-theme` `MutationObserver`. Each spec now runs under the zoneless
+   `TestBed` (`configureZoneless` + `settleZoneless`, no manual `detectChanges`)
+   with a staleness canary; new specs added for `toast-container`,
+   `clipboard-copy`, and `browse-legend`.
 2. **Stats / picker modals:** `find-stats`, `detector-stats`, `dataset-stats`
    (A), the `*-importer`/`*-exporter` mutation-result fields (signalize
    `submitting`/`successMessage`/`status`; the four `setTimeout(close)` →
@@ -585,16 +598,18 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1 complete; Phases 2–5 remain.** Shipped so far: Phase 0 (harness) and
-  all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService SSE pump +
-  ConnectionStateService + BrowseSelectionService signalized) and 1.2
-  (KeyboardService de-zoned + the coupled center-panel state signalized), each
-  with its consumers and a zoneless canary spec. Remaining in **Phase 2**: the
-  rest of the component clusters in the suggested order. Note 2.3's center-panel
-  *state* shipped with 1.2, but 2.3 still owes `image-viewer` (window drag/key
-  handlers + shake + its `ResizeObserver` rendered-size writes) and a check that
-  `video-player` is DOM-only. Then the prod flip (Phase 3), human browser QA
-  (Phase 4), and cleanup (Phase 5).
+- **Phase 1 complete; Phase 2.1 shipped; Phases 2.2–5 remain.** Shipped so far:
+  Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService SSE
+  pump + ConnectionStateService + BrowseSelectionService signalized) and 1.2
+  (KeyboardService de-zoned + the coupled center-panel state signalized); and
+  Phase 2.1 (leaf utility components — toast-container, clipboard-copy,
+  voting-overlay, dialog-host + VtDialogService, browse-legend), each with its
+  consumers and a zoneless canary spec. Remaining in **Phase 2**: clusters
+  2.2–2.9 in the suggested order (next up: 2.2 stats / picker modals). Note 2.3's
+  center-panel *state* shipped with 1.2, but 2.3 still owes `image-viewer` (window
+  drag/key handlers + shake + its `ResizeObserver` rendered-size writes) and a
+  check that `video-player` is DOM-only. Then the prod flip (Phase 3), human
+  browser QA (Phase 4), and cleanup (Phase 5).
 - **Full consumer specs for the browse cluster.** Phase 1.4 added a service unit
   spec + a signal-driven canary, but `browse-canvas`, `browse-bin-popup`, and
   `browse-selection-panel` still have **no** component specs (they are heavy to

--- a/frontend/src/app/components/browse-legend/browse-legend.component.spec.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowseLegendComponent } from './browse-legend.component';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('BrowseLegendComponent', () => {
+  let fixture: ComponentFixture<BrowseLegendComponent>;
+  let priorTheme: string | null;
+
+  beforeEach(async () => {
+    priorTheme = document.documentElement.getAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme'); // defaults to dark
+
+    await configureZoneless({
+      imports: [BrowseLegendComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BrowseLegendComponent);
+    fixture.componentRef.setInput('maxCount', 100);
+    await settleZoneless(fixture);
+  });
+
+  afterEach(() => {
+    if (priorTheme === null) document.documentElement.removeAttribute('data-theme');
+    else document.documentElement.setAttribute('data-theme', priorTheme);
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('renders the single dot and ramp ticks', () => {
+    expect(fixture.nativeElement.querySelector('.browse-legend-dot')).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('.browse-legend-ticks .browse-legend-tick').length)
+      .toBeGreaterThan(0);
+  });
+
+  // Zoneless staleness canary: the live theme is tracked by a `MutationObserver`
+  // on `<html data-theme>`. That observer is an unpatched, non-event callback; it
+  // only repaints the key because `theme` is a signal read (via the gradient/dot
+  // getters) in the template. Flip the document theme and assert the dot's colour
+  // changes (auto colormap: HEAT red in dark → OCEAN grey in light) with no
+  // manual `detectChanges`.
+  it('repaints when the document theme changes (zoneless canary)', async () => {
+    const dot = fixture.nativeElement.querySelector('.browse-legend-dot') as HTMLElement;
+    const darkColor = dot.style.background;
+    expect(darkColor).toBeTruthy();
+
+    document.documentElement.setAttribute('data-theme', 'light');
+    await settleZoneless(fixture);
+
+    expect(dot.style.background).not.toBe(darkColor);
+  });
+});

--- a/frontend/src/app/components/browse-legend/browse-legend.component.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import {
   gradientStops,
   resolveColormap,
@@ -64,13 +64,15 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
   readonly colormap = input<BrowseColormapId>('auto');
 
   private readonly numberFormat = new Intl.NumberFormat();
-  /** Live theme, refreshed by a ``data-theme`` observer so the key repaints. */
-  private theme: CanvasTheme = 'dark';
+  /** Live theme, refreshed by a ``data-theme`` observer so the key repaints. A
+   *  signal so the observer callback (an unpatched, non-event callback) schedules
+   *  change detection under zoneless — the gradient/tick getters read it. */
+  private readonly theme = signal<CanvasTheme>('dark');
   private themeObserver: MutationObserver | null = null;
 
   ngOnInit(): void {
-    this.theme = this.readTheme();
-    this.themeObserver = new MutationObserver(() => (this.theme = this.readTheme()));
+    this.theme.set(this.readTheme());
+    this.themeObserver = new MutationObserver(() => this.theme.set(this.readTheme()));
     this.themeObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['data-theme'],
@@ -89,7 +91,7 @@ export class BrowseLegendComponent implements OnInit, OnDestroy {
 
   /** Colormap resolved for the current preset + theme (same as the canvas). */
   private get resolved() {
-    return resolveColormap(this.colormap(), this.theme);
+    return resolveColormap(this.colormap(), this.theme());
   }
 
   /** Horizontal gradient with the dense (last ramp stop) end at the right. */

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -1,4 +1,4 @@
-@if (showHint) {
+@if (showHint()) {
   <div class="vote-hint" role="status" aria-live="polite">
     Use &larr; / &rarr; or click. Autopilot will find the next question.
   </div>
@@ -6,8 +6,8 @@
 <div class="vote-buttons">
   <button
     class="btn-bad"
-    [class.voted]="isBad"
-    [class.vote-flash]="badFlash"
+    [class.voted]="isBad()"
+    [class.vote-flash]="badFlash()"
     (click)="onVoteBad($event)"
     title="Mark this media as a Bad example."
   >
@@ -16,8 +16,8 @@
   </button>
   <button
     class="btn-good"
-    [class.voted]="isGood"
-    [class.vote-flash]="goodFlash"
+    [class.voted]="isGood()"
+    [class.vote-flash]="goodFlash()"
     (click)="onVoteGood($event)"
     title="Mark this media as a Good example."
   >

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.spec.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.spec.ts
@@ -1,17 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VotingOverlayComponent } from './voting-overlay.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('VotingOverlayComponent', () => {
   let component: VotingOverlayComponent;
   let fixture: ComponentFixture<VotingOverlayComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    await configureZoneless({
       imports: [VotingOverlayComponent],
     }).compileComponents();
     fixture = TestBed.createComponent(VotingOverlayComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -39,21 +41,21 @@ describe('VotingOverlayComponent', () => {
     expect(emitted).toBe('bad');
   });
 
-  it('should apply voted class when isGood is true', () => {
-    component.isGood = true;
-    fixture.detectChanges();
+  it('should apply voted class when isGood is true', async () => {
+    fixture.componentRef.setInput('isGood', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.btn-good').classList.contains('voted')).toBe(true);
   });
 
-  it('should apply voted class when isBad is true', () => {
-    component.isBad = true;
-    fixture.detectChanges();
+  it('should apply voted class when isBad is true', async () => {
+    fixture.componentRef.setInput('isBad', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.btn-bad').classList.contains('voted')).toBe(true);
   });
 
-  it('should not emit when disabled', () => {
-    component.disabled = true;
-    fixture.detectChanges();
+  it('should not emit when disabled', async () => {
+    fixture.componentRef.setInput('disabled', true);
+    await settleZoneless(fixture);
     let emitted = false;
     component.voted.subscribe(() => (emitted = true));
     fixture.nativeElement.querySelector('.btn-good').click();
@@ -74,12 +76,28 @@ describe('VotingOverlayComponent', () => {
     expect(fixture.nativeElement.querySelector('.vote-hint')).toBeNull();
   });
 
-  it('should render the first-vote hint text when showHint is true', () => {
-    component.showHint = true;
-    fixture.detectChanges();
+  it('should render the first-vote hint text when showHint is true', async () => {
+    fixture.componentRef.setInput('showHint', true);
+    await settleZoneless(fixture);
     const hint = fixture.nativeElement.querySelector('.vote-hint');
     expect(hint).toBeTruthy();
     expect(hint.textContent.trim()).toContain('Use');
     expect(hint.textContent).toContain('Autopilot');
+  });
+
+  // Zoneless staleness canary: the flash class is added in a bound `(click)`
+  // (which schedules CD on its own) but cleared by a `setTimeout`. The reset is
+  // the zoneless-sensitive write — it only repaints because `goodFlash` is a
+  // signal read in the template. Click, confirm the flash paints, then let the
+  // 300ms timer fire and confirm the class is removed with no manual pump.
+  it('flashes on vote and clears the flash class after the timer (zoneless canary)', async () => {
+    const good = fixture.nativeElement.querySelector('.btn-good') as HTMLButtonElement;
+    good.click();
+    await settleZoneless(fixture);
+    expect(good.classList.contains('vote-flash')).toBe(true);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 350));
+    await fixture.whenStable();
+    expect(good.classList.contains('vote-flash')).toBe(false);
   });
 });

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, input, output } from '@angular/core';
+import { Component, OnDestroy, input, output, signal } from '@angular/core';
 import { IconComponent } from '../../icon/icon.component';
 
 @Component({
@@ -9,38 +9,40 @@ import { IconComponent } from '../../icon/icon.component';
   styleUrl: './voting-overlay.component.scss',
 })
 export class VotingOverlayComponent implements OnDestroy {
-  @Input() isGood = false;
-  @Input() isBad = false;
-  @Input() disabled = false;
+  readonly isGood = input(false);
+  readonly isBad = input(false);
+  readonly disabled = input(false);
   readonly spinningVote = input<'good' | 'bad' | null>(null);
   /** When true, renders the faint first-vote hint above the buttons. The
    *  parent decides when to show this (zero votes + not previously dismissed)
    *  and dismisses it on first vote. */
-  @Input() showHint = false;
+  readonly showHint = input(false);
   readonly voted = output<'good' | 'bad'>();
 
-  goodFlash = false;
-  badFlash = false;
+  /** Transient flash classes; signals so the `setTimeout` reset repaints under
+   *  zoneless change detection. */
+  readonly goodFlash = signal(false);
+  readonly badFlash = signal(false);
 
   private goodTimer: ReturnType<typeof setTimeout> | null = null;
   private badTimer: ReturnType<typeof setTimeout> | null = null;
 
   onVoteGood(event?: Event): void {
-    if (this.disabled) return;
+    if (this.disabled()) return;
     this.dropFocus(event);
-    this.goodFlash = true;
+    this.goodFlash.set(true);
     this.voted.emit('good');
     if (this.goodTimer) clearTimeout(this.goodTimer);
-    this.goodTimer = setTimeout(() => (this.goodFlash = false), 300);
+    this.goodTimer = setTimeout(() => this.goodFlash.set(false), 300);
   }
 
   onVoteBad(event?: Event): void {
-    if (this.disabled) return;
+    if (this.disabled()) return;
     this.dropFocus(event);
-    this.badFlash = true;
+    this.badFlash.set(true);
     this.voted.emit('bad');
     if (this.badTimer) clearTimeout(this.badTimer);
-    this.badTimer = setTimeout(() => (this.badFlash = false), 300);
+    this.badTimer = setTimeout(() => this.badFlash.set(false), 300);
   }
 
   /**

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.html
@@ -23,6 +23,6 @@
     [disabled]="isDisabled"
     title="Copy to clipboard"
   >
-    {{ buttonText || copyLabel() }}
+    {{ buttonText() || copyLabel() }}
   </button>
 </div>

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.spec.ts
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClipboardCopyComponent } from './clipboard-copy.component';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('ClipboardCopyComponent', () => {
+  let fixture: ComponentFixture<ClipboardCopyComponent>;
+
+  beforeEach(async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: () => Promise.resolve() },
+      configurable: true,
+    });
+
+    await configureZoneless({
+      imports: [ClipboardCopyComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClipboardCopyComponent);
+    fixture.componentRef.setInput('columns', [{ key: 'a', label: 'A' }]);
+    fixture.componentRef.setInput('rows', [{ a: '1' }]);
+    await settleZoneless(fixture);
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('shows the copy label by default', () => {
+    const btn = fixture.nativeElement.querySelector('button.btn') as HTMLButtonElement;
+    expect(btn.textContent?.trim()).toBe('Copy');
+    expect(btn.disabled).toBe(false);
+  });
+
+  // Zoneless staleness canary: `copy()` runs from a bound `(click)`, but the
+  // `flash('Copied!')` that sets the feedback label happens in a post-`await`
+  // continuation (after `navigator.clipboard.writeText`), OUTSIDE the click's
+  // CD-scheduling stack. It only repaints because `buttonText` is a signal.
+  it('flashes "Copied!" after the async write resolves (zoneless canary)', async () => {
+    const btn = fixture.nativeElement.querySelector('button.btn') as HTMLButtonElement;
+    btn.click();
+    await settleZoneless(fixture);
+    expect(btn.textContent?.trim()).toBe('Copied!');
+  });
+
+  it('clears the flash label after the timer (zoneless canary)', async () => {
+    const btn = fixture.nativeElement.querySelector('button.btn') as HTMLButtonElement;
+    btn.click();
+    await settleZoneless(fixture);
+    expect(btn.textContent?.trim()).toBe('Copied!');
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 2100));
+    await fixture.whenStable();
+    expect(btn.textContent?.trim()).toBe('Copy');
+  });
+});

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnDestroy, SimpleChanges, input } from '@angular/core';
+import { Component, OnChanges, OnDestroy, SimpleChanges, input, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -55,7 +55,10 @@ export class ClipboardCopyComponent implements OnChanges, OnDestroy {
   delimiter = ',';
   /** List mode: which single column to copy. */
   selectedColumnKey = '';
-  buttonText = '';
+  /** Transient copy-feedback label ("Copied!" / "Copy failed"). A signal so the
+   *  `setTimeout` reset in {@link flash} repaints back to the default label under
+   *  zoneless change detection. */
+  readonly buttonText = signal('');
 
   private feedbackTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -118,10 +121,10 @@ export class ClipboardCopyComponent implements OnChanges, OnDestroy {
   }
 
   private flash(text: string): void {
-    this.buttonText = text;
+    this.buttonText.set(text);
     if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
     this.feedbackTimer = setTimeout(() => {
-      this.buttonText = '';
+      this.buttonText.set('');
       this.feedbackTimer = null;
     }, 2000);
   }

--- a/frontend/src/app/components/dialog-host/dialog-host.component.html
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.html
@@ -1,16 +1,17 @@
-<vt-modal [open]="dialog.dialogOpen" [title]="dialog.dialogTitle" [showCloseButton]="false" (closed)="onClosed()">
-  <p class="dialog-message"><vt-icon [type]="dialog.getIconType()" [size]="32"></vt-icon> {{ dialog.dialogMessage }}</p>
-  @if (dialog.dialogShowInput) {
+<vt-modal [open]="dialog.dialogOpen()" [title]="dialog.dialogTitle()" [showCloseButton]="false" (closed)="onClosed()">
+  <p class="dialog-message"><vt-icon [type]="dialog.getIconType()" [size]="32"></vt-icon> {{ dialog.dialogMessage() }}</p>
+  @if (dialog.dialogShowInput()) {
     <input
       class="form-input"
-      [(ngModel)]="dialog.dialogInputValue"
+      [ngModel]="dialog.dialogInputValue()"
+      (ngModelChange)="dialog.dialogInputValue.set($event)"
       (keydown.enter)="onButtonClick('__input__')"
-      [attr.aria-label]="dialog.dialogTitle"
+      [attr.aria-label]="dialog.dialogTitle()"
       autofocus
     />
   }
   <div modal-footer>
-    @for (btn of dialog.dialogButtons; track btn.label) {
+    @for (btn of dialog.dialogButtons(); track btn.label) {
       <button
         class="btn"
         [class.btn--primary]="btn.primary"

--- a/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DialogHostComponent } from './dialog-host.component';
 import { VtDialogService } from '../../services/dialog.service';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
 
 describe('DialogHostComponent', () => {
   let component: DialogHostComponent;
@@ -8,14 +10,14 @@ describe('DialogHostComponent', () => {
   let dialogService: VtDialogService;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    await configureZoneless({
       imports: [DialogHostComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DialogHostComponent);
     component = fixture.componentInstance;
     dialogService = TestBed.inject(VtDialogService);
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -24,19 +26,19 @@ describe('DialogHostComponent', () => {
 
   it('should resolve dialog on button click', async () => {
     const promise = dialogService.confirm('Are you sure?');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
 
-    expect(dialogService.dialogOpen).toBe(true);
+    expect(dialogService.dialogOpen()).toBe(true);
 
     component.onButtonClick(true);
     const result = await promise;
     expect(result).toBe(true);
-    expect(dialogService.dialogOpen).toBe(false);
+    expect(dialogService.dialogOpen()).toBe(false);
   });
 
   it('should resolve with false on close', async () => {
     const promise = dialogService.confirm('Delete?');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
 
     component.onClosed();
     const result = await promise;
@@ -45,7 +47,7 @@ describe('DialogHostComponent', () => {
 
   it('should not show close button on dialog modal', async () => {
     const promise = dialogService.confirm('Delete?');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
 
     const closeBtn = fixture.nativeElement.querySelector('.modal-close');
     expect(closeBtn).toBeNull();
@@ -54,4 +56,36 @@ describe('DialogHostComponent', () => {
     await promise;
   });
 
+  // Zoneless staleness canary: the dialog state is signalized precisely so a
+  // dialog opened from a NON-event callback (a `.then()` continuation, a timer)
+  // still schedules change detection and actually renders. Drive `confirm()`
+  // from inside a `setTimeout` — an unpatched callback with no bound listener in
+  // the stack — and assert the modal paints with no manual `detectChanges`.
+  it('renders a dialog opened from a non-event callback (zoneless canary)', async () => {
+    expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeNull();
+
+    setTimeout(() => dialogService.confirm('Opened from a timer'));
+    await settleZoneless(fixture);
+
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.dialog-message').textContent).toContain(
+      'Opened from a timer',
+    );
+  });
+
+  // The button labels are driven by the `dialogButtons` signal; a prompt with an
+  // input must repaint the text field too, again from the plain method call.
+  it('renders the prompt input and OK/Cancel buttons (zoneless canary)', async () => {
+    dialogService.prompt('Name?', 'seed');
+    await settleZoneless(fixture);
+
+    const input = fixture.nativeElement.querySelector('input.form-input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('seed');
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('[modal-footer] button'),
+    ).map((b) => (b as HTMLElement).textContent?.trim());
+    expect(labels).toEqual(['Cancel', 'OK']);
+  });
 });

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -1,5 +1,5 @@
 <div class="toast-stack" aria-live="assertive" aria-atomic="false">
-  @for (t of toasts; track trackById($index, t)) {
+  @for (t of (toastService.toasts$ | async) ?? []; track trackById($index, t)) {
     <div class="toast" [class.toast--success]="t.level === 'success'" role="alert">
       <div class="toast__main">
         @if (t.level === 'success') {
@@ -30,7 +30,7 @@
               {{ expandedId === t.id ? 'Hide details' : 'Details' }}
             </button>
             <button type="button" class="toast__btn" (click)="copyDebugInfo(t)" title="Copy a debug bundle to your clipboard">
-              {{ copiedId === t.id ? 'Copied!' : 'Copy debug info' }}
+              {{ copiedId() === t.id ? 'Copied!' : 'Copy debug info' }}
             </button>
           }
           <button type="button" class="toast__close" (click)="dismiss(t)" aria-label="Dismiss" title="Dismiss">

--- a/frontend/src/app/components/toast-container/toast-container.component.spec.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ToastContainerComponent } from './toast-container.component';
+import { ToastService } from '../../services/toast.service';
+import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('ToastContainerComponent', () => {
+  let fixture: ComponentFixture<ToastContainerComponent>;
+  let toast: ToastService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToastContainerComponent],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ToastContainerComponent);
+    toast = TestBed.inject(ToastService);
+    await settleZoneless(fixture);
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  // Zoneless staleness canary: toasts are bound through `| async`, which calls
+  // `markForCheck` on emit. Push a toast through the production channel
+  // (`ToastService.error`, which `next`s the subject from a plain method call —
+  // no bound listener in the stack), settle, and assert it renders with no
+  // manual `detectChanges`.
+  it('renders a toast pushed through the service (zoneless canary)', async () => {
+    expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
+
+    toast.error({ message: 'Something broke' });
+    await settleZoneless(fixture);
+
+    const el = fixture.nativeElement.querySelector('.toast');
+    expect(el).toBeTruthy();
+    expect(el.textContent).toContain('Something broke');
+  });
+
+  it('removes a toast when dismissed (zoneless canary)', async () => {
+    const id = toast.error({ message: 'Transient' });
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.toast')).toBeTruthy();
+
+    toast.dismiss(id);
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
+  });
+});

--- a/frontend/src/app/components/toast-container/toast-container.component.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.ts
@@ -1,39 +1,32 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, OnDestroy, inject, signal } from '@angular/core';
 
-import { Subscription } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
 import { Toast, ToastService } from '../../services/toast.service';
 
 /**
- * Stacked toast renderer mounted once in ``AppComponent``. Subscribes
- * to ``ToastService.toasts$`` and renders each one. Toasts with a
- * rich ``errorContext`` get the expandable Details + Copy debug info
- * actions (preserves the old global-error-banner UX).
+ * Stacked toast renderer mounted once in ``AppComponent``. Binds
+ * ``ToastService.toasts$`` through the ``async`` pipe and renders each one.
+ * Toasts with a rich ``errorContext`` get the expandable Details + Copy debug
+ * info actions (preserves the old global-error-banner UX).
  */
 @Component({
   selector: 'vt-toast-container',
   standalone: true,
-  imports: [],
+  imports: [AsyncPipe],
   templateUrl: './toast-container.component.html',
   styleUrl: './toast-container.component.scss',
 })
-export class ToastContainerComponent implements OnInit, OnDestroy {
-  private toastService = inject(ToastService);
+export class ToastContainerComponent implements OnDestroy {
+  protected toastService = inject(ToastService);
 
-  toasts: Toast[] = [];
   expandedId: number | null = null;
-  copiedId: number | null = null;
+  /** Signal so the ``setTimeout`` reset in {@link markCopied} repaints the
+   *  "Copied!" label back to its default under zoneless change detection. */
+  readonly copiedId = signal<number | null>(null);
 
-  private sub?: Subscription;
   private copiedTimer?: ReturnType<typeof setTimeout>;
 
-  ngOnInit(): void {
-    this.sub = this.toastService.toasts$.subscribe((toasts) => {
-      this.toasts = toasts;
-    });
-  }
-
   ngOnDestroy(): void {
-    this.sub?.unsubscribe();
     if (this.copiedTimer) clearTimeout(this.copiedTimer);
   }
 
@@ -92,10 +85,10 @@ export class ToastContainerComponent implements OnInit, OnDestroy {
   }
 
   private markCopied(id: number): void {
-    this.copiedId = id;
+    this.copiedId.set(id);
     if (this.copiedTimer) clearTimeout(this.copiedTimer);
     this.copiedTimer = setTimeout(() => {
-      this.copiedId = null;
+      this.copiedId.set(null);
     }, 2000);
   }
 }

--- a/frontend/src/app/services/dialog.service.spec.ts
+++ b/frontend/src/app/services/dialog.service.spec.ts
@@ -19,9 +19,9 @@ describe('VtDialogService', () => {
 
   it('confirm should have Cancel and OK buttons', async () => {
     const promise = service.confirm('Are you sure?');
-    expect(service.dialogButtons.length).toBe(2);
-    expect(service.dialogButtons[0].label).toBe('Cancel');
-    expect(service.dialogButtons[1].label).toBe('OK');
+    expect(service.dialogButtons().length).toBe(2);
+    expect(service.dialogButtons()[0].label).toBe('Cancel');
+    expect(service.dialogButtons()[1].label).toBe('OK');
 
     service.resolve(false);
     const result = await promise;
@@ -30,10 +30,10 @@ describe('VtDialogService', () => {
 
   it('prompt should return input value', async () => {
     const promise = service.prompt('Enter name', 'default');
-    expect(service.dialogShowInput).toBe(true);
-    expect(service.dialogInputValue).toBe('default');
+    expect(service.dialogShowInput()).toBe(true);
+    expect(service.dialogInputValue()).toBe('default');
 
-    service.dialogInputValue = 'typed value';
+    service.dialogInputValue.set('typed value');
     service.resolve('__input__');
     const result = await promise;
     expect(result).toBe('typed value');
@@ -47,13 +47,13 @@ describe('VtDialogService', () => {
   });
 
   it('getIconType should return correct icon type', () => {
-    service.dialogType = 'warning';
+    service.dialogType.set('warning');
     expect(service.getIconType()).toBe('warning');
 
-    service.dialogType = 'error';
+    service.dialogType.set('error');
     expect(service.getIconType()).toBe('x-circle');
 
-    service.dialogType = 'success';
+    service.dialogType.set('success');
     expect(service.getIconType()).toBe('check');
   });
 });

--- a/frontend/src/app/services/dialog.service.ts
+++ b/frontend/src/app/services/dialog.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, ComponentRef, ApplicationRef, createComponent, EnvironmentInjector } from '@angular/core';
-import { ModalComponent } from '../components/modal/modal.component';
+import { Injectable, signal } from '@angular/core';
 
 export type DialogType = 'info' | 'warning' | 'error' | 'success';
 
@@ -18,16 +17,19 @@ interface DialogButton {
 @Injectable({ providedIn: 'root' })
 export class VtDialogService {
   private activeResolve: ((value: unknown) => void) | null = null;
-  private modalRef: ComponentRef<ModalComponent> | null = null;
 
-  // State for the current dialog, consumed by a dialog host component.
-  dialogOpen = false;
-  dialogTitle = '';
-  dialogMessage = '';
-  dialogType: DialogType = 'info';
-  dialogShowInput = false;
-  dialogInputValue = '';
-  dialogButtons: DialogButton[] = [];
+  // State for the current dialog, consumed by the dialog host component. These
+  // are signals so a `show()` invoked from a non-event callback (e.g. a `.then()`
+  // continuation, as in find-view's rename-after-prompt) still schedules change
+  // detection and the dialog actually appears under zoneless. `dialogInputValue`
+  // is written by the host's `[(ngModel)]` (via `.set()` in the template).
+  readonly dialogOpen = signal(false);
+  readonly dialogTitle = signal('');
+  readonly dialogMessage = signal('');
+  readonly dialogType = signal<DialogType>('info');
+  readonly dialogShowInput = signal(false);
+  readonly dialogInputValue = signal('');
+  readonly dialogButtons = signal<DialogButton[]>([]);
 
   private static readonly ICON_TYPES: Record<DialogType, string> = {
     warning: 'warning',
@@ -37,7 +39,7 @@ export class VtDialogService {
   };
 
   getIconType(): string {
-    return VtDialogService.ICON_TYPES[this.dialogType] || VtDialogService.ICON_TYPES.info;
+    return VtDialogService.ICON_TYPES[this.dialogType()] || VtDialogService.ICON_TYPES.info;
   }
 
   confirm(message: string, type: DialogType = 'warning'): Promise<boolean> {
@@ -89,10 +91,10 @@ export class VtDialogService {
   /** Resolve the current dialog with a value. Called by dialog host component. */
   resolve(value: unknown): void {
     if (this.activeResolve) {
-      const resolvedValue = value === '__input__' ? this.dialogInputValue : value;
+      const resolvedValue = value === '__input__' ? this.dialogInputValue() : value;
       this.activeResolve(resolvedValue);
       this.activeResolve = null;
-      this.dialogOpen = false;
+      this.dialogOpen.set(false);
     }
   }
 
@@ -105,13 +107,13 @@ export class VtDialogService {
   }): Promise<unknown> {
     return new Promise(resolve => {
       this.activeResolve = resolve;
-      this.dialogTitle = '';
-      this.dialogMessage = config.message;
-      this.dialogType = config.type;
-      this.dialogShowInput = config.showInput;
-      this.dialogInputValue = config.inputDefault || '';
-      this.dialogButtons = config.buttons;
-      this.dialogOpen = true;
+      this.dialogTitle.set('');
+      this.dialogMessage.set(config.message);
+      this.dialogType.set(config.type);
+      this.dialogShowInput.set(config.showInput);
+      this.dialogInputValue.set(config.inputDefault || '');
+      this.dialogButtons.set(config.buttons);
+      this.dialogOpen.set(true);
     });
   }
 }


### PR DESCRIPTION
Continues the zoneless migration (`docs/plans/zoneless-migration.md`) with **Phase 2.1 — the leaf utility components**, the lightest/most-isolated cluster. All changes are behavior-neutral under the still-zoned production app and land each component's spec under the zoneless `TestBed`.

## What changed

- **`toast-container`** (Recipe A): binds `ToastService.toasts$` through the `async` pipe instead of a `subscribe`-into-field; `copiedId` (set from a `setTimeout`) became a signal.
- **`clipboard-copy`**: the `buttonText` copy-feedback flash became a signal. It is set from a post-`await` continuation (after `navigator.clipboard.writeText`) *and* a reset timer — both outside any bound-listener stack, so this is the exact path that would silently go stale under zoneless.
- **`voting-overlay`**: the `goodFlash`/`badFlash` timer-reset flashes became signals; the `@Input()` decorators were modernized to signal `input()`.
- **`field-hint-icon`**: already signal-based — no change.
- **`VtDialogService` + `dialog-host`**: all dialog state (`dialogOpen`/`dialogTitle`/`dialogMessage`/`dialogType`/`dialogShowInput`/`dialogInputValue`/`dialogButtons`) is signalized so a `confirm`/`prompt` opened from a **non-event callback** (e.g. a `.then()` continuation) still schedules change detection and the dialog actually appears. Also dropped the dead `ApplicationRef`/`createComponent`/`EnvironmentInjector`/`modalRef` code flagged in the plan.
- **`browse-legend`**: `theme` became a signal driven by the `data-theme` `MutationObserver` (an unpatched, non-event callback).

## Tests

Each migrated spec now runs under `configureZoneless()` + `settleZoneless()` with the manual `fixture.detectChanges()` pumps removed, plus a **staleness canary** that drives the value through the production channel and asserts the rendered DOM with no manual CD pump. New specs added for `toast-container`, `clipboard-copy`, and `browse-legend`.

`./run-tests.sh` full pass (4900 passed, 1 skipped, 2 xpassed); frontend gate green (build + audit + 809 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkwCrEbi3tp8rfe1QBdUMk)_