### PR TITLE
Achievement updates: targets, local-time bucketing, icons, and renames

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -6,6 +6,7 @@ import { routes } from './app.routes';
 import { activeContextInterceptor } from './interceptors/active-context.interceptor';
 import { achievementsRefreshInterceptor } from './interceptors/achievements-refresh.interceptor';
 import { errorInterceptor } from './interceptors/error.interceptor';
+import { timezoneInterceptor } from './interceptors/timezone.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -13,6 +14,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(
       withInterceptors([
+        timezoneInterceptor,
         activeContextInterceptor,
         achievementsRefreshInterceptor,
         errorInterceptor,

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -104,7 +104,7 @@
                   <li
                     class="hour-chip"
                     [class.hour-chip--on]="h.seen"
-                    [attr.aria-label]="(h.seen ? 'voted at ' : 'no vote at ') + h.hour + ':00 UTC'">
+                    [attr.aria-label]="(h.seen ? 'voted at ' : 'no vote at ') + h.hour + ':00'">
                     {{ h.hour.toString().padStart(2, '0') }}
                   </li>
                 }

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -76,6 +76,20 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="4" x2="15" y2="4"/><line x1="3" y1="9" x2="13" y2="9"/><line x1="3" y1="14" x2="11" y2="14"/><line x1="3" y1="19" x2="9" y2="19"/><polyline points="19 10 19 20"/><polyline points="16 17 19 20 22 17"/></svg>',
   'steering-wheel':
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="2"/><line x1="12" y1="4" x2="12" y2="1"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4" y1="12" x2="1" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="6.34" y1="6.34" x2="4.22" y2="4.22"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/><line x1="6.34" y1="17.66" x2="4.22" y2="19.78"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/></svg>',
+  // Analog clock whose hands point to 10:10 (hour hand toward 10, minute hand
+  // toward 2) — the classic display-watch pose. Backs the "Around the Clock"
+  // achievement.
+  clock:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="12" x2="16.8" y2="9.2"/><line x1="12" y1="12" x2="8.4" y2="9.5"/></svg>',
+  // Outline of a running man, mid-stride (one leg forward, one pushing off;
+  // arms swinging). Backs the "Marathoner" achievement.
+  running:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="14" cy="4" r="2"/><path d="M14 6 10.5 12.5"/><path d="M10.5 12.5 13 15.5 12 20"/><path d="M10.5 12.5 7.5 15 5.5 17"/><path d="M12.5 8.5 15.5 10 16 6.5"/><path d="M12.5 8.5 9 9.5 7.5 12"/></svg>',
+  // Blank daily calendar page: rounded rectangle with a header rule and two
+  // ring bindings crossing the top edge. Backs the "Your Days are Numbered"
+  // achievement.
+  calendar:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="16" rx="2"/><line x1="4" y1="9" x2="20" y2="9"/><line x1="9" y1="3" x2="9" y2="7"/><line x1="15" y1="3" x2="15" y2="7"/></svg>',
   'cloud-upload':
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>',
   'thumbs-up':

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -81,10 +81,10 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   // achievement.
   clock:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="12" x2="16.8" y2="9.2"/><line x1="12" y1="12" x2="8.4" y2="9.5"/></svg>',
-  // Outline of a running man, mid-stride (one leg forward, one pushing off;
-  // arms swinging). Backs the "Marathoner" achievement.
+  // Outline of a running man mid-stride (head, driving arms, forward/trailing
+  // legs). Backs the "Marathoner" achievement.
   running:
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="14" cy="4" r="2"/><path d="M14 6 10.5 12.5"/><path d="M10.5 12.5 13 15.5 12 20"/><path d="M10.5 12.5 7.5 15 5.5 17"/><path d="M12.5 8.5 15.5 10 16 6.5"/><path d="M12.5 8.5 9 9.5 7.5 12"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"/></svg>',
   // Blank daily calendar page: rounded rectangle with a header rule and two
   // ring bindings crossing the top edge. Backs the "Your Days are Numbered"
   // achievement.

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -23,6 +23,7 @@ const KNOWN_TYPES = new Set([
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
   'thumbs-up', 'thumbs-down', 'factory',
   'house', 'lightning', 'flask', 'cubes', 'database',
+  'clock', 'running', 'calendar',
   'checkbox-checked', 'search', 'trophy',
   'zoom-in', 'zoom-out', 'zoom-fit',
 ]);

--- a/frontend/src/app/interceptors/timezone.interceptor.ts
+++ b/frontend/src/app/interceptors/timezone.interceptor.ts
@@ -1,0 +1,16 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+/**
+ * Attaches an `X-Timezone-Offset` header to every outgoing HTTP request,
+ * carrying the browser's `Date.prototype.getTimezoneOffset()` value (the
+ * difference, in minutes, between UTC and local time: positive west of UTC,
+ * negative east of it).
+ *
+ * The backend uses it to bucket the "Around the Clock" hours and "Your Days
+ * are Numbered" days by the user's local wall-clock time rather than UTC, so
+ * those milestones reflect the clock the user actually saw on their screen.
+ */
+export const timezoneInterceptor: HttpInterceptorFn = (req, next) => {
+  const offset = new Date().getTimezoneOffset();
+  return next(req.clone({ headers: req.headers.set('X-Timezone-Offset', String(offset)) }));
+};

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -297,6 +297,40 @@ class TestHoursVoted:
         assert seen_hours == {0, 9, 23}
 
 
+class TestLocalTimezoneBucketing:
+    """days_active / hours_voted bucket by the voter's local wall clock.
+
+    ``tz_offset_minutes`` follows the JS ``getTimezoneOffset`` convention
+    (UTC minus local, in minutes): positive west of UTC, negative east.
+    """
+
+    def test_hour_shifts_into_local_time_east(self):
+        # 02:00 UTC at UTC+2 (offset -120) is 04:00 local.
+        achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 2), tz_offset_minutes=-120)
+        hours = achievements.get_full_state()["hours"]
+        assert {h["hour"] for h in hours if h["seen"]} == {4}
+
+    def test_hour_shifts_into_local_time_west(self):
+        # 02:00 UTC at UTC-3 (offset 180) is 23:00 local on the prior day.
+        achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 2), tz_offset_minutes=180)
+        state = achievements.get_full_state()
+        assert {h["hour"] for h in state["hours"] if h["seen"]} == {23}
+
+    def test_day_rolls_back_across_local_midnight(self):
+        # 02:00 UTC on the 13th at UTC-3 lands on the 12th locally, while
+        # 12:00 UTC the same day is still the 13th locally — two distinct
+        # local days even though they share a UTC date.
+        achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 2), tz_offset_minutes=180)
+        achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 12), tz_offset_minutes=180)
+        assert _by_id(achievements.get_full_state(), "days_active")["counter"] == 2
+
+    def test_offset_defaults_to_utc_without_request(self):
+        # No tz_offset_minutes and no request context → UTC bucketing.
+        achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 2))
+        hours = achievements.get_full_state()["hours"]
+        assert {h["hour"] for h in hours if h["seen"]} == {2}
+
+
 class TestVoteStreak:
     def test_single_vote_streak_is_one(self):
         achievements.record_vote("det", "audio", now=_ts(2026, 5, 13, 12))

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -583,8 +583,8 @@ class TestTiers:
         assert achievements.acknowledge("datasets_loaded", 0) is False
 
     def test_jumping_multiple_tiers_pends_each(self):
-        # find_media: 200 / 2000 / 20000 / 200000
-        achievements.record_find(2500)  # Bronze + Silver in one go
+        # find_media: 2000 / 20000 / 200000 / 2000000
+        achievements.record_find(25000)  # Bronze + Silver in one go
         state = achievements.get_full_state()
         pending = _pending_for(state, "find_media")
         assert [p["tier_idx"] for p in pending] == [0, 1]
@@ -644,7 +644,7 @@ class TestToasts:
         assert achievements.mark_toasted("datasets_loaded", 0) is False
 
     def test_jumping_multiple_tiers_pends_each_toast(self):
-        achievements.record_find(2500)  # Bronze + Silver in one go
+        achievements.record_find(25000)  # Bronze + Silver in one go
         state = achievements.get_full_state()
         assert [p["tier_idx"] for p in _toasts_for(state, "find_media")] == [0, 1]
 

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from vtsearch.auth import get_current_user
@@ -64,14 +64,14 @@ ACHIEVEMENTS: list[dict[str, Any]] = [
     },
     {
         "id": "detectors_trained",
-        "name": "Detector Collector",
+        "name": "Teacher's Pet",
         "description": "Each detector you trained, counted on its first vote.",
         "icon": "graduation",
         "tiers": [2, 20, 200, 2000],
     },
     {
         "id": "detectors_imported",
-        "name": "Detector Getter",
+        "name": "Detector Collector",
         "description": "Detectors built up from imported labels.",
         "icon": "robot",
         "tiers": [1, 10, 100, 1000],
@@ -81,13 +81,13 @@ ACHIEVEMENTS: list[dict[str, Any]] = [
         "name": "Finders Keepers",
         "description": "Media items scored by Find (GUI and CLI combined).",
         "icon": "search",
-        "tiers": [200, 2000, 20000, 200000],
+        "tiers": [2000, 20000, 200000, 2000000],
     },
     {
         "id": "days_active",
         "name": "Your Days are Numbered",
-        "description": "Distinct UTC calendar days on which you cast at least one vote.",
-        "icon": "lightning",
+        "description": "Distinct calendar days on which you cast at least one vote.",
+        "icon": "calendar",
         "tiers": [2, 20, 200, 2000],
     },
     {
@@ -100,15 +100,15 @@ ACHIEVEMENTS: list[dict[str, Any]] = [
     {
         "id": "vote_streak",
         "name": "Marathoner",
-        "description": "Longest run of consecutive votes with at most a 10-minute gap between any two.",
-        "icon": "flask",
+        "description": "Longest run of consecutive votes with at most a 10-minute gap.",
+        "icon": "running",
         "tiers": [200, 400, 600, 1000],
     },
     {
         "id": "hours_voted",
         "name": "Around the Clock",
-        "description": "Distinct hours of the day (UTC, 0-23) in which you've cast at least one vote.",
-        "icon": "steering-wheel",
+        "description": "Distinct hours of the day (0-23) in which you've cast at least one vote.",
+        "icon": "clock",
         "tiers": [6, 12, 20, 24],
     },
     {
@@ -148,7 +148,8 @@ MEDIA_TYPES: list[dict[str, str]] = [
     {"id": "document", "name": "Document"},
 ]
 
-#: Hours of the day (UTC) tracked by the "Around the Clock" achievement.
+#: Hours of the day tracked by the "Around the Clock" achievement, bucketed
+#: in the voter's local wall-clock time (see :func:`_user_tz_offset_minutes`).
 HOURS_OF_DAY: tuple[int, ...] = tuple(range(24))
 
 #: Readme Reader docs.  Each entry pairs a doc with the code phrase printed at
@@ -287,19 +288,55 @@ def wipe_state() -> None:
     mutate_user(_apply)
 
 
+def _user_tz_offset_minutes() -> int:
+    """Minutes to subtract from UTC to reach the voter's local wall-clock time.
+
+    Read from the ``X-Timezone-Offset`` request header, which the frontend
+    sets to the browser's ``Date.prototype.getTimezoneOffset()`` value (the
+    difference, in minutes, between UTC and local time: positive west of UTC,
+    negative east of it).  Subtracting it from a UTC instant yields the user's
+    local wall clock, so the "Around the Clock" hours and "Your Days are
+    Numbered" days bucket by the time the user actually saw on their screen.
+
+    Returns 0 (i.e. UTC) when there is no request context or header — CLI
+    runs, background threads, and tests all fall back to UTC.
+    """
+    try:
+        from flask import request
+
+        raw = request.headers.get("X-Timezone-Offset")
+    except RuntimeError:
+        # No Flask request context (CLI mode, background thread, etc.)
+        return 0
+    if raw is None:
+        return 0
+    try:
+        offset = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    # Clamp to the real-world range (UTC-14 .. UTC+14) so a malformed or
+    # hostile header can't shove buckets into nonsense values.
+    return max(-14 * 60, min(14 * 60, offset))
+
+
 def record_vote(
     detector_id: str = "",
     media_type: str = "",
     *,
     now: float | None = None,
+    tz_offset_minutes: int | None = None,
 ) -> None:
     """Record one user vote and credit every vote-driven achievement.
 
     Credits ``votes_cast`` always, ``detectors_trained`` on a detector's first
     vote, ``media_types_touched`` on a media type's first vote, ``days_active``
-    on the first vote of each UTC calendar day, ``hours_voted`` on the first
-    vote within each UTC hour-of-day bucket, and updates the ``vote_streak``
+    on the first vote of each local calendar day, ``hours_voted`` on the first
+    vote within each local hour-of-day bucket, and updates the ``vote_streak``
     watermark (longest run of consecutive votes with gaps ≤ 10 minutes).
+
+    Days and hours bucket by the voter's local wall-clock time, resolved from
+    the request's timezone offset (see :func:`_user_tz_offset_minutes`), so the
+    milestones reflect the clock the user actually saw rather than UTC.
 
     Args:
         detector_id: ID of the detector the vote belongs to.  Empty string
@@ -309,13 +346,17 @@ def record_vote(
             ``media_types_touched`` credit.
         now: Override the current unix timestamp (seconds since epoch); only
             used by tests.  Default uses :func:`time.time`.
+        tz_offset_minutes: Override the local-time offset (UTC minus local, in
+            minutes) instead of reading it from the request header; only used
+            by tests.  Default resolves :func:`_user_tz_offset_minutes`.
     """
     if _is_disabled():
         return
     ts = time.time() if now is None else float(now)
-    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-    date_str = dt.strftime("%Y-%m-%d")
-    hour = dt.hour
+    offset = _user_tz_offset_minutes() if tz_offset_minutes is None else int(tz_offset_minutes)
+    local_dt = datetime.fromtimestamp(ts, tz=timezone.utc) - timedelta(minutes=offset)
+    date_str = local_dt.strftime("%Y-%m-%d")
+    hour = local_dt.hour
 
     mutate_user(lambda cache: _credit_vote(cache, ts, detector_id, media_type, date_str, hour))
 


### PR DESCRIPTION
## Summary

Tweaks to the achievement system per request.

### Finders Keepers
- Tier targets bumped to **2k / 20k / 200k / 2M** (Bronze/Silver/Gold/Platinum), up from 200/2k/20k/200k.

### Around the Clock & Your Days are Numbered (local time)
- Hours and days now bucket by the **voter's local timezone** instead of UTC. The frontend sends the browser's offset on every request via a new `X-Timezone-Offset` interceptor; `record_vote` subtracts it to derive the local wall clock (UTC fallback for CLI/background threads/tests). Offset is clamped to ±14h.
- Dropped the "(UTC, 0-23)" / "UTC calendar days" wording from both descriptions, and the "UTC" suffix from the hours-grid labels.
- **Around the Clock** icon is now an analog clock with hands at **10:10** (was a boat-steering-wheel glyph).
- **Your Days are Numbered** icon is now a **blank daily calendar** — rounded page, header rule, and two ring bindings crossing the top edge (was a lightning bolt).

### Marathoner
- Removed "between any two" from the description.
- Icon is now an **outline of a running man** (was a chemistry flask).

### Renames
- **Detector Collector → Teacher's Pet** (`detectors_trained`).
- **Detector Getter → Detector Collector** (`detectors_imported`).

### Note on "Readme Reader" showing Locked
Not a bug and unrelated to demo datasets. `docs_read` is gated only by finding the hidden code phrase at the bottom of each doc and pasting it into the panel; the demo dataset only affects the separate "Data: Set" (`datasets_loaded`) achievement. No change made here.

## Implementation notes
- New stroke-outline icons `clock`, `running`, `calendar` added to the extended icon set and registered in `KNOWN_TYPES`. The existing `steering-wheel` / `flask` / `lightning` icons are still used elsewhere (settings autopilot tab, dataset importer tabs), so they were left intact rather than repurposed.

## Testing
- `./run-tests.sh` — all 4944 pass (added 4 tests covering local-timezone hour/day bucketing; updated two find_media tier-jump tests for the new thresholds).
- `./run-tests.sh frontend` — build + audit + 845 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7LAHhBE5i6yk61cQjsTgU)_