### PR TITLE
Zoneless Phase 2.2: signalize stats + picker modals

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -5,8 +5,11 @@ Status: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
 signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
 signalized, i.e. the center-panel slice of Phase 2.3); Phase 2.1 shipped (leaf
 utility components — toast-container, clipboard-copy, voting-overlay,
-dialog-host + VtDialogService, browse-legend); the rest of Phase 2 (2.2–2.9) and
-Phases 3–5 not started.** This document
+dialog-host + VtDialogService, browse-legend); Phase 2.2 shipped (stats + picker
+modals — find/detector/dataset-stats signalized; label-importer signalized +
+moved onto rxResource; settings-importer/exporter + label-exporter mutation-result
+fields signalized); the rest of Phase 2 (2.3–2.9) and Phases 3–5 not started.**
+This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
 supersedes the earlier stub. Every count and file:line reference was checked
@@ -491,10 +494,17 @@ Suggested order (lightest/most-isolated first to build confidence):
    `TestBed` (`configureZoneless` + `settleZoneless`, no manual `detectChanges`)
    with a staleness canary; new specs added for `toast-container`,
    `clipboard-copy`, and `browse-legend`.
-2. **Stats / picker modals:** `find-stats`, `detector-stats`, `dataset-stats`
-   (A), the `*-importer`/`*-exporter` mutation-result fields (signalize
-   `submitting`/`successMessage`/`status`; the four `setTimeout(close)` →
-   signal/`markForCheck`).
+2. **Stats / picker modals. ✅ DONE (Phase 2.2).** `find-stats`/`detector-stats`/
+   `dataset-stats` signalized `loading`/`error`/`stats` (Recipe B; templates use
+   `@else if (stats(); as stats)`). `label-importer` moved its list read onto an
+   eager `rxResource` and signalized all its subscribe-written fields (mutation
+   results + the dynamic-field-option dicts). `settings-importer`/
+   `settings-exporter`/`label-exporter` were already on `rxResource`+signals;
+   their `submitting`/`successMessage` mutation-result fields were signalized to
+   finish them. The four `setTimeout(close)` paths needed no change — a
+   template-bound `(closed)` output emit schedules the parent's CD under zoneless
+   (proven by `testing/output-emit-zoneless.spec.ts`; see Open follow-ups). Each
+   has a zoneless DOM-canary spec.
 3. **`center-panel` + viewers** (couples with Phase 1.2): signalize voting state;
    `image-viewer` window drag/key handlers + shake + its `ResizeObserver`
    rendered-size writes (signals); `video-player` clip-loop is DOM-only (safe;
@@ -598,18 +608,49 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1 complete; Phase 2.1 shipped; Phases 2.2–5 remain.** Shipped so far:
-  Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService SSE
-  pump + ConnectionStateService + BrowseSelectionService signalized) and 1.2
-  (KeyboardService de-zoned + the coupled center-panel state signalized); and
-  Phase 2.1 (leaf utility components — toast-container, clipboard-copy,
-  voting-overlay, dialog-host + VtDialogService, browse-legend), each with its
-  consumers and a zoneless canary spec. Remaining in **Phase 2**: clusters
-  2.2–2.9 in the suggested order (next up: 2.2 stats / picker modals). Note 2.3's
-  center-panel *state* shipped with 1.2, but 2.3 still owes `image-viewer` (window
-  drag/key handlers + shake + its `ResizeObserver` rendered-size writes) and a
-  check that `video-player` is DOM-only. Then the prod flip (Phase 3), human
-  browser QA (Phase 4), and cleanup (Phase 5).
+- **Phase 1 complete; Phases 2.1 + 2.2 shipped; Phases 2.3–5 remain.** Shipped so
+  far: Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService
+  SSE pump + ConnectionStateService + BrowseSelectionService signalized) and 1.2
+  (KeyboardService de-zoned + the coupled center-panel state signalized); Phase
+  2.1 (leaf utility components — toast-container, clipboard-copy, voting-overlay,
+  dialog-host + VtDialogService, browse-legend); and **Phase 2.2** (stats / picker
+  modals), each with its consumers and a zoneless canary spec. Remaining in
+  **Phase 2**: clusters 2.3–2.9 in the suggested order (next up: 2.3 center-panel
+  *viewers* — note the center-panel *state* shipped with 1.2, but 2.3 still owes
+  `image-viewer` (window drag/key handlers + shake + its `ResizeObserver`
+  rendered-size writes) and a check that `video-player` is DOM-only). Then the
+  prod flip (Phase 3), human browser QA (Phase 4), and cleanup (Phase 5).
+- **What Phase 2.2 covered.** `find-stats`/`detector-stats`/`dataset-stats`:
+  `loading`/`error`/`stats` plain fields → signals (templates read them via
+  `@else if (stats(); as stats)` so the bodies were untouched); the stat-derived
+  getters now read `stats()`. `label-importer-modal`: moved the list read onto an
+  eager `rxResource` (mirroring `settings-importer`), and signalized every
+  subscribe-written template field (`submitting`, `error` via an `importError`
+  signal merged with the resource error, `successMessage`, `addingGood`,
+  `addingBad`, and the three `dynamicFieldOptions`/`Loading`/`Error` dicts via
+  `signal<Record<…>>` + `.update`). `settings-importer`/`settings-exporter`/
+  `label-exporter` were already on `rxResource`+signals from the httpresource work;
+  Phase 2.2 finished them by signalizing `submitting`/`successMessage`. New
+  zoneless DOM-canary specs added for all three stats modals + the two settings
+  modals; the existing `label-importer`/`label-exporter` specs migrated to the
+  zoneless `TestBed` (no manual `detectChanges`). **rxResource test gotcha:** a
+  loading `rxResource` holds the app *unstable*, so `await fixture.whenStable()`
+  before flushing the GET deadlocks — the rxResource specs issue the GET with
+  `TestBed.tick()` then `settleResource()` instead (a plain `ngOnInit` HTTP
+  subscribe does *not* block `whenStable`, so the stats specs use it freely).
+- **`setTimeout(close)` finding — Recipe D caveat corrected for template-bound
+  outputs.** The four `setTimeout(() => this.close())` auto-close paths
+  (`settings-importer`, `label-importer`, `settings-exporter`, …) needed **no**
+  rework: `close()` emits a bound `output()`, and a parent's `(closed)="…"` is a
+  *bound template listener*, which is on the zoneless notification path — so the
+  emit schedules the parent's CD and its `@if` gate drops the modal even though
+  the emit fired from an unpatched timer. Proven by a new framework canary,
+  `frontend/src/app/testing/output-emit-zoneless.spec.ts`. Recipe D's warning that
+  "a bare `output()` emit from an unpatched callback will not schedule the
+  parent's CD" holds only for an output the parent subscribes to **imperatively**
+  in TS (a raw callback), *not* for a template `(event)` binding. So only the
+  components' own template-bound state (`submitting`/`successMessage`/…) was
+  signalized; the timer-driven close was left as-is.
 - **Full consumer specs for the browse cluster.** Phase 1.4 added a service unit
   spec + a signal-driven canary, but `browse-canvas`, `browse-bin-popup`, and
   `browse-selection-panel` still have **no** component specs (they are heavy to

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -1,9 +1,9 @@
 <vt-modal [open]="true" [title]="'Stats: ' + datasetName()" (closed)="close()">
-  @if (loading) {
+  @if (loading()) {
     <p class="loading-text">Loading stats...</p>
-  } @else if (error) {
-    <p class="error-text">{{ error }}</p>
-  } @else if (stats) {
+  } @else if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  } @else if (stats(); as stats) {
     <table class="stats-table">
       <tbody>
         <tr>

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DatasetStatsModalComponent } from './dataset-stats-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+describe('DatasetStatsModalComponent', () => {
+  let component: DatasetStatsModalComponent;
+  let fixture: ComponentFixture<DatasetStatsModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockStats = {
+    num_items: 100,
+    num_dupes: 3,
+    ingest_started_at: 1700000000,
+    ingest_finished_at: 1700000075,
+    clipper: 'whole',
+    embedder: 'clap',
+    file_type_counts: { wav: 80, mp3: 20 },
+    source: { importer: 'server_folder', params: { path: '/data', media_type: 'audio' } },
+  };
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [DatasetStatsModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetStatsModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('datasetId', 'ds1');
+    fixture.componentRef.setInput('datasetName', 'My Dataset');
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+    expect(component).toBeTruthy();
+  });
+
+  // Zoneless staleness canary: the stats land in an HTTP subscribe (an unpatched
+  // callback) and repaint only because `loading`/`stats` are signals read in the
+  // template. Flush the GET and assert the loaded table renders with no manual
+  // `detectChanges`.
+  it('repaints from loading to the loaded table (zoneless canary)', async () => {
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeTruthy();
+
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeFalsy();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('server_folder'); // importerName
+    expect(text).toContain('1m 15s'); // duration getter
+  });
+
+  it('repaints the error text on a failed load (zoneless canary)', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(
+      { error: 'gone' },
+      { status: 404, statusText: 'Not Found' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('gone');
+  });
+});

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output } from '@angular/core';
+import { Component, OnInit, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
@@ -19,19 +19,21 @@ export class DatasetStatsModalComponent implements OnInit {
   readonly datasetName = input('');
   readonly closed = output<void>();
 
-  loading = true;
-  error = '';
-  stats: DatasetRegistryStatsResponse | null = null;
+  // Signalized so the `ngOnInit` subscribe (an unpatched callback under zoneless)
+  // schedules CD when the stats land. See docs/plans/zoneless-migration.md.
+  readonly loading = signal(true);
+  readonly error = signal('');
+  readonly stats = signal<DatasetRegistryStatsResponse | null>(null);
 
   ngOnInit(): void {
     this.datasetsRegistryApi.getDatasetStats(this.datasetId()).subscribe({
       next: (data) => {
-        this.stats = data;
-        this.loading = false;
+        this.stats.set(data);
+        this.loading.set(false);
       },
       error: (err) => {
-        this.error = err.error?.error || 'Failed to load stats';
-        this.loading = false;
+        this.error.set(err.error?.error || 'Failed to load stats');
+        this.loading.set(false);
       },
     });
   }
@@ -41,19 +43,20 @@ export class DatasetStatsModalComponent implements OnInit {
   }
 
   get fileTypes(): { ext: string; count: number }[] {
-    if (!this.stats?.file_type_counts) return [];
-    return Object.entries(this.stats.file_type_counts)
+    const counts = this.stats()?.file_type_counts;
+    if (!counts) return [];
+    return Object.entries(counts)
       .sort(([, a], [, b]) => b - a)
       .map(([ext, count]) => ({ ext, count }));
   }
 
   get importerName(): string {
-    const src = this.stats?.source as { importer?: string } | undefined;
+    const src = this.stats()?.source as { importer?: string } | undefined;
     return src?.importer || '';
   }
 
   get originParams(): { key: string; label: string; value: string }[] {
-    const src = this.stats?.source as { params?: Record<string, unknown> } | undefined;
+    const src = this.stats()?.source as { params?: Record<string, unknown> } | undefined;
     const params = src?.params;
     if (!params) return [];
     return Object.entries(params)
@@ -75,8 +78,9 @@ export class DatasetStatsModalComponent implements OnInit {
   }
 
   get duration(): string {
-    if (!this.stats?.ingest_started_at || !this.stats?.ingest_finished_at) return '-';
-    const seconds = Math.round(this.stats.ingest_finished_at - this.stats.ingest_started_at);
+    const s = this.stats();
+    if (!s?.ingest_started_at || !s?.ingest_finished_at) return '-';
+    const seconds = Math.round(s.ingest_finished_at - s.ingest_started_at);
     if (seconds < 60) return `${seconds}s`;
     const minutes = Math.floor(seconds / 60);
     const secs = seconds % 60;

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
@@ -1,9 +1,9 @@
 <vt-modal [open]="true" [title]="'Stats: ' + detectorName()" (closed)="close()">
-  @if (loading) {
+  @if (loading()) {
     <p class="loading-text">Loading stats...</p>
-  } @else if (error) {
-    <p class="error-text">{{ error }}</p>
-  } @else if (stats) {
+  } @else if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  } @else if (stats(); as stats) {
     <table class="stats-table">
       <tbody>
         <tr>

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DetectorStatsModalComponent } from './detector-stats-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+describe('DetectorStatsModalComponent', () => {
+  let component: DetectorStatsModalComponent;
+  let fixture: ComponentFixture<DetectorStatsModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockStats = {
+    num_positive: 12,
+    num_positive_resolved: 10,
+    num_negative: 8,
+    num_total: 20,
+    active_dataset_name: 'My Dataset',
+    media_type: 'audio',
+    embedder: 'clap',
+    clipper: 'whole',
+    text_query: '',
+    media_example: '',
+    created_at: 1700000000,
+    last_trained_at: 1700000100,
+    created_by: 'sam',
+    autofind: false,
+    readers: [],
+  };
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [DetectorStatsModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DetectorStatsModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('detectorId', 'det1');
+    fixture.componentRef.setInput('detectorName', 'My Detector');
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/detectors/registry/det1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+    expect(component).toBeTruthy();
+  });
+
+  // Zoneless staleness canary: the stats land in an HTTP subscribe (an unpatched
+  // callback) and repaint only because `loading`/`stats` are signals read in the
+  // template. Flush the GET and assert the loaded table renders with no manual
+  // `detectChanges`.
+  it('repaints from loading to the loaded table (zoneless canary)', async () => {
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeTruthy();
+
+    httpMock.expectOne('/api/detectors/registry/det1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeFalsy();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('10 of 12 in "My Dataset"'); // resolvedSummary
+  });
+
+  it('repaints the error text on a failed load (zoneless canary)', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/detectors/registry/det1/stats').flush(
+      { error: 'gone' },
+      { status: 404, statusText: 'Not Found' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('gone');
+  });
+});

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output } from '@angular/core';
+import { Component, OnInit, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsRegistryApiService } from '../../../services/detectors-registry-api.service';
@@ -24,19 +24,21 @@ export class DetectorStatsModalComponent implements OnInit {
   readonly detectorName = input('');
   readonly closed = output<void>();
 
-  loading = true;
-  error = '';
-  stats: DetectorRegistryStatsResponse | null = null;
+  // Signalized so the `ngOnInit` subscribe (an unpatched callback under zoneless)
+  // schedules CD when the stats land. See docs/plans/zoneless-migration.md.
+  readonly loading = signal(true);
+  readonly error = signal('');
+  readonly stats = signal<DetectorRegistryStatsResponse | null>(null);
 
   ngOnInit(): void {
     this.detectorsRegistryApi.getDetectorStats(this.detectorId()).subscribe({
       next: (data) => {
-        this.stats = data;
-        this.loading = false;
+        this.stats.set(data);
+        this.loading.set(false);
       },
       error: (err) => {
-        this.error = err.error?.error || err.error?.message || 'Failed to load stats';
-        this.loading = false;
+        this.error.set(err.error?.error || err.error?.message || 'Failed to load stats');
+        this.loading.set(false);
       },
     });
   }
@@ -52,7 +54,7 @@ export class DetectorStatsModalComponent implements OnInit {
   /** "N of M (in \"dataset\")" for the resolved-positives row, or a hint
    *  when no dataset is loaded to resolve against. */
   get resolvedSummary(): string {
-    const s = this.stats;
+    const s = this.stats();
     if (!s) return '-';
     if (!s.active_dataset_name) return 'No dataset loaded';
     return `${s.num_positive_resolved} of ${s.num_positive} in "${s.active_dataset_name}"`;

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -1,9 +1,9 @@
 <vt-modal [open]="true" title="Detector Stats" (closed)="close()">
-  @if (loading) {
+  @if (loading()) {
     <p class="loading-text">Loading stats…</p>
-  } @else if (error) {
-    <p class="error-text">{{ error }}</p>
-  } @else if (stats) {
+  } @else if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  } @else if (stats(); as stats) {
     @if (stats.stale) {
       <p class="stale-note" role="note">
         ⚠ Out of date: these numbers evaluate the detector <strong>before</strong> your last corrections were added.

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { FindStatsModalComponent } from './find-stats-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+describe('FindStatsModalComponent', () => {
+  let component: FindStatsModalComponent;
+  let fixture: ComponentFixture<FindStatsModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockStats = {
+    stale: false,
+    total_good: 40,
+    total_bad: 60,
+    verified_count: 12,
+    confirmed_good: 30,
+    rescued_false_neg: 4,
+    culled_false_pos: 5,
+    confirmed_bad: 50,
+    agreements: 90,
+    corrections: 10,
+    agreement_rate: 0.9,
+    precision: 0.85,
+    inclusion: 0,
+    sweep: [
+      { inclusion: -10, false_pos: 1, false_neg: 9 },
+      { inclusion: 0, false_pos: 5, false_neg: 5 },
+      { inclusion: 10, false_pos: 9, false_neg: 1 },
+    ],
+  };
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [FindStatsModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FindStatsModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/find/stats').flush(mockStats);
+    await settleZoneless(fixture);
+    expect(component).toBeTruthy();
+  });
+
+  // Zoneless staleness canary: the stats land in an HTTP subscribe (an unpatched
+  // callback). The table repaints only because `loading`/`stats` are signals read
+  // in the template. Flush the GET and assert the loaded DOM renders with no
+  // manual `detectChanges`.
+  it('repaints from loading to the loaded table (zoneless canary)', async () => {
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeTruthy();
+
+    httpMock.expectOne('/api/find/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.loading-text')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('.fpfn-chart')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('90%'); // agreement rate
+  });
+
+  it('repaints the error text on a failed load (zoneless canary)', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/find/stats').flush(
+      { error: 'no find run' },
+      { status: 404, statusText: 'Not Found' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('no find run');
+  });
+
+  it('emits closed on close', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/find/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    vi.spyOn(component.closed, 'emit');
+    component.close();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, output } from '@angular/core';
+import { Component, OnInit, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsFindApiService } from '../../../services/detectors-find-api.service';
@@ -31,9 +31,11 @@ export class FindStatsModalComponent implements OnInit {
 
   readonly closed = output<void>();
 
-  loading = true;
-  error = '';
-  stats: FindStatsResponse | null = null;
+  // Signalized so the `ngOnInit` subscribe (an unpatched callback under zoneless)
+  // schedules CD when the stats land. See docs/plans/zoneless-migration.md.
+  readonly loading = signal(true);
+  readonly error = signal('');
+  readonly stats = signal<FindStatsResponse | null>(null);
 
   // Chart geometry (SVG user units; the viewBox scales to the container width).
   readonly chartWidth = 320;
@@ -46,12 +48,12 @@ export class FindStatsModalComponent implements OnInit {
   ngOnInit(): void {
     this.findApi.getFindStats().subscribe({
       next: (data) => {
-        this.stats = data;
-        this.loading = false;
+        this.stats.set(data);
+        this.loading.set(false);
       },
       error: (err) => {
-        this.error = err?.error?.error || err?.error?.message || 'Failed to load stats';
-        this.loading = false;
+        this.error.set(err?.error?.error || err?.error?.message || 'Failed to load stats');
+        this.loading.set(false);
       },
     });
   }
@@ -61,11 +63,13 @@ export class FindStatsModalComponent implements OnInit {
   }
 
   get agreementPct(): string {
-    return this.stats ? `${Math.round(this.stats.agreement_rate * 100)}%` : '-';
+    const s = this.stats();
+    return s ? `${Math.round(s.agreement_rate * 100)}%` : '-';
   }
 
   get precisionPct(): string {
-    return this.stats ? `${Math.round(this.stats.precision * 100)}%` : '-';
+    const s = this.stats();
+    return s ? `${Math.round(s.precision * 100)}%` : '-';
   }
 
   // --- FP/FN-vs-inclusion chart -------------------------------------------
@@ -80,9 +84,10 @@ export class FindStatsModalComponent implements OnInit {
 
   /** Largest FP/FN count in the sweep; the chart's y-axis top (min 1). */
   get maxCount(): number {
-    if (!this.stats) return 1;
+    const s = this.stats();
+    if (!s) return 1;
     let m = 1;
-    for (const p of this.stats.sweep) {
+    for (const p of s.sweep) {
       m = Math.max(m, p.false_pos, p.false_neg);
     }
     return m;
@@ -97,8 +102,9 @@ export class FindStatsModalComponent implements OnInit {
   }
 
   get points(): ChartPoint[] {
-    if (!this.stats) return [];
-    return this.stats.sweep.map((p) => ({
+    const s = this.stats();
+    if (!s) return [];
+    return s.sweep.map((p) => ({
       inclusion: p.inclusion,
       x: this.xFor(p.inclusion),
       yFp: this.yFor(p.false_pos),
@@ -116,7 +122,8 @@ export class FindStatsModalComponent implements OnInit {
 
   /** X position of the current-inclusion marker line. */
   get currentX(): number {
-    return this.stats ? this.xFor(this.stats.inclusion) : 0;
+    const s = this.stats();
+    return s ? this.xFor(s.inclusion) : 0;
   }
 
   get axisTop(): number {

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
@@ -2,7 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LabelExporterModalComponent } from './label-exporter-modal.component';
-import { settleResource } from '../../../testing/settle-resource';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 
 describe('LabelExporterModalComponent', () => {
   let component: LabelExporterModalComponent;
@@ -15,7 +16,7 @@ describe('LabelExporterModalComponent', () => {
   ];
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    await configureZoneless({
       imports: [LabelExporterModalComponent],
       providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
@@ -29,14 +30,14 @@ describe('LabelExporterModalComponent', () => {
     httpMock.verify();
   });
 
-  // The exporter list now rides an eager `rxResource`, whose loader runs in a
-  // root effect rather than during `detectChanges()`; tick to issue the GET,
-  // then settle so the resolved value commits before assertions.
+  // The exporter list rides an eager `rxResource` whose loader runs in a root
+  // effect. Let the initial scheduled CD run the loader (no manual
+  // `detectChanges`), flush the GET, then settle so the resolved value commits.
   async function flushInit(): Promise<void> {
-    fixture.detectChanges();
-    TestBed.tick();
+    await fixture.whenStable();
     httpMock.expectOne('/api/exporters').flush(mockExporters);
     await settleResource();
+    await fixture.whenStable();
   }
 
   it('should create', async () => {
@@ -82,7 +83,6 @@ describe('LabelExporterModalComponent', () => {
 
   it('should render exporter cards', async () => {
     await flushInit();
-    fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
     const cards = el.querySelectorAll('.exporter-card');
     expect(cards.length).toBe(2);
@@ -93,5 +93,24 @@ describe('LabelExporterModalComponent', () => {
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
+  });
+
+  // Zoneless staleness canary: a failed labels fetch lands in an HTTP subscribe
+  // (an unpatched callback). It repaints only because `exportError` (merged into
+  // the `error` computed) is a signal read in the template. Drive the failure and
+  // assert the error text renders with no manual `detectChanges`.
+  it('repaints the error text after a failed export (zoneless canary)', async () => {
+    await flushInit();
+
+    component.selectExporter(mockExporters[0] as any);
+    httpMock.expectOne('/api/labels/export').flush(
+      { error: 'nope' },
+      { status: 500, statusText: 'Server Error' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('Failed to fetch labels');
   });
 });

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
@@ -31,13 +31,14 @@ describe('LabelExporterModalComponent', () => {
   });
 
   // The exporter list rides an eager `rxResource` whose loader runs in a root
-  // effect. Let the initial scheduled CD run the loader (no manual
-  // `detectChanges`), flush the GET, then settle so the resolved value commits.
+  // effect. `TestBed.tick()` runs that effect to issue the GET — `whenStable()`
+  // can't be used here: a loading `rxResource` holds the app unstable, so it
+  // would deadlock waiting for the flush. After flushing, `settleResource()`
+  // commits the resolved value (microtask + tick) with no manual `detectChanges`.
   async function flushInit(): Promise<void> {
-    await fixture.whenStable();
+    TestBed.tick();
     httpMock.expectOne('/api/exporters').flush(mockExporters);
     await settleResource();
-    await fixture.whenStable();
   }
 
   it('should create', async () => {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -1,12 +1,12 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="importer-picker">
-      @if (loading) {
+      @if (loading()) {
         <p class="empty-state">Loading importers...</p>
-      } @else if (importers.length === 0) {
+      } @else if (importers().length === 0) {
         <p class="empty-state">No label importers available.</p>
       } @else {
-        @for (imp of importers; track imp.name) {
+        @for (imp of importers(); track imp.name) {
           <button class="importer-card" (click)="selectImporter(imp)">
             <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
             @if (imp.description) {
@@ -29,11 +29,11 @@
         />
         <button
           class="btn btn-add-bad"
-          [disabled]="addingBad"
+          [disabled]="addingBad()"
           (click)="triggerAddBad()"
           title="Upload a media file and add it to the Bad pile."
         >
-          {{ addingBad ? 'Adding to Bad pile…' : 'Add media to Bad' }}
+          {{ addingBad() ? 'Adding to Bad pile…' : 'Add media to Bad' }}
         </button>
         <input
           #addGoodInput
@@ -43,21 +43,21 @@
         />
         <button
           class="btn btn-add-good"
-          [disabled]="addingGood"
+          [disabled]="addingGood()"
           (click)="triggerAddGood()"
           title="Upload a media file and add it to the Good pile."
         >
-          {{ addingGood ? 'Adding to Good pile…' : 'Add media to Good' }}
+          {{ addingGood() ? 'Adding to Good pile…' : 'Add media to Good' }}
         </button>
       </div>
     </div>
     }
 
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
+    @if (error()) {
+      <p class="error-text">{{ error() }}</p>
     }
-    @if (successMessage) {
-      <p class="success-text">{{ successMessage }}</p>
+    @if (successMessage()) {
+      <p class="success-text">{{ successMessage() }}</p>
     }
   }
 
@@ -125,19 +125,19 @@
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
                 (ngModelChange)="onFormFieldChanged(field.key)"
-                [disabled]="!!dynamicFieldLoading[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
+                [disabled]="!!dynamicFieldLoading()[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
               >
-                @if (field.dynamic_options && dynamicFieldLoading[field.key]) {
+                @if (field.dynamic_options && dynamicFieldLoading()[field.key]) {
                   <option value="">Loading…</option>
-                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError[field.key]) {
+                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError()[field.key]) {
                   <option value="">No options available</option>
                 }
                 @for (opt of optionsFor(field); track opt) {
                   <option [value]="opt">{{ opt }}</option>
                 }
               </select>
-              @if (field.dynamic_options && dynamicFieldError[field.key]) {
-                <p class="error-text">{{ dynamicFieldError[field.key] }}</p>
+              @if (field.dynamic_options && dynamicFieldError()[field.key]) {
+                <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
               }
             } @else if (field.field_type === 'number') {
               <input
@@ -165,18 +165,18 @@
         <p class="info-text">This importer requires no additional configuration.</p>
       }
 
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
+      @if (error()) {
+        <p class="error-text">{{ error() }}</p>
       }
-      @if (successMessage) {
-        <p class="success-text">{{ successMessage }}</p>
+      @if (successMessage()) {
+        <p class="success-text">{{ successMessage() }}</p>
       }
 
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
-        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-          @if (submitting) {
+        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          @if (submitting()) {
             Importing labels from {{ selectedImporter.display_name || selectedImporter.name }}…
           } @else {
             Import

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -41,13 +41,14 @@ describe('LabelImporterModalComponent', () => {
   });
 
   // The importer list rides an eager `rxResource` whose loader runs in a root
-  // effect. Let the initial scheduled CD run the loader (no manual
-  // `detectChanges`), flush the GET, then settle so the resolved value commits.
+  // effect. `TestBed.tick()` runs that effect to issue the GET — `whenStable()`
+  // can't be used here: a loading `rxResource` holds the app unstable, so it
+  // would deadlock waiting for the flush. After flushing, `settleResource()`
+  // commits the resolved value (microtask + tick) with no manual `detectChanges`.
   async function flushInit(): Promise<void> {
-    await fixture.whenStable();
+    TestBed.tick();
     httpMock.expectOne('/api/label-importers').flush(mockImporters);
     await settleResource();
-    await fixture.whenStable();
   }
 
   it('should create', async () => {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LabelImporterModalComponent } from './label-importer-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 
 describe('LabelImporterModalComponent', () => {
   let component: LabelImporterModalComponent;
@@ -24,7 +26,7 @@ describe('LabelImporterModalComponent', () => {
   ];
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    await configureZoneless({
       imports: [LabelImporterModalComponent],
       providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
@@ -38,43 +40,48 @@ describe('LabelImporterModalComponent', () => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
-    fixture.detectChanges();
+  // The importer list rides an eager `rxResource` whose loader runs in a root
+  // effect. Let the initial scheduled CD run the loader (no manual
+  // `detectChanges`), flush the GET, then settle so the resolved value commits.
+  async function flushInit(): Promise<void> {
+    await fixture.whenStable();
     httpMock.expectOne('/api/label-importers').flush(mockImporters);
+    await settleResource();
+    await fixture.whenStable();
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should fetch importers on init', () => {
-    flushInit();
-    expect(component.importers.length).toBe(2);
+  it('should fetch importers on init', async () => {
+    await flushInit();
+    expect(component.importers().length).toBe(2);
   });
 
-  it('should start in picker view', () => {
-    flushInit();
+  it('should start in picker view', async () => {
+    await flushInit();
     expect(component.view).toBe('picker');
   });
 
-  it('should switch to form view on selection', () => {
-    flushInit();
+  it('should switch to form view on selection', async () => {
+    await flushInit();
     component.selectImporter(mockImporters[0] as any);
     expect(component.view).toBe('form');
     expect(component.selectedImporter!.name).toBe('server_json_file');
   });
 
-  it('should go back to picker', () => {
-    flushInit();
+  it('should go back to picker', async () => {
+    await flushInit();
     component.selectImporter(mockImporters[0] as any);
     component.back();
     expect(component.view).toBe('picker');
     expect(component.selectedImporter).toBeNull();
   });
 
-  it('should submit form and emit imported', () => {
-    flushInit();
+  it('should submit form and emit imported', async () => {
+    await flushInit();
     vi.spyOn(component.imported, 'emit');
     component.selectImporter(mockImporters[0] as any);
     component.formValues['filepath'] = '/data/labels.json';
@@ -84,12 +91,14 @@ describe('LabelImporterModalComponent', () => {
     expect(req.request.method).toBe('POST');
     req.flush({ applied: 5, message: 'Applied 5 labels' });
 
-    expect(component.submitting).toBe(false);
+    expect(component.submitting()).toBe(false);
     expect(component.imported.emit).toHaveBeenCalled();
+    // The post-success auto-close timer must not leak past the test.
+    component.close();
   });
 
-  it('should show error on import failure', () => {
-    flushInit();
+  it('should show error on import failure', async () => {
+    await flushInit();
     component.selectImporter(mockImporters[0] as any);
     component.submit();
 
@@ -98,27 +107,25 @@ describe('LabelImporterModalComponent', () => {
       { status: 404, statusText: 'Not Found' },
     );
 
-    expect(component.error).toBe('File not found');
+    expect(component.error()).toBe('File not found');
   });
 
-  it('should render importer cards', () => {
-    flushInit();
-    fixture.detectChanges();
+  it('should render importer cards', async () => {
+    await flushInit();
     const el = fixture.nativeElement as HTMLElement;
     const cards = el.querySelectorAll('.importer-card');
     expect(cards.length).toBe(2);
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render Add media to Good and Add media to Bad buttons in picker view', () => {
-    flushInit();
-    fixture.detectChanges();
+  it('should render Add media to Good and Add media to Bad buttons in picker view', async () => {
+    await flushInit();
     const el = fixture.nativeElement as HTMLElement;
     const addGoodBtn = el.querySelector('.btn-add-good');
     const addBadBtn = el.querySelector('.btn-add-bad');
@@ -128,10 +135,31 @@ describe('LabelImporterModalComponent', () => {
     expect(addBadBtn!.textContent!.trim()).toBe('Add media to Bad');
   });
 
-  it('should have hidden file inputs for add-to-pile', () => {
-    flushInit();
-    fixture.detectChanges();
+  it('should have hidden file inputs for add-to-pile', async () => {
+    await flushInit();
     const hiddenInputs = fixture.nativeElement.querySelectorAll('.hidden-file-input');
     expect(hiddenInputs.length).toBe(2);
+  });
+
+  // Zoneless staleness canary: the submit error lands in an HTTP subscribe — an
+  // unpatched callback under zoneless. It repaints only because `importError`
+  // (merged into the `error` computed) is a signal read in the template. Drive a
+  // failed import and assert the error text renders with no manual
+  // `detectChanges`.
+  it('repaints the error text after a failed import (zoneless canary)', async () => {
+    await flushInit();
+    component.selectImporter(mockImporters[0] as any);
+    await settleZoneless(fixture);
+
+    component.submit();
+    httpMock.expectOne('/api/label-importers/import/server_json_file').flush(
+      { error: 'Import blew up' },
+      { status: 500, statusText: 'Server Error' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('Import blew up');
   });
 });

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -1,4 +1,15 @@
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild, inject, input, output } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  ViewChild,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -19,7 +30,7 @@ type ModalView = 'picker' | 'form';
   templateUrl: './label-importer-modal.component.html',
   styleUrl: './label-importer-modal.component.scss',
 })
-export class LabelImporterModalComponent implements OnInit, OnDestroy {
+export class LabelImporterModalComponent implements OnDestroy {
   private labelImportersApi = inject(LabelImportersApiService);
   private mediasApi = inject(MediasApiService);
   private voteState = inject(VoteStateService);
@@ -35,20 +46,41 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
   @ViewChild('addBadInput') addBadInput!: ElementRef<HTMLInputElement>;
 
   view: ModalView = 'picker';
-  importers: LabelImporterEntry[] = [];
-  loading = true;
+
+  // Eager `rxResource`: loads the label-importer list once on creation, wrapping
+  // the generated-client read so the interceptor chain still applies. Mirrors the
+  // settings-importer modal; replaces the old `ngOnInit` subscribe so the list
+  // commits via a signal (schedules CD under zoneless).
+  private readonly importersResource = rxResource({
+    stream: () => this.labelImportersApi.list(),
+  });
+  readonly importers = computed<LabelImporterEntry[]>(() =>
+    (this.importersResource.value() ?? []).filter((imp) => !imp.hidden_from_picker),
+  );
+  readonly loading = computed(() => this.importersResource.isLoading());
+
   selectedImporter: LabelImporterEntry | null = null;
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
   selectedFileFieldKey: string | null = null;
-  submitting = false;
-  error = '';
-  successMessage = '';
-  dynamicFieldOptions: Record<string, string[]> = {};
-  dynamicFieldLoading: Record<string, boolean> = {};
-  dynamicFieldError: Record<string, string> = {};
-  addingGood = false;
-  addingBad = false;
+  // Mutation-result state, signalized so the submit/add-to-pile subscribes (and
+  // the dynamic-field-option fetches) — all unpatched callbacks under zoneless —
+  // schedule CD when they land. See docs/plans/zoneless-migration.md.
+  readonly submitting = signal(false);
+
+  /** Error from a failed import action; the list-load failure is merged in. */
+  private readonly importError = signal('');
+  readonly error = computed(
+    () =>
+      this.importError() ||
+      (this.importersResource.error() ? 'Failed to load label importers' : ''),
+  );
+  readonly successMessage = signal('');
+  readonly dynamicFieldOptions = signal<Record<string, string[]>>({});
+  readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
+  readonly dynamicFieldError = signal<Record<string, string>>({});
+  readonly addingGood = signal(false);
+  readonly addingBad = signal(false);
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -66,29 +98,16 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
     return (this.selectedImporter?.fields ?? []) as ImporterField[];
   }
 
-  ngOnInit(): void {
-    this.labelImportersApi.list().subscribe({
-      next: (list) => {
-        this.importers = list.filter((imp) => !imp.hidden_from_picker);
-        this.loading = false;
-      },
-      error: () => {
-        this.loading = false;
-        this.error = 'Failed to load label importers';
-      },
-    });
-  }
-
   selectImporter(importer: LabelImporterEntry): void {
     this.selectedImporter = importer;
     this.formValues = {};
     this.selectedFile = null;
     this.selectedFileFieldKey = null;
-    this.error = '';
-    this.successMessage = '';
-    this.dynamicFieldOptions = {};
-    this.dynamicFieldLoading = {};
-    this.dynamicFieldError = {};
+    this.importError.set('');
+    this.successMessage.set('');
+    this.dynamicFieldOptions.set({});
+    this.dynamicFieldLoading.set({});
+    this.dynamicFieldError.set({});
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -122,7 +141,7 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
 
   optionsFor(field: ImporterField): string[] {
     if (field.dynamic_options) {
-      return this.dynamicFieldOptions[field.key] || [];
+      return this.dynamicFieldOptions()[field.key] || [];
     }
     return field.options || [];
   }
@@ -131,26 +150,30 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
     const importer = this.selectedImporter;
     if (!importer) return;
     const key = field.key;
-    this.dynamicFieldLoading[key] = true;
-    this.dynamicFieldError[key] = '';
+    this.dynamicFieldLoading.update((m) => ({ ...m, [key]: true }));
+    this.dynamicFieldError.update((m) => ({ ...m, [key]: '' }));
     this.labelImportersApi
       .getFieldOptions(importer.name, key, { ...this.formValues })
       .subscribe({
         next: (res) => {
-          this.dynamicFieldOptions[key] = res.options || [];
-          this.dynamicFieldLoading[key] = false;
+          const options = res.options || [];
+          this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
+          this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
           const current = this.formValues[key];
-          if (current && !this.dynamicFieldOptions[key].includes(String(current))) {
+          if (current && !options.includes(String(current))) {
             this.formValues[key] = '';
           }
-          if (!this.formValues[key] && field.required && this.dynamicFieldOptions[key].length > 0) {
-            this.formValues[key] = this.dynamicFieldOptions[key][0];
+          if (!this.formValues[key] && field.required && options.length > 0) {
+            this.formValues[key] = options[0];
           }
         },
         error: (err) => {
-          this.dynamicFieldLoading[key] = false;
-          this.dynamicFieldError[key] = err?.error?.error || 'Could not load options';
-          this.dynamicFieldOptions[key] = [];
+          this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
+          this.dynamicFieldError.update((m) => ({
+            ...m,
+            [key]: err?.error?.error || 'Could not load options',
+          }));
+          this.dynamicFieldOptions.update((m) => ({ ...m, [key]: [] }));
         },
       });
   }
@@ -158,8 +181,8 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
   back(): void {
     this.view = 'picker';
     this.selectedImporter = null;
-    this.error = '';
-    this.successMessage = '';
+    this.importError.set('');
+    this.successMessage.set('');
   }
 
   onFileSelected(event: Event, fieldName: string): void {
@@ -173,9 +196,9 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
 
   submit(): void {
     if (!this.selectedImporter) return;
-    this.submitting = true;
-    this.error = '';
-    this.successMessage = '';
+    this.submitting.set(true);
+    this.importError.set('');
+    this.successMessage.set('');
 
     const targetModelName = this.targetModelName();
     const request$ = targetModelName
@@ -195,26 +218,30 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
 
     request$.subscribe({
       next: (res: any) => {
-        this.submitting = false;
-        this.successMessage = res.message || `Applied ${res.applied ?? 0} labels`;
+        this.submitting.set(false);
+        this.successMessage.set(res.message || `Applied ${res.applied ?? 0} labels`);
         this.imported.emit();
 
         if (res.missing_count > 0 && res.missing?.length) {
           // Show unresolved elements as a warning but don't prompt; the
           // backend already tried to auto-resolve them.
-          this.error = `${res.missing_count} element(s) could not be resolved from their original sources.`;
+          this.importError.set(
+            `${res.missing_count} element(s) could not be resolved from their original sources.`,
+          );
         } else if (res.failed_count > 0) {
           // Per-entry application failures (logical-bug-audit H31); the
           // import partially landed and the user should know which entries
           // need to be retried.
-          this.error = `${res.failed_count} element(s) failed to apply. The remaining labels were applied successfully.`;
+          this.importError.set(
+            `${res.failed_count} element(s) failed to apply. The remaining labels were applied successfully.`,
+          );
         }
         const hasIssue = res.missing_count > 0 || res.failed_count > 0;
         this.closeTimer = setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
       },
       error: (err) => {
-        this.submitting = false;
-        this.error = err.error?.error || 'Import failed';
+        this.submitting.set(false);
+        this.importError.set(err.error?.error || 'Import failed');
       },
     });
   }
@@ -235,31 +262,31 @@ export class LabelImporterModalComponent implements OnInit, OnDestroy {
     input.value = '';
 
     if (label === 'good') {
-      this.addingGood = true;
+      this.addingGood.set(true);
     } else {
-      this.addingBad = true;
+      this.addingBad.set(true);
     }
-    this.error = '';
-    this.successMessage = '';
+    this.importError.set('');
+    this.successMessage.set('');
 
     this.mediasApi.addToPile(file, label).subscribe({
       next: (result) => {
         const action = result.is_new ? 'Added new media' : 'Matched existing media';
-        this.successMessage = `${action} to ${label} pile.`;
+        this.successMessage.set(`${action} to ${label} pile.`);
         this.voteState.loadVotes();
         this.imported.emit();
         if (label === 'good') {
-          this.addingGood = false;
+          this.addingGood.set(false);
         } else {
-          this.addingBad = false;
+          this.addingBad.set(false);
         }
       },
       error: (err) => {
-        this.error = err.error?.error || `Failed to add media to ${label} pile`;
+        this.importError.set(err.error?.error || `Failed to add media to ${label} pile`);
         if (label === 'good') {
-          this.addingGood = false;
+          this.addingGood.set(false);
         } else {
-          this.addingBad = false;
+          this.addingBad.set(false);
         }
       },
     });

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -20,8 +20,8 @@
     @if (error()) {
       <p class="error-text">{{ error() }}</p>
     }
-    @if (successMessage) {
-      <p class="success-text">{{ successMessage }}</p>
+    @if (successMessage()) {
+      <p class="success-text">{{ successMessage() }}</p>
     }
   }
 
@@ -84,7 +84,7 @@
           </div>
         }
       } @else {
-        @if (!submitting && !successMessage) {
+        @if (!submitting() && !successMessage()) {
           <p class="info-text">This exporter requires no additional configuration.</p>
         }
       }
@@ -92,15 +92,15 @@
       @if (error()) {
         <p class="error-text">{{ error() }}</p>
       }
-      @if (successMessage) {
-        <p class="success-text">{{ successMessage }}</p>
+      @if (successMessage()) {
+        <p class="success-text">{{ successMessage() }}</p>
       }
 
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
-        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
-          @if (submitting) {
+        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
+          @if (submitting()) {
             Exporting...
           } @else {
             Export

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { SettingsExporterModalComponent } from './settings-exporter-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleResource, settleZoneless } from '../../../testing/settle-resource';
+
+describe('SettingsExporterModalComponent', () => {
+  let component: SettingsExporterModalComponent;
+  let fixture: ComponentFixture<SettingsExporterModalComponent>;
+  let httpMock: HttpTestingController;
+
+  // A fields-bearing exporter so selecting it does NOT immediately submit (the
+  // field-less branch auto-submits); keeps the picker→form transition explicit.
+  const mockExporters = [
+    {
+      name: 'server_json_file',
+      display_name: 'JSON File',
+      description: 'Export settings to JSON',
+      fields: [{ key: 'filepath', field_type: 'text', label: 'File Path', required: true }],
+    },
+  ];
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [SettingsExporterModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsExporterModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function flushInit(): Promise<void> {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/settings-exporters').flush(mockExporters);
+    await settleResource();
+    await fixture.whenStable();
+  }
+
+  it('should create and render exporter cards', async () => {
+    await flushInit();
+    expect(component).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('.exporter-card').length).toBe(1);
+  });
+
+  // Zoneless staleness canary: the success message lands in an HTTP subscribe (an
+  // unpatched callback) and repaints only because `successMessage` is a signal
+  // read in the template. Drive a successful export and assert it renders with no
+  // manual `detectChanges`.
+  it('repaints the success message after a successful export (zoneless canary)', async () => {
+    await flushInit();
+    component.selectExporter(mockExporters[0] as any);
+    await settleZoneless(fixture);
+
+    component.submit();
+    httpMock
+      .expectOne('/api/settings-exporters/export')
+      .flush({ message: 'Exported settings' });
+    await settleZoneless(fixture);
+
+    const ok = fixture.nativeElement.querySelector('.success-text') as HTMLElement;
+    expect(ok).toBeTruthy();
+    expect(ok.textContent).toContain('Exported settings');
+
+    // Cancel the queued auto-close timer so it cannot leak past the test.
+    component.close();
+  });
+
+  it('repaints the error text after a failed export (zoneless canary)', async () => {
+    await flushInit();
+    component.selectExporter(mockExporters[0] as any);
+    await settleZoneless(fixture);
+
+    component.submit();
+    httpMock.expectOne('/api/settings-exporters/export').flush(
+      { error: 'cannot write' },
+      { status: 500, statusText: 'Server Error' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('cannot write');
+  });
+});

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -36,11 +36,15 @@ describe('SettingsExporterModalComponent', () => {
     httpMock.verify();
   });
 
+  // The exporter list rides an eager `rxResource` whose loader runs in a root
+  // effect. `TestBed.tick()` runs that effect to issue the GET — `whenStable()`
+  // can't be used here: a loading `rxResource` holds the app unstable, so it
+  // would deadlock waiting for the flush. After flushing, `settleResource()`
+  // commits the resolved value (microtask + tick) with no manual `detectChanges`.
   async function flushInit(): Promise<void> {
-    await fixture.whenStable();
+    TestBed.tick();
     httpMock.expectOne('/api/settings-exporters').flush(mockExporters);
     await settleResource();
-    await fixture.whenStable();
   }
 
   it('should create and render exporter cards', async () => {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -39,7 +39,8 @@ export class SettingsExporterModalComponent implements OnDestroy {
 
   selectedExporter: SettingsExporterEntry | null = null;
   formValues: Record<string, string> = {};
-  submitting = false;
+  // Signalized: the submit subscribe writes these from an unpatched callback.
+  readonly submitting = signal(false);
 
   /** Error from a failed export action; the list-load failure is merged in. */
   private readonly exportError = signal('');
@@ -48,7 +49,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
       this.exportError() ||
       (this.exportersResource.error() ? 'Failed to load settings exporters' : ''),
   );
-  successMessage = '';
+  readonly successMessage = signal('');
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -69,7 +70,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
     this.selectedExporter = exporter;
     this.formValues = {};
     this.exportError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
     const fields = (exporter.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -95,18 +96,18 @@ export class SettingsExporterModalComponent implements OnDestroy {
     this.view = 'picker';
     this.selectedExporter = null;
     this.exportError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
   }
 
   submit(): void {
     if (!this.selectedExporter) return;
-    this.submitting = true;
+    this.submitting.set(true);
     this.exportError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
 
     this.settingsIoApi.runExport(this.selectedExporter.name, this.formValues).subscribe({
       next: (res: RunSettingsExportResponse) => {
-        this.submitting = false;
+        this.submitting.set(false);
 
         // Handle browser download response
         if (res.download && res.data) {
@@ -119,12 +120,12 @@ export class SettingsExporterModalComponent implements OnDestroy {
           URL.revokeObjectURL(url);
         }
 
-        this.successMessage = res.message || 'Settings exported successfully';
+        this.successMessage.set(res.message || 'Settings exported successfully');
         this.exported.emit();
         this.closeTimer = setTimeout(() => this.close(), 1500);
       },
       error: (err) => {
-        this.submitting = false;
+        this.submitting.set(false);
         this.exportError.set(err.error?.error || 'Export failed');
       },
     });

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -20,8 +20,8 @@
     @if (error()) {
       <p class="error-text">{{ error() }}</p>
     }
-    @if (successMessage) {
-      <p class="success-text">{{ successMessage }}</p>
+    @if (successMessage()) {
+      <p class="success-text">{{ successMessage() }}</p>
     }
   }
 
@@ -98,15 +98,15 @@
       @if (error()) {
         <p class="error-text">{{ error() }}</p>
       }
-      @if (successMessage) {
-        <p class="success-text">{{ successMessage }}</p>
+      @if (successMessage()) {
+        <p class="success-text">{{ successMessage() }}</p>
       }
 
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="back()">Cancel</button>
-        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          <svg aria-hidden="true" [class.icon-waggle]="submitting" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-          @if (submitting) {
+        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
+          <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          @if (submitting()) {
             Importing...
           } @else {
             Import

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { SettingsImporterModalComponent } from './settings-importer-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleResource, settleZoneless } from '../../../testing/settle-resource';
+
+describe('SettingsImporterModalComponent', () => {
+  let component: SettingsImporterModalComponent;
+  let fixture: ComponentFixture<SettingsImporterModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockImporters = [
+    {
+      name: 'server_json_file',
+      display_name: 'JSON File',
+      description: 'Import settings from JSON',
+      fields: [{ key: 'filepath', field_type: 'text', label: 'File Path', required: true }],
+    },
+  ];
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [SettingsImporterModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsImporterModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  // The importer list rides an eager `rxResource` whose loader runs in a root
+  // effect; let the initial scheduled CD run it (no manual `detectChanges`),
+  // flush the GET, then settle so the resolved value commits.
+  async function flushInit(): Promise<void> {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/settings-importers').flush(mockImporters);
+    await settleResource();
+    await fixture.whenStable();
+  }
+
+  it('should create and render importer cards', async () => {
+    await flushInit();
+    expect(component).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('.importer-card').length).toBe(1);
+  });
+
+  // Zoneless staleness canary: the success message lands in an HTTP subscribe (an
+  // unpatched callback) and repaints only because `successMessage` is a signal
+  // read in the template. Drive a successful import and assert it renders with no
+  // manual `detectChanges`.
+  it('repaints the success message after a successful import (zoneless canary)', async () => {
+    await flushInit();
+    component.selectImporter(mockImporters[0] as any);
+    await settleZoneless(fixture);
+
+    component.submit();
+    httpMock
+      .expectOne('/api/settings-importers/import/server_json_file')
+      .flush({ message: 'Imported 7 settings' });
+    await settleZoneless(fixture);
+
+    const ok = fixture.nativeElement.querySelector('.success-text') as HTMLElement;
+    expect(ok).toBeTruthy();
+    expect(ok.textContent).toContain('Imported 7 settings');
+
+    // Cancel the queued auto-close timer so it cannot leak past the test.
+    component.close();
+  });
+
+  it('repaints the error text after a failed import (zoneless canary)', async () => {
+    await flushInit();
+    component.selectImporter(mockImporters[0] as any);
+    await settleZoneless(fixture);
+
+    component.submit();
+    httpMock.expectOne('/api/settings-importers/import/server_json_file').flush(
+      { error: 'bad file' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('bad file');
+  });
+});

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -35,13 +35,14 @@ describe('SettingsImporterModalComponent', () => {
   });
 
   // The importer list rides an eager `rxResource` whose loader runs in a root
-  // effect; let the initial scheduled CD run it (no manual `detectChanges`),
-  // flush the GET, then settle so the resolved value commits.
+  // effect. `TestBed.tick()` runs that effect to issue the GET — `whenStable()`
+  // can't be used here: a loading `rxResource` holds the app unstable, so it
+  // would deadlock waiting for the flush. After flushing, `settleResource()`
+  // commits the resolved value (microtask + tick) with no manual `detectChanges`.
   async function flushInit(): Promise<void> {
-    await fixture.whenStable();
+    TestBed.tick();
     httpMock.expectOne('/api/settings-importers').flush(mockImporters);
     await settleResource();
-    await fixture.whenStable();
   }
 
   it('should create and render importer cards', async () => {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -40,7 +40,8 @@ export class SettingsImporterModalComponent implements OnDestroy {
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
   selectedFileFieldKey: string | null = null;
-  submitting = false;
+  // Signalized: the submit subscribe writes these from an unpatched callback.
+  readonly submitting = signal(false);
 
   /** Error from a failed import action; the list-load failure is merged in. */
   private readonly importError = signal('');
@@ -49,7 +50,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
       this.importError() ||
       (this.importersResource.error() ? 'Failed to load settings importers' : ''),
   );
-  successMessage = '';
+  readonly successMessage = signal('');
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -72,7 +73,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
     this.selectedFile = null;
     this.selectedFileFieldKey = null;
     this.importError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -92,7 +93,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
     this.view = 'picker';
     this.selectedImporter = null;
     this.importError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
   }
 
   onFileSelected(event: Event, fieldName: string): void {
@@ -106,9 +107,9 @@ export class SettingsImporterModalComponent implements OnDestroy {
 
   submit(): void {
     if (!this.selectedImporter) return;
-    this.submitting = true;
+    this.submitting.set(true);
     this.importError.set('');
-    this.successMessage = '';
+    this.successMessage.set('');
 
     this.settingsIoApi
       .runImport(
@@ -119,13 +120,13 @@ export class SettingsImporterModalComponent implements OnDestroy {
       )
       .subscribe({
         next: (res) => {
-          this.submitting = false;
-          this.successMessage = res.message || 'Settings imported successfully';
+          this.submitting.set(false);
+          this.successMessage.set(res.message || 'Settings imported successfully');
           this.imported.emit();
           this.closeTimer = setTimeout(() => this.close(), 1500);
         },
         error: (err) => {
-          this.submitting = false;
+          this.submitting.set(false);
           this.importError.set(err.error?.error || 'Import failed');
         },
       });

--- a/frontend/src/app/testing/output-emit-zoneless.spec.ts
+++ b/frontend/src/app/testing/output-emit-zoneless.spec.ts
@@ -1,0 +1,72 @@
+import { Component, output, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { configureZoneless } from './zoneless-testbed';
+import { settleZoneless } from './settle-resource';
+
+/**
+ * Framework canary for the zoneless migration (see
+ * `docs/plans/zoneless-migration.md`, Phase 2.2 and Recipe D).
+ *
+ * Several modals close themselves from a `setTimeout(() => this.close())` where
+ * `close()` emits a bound `output()` (`settings-importer`, `label-importer`,
+ * `settings-exporter`, …). Under zoneless, the `setTimeout` callback is unpatched
+ * and does not itself schedule change detection — so the question is whether the
+ * *parent's* `(closed)="..."` handler (a **bound template listener**) still runs
+ * and schedules CD when the child emits from that timer.
+ *
+ * The official trigger list names "bound host or template listener callbacks" as
+ * a notification source, so emitting through a template `(event)` binding — even
+ * from an unpatched callback — should schedule the parent's CD and let its `@if`
+ * gate drop the child. This spec proves it: a bare `output()` emit from a real
+ * `setTimeout` removes the child from the parent DOM with no manual
+ * `detectChanges`. That is why the four `setTimeout(close)` paths need no
+ * Recipe-D rework — only the components' own template-bound state was signalized.
+ */
+@Component({
+  selector: 'vt-emit-child',
+  standalone: true,
+  template: '<span class="child">child</span>',
+})
+class EmitChildComponent {
+  readonly closed = output<void>();
+
+  /** Emit `closed` from an unpatched macrotask, mimicking the modals'
+   *  `setTimeout(() => this.close())` auto-close. */
+  closeLater(): void {
+    setTimeout(() => this.closed.emit());
+  }
+}
+
+@Component({
+  selector: 'vt-emit-host',
+  standalone: true,
+  imports: [EmitChildComponent],
+  template: `
+    @if (open()) {
+      <vt-emit-child (closed)="open.set(false)" />
+    }
+  `,
+})
+class EmitHostComponent {
+  readonly open = signal(true);
+}
+
+describe('output() emit from setTimeout (zoneless framework canary)', () => {
+  let fixture: ComponentFixture<EmitHostComponent>;
+
+  beforeEach(async () => {
+    await configureZoneless({ imports: [EmitHostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(EmitHostComponent);
+    await settleZoneless(fixture);
+  });
+
+  it('removes the child via the parent @if when the child emits from a timer', async () => {
+    const child = fixture.debugElement.children[0].componentInstance as EmitChildComponent;
+    expect(fixture.nativeElement.querySelector('.child')).toBeTruthy();
+
+    child.closeLater();
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.child')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Zoneless migration — Phase 2.2 (stats / picker modals)

Continues the [zoneless-migration plan](../blob/dev/docs/plans/zoneless-migration.md). Phase 1 + Phase 2.1 already shipped; this lands the **stats / picker modal** cluster. All changes are behavior-neutral under the still-zoned production app (prod flips in Phase 3).

### What landed

**Stats modals** (`find-stats`, `detector-stats`, `dataset-stats`)
- `loading` / `error` / `stats` plain fields → `signal`s, so the `ngOnInit` HTTP subscribe (an unpatched callback under zoneless) schedules CD when the stats land.
- Templates read the stats via `@else if (stats(); as stats)`, leaving each table body untouched; the stat-derived getters read `stats()`.

**`label-importer-modal`**
- List read moved onto an eager `rxResource` (mirroring the already-migrated `settings-importer`), dropping the `ngOnInit` subscribe.
- Every subscribe-written template field signalized: `submitting`, `error` (an `importError` signal merged with the resource error via `computed`), `successMessage`, `addingGood`/`addingBad`, and the three `dynamicFieldOptions`/`Loading`/`Error` dicts (`signal<Record<…>>` + `.update`).

**`settings-importer` / `settings-exporter` / `label-exporter`**
- Already on `rxResource`+signals from the httpresource work; finished by signalizing the `submitting`/`successMessage` mutation-result fields.

**The four `setTimeout(close)` auto-close paths — no rework needed**
- `close()` emits a bound `output()`; a parent's `(closed)="…"` is a *bound template listener*, which is on the zoneless notification path, so the emit schedules the parent's CD (and drops the modal via its `@if`) even though it fired from an unpatched timer.
- Proven by a new framework canary, `testing/output-emit-zoneless.spec.ts`. This corrects Recipe D's caveat: it applies only to outputs a parent subscribes to **imperatively** in TS, not to template `(event)` bindings.

### Tests
- New zoneless DOM-canary specs for all three stats modals + the two settings modals.
- Existing `label-importer` / `label-exporter` specs migrated to the zoneless `TestBed` (no manual `detectChanges`).
- **rxResource test gotcha** (documented in the plan): a loading `rxResource` holds the app *unstable*, so `await fixture.whenStable()` before flushing the GET deadlocks — those specs issue the GET with `TestBed.tick()` then `settleResource()`. Plain `ngOnInit` HTTP subscribes don't block `whenStable`, so the stats specs use it freely.
- `./run-tests.sh frontend` green: `build:prod` clean (0 warnings), `npm audit` clean, **828 Vitest tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9CYz44pE1hy1AeKmtpbLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9CYz44pE1hy1AeKmtpbLM)_