### PR TITLE
Multi-embedder Phase 2b.1: make the matrix layer embedder-aware

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -1,9 +1,11 @@
 # Patch-based Image Embedder - Design
 
-**Status:** V1 shipped, V2 shipped, **V3 in design (not started).** The design
+**Status:** V1 shipped, V2 shipped, **V3 in progress.** The design
 body below is the living spec for the shipped V1/V2 behaviour; the *V1 - DONE*
 and *V2 - DONE* closeouts are collapsed to struck-through lists. **Remaining
-work** is *V3 - design* (one text + one patch embedder per dataset).
+work** is *V3* (one text + one patch embedder per dataset); see
+"V3 - implementation status" under "V3 work plan" for what's landed and the
+ordered phases that remain.
 
 ## Status of related work
 
@@ -672,6 +674,49 @@ during impl.  Rough size estimate: backend ~2× v2 (schema +
 loader + per-embedder MLP keying), frontend ~0.5× v2 (just the
 dual-picker on dataset-create).  No new ML algorithms - v3 is
 plumbing, not modelling.
+
+### V3 - implementation status
+
+V3 lands as a sequence of behavior-preserving substrate phases (so each
+commit is reviewable and the single-embedder world keeps working) followed by
+the user-visible binding.  Ordering is by dependency: each phase needs the one
+above it.
+
+**Shipped:**
+
+- **Phase 2a - per-media accessor substrate.** `vtscore/embedding/media_vectors.py`:
+  `media["embeddings"]` (dict keyed by embedder name) is the forward
+  representation; the singular `media["embedding"]` is kept as the *primary
+  mirror / fallback* so the ~50 not-yet-converted read sites stay valid while
+  only one embedder is bound.  `embed_missing` writes through
+  `set_media_embedding`; the `matrix.py` chokepoint reads through
+  `media_embedding`.
+- **Phase 2b.1 - matrix layer made embedder-aware.** `get_embedding_matrix`,
+  `get_embedding_submatrix`, and `get_embedding_matrix_for_snap` take an
+  optional `embedder_name`.  Unset → the cached primary path (byte-for-byte the
+  old behaviour).  Set → a fresh, uncached matrix built from that bound
+  embedder's vectors via the accessor.  This is the aggregate read chokepoint
+  every consumer (sorting / scoring / find / projection / training /
+  positives-browse) funnels through, so routing can later request the right
+  embedder per operation.
+
+**Remaining, in order:**
+
+- **Phase 2b.2 - dataset binding.** Add `text_embedder` / `patch_embedder`
+  slots (today there is no dataset-level embedder field at all; the embedder is
+  recorded per-media).  `dataset.supports_text` / `supports_patch_regions`
+  become derived from which slot is filled.  See "Dataset binding" above.
+- **Phase 2b.3 - loader multi-embed.** Run both bound embedders at ingest so
+  `media["embeddings"]` / `patch_regions` / `patch_grid` carry a per-embedder
+  entry each.  See "Loader / exporter / importer impact".
+- **Phase 2b.4 - routing.** Wire the routing table (text sort → `text_embedder`;
+  cosine/region ops → `patch_embedder`); pass the resolved embedder name into
+  the now-embedder-aware matrix layer at each consumer.  See "Routing rules".
+- **Phase 2b.5 - MLP keying.** Key MLPs by `(detector, dataset, embedder)`.
+  See "Detector MLP keying".
+- **Phase 2c - drop the singular mirror.** Once every read site routes through
+  the accessor with an explicit embedder, remove the `media["embedding"]`
+  primary mirror (read-time re-key on load handles old pickles).
 
 ## Phasing
 

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -101,6 +101,87 @@ class TestGetEmbeddingSubmatrix:
         assert ctx._emb_matrix_ids is None
 
 
+class TestEmbedderAwareMatrix:
+    """The matrix builders can source rows from a specific bound embedder.
+
+    A multi-embedder dataset carries ``media["embeddings"]`` (dict keyed by
+    embedder name); requesting an explicit name builds that embedder's matrix,
+    while the default (no name) follows the primary mirror.
+    """
+
+    def _ctx(self) -> DatasetContext:
+        ctx = DatasetContext("test_embedder_aware")
+        for cid in (1, 2, 3):
+            ctx.medias[cid] = {
+                "id": cid,
+                "embedder": "siglip",
+                "embedding": np.full(4, float(cid), dtype=np.float32),
+                "embeddings": {
+                    "siglip": np.full(4, float(cid), dtype=np.float32),
+                    "dinov3_patch": np.full(4, float(cid) + 100.0, dtype=np.float32),
+                },
+            }
+        return ctx
+
+    def test_named_embedder_selects_that_matrix(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_matrix(ctx, "dinov3_patch")
+        assert ids == [1, 2, 3]
+        assert mat[0, 0] == 101.0
+        assert mat[2, 0] == 103.0
+
+    def test_default_follows_primary(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_matrix(ctx)
+        assert mat[0, 0] == 1.0
+        assert mat[2, 0] == 3.0
+
+    def test_named_path_does_not_populate_cache(self):
+        """The named path is uncached; the primary cache stays untouched."""
+        ctx = self._ctx()
+        get_embedding_matrix(ctx, "dinov3_patch")
+        assert ctx._emb_matrix is None
+        assert ctx._emb_matrix_ids is None
+
+    def test_named_missing_vector_raises_with_embedder_name(self):
+        ctx = self._ctx()
+        del ctx.medias[2]["embeddings"]["dinov3_patch"]
+        ctx.medias[2]["embedder"] = "siglip"  # singular mirror is siglip's, not the requested one
+        with pytest.raises(ValueError, match=r"media 2.*has no embedding for 'dinov3_patch'"):
+            get_embedding_matrix(ctx, "dinov3_patch")
+
+    def test_submatrix_named_embedder(self):
+        ctx = self._ctx()
+        ids, mat = get_embedding_submatrix(ctx, [3, 1], "dinov3_patch")
+        assert ids == [1, 3]
+        assert mat[0, 0] == 101.0
+        assert mat[1, 0] == 103.0
+
+    def test_snap_named_embedder_matching_active_ctx(self):
+        ctx = self._ctx()
+        set_thread_dataset_context(ctx)
+        invalidate_embedding_matrix(ctx)
+        snap = {cid: ctx.medias[cid] for cid in ctx.medias}
+        ids, mat = get_embedding_matrix_for_snap(snap, "dinov3_patch")
+        assert ids == [1, 2, 3]
+        assert mat[0, 0] == 101.0
+        # Delegated to the context builder, but the named path must not cache.
+        assert ctx._emb_matrix is None
+
+    def test_snap_named_embedder_temp_dict(self):
+        # Active ctx empty → snap can't match → fresh-build path.
+        ctx = DatasetContext("test_snap_named_temp")
+        set_thread_dataset_context(ctx)
+        snap = {
+            10: {"embedder": "siglip", "embeddings": {"dinov3_patch": np.full(4, 5.0, dtype=np.float32)}},
+            11: {"embedder": "siglip", "embeddings": {"dinov3_patch": np.full(4, 6.0, dtype=np.float32)}},
+        }
+        ids, mat = get_embedding_matrix_for_snap(snap, "dinov3_patch")
+        assert ids == [10, 11]
+        assert mat[0, 0] == 5.0
+        assert mat[1, 0] == 6.0
+
+
 class TestGetEmbeddingMatrixForSnapRaisesOnNoneEmbedding:
     """Same guarantee for the snap helper, including the cross-dataset
     'temp dict' path that does NOT hit the cached active-ctx branch."""

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -147,7 +147,7 @@ class TestEmbedderAwareMatrix:
         ctx = self._ctx()
         del ctx.medias[2]["embeddings"]["dinov3_patch"]
         ctx.medias[2]["embedder"] = "siglip"  # singular mirror is siglip's, not the requested one
-        with pytest.raises(ValueError, match=r"media 2.*has no embedding for 'dinov3_patch'"):
+        with pytest.raises(ValueError, match=r"media 2.*has no embedding for embedder 'dinov3_patch'"):
             get_embedding_matrix(ctx, "dinov3_patch")
 
     def test_submatrix_named_embedder(self):

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -35,62 +35,88 @@ if TYPE_CHECKING:
     from vtscore.state.core import DatasetContext
 
 
-def _require_embedding(cid: int, media: dict[str, Any]) -> Any:
-    emb = media_embedding(media)
+def _require_embedding(cid: int, media: dict[str, Any], embedder_name: str | None = None) -> Any:
+    emb = media_embedding(media, embedder_name)
     if emb is None:
+        suffix = f" for embedder {embedder_name!r}" if embedder_name else ""
         raise ValueError(
-            f"media {cid!r} has no embedding (embedding=None); "
+            f"media {cid!r} has no embedding{suffix} (embedding=None); "
             "scoring/sorting require every media to have a vector. "
             "This usually means an importer or re-embed step silently failed."
         )
     return emb
 
 
-def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
+def _stack_embeddings(
+    sorted_ids: list[int],
+    source: dict[int, dict[str, Any]],
+    embedder_name: str | None,
+) -> np.ndarray:
+    """Build a contiguous ``(N, D)`` float32 matrix of *embedder_name*'s vectors.
+
+    Rows follow *sorted_ids* order, pulling each media's vector via
+    :func:`_require_embedding` (which routes through the dict-keyed accessor).
+    Raises ``ValueError`` naming the first media that lacks a vector.
+    """
+    first_emb = np.asarray(_require_embedding(sorted_ids[0], source[sorted_ids[0]], embedder_name), dtype=np.float32)
+    dim = int(first_emb.shape[-1])
+    matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
+    for i, cid in enumerate(sorted_ids):
+        matrix[i] = _require_embedding(cid, source[cid], embedder_name)
+    return matrix
+
+
+def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None) -> tuple[list[int], np.ndarray]:
     """Return ``(sorted_ids, (N, D) float32 matrix)`` for *ctx*'s medias.
 
-    The matrix is cached on the context and rebuilt only when the set of
-    media IDs changes.  Convert to a tensor with ``torch.from_numpy(matrix)``
-    for a zero-copy view.
+    With *embedder_name* unset the matrix is built from each media's *primary*
+    embedder and cached on the context, rebuilt only when the set of media IDs
+    changes.  Pass an explicit *embedder_name* (one of a multi-embedder
+    dataset's bound slots) to build a matrix from that embedder's vectors
+    instead; the named path builds fresh on every call and never touches the
+    cache, since the cache is reserved for the hot primary path.  Convert to a
+    tensor with ``torch.from_numpy(matrix)`` for a zero-copy view.
 
     Returns ``([], np.empty((0, 0), dtype=np.float32))`` when the dataset is
-    empty.  Raises ``ValueError`` if any media has ``embedding=None``.
+    empty.  Raises ``ValueError`` if any media lacks the requested vector.
     """
     with _state_lock:
         sorted_ids = sorted(ctx.medias.keys())
-        cached_ids = ctx._emb_matrix_ids
-        cached_matrix = ctx._emb_matrix
-        if cached_matrix is not None and cached_ids == sorted_ids:
-            return list(sorted_ids), cached_matrix
+        if embedder_name is None:
+            cached_ids = ctx._emb_matrix_ids
+            cached_matrix = ctx._emb_matrix
+            if cached_matrix is not None and cached_ids == sorted_ids:
+                return list(sorted_ids), cached_matrix
 
         if not sorted_ids:
-            ctx._emb_matrix_ids = []
-            ctx._emb_matrix = np.empty((0, 0), dtype=np.float32)
-            return [], ctx._emb_matrix
+            if embedder_name is None:
+                ctx._emb_matrix_ids = []
+                ctx._emb_matrix = np.empty((0, 0), dtype=np.float32)
+                return [], ctx._emb_matrix
+            return [], np.empty((0, 0), dtype=np.float32)
 
-        medias = ctx.medias
-        first_emb = np.asarray(_require_embedding(sorted_ids[0], medias[sorted_ids[0]]), dtype=np.float32)
-        dim = int(first_emb.shape[-1])
-        matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
-        for i, cid in enumerate(sorted_ids):
-            matrix[i] = _require_embedding(cid, medias[cid])
+        matrix = _stack_embeddings(sorted_ids, ctx.medias, embedder_name)
 
-        ctx._emb_matrix_ids = sorted_ids
-        ctx._emb_matrix = matrix
+        if embedder_name is None:
+            ctx._emb_matrix_ids = sorted_ids
+            ctx._emb_matrix = matrix
         return list(sorted_ids), matrix
 
 
-def get_embedding_submatrix(ctx: "DatasetContext", ids: list[int]) -> tuple[list[int], np.ndarray]:
+def get_embedding_submatrix(
+    ctx: "DatasetContext", ids: list[int], embedder_name: str | None = None
+) -> tuple[list[int], np.ndarray]:
     """Return ``(sorted_ids, (N, D) float32 matrix)`` for a *subset* of *ctx*'s medias.
 
     Unlike :func:`get_embedding_matrix`, this builds a fresh matrix over only
     the requested *ids* (intersected with the dataset's current medias) and
     never populates the context-wide cache - subset projections (e.g. the
     positives of a Find run) are ephemeral.  The returned id list is sorted and
-    de-duplicated; ids absent from the dataset are dropped silently.
+    de-duplicated; ids absent from the dataset are dropped silently.  Pass
+    *embedder_name* to source the rows from a specific bound embedder.
 
     Returns ``([], np.empty((0, 0), dtype=np.float32))`` when nothing matches.
-    Raises ``ValueError`` if any requested media has ``embedding=None``.
+    Raises ``ValueError`` if any requested media lacks the requested vector.
     """
     with _state_lock:
         medias = ctx.medias
@@ -98,12 +124,7 @@ def get_embedding_submatrix(ctx: "DatasetContext", ids: list[int]) -> tuple[list
         if not sorted_ids:
             return [], np.empty((0, 0), dtype=np.float32)
 
-        first_emb = np.asarray(_require_embedding(sorted_ids[0], medias[sorted_ids[0]]), dtype=np.float32)
-        dim = int(first_emb.shape[-1])
-        matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
-        for i, cid in enumerate(sorted_ids):
-            matrix[i] = _require_embedding(cid, medias[cid])
-        return sorted_ids, matrix
+        return sorted_ids, _stack_embeddings(sorted_ids, medias, embedder_name)
 
 
 def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
@@ -221,14 +242,16 @@ def get_region_matrix_for_snap(
 
 def get_embedding_matrix_for_snap(
     snap: dict,
+    embedder_name: str | None = None,
 ) -> tuple[list[int], np.ndarray]:
     """Return ``(sorted_ids, matrix)`` for *snap*.
 
-    When *snap*'s key set matches the active :class:`DatasetContext`'s
-    medias, the cached matrix is reused.  Otherwise (a different snapshot
-    or a temp dict from cross-dataset Find) the matrix is built fresh
-    without populating the cache.  Raises ``ValueError`` if any entry in
-    *snap* has ``embedding=None``.
+    With *embedder_name* unset and *snap*'s key set matching the active
+    :class:`DatasetContext`'s medias, the cached primary matrix is reused.
+    Otherwise (a different snapshot, a temp dict from cross-dataset Find, or an
+    explicit non-primary embedder) the matrix is built fresh without populating
+    the cache.  Raises ``ValueError`` if any entry in *snap* lacks the
+    requested vector.
     """
     from vtscore.state.core import get_active_context
 
@@ -237,21 +260,21 @@ def get_embedding_matrix_for_snap(
         return [], np.empty((0, 0), dtype=np.float32)
 
     ctx = get_active_context()
-    with _state_lock:
-        cached_ids = ctx._emb_matrix_ids
-        cached_matrix = ctx._emb_matrix
-    if cached_matrix is not None and cached_ids == sorted_ids:
-        return sorted_ids, cached_matrix
+    matches_active = sorted_ids == sorted(ctx.medias.keys())
 
-    # Populate the cache when *snap* matches the active dataset's medias
-    # (the common case: `snap = snapshot_medias()`).
-    if sorted_ids == sorted(ctx.medias.keys()):
-        return get_embedding_matrix(ctx)
+    if embedder_name is None:
+        with _state_lock:
+            cached_ids = ctx._emb_matrix_ids
+            cached_matrix = ctx._emb_matrix
+        if cached_matrix is not None and cached_ids == sorted_ids:
+            return sorted_ids, cached_matrix
+
+    # When *snap* matches the active dataset's medias (the common case:
+    # `snap = snapshot_medias()`), delegate to the context builder so the
+    # primary path populates / reuses the cache; the named path builds fresh
+    # there too.
+    if matches_active:
+        return get_embedding_matrix(ctx, embedder_name)
 
     # Temp dict / cross-dataset case: build fresh, don't cache.
-    first_emb = np.asarray(_require_embedding(sorted_ids[0], snap[sorted_ids[0]]), dtype=np.float32)
-    dim = int(first_emb.shape[-1])
-    matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
-    for i, cid in enumerate(sorted_ids):
-        matrix[i] = _require_embedding(cid, snap[cid])
-    return sorted_ids, matrix
+    return sorted_ids, _stack_embeddings(sorted_ids, snap, embedder_name)


### PR DESCRIPTION
## What

Continues the multi-embedder (v3 three-slot) work. Phase 2a shipped the per-media accessor substrate (`media["embeddings"]` dict keyed by embedder name, with the singular `media["embedding"]` kept as a primary mirror). This phase makes the **aggregate read chokepoint** — the embedding-matrix builders — embedder-aware.

`get_embedding_matrix`, `get_embedding_submatrix`, and `get_embedding_matrix_for_snap` now take an optional `embedder_name`:

- **Unset** → the cached primary path, byte-for-byte the old behaviour (the existing single-matrix cache on `DatasetContext` is untouched).
- **Set** → a fresh, *uncached* matrix built from that bound embedder's vectors via the `media_vectors` accessor. Caching stays reserved for the hot primary path; the named path is for the future two-embedder world.

This is the piece every consumer (sorting / scoring / find / projection / training / positives-browse) funnels through, so the routing phase can request the right embedder per operation without further matrix surgery.

## Changes

- `vtscore/embedding/matrix.py`: thread `embedder_name` through the three builders; extract a shared `_stack_embeddings` helper (de-duplicates the three identical build loops); `_require_embedding` names the embedder in its error.
- `tests_lib/core/test_embedding_matrix.py`: `TestEmbedderAwareMatrix` — named selection, primary default, no-cache on the named path, named-missing error, and the submatrix / snap (matching-ctx + temp-dict) variants.
- `docs/plans/patch-embedder.md`: V3 implementation-status section recording what's shipped (Phase 2a, 2b.1) and the ordered remaining phases (binding → loader multi-embed → routing → MLP keying → drop the mirror).

## Behaviour / compat

No behaviour change for existing single-embedder datasets — every current caller still passes no name and hits the identical cached path. The full `./run-tests.sh` suite passes (4943 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ81EkjVSyeWjWeJywaYw1)_