### PR TITLE
feat(embedding): loader multi-embed (three-slot embedder Phase 2b.3)

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -711,12 +711,31 @@ above it.
   no routing rewire, no frontend.  Persistence rides along with the loader
   multi-embed slice (2b.3), where a real second vector exists to persist; the
   documented `meta["embedder"]` → slot migration lands there.
+- **Phase 2b.3 - loader multi-embed.** The embed stage
+  (`vtscore/datasets/stages/embedding.py`) now runs the *set* of bound
+  embedders, not a single one: `_embed_missing_stage` resolves an ordered
+  embedder list via `_ordered_load_embedders` (the create-time pick leads,
+  followed by any embedders already present on the medias for the reload
+  back-fill) and calls `embed_missing` once per name.  `embed_missing`'s
+  "missing" and patch/structural back-fill detection are keyed to *that*
+  embedder's per-media vector (via `media_embedding(m, name)`) when a name is
+  given, so a second bound embedder embeds items the first already covered
+  without disturbing them; a bare default-resolution call keeps the legacy
+  "embed only the un-embedded" contract.  The binding derives from the full
+  set of embedder names present (`media_embedder_names` →
+  `derive_binding_from_names`), so a reloaded text+patch dataset recovers both
+  slots, not just the recorded primary.  Persistence rides along:
+  `export_dataset_to_file` serialises `media["embeddings"]` (one entry per
+  bound embedder) and records the role-typed slots in `meta`
+  (`text_embedder` / `patch_embedder`); the pickle loader re-keys the dict on
+  load, and a legacy single-vector pickle materialises its dict from the
+  singular mirror via `ensure_embeddings_dict`.  `patch_regions` / `patch_grid`
+  stay singular (the binding allows only one patch embedder, so per-embedder
+  keying would be a ≤1-entry dict); dict-keying them is deferred to whenever a
+  second patch slot is actually allowed.  See "Open follow-ups".
 
 **Remaining, in order:**
 
-- **Phase 2b.3 - loader multi-embed.** Run both bound embedders at ingest so
-  `media["embeddings"]` / `patch_regions` / `patch_grid` carry a per-embedder
-  entry each.  See "Loader / exporter / importer impact".
 - **Phase 2b.4 - routing.** Wire the routing table (text sort → `text_embedder`;
   cosine/region ops → `patch_embedder`); pass the resolved embedder name into
   the now-embedder-aware matrix layer at each consumer.  See "Routing rules".
@@ -732,6 +751,30 @@ above it.
 - **Phase 2c - drop the singular mirror.** Once every read site routes through
   the accessor with an explicit embedder, remove the `media["embedding"]`
   primary mirror (read-time re-key on load handles old pickles).
+
+### Open follow-ups (from 2b.3)
+
+- **No create-time path to bind two embedders yet.** 2b.3 makes the loader,
+  exporter, and pickle reader multi-embedder-*correct* (and exercises it via
+  the embed driver + persistence round-trip), but the standard create flow
+  still passes one `embedder` field, so production datasets remain
+  single-embedder until the frontend dual-picker (under "Frontend" in the v3
+  design) threads a `(text_embedder, patch_embedder)` pair into the load
+  pipeline.  Wire that alongside or after routing (2b.4).
+- **`patch_regions` / `patch_grid` stay singular.** The binding allows at most
+  one patch embedder, so these remain single-valued (owned by that embedder)
+  rather than dict-keyed.  Only revisit if "more than one patch embedder per
+  dataset" ever comes off the v3 non-goals list.
+- **Combine Datasets pair-match guard not added.** `combine_datasets` still
+  guards only on media type, not on the `(text_embedder, patch_embedder)`
+  pair (a pre-existing latitude — it never checked the single `embedder`
+  either).  Since nothing can create a two-embedder dataset yet, this is
+  harmless today; add the strict pair-match refusal (v3 design open question
+  #2) when the dual-picker lands.
+- **NPZ per-embedder layout (`vectors_<name>`) not added.** The `server_files`
+  NPZ importer still carries a single `vectors` array; the per-embedder layout
+  in "Loader / exporter / importer impact" lands with the create-time
+  multi-embed path that would populate it.
 
 ## Phasing
 

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from vtscore.embedding import binding as binding_mod
-from vtscore.embedding.binding import derive_binding, validate_binding
+from vtscore.embedding.binding import derive_binding, derive_binding_from_names, validate_binding
 from vtscore.state.core import DatasetContext
 
 # embedder name -> (supports_text, supports_patch_regions)
@@ -49,6 +49,25 @@ class TestDeriveBinding:
 
     def test_unknown_name_fills_neither(self, fake_caps):
         assert derive_binding("nope") == (None, None)
+
+
+class TestDeriveBindingFromNames:
+    def test_empty_iterable(self):
+        assert derive_binding_from_names([]) == (None, None)
+        assert derive_binding_from_names([None, ""]) == (None, None)
+
+    def test_text_plus_patch_fills_both_slots(self, fake_caps):
+        assert derive_binding_from_names(["faketext", "fakepatch"]) == ("faketext", "fakepatch")
+
+    def test_order_independent(self, fake_caps):
+        assert derive_binding_from_names(["fakepatch", "faketext"]) == ("faketext", "fakepatch")
+
+    def test_first_of_each_role_wins(self, fake_caps):
+        # A second text-capable name does not displace the first.
+        assert derive_binding_from_names(["faketext", "fakeboth"]) == ("faketext", "fakeboth")
+
+    def test_single_vector_among_others_is_skipped(self, fake_caps):
+        assert derive_binding_from_names(["fakesingle", "faketext"]) == ("faketext", None)
 
 
 class TestValidateBinding:
@@ -103,6 +122,25 @@ class TestDatasetContextDerivedBinding:
         ctx = _ctx_with_embedder("fakesingle")
         assert ctx.text_embedder is None
         assert ctx.patch_embedder is None
+
+    def test_two_embedder_dataset_derives_both_slots(self, fake_caps):
+        # A v3 media carries one vector per bound embedder under "embeddings";
+        # the binding is recovered by role-typing both keys, not just the
+        # recorded primary.
+        ctx = DatasetContext("two")
+        ctx.medias[1] = {
+            "id": 1,
+            "embedder": "fakepatch",
+            "embedding": np.ones(4, dtype=np.float32),
+            "embeddings": {
+                "faketext": np.ones(4, dtype=np.float32),
+                "fakepatch": np.ones(4, dtype=np.float32),
+            },
+        }
+        assert ctx.text_embedder == "faketext"
+        assert ctx.patch_embedder == "fakepatch"
+        assert ctx.supports_text is True
+        assert ctx.supports_patch_regions is True
 
 
 class TestDatasetContextExplicitBinding:

--- a/tests_lib/core/test_media_vectors.py
+++ b/tests_lib/core/test_media_vectors.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from vtscore.embedding.media_vectors import (
     ensure_embeddings_dict,
+    media_embedder_names,
     media_embedding,
     primary_embedder_name,
     set_media_embedding,
@@ -111,3 +112,27 @@ def test_primary_embedder_name():
     assert primary_embedder_name({"embedder": "siglip"}) == "siglip"
     assert primary_embedder_name({"embeddings": {"clap": _vec(1)}}) == "clap"
     assert primary_embedder_name({}) is None
+
+
+class TestMediaEmbedderNames:
+    def test_empty(self):
+        assert media_embedder_names({}) == []
+
+    def test_singular_only(self):
+        assert media_embedder_names({"embedding": _vec(1), "embedder": "siglip"}) == ["siglip"]
+
+    def test_dict_keys(self):
+        media = {"embeddings": {"siglip": _vec(1), "dinov3_patch": _vec(2)}}
+        assert set(media_embedder_names(media)) == {"siglip", "dinov3_patch"}
+
+    def test_recorded_primary_ordered_first(self):
+        media = {
+            "embeddings": {"siglip": _vec(1), "dinov3_patch": _vec(2)},
+            "embedder": "dinov3_patch",
+        }
+        assert media_embedder_names(media) == ["dinov3_patch", "siglip"]
+
+    def test_dict_takes_precedence_over_singular_embedder(self):
+        media = {"embeddings": {"a": _vec(1)}, "embedder": "siglip"}
+        # "siglip" isn't a dict key, so it doesn't get prepended; the dict wins.
+        assert media_embedder_names(media) == ["a"]

--- a/tests_lib/datasets/test_multi_embedder_loader.py
+++ b/tests_lib/datasets/test_multi_embedder_loader.py
@@ -1,0 +1,206 @@
+"""Loader multi-embed (v3 Phase 2b.3).
+
+A dataset may bind up to one text-capable and one patch-capable embedder.
+At ingest the embed stage runs each in turn so ``media["embeddings"]``
+carries one vector per bound embedder, and the per-embedder vectors survive
+a pickle save/reload round-trip.  Single-embedder datasets are unchanged.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from pathlib import Path
+
+import numpy as np
+
+from vtscore.datasets.loader import export_dataset_to_file, load_dataset_from_pickle
+from vtscore.datasets.stages.embedding import _ordered_load_embedders, embed_missing
+from vtscore.embedding.media_vectors import media_embedder_names, media_embedding
+
+
+def _fake_embedder(name: str, dim: int = 3):
+    """A MagicMock embedder with a native bulk path and no patch support."""
+    emb = mock.MagicMock()
+    emb.name = name
+    emb.media_type_id = "audio"
+    emb._model = True
+    emb._on_progress = lambda *a, **kw: None
+    emb.supports_patch_regions = False
+    emb.supports_geometric_verification = False
+
+    def _bulk(medias):
+        return [np.full(dim, float(i + 1), dtype=np.float32) for i, _ in enumerate(medias)]
+
+    emb.embed_media_bulk.side_effect = _bulk
+    return emb
+
+
+# ---------------------------------------------------------------------------
+# _ordered_load_embedders: which embedders the stage runs, in what order
+# ---------------------------------------------------------------------------
+
+
+class TestOrderedLoadEmbedders:
+    def test_fresh_create_uses_requested_only(self):
+        medias = {1: {"media_type": "audio", "embedding": None}}
+        assert _ordered_load_embedders(medias, "siglip") == ["siglip"]
+
+    def test_fresh_create_no_pick_falls_back_to_blank(self):
+        # No embedder anywhere → [""], which lets embed_missing resolve the
+        # media-type default (single-embedder create path, unchanged).
+        medias = {1: {"media_type": "audio", "embedding": None}}
+        assert _ordered_load_embedders(medias, "") == [""]
+
+    def test_reload_runs_present_embedders(self):
+        # A reloaded two-embedder pickle: no requested pick, run both present.
+        medias = {
+            1: {
+                "embedder": "siglip",
+                "embeddings": {"siglip": np.ones(3), "dinov3_patch": np.ones(3)},
+            }
+        }
+        assert _ordered_load_embedders(medias, "") == ["siglip", "dinov3_patch"]
+
+    def test_requested_leads_then_present(self):
+        medias = {1: {"embeddings": {"dinov3_patch": np.ones(3)}}}
+        assert _ordered_load_embedders(medias, "siglip") == ["siglip", "dinov3_patch"]
+
+
+# ---------------------------------------------------------------------------
+# embed_missing: a second bound embedder embeds items the first already covered
+# ---------------------------------------------------------------------------
+
+
+class TestSecondEmbedderPass:
+    def test_second_embedder_writes_own_key_without_disturbing_first(self):
+        text_emb = _fake_embedder("emb_text")
+        patch_emb = _fake_embedder("emb_patch")
+        by_name = {"emb_text": text_emb, "emb_patch": patch_emb}
+
+        medias = {i: {"media_type": "audio", "embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)}
+
+        with (
+            mock.patch("vtscore.media.get_embedder", side_effect=lambda n: by_name[n]),
+            mock.patch("vtscore.media.embedders_for_type", return_value=[text_emb]),
+        ):
+            embed_missing(medias, "emb_text")
+            # Singular mirror + first key now belong to emb_text.
+            for m in medias.values():
+                assert m["embedder"] == "emb_text"
+                assert "emb_text" in m["embeddings"]
+            first_vecs = {i: m["embeddings"]["emb_text"] for i, m in medias.items()}
+
+            embed_missing(medias, "emb_patch")
+
+        # The second embedder ran over every item even though the singular
+        # mirror was already set (its missing-detection is per-embedder).
+        assert patch_emb.embed_media_bulk.call_count == 1
+        assert len(patch_emb.embed_media_bulk.call_args.args[0]) == 3
+
+        for i, m in medias.items():
+            assert set(m["embeddings"]) == {"emb_text", "emb_patch"}
+            # First embedder's vectors untouched; mirror still on the primary.
+            np.testing.assert_array_equal(m["embeddings"]["emb_text"], first_vecs[i])
+            assert m["embedder"] == "emb_text"
+            np.testing.assert_array_equal(media_embedding(m, "emb_text"), m["embeddings"]["emb_text"])
+            np.testing.assert_array_equal(media_embedding(m, "emb_patch"), m["embeddings"]["emb_patch"])
+
+    def test_single_embedder_path_unchanged(self):
+        emb = _fake_embedder("solo")
+        medias = {i: {"media_type": "audio", "embedding": None, "media_path": f"/tmp/{i}.wav"} for i in range(1, 4)}
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
+
+        assert emb.embed_media_bulk.call_count == 1
+        for m in medias.values():
+            assert m["embedding"] is not None
+            assert m["embeddings"] == {"solo": m["embedding"]}
+
+
+# ---------------------------------------------------------------------------
+# Persistence: per-embedder vectors round-trip through save/reload
+# ---------------------------------------------------------------------------
+
+
+def _two_embedder_text_media(mid: int) -> dict:
+    rng = np.random.default_rng(mid)
+    a = rng.standard_normal(4).astype(np.float32)
+    b = rng.standard_normal(4).astype(np.float32)
+    return {
+        "id": mid,
+        "media_type": "text",
+        "duration": 0,
+        "file_size": 10,
+        "md5": f"md5{mid}",
+        "embedder": "emb_text",
+        "embedding": a,
+        "embeddings": {"emb_text": a, "emb_patch": b},
+        "media_string": f"document {mid}",
+        "filename": f"doc{mid}.txt",
+        "category": "unknown",
+    }
+
+
+class TestPersistenceRoundTrip:
+    def test_embeddings_dict_survives_save_reload(self, tmp_path):
+        medias = {i: _two_embedder_text_media(i) for i in range(1, 4)}
+        data = export_dataset_to_file(medias, embedder="emb_text", media_type="text", name="rt")
+        pkl = tmp_path / "rt.pkl"
+        pkl.write_bytes(data)
+
+        loaded: dict[int, dict] = {}
+        load_dataset_from_pickle(pkl, loaded)
+
+        assert len(loaded) == 3
+        for m in loaded.values():
+            assert set(m["embeddings"]) == {"emb_text", "emb_patch"}
+            assert set(media_embedder_names(m)) == {"emb_text", "emb_patch"}
+            # Stored normalised on load; vectors differ between the two slots.
+            ta = m["embeddings"]["emb_text"]
+            pa = m["embeddings"]["emb_patch"]
+            assert not np.allclose(ta, pa)
+            np.testing.assert_allclose(np.linalg.norm(ta), 1.0, atol=1e-5)
+
+    def test_legacy_single_vector_pickle_has_no_dict(self, tmp_path):
+        # A media with only a singular vector writes no "embeddings" key; the
+        # embed stage's ensure_embeddings_dict materialises it later.
+        rng = np.random.default_rng(7)
+        v = rng.standard_normal(4).astype(np.float32)
+        media = {
+            "id": 1,
+            "media_type": "text",
+            "duration": 0,
+            "file_size": 10,
+            "md5": "m",
+            "embedder": "solo",
+            "embedding": v,
+            "media_string": "doc",
+            "filename": "doc.txt",
+            "category": "unknown",
+        }
+        data = export_dataset_to_file({1: media}, embedder="solo", media_type="text", name="legacy")
+        pkl = tmp_path / "legacy.pkl"
+        pkl.write_bytes(data)
+
+        loaded: dict[int, dict] = {}
+        load_dataset_from_pickle(pkl, loaded)
+        assert loaded[1].get("embeddings") is None
+        assert media_embedder_names(loaded[1]) == ["solo"]
+
+
+def test_meta_records_binding_slots(tmp_path):
+    """export writes the role-typed slots to meta (informational)."""
+    from vtscore.datasets.container import read_meta
+
+    medias = {i: _two_embedder_text_media(i) for i in range(1, 3)}
+    data = export_dataset_to_file(medias, embedder="emb_text", media_type="text", name="rt")
+    pkl = tmp_path / "rt.pkl"
+    pkl.write_bytes(data)
+
+    meta = read_meta(pkl)
+    # emb_text / emb_patch aren't registered, so capability lookup yields no
+    # role match; the slots are present but None.  The keys themselves must
+    # exist so external readers can rely on the schema.
+    assert "text_embedder" in meta
+    assert "patch_embedder" in meta

--- a/tests_lib/datasets/test_multi_embedder_loader.py
+++ b/tests_lib/datasets/test_multi_embedder_loader.py
@@ -9,7 +9,6 @@ a pickle save/reload round-trip.  Single-embedder datasets are unchanged.
 from __future__ import annotations
 
 import unittest.mock as mock
-from pathlib import Path
 
 import numpy as np
 

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -156,6 +156,24 @@ def _embedding_for_pickle(embedding: Any) -> np.ndarray | None:
     return np.ascontiguousarray(embedding, dtype=np.float32)
 
 
+def _embeddings_dict_for_pickle(embeddings: Any) -> dict[str, np.ndarray] | None:
+    """Coerce a per-embedder ``{name: vector}`` map to compact ``float32`` arrays.
+
+    Returns ``None`` when there is nothing to store (no dict / empty), so a
+    legacy single-vector media adds no key to the pickle and a v3 media carries
+    one entry per bound embedder.  Entries whose vector coerces to ``None`` are
+    dropped.
+    """
+    if not isinstance(embeddings, dict) or not embeddings:
+        return None
+    out: dict[str, np.ndarray] = {}
+    for name, vec in embeddings.items():
+        coerced = _embedding_for_pickle(vec)
+        if name and coerced is not None:
+            out[name] = coerced
+    return out or None
+
+
 def export_dataset_to_file(
     medias: dict[int, dict[str, Any]],
     *,
@@ -217,6 +235,11 @@ def export_dataset_to_file(
             "md5": media["md5"],
             "embedder": media.get("embedder", ""),
             "embedding": _embedding_for_pickle(media["embedding"]),
+            # Per-embedder vectors (v3 three-slot model).  A single-embedder
+            # dataset writes a one-entry dict that the load side re-keys back;
+            # a text+patch dataset writes both, which the singular ``embedding``
+            # mirror alone could not round-trip.
+            "embeddings": _embeddings_dict_for_pickle(media.get("embeddings")),
             "filename": media.get("filename", f"media_{cid}.wav"),
             "category": media.get("category", "unknown"),
             "origin": media.get("origin"),
@@ -240,9 +263,25 @@ def export_dataset_to_file(
     pickle.dump(data, pkl_buf, protocol=_PICKLE_PROTOCOL)
     medias_pkl_bytes = pkl_buf.getvalue()
 
+    # Role-typed binding slots (v3): derived from the embedders actually
+    # present on the medias, so a text+patch dataset records both.  The legacy
+    # singular ``embedder`` is kept for older readers and the dashboard.  On
+    # reload the binding is re-derived from each media's ``embeddings`` keys, so
+    # these meta fields are informational (read_meta / external tooling), not
+    # the load-time source of truth.
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
+
+    text_embedder = patch_embedder = None
+    if medias:
+        first = next(iter(medias.values()))
+        text_embedder, patch_embedder = derive_binding_from_names(media_embedder_names(first))
+
     meta = {
         "format_version": 1,
         "embedder": embedder,
+        "text_embedder": text_embedder,
+        "patch_embedder": patch_embedder,
         "clipper": clipper,
         "media_type": media_type,
         "name": name,

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -21,6 +21,24 @@ from vtscore.embedding.normalize import l2_normalize
 logger = logging.getLogger(__name__)
 
 
+def _load_embeddings_dict(media_info: dict[str, Any]) -> dict[str, Any] | None:
+    """Re-key a pickle entry's per-embedder vectors, L2-normalising each.
+
+    Returns the ``{name: vector}`` dict (v3 pickles carry one entry per bound
+    embedder) or ``None`` for legacy single-vector pickles, where the embed
+    stage materialises the dict from the singular ``embedding`` on load via
+    :func:`vtscore.embedding.media_vectors.ensure_embeddings_dict`.
+    """
+    embs = media_info.get("embeddings")
+    if not isinstance(embs, dict) or not embs:
+        return None
+    out: dict[str, Any] = {}
+    for name, vec in embs.items():
+        if name and vec is not None:
+            out[name] = l2_normalize(vec)
+    return out or None
+
+
 def _read_pickle_dataset(file_path: Path) -> dict[str, Any]:
     """Load a dataset ZIP container and assert the ``"medias"`` envelope.
 
@@ -127,6 +145,7 @@ def _build_pickle_thin_media(
         "embedding": l2_normalize(media_info["embedding"]),
         "media_bytes": None,
         "media_string": None,
+        "embeddings": _load_embeddings_dict(media_info),
         "media_path": media_path,
         "filename": fname,
         "category": media_info.get("category", "unknown"),
@@ -160,6 +179,7 @@ def _build_pickle_full_media(
         "file_size": media_info.get("file_size", len(media_bytes)),
         "md5": media_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),
         "embedding": l2_normalize(media_info["embedding"]),
+        "embeddings": _load_embeddings_dict(media_info),
         "media_bytes": media_bytes,
         "media_string": media_string,
         "media_path": media_path or media_info.get("media_path"),

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -116,10 +116,21 @@ def embed_missing(  # noqa: C901
     if emb is None:
         return
 
-    # Items lacking *this* embedder's vector.  Keyed to the per-embedder
-    # accessor, not the singular mirror, so a second embedder embeds items the
-    # first already covered (their singular vector belongs to the first model).
-    missing = [(mid, m) for mid, m in medias.items() if media_embedding(m, emb.name) is None]
+    # Which items still need *this* embedder's vector.
+    #
+    # When the caller named an embedder explicitly (the bound-set driver and
+    # the reload path both do), "missing" is keyed to that embedder's own
+    # per-media entry, so a second bound embedder embeds items the first
+    # already covered (their singular vector belongs to the first model).
+    #
+    # When no embedder was named (bare default-resolution call), keep the
+    # legacy contract: only items with *no* vector at all are embedded, so a
+    # dataset already populated by some other source isn't re-embedded under
+    # the resolved default.
+    if embedder_name:
+        missing = [(mid, m) for mid, m in medias.items() if media_embedding(m, emb.name) is None]
+    else:
+        missing = [(mid, m) for mid, m in medias.items() if m.get("embedding") is None]
 
     # Patch-capable embedders attach a per-image HAC region tree + patch grid
     # alongside the CLS ``embedding``.  That side-channel must exist for any

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -14,7 +14,12 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
 from vtscore.embedding.matrix import invalidate_embedding_matrix
-from vtscore.embedding.media_vectors import ensure_embeddings_dict, set_media_embedding
+from vtscore.embedding.media_vectors import (
+    ensure_embeddings_dict,
+    media_embedder_names,
+    media_embedding,
+    set_media_embedding,
+)
 
 from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
 
@@ -67,15 +72,19 @@ def embed_missing(  # noqa: C901
     load pipeline drops them via :func:`_drop_none_embeddings_stage`.
     Patch-region tensors are also attached here for embedders that
     report ``supports_patch_regions``.
-    """
-    missing = [(mid, m) for mid, m in medias.items() if m.get("embedding") is None]
 
-    # Resolve the media type from the items that need work.  Prefer the
-    # unembedded items, but fall back to any media so the patch-region
-    # back-fill below can run even when every image already carries an
-    # embedding (e.g. a pre-embedded pickle or content-vector importer bound
-    # to a patch embedder).
-    media_type = _first_media_type(missing) or _first_media_type(medias.items())
+    Multi-embedder note: "missing" and the patch / structural back-fills are
+    keyed to *this* embedder's per-media vector (``media["embeddings"][name]``,
+    via :func:`media_embedding`), not the singular ``media["embedding"]``
+    mirror.  So a second bound embedder run over an already-text-embedded
+    dataset still embeds every item (it has no vector under its own key yet)
+    without disturbing the first embedder's vectors.
+    """
+    # Resolve the media type from any media so the patch-region back-fill
+    # below can run even when every image already carries an embedding (e.g. a
+    # pre-embedded pickle or content-vector importer bound to a patch
+    # embedder).  Homogeneous datasets share one media type.
+    media_type = _first_media_type(medias.items())
     if not media_type:
         return
 
@@ -107,6 +116,11 @@ def embed_missing(  # noqa: C901
     if emb is None:
         return
 
+    # Items lacking *this* embedder's vector.  Keyed to the per-embedder
+    # accessor, not the singular mirror, so a second embedder embeds items the
+    # first already covered (their singular vector belongs to the first model).
+    missing = [(mid, m) for mid, m in medias.items() if media_embedding(m, emb.name) is None]
+
     # Patch-capable embedders attach a per-image HAC region tree + patch grid
     # alongside the CLS ``embedding``.  That side-channel must exist for any
     # image *this* embedder produced but that lacks ``patch_regions`` - not
@@ -120,13 +134,11 @@ def embed_missing(  # noqa: C901
     patch_capable = getattr(emb, "supports_patch_regions", False) is True
 
     def _needs_patch(m: dict[str, Any]) -> bool:
-        # Match the embedder so we never re-pool regions for an image whose
-        # CLS embedding came from a different model.
-        return (
-            m.get("embedding") is not None
-            and m.get("patch_regions") is None
-            and m.get("embedder") in (None, "", emb.name)
-        )
+        # This embedder must have produced a CLS vector for the image (so we
+        # never re-pool regions for an image it never embedded), but key off
+        # its own per-embedder entry rather than the singular mirror: in a
+        # multi-embedder dataset the mirror may belong to a *different* model.
+        return media_embedding(m, emb.name) is not None and m.get("patch_regions") is None
 
     # Structural embedders (SIFT/VLAD) attach a per-image keypoint+descriptor set
     # alongside the VLAD ``embedding``, on the same back-fill terms as patch
@@ -136,11 +148,7 @@ def embed_missing(  # noqa: C901
     structural_capable = getattr(emb, "supports_geometric_verification", False) is True
 
     def _needs_local_features(m: dict[str, Any]) -> bool:
-        return (
-            m.get("embedding") is not None
-            and m.get("local_features") is None
-            and m.get("embedder") in (None, "", emb.name)
-        )
+        return media_embedding(m, emb.name) is not None and m.get("local_features") is None
 
     has_patch_backfill = patch_capable and any(_needs_patch(m) for m in medias.values())
     has_structural_backfill = structural_capable and any(_needs_local_features(m) for m in medias.values())
@@ -250,17 +258,50 @@ def _attach_patch_regions_to_media(media: dict, patch_out) -> None:
     media["patch_grid"] = patch_out.patch_grid.astype(np.float16, copy=False)
 
 
+def _ordered_load_embedders(medias: dict[int, dict[str, Any]], requested: str) -> list[str]:
+    """Resolve the ordered set of embedders to run over *medias* at load.
+
+    The *requested* embedder (the create-time pick, if any) leads, followed by
+    any embedders already present on the medias that it doesn't cover — the
+    reload case, where a v3 pickle restores one vector per bound embedder under
+    ``media["embeddings"]`` and each must have its in-memory patch / structural
+    side-channels re-derived.
+
+    Returns ``[requested]`` (possibly ``[""]``, which lets
+    :func:`embed_missing` resolve the media-type default) when the medias carry
+    no embedder yet — the single-embedder create path, unchanged.
+    """
+    names: list[str] = []
+    if requested:
+        names.append(requested)
+    for m in medias.values():
+        present = media_embedder_names(m)
+        if present:
+            for name in present:
+                if name not in names:
+                    names.append(name)
+            break
+    return names or [requested]
+
+
 def _embed_missing_stage(
     ctx: DatasetContext,
     tracker,
     embedder_name: str,
 ) -> None:
-    """Pipeline wrapper around :func:`embed_missing` with tracker-routed progress."""
+    """Run every bound embedder over the context's medias (tracker-routed progress).
+
+    Single-embedder datasets resolve to one name and behave exactly as before;
+    a dataset bound to both a text and a patch embedder runs each in turn, so
+    ``media["embeddings"]`` carries a per-embedder vector and the patch
+    embedder also populates ``patch_regions`` / ``patch_grid``.
+    """
 
     def _emb_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
         tracker.check_cancelled()
         step = _STATUS_TO_STEP.get(status, _STATUS_TO_STEP["embedding"])
         tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
 
-    embed_missing(ctx.medias, embedder_name, on_progress=_emb_progress)
+    for name in _ordered_load_embedders(ctx.medias, embedder_name):
+        embed_missing(ctx.medias, name, on_progress=_emb_progress)
     invalidate_embedding_matrix(ctx)

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -24,6 +24,8 @@ capabilities" (and is therefore ineligible for either slot).
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 
 def _capabilities(embedder_name: str) -> tuple[bool, bool]:
     """Return ``(supports_text, supports_patch_regions)`` for *embedder_name*.
@@ -52,11 +54,33 @@ def derive_binding(embedder_name: str | None) -> tuple[str | None, str | None]:
 
     ``None`` / empty in → ``(None, None)``.
     """
-    if not embedder_name:
-        return (None, None)
-    supports_text, supports_patch = _capabilities(embedder_name)
-    text_embedder = embedder_name if supports_text else None
-    patch_embedder = embedder_name if supports_patch else None
+    return derive_binding_from_names([embedder_name] if embedder_name else [])
+
+
+def derive_binding_from_names(embedder_names: Iterable[str | None]) -> tuple[str | None, str | None]:
+    """Role-type a *set* of embedder names into ``(text_embedder, patch_embedder)``.
+
+    This is the multi-embedder generalisation of :func:`derive_binding`: a
+    v3 dataset carries one vector per bound embedder under
+    ``media["embeddings"]``, so its binding is recovered by role-typing the
+    full set of embedder names present (the dict keys), not just one legacy
+    name.  Each role slot takes the **first** name that advertises that
+    capability; a dual-capability embedder (``supports_text`` *and*
+    ``supports_patch_regions``) can fill both.  Single-vector, non-text
+    names (e.g. ``dinov2_single``) fill neither and are skipped.
+
+    Empty / all-unknown in → ``(None, None)``.
+    """
+    text_embedder: str | None = None
+    patch_embedder: str | None = None
+    for name in embedder_names:
+        if not name:
+            continue
+        supports_text, supports_patch = _capabilities(name)
+        if supports_text and text_embedder is None:
+            text_embedder = name
+        if supports_patch and patch_embedder is None:
+            patch_embedder = name
     return (text_embedder, patch_embedder)
 
 

--- a/vtscore/embedding/media_vectors.py
+++ b/vtscore/embedding/media_vectors.py
@@ -37,6 +37,26 @@ def primary_embedder_name(media: dict[str, Any]) -> str | None:
     return None
 
 
+def media_embedder_names(media: dict[str, Any]) -> list[str]:
+    """Return every embedder name that has a vector on *media*, primary first.
+
+    Reads the keys of ``media["embeddings"]`` (the dict-keyed form) and falls
+    back to the singular ``media["embedder"]`` when no dict is present.  The
+    recorded primary embedder is ordered first so role derivation and the
+    primary-vector mirror agree on which embedder leads.
+    """
+    embs = media.get(EMBEDDINGS_KEY)
+    if isinstance(embs, dict) and embs:
+        names = list(embs.keys())
+        primary = media.get("embedder")
+        if primary and primary in names:
+            names.remove(primary)
+            names.insert(0, primary)
+        return names
+    name = primary_embedder_name(media)
+    return [name] if name else []
+
+
 def media_embedding(media: dict[str, Any], embedder_name: str | None = None) -> Any:
     """Return the embedding vector for *embedder_name*, or the primary one.
 

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -385,11 +385,11 @@ class DatasetContext:
             return (self._text_embedder, self._patch_embedder)
         if not self.medias:
             return (None, None)
-        from vtscore.embedding.binding import derive_binding  # noqa: PLC0415
-        from vtscore.embedding.media_vectors import primary_embedder_name  # noqa: PLC0415
+        from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+        from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
 
         first = next(iter(self.medias.values()))
-        return derive_binding(primary_embedder_name(first))
+        return derive_binding_from_names(media_embedder_names(first))
 
     @property
     def text_embedder(self) -> str | None:


### PR DESCRIPTION
## Phase 2b.3 — loader multi-embed

Next phase of the v3 three-slot embedder work (`docs/plans/patch-embedder.md`). Makes the loader, exporter, and pickle reader **multi-embedder-correct** so a dataset can carry one CLS vector per bound embedder under `media["embeddings"]`, while keeping single-embedder behavior byte-for-byte unchanged.

### What landed

- **Embed stage runs the bound set.** `_embed_missing_stage` resolves an ordered embedder list via the new `_ordered_load_embedders` (the create-time pick leads, then any embedders already present on the medias for the reload back-fill) and calls `embed_missing` once per name. `embed_missing`'s "missing" and patch/structural back-fill detection are now keyed to *that* embedder's per-media vector (`media_embedding(m, name)`) **when a name is given**, so a second bound embedder embeds items the first already covered without disturbing them. A bare default-resolution call (`embedder_name=""`) keeps the legacy "embed only the un-embedded" contract.
- **Binding derives from the full embedder set.** New `derive_binding_from_names` + `media_embedder_names` role-type every embedder name present on a media, so a reloaded text+patch dataset recovers **both** slots, not just the recorded primary. `DatasetContext._resolve_binding` now uses them.
- **Persistence.** `export_dataset_to_file` serialises `media["embeddings"]` (one entry per bound embedder) and records the role-typed `text_embedder` / `patch_embedder` slots in `meta`; the pickle loader re-keys the dict on load (L2-normalising each), and a legacy single-vector pickle materialises its dict from the singular mirror via `ensure_embeddings_dict`.

### Scope notes

- `patch_regions` / `patch_grid` stay singular — the binding allows only one patch embedder, so per-embedder keying would be a ≤1-entry dict.
- No create-time UI to bind two embedders yet (deferred to the dual-picker, alongside/after routing 2b.4); the combine pair-match guard and NPZ per-embedder layout are likewise deferred. All recorded under "Open follow-ups" in the plan.

### Tests

- New `tests_lib/datasets/test_multi_embedder_loader.py`: `_ordered_load_embedders` ordering, second-embedder pass, single-embedder unchanged, and persistence round-trip.
- Extended `test_dataset_binding.py` (multi-name derivation, two-embedder context) and `test_media_vectors.py` (`media_embedder_names`).
- Full suite: **4980 passed, 1 skipped** (`./run-tests.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bWzP4EAYLGz4PZMg9QM91

---
_Generated by [Claude Code](https://claude.ai/code/session_012bWzP4EAYLGz4PZMg9QM91)_