### PR TITLE
fix(perf): keep the jobs/active spinner poll off the global _state_lock

### DIFF
--- a/app.py
+++ b/app.py
@@ -241,6 +241,15 @@ def _set_user_context():
         g.user = "default"
 
 
+# Endpoints whose handlers never read the dataset/detector proxies do not
+# need the lock-taking state-sync in `_set_request_context` below. Keeping
+# them off `_state_lock` stops a high-frequency poll (e.g. the jobs/active
+# spinner feed) from piling up behind a long lock-holder and exhausting
+# the worker's threads (2026-06-19: one stuck job parked 23 threads on
+# the futex and froze the whole UI).
+_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active",)
+
+
 @app.before_request
 def _set_request_context():
     """Resolve per-request dataset/detector context from HTTP headers.
@@ -311,20 +320,24 @@ def _set_request_context():
     # trained on; scoring with a cross-space MLP either crashes (different
     # dim) or silently produces garbage labels (same dim).  See H5 in
     # docs/plans/logical-bug-audit.md.
-    try:
-        from vtscore.detectors.dataset_sync import (
-            ensure_detector_model_matches_active_embedder,
-            ensure_votes_match_active_dataset,
-        )
+    # Skip the lock-taking state-sync for endpoints whose handlers never
+    # read the proxies (e.g. the jobs/active spinner poll), so a frequent
+    # poll cannot queue on `_state_lock` behind a long-running job.
+    if not request.path.startswith(_STATE_SYNC_EXEMPT_PREFIXES):
+        try:
+            from vtscore.detectors.dataset_sync import (
+                ensure_detector_model_matches_active_embedder,
+                ensure_votes_match_active_dataset,
+            )
 
-        ensure_votes_match_active_dataset()
-        ensure_detector_model_matches_active_embedder()
-    except (DatasetNotLoadedError, DetectorNotLoadedError):
-        # The route handler will hit the same error when it touches the
-        # proxies; the global error handler turns it into a clean 409.
-        pass
-    except Exception:
-        logging.getLogger(__name__).exception("Vote rehydrate failed")
+            ensure_votes_match_active_dataset()
+            ensure_detector_model_matches_active_embedder()
+        except (DatasetNotLoadedError, DetectorNotLoadedError):
+            # The route handler will hit the same error when it touches
+            # the proxies; the global error handler turns it into a 409.
+            pass
+        except Exception:
+            logging.getLogger(__name__).exception("Vote rehydrate failed")
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/app/services/running-jobs.service.ts
+++ b/frontend/src/app/services/running-jobs.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
-import { catchError, distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, exhaustMap, map, takeUntil, timeout } from 'rxjs/operators';
 
 /**
  * One entry returned by ``GET /api/jobs/active``.
@@ -42,7 +42,11 @@ export function pairKey(datasetId: string, detectorId: string): string {
 export class RunningJobsService implements OnDestroy {
   private http = inject(HttpClient);
 
-  private readonly intervalMs = 3000;
+  private readonly intervalMs = 5000;
+  // Bound a single poll so a hung backend request cannot stall the
+  // pipeline forever; on timeout we emit empty (clear spinners) and the
+  // next tick retries.
+  private readonly requestTimeoutMs = 10000;
   private readonly busyPairsSubject = new BehaviorSubject<Map<string, string[]>>(new Map());
   private readonly stopPolling$ = new Subject<void>();
   private readonly destroy$ = new Subject<void>();
@@ -98,12 +102,18 @@ export class RunningJobsService implements OnDestroy {
       .pipe(
         takeUntil(this.stopPolling$),
         takeUntil(this.destroy$),
-        switchMap(() =>
+        // exhaustMap (not switchMap): while one /api/jobs/active request
+        // is in flight, ignore further ticks instead of aborting and
+        // re-issuing. A slow or wedged backend then sees at most one poll
+        // at a time, not a growing pile of aborted requests that exhaust
+        // the worker's threads. timeout() bounds a hung request.
+        exhaustMap(() =>
           this.http.get<ActiveJobsResponse>('/api/jobs/active').pipe(
+            timeout(this.requestTimeoutMs),
             catchError(() => {
-              // A transient registry-fetch failure should not tear the
-              // polling pipeline down; the next tick will retry. Emit
-              // an empty payload so the UI clears any stale spinners.
+              // A transient failure (or the timeout above) should not
+              // tear the polling pipeline down; the next tick retries.
+              // Emit an empty payload so the UI clears stale spinners.
               return [{ busy_pairs: [] } as ActiveJobsResponse];
             }),
           ),


### PR DESCRIPTION
## Problem
The find/label UI froze ~15s per vote over the GRID. Root cause is **server-side lock contention, not the Angular 21 upgrade**: every request runs a `before_request` state-sync that takes the global `_state_lock`, and the 3s `/api/jobs/active` spinner poll (`timer` + `switchMap`) re-fired on every tick while the prior request was still in flight. When a long-running job held `_state_lock`, the polls piled up behind it and exhausted the single Flask worker's threads (observed: 23/26 threads parked on the futex; a bare `curl` to the endpoint hung >30s even at idle).

## Changes
- **Backend (`app.py`)**: `_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active",)` — skip the lock-taking dataset/detector state-sync in `before_request` for endpoints whose handlers never read the proxies. The spinner poll can no longer queue on `_state_lock`.
- **Frontend (`running-jobs.service.ts`)**: `switchMap` -> `exhaustMap` (at most one in-flight poll, no pile-up of aborted requests); add `timeout(10s)` so a hung poll recovers (emits empty -> clears spinners); interval 3s -> 5s.

## Validation
`ruff check` OK, `codespell` OK, `tsc --noEmit -p tsconfig.app.json` exit 0.

## Scope / follow-up
Makes a stuck job degrade gracefully (spinner stops updating) instead of freezing the app. It does **not** change that a `JobManager` holding `_state_lock` across its compute still stalls real proxy-using requests (votes, images) - scoping `_state_lock` to state reads/writes is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
