### PR TITLE
Three-slot embedder binding — Phase 1: role-typed slot foundation

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -463,19 +463,38 @@ fallback box is suppressed (same rule as the gallery outline). Frontend-only.
 
 ## V3 - design
 
-V3 lets a dataset bind **up to one text-capable embedder + up to one
-patch-capable embedder** instead of exactly one embedder.  Text sort
-runs against the text embedder; region similarity, region voting, and
-the detector MLP run against the patch embedder; both live side-by-
-side in the pickle.  No dataset is forced to take two embedders - a
-single-embedder dataset still works, and a dataset that doesn't
-benefit from one of the two roles simply leaves that slot empty.
+**Status: implementation started (three-slot model).** This section was
+originally scoped for **two** slots (text + patch). It is now the
+**three-slot** spec: a dataset binds **any non-empty subset** of three
+role-typed slots - one text-capable embedder, one patch-capable
+embedder, and one structural (geometric-verification) embedder. The
+structural slot is the "third role" the structural-embedder plan
+explicitly deferred to "patch v3"; it lands here.
+
+V3 lets a dataset bind **up to one embedder per role** instead of
+exactly one embedder total.  Text sort runs against the text embedder;
+region similarity, region voting, and patch region-voting run against
+the patch embedder; two-stage instance retrieval + geometric
+verification run against the structural embedder; the detector MLP runs
+against whichever visual slot is bound.  All bound embedders live
+side-by-side in the pickle.  No dataset is forced to take more than one
+- a single-embedder dataset still works, and a dataset that doesn't
+benefit from a role simply leaves that slot empty.
+
+**The binding invariant is "any non-empty subset of {text, patch,
+structural}."** All seven combinations are legal (text-only,
+patch-only, structural-only, text+patch, text+structural,
+patch+structural, all three); the only illegal state is all-empty. The
+three slots are **independent** - in particular patch and structural
+may both be bound (they are different visual capabilities, not
+mutually exclusive), and a power user who wants to keep every detector
+type open can bind all three at ingest.
 
 The point is to **stop forcing the user to choose** between "good
-text queries" (SigLIP/CLIP) and "good region voting + visual quality"
-(DINOv3 patch).  Today those are mutually exclusive because the
-dataset has exactly one embedder; in v3 they coexist on the same
-pickle.
+text queries" (SigLIP/CLIP), "good region voting + visual quality"
+(DINOv3 patch), and "exact-instance matching" (SIFT/VLAD structural).
+Today those are mutually exclusive because the dataset has exactly one
+embedder; in v3 they coexist on the same pickle.
 
 ### Schema change
 
@@ -503,36 +522,72 @@ After the first save under v3, the legacy fields are gone.  Per
 CLAUDE.md ("Backwards Compatibility"), we don't keep a parallel
 `media["embedding"]` mirror.
 
-### Dataset binding
+### Dataset binding (three slots, capability-matching only)
 
-Two new fields on the dataset header (the part of the pickle that
-describes the dataset, not the per-media list):
+Three new optional role-typed fields on the dataset header (the part
+of the pickle that describes the dataset, not the per-media list),
+**additive** to the existing single `embedder` field:
 
 ```python
-dataset.text_embedder:  str | None   # e.g. "siglip" or "e5" or None
-dataset.patch_embedder: str | None   # e.g. "dinov3_patch" or None
+dataset.embedder:            str        # legacy primary/content embedder (kept)
+dataset.text_embedder:       str | None # a supports_text embedder, or None
+dataset.patch_embedder:      str | None # a supports_patch_regions embedder, or None
+dataset.structural_embedder: str | None # a supports_geometric_verification embedder, or None
 ```
+
+The `embedder` field stays as the **always-present primary/content
+embedder** (used for the dataset card display, demo-cache reuse, the
+plain-single-vector legacy path, and back-compat). The three slot
+fields record which capability-matching embedder is bound to which
+role; they are populated *only* by an embedder whose capability flag
+matches the slot.
 
 Constraints:
 
-- At least one of the two must be set (otherwise no sort/search/vote
-  works).
 - `text_embedder` must point at an embedder with
   `supports_text == True`.
 - `patch_embedder` must point at an embedder with
-  `supports_patch_regions == True`.  Slots are role-typed; a
-  single-vector embedder (e.g. `dinov3_single`) is not eligible for
-  the patch slot.
-- Both slots may be filled - that's the new capability v3 unlocks.
-  The two embedders run independently at load time; their outputs
-  share nothing.
+  `supports_patch_regions == True`.  A single-vector embedder (e.g.
+  `dinov3_single`) is **not** eligible for the patch slot.
+- `structural_embedder` must point at an embedder with
+  `supports_geometric_verification == True`.
+- Slots are **independent** - any non-empty subset of the three is
+  legal (all seven combinations), and in particular `patch_embedder`
+  and `structural_embedder` may both be set (different visual
+  capabilities, not mutually exclusive).
+- **Capability-matching only (decided).** Plain single-vector
+  embedders that match *none* of the three capability flags
+  (`dinov2_single`, `dinov3_single`, `eupe_single`, `face`,
+  `whisper`, `ast`, `paraspeechclap`, `videomae`, …) are **not
+  eligible for any slot** and cannot participate in a multi-slot
+  dataset. They remain single-embedder datasets bound through the
+  legacy `embedder` field, exactly as today - the new feature simply
+  does not extend to them. A multi-slot dataset therefore always has
+  ≥1 of the three slots set; a plain-single dataset has zero slots
+  set and is driven entirely by `embedder`.
 
 `dataset.supports_text` becomes `text_embedder is not None`;
-`dataset.supports_patch_regions` becomes `patch_embedder is not None`.
-The existing `MediaEmbedder.supports_text` /
-`supports_patch_regions` flags stay - they describe an embedder's
+`dataset.supports_patch_regions` becomes `patch_embedder is not None`;
+`dataset.supports_geometric_verification` becomes
+`structural_embedder is not None`.  (A plain-single legacy dataset
+reports all three as `False`, matching today - its content vector
+still drives cosine/example sort and the MLP via `media["embedding"]`,
+which is a *content* vector, not a capability.)  The existing
+`MediaEmbedder.supports_*` flags stay - they describe an embedder's
 *capabilities*; the dataset slots record which embedder is *bound* to
 which role.
+
+**Migration of a legacy single `embedder` X into slots** (read-time,
+by capability):
+
+- `X.supports_text` → `text_embedder = X`
+- elif `X.supports_patch_regions` → `patch_embedder = X`
+- elif `X.supports_geometric_verification` → `structural_embedder = X`
+- else (plain single-vector) → **no slot set**; `embedder = X` stands
+  alone.
+
+The structural slot is the "third role" the structural-embedder plan
+explicitly deferred to "patch v3"; it lands here as a co-equal slot.
 
 ### Routing rules
 

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -747,6 +747,32 @@ plumbing, not modelling.
   slot embedder; the routing table (text→text slot, region→patch slot,
   instance→structural slot, diversity/MLP→preferred visual slot) wires
   reads to the right slot.  Detector MLP keying gains `embedder_name`.
+  - **Phase 2a - dict accessor substrate. SHIPPED (PR #2001, branch
+    `claude/three-slot-embedder-2`, separate from the Phase 1 PR #1999).**
+    `vtscore/embedding/media_vectors.py` introduces `media["embeddings"]`
+    (dict keyed by embedder name) with `media_embedding` /
+    `ensure_embeddings_dict` / `set_media_embedding` /
+    `primary_embedder_name`.  Fresh embeds write through
+    `set_media_embedding` (`stages/embedding.py`); a load-time pass
+    materializes the dict for pre-embedded / reloaded media; the
+    `_require_embedding` chokepoint in `embedding/matrix.py` reads via the
+    accessor.  The legacy singular `media["embedding"]` is kept as the
+    **primary mirror / fallback** so the ~50 read sites not yet converted
+    stay valid while only one embedder is bound (unambiguous for its whole
+    lifetime; removed in 2c).  Pickle format unchanged — the dict is an
+    in-RAM representation rebuilt on load.  Tests in
+    `tests_lib/core/test_media_vectors.py`.
+  - **Phase 2b - convert remaining read sites + loader multi-embed +
+    routing.**  Point the ~50 remaining `media["embedding"]` / patch /
+    structural read sites at the accessor; loader runs every bound slot
+    embedder and persists multiple vectors (pickle format change); routing
+    table wires each operation to its slot; MLP keying gains
+    `embedder_name`.  Needs a backend create-path for multi-slot datasets
+    so multi-embed + routing are testable before the Phase 3 frontend.
+  - **Phase 2c - drop the singular mirror.**  Once every read goes through
+    the accessor and all media carry the dict, remove the legacy
+    `media["embedding"]` primary mirror (and update the ~50 test sites that
+    construct it directly).
 - **Phase 3 - frontend.** N-slot progressive-disclosure picker on
   dataset-create (primary content embedder + collapsible "add text /
   add structural" rows, each filtered to its capability), and the

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -720,13 +720,40 @@ inconsistency window.
    sanity check on a mixed dataset before we lock the preference
    in.
 
-### V3 work plan (sketch)
+### V3 work plan (phased)
 
-Filled in when we start, just like the v2 plan was a punchlist
-during impl.  Rough size estimate: backend ~2× v2 (schema +
-loader + per-embedder MLP keying), frontend ~0.5× v2 (just the
-dual-picker on dataset-create).  No new ML algorithms - v3 is
+Phased during impl, like the v2 punchlist.  Rough size: backend ~2× v2
+(schema + loader + per-embedder MLP keying), frontend ~0.5× v2 (the
+N-slot picker on dataset-create).  No new ML algorithms - v3 is
 plumbing, not modelling.
+
+- **Phase 1 - slot-binding foundation. SHIPPED.** `EmbedderSlots`
+  value object (`vtscore/datasets/embedder_slots.py`): the three
+  role-typed slots (text / patch / structural), capability-matching
+  migration from a legacy single embedder, capability getters, and
+  validation.  Slot keys persist in `meta.json` additively next to the
+  legacy `embedder` field (`export_dataset_to_file`), and
+  `read_pkl_slots` reads/migrates them back.  Capability-matching only:
+  plain single-vector embedders stay on the legacy field with empty
+  slots.  Create-flow still binds one embedder (frontend untouched);
+  runtime capability resolution still reads the per-media `embedder`,
+  so single-embedder datasets round-trip identically.  Tests in
+  `tests_lib/datasets/test_embedder_slots.py`.
+- **Phase 2 - per-media dict schema + loader multi-embed + routing.**
+  Flip `media["embedding"]` (singular) → `media["embeddings"]` (dict
+  keyed by embedder name) and the patch/structural per-media fields to
+  dict-keyed, with read-time migration of old pickles (the ~100-site
+  change the foundation was built to absorb).  Loader runs every bound
+  slot embedder; the routing table (text→text slot, region→patch slot,
+  instance→structural slot, diversity/MLP→preferred visual slot) wires
+  reads to the right slot.  Detector MLP keying gains `embedder_name`.
+- **Phase 3 - frontend.** N-slot progressive-disclosure picker on
+  dataset-create (primary content embedder + collapsible "add text /
+  add structural" rows, each filtered to its capability), and the
+  importer payloads carry `text_embedder` / `patch_embedder` /
+  `structural_embedder`.
+- **Phase 4 - import-path polish.** NPZ per-embedder `vectors_<name>`
+  layout; Combine-Datasets requires identical slot triples.
 
 ## Phasing
 

--- a/tests_lib/datasets/test_embedder_slots.py
+++ b/tests_lib/datasets/test_embedder_slots.py
@@ -1,0 +1,173 @@
+"""Tests for role-typed embedder slot binding (text / patch / structural).
+
+Covers the Phase-1 backend foundation of the three-slot dataset model:
+capability-matching migration, the capability getters, meta.json
+round-tripping, validation, and the export-side persistence of slot keys.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.datasets.container import read_meta
+from vtscore.datasets.embedder_slots import (
+    PATCH_KEY,
+    STRUCTURAL_KEY,
+    TEXT_KEY,
+    EmbedderSlots,
+    legacy_embedder_role,
+)
+from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader_pickle import read_pkl_slots
+
+
+class TestLegacyMigration:
+    """A single legacy embedder maps into its capability-matching slot."""
+
+    def test_text_capable_embedder_fills_text_slot(self):
+        slots = EmbedderSlots.from_legacy("siglip")
+        assert slots.text == "siglip"
+        assert slots.patch is None
+        assert slots.structural is None
+
+    def test_patch_capable_embedder_fills_patch_slot(self):
+        slots = EmbedderSlots.from_legacy("dinov3_patch")
+        assert slots.patch == "dinov3_patch"
+        assert slots.text is None
+        assert slots.structural is None
+
+    def test_structural_embedder_fills_structural_slot(self):
+        slots = EmbedderSlots.from_legacy("sift_vlad")
+        assert slots.structural == "sift_vlad"
+        assert slots.text is None
+        assert slots.patch is None
+
+    def test_plain_single_vector_embedder_fills_no_slot(self):
+        # dinov2_single matches none of text/patch/structural -> not slottable.
+        slots = EmbedderSlots.from_legacy("dinov2_single")
+        assert slots.is_empty
+        assert slots.bound() == []
+
+    def test_empty_and_unknown_names_fill_no_slot(self):
+        assert EmbedderSlots.from_legacy("").is_empty
+        assert EmbedderSlots.from_legacy("no_such_embedder").is_empty
+
+    def test_legacy_embedder_role_helper(self):
+        assert legacy_embedder_role("siglip") == "text"
+        assert legacy_embedder_role("dinov3_patch") == "patch"
+        assert legacy_embedder_role("sift_vlad") == "structural"
+        assert legacy_embedder_role("dinov2_single") is None
+        assert legacy_embedder_role("") is None
+
+
+class TestCapabilityGetters:
+    def test_getters_follow_bound_slots(self):
+        slots = EmbedderSlots(text="siglip", structural="sift_vlad")
+        assert slots.supports_text is True
+        assert slots.supports_geometric_verification is True
+        assert slots.supports_patch_regions is False
+        assert not slots.is_empty
+
+    def test_empty_binding_reports_no_capabilities(self):
+        slots = EmbedderSlots()
+        assert slots.supports_text is False
+        assert slots.supports_patch_regions is False
+        assert slots.supports_geometric_verification is False
+        assert slots.is_empty
+
+    def test_bound_dedups_and_orders(self):
+        # Same embedder in two roles (hypothetical) is reported once, in role order.
+        slots = EmbedderSlots(text="a", patch="b", structural="a")
+        assert slots.bound() == ["a", "b"]
+
+
+class TestMetaRoundTrip:
+    def test_to_meta_omits_empty_slots(self):
+        assert EmbedderSlots().to_meta() == {}
+        assert EmbedderSlots(text="siglip").to_meta() == {TEXT_KEY: "siglip"}
+
+    def test_to_meta_then_from_meta_round_trips(self):
+        slots = EmbedderSlots(text="siglip", patch="dinov3_patch", structural="sift_vlad")
+        meta = {"embedder": "siglip", **slots.to_meta()}
+        restored = EmbedderSlots.from_meta(meta)
+        assert restored == slots
+
+    def test_explicit_slot_keys_take_priority_over_legacy(self):
+        # Slot keys present -> legacy embedder is ignored for slot resolution.
+        meta = {"embedder": "dinov2_single", PATCH_KEY: "dinov3_patch"}
+        slots = EmbedderSlots.from_meta(meta)
+        assert slots.patch == "dinov3_patch"
+        assert slots.text is None
+
+    def test_legacy_only_meta_is_migrated(self):
+        # No slot keys -> migrate the legacy embedder by capability.
+        assert EmbedderSlots.from_meta({"embedder": "siglip"}).text == "siglip"
+        assert EmbedderSlots.from_meta({"embedder": "sift_vlad"}).structural == "sift_vlad"
+        assert EmbedderSlots.from_meta({"embedder": "dinov2_single"}).is_empty
+        assert EmbedderSlots.from_meta({}).is_empty
+
+
+class TestValidate:
+    def test_valid_bindings_pass(self):
+        EmbedderSlots().validate()
+        EmbedderSlots(text="siglip", patch="dinov3_patch", structural="sift_vlad").validate()
+
+    def test_capability_mismatch_raises(self):
+        # A patch embedder in the text slot is not eligible.
+        import pytest
+
+        with pytest.raises(ValueError, match="not eligible for the 'text' slot"):
+            EmbedderSlots(text="dinov3_patch").validate()
+
+    def test_structural_embedder_in_patch_slot_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="not eligible for the 'patch' slot"):
+            EmbedderSlots(patch="sift_vlad").validate()
+
+
+class TestExportPersistsSlots:
+    """``export_dataset_to_file`` writes slot keys derived from the embedder."""
+
+    @staticmethod
+    def _media(i: int) -> dict:
+        rng = np.random.default_rng(i)
+        return {
+            "id": i,
+            "media_type": "image",
+            "duration": 0.0,
+            "file_size": 100,
+            "md5": f"md5_{i}",
+            "embedding": rng.standard_normal(8).astype(np.float32),
+            "filename": f"img_{i}.jpg",
+        }
+
+    def _export(self, tmp_path, embedder: str):
+        medias = {i: self._media(i) for i in range(3)}
+        blob = export_dataset_to_file(medias, embedder=embedder, media_type="image", name="t")
+        path = tmp_path / "ds.pkl"
+        path.write_bytes(blob)
+        return path
+
+    def test_text_embedder_slot_persisted(self, tmp_path):
+        path = self._export(tmp_path, "siglip")
+        meta = read_meta(path)
+        assert meta[TEXT_KEY] == "siglip"
+        assert PATCH_KEY not in meta
+        assert STRUCTURAL_KEY not in meta
+        assert read_pkl_slots(path) == EmbedderSlots(text="siglip")
+
+    def test_plain_single_vector_writes_no_slot_keys(self, tmp_path):
+        path = self._export(tmp_path, "dinov2_single")
+        meta = read_meta(path)
+        assert TEXT_KEY not in meta
+        assert PATCH_KEY not in meta
+        assert STRUCTURAL_KEY not in meta
+        # Legacy field still carries the embedder; slots migrate to empty.
+        assert meta["embedder"] == "dinov2_single"
+        assert read_pkl_slots(path).is_empty
+
+    def test_structural_embedder_slot_persisted(self, tmp_path):
+        path = self._export(tmp_path, "sift_vlad")
+        assert read_meta(path)[STRUCTURAL_KEY] == "sift_vlad"
+        assert read_pkl_slots(path) == EmbedderSlots(structural="sift_vlad")

--- a/vtscore/datasets/embedder_slots.py
+++ b/vtscore/datasets/embedder_slots.py
@@ -1,0 +1,173 @@
+"""Role-typed embedder slot binding for datasets (text / patch / structural).
+
+A dataset's header binds up to one embedder per capability role:
+
+- ``text_embedder``       — a ``supports_text`` embedder (text queries)
+- ``patch_embedder``      — a ``supports_patch_regions`` embedder (region voting)
+- ``structural_embedder`` — a ``supports_geometric_verification`` embedder
+  (instance / geometric-verification matching)
+
+Only a **capability-matching** embedder is eligible for a slot.  Plain
+single-vector embedders that match none of the three capability flags
+(``dinov2_single``, ``face``, ``whisper``, ``ast``, ``videomae``, …) are not
+slottable and remain single-embedder datasets driven by the legacy
+``embedder`` field, exactly as before.  The three slot fields are *additive*
+to that legacy field, which stays as the always-present primary/content
+embedder.
+
+This module is library-tier (no Flask) and resolves embedder capabilities
+lazily via :func:`vtscore.media.get_embedder`, so importing it never forces
+the media registry to load.
+
+See ``docs/plans/patch-embedder.md`` → "V3 — design" for the full spec.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Role identifiers.
+TEXT = "text"
+PATCH = "patch"
+STRUCTURAL = "structural"
+
+# meta.json keys for each slot.
+TEXT_KEY = "text_embedder"
+PATCH_KEY = "patch_embedder"
+STRUCTURAL_KEY = "structural_embedder"
+
+SLOT_KEYS = (TEXT_KEY, PATCH_KEY, STRUCTURAL_KEY)
+
+
+def _slot_capability_ok(name: str, role: str) -> bool:
+    """Whether *name* names a registered embedder eligible for *role*'s slot.
+
+    Eligibility is the embedder's matching capability flag: ``supports_text``
+    for the text slot, ``supports_patch_regions`` for the patch slot,
+    ``supports_geometric_verification`` for the structural slot.  Unknown
+    embedder names return ``False``.
+    """
+    from vtscore.media import get_embedder  # noqa: PLC0415
+
+    try:
+        emb = get_embedder(name)
+    except KeyError:
+        return False
+    if role == TEXT:
+        return bool(getattr(emb, "supports_text", False))
+    if role == PATCH:
+        return bool(getattr(emb, "supports_patch_regions", False))
+    if role == STRUCTURAL:
+        return bool(getattr(emb, "supports_geometric_verification", False))
+    return False
+
+
+def legacy_embedder_role(name: str) -> str | None:
+    """Return the slot role a single legacy embedder migrates into, or ``None``.
+
+    Capability flags are disjoint across the shipped embedders, but we resolve
+    in a fixed priority (text → patch → structural) so the mapping is
+    deterministic even if a future embedder reports more than one flag.  A
+    plain single-vector embedder (no matching flag) and an unknown name both
+    return ``None`` — they are not slottable.
+    """
+    if not name:
+        return None
+    for role in (TEXT, PATCH, STRUCTURAL):
+        if _slot_capability_ok(name, role):
+            return role
+    return None
+
+
+@dataclass(frozen=True)
+class EmbedderSlots:
+    """The three role-typed embedder bindings of a dataset.
+
+    ``None`` means the slot is empty.  A multi-slot dataset has at least one
+    slot set; a plain single-vector dataset has all three empty and is driven
+    by the legacy ``embedder`` field instead.
+    """
+
+    text: str | None = None
+    patch: str | None = None
+    structural: str | None = None
+
+    @property
+    def supports_text(self) -> bool:
+        return self.text is not None
+
+    @property
+    def supports_patch_regions(self) -> bool:
+        return self.patch is not None
+
+    @property
+    def supports_geometric_verification(self) -> bool:
+        return self.structural is not None
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no slot is bound (a plain-single / legacy dataset)."""
+        return self.text is None and self.patch is None and self.structural is None
+
+    def bound(self) -> list[str]:
+        """Distinct bound embedder names, in role order (text, patch, structural)."""
+        ordered: dict[str, None] = {}
+        for name in (self.text, self.patch, self.structural):
+            if name:
+                ordered.setdefault(name, None)
+        return list(ordered)
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` if any slot holds a capability-mismatched embedder.
+
+        A plain (all-empty) binding is valid here; the "must be non-empty"
+        rule for *multi-slot* datasets is enforced at dataset-create time, not
+        on every read (legacy plain-single datasets are legitimately empty).
+        """
+        for role, name in ((TEXT, self.text), (PATCH, self.patch), (STRUCTURAL, self.structural)):
+            if name and not _slot_capability_ok(name, role):
+                raise ValueError(f"Embedder {name!r} is not eligible for the {role!r} slot")
+
+    def to_meta(self) -> dict[str, str]:
+        """Slot fields for writing into a container ``meta.json`` (empties omitted)."""
+        out: dict[str, str] = {}
+        if self.text:
+            out[TEXT_KEY] = self.text
+        if self.patch:
+            out[PATCH_KEY] = self.patch
+        if self.structural:
+            out[STRUCTURAL_KEY] = self.structural
+        return out
+
+    @classmethod
+    def from_legacy(cls, embedder: str) -> EmbedderSlots:
+        """Migrate a single legacy embedder name into its capability-matching slot.
+
+        A plain single-vector embedder (or an empty/unknown name) maps to an
+        all-empty binding — it is not slottable and stays on the legacy
+        ``embedder`` field.
+        """
+        role = legacy_embedder_role(embedder)
+        if role == TEXT:
+            return cls(text=embedder)
+        if role == PATCH:
+            return cls(patch=embedder)
+        if role == STRUCTURAL:
+            return cls(structural=embedder)
+        return cls()
+
+    @classmethod
+    def from_meta(cls, meta: dict) -> EmbedderSlots:
+        """Build slots from a container ``meta.json`` dict.
+
+        If any explicit slot key is present, use the slot keys verbatim.
+        Otherwise fall back to migrating the legacy ``embedder`` field by
+        capability (read-time migration of pre-slot containers).
+        """
+        if any(key in meta for key in SLOT_KEYS):
+            return cls(
+                text=meta.get(TEXT_KEY) or None,
+                patch=meta.get(PATCH_KEY) or None,
+                structural=meta.get(STRUCTURAL_KEY) or None,
+            )
+        return cls.from_legacy(meta.get("embedder") or "")

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -240,6 +240,8 @@ def export_dataset_to_file(
     pickle.dump(data, pkl_buf, protocol=_PICKLE_PROTOCOL)
     medias_pkl_bytes = pkl_buf.getvalue()
 
+    from vtscore.datasets.embedder_slots import EmbedderSlots  # noqa: PLC0415
+
     meta = {
         "format_version": 1,
         "embedder": embedder,
@@ -249,6 +251,12 @@ def export_dataset_to_file(
         "created_at": created_at or time.time(),
         "expires_at": expires_at,
     }
+    # Persist the role-typed embedder slots alongside the legacy ``embedder``
+    # field.  A capability-matching embedder writes its slot key (e.g.
+    # ``text_embedder``); a plain single-vector embedder adds no slot keys and
+    # is driven by ``embedder`` alone.  Old containers without slot keys are
+    # migrated on read by ``EmbedderSlots.from_meta``.
+    meta.update(EmbedderSlots.from_legacy(embedder).to_meta())
 
     if on_stage:
         on_stage("Packaging dataset…")

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -11,12 +11,15 @@ import gc
 import hashlib
 import logging
 from pathlib import Path
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 from vtscore.datasets.loader import (
     ProgressCallback,
 )
 from vtscore.embedding.normalize import l2_normalize
+
+if TYPE_CHECKING:
+    from vtscore.datasets.embedder_slots import EmbedderSlots
 
 logger = logging.getLogger(__name__)
 
@@ -401,3 +404,16 @@ def read_pkl_clipper(pkl_path: Path) -> str | None:
 def read_pkl_embedder(pkl_path: Path) -> str | None:
     """Return the embedder name from the container's ``meta.json``, or ``None`` if unreadable."""
     return _read_pkl_meta_safe(pkl_path).get("embedder") or None
+
+
+def read_pkl_slots(pkl_path: Path) -> EmbedderSlots:
+    """Return the role-typed embedder slots from the container's ``meta.json``.
+
+    Slot keys (``text_embedder`` / ``patch_embedder`` / ``structural_embedder``)
+    are used verbatim when present; an older container without them is migrated
+    on the fly from its legacy ``embedder`` field by capability.  An unreadable
+    container yields empty slots.
+    """
+    from vtscore.datasets.embedder_slots import EmbedderSlots
+
+    return EmbedderSlots.from_meta(_read_pkl_meta_safe(pkl_path))


### PR DESCRIPTION
First slice of the **three-slot embedder binding** for datasets (patch-embedder.md → "V3 — design"): a dataset will eventually bind any non-empty subset of three **role-typed** slots — `text` / `patch` / `structural`.

## Design decisions (locked)

- **Three independent slots, any non-empty subset** — `text` (`supports_text`), `patch` (`supports_patch_regions`), `structural` (`supports_geometric_verification`). The structural slot is the "third role" the structural-embedder plan deferred to "patch v3".
- **Capability-matching only** — plain single-vector embedders (`dinov2_single`, `dinov3_single`, `eupe_single`, `face`, `whisper`, `ast`, `paraspeechclap`, `videomae`) are not slottable; they stay single-embedder datasets on the legacy `embedder` field.

## What landed (Phase 1)

- `vtscore/datasets/embedder_slots.py` — `EmbedderSlots`: capability-matching migration from a legacy single embedder, capability getters, `validate()`, and `meta.json` (de)serialization.
- Dataset export persists slot keys **additively** next to the legacy `embedder` field; the reader reads/migrates them, so old pickles keep loading.
- `tests_lib/datasets/test_embedder_slots.py`.

## Follow-ups

Phase 2 (dict-keyed per-media embeddings + routing + MLP keying) ships as its **own PR**, independent of this one. Remaining phases (loader multi-embed, frontend N-slot picker, NPZ/combine-dataset polish) are tracked in the plan's "V3 work plan (phased)".

## Tests

`./run-tests.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)