### PR TITLE
Zoneless Phase 2.4: signalize label-view + bridge sort/vote reads

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -10,8 +10,11 @@ modals — find/detector/dataset-stats signalized; label-importer signalized +
 moved onto rxResource; settings-importer/exporter + label-exporter mutation-result
 fields signalized); Phase 2.3 shipped (center-panel viewers — image-viewer's
 window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
-writes signalized; video-player verified DOM-only, no change); the rest of Phase 2
-(2.4–2.9) and Phases 3–5 not started.**
+writes signalized; video-player verified DOM-only, no change); Phase 2.4 shipped
+(label-view — its subscribe/timer/effect-written template state signalized and
+the still-Observable `SortStateService`/`VoteStateService` channels it binds
+bridged into signals via `toSignal`); the rest of Phase 2 (2.5–2.9) and Phases
+3–5 not started.**
 This document
 is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
 21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
@@ -530,8 +533,33 @@ Suggested order (lightest/most-isolated first to build confidence):
    `image-viewer.zoneless.spec.ts` canary drives a real window `keydown`/`keyup`/
    `blur` (Shift) through the live constructor listener and asserts the
    `.region-mode` crosshair affordance repaints with no manual `detectChanges`.
-4. **`label-view`** (24 subscribes; learned-sort timer): convert reads to
-   `async`/signals; the `setTimeout` learned-sort toggle → signal.
+4. **`label-view`. ✅ DONE (Phase 2.4).** Signalized every template-bound field
+   written from a non-CD-scheduling context: `datasetName`, `labelingStatus`
+   (status-polling timer), `trainableModelName`, `leftWidth`/`rightWidth` (the
+   settings-mirror `effect()` — Recipe F), `autopilotCollapsed`,
+   `autopilotEnabled`, `showResortPrompt`, and `cropPending` (set from a
+   `fetch().then()` continuation — the un-bound microtask path). The two
+   constructor `effect()`s now read only their intended tracked signals and run
+   the rest `untracked`, because `applyPanelPx`/`setAutopilotCollapsed` both read
+   *and* write the width/collapse signals (an `effect` that reads a signal it
+   also writes would loop, and would spuriously revert a manual collapse toggle
+   on stale settings). label-view also binds `SortStateService` (11 reads) and
+   `VoteStateService` (good/bad votes, label counts, derived
+   `learnedSortAvailable`) getters directly in its template; those services stay
+   `BehaviorSubject`-backed (un-signalized, per the per-cluster plan and the
+   center-panel precedent of not signalizing shared services mid-migration), so
+   label-view bridges the channels it binds into local signals via
+   `toSignal(…$, { requireSync: true })` (a `computed` for `learnedSortAvailable`)
+   — the cheapest way to make those reads repaint under zoneless without
+   touching the shared services or the not-yet-migrated find-view/right-panel
+   consumers. The learned-sort `setTimeout` needed no change beyond the bridge:
+   it writes only the private `learnedSortPending` guard and re-fires
+   `onLearnedSort`, whose sortState writes now repaint via the bridge. New
+   `label-view.zoneless.spec.ts` canary drives the `/api/dataset/status`
+   subscribe (an un-bound callback) and asserts the left panel's `.dataset-name`
+   header repaints with no manual `detectChanges`; the existing contract spec was
+   updated to the signal accessors (kept on the default TestBed, mirroring the
+   center-panel/image-viewer split).
 5. **`find-view`** (13; divider drag re-entry → signal widths; two `.then`
    confirm flows already route through HTTP, safe).
 6. **Browse cluster:** `browse-view` (panel-width re-entry → signal; build poller
@@ -629,19 +657,31 @@ A checklist version of the above goes in the PR description for the QA pass.
 
 ### Open follow-ups
 
-- **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 shipped; Phases 2.4–5 remain.**
+- **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 + 2.4 shipped; Phases 2.5–5 remain.**
   Shipped so far: Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4
   (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
   signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
   signalized); Phase 2.1 (leaf utility components — toast-container, clipboard-copy,
   voting-overlay, dialog-host + VtDialogService, browse-legend); **Phase 2.2**
-  (stats / picker modals); and **Phase 2.3** (center-panel viewers — image-viewer's
+  (stats / picker modals); **Phase 2.3** (center-panel viewers — image-viewer's
   window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
-  writes signalized; video-player verified DOM-only, no change), each with its
-  consumers and a zoneless canary spec. Remaining in **Phase 2**: clusters 2.4–2.9
-  in the suggested order (next up: 2.4 `label-view` — 24 subscribes + the
-  learned-sort `setTimeout` toggle). Then the prod flip (Phase 3), human browser QA
-  (Phase 4), and cleanup (Phase 5).
+  writes signalized; video-player verified DOM-only, no change); and **Phase 2.4**
+  (`label-view` — own subscribe/timer/effect-written fields signalized; the bound
+  `SortStateService`/`VoteStateService` reads bridged via `toSignal`), each with
+  its consumers and a zoneless canary spec. Remaining in **Phase 2**: clusters
+  2.5–2.9 in the suggested order (next up: 2.5 `find-view` — 13 subscribes; divider
+  drag re-entry → signal widths; two `.then` confirm flows already route through
+  HTTP). Then the prod flip (Phase 3), human browser QA (Phase 4), and cleanup
+  (Phase 5).
+- **Shared `SortStateService`/`VoteStateService` are still `BehaviorSubject`-backed.**
+  Phase 2.4 bridged them *per-consumer* in label-view rather than signalizing the
+  services, to keep the cluster shippable (signalizing would force-update
+  find-view, right-panel, center-panel, context-pulldown, label-importer at once).
+  When the later clusters that bind these services land (2.5 find-view binds
+  sortState in its template; 2.8 right-panel binds voteState), either bridge them
+  the same way or, once all consumers are migrated, signalize the two services and
+  drop the per-consumer bridges. Track this as the natural cleanup at the end of
+  Phase 2.
 - **What Phase 2.2 covered.** `find-stats`/`detector-stats`/`dataset-stats`:
   `loading`/`error`/`stats` plain fields → signals (templates read them via
   `@else if (stats(); as stats)` so the bodies were untouched); the stat-derived

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -2,27 +2,27 @@
   <div class="panel-left">
     <vt-left-panel
       [medias]="mediaState.mediasSignal()"
-      [sortOrder]="sortState.sortOrder"
-      [threshold]="sortState.threshold"
+      [sortOrder]="sortOrderSig()"
+      [threshold]="thresholdSig()"
       [selectedId]="mediaState.selectedId()"
-      [goodVotes]="voteState.goodVotes"
-      [badVotes]="voteState.badVotes"
-      [learnedSortAvailable]="voteState.learnedSortAvailable"
-      [labelsetGoodCount]="voteState.labelsetGoodCount"
-      [labelsetBadCount]="voteState.labelsetBadCount"
-      [sortMode]="sortState.sortMode"
-      [selectMode]="sortState.selectMode"
-      [inclusion]="sortState.inclusion"
-      [sortBusy]="sortState.sortBusy"
-      [sortStatus]="sortState.sortStatus"
-      [sortProgress]="sortState.sortProgress"
-      [sortProgressTotal]="sortState.sortProgressTotal"
-      [labelingStatus]="labelingStatus"
+      [goodVotes]="goodVotesSig()"
+      [badVotes]="badVotesSig()"
+      [learnedSortAvailable]="learnedSortAvailableSig()"
+      [labelsetGoodCount]="labelsetGoodCountSig()"
+      [labelsetBadCount]="labelsetBadCountSig()"
+      [sortMode]="sortModeSig()"
+      [selectMode]="selectModeSig()"
+      [inclusion]="inclusionSig()"
+      [sortBusy]="sortBusySig()"
+      [sortStatus]="sortStatusSig()"
+      [sortProgress]="sortProgressSig()"
+      [sortProgressTotal]="sortProgressTotalSig()"
+      [labelingStatus]="labelingStatus()"
       [viewMode]="viewModeLeft"
       [gridGoalWidth]="gridGoalWidthLeft"
       [focusMode]="focusModeLeft"
-      [loadSortLabel]="sortState.loadSortLabel"
-      [textQuery]="sortState.textQuery"
+      [loadSortLabel]="loadSortLabelSig()"
+      [textQuery]="textQuerySig()"
       (sortModeChange)="onSortModeChange($event)"
       (selectModeChange)="onSelectModeChange($event)"
       (inclusionChange)="onInclusionChange($event)"
@@ -36,9 +36,9 @@
       (mediaContextRequest)="onMediaContextRequest($event)"
       (indicatorClick)="onIndicatorClick($event)"
       (sortCancel)="onSortCancel()"
-      [datasetName]="datasetName"
-      [autopilotCollapsed]="autopilotCollapsed"
-      [autopilotEnabled]="autopilotEnabled"
+      [datasetName]="datasetName()"
+      [autopilotCollapsed]="autopilotCollapsed()"
+      [autopilotEnabled]="autopilotEnabled()"
       [autopilotDisabled]="autopilotDisabled"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
@@ -52,7 +52,7 @@
     vtPanelResize="left"
     [layoutEl]="layoutRef.nativeElement"
     [minWidth]="leftMin"
-    [opposingWidth]="rightWidth"
+    [opposingWidth]="rightWidth()"
     [centerMin]="CENTER_MIN"
     [dividerTotal]="DIVIDER_TOTAL"
     (widthChange)="onLeftWidthChange($event)"
@@ -69,7 +69,7 @@
     vtPanelResize="right"
     [layoutEl]="layoutRef.nativeElement"
     [minWidth]="RIGHT_MIN"
-    [opposingWidth]="leftWidth"
+    [opposingWidth]="leftWidth()"
     [centerMin]="CENTER_MIN"
     [dividerTotal]="DIVIDER_TOTAL"
     (widthChange)="onRightWidthChange($event)"
@@ -79,7 +79,7 @@
     <vt-right-panel
       [medias]="mediaState.mediasSignal()"
       [focusMode]="focusModeRight"
-      [trainableModelName]="trainableModelName"
+      [trainableModelName]="trainableModelName()"
       (mediaSelected)="onMediaSelect($event)"
       (mediaVoted)="onHoverVote($event)"
     />
@@ -104,16 +104,16 @@
   />
 }
 
-@if (cropPending) {
+@if (cropPending(); as crop) {
   <vt-media-crop-modal
-    [file]="cropPending.file"
-    [mediaType]="cropPending.mediaType"
+    [file]="crop.file"
+    [mediaType]="crop.mediaType"
     (confirmed)="onCropConfirmed($event)"
     (cancelled)="onCropCancelled()"
   />
 }
 
-@if (showResortPrompt) {
+@if (showResortPrompt()) {
   <vt-resort-prompt-modal
     [currentExampleType]="resortCurrentType"
     [currentExampleDisplay]="resortCurrentDisplay"

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -424,7 +424,7 @@ describe('LabelViewComponent', () => {
       session.mediaExample = 'example.jpg';
       // Keep the panel out of autopilot so we assert the gating getters
       // without firing an example sort that auto-start would kick off.
-      component.autopilotEnabled = false;
+      component.autopilotEnabled.set(false);
       loadNoTextDataset();
       await settleResource();
 
@@ -619,7 +619,7 @@ describe('LabelViewComponent', () => {
       );
     }
 
-    expect(component.showResortPrompt).toBe(false);
+    expect(component.showResortPrompt()).toBe(false);
   });
 
   it('should not show resort prompt after phase transitions past good', () => {
@@ -646,7 +646,7 @@ describe('LabelViewComponent', () => {
 
     // Phase should have transitioned to 'bad', so no resort prompt
     expect(autopilot.state.phase).toBe('bad');
-    expect(component.showResortPrompt).toBe(false);
+    expect(component.showResortPrompt()).toBe(false);
   });
 
   it('should re-select autopilot suggestion on refocus', () => {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, effect, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, computed, effect, inject, signal, untracked } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -79,17 +80,43 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
   @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
 
-  datasetName = '';
+  readonly datasetName = signal('');
   /** Name of the trainable model owning the labels shown on the right pane.
    *  Empty when no trainable model is active; the right pane then falls
    *  back to cid-based vote display. */
-  trainableModelName: string | null = null;
-  labelingStatus: LabelingStatusResponse | null = null;
-  leftWidth = 260;
-  rightWidth = 300;
-  autopilotCollapsed = false;
-  autopilotEnabled = true;
+  readonly trainableModelName = signal<string | null>(null);
+  readonly labelingStatus = signal<LabelingStatusResponse | null>(null);
+  readonly leftWidth = signal(260);
+  readonly rightWidth = signal(300);
+  readonly autopilotCollapsed = signal(false);
+  readonly autopilotEnabled = signal(true);
   progressModalMetric: ProgressMetric | null = null;
+
+  // Shared sort/vote state is still Observable-backed (un-signalized hot
+  // services). Bridge the channels label-view binds in its template into
+  // signals so those bindings repaint under zoneless when the state changes
+  // from async callbacks (HTTP subscribes, the status / learned-sort timers).
+  // requireSync is safe: every source is a BehaviorSubject that emits its
+  // current value on subscribe. Imperative consumers keep reading the service
+  // getters directly.
+  readonly sortOrderSig = toSignal(this.sortState.sortOrder$, { requireSync: true });
+  readonly thresholdSig = toSignal(this.sortState.threshold$, { requireSync: true });
+  readonly sortModeSig = toSignal(this.sortState.sortMode$, { requireSync: true });
+  readonly selectModeSig = toSignal(this.sortState.selectMode$, { requireSync: true });
+  readonly inclusionSig = toSignal(this.sortState.inclusion$, { requireSync: true });
+  readonly sortBusySig = toSignal(this.sortState.sortBusy$, { requireSync: true });
+  readonly sortStatusSig = toSignal(this.sortState.sortStatus$, { requireSync: true });
+  readonly sortProgressSig = toSignal(this.sortState.sortProgress$, { requireSync: true });
+  readonly sortProgressTotalSig = toSignal(this.sortState.sortProgressTotal$, { requireSync: true });
+  readonly loadSortLabelSig = toSignal(this.sortState.loadSortLabel$, { requireSync: true });
+  readonly textQuerySig = toSignal(this.sortState.textQuery$, { requireSync: true });
+  readonly goodVotesSig = toSignal(this.voteState.goodVotes$, { requireSync: true });
+  readonly badVotesSig = toSignal(this.voteState.badVotes$, { requireSync: true });
+  readonly labelsetGoodCountSig = toSignal(this.voteState.labelsetGoodCount$, { requireSync: true });
+  readonly labelsetBadCountSig = toSignal(this.voteState.labelsetBadCount$, { requireSync: true });
+  readonly learnedSortAvailableSig = computed(
+    () => this.labelsetGoodCountSig() > 0 && this.labelsetBadCountSig() > 0,
+  );
 
   // Per-media-type panel preferences (view mode, grid size, focus mode, saved
   // widths) live on `panelState`; the template reads getters on it directly.
@@ -99,7 +126,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   get focusModeRight(): 'click' | 'hover' { return this.panelState.focusModeRight; }
 
   // Re-sort prompt state
-  showResortPrompt = false;
+  readonly showResortPrompt = signal(false);
   resortCurrentType: 'text' | 'media' = 'text';
   resortCurrentDisplay = '';
   private resortInterval = 10;
@@ -137,48 +164,60 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
-      this.panelState.loadFromSettings(settings);
-      if (this.panelState.currentMediaType) {
-        this.applyPanelPx();
-      }
-      if (settings.autopilot_enabled != null) {
-        this.autopilotEnabled = settings.autopilot_enabled;
-      }
-      if (settings.hide_autopilot && !this.autopilotCollapsed) {
-        this.setAutopilotCollapsed(true);
-      } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {
-        this.setAutopilotCollapsed(false);
-      }
-      if (settings.autopilot_resort_interval != null) {
-        this.resortInterval = settings.autopilot_resort_interval;
-        // Initialize the threshold if not yet set
-        if (this.resortNextThreshold === 0) {
-          this.resortNextThreshold = this.resortInterval;
+      // Settings is the only intended dependency. The body reads and writes the
+      // panel-width / autopilot-collapsed signals (directly and via
+      // `applyPanelPx`/`setAutopilotCollapsed`); without `untracked` those reads
+      // would make the effect depend on signals it also writes — an infinite
+      // loop, plus spurious re-runs that revert a manual collapse toggle while
+      // the settings write is still in flight.
+      untracked(() => {
+        this.panelState.loadFromSettings(settings);
+        if (this.panelState.currentMediaType) {
+          this.applyPanelPx();
         }
-      }
+        if (settings.autopilot_enabled != null) {
+          this.autopilotEnabled.set(settings.autopilot_enabled);
+        }
+        if (settings.hide_autopilot && !this.autopilotCollapsed()) {
+          this.setAutopilotCollapsed(true);
+        } else if (settings.hide_autopilot === false && this.autopilotCollapsed()) {
+          this.setAutopilotCollapsed(false);
+        }
+        if (settings.autopilot_resort_interval != null) {
+          this.resortInterval = settings.autopilot_resort_interval;
+          // Initialize the threshold if not yet set
+          if (this.resortNextThreshold === 0) {
+            this.resortNextThreshold = this.resortInterval;
+          }
+        }
+      });
     });
 
     effect(() => {
       const medias = this.mediaState.mediasSignal();
-      if (medias.length > 0) {
-        const newType = medias[0].media_type;
-        if (newType !== this.panelState.currentMediaType) {
-          this.panelState.setMediaType(newType);
-          this.applyPanelPx();
+      // Track the embedder registry too, so the text-support check inside
+      // `triggerAutopilotTextSort` is reliable (and we never fire a doomed text
+      // sort on a no-text dataset); reading `infos()` here makes this effect
+      // re-run once the registry resolves. Everything else runs `untracked` so
+      // `applyPanelPx`'s width-signal reads/writes don't loop the effect.
+      const infos = this.embedderCaps.infos();
+      untracked(() => {
+        if (medias.length > 0) {
+          const newType = medias[0].media_type;
+          if (newType !== this.panelState.currentMediaType) {
+            this.panelState.setMediaType(newType);
+            this.applyPanelPx();
+          }
         }
-      }
-      // Wait for the embedder registry too, so the text-support check inside
-      // `triggerAutopilotTextSort` is reliable (and we never fire a doomed
-      // text sort on a no-text dataset). `infos()` is tracked so this effect
-      // re-runs once the registry resolves.
-      if (this.autopilotTextSortPending && medias.length > 0 && this.embedderCaps.infos() !== null) {
-        this.autopilotTextSortPending = false;
-        this.triggerAutopilotTextSort();
-      }
-      if (this.autopilotMediaSortPending && medias.length > 0) {
-        this.autopilotMediaSortPending = false;
-        this.triggerAutopilotMediaSort();
-      }
+        if (this.autopilotTextSortPending && medias.length > 0 && infos !== null) {
+          this.autopilotTextSortPending = false;
+          this.triggerAutopilotTextSort();
+        }
+        if (this.autopilotMediaSortPending && medias.length > 0) {
+          this.autopilotMediaSortPending = false;
+          this.triggerAutopilotMediaSort();
+        }
+      });
     });
   }
 
@@ -186,14 +225,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.autopilotStateService.clear();
     this.embedderCaps.ensureLoaded();
     this.voteState.clear();
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
-    this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
+    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
+    this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
     this.loadSettings();
     this.startStatusPolling();
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (status) => { this.datasetName = status.display_name || ''; },
+      next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
 
     this.activeContext.modelId$
@@ -268,7 +307,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (status) => { this.datasetName = status.display_name || ''; },
+      next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
     // Re-seed the slider for the detector we just switched to.
     this.seedInclusion();
@@ -299,52 +338,52 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Min width the left panel can shrink to right now (autopilot-collapsed
    *  state lets the user drag down to a thin sliver). */
   get leftMin(): number {
-    return this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
+    return this.autopilotCollapsed() ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
   }
 
   onLeftWidthChange(width: number): void {
-    if (this.autopilotCollapsed && width >= this.LEFT_MIN) {
-      this.autopilotCollapsed = false;
+    if (this.autopilotCollapsed() && width >= this.LEFT_MIN) {
+      this.autopilotCollapsed.set(false);
       this.settingsState.update({ hide_autopilot: false }).subscribe();
     }
-    this.leftWidth = width;
+    this.leftWidth.set(width);
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${width}px`);
   }
 
   onLeftResizeEnd(width: number): void {
-    this.leftWidth = width;
+    this.leftWidth.set(width);
     const leftPanelEl = this.layoutRef.nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
     if (leftPanelEl) {
-      const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth);
+      const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth());
       if (snapped !== null) {
-        const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+        const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth();
         const clamped = Math.max(this.leftMin, Math.min(leftMax, snapped));
-        this.leftWidth = clamped;
+        this.leftWidth.set(clamped);
         this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
       }
     }
-    this.panelState.savePanelPx('left', this.leftWidth);
+    this.panelState.savePanelPx('left', this.leftWidth());
   }
 
   onRightWidthChange(width: number): void {
-    this.rightWidth = width;
+    this.rightWidth.set(width);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${width}px`);
   }
 
   onRightResizeEnd(width: number): void {
-    this.rightWidth = width;
+    this.rightWidth.set(width);
     const rightPanelEl = this.layoutRef.nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
     if (rightPanelEl) {
-      const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth);
+      const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth());
       if (snapped !== null) {
         const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
-        const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
+        const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth();
         const clamped = Math.max(this.RIGHT_MIN, Math.min(rightMax, snapped));
-        this.rightWidth = clamped;
+        this.rightWidth.set(clamped);
         this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
       }
     }
-    this.panelState.savePanelPx('right', this.rightWidth);
+    this.panelState.savePanelPx('right', this.rightWidth());
   }
 
   // --- Data loading ---
@@ -365,7 +404,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       )
       .subscribe({
         next: (status) => {
-          this.labelingStatus = status;
+          this.labelingStatus.set(status);
         },
       });
   }
@@ -641,13 +680,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   /** Pending crop modal state. When set, the user has chosen a "Crop and …"
    *  action and we have fetched the media bytes; the crop modal renders. */
-  cropPending: {
+  readonly cropPending = signal<{
     file: File;
     mediaId: number;
     mediaType: string;
     /** What to do after the crop is confirmed. */
     action: 'sort' | 'seed';
-  } | null = null;
+  } | null>(null);
 
   onMediaContextRequest(event: { id: number; x: number; y: number }): void {
     const media = this.mediaState.mediasSignal().find((m) => m.id === event.id);
@@ -732,7 +771,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .then((blob) => {
         const name = media.filename || `media_${mediaId}`;
         const file = new File([blob], name, { type: blob.type });
-        this.cropPending = { file, mediaId, mediaType, action };
+        this.cropPending.set({ file, mediaId, mediaType, action });
         this.sortState.setSortBusy(false);
         this.sortState.setSortStatus('');
       })
@@ -744,8 +783,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onCropConfirmed(result: MediaCropResult): void {
-    const pending = this.cropPending;
-    this.cropPending = null;
+    const pending = this.cropPending();
+    this.cropPending.set(null);
     if (!pending) return;
     const cropParams = result.cropParams as Record<string, unknown> | undefined;
     if (pending.action === 'sort') {
@@ -756,21 +795,21 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onCropCancelled(): void {
-    this.cropPending = null;
+    this.cropPending.set(null);
   }
 
   private refreshTrainableModelName(modelId: string): void {
     if (!modelId) {
-      this.trainableModelName = null;
+      this.trainableModelName.set(null);
       return;
     }
     this.detectorsRegistryApi.getRegistry().pipe(takeUntil(this.destroy$)).subscribe({
       next: (resp) => {
         const entry = resp.detectors.find((m: DetectorRegistryEntry) => m.id === modelId);
-        this.trainableModelName = entry?.name || null;
+        this.trainableModelName.set(entry?.name || null);
       },
       error: () => {
-        this.trainableModelName = null;
+        this.trainableModelName.set(null);
       },
     });
   }
@@ -958,19 +997,19 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       } else {
         return; // No example to prompt about
       }
-      this.showResortPrompt = true;
+      this.showResortPrompt.set(true);
     }
   }
 
   onResortKeep(): void {
-    this.showResortPrompt = false;
+    this.showResortPrompt.set(false);
     // Multiply threshold by 1.5 for next prompt
     this.resortNextThreshold = Math.round(this.resortNextThreshold * 1.5);
     this.resortVoteCount = 0;
   }
 
   onResortNewExample(result: ResortResult): void {
-    this.showResortPrompt = false;
+    this.showResortPrompt.set(false);
     this.resortVoteCount = 0;
     // Reset threshold back to the base interval
     this.resortNextThreshold = this.resortInterval;
@@ -998,24 +1037,24 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onAutopilotToggleCollapse(): void {
-    const newVal = !this.autopilotCollapsed;
+    const newVal = !this.autopilotCollapsed();
     this.setAutopilotCollapsed(newVal);
     this.settingsState.update({ hide_autopilot: newVal }).subscribe();
   }
 
   private setAutopilotCollapsed(collapsed: boolean): void {
-    this.autopilotCollapsed = collapsed;
+    this.autopilotCollapsed.set(collapsed);
     if (collapsed) {
-      this.savedLeftWidth = this.leftWidth;
-      this.leftWidth = this.COLLAPSED_WIDTH;
+      this.savedLeftWidth = this.leftWidth();
+      this.leftWidth.set(this.COLLAPSED_WIDTH);
     } else {
-      this.leftWidth = this.savedLeftWidth;
+      this.leftWidth.set(this.savedLeftWidth);
     }
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
   }
 
   onAutopilotEnabledChange(enabled: boolean): void {
-    this.autopilotEnabled = enabled;
+    this.autopilotEnabled.set(enabled);
     this.settingsState.update({ autopilot_enabled: enabled }).subscribe();
   }
 
@@ -1046,7 +1085,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // Deactivate autopilot state so resort prompt and phase logic stop firing.
     this.autopilotStateService.deactivate();
-    this.showResortPrompt = false;
+    this.showResortPrompt.set(false);
     // Drop any deferred seed sort that hasn't fired yet (e.g. we stopped before
     // medias finished loading) so it can't fire after autopilot is gone.
     this.autopilotTextSortPending = false;
@@ -1061,16 +1100,16 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private applyPanelPx(): void {
     const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width || 1200;
     const leftPx = this.panelState.getPanelPx('left');
-    if (leftPx != null && !this.autopilotCollapsed) {
-      const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
-      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx));
-      this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+    if (leftPx != null && !this.autopilotCollapsed()) {
+      const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth();
+      this.leftWidth.set(Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx)));
+      this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
     }
     const rightPx = this.panelState.getPanelPx('right');
     if (rightPx != null) {
-      const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
-      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx));
-      this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
+      const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth();
+      this.rightWidth.set(Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx)));
+      this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
     }
   }
 

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -5,7 +5,7 @@ import { provideRouter } from '@angular/router';
 
 import { LabelViewComponent } from './label-view.component';
 import { configureZoneless } from '../../testing/zoneless-testbed';
-import { settleZoneless } from '../../testing/settle-resource';
+import { settleResource, settleZoneless } from '../../testing/settle-resource';
 
 /**
  * Zoneless staleness canary for the label view (docs/plans/zoneless-migration.md,
@@ -47,24 +47,43 @@ describe('LabelViewComponent (zoneless dataset-name canary)', () => {
     fixture.destroy();
   });
 
-  it('renders the dataset name pushed from the /api/dataset/status subscribe, with no manual detectChanges', async () => {
-    // `TestBed.tick()` runs the initial CD (ngOnInit) and the rxResource loader
-    // effect so the init GETs are issued. We must NOT `whenStable()` while the
-    // medias/settings resources are loading (a loading rxResource holds the app
-    // unstable and would deadlock), so flush them first, holding back only the
-    // dataset-status response that is under assertion.
+  // Drain label-view's init loads, holding back only the dataset-status
+  // response that is under assertion. The medias/settings reads ride
+  // promise-based `rxResource` loaders that issue their GET on a microtask, so
+  // we drain with `settleResource()` (macrotask + tick — NOT `whenStable()`,
+  // which would deadlock on a loading resource) across a few cycles before any
+  // `whenStable()` so every resource is resolved (not loading) by then.
+  async function flushInit(): Promise<void> {
     TestBed.tick();
-    httpMock.match('/api/medias/ids').forEach((req) =>
-      req.flush([{ id: 1, media_type: 'audio' }]),
-    );
-    httpMock.match('/api/votes').forEach((req) =>
-      req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
-    );
-    httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
-    httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
-    httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
-    httpMock.match('/api/embedders').forEach((req) => req.flush([]));
+    for (let i = 0; i < 3; i++) {
+      await settleResource();
+      httpMock.match('/api/medias/ids').forEach((req) =>
+        req.flush([{ id: 1, media_type: 'audio' }]),
+      );
+      httpMock.match('/api/votes').forEach((req) =>
+        req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
+      );
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
+      httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
+      httpMock.match('/api/embedders').forEach((req) => req.flush([]));
+      // Include smart/stable/span: the autopilot panel's ngOnChanges feeds this
+      // into AutopilotStateService.updateFromLabelingStatus, which reads them.
+      httpMock.match('/api/labeling-status').forEach((req) =>
+        req.flush({
+          good_count: 0,
+          bad_count: 0,
+          total_count: 0,
+          smart: { status: 'green' },
+          stable: { status: 'green' },
+          span: { status: 'green' },
+        }),
+      );
+    }
+  }
 
+  it('renders the dataset name pushed from the /api/dataset/status subscribe, with no manual detectChanges', async () => {
+    await flushInit();
     await settleZoneless(fixture);
 
     // datasetName starts '' → the left panel's `.dataset-name` node is absent.

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+
+import { LabelViewComponent } from './label-view.component';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+/**
+ * Zoneless staleness canary for the label view (docs/plans/zoneless-migration.md,
+ * Phases 0.3/0.4 + 2.4). Phase 2.4 signalized label-view's subscribe/timer/effect
+ * written template-bound state (`datasetName`, `labelingStatus`,
+ * `trainableModelName`, the panel widths, the autopilot flags, `showResortPrompt`,
+ * `cropPending`) and bridged the still-Observable `SortStateService` /
+ * `VoteStateService` channels it binds into signals via `toSignal`.
+ *
+ * This spec runs under a zoneless `TestBed` and drives the component through the
+ * *production channel* — the `/api/dataset/status` HTTP response, handled in an
+ * un-bound `.subscribe()` callback — then asserts on the rendered DOM after
+ * `settleZoneless()` with NO manual `detectChanges()`. The subscribe write to the
+ * `datasetName` signal is the only thing that can schedule CD for that un-bound
+ * chain; were it still a plain field, the left panel's `.dataset-name` header
+ * would never appear and this assertion would fail.
+ */
+describe('LabelViewComponent (zoneless dataset-name canary)', () => {
+  let fixture: ComponentFixture<LabelViewComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [LabelViewComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LabelViewComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    fixture.componentInstance.ngOnDestroy();
+    // Drain the timer-driven pollers (labeling-status / votes) and any
+    // child-panel reads still in flight; cancelled requests can't be flushed.
+    httpMock.match(() => true).forEach((req) => {
+      if (!req.cancelled) req.flush([]);
+    });
+    fixture.destroy();
+  });
+
+  it('renders the dataset name pushed from the /api/dataset/status subscribe, with no manual detectChanges', async () => {
+    // `TestBed.tick()` runs the initial CD (ngOnInit) and the rxResource loader
+    // effect so the init GETs are issued. We must NOT `whenStable()` while the
+    // medias/settings resources are loading (a loading rxResource holds the app
+    // unstable and would deadlock), so flush them first, holding back only the
+    // dataset-status response that is under assertion.
+    TestBed.tick();
+    httpMock.match('/api/medias/ids').forEach((req) =>
+      req.flush([{ id: 1, media_type: 'audio' }]),
+    );
+    httpMock.match('/api/votes').forEach((req) =>
+      req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
+    );
+    httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+    httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
+    httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
+    httpMock.match('/api/embedders').forEach((req) => req.flush([]));
+
+    await settleZoneless(fixture);
+
+    // datasetName starts '' → the left panel's `.dataset-name` node is absent.
+    expect(fixture.nativeElement.querySelector('.dataset-name')).toBeNull();
+
+    // Production channel: the un-bound dataset-status subscribe writes the
+    // `datasetName` signal.
+    httpMock.expectOne('/api/dataset/status').flush({ display_name: 'Canary Dataset' });
+    await settleZoneless(fixture);
+
+    // The signal write scheduled CD with no manual pump; the header now reflects
+    // it. A plain field would have left this null/empty.
+    const nameEl = fixture.nativeElement.querySelector('.dataset-name');
+    expect(nameEl).not.toBeNull();
+    expect(nameEl!.textContent).toContain('Canary Dataset');
+  });
+});


### PR DESCRIPTION
## Zoneless migration — Phase 2.4 (`label-view`)

Continues `docs/plans/zoneless-migration.md`. Behavior-neutral under the still-zoned prod app; converts the `label-view` cluster's reactivity surface to patterns that are correct under both zone and zoneless.

### What landed

- **Signalized every `label-view` template-bound field written from a non-CD-scheduling context:** `datasetName`, `labelingStatus` (status-polling timer), `trainableModelName`, `leftWidth`/`rightWidth` (written by the settings-mirror `effect()` — the Recipe F trap), `autopilotCollapsed`, `autopilotEnabled`, `showResortPrompt`, and `cropPending` (set from a `fetch().then()` continuation — the un-bound microtask path).
- **Guarded the two constructor `effect()`s:** they now read only their intended tracked signals up front and run the rest `untracked`. `applyPanelPx`/`setAutopilotCollapsed` both read *and* write the width/collapse signals, so without `untracked` the effects would loop (an effect reading a signal it also writes) and would spuriously revert a manual collapse toggle on stale settings.
- **Bridged the bound shared-service reads.** `label-view` binds `SortStateService` (11 reads) and `VoteStateService` getters (good/bad votes, label counts, derived `learnedSortAvailable`) directly in its template. Those services stay `BehaviorSubject`-backed (un-signalized, per the per-cluster plan and the center-panel precedent of not signalizing shared services mid-migration), so `label-view` bridges only the channels it binds into local signals via `toSignal(…$, { requireSync: true })` (a `computed` for `learnedSortAvailable`). This is the cheapest way to make those reads repaint under zoneless without touching the shared services or the not-yet-migrated find-view/right-panel consumers.

The learned-sort `setTimeout` needed no change beyond the bridge: it writes only the private `learnedSortPending` guard and re-fires `onLearnedSort`, whose sortState writes now repaint through the bridge signals.

### Tests

- New `label-view.zoneless.spec.ts` staleness canary: runs under the zoneless `TestBed` and drives the `/api/dataset/status` subscribe (an un-bound callback), asserting the left panel's `.dataset-name` header repaints with **no manual `detectChanges`**. A plain field would leave it stale.
- Existing contract spec updated to the signal accessors (kept on the default `TestBed`, mirroring the center-panel/image-viewer split).
- `./run-tests.sh` full suite green (4901 passed); `./run-tests.sh frontend` green (831 passed, build + audit clean).

### Follow-up (recorded in the plan)

`SortStateService`/`VoteStateService` remain `BehaviorSubject`-backed; once the later clusters that bind them (2.5 find-view, 2.8 right-panel) land, either bridge the same way or signalize the two services and drop the per-consumer bridges. Tracked in the plan's Open follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGrQWxbzNpnX7Gq13RYUGM)_