### PR TITLE
perf(embedding): build embedding matrices outside _state_lock

### DIFF
--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -8,16 +8,19 @@ offending cid instead.
 
 from __future__ import annotations
 
+import threading
+
 import numpy as np
 import pytest
 
+from vtscore.embedding import matrix as matrix_mod
 from vtscore.embedding.matrix import (
     get_embedding_matrix,
     get_embedding_matrix_for_snap,
     get_embedding_submatrix,
     invalidate_embedding_matrix,
 )
-from vtscore.state.core import DatasetContext, set_thread_dataset_context
+from vtscore.state.core import DatasetContext, _state_lock, set_thread_dataset_context
 
 
 class TestGetEmbeddingMatrixRaisesOnNoneEmbedding:
@@ -211,3 +214,69 @@ class TestGetEmbeddingMatrixForSnapRaisesOnNoneEmbedding:
         snap = {cid: ctx.medias[cid] for cid in ctx.medias}
         with pytest.raises(ValueError, match=r"media 2.*has no embedding"):
             get_embedding_matrix_for_snap(snap)
+
+
+class TestEmbeddingMatrixLockScoping:
+    """The contiguous (N, D) build must run OUTSIDE ``_state_lock``.
+
+    Holding the global state lock across ``_stack_embeddings`` lets a large
+    (or multi-embedder named-path) build stall every other request's
+    ``before_request`` state-sync, which also takes ``_state_lock``, on the
+    single worker. These guard against re-introducing the in-lock build.
+    """
+
+    def _ctx(self) -> DatasetContext:
+        ctx = DatasetContext("test_lock_scoping")
+        for cid in (1, 2, 3, 4):
+            ctx.medias[cid] = {"id": cid, "embedding": np.full(4, float(cid), dtype=np.float32)}
+        return ctx
+
+    def _assert_lock_free_during_build(self, monkeypatch, call) -> None:
+        real_stack = matrix_mod._stack_embeddings
+        lock_was_free = threading.Event()
+
+        def probing_stack(sorted_ids, source, embedder_name):
+            def grab():
+                if _state_lock.acquire(timeout=2.0):
+                    lock_was_free.set()
+                    _state_lock.release()
+
+            t = threading.Thread(target=grab)
+            t.start()
+            t.join(3.0)
+            return real_stack(sorted_ids, source, embedder_name)
+
+        monkeypatch.setattr(matrix_mod, "_stack_embeddings", probing_stack)
+        call()
+        assert lock_was_free.is_set(), "_state_lock was held across the matrix build"
+
+    def test_get_embedding_matrix_builds_outside_state_lock(self, monkeypatch):
+        ctx = self._ctx()  # fresh context -> cache miss -> reaches the build
+        self._assert_lock_free_during_build(monkeypatch, lambda: get_embedding_matrix(ctx))
+
+    def test_get_embedding_submatrix_builds_outside_state_lock(self, monkeypatch):
+        ctx = self._ctx()
+        self._assert_lock_free_during_build(
+            monkeypatch, lambda: get_embedding_submatrix(ctx, [1, 2, 3, 4])
+        )
+
+    def test_stale_matrix_not_cached_when_medias_change_during_build(self, monkeypatch):
+        """Phase-3 double-check: a media-set change during the unlocked build
+        must NOT populate the primary cache with the now-stale matrix.
+        """
+        ctx = self._ctx()
+        real_stack = matrix_mod._stack_embeddings
+
+        def mutating_stack(sorted_ids, source, embedder_name):
+            built = real_stack(sorted_ids, source, embedder_name)
+            # A concurrent media insert lands while we build outside the lock.
+            ctx.medias[99] = {"id": 99, "embedding": np.full(4, 9.0, dtype=np.float32)}
+            return built
+
+        monkeypatch.setattr(matrix_mod, "_stack_embeddings", mutating_stack)
+        ids, mat = get_embedding_matrix(ctx)
+
+        assert ids == [1, 2, 3, 4]
+        assert mat.shape == (4, 4)
+        # Cache must not hold the stale [1,2,3,4] build now that medias changed.
+        assert ctx._emb_matrix_ids != [1, 2, 3, 4]

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -80,12 +80,15 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
     Returns ``([], np.empty((0, 0), dtype=np.float32))`` when the dataset is
     empty.  Raises ``ValueError`` if any media lacks the requested vector.
     """
+    # Phase 1 (locked): snapshot the media refs and serve a cache hit. The
+    # expensive _stack_embeddings build runs OUTSIDE the lock (phase 2) so a
+    # large primary or named-embedder build cannot hold _state_lock across the
+    # numpy stack and stall every other request's before_request state-sync.
     with _state_lock:
         sorted_ids = sorted(ctx.medias.keys())
         if embedder_name is None:
-            cached_ids = ctx._emb_matrix_ids
             cached_matrix = ctx._emb_matrix
-            if cached_matrix is not None and cached_ids == sorted_ids:
+            if cached_matrix is not None and ctx._emb_matrix_ids == sorted_ids:
                 return list(sorted_ids), cached_matrix
 
         if not sorted_ids:
@@ -95,12 +98,22 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
                 return [], ctx._emb_matrix
             return [], np.empty((0, 0), dtype=np.float32)
 
-        matrix = _stack_embeddings(sorted_ids, ctx.medias, embedder_name)
+        # Shallow ref-copy so the build below reads a stable view even if
+        # ctx.medias is reassigned concurrently (cheap: pointers, not vectors).
+        medias_snapshot = dict(ctx.medias)
 
-        if embedder_name is None:
-            ctx._emb_matrix_ids = sorted_ids
-            ctx._emb_matrix = matrix
-        return list(sorted_ids), matrix
+    # Phase 2 (unlocked): the heavy contiguous (N, D) build.
+    matrix = _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
+
+    # Phase 3 (locked): repopulate the primary cache, double-checking the id
+    # set still matches so a media mutation during the unlocked build cannot
+    # cache a stale matrix. The named path never touches the cache.
+    if embedder_name is None:
+        with _state_lock:
+            if sorted(ctx.medias.keys()) == sorted_ids:
+                ctx._emb_matrix_ids = sorted_ids
+                ctx._emb_matrix = matrix
+    return list(sorted_ids), matrix
 
 
 def get_embedding_submatrix(
@@ -118,13 +131,17 @@ def get_embedding_submatrix(
     Returns ``([], np.empty((0, 0), dtype=np.float32))`` when nothing matches.
     Raises ``ValueError`` if any requested media lacks the requested vector.
     """
+    # Snapshot just the requested rows under the lock, then build the matrix
+    # outside it so a large subset stack does not hold _state_lock across the
+    # numpy build (see get_embedding_matrix for the rationale).
     with _state_lock:
         medias = ctx.medias
         sorted_ids = sorted({cid for cid in ids if cid in medias})
         if not sorted_ids:
             return [], np.empty((0, 0), dtype=np.float32)
+        medias_snapshot = {cid: medias[cid] for cid in sorted_ids}
 
-        return sorted_ids, _stack_embeddings(sorted_ids, medias, embedder_name)
+    return sorted_ids, _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
 
 
 def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:


### PR DESCRIPTION
## Problem
`get_embedding_matrix` / `get_embedding_submatrix` held the global `_state_lock` across the `_stack_embeddings` `(N, D)` numpy build. On a cache miss -- and on **every** call of the multi-embedder *named* path, which never caches (added in `c5728498` "make the matrix layer embedder-aware") -- the lock is pinned for the whole build. Since every request's `before_request` state-sync also takes `_state_lock`, a large build stalls all other requests; on the single worker this serializes the UI.

Hardening follow-up to #2007 (which took the `/api/jobs/active` poll off `_state_lock`).

## Change
Mirror the existing region-matrix pattern (`8c0d2c2d`):
1. snapshot the media refs under the lock,
2. build the matrix **outside** the lock,
3. re-acquire briefly to repopulate the primary cache, double-checking the id set still matches so a concurrent media mutation cannot cache a stale matrix.

The named path builds outside the lock and never touches the cache.

## Not changed (verified during investigation)
- The per-vote retrain (`run_learned_sort` -> `train_and_score`) already runs outside `_state_lock`.
- MLP scoring runs on the GPU (torch releases the GIL), so the contention is the CPU-side numpy stack, not the scoring.
- `JobManager.start()` already coalesces rapid votes (current + one superseding pending).

So this targets the matrix build specifically -- correctness/contention hardening, most impactful on multi-embedder datasets, not the everyday latency (already restored by #2007).

## Tests
New `TestEmbeddingMatrixLockScoping`:
- a probe thread can acquire `_state_lock` while the build runs (both `get_embedding_matrix` and `get_embedding_submatrix`);
- a media-set change mid-build does not cache the stale matrix.

54 embedding-matrix tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
