### PR TITLE
Three-slot embedder binding — Phase 2a: dict-keyed embedding accessor substrate

### DIFF
--- a/tests_lib/core/test_media_vectors.py
+++ b/tests_lib/core/test_media_vectors.py
@@ -1,0 +1,113 @@
+"""Tests for the dict-keyed per-media embedding accessor (Phase 2 substrate).
+
+The accessor resolves a media's embedding from ``media["embeddings"]`` (the
+dict-keyed form) with a fallback to the legacy singular ``media["embedding"]``,
+so the two representations coexist during the migration.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.embedding.media_vectors import (
+    ensure_embeddings_dict,
+    media_embedding,
+    primary_embedder_name,
+    set_media_embedding,
+)
+
+
+def _vec(seed: int, dim: int = 4) -> np.ndarray:
+    return np.random.default_rng(seed).standard_normal(dim).astype(np.float32)
+
+
+class TestMediaEmbedding:
+    def test_legacy_singular_only(self):
+        v = _vec(1)
+        media = {"embedding": v, "embedder": "siglip"}
+        assert media_embedding(media) is v
+        assert media_embedding(media, "siglip") is v
+
+    def test_dict_entry_by_name(self):
+        a, b = _vec(1), _vec(2)
+        media = {"embeddings": {"siglip": a, "dinov3_patch": b}, "embedder": "siglip"}
+        assert media_embedding(media, "siglip") is a
+        assert media_embedding(media, "dinov3_patch") is b
+
+    def test_primary_prefers_recorded_embedder(self):
+        a, b = _vec(1), _vec(2)
+        media = {"embeddings": {"siglip": a, "dinov3_patch": b}, "embedder": "dinov3_patch"}
+        assert media_embedding(media) is b
+
+    def test_primary_single_entry_without_recorded_embedder(self):
+        a = _vec(1)
+        media = {"embeddings": {"siglip": a}}
+        assert media_embedding(media) is a
+
+    def test_ambiguous_multiple_entries_falls_back_to_singular(self):
+        a, b, s = _vec(1), _vec(2), _vec(3)
+        media = {"embeddings": {"x": a, "y": b}, "embedding": s}
+        # No recorded primary + >1 entry → legacy singular wins.
+        assert media_embedding(media) is s
+
+    def test_named_lookup_misses_when_embedder_differs(self):
+        s = _vec(1)
+        media = {"embedding": s, "embedder": "siglip"}
+        # Singular belongs to siglip; a request for a different embedder misses.
+        assert media_embedding(media, "dinov3_patch") is None
+        assert media_embedding(media, "siglip") is s
+
+    def test_missing_everything_returns_none(self):
+        assert media_embedding({}) is None
+        assert media_embedding({}, "siglip") is None
+
+
+class TestEnsureEmbeddingsDict:
+    def test_materializes_from_singular(self):
+        v = _vec(1)
+        media = {"embedding": v, "embedder": "siglip"}
+        ensure_embeddings_dict(media)
+        assert media["embeddings"] == {"siglip": v}
+
+    def test_idempotent(self):
+        a = _vec(1)
+        media = {"embeddings": {"siglip": a}, "embedder": "siglip"}
+        ensure_embeddings_dict(media)
+        assert media["embeddings"] == {"siglip": a}
+
+    def test_no_dict_when_embedder_unknown(self):
+        media = {"embedding": _vec(1)}
+        ensure_embeddings_dict(media)
+        assert "embeddings" not in media
+
+    def test_no_op_without_vector(self):
+        media = {"embedder": "siglip"}
+        ensure_embeddings_dict(media)
+        assert "embeddings" not in media
+
+
+class TestSetMediaEmbedding:
+    def test_writes_dict_and_primary_mirror(self):
+        v = _vec(1)
+        media: dict = {}
+        set_media_embedding(media, "siglip", v)
+        assert media["embeddings"] == {"siglip": v}
+        assert media["embedding"] is v
+        assert media["embedder"] == "siglip"
+
+    def test_second_embedder_keeps_primary_mirror(self):
+        a, b = _vec(1), _vec(2)
+        media: dict = {}
+        set_media_embedding(media, "siglip", a)
+        set_media_embedding(media, "dinov3_patch", b)
+        # Both stored; the singular mirror stays on the primary (first/recorded).
+        assert media["embeddings"]["siglip"] is a
+        assert media["embeddings"]["dinov3_patch"] is b
+        assert media["embedding"] is a
+        assert media["embedder"] == "siglip"
+
+
+def test_primary_embedder_name():
+    assert primary_embedder_name({"embedder": "siglip"}) == "siglip"
+    assert primary_embedder_name({"embeddings": {"clap": _vec(1)}}) == "clap"
+    assert primary_embedder_name({}) is None

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
 from vtscore.embedding.matrix import invalidate_embedding_matrix
+from vtscore.embedding.media_vectors import ensure_embeddings_dict, set_media_embedding
 
 from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
 
@@ -182,9 +183,7 @@ def embed_missing(  # noqa: C901
                 media = medias.get(mid)
                 if media is None:
                     continue
-                media["embedding"] = vec
-                if not media.get("embedder"):
-                    media["embedder"] = embedder_id
+                set_media_embedding(media, embedder_id, vec)
 
     # Patch-region pass for embedders that support it (DINOv2/v3/EUPE).  Runs
     # over every patch-capable image still lacking a region tree, including
@@ -231,6 +230,13 @@ def embed_missing(  # noqa: C901
                 if feats is None:
                     continue
                 media["local_features"] = feats.compact()
+
+    # Materialize the dict-keyed representation (Phase 2 substrate): every
+    # media with a known embedder gets media["embeddings"][name] = vec.  The
+    # singular media["embedding"] stays as the primary mirror / legacy fallback
+    # for read sites not yet converted to the media_vectors accessor.
+    for media in medias.values():
+        ensure_embeddings_dict(media)
 
 
 def _attach_patch_regions_to_media(media: dict, patch_out) -> None:

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from vtscore.embedding.media_vectors import media_embedding
 from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
 
 
 def _require_embedding(cid: int, media: dict[str, Any]) -> Any:
-    emb = media.get("embedding")
+    emb = media_embedding(media)
     if emb is None:
         raise ValueError(
             f"media {cid!r} has no embedding (embedding=None); "

--- a/vtscore/embedding/media_vectors.py
+++ b/vtscore/embedding/media_vectors.py
@@ -1,0 +1,106 @@
+"""Per-media embedding vector access (dict-keyed, with legacy fallback).
+
+Phase 2 of the three-slot embedder work (``docs/plans/patch-embedder.md`` →
+"V3 — design") moves a media's embedding from a single ``media["embedding"]``
+ndarray to ``media["embeddings"]`` — a dict keyed by embedder name — so the
+vectors of multiple bound embedders can coexist on one media.
+
+During the migration the singular ``media["embedding"]`` is kept as the
+**primary mirror / legacy fallback**: it always reflects the dataset's single
+bound embedder while only one is bound, so the many read sites not yet
+converted to this accessor keep working unchanged.  This module is the one
+place that knows how to resolve a vector from either shape; new and converted
+read sites go through :func:`media_embedding`.
+
+Library-tier: imports only numpy, no Flask, no media registry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+EMBEDDINGS_KEY = "embeddings"
+
+
+def primary_embedder_name(media: dict[str, Any]) -> str | None:
+    """Return the media's primary embedder name, or ``None`` if unknown.
+
+    Prefers the recorded ``media["embedder"]``; falls back to the first key of
+    the ``embeddings`` dict when the field is absent.
+    """
+    name = media.get("embedder")
+    if name:
+        return name
+    embs = media.get(EMBEDDINGS_KEY)
+    if embs:
+        return next(iter(embs))
+    return None
+
+
+def media_embedding(media: dict[str, Any], embedder_name: str | None = None) -> Any:
+    """Return the embedding vector for *embedder_name*, or the primary one.
+
+    Resolution order:
+
+    * ``embedder_name`` given → ``media["embeddings"][embedder_name]`` when a
+      dict is present; otherwise the legacy singular vector, but only if it
+      belongs to that embedder (the media's recorded ``embedder`` matches or is
+      unset).  Returns ``None`` when no matching vector exists.
+    * ``embedder_name`` omitted → the primary vector: the recorded embedder's
+      entry in the dict, else the sole dict entry, else the legacy singular
+      ``media["embedding"]``.
+    """
+    embs = media.get(EMBEDDINGS_KEY)
+    if embedder_name is not None:
+        if isinstance(embs, dict) and embedder_name in embs:
+            return embs[embedder_name]
+        # No dict entry: the legacy singular vector only answers for the
+        # media's own embedder.
+        if media.get("embedder") in (None, "", embedder_name):
+            return media.get("embedding")
+        return None
+
+    if isinstance(embs, dict) and embs:
+        name = media.get("embedder")
+        if name and name in embs:
+            return embs[name]
+        if len(embs) == 1:
+            return next(iter(embs.values()))
+        # Ambiguous (multiple entries, no recorded primary) → fall through.
+    return media.get("embedding")
+
+
+def ensure_embeddings_dict(media: dict[str, Any]) -> None:
+    """Materialize ``media["embeddings"]`` from the legacy singular vector.
+
+    Idempotent.  A media that already carries a non-empty ``embeddings`` dict
+    is left untouched.  One with only a singular ``embedding`` *and* a known
+    embedder name gets a one-entry dict; a media whose embedder is unknown
+    stays singular-only (the accessor falls back to ``embedding``), so no
+    empty-string keys are minted.
+    """
+    if media.get(EMBEDDINGS_KEY):
+        return
+    vec = media.get("embedding")
+    name = media.get("embedder")
+    if vec is None or not name:
+        return
+    media[EMBEDDINGS_KEY] = {name: vec}
+
+
+def set_media_embedding(media: dict[str, Any], embedder_name: str, vec: Any) -> None:
+    """Store *vec* for *embedder_name* on *media*, maintaining the primary mirror.
+
+    Writes ``media["embeddings"][embedder_name]`` (creating the dict) and keeps
+    the legacy singular ``media["embedding"]`` pointing at the primary embedder's
+    vector so unconverted readers stay correct while only one embedder is bound.
+    """
+    embs = media.get(EMBEDDINGS_KEY)
+    if not isinstance(embs, dict):
+        embs = {}
+        media[EMBEDDINGS_KEY] = embs
+    embs[embedder_name] = vec
+    if media.get("embedder") in (None, "", embedder_name) or media.get("embedding") is None:
+        media["embedding"] = vec
+        if not media.get("embedder"):
+            media["embedder"] = embedder_name


### PR DESCRIPTION
Phase 2 of the **three-slot embedder binding** (patch-embedder.md → "V3 — design"). This first slice (2a) lays the per-media storage substrate that multi-embedder routing and MLP keying build on. Independent of the Phase 1 slot-foundation PR (#1999) — different files, either can merge first.

## What landed (Phase 2a)

Moves a media's embedding from a single `media["embedding"]` ndarray toward `media["embeddings"]` — a dict keyed by embedder name — so the vectors of multiple bound embedders can eventually coexist on one media.

- **`vtscore/embedding/media_vectors.py`** (new) — the one place that resolves a vector from either shape:
  - `media_embedding(media, embedder_name=None)` — dict lookup with legacy singular fallback; primary = recorded embedder's entry, else sole entry, else singular.
  - `ensure_embeddings_dict` / `set_media_embedding` / `primary_embedder_name`.
- **`stages/embedding.py`** — fresh embeds write through `set_media_embedding`; a load-time pass materializes the dict for pre-embedded / reloaded media.
- **`embedding/matrix.py`** — the `_require_embedding` chokepoint (feeds every scoring/sorting matrix) reads via the accessor.
- **`tests_lib/core/test_media_vectors.py`** — 14 cases covering resolution order, migration, and the primary mirror.

## Transitional mirror (intentional)

While only one embedder is bound, the legacy singular `media["embedding"]` is kept as the **primary mirror / fallback** so the ~50 read sites not yet converted to the accessor keep working unchanged. This is a staged-migration device, not a back-compat shim: with one bound embedder the mirror equals `embeddings[only_key]`, so it is unambiguous for its whole lifetime. It gets removed in **Phase 2c**, alongside loader multi-embed and routing, exactly when a second embedder would make it ambiguous.

## Deferred (Phase 2b/2c)

Routing table (text→text slot, region→patch, instance→structural, diversity/MLP→preferred visual), MLP keying by embedder, loader multi-embed, and dropping the singular mirror. Tracked in the plan's "V3 work plan (phased)".

## Tests

`./run-tests.sh` — **4951 passed, 1 skipped** (ruff / format / codespell / deptry / frontend build all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTvWNULphmkr4HieApUhx1)_