### PR TITLE
Zoneless Phase 2.3: signalize center-panel image-viewer state

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -8,7 +8,10 @@ utility components — toast-container, clipboard-copy, voting-overlay,
 dialog-host + VtDialogService, browse-legend); Phase 2.2 shipped (stats + picker
 modals — find/detector/dataset-stats signalized; label-importer signalized +
 moved onto rxResource; settings-importer/exporter + label-exporter mutation-result
-fields signalized); the rest of Phase 2 (2.3–2.9) and Phases 3–5 not started.**
+fields signalized); Phase 2.3 shipped (center-panel viewers — image-viewer's
+window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
+writes signalized; video-player verified DOM-only, no change); the rest of Phase 2
+(2.4–2.9) and Phases 3–5 not started.**
 This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
@@ -505,10 +508,28 @@ Suggested order (lightest/most-isolated first to build confidence):
    template-bound `(closed)` output emit schedules the parent's CD under zoneless
    (proven by `testing/output-emit-zoneless.spec.ts`; see Open follow-ups). Each
    has a zoneless DOM-canary spec.
-3. **`center-panel` + viewers** (couples with Phase 1.2): signalize voting state;
-   `image-viewer` window drag/key handlers + shake + its `ResizeObserver`
-   rendered-size writes (signals); `video-player` clip-loop is DOM-only (safe;
-   its `(timeupdate)`/`(play)` are bound listeners, safe).
+3. **`center-panel` + viewers. ✅ DONE (Phase 2.3).** The center-panel voting
+   state shipped with Phase 1.2. Phase 2.3 finished the viewers: `image-viewer`
+   signalized the seven fields written from un-patched callbacks — `regionBox`,
+   `shiftHeld`, `panX`/`panY` (window `mousemove`/`mouseup` drag + `keydown`/
+   `keyup`/`blur` listeners), `renderedW`/`renderedH` (the `ResizeObserver`
+   rendered-size writes), and `regionBoxShake` (the shake `setTimeout`); its
+   getters (`imageTransform`/`regionBoxStyle`/`regionDrawActive`/`wrapCursor`)
+   now read those signals and stay plain getters (so the contract spec keeps
+   reading them without `()`). `zoom`/`rotation`/`zoomLabel`/`marqueeMode`/
+   `highlightMode`/`imageReady`/`imageSrc` stayed plain — they are written only
+   from bound handlers / `ngOnChanges`, which already schedule CD, and the parent
+   `center-panel` reads `marqueeMode`/`highlightMode`/`zoom`/`zoomLabel` only via
+   bound-event-driven re-checks. `video-player` was verified DOM-only and left
+   unchanged: its `videoSrc`/`videoError` are written only in `ngOnChanges` and
+   the bound `(error)` handler, and the `setInterval` clip-loop only writes
+   `video.currentTime` (a DOM property, not template state); `(loadedmetadata)`/
+   `(play)`/`(pause)`/`(error)` are bound listeners. The existing image-viewer
+   contract spec was updated to the signal accessors (kept on the default
+   TestBed, mirroring the center-panel split); a new
+   `image-viewer.zoneless.spec.ts` canary drives a real window `keydown`/`keyup`/
+   `blur` (Shift) through the live constructor listener and asserts the
+   `.region-mode` crosshair affordance repaints with no manual `detectChanges`.
 4. **`label-view`** (24 subscribes; learned-sort timer): convert reads to
    `async`/signals; the `setTimeout` learned-sort toggle → signal.
 5. **`find-view`** (13; divider drag re-entry → signal widths; two `.then`
@@ -608,18 +629,19 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1 complete; Phases 2.1 + 2.2 shipped; Phases 2.3–5 remain.** Shipped so
-  far: Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4 (ProgressEventsService
-  SSE pump + ConnectionStateService + BrowseSelectionService signalized) and 1.2
-  (KeyboardService de-zoned + the coupled center-panel state signalized); Phase
-  2.1 (leaf utility components — toast-container, clipboard-copy, voting-overlay,
-  dialog-host + VtDialogService, browse-legend); and **Phase 2.2** (stats / picker
-  modals), each with its consumers and a zoneless canary spec. Remaining in
-  **Phase 2**: clusters 2.3–2.9 in the suggested order (next up: 2.3 center-panel
-  *viewers* — note the center-panel *state* shipped with 1.2, but 2.3 still owes
-  `image-viewer` (window drag/key handlers + shake + its `ResizeObserver`
-  rendered-size writes) and a check that `video-player` is DOM-only). Then the
-  prod flip (Phase 3), human browser QA (Phase 4), and cleanup (Phase 5).
+- **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 shipped; Phases 2.4–5 remain.**
+  Shipped so far: Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4
+  (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
+  signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
+  signalized); Phase 2.1 (leaf utility components — toast-container, clipboard-copy,
+  voting-overlay, dialog-host + VtDialogService, browse-legend); **Phase 2.2**
+  (stats / picker modals); and **Phase 2.3** (center-panel viewers — image-viewer's
+  window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
+  writes signalized; video-player verified DOM-only, no change), each with its
+  consumers and a zoneless canary spec. Remaining in **Phase 2**: clusters 2.4–2.9
+  in the suggested order (next up: 2.4 `label-view` — 24 subscribes + the
+  learned-sort `setTimeout` toggle). Then the prod flip (Phase 3), human browser QA
+  (Phase 4), and cleanup (Phase 5).
 - **What Phase 2.2 covered.** `find-stats`/`detector-stats`/`dataset-stats`:
   `loading`/`error`/`stats` plain fields → signals (templates read them via
   `@else if (stats(); as stats)` so the bodies were untouched); the stat-derived

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -18,11 +18,11 @@
     draggable="false"
     fetchpriority="high"
   />
-  @if (highlightVisible && renderedW > 0 && renderedH > 0) {
+  @if (highlightVisible && renderedW() > 0 && renderedH() > 0) {
     <div
       class="region-stage"
-      [style.width.px]="renderedW"
-      [style.height.px]="renderedH"
+      [style.width.px]="renderedW()"
+      [style.height.px]="renderedH()"
       [style.transform]="'translate(-50%, -50%) ' + imageTransform"
     >
       <div
@@ -33,17 +33,17 @@
       ></div>
     </div>
   }
-  @if (regionBox && renderedW > 0 && renderedH > 0) {
+  @if (regionBox() && renderedW() > 0 && renderedH() > 0) {
     <div
       class="region-stage"
-      [style.width.px]="renderedW"
-      [style.height.px]="renderedH"
+      [style.width.px]="renderedW()"
+      [style.height.px]="renderedH()"
       [style.transform]="'translate(-50%, -50%) ' + imageTransform"
       [style.--region-zoom]="zoom"
     >
       <div
         class="region-box"
-        [class.shake]="regionBoxShake"
+        [class.shake]="regionBoxShake()"
         [class.armed]="pendingBadConfirm"
         [ngStyle]="regionBoxStyle!"
         (mousedown)="onRegionBodyMouseDown($event)"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -150,8 +150,8 @@ describe('ImageViewerComponent', () => {
     // rendered image. Lets each test focus on the transform math, not on DOM
     // plumbing.
     function setupWrap(component: ImageViewerComponent) {
-      component.renderedW = 100;
-      component.renderedH = 100;
+      component.renderedW.set(100);
+      component.renderedH.set(100);
       component.wrapRef = {
         nativeElement: {
           getBoundingClientRect: () => ({
@@ -211,7 +211,7 @@ describe('ImageViewerComponent', () => {
       // Image translated 20px right; a click at screen 70 used to map to image
       // 0.7 at zoom 2 (50px = 0.5 + 20/100/2 * 2... see math). Concretely:
       // dx = 70 - 50 - 20 = 0; sx = 0; image x = 0.5.
-      component.panX = 20;
+      component.panX.set(20);
       const local = component.screenToImageNormalized(makeEvent(70, 50))!;
       expect(local.x).toBeCloseTo(0.5, 6);
       expect(local.y).toBeCloseTo(0.5, 6);
@@ -235,8 +235,8 @@ describe('ImageViewerComponent', () => {
       // visual→layout conversion, every offset from the wrap centre came out
       // 1.1× too large, drawing the box further from the view centre than the
       // cursor (proportional to distance from centre, sign-flipping across it).
-      component.renderedW = 100;
-      component.renderedH = 100;
+      component.renderedW.set(100);
+      component.renderedH.set(100);
       component.wrapRef = {
         nativeElement: {
           clientWidth: 100,
@@ -264,8 +264,8 @@ describe('ImageViewerComponent', () => {
     it('combines pan + zoom + rotate self-consistently', () => {
       setupWrap(component);
       component.zoom = 2;
-      component.panX = 10;
-      component.panY = -5;
+      component.panX.set(10);
+      component.panY.set(-5);
       component.rotation = 90;
       // Map a couple of points and verify the transform is invertible:
       // taking two points on screen and rotating by the matching angle, the
@@ -290,17 +290,17 @@ describe('ImageViewerComponent', () => {
    */
   describe('region box coord stability', () => {
     it('does not mutate the box coords when zoom changes', () => {
-      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
       component.zoom = 2;
-      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
       component.zoom = 4;
-      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
       component.zoom = 1;
-      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
     });
 
     it('keeps regionBoxStyle (percent-of-stage) stable across zoom changes', () => {
-      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
       const before = component.regionBoxStyle;
       component.zoom = 3;
       expect(component.regionBoxStyle).toEqual(before);
@@ -309,7 +309,7 @@ describe('ImageViewerComponent', () => {
     });
 
     it('returns null style when no box is drawn', () => {
-      component.regionBox = null;
+      component.regionBox.set(null);
       expect(component.regionBoxStyle).toBeNull();
     });
   });
@@ -321,8 +321,8 @@ describe('ImageViewerComponent', () => {
    */
   describe('region box preservation on zero-area Shift-drag', () => {
     function setupWrap(component: ImageViewerComponent) {
-      component.renderedW = 100;
-      component.renderedH = 100;
+      component.renderedW.set(100);
+      component.renderedH.set(100);
       component.wrapRef = {
         nativeElement: {
           getBoundingClientRect: () => ({
@@ -343,8 +343,8 @@ describe('ImageViewerComponent', () => {
     it('keeps the prior box when a Shift-click resolves to zero area', () => {
       setupWrap(component);
       const original: RegionBox = [0.2, 0.3, 0.6, 0.7];
-      component.regionBox = original;
-      component.shiftHeld = true;
+      component.regionBox.set(original);
+      component.shiftHeld.set(true);
 
       let lastEmitted: RegionBox | null | undefined = undefined;
       component.regionBoxChange.subscribe((v) => (lastEmitted = v));
@@ -361,15 +361,15 @@ describe('ImageViewerComponent', () => {
       // mouseup with no motion should restore the original box.
       (component as unknown as { onWindowMouseUp: () => void }).onWindowMouseUp();
 
-      expect(component.regionBox).toEqual(original);
+      expect(component.regionBox()).toEqual(original);
       // Restored to a state the parent already knew; no emit needed.
       expect(lastEmitted).toBeUndefined();
     });
 
     it('leaves the box null when the canvas was already empty and the click is zero-area', () => {
       setupWrap(component);
-      component.regionBox = null;
-      component.shiftHeld = true;
+      component.regionBox.set(null);
+      component.shiftHeld.set(true);
 
       const ev: MouseEvent = {
         button: 0,
@@ -380,14 +380,14 @@ describe('ImageViewerComponent', () => {
       component.onMouseDown(ev);
       (component as unknown as { onWindowMouseUp: () => void }).onWindowMouseUp();
 
-      expect(component.regionBox).toBeNull();
+      expect(component.regionBox()).toBeNull();
     });
   });
 
   describe('marquee mode toggle', () => {
     function setupWrap(component: ImageViewerComponent) {
-      component.renderedW = 100;
-      component.renderedH = 100;
+      component.renderedW.set(100);
+      component.renderedH.set(100);
       component.wrapRef = {
         nativeElement: {
           getBoundingClientRect: () => ({
@@ -415,9 +415,9 @@ describe('ImageViewerComponent', () => {
 
     it('reports regionDrawActive when either Shift is held or marquee is on', () => {
       expect(component.regionDrawActive).toBe(false);
-      component.shiftHeld = true;
+      component.shiftHeld.set(true);
       expect(component.regionDrawActive).toBe(true);
-      component.shiftHeld = false;
+      component.shiftHeld.set(false);
       component.marqueeMode = true;
       expect(component.regionDrawActive).toBe(true);
     });
@@ -441,9 +441,9 @@ describe('ImageViewerComponent', () => {
       component.onMouseDown(ev);
 
       // Mid-drag the box should already exist as the zero-area anchor.
-      expect(component.regionBox).not.toBeNull();
-      expect(component.regionBox![0]).toBeCloseTo(0.3, 5);
-      expect(component.regionBox![1]).toBeCloseTo(0.3, 5);
+      expect(component.regionBox()).not.toBeNull();
+      expect(component.regionBox()![0]).toBeCloseTo(0.3, 5);
+      expect(component.regionBox()![1]).toBeCloseTo(0.3, 5);
     });
 
     it('persists across media changes', () => {
@@ -508,7 +508,7 @@ describe('ImageViewerComponent', () => {
 
   describe('armed-confirm cancel routing', () => {
     it('emits armedConfirmCanceled instead of clearing the box when Esc is pressed while armed', () => {
-      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
       component.pendingBadConfirm = true;
       let canceled = false;
       let cleared = false;
@@ -520,17 +520,17 @@ describe('ImageViewerComponent', () => {
       (component as unknown as { onWindowKeyDown: (e: KeyboardEvent) => void }).onWindowKeyDown(esc);
       expect(canceled).toBe(true);
       expect(cleared).toBe(false);
-      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
     });
 
     it('clears the box on Esc when no armed confirm is pending', () => {
-      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
       component.pendingBadConfirm = false;
       let emitted: RegionBox | null | undefined = undefined;
       component.regionBoxChange.subscribe((v) => (emitted = v));
       const esc = new KeyboardEvent('keydown', { key: 'Escape' });
       (component as unknown as { onWindowKeyDown: (e: KeyboardEvent) => void }).onWindowKeyDown(esc);
-      expect(component.regionBox).toBeNull();
+      expect(component.regionBox()).toBeNull();
       expect(emitted).toBeNull();
     });
   });

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, output } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, output, signal } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -66,9 +66,12 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   private lastMediaId: number | null = null;
 
   // Region voting state (v2 of the patch-embedder plan, UI only; see docs/plans/patch-embedder.md).
-  regionBox: RegionBox | null = null;
-  regionBoxShake = false;
-  shiftHeld = false;
+  // These are signals because they are written from un-patched callbacks (window
+  // mouse/key listeners, the shake `setTimeout`) that schedule no change detection
+  // under zoneless; a signal write read in the template is on the notification path.
+  readonly regionBox = signal<RegionBox | null>(null);
+  readonly regionBoxShake = signal(false);
+  readonly shiftHeld = signal(false);
   // Sticky toggle exposed by the Marquee button in .image-view-controls. While true the
   // viewer behaves as if Shift were held: cursor is a crosshair and a left-drag draws a
   // new region instead of panning. Shift+drag remains a power-user shortcut even when
@@ -80,13 +83,18 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   // both can be on at once (the highlight is read-only and sits behind the
   // interactive voting box).
   highlightMode = false;
-  renderedW = 0;
-  renderedH = 0;
+  // renderedW/H are written from a raw ResizeObserver callback (un-patched, no CD
+  // under zoneless), so they are signals; reading them in the template keeps the
+  // overlay geometry fresh when the wrap resizes.
+  readonly renderedW = signal(0);
+  readonly renderedH = signal(0);
 
-  // panX/panY are not `private` so tests can drive screenToImageNormalized()
-  // with non-zero pan without simulating a full wheel + drag sequence.
-  panX = 0;
-  panY = 0;
+  // panX/panY are signals (written from the window-level mousemove drag handler,
+  // an un-patched callback). They are not `private` so tests can drive
+  // screenToImageNormalized() with non-zero pan without simulating a full wheel +
+  // drag sequence.
+  readonly panX = signal(0);
+  readonly panY = signal(0);
   private drag: DragMode | null = null;
 
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
@@ -163,8 +171,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   resetView(): void {
     this.zoom = 1;
     this.rotation = 0;
-    this.panX = 0;
-    this.panY = 0;
+    this.panX.set(0);
+    this.panY.set(0);
     this.applyTransform();
   }
 
@@ -181,15 +189,15 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       const cx = (event.clientX - rect.left - rect.width / 2) / s;
       const cy = (event.clientY - rect.top - rect.height / 2) / s;
       const ratio = this.zoom / oldZoom;
-      this.panX = cx - ratio * (cx - this.panX);
-      this.panY = cy - ratio * (cy - this.panY);
+      this.panX.set(cx - ratio * (cx - this.panX()));
+      this.panY.set(cy - ratio * (cy - this.panY()));
     }
     this.applyTransform();
   }
 
   /** True when a drag should draw a region (either Shift-held or Marquee toggle on). */
   get regionDrawActive(): boolean {
-    return this.shiftHeld || this.marqueeMode;
+    return this.shiftHeld() || this.marqueeMode;
   }
 
   toggleMarqueeMode(): void {
@@ -230,7 +238,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   onMouseDown(event: MouseEvent): void {
     if (event.button !== 0) return;
 
-    if (this.regionDrawActive && this.renderedW > 0 && this.renderedH > 0) {
+    if (this.regionDrawActive && this.renderedW() > 0 && this.renderedH() > 0) {
       // Drag from anywhere on the canvas (Shift-held or marquee mode) starts a fresh
       // box. If an older box existed, discard it before recording the new anchor.
       const local = this.screenToImageNormalized(event);
@@ -240,8 +248,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
       // Remember the prior box so we can restore it on a zero-area release;
       // a stray Shift-click on empty space must not throw away real work.
-      this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox };
-      this.regionBox = [x, y, x, y];
+      this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox() };
+      this.regionBox.set([x, y, x, y]);
       event.preventDefault();
       this.setupWindowMouseListeners();
       return;
@@ -254,50 +262,52 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       kind: 'pan',
       startX: event.clientX,
       startY: event.clientY,
-      originX: this.panX,
-      originY: this.panY,
+      originX: this.panX(),
+      originY: this.panY(),
     };
     event.preventDefault();
     this.setupWindowMouseListeners();
   }
 
   onRegionBodyMouseDown(event: MouseEvent): void {
-    if (event.button !== 0 || !this.regionBox) return;
+    const box = this.regionBox();
+    if (event.button !== 0 || !box) return;
     event.stopPropagation();
     event.preventDefault();
     const local = this.screenToImageNormalized(event);
     if (!local) return;
     if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
-    this.drag = { kind: 'move', startLocal: local, startBox: this.regionBox };
+    this.drag = { kind: 'move', startLocal: local, startBox: box };
     this.setupWindowMouseListeners();
   }
 
   onResizeHandleMouseDown(handle: ResizeHandle, event: MouseEvent): void {
-    if (event.button !== 0 || !this.regionBox) return;
+    const box = this.regionBox();
+    if (event.button !== 0 || !box) return;
     event.stopPropagation();
     event.preventDefault();
     if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
-    this.drag = { kind: 'resize', handle, startBox: this.regionBox };
+    this.drag = { kind: 'resize', handle, startBox: box };
     this.setupWindowMouseListeners();
   }
 
   /** Clear the current region box and notify the parent. */
   clearRegionBox(opts: { emit: boolean } = { emit: true }): void {
-    if (this.regionBox === null) return;
-    this.regionBox = null;
+    if (this.regionBox() === null) return;
+    this.regionBox.set(null);
     if (opts.emit) this.regionBoxChange.emit(null);
   }
 
   /** Visually flash the region box (used by bad-vote-confirm flow). */
   pulseRegionBox(): void {
-    if (!this.regionBox) return;
-    this.regionBoxShake = true;
+    if (!this.regionBox()) return;
+    this.regionBoxShake.set(true);
     if (this.shakeTimer) clearTimeout(this.shakeTimer);
-    this.shakeTimer = setTimeout(() => (this.regionBoxShake = false), 500);
+    this.shakeTimer = setTimeout(() => this.regionBoxShake.set(false), 500);
   }
 
   get imageTransform(): string {
-    return `translate(${this.panX}px, ${this.panY}px) scale(${this.zoom}) rotate(${this.rotation}deg)`;
+    return `translate(${this.panX()}px, ${this.panY()}px) scale(${this.zoom}) rotate(${this.rotation}deg)`;
   }
 
   get wrapCursor(): string {
@@ -307,8 +317,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   get regionBoxStyle(): { [k: string]: string } | null {
-    if (!this.regionBox) return null;
-    const [x0, y0, x1, y1] = this.regionBox;
+    const box = this.regionBox();
+    if (!box) return null;
+    const [x0, y0, x1, y1] = box;
     return {
       left: pct(x0),
       top: pct(y0),
@@ -319,8 +330,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   private applyTransform(): void {
     const max = this.getMaxPan();
-    this.panX = Math.max(-max.x, Math.min(max.x, this.panX));
-    this.panY = Math.max(-max.y, Math.min(max.y, this.panY));
+    this.panX.set(Math.max(-max.x, Math.min(max.x, this.panX())));
+    this.panY.set(Math.max(-max.y, Math.min(max.y, this.panY())));
     const zoomVal = this.zoom;
     this.zoomLabel = (zoomVal === Math.floor(zoomVal) ? zoomVal.toFixed(0) : zoomVal.toFixed(1)) + '×';
   }
@@ -338,18 +349,18 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const wrapW = wrap.clientWidth;
     const wrapH = wrap.clientHeight;
     if (!natW || !natH || !wrapW || !wrapH) {
-      this.renderedW = 0;
-      this.renderedH = 0;
+      this.renderedW.set(0);
+      this.renderedH.set(0);
       return;
     }
     const imgAspect = natW / natH;
     const wrapAspect = wrapW / wrapH;
     if (imgAspect > wrapAspect) {
-      this.renderedW = wrapW;
-      this.renderedH = wrapW / imgAspect;
+      this.renderedW.set(wrapW);
+      this.renderedH.set(wrapW / imgAspect);
     } else {
-      this.renderedH = wrapH;
-      this.renderedW = wrapH * imgAspect;
+      this.renderedH.set(wrapH);
+      this.renderedW.set(wrapH * imgAspect);
     }
   }
 
@@ -363,13 +374,15 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   private getMaxPan(): { x: number; y: number } {
     const wrap = this.wrapRef?.nativeElement;
-    if (!wrap || !this.renderedW || !this.renderedH) return { x: 0, y: 0 };
+    const renderedW = this.renderedW();
+    const renderedH = this.renderedH();
+    if (!wrap || !renderedW || !renderedH) return { x: 0, y: 0 };
     const wrapW = wrap.clientWidth;
     const wrapH = wrap.clientHeight;
     const rot = ((this.rotation % 360) + 360) % 360;
     const swapped = rot === 90 || rot === 270;
-    const effW = swapped ? this.renderedH : this.renderedW;
-    const effH = swapped ? this.renderedW : this.renderedH;
+    const effW = swapped ? renderedH : renderedW;
+    const effH = swapped ? renderedW : renderedH;
     return {
       x: Math.max(0, (effW * this.zoom - wrapW) / 2),
       y: Math.max(0, (effH * this.zoom - wrapH) / 2),
@@ -395,11 +408,13 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    *  with a mocked wrapRef + arbitrary pan/zoom/rotate state. */
   screenToImageNormalized(event: MouseEvent): { x: number; y: number } | null {
     const wrap = this.wrapRef?.nativeElement;
-    if (!wrap || !this.renderedW || !this.renderedH) return null;
+    const renderedW = this.renderedW();
+    const renderedH = this.renderedH();
+    if (!wrap || !renderedW || !renderedH) return null;
     const rect = wrap.getBoundingClientRect();
     const s = this.layoutScale(wrap, rect);
-    const dx = (event.clientX - (rect.left + rect.width / 2)) / s - this.panX;
-    const dy = (event.clientY - (rect.top + rect.height / 2)) / s - this.panY;
+    const dx = (event.clientX - (rect.left + rect.width / 2)) / s - this.panX();
+    const dy = (event.clientY - (rect.top + rect.height / 2)) / s - this.panY();
     const sx = dx / this.zoom;
     const sy = dy / this.zoom;
     const rad = (-this.rotation * Math.PI) / 180;
@@ -408,8 +423,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const rx = sx * cos - sy * sin;
     const ry = sx * sin + sy * cos;
     return {
-      x: (rx + this.renderedW / 2) / this.renderedW,
-      y: (ry + this.renderedH / 2) / this.renderedH,
+      x: (rx + renderedW / 2) / renderedW,
+      y: (ry + renderedH / 2) / renderedH,
     };
   }
 
@@ -440,8 +455,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       // a LAYOUT-px transform value; convert so the image tracks the cursor 1:1.
       const wrap = this.wrapRef?.nativeElement;
       const s = wrap ? this.layoutScale(wrap, wrap.getBoundingClientRect()) : 1;
-      this.panX = d.originX + (e.clientX - d.startX) / s;
-      this.panY = d.originY + (e.clientY - d.startY) / s;
+      this.panX.set(d.originX + (e.clientX - d.startX) / s);
+      this.panY.set(d.originY + (e.clientY - d.startY) / s);
       this.applyTransform();
       return;
     }
@@ -452,7 +467,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       const ay = d.anchor.y;
       const bx = clamp01(local.x);
       const by = clamp01(local.y);
-      this.regionBox = [Math.min(ax, bx), Math.min(ay, by), Math.max(ax, bx), Math.max(ay, by)];
+      this.regionBox.set([Math.min(ax, bx), Math.min(ay, by), Math.max(ax, bx), Math.max(ay, by)]);
       return;
     }
     if (d.kind === 'move') {
@@ -463,7 +478,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       const h = sy1 - sy0;
       const x0 = clamp(sx0 + dx, 0, 1 - w);
       const y0 = clamp(sy0 + dy, 0, 1 - h);
-      this.regionBox = [x0, y0, x0 + w, y0 + h];
+      this.regionBox.set([x0, y0, x0 + w, y0 + h]);
       return;
     }
     // resize
@@ -474,7 +489,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     if (d.handle.includes('s')) y1 = Math.max(ly, y0 + MIN_BOX_SIZE);
     if (d.handle.includes('w')) x0 = Math.min(lx, x1 - MIN_BOX_SIZE);
     if (d.handle.includes('e')) x1 = Math.max(lx, x0 + MIN_BOX_SIZE);
-    this.regionBox = [x0, y0, x1, y1];
+    this.regionBox.set([x0, y0, x1, y1]);
   }
 
   private onWindowMouseUp(): void {
@@ -485,18 +500,19 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const drag = this.drag;
     this.drag = null;
     this.removeWindowMouseListeners();
-    if (!this.regionBox) return;
-    const [x0, y0, x1, y1] = this.regionBox;
+    const box = this.regionBox();
+    if (!box) return;
+    const [x0, y0, x1, y1] = box;
     const tooSmall = x1 - x0 < MIN_BOX_SIZE || y1 - y0 < MIN_BOX_SIZE;
     if (drag.kind === 'draw' && tooSmall) {
       // Zero-area Shift-drag (a stray click without motion). Restore the
       // prior box rather than discarding it; drawing a box is real work.
       // Don't emit: the parent's last-known state was already previousBox
       // (the transient zero-area draw was never emitted).
-      this.regionBox = drag.previousBox;
+      this.regionBox.set(drag.previousBox);
       return;
     }
-    this.regionBoxChange.emit(this.regionBox);
+    this.regionBoxChange.emit(box);
   }
 
   private setupWindowKeyListeners(): void {
@@ -505,7 +521,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     this.blurHandler = () => {
       // Releasing focus (alt-tab, etc.) drops the Shift state; don't leave the
       // user stuck in region mode invisibly.
-      this.shiftHeld = false;
+      this.shiftHeld.set(false);
     };
     window.addEventListener('keydown', this.keyDownHandler);
     window.addEventListener('keyup', this.keyUpHandler);
@@ -529,7 +545,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   private onWindowKeyDown(e: KeyboardEvent): void {
     if (e.key === 'Shift') {
-      this.shiftHeld = true;
+      this.shiftHeld.set(true);
       return;
     }
     if (e.key !== 'Escape' || this.isTyping()) return;
@@ -542,14 +558,14 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       this.armedConfirmCanceled.emit();
       return;
     }
-    if (this.regionBox) {
+    if (this.regionBox()) {
       e.preventDefault();
       this.clearRegionBox({ emit: true });
     }
   }
 
   private onWindowKeyUp(e: KeyboardEvent): void {
-    if (e.key === 'Shift') this.shiftHeld = false;
+    if (e.key === 'Shift') this.shiftHeld.set(false);
   }
 
   private isTyping(): boolean {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImageViewerComponent } from './image-viewer.component';
+import { ActiveContextService } from '../../../services/active-context.service';
+import { Media } from '../../../models/api.models';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+/**
+ * Zoneless staleness canary for the image viewer (docs/plans/zoneless-migration.md,
+ * Phases 0.3/0.4 + 2.3). Phase 2.3 signalized the viewer state that is written from
+ * *un-patched* callbacks — the window-level `keydown`/`keyup`/`blur` (Shift) and
+ * `mousemove`/`mouseup` drag handlers, the `ResizeObserver` rendered-size writes,
+ * and the shake `setTimeout`. None of those callbacks are bound template/host
+ * listeners, so under zoneless they schedule no change detection on their own; only
+ * because the destinations are signals read in the template does a write notify the
+ * scheduler.
+ *
+ * This spec runs under a zoneless `TestBed` and drives the component through the
+ * *production channel* — a real `keydown`/`keyup` dispatched on `window` (handled by
+ * the live constructor-registered listener, NOT a bound template event) — then
+ * asserts on the rendered DOM after `settleZoneless()` with NO manual
+ * `detectChanges()`. If `shiftHeld` were still a plain field, the `Shift` press
+ * would never repaint the `.region-mode` crosshair affordance and these assertions
+ * would fail.
+ */
+describe('ImageViewerComponent (zoneless Shift-drag canary)', () => {
+  let fixture: ComponentFixture<ImageViewerComponent>;
+
+  const mockMedia: Media = {
+    id: 2,
+    media_type: 'image',
+    filename: 'test.png',
+    md5: 'def456',
+    custom_metadata: {},
+  };
+
+  beforeEach(async () => {
+    configureZoneless({
+      imports: [ImageViewerComponent],
+      providers: [ActiveContextService],
+    });
+    fixture = TestBed.createComponent(ImageViewerComponent);
+    // `media` is a decorator @Input; set it through `setInput` (the same channel
+    // the parent's binding uses) so the first render has a media to read.
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  function wrap(): HTMLElement {
+    return fixture.nativeElement.querySelector('.image-wrap');
+  }
+
+  it('toggles the region-mode crosshair when Shift is pressed/released via the window listener, with no manual detectChanges', async () => {
+    expect(wrap().classList.contains('region-mode')).toBe(false);
+
+    // Production channel: a real Shift keydown, handled by the live constructor
+    // listener (an un-bound window callback). It writes the `shiftHeld` signal,
+    // which `regionDrawActive` reads in the template — the only thing that can
+    // schedule CD for this un-bound chain under zoneless.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+    await settleZoneless(fixture);
+    expect(wrap().classList.contains('region-mode')).toBe(true);
+
+    // Releasing Shift (also an un-bound window callback) must repaint it away.
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift' }));
+    await settleZoneless(fixture);
+    expect(wrap().classList.contains('region-mode')).toBe(false);
+  });
+
+  it('clears region-mode on window blur via the un-bound blur listener', async () => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+    await settleZoneless(fixture);
+    expect(wrap().classList.contains('region-mode')).toBe(true);
+
+    // alt-tab / focus loss fires a window 'blur' that drops the Shift state.
+    window.dispatchEvent(new Event('blur'));
+    await settleZoneless(fixture);
+    expect(wrap().classList.contains('region-mode')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this is

Phase 2.3 of the zoneless change-detection migration (`docs/plans/zoneless-migration.md`): the **center-panel viewers**. The center-panel *voting* state already shipped with Phase 1.2; this finishes the cluster.

Behavior-neutral under the still-zoned production app, like the rest of Phases 1–2.

## image-viewer

Signalized the seven `image-viewer` fields written from **un-patched callbacks** (window-level listeners, `ResizeObserver`, `setTimeout`) — the writes that schedule no change detection under zoneless unless their destination is a signal read in the template:

- `regionBox`, `shiftHeld`, `panX`/`panY` — written by the window `mousemove`/`mouseup` drag handlers and the `keydown`/`keyup`/`blur` (Shift) listeners.
- `renderedW`/`renderedH` — written by the `ResizeObserver` rendered-size recompute.
- `regionBoxShake` — written by the shake `setTimeout`.

The getters (`imageTransform`/`regionBoxStyle`/`regionDrawActive`/`wrapCursor`) now read those signals but stay plain getters (so the contract spec keeps reading them without `()`, and the parent `center-panel` template is untouched).

Fields left plain on purpose: `zoom`/`rotation`/`zoomLabel`/`marqueeMode`/`highlightMode`/`imageReady`/`imageSrc` — all written only from bound handlers or `ngOnChanges`, which already schedule CD; the parent reads `marqueeMode`/`highlightMode`/`zoom`/`zoomLabel` only via bound-event-driven re-checks.

## video-player

Verified **DOM-only** and left unchanged: `videoSrc`/`videoError` are written only in `ngOnChanges` and the bound `(error)` handler; the `setInterval` clip-loop only writes `video.currentTime` (a DOM property, not template state); `(loadedmetadata)`/`(play)`/`(pause)`/`(error)` are bound listeners.

## Tests

- Existing `image-viewer.component.spec.ts` updated to the signal accessors (kept on the default TestBed, mirroring the center-panel contract/canary split).
- New `image-viewer.zoneless.spec.ts` canary: drives a real window `keydown`/`keyup`/`blur` (Shift) through the live constructor listener under a zoneless `TestBed` and asserts the `.region-mode` crosshair affordance repaints with **no manual `detectChanges`** — a forgotten signal write would leave the DOM stale and fail it.
- `./run-tests.sh frontend` green (build OK, audit clean, 830 Vitest tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Htr6aUApdfqhBKJfaND9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_011Htr6aUApdfqhBKJfaND9Q)_