### PR TITLE
feat(embedding): per-operation embedder routing (Phase 2b.4)

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -680,7 +680,8 @@ plumbing, not modelling.
 V3 lands as a sequence of behavior-preserving substrate phases (so each
 commit is reviewable and the single-embedder world keeps working) followed by
 the user-visible binding.  Ordering is by dependency: each phase needs the one
-above it.
+above it.  **Status: Phases 2a-2b.4 shipped; 2b.5 (MLP keying) and 2c (drop
+the singular mirror) remain, then the create-time dual-picker.**
 
 **Shipped:**
 
@@ -734,23 +735,52 @@ above it.
   keying would be a ≤1-entry dict); dict-keying them is deferred to whenever a
   second patch slot is actually allowed.  See "Open follow-ups".
 
+- **Phase 2b.4 - routing.** `DatasetContext.routed_embedder(role)` is the one
+  place that encodes the routing table: ``"text"`` → text slot (else the caller
+  400s), ``"patch"`` → patch slot, ``"score"`` → patch-else-text (else ``None``).
+  Each active-dataset consumer resolves its role and threads the name into the
+  embedder-aware matrix layer: text sort (`/api/sort`, role text), example /
+  by-id cosine sort (`/api/example-sort`, role score), label-file sort (embeds
+  *and* scores with the score embedder so they share a space), the detector MLP
+  (`_score_all_media`, `_build_vote_xy`, `train_and_threshold` safe-scoring, the
+  labelset embed name, and Auto-Find scoring), and the diversity tree /
+  projection (full + subset + load-stage + positives-browse).  The query side is
+  routed too: example/by-id sort embeds the example with the score embedder, and
+  text sort embeds the query with the text slot.  **Single-vector gap handled:**
+  a `*_single` embedder binds neither slot, so `score` resolves to ``None`` and
+  the matrix layer reads the primary vector (cosine sort / MLP scoring keep
+  working rather than 400-ing).  **Cache preserved:** a routed name equal to the
+  dataset's primary collapses to the cached primary path
+  (`matrix._collapse_to_primary`), so the single-embedder hot path is
+  byte-for-byte unchanged.  Region-aware cosine scoring is gated on the resolved
+  embedder being the patch embedder, so a text query on a dual dataset scores
+  against the text embedder's full-image vectors, not the patch tree.  See "Open
+  follow-ups" for the cross-dataset Find / CLI-chunk scoring still on primary.
+
 **Remaining, in order:**
 
-- **Phase 2b.4 - routing.** Wire the routing table (text sort → `text_embedder`;
-  cosine/region ops → `patch_embedder`); pass the resolved embedder name into
-  the now-embedder-aware matrix layer at each consumer.  See "Routing rules".
-  **Watch the single-vector gap:** a `*_single` embedder (e.g. `dinov2_single`,
-  `supports_text=False`, `supports_patch_regions=False`) binds *neither* role
-  slot, so the routing table's "patch_embedder if set, else text_embedder" rule
-  resolves to nothing for those datasets.  The 2b.2 binding leaves them working
-  via each media's primary vector (the per-media read path is untouched);
-  routing must keep a primary-vector fallback for cosine sort / MLP scoring on
-  no-slot datasets rather than 400-ing them.
 - **Phase 2b.5 - MLP keying.** Key MLPs by `(detector, dataset, embedder)`.
   See "Detector MLP keying".
 - **Phase 2c - drop the singular mirror.** Once every read site routes through
   the accessor with an explicit embedder, remove the `media["embedding"]`
   primary mirror (read-time re-key on load handles old pickles).
+
+### Open follow-ups (from 2b.4)
+
+- **Cross-dataset Find and CLI-chunk scoring stay on the primary vector.**
+  `find._score_dataset` / `_score_with_cold_detector` score *other* datasets'
+  `temp_medias`, and `cli._score_medias_with_detectors` scores per-chunk
+  subsets - neither is the active `DatasetContext`, so they keep building the
+  matrix from each media's primary vector (no `routed_embedder` call).  This is
+  correct for every single-embedder dataset (primary == score embedder) and
+  only matters once a dual-embedder dataset can be created and Find-scored; wire
+  a binding derived from those medias' own embedder names when the create-time
+  dual path lands.
+- **Region-less media in a region matrix fall back to the primary vector.**
+  `matrix._build_region_arrays` sources a region-less media's single row from
+  `media["embedding"]` (primary), not the patch embedder's vector.  On a real
+  patch dataset every media has `patch_regions`, so this branch is unreachable
+  today; revisit if a dual dataset ever mixes patch and non-patch media.
 
 ### Open follow-ups (from 2b.3)
 

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -167,6 +167,49 @@ class TestDatasetContextExplicitBinding:
         assert ctx.patch_embedder is None
 
 
+class TestRoutedEmbedder:
+    """The v3 routing table: which bound embedder serves each operation role."""
+
+    def test_text_dataset_roles(self, fake_caps):
+        ctx = _ctx_with_embedder("faketext")
+        assert ctx.routed_embedder("text") == "faketext"
+        assert ctx.routed_embedder("patch") is None
+        assert ctx.routed_embedder("score") == "faketext"
+
+    def test_patch_dataset_roles(self, fake_caps):
+        ctx = _ctx_with_embedder("fakepatch")
+        assert ctx.routed_embedder("text") is None
+        assert ctx.routed_embedder("patch") == "fakepatch"
+        assert ctx.routed_embedder("score") == "fakepatch"
+
+    def test_single_vector_dataset_routes_nothing(self, fake_caps):
+        # A slot-less single-vector dataset (e.g. dinov2_single) binds neither
+        # role; score falls through to None so the matrix layer reads the
+        # primary vector rather than 400-ing.
+        ctx = _ctx_with_embedder("fakesingle")
+        assert ctx.routed_embedder("text") is None
+        assert ctx.routed_embedder("patch") is None
+        assert ctx.routed_embedder("score") is None
+
+    def test_score_prefers_patch_over_text(self, fake_caps):
+        ctx = DatasetContext("dual")
+        ctx.bind_embedders(text_embedder="faketext", patch_embedder="fakepatch")
+        assert ctx.routed_embedder("text") == "faketext"
+        assert ctx.routed_embedder("patch") == "fakepatch"
+        # score = patch-if-set-else-text
+        assert ctx.routed_embedder("score") == "fakepatch"
+
+    def test_score_falls_back_to_text_when_no_patch(self, fake_caps):
+        ctx = DatasetContext("texty")
+        ctx.bind_embedders(text_embedder="faketext", patch_embedder=None)
+        assert ctx.routed_embedder("score") == "faketext"
+
+    def test_unknown_role_raises(self, fake_caps):
+        ctx = _ctx_with_embedder("faketext")
+        with pytest.raises(ValueError, match="unknown embedder routing role"):
+            ctx.routed_embedder("bogus")
+
+
 class TestRealRegisteredEmbedder:
     """Smoke test against the live registry.  Reading the capability flags
     does not load model weights, so this is cheap and CPU-only."""

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -153,6 +153,30 @@ class TestEmbedderAwareMatrix:
         with pytest.raises(ValueError, match=r"media 2.*has no embedding for embedder 'dinov3_patch'"):
             get_embedding_matrix(ctx, "dinov3_patch")
 
+    def test_primary_name_collapses_to_cache(self):
+        """Routing hands a name even for single-embedder datasets; a name equal
+        to the primary must collapse to the cached primary path, not the
+        uncached named path - keeping the hot path byte-for-byte unchanged."""
+        ctx = self._ctx()
+        # "siglip" is the primary (the recorded ``embedder``).
+        ids, mat = get_embedding_matrix(ctx, "siglip")
+        assert ids == [1, 2, 3]
+        # Primary's vectors (1,2,3), not dinov3's (101,...).
+        assert mat[0, 0] == 1.0
+        # ...and the cache was populated (the named path would not cache).
+        assert ctx._emb_matrix is not None
+        assert ctx._emb_matrix_ids == [1, 2, 3]
+
+    def test_primary_name_snap_collapses_to_cache(self):
+        ctx = self._ctx()
+        set_thread_dataset_context(ctx)
+        invalidate_embedding_matrix(ctx)
+        snap = {cid: ctx.medias[cid] for cid in ctx.medias}
+        ids, mat = get_embedding_matrix_for_snap(snap, "siglip")
+        assert ids == [1, 2, 3]
+        assert mat[0, 0] == 1.0
+        assert ctx._emb_matrix is not None
+
     def test_submatrix_named_embedder(self):
         ctx = self._ctx()
         ids, mat = get_embedding_submatrix(ctx, [3, 1], "dinov3_patch")

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -280,9 +280,7 @@ class TestEmbeddingMatrixLockScoping:
 
     def test_get_embedding_submatrix_builds_outside_state_lock(self, monkeypatch):
         ctx = self._ctx()
-        self._assert_lock_free_during_build(
-            monkeypatch, lambda: get_embedding_submatrix(ctx, [1, 2, 3, 4])
-        )
+        self._assert_lock_free_during_build(monkeypatch, lambda: get_embedding_submatrix(ctx, [1, 2, 3, 4]))
 
     def test_stale_matrix_not_cached_when_medias_change_during_build(self, monkeypatch):
         """Phase-3 double-check: a media-set change during the unlocked build

--- a/tests_lib/detectors/test_region_similarity_routing.py
+++ b/tests_lib/detectors/test_region_similarity_routing.py
@@ -1,0 +1,84 @@
+"""Embedder routing through region-aware cosine similarity (Phase 2b.4).
+
+``cosine_sort_with_boxes`` / ``score_against_query`` gained an
+``embedder_name`` (which bound embedder's vectors to score against) and a
+``region_aware`` gate (the per-region max-pool is valid only when the query
+was embedded by the embedder that owns ``patch_regions``).  These cover the
+dual-embedder dataset where a text query must score against the text
+embedder's full-image vectors even though the medias also carry a *patch*
+embedder's region trees.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from vtscore.training.region_similarity import cosine_sort_with_boxes, score_against_query
+
+
+def _basis(i: int) -> np.ndarray:
+    return np.eye(4, dtype=np.float32)[i]
+
+
+def _dual_snap() -> dict[int, dict]:
+    """Two medias with distinct text (siglip) vectors + a patch (dinov3) tree.
+
+    media 1's siglip vector is e1, media 2's is e2; both share a dinov3
+    full-image vector e0 and one region vector e3.
+    """
+    snap: dict[int, dict] = {}
+    for cid in (1, 2):
+        snap[cid] = {
+            "id": cid,
+            "embedder": "dinov3_patch",  # the recorded primary
+            "embedding": _basis(0),
+            "embeddings": {"siglip": _basis(cid), "dinov3_patch": _basis(0)},
+            "patch_regions": [SimpleNamespace(vec=_basis(3), box=(0.0, 0.0, 1.0, 1.0))],
+        }
+    return snap
+
+
+class TestScoreAgainstQueryEmbedderName:
+    def test_named_embedder_selects_that_full_image_vector(self):
+        media = _dual_snap()[1]
+        # Drop patch_regions to exercise the single-vector branch.
+        media = {k: v for k, v in media.items() if k != "patch_regions"}
+        # siglip vector is e1 -> matches a query of e1, not the dinov3 e0.
+        sim, box = score_against_query(media, _basis(1), "siglip")
+        assert sim == 1.0
+        assert box == (0.0, 0.0, 1.0, 1.0)
+        sim0, _ = score_against_query(media, _basis(0), "siglip")
+        assert sim0 == 0.0
+
+    def test_default_uses_primary_vector(self):
+        media = {
+            "embedder": "dinov3_patch",
+            "embedding": _basis(0),
+            "embeddings": {"siglip": _basis(1), "dinov3_patch": _basis(0)},
+        }
+        sim, _ = score_against_query(media, _basis(0))
+        assert sim == 1.0
+
+
+class TestCosineSortRouting:
+    def test_text_query_scores_against_text_embedder_no_regions(self):
+        snap = _dual_snap()
+        # Text query e1 matches media 1's siglip vector; region path suppressed.
+        results, _sims = cosine_sort_with_boxes(snap, _basis(1), "siglip", region_aware=False)
+        assert results[0]["id"] == 1
+        assert results[0]["similarity"] == 1.0
+        assert "best_region" not in results[0]
+
+    def test_patch_query_uses_region_path(self):
+        snap = _dual_snap()
+        results, _sims = cosine_sort_with_boxes(snap, _basis(3), "dinov3_patch", region_aware=True)
+        assert results[0]["similarity"] == 1.0
+        assert "best_region" in results[0]
+
+    def test_region_aware_none_defaults_to_snapshot_detection(self):
+        # Legacy single-embedder behaviour: regions present -> region path.
+        snap = _dual_snap()
+        results, _sims = cosine_sort_with_boxes(snap, _basis(3))
+        assert "best_region" in results[0]

--- a/vtscore/datasets/stages/projection.py
+++ b/vtscore/datasets/stages/projection.py
@@ -74,7 +74,8 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
         )
 
     try:
-        sorted_ids, matrix = get_embedding_matrix(ctx)
+        # Cluster in the score embedder's space (patch-else-text; v3 routing).
+        sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
     except ValueError:
         return
     if matrix.size == 0:

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -32,18 +32,22 @@ ProgressCallback = Callable[[str, int, int], None]
 def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     """Return the embedder name to use for fresh resolve+embed work.
 
-    Prefers the active dataset's **score** embedder (patch-else-text; the v3
-    routing table) so that newly embedded cross-dataset vectors line up with
-    the in-dataset vectors the MLP is scored against.  Falls back to the
-    recorded primary embedder for a slot-less single-vector dataset (where the
-    two coincide).
+    Prefers the **score** embedder (patch-else-text; the v3 routing table)
+    *derived from the medias in snap* so that newly embedded cross-dataset
+    vectors line up with the in-dataset vectors the MLP is scored against.
+    Derived from the snap's own embedder names rather than the active context
+    so a non-active snapshot resolves correctly.  Falls back to the recorded
+    primary embedder for a slot-less single-vector dataset (where the two
+    coincide), and ``""`` when *snap* is empty.
     """
     if not snap:
         return ""
-    from vtscore.state.core import get_active_context  # noqa: PLC0415
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
 
     first = next(iter(snap.values()), {})
-    return get_active_context().routed_embedder("score") or first.get("embedder", "") or ""
+    text, patch = derive_binding_from_names(media_embedder_names(first))
+    return patch or text or first.get("embedder", "") or ""
 
 
 def _patch_pooled_from_file(

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -32,13 +32,18 @@ ProgressCallback = Callable[[str, int, int], None]
 def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     """Return the embedder name to use for fresh resolve+embed work.
 
-    Prefers the active dataset's recorded embedder so that newly embedded
-    cross-dataset vectors line up with the existing in-dataset vectors.
+    Prefers the active dataset's **score** embedder (patch-else-text; the v3
+    routing table) so that newly embedded cross-dataset vectors line up with
+    the in-dataset vectors the MLP is scored against.  Falls back to the
+    recorded primary embedder for a slot-less single-vector dataset (where the
+    two coincide).
     """
     if not snap:
         return ""
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
+
     first = next(iter(snap.values()), {})
-    return first.get("embedder", "") or ""
+    return get_active_context().routed_embedder("score") or first.get("embedder", "") or ""
 
 
 def _patch_pooled_from_file(

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -145,7 +145,7 @@ def build_positives_browse_context(
 
     if on_progress is not None:
         on_progress(total, total, "Building projection…")
-    sorted_ids, matrix = get_embedding_matrix(ctx)
+    sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
     proj = fit_projection(matrix, sorted_ids)
     pyr = build_pyramid(proj, bin_shape=bin_shape)
     ctx._projection = proj

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -23,6 +23,21 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
+def _active_score_embedder() -> str | None:
+    """Resolve the active dataset's score embedder (patch-else-text).
+
+    The detector MLP trains and scores against this embedder's vectors (the v3
+    routing table; see :meth:`DatasetContext.routed_embedder`).  Returns
+    ``None`` for a slot-less single-vector dataset, where the matrix layer
+    falls back to each media's primary vector.  For a single-embedder dataset
+    the resolved name equals the primary, which the matrix layer collapses to
+    the cached primary path.
+    """
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
+
+    return get_active_context().routed_embedder("score")
+
+
 def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
     """Check that *y_list* contains at least one good and one bad label.
 
@@ -106,7 +121,7 @@ def train_and_threshold(
         # `safe` is only True when `snap` is truthy (see assignment above),
         # so the narrowing is real even though pyright can't track it.
         assert snap is not None
-        _all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, _active_score_embedder())
         X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             X_all = X_all.to(next(model.parameters()).device)
@@ -157,15 +172,19 @@ def pool_box_from_media(
 def _training_vec_for_vote(
     media: dict[str, Any],
     region_box: tuple[float, float, float, float] | None,
+    embedder_name: str | None = None,
 ) -> np.ndarray:
     """Return the training vector for one vote on *media*.
 
     Region-pools via :func:`pool_box_from_media` when the vote designated a
-    box and *media* carries a ``patch_grid``; otherwise falls back to
-    ``media["embedding"]`` - the v1/legacy image-level vector.
+    box and *media* carries a ``patch_grid``; otherwise falls back to the
+    image-level vector of *embedder_name* (the score embedder) - or the
+    primary vector when ``None``.
     """
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
     pooled = pool_box_from_media(media, region_box)
-    return pooled if pooled is not None else media["embedding"]
+    return pooled if pooled is not None else media_embedding(media, embedder_name)
 
 
 def _build_vote_xy(
@@ -182,15 +201,20 @@ def _build_vote_xy(
     (:func:`_train_and_score_xy`) enforces the ≥2-samples / ≥1-good /
     ≥1-bad guard.
     """
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    # Train against the dataset's score embedder so the MLP shares the space
+    # _score_all_media scores against (the v3 routing table).
+    embedder_name = _active_score_embedder()
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     for cid in good_votes:
         if cid in clips_dict:
-            X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid)))
+            X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid), embedder_name))
             y_list.append(1.0)
     for cid in bad_votes:
         if cid in clips_dict:
-            X_list.append(clips_dict[cid]["embedding"])
+            X_list.append(media_embedding(clips_dict[cid], embedder_name))
             y_list.append(0.0)
     return X_list, y_list
 
@@ -224,7 +248,7 @@ def _score_all_media(
         # a multi-hundred-thousand-row matrix on every vote.
         all_ids, X_np, media_index_per_row, region_index_per_row = get_region_matrix_for_snap(clips_dict)
     else:
-        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict)
+        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict, _active_score_embedder())
         n = len(all_ids)
         media_index_per_row = np.arange(n, dtype=np.int64)
         region_index_per_row = np.zeros(n, dtype=np.int64)

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -23,19 +23,27 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
-def _active_score_embedder() -> str | None:
-    """Resolve the active dataset's score embedder (patch-else-text).
+def _score_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | None:
+    """Resolve the score embedder (patch-else-text) for the medias in *snap*.
 
     The detector MLP trains and scores against this embedder's vectors (the v3
-    routing table; see :meth:`DatasetContext.routed_embedder`).  Returns
-    ``None`` for a slot-less single-vector dataset, where the matrix layer
-    falls back to each media's primary vector.  For a single-embedder dataset
-    the resolved name equals the primary, which the matrix layer collapses to
-    the cached primary path.
+    routing table).  Derived from the embedder names *those* medias carry
+    rather than the active context, since :func:`_score_all_media` /
+    :func:`_build_vote_xy` may be handed an arbitrary snapshot (a test fixture,
+    a cross-dataset dict).  Returns ``None`` for a slot-less single-vector
+    dataset (e.g. ``dinov2_single``) or medias whose embedder is unregistered,
+    so the matrix layer falls back to each media's primary vector.  For a
+    single-embedder dataset the resolved name equals the primary, which the
+    matrix layer collapses to the cached primary path.
     """
-    from vtscore.state.core import get_active_context  # noqa: PLC0415
+    if not snap:
+        return None
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
 
-    return get_active_context().routed_embedder("score")
+    first = next(iter(snap.values()))
+    text, patch = derive_binding_from_names(media_embedder_names(first))
+    return patch or text
 
 
 def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
@@ -121,7 +129,7 @@ def train_and_threshold(
         # `safe` is only True when `snap` is truthy (see assignment above),
         # so the narrowing is real even though pyright can't track it.
         assert snap is not None
-        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, _active_score_embedder())
+        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, _score_embedder_for_snap(snap))
         X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             X_all = X_all.to(next(model.parameters()).device)
@@ -205,7 +213,7 @@ def _build_vote_xy(
 
     # Train against the dataset's score embedder so the MLP shares the space
     # _score_all_media scores against (the v3 routing table).
-    embedder_name = _active_score_embedder()
+    embedder_name = _score_embedder_for_snap(clips_dict)
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     for cid in good_votes:
@@ -248,7 +256,7 @@ def _score_all_media(
         # a multi-hundred-thousand-row matrix on every vote.
         all_ids, X_np, media_index_per_row, region_index_per_row = get_region_matrix_for_snap(clips_dict)
     else:
-        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict, _active_score_embedder())
+        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict, _score_embedder_for_snap(clips_dict))
         n = len(all_ids)
         media_index_per_row = np.arange(n, dtype=np.int64)
         region_index_per_row = np.zeros(n, dtype=np.int64)

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -28,11 +28,34 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtscore.embedding.media_vectors import media_embedding
+from vtscore.embedding.media_vectors import media_embedding, primary_embedder_name
 from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
     from vtscore.state.core import DatasetContext
+
+
+def _collapse_to_primary(medias: dict[int, dict[str, Any]], embedder_name: str | None) -> str | None:
+    """Map a routed embedder name to ``None`` when it is the dataset's primary.
+
+    The routing layer (``DatasetContext.routed_embedder``) hands callers an
+    explicit embedder name even for the common single-embedder dataset, where
+    that name *is* the primary mirror.  The named matrix path builds fresh on
+    every call; the primary path is cached on the context.  Since a name equal
+    to the primary yields byte-for-byte the same vectors as the primary path
+    (the singular ``embedding`` mirrors the recorded embedder's vector), we
+    collapse it to ``None`` here so the cache is reused - keeping the
+    single-embedder hot path unchanged after routing threads names through.
+
+    A name that differs from the primary (a genuine second bound embedder)
+    passes through unchanged and takes the uncached named path.
+    """
+    if embedder_name is None or not medias:
+        return embedder_name
+    first = next(iter(medias.values()))
+    if embedder_name == primary_embedder_name(first):
+        return None
+    return embedder_name
 
 
 def _require_embedding(cid: int, media: dict[str, Any], embedder_name: str | None = None) -> Any:
@@ -86,6 +109,8 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
     # numpy stack and stall every other request's before_request state-sync.
     with _state_lock:
         sorted_ids = sorted(ctx.medias.keys())
+        # A routed name equal to the primary collapses to the cached path.
+        embedder_name = _collapse_to_primary(ctx.medias, embedder_name)
         if embedder_name is None:
             cached_matrix = ctx._emb_matrix
             if cached_matrix is not None and ctx._emb_matrix_ids == sorted_ids:
@@ -275,6 +300,11 @@ def get_embedding_matrix_for_snap(
     sorted_ids = sorted(snap.keys())
     if not sorted_ids:
         return [], np.empty((0, 0), dtype=np.float32)
+
+    # A routed name equal to the snapshot's primary collapses to the cached
+    # primary path (matching get_embedding_matrix), so single-embedder
+    # snapshots keep reusing the context cache after routing names through.
+    embedder_name = _collapse_to_primary(snap, embedder_name)
 
     ctx = get_active_context()
     matches_active = sorted_ids == sorted(ctx.medias.keys())

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -401,6 +401,36 @@ class DatasetContext:
         """Name of the bound patch-capable embedder, or ``None``."""
         return self._resolve_binding()[1]
 
+    def routed_embedder(self, role: str) -> str | None:
+        """Resolve which bound embedder serves *role* (the v3 routing table).
+
+        Roles (see "Routing rules" in ``docs/plans/patch-embedder.md``):
+
+        * ``"text"`` - text queries (``POST /api/sort``): the text slot, or
+          ``None`` (the caller 400s with ``supports_text=False``).
+        * ``"patch"`` - region similarity / voting (``/api/find-label`` region
+          overlays, region votes): the patch slot, or ``None`` (the caller 400s;
+          region ops need a patch embedder).
+        * ``"score"`` - cosine example sort, the detector MLP (train + score),
+          and the diversity tree: the patch slot if bound, else the text slot,
+          else ``None``.  ``None`` means a slot-less single-vector dataset (e.g.
+          ``dinov2_single``); the matrix layer then reads each media's primary
+          vector, so cosine sort / MLP scoring keep working rather than 400-ing.
+
+        Returns an embedder *name* (or ``None``).  Pass the result straight to
+        the embedder-aware matrix layer: a name equal to the dataset's primary
+        embedder collapses to the cached primary path there, so the
+        single-embedder hot path is unchanged byte-for-byte.
+        """
+        text, patch = self._resolve_binding()
+        if role == "text":
+            return text
+        if role == "patch":
+            return patch
+        if role == "score":
+            return patch or text
+        raise ValueError(f"unknown embedder routing role: {role!r}")
+
     @property
     def supports_text(self) -> bool:
         """Whether this dataset can answer text queries (text slot is bound)."""

--- a/vtscore/training/region_similarity.py
+++ b/vtscore/training/region_similarity.py
@@ -34,6 +34,7 @@ import numpy as np
 def score_against_query(
     media: dict,
     query_vec: np.ndarray,
+    embedder_name: Optional[str] = None,
 ) -> tuple[float, Optional[tuple[float, float, float, float]]]:
     """Return ``(max_cosine_similarity, best_region_box)`` for *media*.
 
@@ -46,9 +47,12 @@ def score_against_query(
     which are already unit-norm.
 
     For patch-region media, we score every region vector and return the max
-    along with that region's bounding box.  For legacy single-vector media,
-    we score ``media["embedding"]`` and return ``(score, (0, 0, 1, 1))``.  A
-    zero/empty query, or a missing embedding, yields ``(0.0, None)``.
+    along with that region's bounding box.  For single-vector media we score
+    the full-image vector and return ``(score, (0, 0, 1, 1))``.  *embedder_name*
+    selects which bound embedder's full-image vector to use (the region path is
+    always against the patch embedder that owns ``patch_regions``); ``None``
+    reads the media's primary vector.  A zero/empty query, or a missing
+    embedding, yields ``(0.0, None)``.
     """
     if float(np.linalg.norm(query_vec)) == 0:
         return 0.0, None
@@ -65,7 +69,9 @@ def score_against_query(
                 best_box = r.box
         return (best_score if best_box is not None else 0.0), best_box
 
-    emb = media.get("embedding")
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    emb = media_embedding(media, embedder_name)
     if emb is None:
         return 0.0, None
     emb_arr = np.asarray(emb, dtype=np.float32)
@@ -89,12 +95,29 @@ def _snapshot_has_patch_regions(snap: dict[Any, dict]) -> bool:
 def cosine_sort_with_boxes(
     snap: dict[Any, dict],
     query_vec: np.ndarray,
+    embedder_name: Optional[str] = None,
+    *,
+    region_aware: Optional[bool] = None,
 ) -> tuple[list[dict], list[float]]:
     """Score every media in *snap* against *query_vec*, return per-media dicts.
 
-    Each result dict has ``id``, ``similarity``, and (only when the active
-    snapshot is patch-region-aware) ``best_region`` - a 4-tuple
+    Each result dict has ``id``, ``similarity``, and (only when the
+    snapshot is scored region-aware) ``best_region`` - a 4-tuple
     ``(x0, y0, x1, y1)`` in normalised image coordinates.
+
+    *embedder_name* selects which bound embedder's vectors to score against
+    (``None`` = the media's primary vector); for a single-embedder dataset
+    the routing layer collapses this to the cached primary path.
+
+    *region_aware* gates the per-region max-pool path.  Region vectors
+    (``patch_regions``) belong to the dataset's **patch** embedder, so the
+    region path is valid only when *query_vec* was embedded by that same
+    embedder.  Callers pass ``region_aware=True`` when the resolved
+    *embedder_name* is the dataset's patch embedder (cosine example sort,
+    text sort on a patch-capable embedder), and ``region_aware=False`` for a
+    text query against a separate text embedder on a dual-embedder dataset.
+    ``None`` (the default) means "use regions if the snapshot has any" - the
+    legacy single-embedder behaviour.
 
     Returns ``(results, raw_similarities)`` - *results* sorted descending
     by similarity, *raw_similarities* in the original snapshot order
@@ -109,11 +132,12 @@ def cosine_sort_with_boxes(
     if not snap:
         return [], []
 
-    if _snapshot_has_patch_regions(snap):
+    use_regions = _snapshot_has_patch_regions(snap) if region_aware is None else region_aware
+    if use_regions and _snapshot_has_patch_regions(snap):
         results: list[dict] = []
         sims: list[float] = []
         for cid, m in snap.items():
-            sim, box = score_against_query(m, query_vec)
+            sim, box = score_against_query(m, query_vec, embedder_name)
             entry = {"id": cid, "similarity": round(sim, 4)}
             if box is not None:
                 entry["best_region"] = list(box)
@@ -131,7 +155,7 @@ def cosine_sort_with_boxes(
     # active DatasetContext cache when available.
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap
 
-    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap, embedder_name)
     similarities = np.dot(all_embs, query_vec)
     sims_list = similarities.tolist()
     results = [{"id": cid, "similarity": round(float(sim), 4)} for cid, sim in zip(all_ids, similarities, strict=True)]

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -612,8 +612,9 @@ def auto_detect(body: dict):
         abort(400, message=f"No Auto-Find detectors found for media type: {media_type}")
 
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
 
-    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap, get_active_context().routed_embedder("score"))
     X_all = torch.from_numpy(all_embs)
 
     embed_dim = int(all_embs.shape[1]) if all_embs.ndim > 1 else 0

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -438,7 +438,14 @@ def example_sort_by_id(body: dict):
             finally:
                 tmp.unlink(missing_ok=True)
         else:
-            embedding = media.get("embedding")
+            # Sort by this media's own vector in the score embedder's space
+            # (patch-else-text; the v3 routing table), so the query matches the
+            # haystack _cosine_sort scores against.
+            from vtscore.embedding.media_vectors import media_embedding
+            from vtscore.state.core import get_active_context
+
+            score_name = get_active_context().routed_embedder("score")
+            embedding = media_embedding(media, score_name)
             if embedding is None:
                 abort(400, message="Media has no embedding (cannot sort)")
             results, thresh = _cosine_sort(embedding)

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -289,7 +289,7 @@ def _build_subset(ctx, requested_ids: list[int], bin_shape: str, *, force: bool 
     from vtscore.embedding.matrix import get_embedding_submatrix
     from vtscore.projection import build_pyramid
 
-    sorted_ids, matrix = get_embedding_submatrix(ctx, requested_ids)
+    sorted_ids, matrix = get_embedding_submatrix(ctx, requested_ids, ctx.routed_embedder("score"))
     if matrix.size == 0:
         abort(409, message="None of the selected items have embeddings — nothing to project.")
 
@@ -417,7 +417,9 @@ def build_projection():
         abort(409, message="Dataset is empty — nothing to project.")
 
     try:
-        sorted_ids, matrix = get_embedding_matrix(ctx)
+        # The diversity tree / projection clusters in the score embedder's
+        # space (patch-else-text; the v3 routing table).
+        sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
     except ValueError as exc:
         abort(409, message=str(exc))
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -81,12 +81,17 @@ sorting_bp = Blueprint(
 )
 
 
-def _cosine_sort(query_vec):
+def _cosine_sort(query_vec, *, role: str = "score"):
     """Sort all loaded medias by cosine similarity to *query_vec*.
 
     Returns ``(results, threshold)`` where *results* is a list of
     ``{"id": …, "similarity": …}`` dicts sorted descending, and
     *threshold* is the GMM-based boundary (rounded to 4 decimals).
+
+    *role* selects which bound embedder the haystack is scored against (the
+    v3 routing table, see :meth:`DatasetContext.routed_embedder`): ``"text"``
+    for a text query, ``"score"`` (patch-else-text) for an example/cosine
+    query.  *query_vec* must have been embedded by that same embedder.
 
     For datasets embedded with a patch-aware embedder (DINOv2, DINOv3,
     EUPE), each result also carries a ``best_region`` field containing the
@@ -96,10 +101,17 @@ def _cosine_sort(query_vec):
 
     Both paths live in :mod:`vtscore.training.region_similarity`.
     """
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
     from vtscore.training.region_similarity import cosine_sort_with_boxes  # noqa: PLC0415
 
+    ctx = get_active_context()
+    embedder_name = ctx.routed_embedder(role)
+    # Region vectors belong to the patch embedder; the per-region max-pool is
+    # valid only when the query was scored against that same embedder.
+    region_aware = embedder_name is not None and embedder_name == ctx.patch_embedder
+
     snap = snapshot_medias()
-    results, sims_list = cosine_sort_with_boxes(snap, query_vec)
+    results, sims_list = cosine_sort_with_boxes(snap, query_vec, embedder_name, region_aware=region_aware)
     threshold = calculate_gmm_threshold(sims_list)
     return results, round(threshold, 4)
 
@@ -110,6 +122,29 @@ _embedder_load_lock = threading.Lock()
 def _get_embedder_for_loaded_data():
     """Return the appropriate embedder for the currently loaded dataset."""
     return get_embedder_for_medias(snapshot_medias())
+
+
+def _score_embedder_for_loaded_data() -> tuple[object | None, str | None]:
+    """Return ``(embedder, embedder_name)`` for the dataset's score embedder.
+
+    The score embedder is the patch slot if bound, else the text slot (the v3
+    routing table; see :meth:`DatasetContext.routed_embedder`).  Used to embed
+    an example/label query so it shares the space the haystack is scored
+    against.  A slot-less single-vector dataset falls back to the primary
+    embedder and a ``None`` name (the matrix layer then reads the primary
+    vector); for single-embedder datasets the two coincide.
+    """
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
+
+    score_name = get_active_context().routed_embedder("score")
+    if score_name is not None:
+        from vtscore.media import get_embedder  # noqa: PLC0415
+
+        try:
+            return get_embedder(score_name), score_name
+        except KeyError:
+            pass
+    return _get_embedder_for_loaded_data(), score_name
 
 
 def _load_embedder_with_progress(media_type, total_steps):
@@ -156,37 +191,27 @@ def sort_clips(body: dict):
 
     first = next(iter(snap.values()))
     media_type = first.get("media_type", "audio")
-    embedder_name = first.get("embedder", "")
     total_steps = 3  # load embedder, embed query, compute similarities
 
-    # Reject the request up-front when the active embedder is vision-only
-    # (e.g. DINOv3, Perception Encoder). Without this short-circuit we'd
-    # waste time loading the model into RAM just to discover it can't embed
-    # text; the frontend wouldn't get a clean ``supports_text=False``
-    # signal to hide its text-search UI.
-    if embedder_name:
-        try:
-            from vtscore.media import get_embedder  # noqa: PLC0415
+    # Resolve the dataset's bound text embedder (v3 routing table). Reject the
+    # request up-front when no text slot is bound (a vision-only dataset, e.g.
+    # DINOv3 patch). Without this short-circuit we'd waste time loading a model
+    # just to discover it can't embed text; the frontend already reads the same
+    # ``supports_text`` signal per embedder to hide its text-search UI.
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
 
-            _active_emb = get_embedder(embedder_name)
-        except KeyError:
-            _active_emb = None
-        if _active_emb is not None and not _active_emb.supports_text:
-            update_sort_progress("idle")
-            # flask-smorest's error handler only flows ``message`` and
-            # ``errors`` from ``abort()`` kwargs into the response body,
-            # so the original ``supports_text=False`` flag would be
-            # silently dropped. The frontend already reads the same flag
-            # from each embedder's ``EmbedderInfo`` (see
-            # ``left-panel.component.ts: updateTextSortAvailable``), so
-            # we don't need to ship it on the error response too.
-            abort(
-                400,
-                message=(
-                    f"Embedder '{_active_emb.name}' does not support text queries. "
-                    "Use learned sort or load a saved sort instead."
-                ),
-            )
+    ctx = get_active_context()
+    embedder_name = ctx.routed_embedder("text")
+    if embedder_name is None:
+        update_sort_progress("idle")
+        primary = first.get("embedder", "") or "this dataset's embedder"
+        abort(
+            400,
+            message=(
+                f"Embedder '{primary}' does not support text queries. "
+                "Use learned sort or load a saved sort instead."
+            ),
+        )
 
     try:
         _load_embedder_with_progress(media_type, total_steps)
@@ -201,7 +226,7 @@ def sort_clips(body: dict):
             abort(500, message=f"Could not embed text for media type {media_type}")
 
         update_sort_progress("sorting", "Computing similarities…", 2, total_steps)
-        results, threshold = _cosine_sort(text_vec)
+        results, threshold = _cosine_sort(text_vec, role="text")
         update_sort_progress("idle")
         return {"results": results, "threshold": threshold}
     except Exception as exc:
@@ -586,7 +611,9 @@ def _example_sort_from_path(file_path: Path) -> tuple:
     if not snap:
         raise ValueError("No medias loaded")
 
-    emb = _get_embedder_for_loaded_data()
+    # Embed the example with the dataset's score embedder so the query shares
+    # the space the haystack is scored against.
+    emb, _score_name = _score_embedder_for_loaded_data()
     if emb is None:
         raise ValueError("No embedder available for loaded dataset")
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
@@ -769,8 +796,16 @@ def _embed_external_labels(labels: list[dict], emb) -> tuple[list, list[float], 
     return X_list, y_list, loaded, skipped
 
 
-def _train_and_score_dataset(X_list: list, y_list: list[float]) -> tuple[list[dict], float]:
-    """Train an MLP on (X, y), then score every media in the active dataset."""
+def _train_and_score_dataset(
+    X_list: list, y_list: list[float], embedder_name: str | None = None
+) -> tuple[list[dict], float]:
+    """Train an MLP on (X, y), then score every media in the active dataset.
+
+    *embedder_name* is the embedder the external labels in *X_list* were
+    embedded with; scoring sources the haystack matrix from the same embedder
+    so the trained MLP and the scored vectors share one space.  ``None`` reads
+    each media's primary vector.
+    """
     import torch  # noqa: PLC0415
 
     from vtscore.detectors.training import train_and_threshold
@@ -780,7 +815,7 @@ def _train_and_score_dataset(X_list: list, y_list: list[float]) -> tuple[list[di
     snap = snapshot_medias()
     model, threshold = train_and_threshold(X_list, y_list, snap=snap)
 
-    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap, embedder_name)
     X_all = torch.from_numpy(all_embs)
     with torch.no_grad():
         X_all = X_all.to(next(model.parameters()).device)
@@ -813,7 +848,9 @@ def label_file_sort():
     if not snapshot_medias():
         abort(400, message="No medias loaded")
 
-    emb = _get_embedder_for_loaded_data()
+    # Embed external labels with (and later score against) the dataset's
+    # score embedder so training and scoring share one space.
+    emb, score_name = _score_embedder_for_loaded_data()
     if emb is None:
         abort(400, message="No embedder available for loaded dataset")
 
@@ -834,7 +871,7 @@ def label_file_sort():
         except ValueError:
             abort(400, message="Need at least one good and one bad labeled example")
 
-        results, threshold = _train_and_score_dataset(X_list, y_list)
+        results, threshold = _train_and_score_dataset(X_list, y_list, score_name)
         return {
             "results": results,
             "threshold": round(threshold, 4),

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -19,6 +19,7 @@ import json
 import logging
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from flask import request
 from flask_smorest import Blueprint, abort
@@ -74,6 +75,9 @@ from vtsearch.state import (
 )
 from vtscore.concurrency.progress import update_sort_progress
 
+if TYPE_CHECKING:
+    from vtscore.media.embedder import MediaEmbedder
+
 sorting_bp = Blueprint(
     "sorting",
     __name__,
@@ -124,7 +128,7 @@ def _get_embedder_for_loaded_data():
     return get_embedder_for_medias(snapshot_medias())
 
 
-def _score_embedder_for_loaded_data() -> tuple[object | None, str | None]:
+def _score_embedder_for_loaded_data() -> tuple["MediaEmbedder | None", str | None]:
     """Return ``(embedder, embedder_name)`` for the dataset's score embedder.
 
     The score embedder is the patch slot if bound, else the text slot (the v3
@@ -208,8 +212,7 @@ def sort_clips(body: dict):
         abort(
             400,
             message=(
-                f"Embedder '{primary}' does not support text queries. "
-                "Use learned sort or load a saved sort instead."
+                f"Embedder '{primary}' does not support text queries. Use learned sort or load a saved sort instead."
             ),
         )
 


### PR DESCRIPTION
## Summary

Phase **2b.4** of the multi-embedder (v3 three-slot) work in `docs/plans/patch-embedder.md`: wire the routing table so each operation scores against the right bound embedder. Behavior-preserving for every single-embedder dataset (i.e. all datasets today); makes the code correct for the future dual-embedder case.

### What landed

- **`DatasetContext.routed_embedder(role)`** is the single source of the v3 routing table:
  - `"text"` → the text slot (else the caller 400s with `supports_text=false`)
  - `"patch"` → the patch slot
  - `"score"` → patch-else-text, or `None` for a slot-less single-vector dataset (e.g. `dinov2_single`), where the matrix layer reads the primary vector instead of 400-ing.
- **Consumers wired** to resolve their role and thread the embedder name into the embedder-aware matrix layer:
  - text sort (`/api/sort`), example / by-id cosine sort (`/api/example-sort`), label-file sort (embeds *and* scores with the score embedder so they share a space)
  - the detector MLP — `_score_all_media`, `_build_vote_xy`, `train_and_threshold` safe-scoring, the labelset embed-name, and Auto-Find scoring
  - the diversity tree / projection (full + subset + load-stage + positives-browse)
  - query side too: example/by-id sort embeds the example with the score embedder; text sort embeds the query with the text slot.
- **Cache preserved:** a routed name equal to the dataset's primary embedder collapses to the cached primary path (`matrix._collapse_to_primary`), so the single-embedder hot path is byte-for-byte unchanged.
- **Region-aware gating:** the per-region max-pool runs only when the resolved embedder is the dataset's patch embedder, so a text query on a dual dataset scores against the text embedder's full-image vectors rather than the patch tree.
- Library training/scoring functions derive the score embedder from the **snapshot they're handed** (not the active context), since they may be given an arbitrary/cross-dataset dict.

### Tests

- `routed_embedder` role resolution (text / patch / single-vector / dual / unknown-role).
- Matrix collapse-to-primary keeps the cache for a routed primary name.
- `cosine_sort_with_boxes` / `score_against_query` embedder selection + region gating on a dual snapshot.
- Full suite: **5000 passed, 1 skipped**.

### Follow-ups (recorded in the plan)

- Cross-dataset Find and CLI-chunk scoring still build from the primary vector (not the active context) — correct for every single-embedder dataset; wire when the create-time dual path lands.
- Phase 2b.5 (MLP keying by `(detector, dataset, embedder)`) and 2c (drop the singular mirror) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX9JmHtCy7wz1sHTPdS7ee)_