### PR TITLE
Multi-embedder Phase 2b.2: in-memory role-typed dataset embedder binding

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -699,19 +699,34 @@ above it.
   every consumer (sorting / scoring / find / projection / training /
   positives-browse) funnels through, so routing can later request the right
   embedder per operation.
+- **Phase 2b.2 - dataset binding (in-memory).** `DatasetContext` gains
+  `text_embedder` / `patch_embedder` slots plus derived `supports_text` /
+  `supports_patch_regions` properties (today there is no dataset-level embedder
+  field at all; the embedder is recorded per-media).  By default the pair is
+  *derived* on demand from the dataset's medias - the single embedder a pre-v3
+  dataset was loaded with, role-typed against its capability flags by
+  `vtscore.embedding.binding.derive_binding`.  `bind_embedders()` sets an
+  explicit, validated pair for genuinely multi-embedder datasets (overrides the
+  derivation).  This is *in-memory only*: no pickle/registry/meta schema change,
+  no routing rewire, no frontend.  Persistence rides along with the loader
+  multi-embed slice (2b.3), where a real second vector exists to persist; the
+  documented `meta["embedder"]` → slot migration lands there.
 
 **Remaining, in order:**
 
-- **Phase 2b.2 - dataset binding.** Add `text_embedder` / `patch_embedder`
-  slots (today there is no dataset-level embedder field at all; the embedder is
-  recorded per-media).  `dataset.supports_text` / `supports_patch_regions`
-  become derived from which slot is filled.  See "Dataset binding" above.
 - **Phase 2b.3 - loader multi-embed.** Run both bound embedders at ingest so
   `media["embeddings"]` / `patch_regions` / `patch_grid` carry a per-embedder
   entry each.  See "Loader / exporter / importer impact".
 - **Phase 2b.4 - routing.** Wire the routing table (text sort → `text_embedder`;
   cosine/region ops → `patch_embedder`); pass the resolved embedder name into
   the now-embedder-aware matrix layer at each consumer.  See "Routing rules".
+  **Watch the single-vector gap:** a `*_single` embedder (e.g. `dinov2_single`,
+  `supports_text=False`, `supports_patch_regions=False`) binds *neither* role
+  slot, so the routing table's "patch_embedder if set, else text_embedder" rule
+  resolves to nothing for those datasets.  The 2b.2 binding leaves them working
+  via each media's primary vector (the per-media read path is untouched);
+  routing must keep a primary-vector fallback for cosine sort / MLP scoring on
+  no-slot datasets rather than 400-ing them.
 - **Phase 2b.5 - MLP keying.** Key MLPs by `(detector, dataset, embedder)`.
   See "Detector MLP keying".
 - **Phase 2c - drop the singular mirror.** Once every read site routes through

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -1,0 +1,154 @@
+"""Role-typed embedder binding on a dataset (v3 three-slot model).
+
+Covers the pure derivation/validation helpers in
+``vtscore.embedding.binding`` and the ``DatasetContext`` binding
+properties that consume them.  Capability lookups are stubbed so the
+tests don't depend on which concrete embedders happen to be registered;
+one smoke class exercises the live registry for the wiring.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.embedding import binding as binding_mod
+from vtscore.embedding.binding import derive_binding, validate_binding
+from vtscore.state.core import DatasetContext
+
+# embedder name -> (supports_text, supports_patch_regions)
+_FAKE_CAPS = {
+    "faketext": (True, False),
+    "fakepatch": (False, True),
+    "fakesingle": (False, False),
+    "fakeboth": (True, True),
+}
+
+
+@pytest.fixture
+def fake_caps(monkeypatch):
+    monkeypatch.setattr(binding_mod, "_capabilities", lambda name: _FAKE_CAPS.get(name, (False, False)))
+
+
+class TestDeriveBinding:
+    def test_none_and_empty(self):
+        assert derive_binding(None) == (None, None)
+        assert derive_binding("") == (None, None)
+
+    def test_text_embedder_fills_text_slot(self, fake_caps):
+        assert derive_binding("faketext") == ("faketext", None)
+
+    def test_patch_embedder_fills_patch_slot(self, fake_caps):
+        assert derive_binding("fakepatch") == (None, "fakepatch")
+
+    def test_single_vector_fills_neither(self, fake_caps):
+        assert derive_binding("fakesingle") == (None, None)
+
+    def test_dual_capability_fills_both(self, fake_caps):
+        assert derive_binding("fakeboth") == ("fakeboth", "fakeboth")
+
+    def test_unknown_name_fills_neither(self, fake_caps):
+        assert derive_binding("nope") == (None, None)
+
+
+class TestValidateBinding:
+    def test_none_slots_ok(self, fake_caps):
+        validate_binding(None, None)  # no raise
+
+    def test_valid_roles_ok(self, fake_caps):
+        validate_binding("faketext", "fakepatch")  # no raise
+
+    def test_text_slot_rejects_non_text(self, fake_caps):
+        with pytest.raises(ValueError, match=r"text_embedder 'fakepatch' does not support text"):
+            validate_binding("fakepatch", None)
+
+    def test_patch_slot_rejects_non_patch(self, fake_caps):
+        with pytest.raises(ValueError, match=r"patch_embedder 'faketext' does not produce patch"):
+            validate_binding(None, "faketext")
+
+    def test_unknown_name_rejected(self, fake_caps):
+        with pytest.raises(ValueError):
+            validate_binding("nope", None)
+
+
+def _ctx_with_embedder(name: str) -> DatasetContext:
+    ctx = DatasetContext("test_binding")
+    ctx.medias[1] = {"id": 1, "embedder": name, "embedding": np.ones(4, dtype=np.float32)}
+    return ctx
+
+
+class TestDatasetContextDerivedBinding:
+    def test_empty_dataset_binds_nothing(self):
+        ctx = DatasetContext("empty")
+        assert ctx.text_embedder is None
+        assert ctx.patch_embedder is None
+        assert ctx.supports_text is False
+        assert ctx.supports_patch_regions is False
+
+    def test_text_dataset(self, fake_caps):
+        ctx = _ctx_with_embedder("faketext")
+        assert ctx.text_embedder == "faketext"
+        assert ctx.patch_embedder is None
+        assert ctx.supports_text is True
+        assert ctx.supports_patch_regions is False
+
+    def test_patch_dataset(self, fake_caps):
+        ctx = _ctx_with_embedder("fakepatch")
+        assert ctx.text_embedder is None
+        assert ctx.patch_embedder == "fakepatch"
+        assert ctx.supports_text is False
+        assert ctx.supports_patch_regions is True
+
+    def test_single_vector_dataset_binds_neither(self, fake_caps):
+        ctx = _ctx_with_embedder("fakesingle")
+        assert ctx.text_embedder is None
+        assert ctx.patch_embedder is None
+
+
+class TestDatasetContextExplicitBinding:
+    def test_explicit_overrides_derivation(self, fake_caps):
+        # Derived binding would be text-only; explicit binding adds the patch slot.
+        ctx = _ctx_with_embedder("faketext")
+        ctx.bind_embedders(text_embedder="faketext", patch_embedder="fakepatch")
+        assert ctx.text_embedder == "faketext"
+        assert ctx.patch_embedder == "fakepatch"
+        assert ctx.supports_text is True
+        assert ctx.supports_patch_regions is True
+
+    def test_explicit_validates_roles(self, fake_caps):
+        ctx = DatasetContext("bad")
+        with pytest.raises(ValueError, match="does not support text"):
+            ctx.bind_embedders(text_embedder="fakepatch")
+        # A rejected binding must not be stored - derivation still governs.
+        assert ctx._binding_explicit is False
+
+    def test_explicit_empty_pair_overrides_derivation(self, fake_caps):
+        ctx = _ctx_with_embedder("faketext")
+        ctx.bind_embedders()  # both None, explicit
+        assert ctx.text_embedder is None
+        assert ctx.patch_embedder is None
+
+
+class TestRealRegisteredEmbedder:
+    """Smoke test against the live registry.  Reading the capability flags
+    does not load model weights, so this is cheap and CPU-only."""
+
+    def test_real_text_embedder_binds_text_slot(self):
+        from vtscore.media import all_embedders
+
+        text_emb = next((e for e in all_embedders() if e.supports_text), None)
+        if text_emb is None:
+            pytest.skip("no text-capable embedder registered")
+        ctx = _ctx_with_embedder(text_emb.name)
+        assert ctx.text_embedder == text_emb.name
+        assert ctx.supports_text is True
+
+    def test_real_patch_embedder_binds_patch_slot(self):
+        from vtscore.media import all_embedders
+
+        patch_emb = next((e for e in all_embedders() if e.supports_patch_regions), None)
+        if patch_emb is None:
+            pytest.skip("no patch-capable embedder registered")
+        ctx = _ctx_with_embedder(patch_emb.name)
+        assert ctx.patch_embedder == patch_emb.name
+        assert ctx.supports_patch_regions is True

--- a/vtscore/embedding/__init__.py
+++ b/vtscore/embedding/__init__.py
@@ -6,6 +6,10 @@ package exposes thin call-sites used throughout the rest of VTSearch
 :mod:`vtscore.eval.runner`, etc.).
 """
 
+from vtscore.embedding.binding import (
+    derive_binding,
+    validate_binding,
+)
 from vtscore.embedding.helpers import (
     clear_text_query_cache,
     embed_audio_file,
@@ -54,4 +58,6 @@ __all__ = [
     "invalidate_embedding_matrix",
     "get_embedding_matrix_for_snap",
     "get_region_matrix_for_snap",
+    "derive_binding",
+    "validate_binding",
 ]

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -78,8 +78,7 @@ def validate_binding(text_embedder: str | None, patch_embedder: str | None) -> N
         supports_text, _ = _capabilities(text_embedder)
         if not supports_text:
             raise ValueError(
-                f"text_embedder {text_embedder!r} does not support text queries "
-                "(no supports_text capability)"
+                f"text_embedder {text_embedder!r} does not support text queries (no supports_text capability)"
             )
     if patch_embedder is not None:
         _, supports_patch = _capabilities(patch_embedder)

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -1,0 +1,90 @@
+"""Role-typed embedder binding for a dataset.
+
+A dataset binds **up to one text-capable embedder** and **up to one
+patch-capable embedder** (the v3 "three-slot" model in
+``docs/plans/patch-embedder.md``).  Text sort runs against the text
+embedder; region similarity, region voting, and the detector MLP run
+against the patch embedder; both can coexist on one dataset.
+
+This module is the library-tier source of truth for two pure operations
+on that binding:
+
+* :func:`derive_binding` - map a single (legacy) embedder name onto the
+  ``(text_embedder, patch_embedder)`` pair, by role-typing it against the
+  embedder's declared capabilities.  This is how a pre-v3 dataset (one
+  ``embedder`` name) resolves into the two-slot model on load.
+* :func:`validate_binding` - reject an explicit binding whose slot points
+  at an embedder lacking that role's capability.
+
+Neither function holds state; the binding itself lives on
+:class:`vtscore.state.core.DatasetContext`.  Capability lookups go
+through the embedder registry, so an unknown name resolves to "no
+capabilities" (and is therefore ineligible for either slot).
+"""
+
+from __future__ import annotations
+
+
+def _capabilities(embedder_name: str) -> tuple[bool, bool]:
+    """Return ``(supports_text, supports_patch_regions)`` for *embedder_name*.
+
+    An unregistered name resolves to ``(False, False)`` so it can fill
+    neither role - the caller treats that as "ineligible", not "raise".
+    """
+    from vtscore.media import get_embedder  # noqa: PLC0415 - avoid import cycle
+
+    try:
+        emb = get_embedder(embedder_name)
+    except KeyError:
+        return (False, False)
+    return (bool(emb.supports_text), bool(emb.supports_patch_regions))
+
+
+def derive_binding(embedder_name: str | None) -> tuple[str | None, str | None]:
+    """Map a single (legacy) embedder name to ``(text_embedder, patch_embedder)``.
+
+    A text-capable embedder fills the text slot; a patch-capable embedder
+    fills the patch slot.  A single-vector, non-text embedder (e.g.
+    ``dinov2_single``) fills **neither** slot (both ``None``): it still
+    drives cosine sort and the detector MLP via each media's primary
+    vector, which the routing layer reads directly rather than through a
+    role slot.
+
+    ``None`` / empty in → ``(None, None)``.
+    """
+    if not embedder_name:
+        return (None, None)
+    supports_text, supports_patch = _capabilities(embedder_name)
+    text_embedder = embedder_name if supports_text else None
+    patch_embedder = embedder_name if supports_patch else None
+    return (text_embedder, patch_embedder)
+
+
+def validate_binding(text_embedder: str | None, patch_embedder: str | None) -> None:
+    """Raise ``ValueError`` if a slot points at an embedder lacking its role.
+
+    The slots are role-typed: ``text_embedder`` must name an embedder with
+    ``supports_text``; ``patch_embedder`` must name one with
+    ``supports_patch_regions``.  An unregistered name is rejected for any
+    slot it is placed in (it advertises no capabilities).  ``None`` slots
+    are always valid.
+
+    Note this does **not** enforce "at least one slot is set" - a
+    single-vector dataset legitimately binds neither role.  That
+    higher-level rule (no usable sort/search) belongs to the
+    dataset-create flow, not the per-slot type check.
+    """
+    if text_embedder is not None:
+        supports_text, _ = _capabilities(text_embedder)
+        if not supports_text:
+            raise ValueError(
+                f"text_embedder {text_embedder!r} does not support text queries "
+                "(no supports_text capability)"
+            )
+    if patch_embedder is not None:
+        _, supports_patch = _capabilities(patch_embedder)
+        if not supports_patch:
+            raise ValueError(
+                f"patch_embedder {patch_embedder!r} does not produce patch regions "
+                "(no supports_patch_regions capability)"
+            )

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -310,6 +310,17 @@ class DatasetContext:
         "_subset_ids",
         "_subset_job_id",
         "_subset_content_version",
+        # Role-typed embedder binding (v3 "three-slot" model; see
+        # docs/plans/patch-embedder.md).  A dataset binds up to one
+        # text-capable embedder and up to one patch-capable embedder.  By
+        # default the binding is *derived* on demand from the dataset's
+        # medias (the single embedder a pre-v3 dataset was loaded with);
+        # ``bind_embedders`` overrides that with an explicit, validated
+        # pair for genuinely multi-embedder datasets.  The values are
+        # embedder *names*, never vectors - no embeddings live here.
+        "_text_embedder",
+        "_patch_embedder",
+        "_binding_explicit",
     )
 
     def __init__(self, dataset_id: str = "") -> None:
@@ -335,6 +346,72 @@ class DatasetContext:
         # only the tile cache key/URL so stale tiles aren't served (the tile URL
         # is otherwise cached ``immutable``).  Reset to 0 on a fresh subset fit.
         self._subset_content_version: int = 0
+        # Role-typed embedder binding (see __slots__ comment).  ``None``
+        # until either explicitly bound or derived from the medias.
+        self._text_embedder: str | None = None
+        self._patch_embedder: str | None = None
+        self._binding_explicit: bool = False
+
+    # ------------------------------------------------------------------
+    # Role-typed embedder binding
+    # ------------------------------------------------------------------
+
+    def bind_embedders(
+        self, *, text_embedder: str | None = None, patch_embedder: str | None = None
+    ) -> None:
+        """Explicitly bind role-typed embedders to this dataset.
+
+        Validates that each slot points at an embedder with the matching
+        capability (text / patch) and then stores the pair, overriding the
+        default media-derived binding.  Use this for genuinely
+        multi-embedder datasets; a single-embedder dataset can rely on the
+        derived binding instead.
+
+        Stores embedder *names* only - never vectors or models.
+        """
+        from vtscore.embedding.binding import validate_binding  # noqa: PLC0415
+
+        validate_binding(text_embedder, patch_embedder)
+        self._text_embedder = text_embedder
+        self._patch_embedder = patch_embedder
+        self._binding_explicit = True
+
+    def _resolve_binding(self) -> tuple[str | None, str | None]:
+        """Return the ``(text_embedder, patch_embedder)`` pair for this dataset.
+
+        An explicit binding (set via :meth:`bind_embedders`) wins; otherwise
+        the pair is derived from the dataset's medias - the single embedder a
+        pre-v3 dataset was loaded with, role-typed by its capabilities.
+        """
+        if self._binding_explicit:
+            return (self._text_embedder, self._patch_embedder)
+        if not self.medias:
+            return (None, None)
+        from vtscore.embedding.binding import derive_binding  # noqa: PLC0415
+        from vtscore.embedding.media_vectors import primary_embedder_name  # noqa: PLC0415
+
+        first = next(iter(self.medias.values()))
+        return derive_binding(primary_embedder_name(first))
+
+    @property
+    def text_embedder(self) -> str | None:
+        """Name of the bound text-capable embedder, or ``None``."""
+        return self._resolve_binding()[0]
+
+    @property
+    def patch_embedder(self) -> str | None:
+        """Name of the bound patch-capable embedder, or ``None``."""
+        return self._resolve_binding()[1]
+
+    @property
+    def supports_text(self) -> bool:
+        """Whether this dataset can answer text queries (text slot is bound)."""
+        return self.text_embedder is not None
+
+    @property
+    def supports_patch_regions(self) -> bool:
+        """Whether this dataset has region overlays / voting (patch slot is bound)."""
+        return self.patch_embedder is not None
 
 
 class DetectorContext:
@@ -548,6 +625,9 @@ class _RequestMissingDatasetContext(DatasetContext):
         object.__setattr__(self, "_region_matrix", None)
         object.__setattr__(self, "_region_media_index", None)
         object.__setattr__(self, "_region_index_per_row", None)
+        object.__setattr__(self, "_text_embedder", None)
+        object.__setattr__(self, "_patch_embedder", None)
+        object.__setattr__(self, "_binding_explicit", False)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise _frozen_mutation_error("dataset")

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -356,9 +356,7 @@ class DatasetContext:
     # Role-typed embedder binding
     # ------------------------------------------------------------------
 
-    def bind_embedders(
-        self, *, text_embedder: str | None = None, patch_embedder: str | None = None
-    ) -> None:
+    def bind_embedders(self, *, text_embedder: str | None = None, patch_embedder: str | None = None) -> None:
         """Explicitly bind role-typed embedders to this dataset.
 
         Validates that each slot points at an embedder with the matching


### PR DESCRIPTION
## What

Continues the multi-embedder (v3 three-slot) work. Phase 2b.1 made the matrix layer embedder-aware; this phase gives a **dataset** the role-typed binding the routing layer will read: up to one text-capable embedder and up to one patch-capable embedder.

`DatasetContext` gains:

- `text_embedder` / `patch_embedder` properties — the bound embedder name per role, or `None`.
- `supports_text` / `supports_patch_regions` properties — derived as "that slot is bound".
- `bind_embedders(text_embedder=…, patch_embedder=…)` — sets an explicit, validated pair for genuinely multi-embedder datasets.

By default the pair is **derived on demand** from the dataset's medias — the single embedder a pre-v3 dataset was loaded with — role-typed against the embedder's capability flags. So every existing dataset gets a correct binding with zero migration: a SigLIP dataset reports `text_embedder="siglip"`, a `dinov3_patch` dataset reports `patch_embedder="dinov3_patch"`.

New pure helpers in `vtscore/embedding/binding.py`:
- `derive_binding(name)` → `(text_embedder, patch_embedder)` by role-typing one embedder.
- `validate_binding(text, patch)` → raises if a slot points at an embedder lacking that role's capability.

## Scope (deliberately in-memory only)

Per the agreed slicing: **no pickle/registry/meta schema change, no routing rewire, no frontend.** Nothing reads the new properties yet, so there is zero behaviour change. This is the substrate the routing slice (2b.4) consumes via `ctx.text_embedder` / `ctx.patch_embedder`. Persistence + the documented `meta["embedder"]` → slot migration ride along with the loader multi-embed slice (2b.3), where a real second vector exists to persist.

### Single-vector embedder note

A `*_single` embedder (`supports_text=False`, `supports_patch_regions=False`) binds **neither** slot. Those datasets keep working through each media's primary vector (the per-media read path is untouched). The routing slice must keep a primary-vector fallback for cosine/MLP on no-slot datasets rather than 400-ing them — flagged in the plan doc.

## Changes

- `vtscore/embedding/binding.py` — `derive_binding` / `validate_binding` (pure, library-tier).
- `vtscore/state/core.py` — `DatasetContext` binding slots, properties, `bind_embedders()`; the request-missing sentinel initializes the new slots so reads return the empty-dataset answer.
- `vtscore/embedding/__init__.py` — export the two helpers.
- `tests_lib/core/test_dataset_binding.py` — derivation/validation units (stubbed caps) + `DatasetContext` property tests + a live-registry smoke test.
- `docs/plans/patch-embedder.md` — 2b.2 status + the single-vector routing gap note.

## Verification

Full `./run-tests.sh` passes — 4963 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ81EkjVSyeWjWeJywaYw1)_