### PR TITLE
Fall back to CPU when the installed torch wheel can't run on the GPU

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -192,10 +192,17 @@ bash scripts/install-cpu.sh
 **For GPU** (NVIDIA CUDA-compatible systems):
 
 ```bash
-bash scripts/install-gpu.sh          # defaults to CUDA 11.8 (cu118)
-bash scripts/install-gpu.sh cu121    # for CUDA 12.1
-bash scripts/install-gpu.sh cu124    # for CUDA 12.4
+bash scripts/install-gpu.sh          # defaults to CUDA 12.4 (cu124)
+bash scripts/install-gpu.sh cu118    # for CUDA 11.8 (older drivers)
+bash scripts/install-gpu.sh cu128    # for CUDA 12.8 (Blackwell GPUs)
 ```
+
+The CUDA tag picks a torch wheel that only ships kernels for certain GPU
+architectures, so match it to your hardware: Ampere/Ada on `cu118`+, Hopper
+(H100) on `cu121`+, Blackwell on `cu128`+. A mismatched wheel imports fine
+and then raises `cudaErrorNoKernelImageForDevice` on the first GPU op;
+VTSearch detects this at runtime and falls back to CPU (with a warning)
+rather than crashing, but you only get GPU acceleration with a matching wheel.
 
 Both scripts run `pip install -r requirements/{base,gpu}.txt`, which
 installs every runtime + dev dep and editable-installs the `vtsearch`
@@ -427,7 +434,7 @@ with a shared filesystem.
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   bash scripts/install-gpu.sh cu124     # or cu121 / cu118 to match your cluster
+   bash scripts/install-gpu.sh cu124     # or cu118 / cu121 / cu128 to match your node's GPU
    ```
 
    The scripts default to a venv named `.venv` in the project dir; override with

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -8,12 +8,23 @@ set -euo pipefail
 # pre-installs them as binary-only wheels before processing the full
 # requirements, avoiding the need for a C++ compiler.
 #
+# The CUDA tag selects which prebuilt torch wheel you get, and each wheel
+# only ships kernel images for a fixed set of GPU architectures. Pick a tag
+# that covers your GPU's compute capability, or torch will import fine and
+# then raise `cudaErrorNoKernelImageForDevice` on the first real op. Newer
+# GPUs need newer tags: Ampere/Ada work on cu118+, Hopper (H100) on cu121+,
+# Blackwell (B100/B200, RTX 50xx) on cu128+. When in doubt, prefer a recent
+# tag. (VTSearch also smoke-tests CUDA at runtime and falls back to CPU if the
+# installed wheel can't run on the GPU, so a mismatch degrades instead of
+# crashing - but you only get GPU acceleration with a matching wheel.)
+#
 # Usage:
-#   bash scripts/install-gpu.sh              # defaults to cu118
+#   bash scripts/install-gpu.sh              # defaults to cu124
+#   bash scripts/install-gpu.sh cu118        # for CUDA 11.8 (older drivers)
 #   bash scripts/install-gpu.sh cu121        # for CUDA 12.1
-#   bash scripts/install-gpu.sh cu124        # for CUDA 12.4
+#   bash scripts/install-gpu.sh cu128        # for CUDA 12.8 (Blackwell)
 
-CUDA_TAG="${1:-cu118}"
+CUDA_TAG="${1:-cu124}"
 EXTRA_INDEX="https://download.pytorch.org/whl/${CUDA_TAG}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -256,9 +256,7 @@ class TestEmbeddingMatrixLockScoping:
 
     def test_get_embedding_submatrix_builds_outside_state_lock(self, monkeypatch):
         ctx = self._ctx()
-        self._assert_lock_free_during_build(
-            monkeypatch, lambda: get_embedding_submatrix(ctx, [1, 2, 3, 4])
-        )
+        self._assert_lock_free_during_build(monkeypatch, lambda: get_embedding_submatrix(ctx, [1, 2, 3, 4]))
 
     def test_stale_matrix_not_cached_when_medias_change_during_build(self, monkeypatch):
         """Phase-3 double-check: a media-set change during the unlocked build

--- a/tests_lib/core/test_torch_config.py
+++ b/tests_lib/core/test_torch_config.py
@@ -29,6 +29,16 @@ def reset_torch_configured_flag():
     torch_setup._torch_configured = False
 
 
+@pytest.fixture(autouse=True)
+def reset_cuda_probe_cache():
+    """Clear the per-process CUDA smoke-test cache so each test re-probes."""
+    import vtscore.config as config
+
+    config._cuda_runnable.clear()
+    yield
+    config._cuda_runnable.clear()
+
+
 def test_torch_threads_constant_default(monkeypatch):
     """``TORCH_THREADS`` defaults to 1 when the env var is unset."""
     monkeypatch.delenv("VTSEARCH_TORCH_THREADS", raising=False)
@@ -95,17 +105,85 @@ def test_get_torch_device_honours_explicit_cpu(monkeypatch):
 
 
 def test_get_torch_device_returns_cuda_when_available(monkeypatch):
-    """``auto`` resolves to cuda when torch reports CUDA is available."""
+    """``auto`` resolves to cuda when CUDA is available AND a kernel can run."""
     monkeypatch.setenv("VTSEARCH_DEVICE", "auto")
     import vtscore.config as config
     import vtscore.embedding.loader as loader
 
     importlib.reload(config)
     importlib.reload(loader)
-    with mock.patch.object(torch.cuda, "is_available", return_value=True):
+    with (
+        mock.patch.object(torch.cuda, "is_available", return_value=True),
+        mock.patch.object(config, "_cuda_can_run", return_value=True),
+    ):
         dev = loader.get_torch_device()
 
     assert dev.type == "cuda"
+
+
+def test_auto_falls_back_to_cpu_when_kernel_cannot_run(monkeypatch):
+    """CUDA visible but no runnable kernel image -> CPU under ``auto``.
+
+    Reproduces the ``cudaErrorNoKernelImageForDevice`` case: the wheel was
+    built without a kernel image for this GPU, so ``is_available()`` is True
+    but the smoke-test launch raises. The host must degrade to CPU, not crash.
+    """
+    monkeypatch.setenv("VTSEARCH_DEVICE", "auto")
+    import vtscore.config as config
+    import vtscore.embedding.loader as loader
+
+    importlib.reload(config)
+    importlib.reload(loader)
+    with (
+        mock.patch.object(torch.cuda, "is_available", return_value=True),
+        mock.patch.object(config, "_cuda_can_run", return_value=False),
+    ):
+        dev = loader.get_torch_device()
+
+    assert dev.type == "cpu"
+
+
+def test_explicit_cuda_pin_falls_back_when_kernel_cannot_run(monkeypatch):
+    """Even an explicit ``VTSEARCH_DEVICE=cuda`` pin degrades to CPU if unusable."""
+    monkeypatch.setenv("VTSEARCH_DEVICE", "cuda")
+    import vtscore.config as config
+    import vtscore.embedding.loader as loader
+
+    importlib.reload(config)
+    importlib.reload(loader)
+    with mock.patch.object(config, "_cuda_can_run", return_value=False):
+        dev = loader.get_torch_device()
+
+    assert dev.type == "cpu"
+
+
+def test_cuda_can_run_returns_false_when_launch_raises(monkeypatch):
+    """``_cuda_can_run`` swallows a kernel-launch error and caches False."""
+    import vtscore.config as config
+
+    importlib.reload(config)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("no kernel image is available for execution on the device")
+
+    with (
+        mock.patch.object(torch.cuda, "is_available", return_value=True),
+        mock.patch.object(torch, "zeros", side_effect=_boom),
+    ):
+        assert config._cuda_can_run("cuda") is False
+        # Cached: a second call doesn't re-probe (would raise if it did, but
+        # the cache short-circuits before touching torch).
+        assert config._cuda_can_run("cuda") is False
+    assert config._cuda_runnable["cuda"] is False
+
+
+def test_cuda_can_run_false_without_cuda(monkeypatch):
+    """No CUDA at all -> ``_cuda_can_run`` is False without launching anything."""
+    import vtscore.config as config
+
+    importlib.reload(config)
+    with mock.patch.object(torch.cuda, "is_available", return_value=False):
+        assert config._cuda_can_run("cuda") is False
 
 
 def test_train_model_places_model_on_selected_device(monkeypatch):

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -42,24 +42,91 @@ TORCH_THREADS = max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1")))
 DEVICE = os.environ.get("VTSEARCH_DEVICE", "auto").lower()
 
 
+# Per-device cache for the CUDA smoke-test below.  ``None`` until probed;
+# the probe runs once per device string per process and is cheap thereafter.
+_cuda_runnable: dict[str, bool] = {}
+
+
+def _cuda_can_run(device: str = "cuda") -> bool:
+    """Return ``True`` only if torch can actually launch a kernel on *device*.
+
+    ``torch.cuda.is_available()`` is necessary but **not** sufficient: it
+    reports ``True`` whenever a driver and a CUDA device are visible, even when
+    the installed torch wheel was compiled without a kernel image for that GPU's
+    compute capability.  In that case every real op raises
+    ``cudaErrorNoKernelImageForDevice`` (``torch.AcceleratorError``), which is
+    exactly what makes a "switched GPU" host 500 on every MLP train.
+
+    We force one tiny kernel launch + synchronize so the failure surfaces here,
+    once, instead of deep inside training.  The result is cached per device so
+    the rest of the app can fall back to CPU and keep working rather than
+    crash-looping on a GPU it cannot use.  This keeps VTSearch resilient across
+    heterogeneous fleets: the same install runs on whatever node it lands on,
+    using the GPU when the wheel supports it and CPU when it doesn't.
+    """
+    import logging  # noqa: PLC0415
+
+    cached = _cuda_runnable.get(device)
+    if cached is not None:
+        return cached
+
+    ok = False
+    try:
+        import torch  # noqa: PLC0415
+
+        if torch.cuda.is_available():
+            # A real launch + sync: allocation alone can succeed lazily, so we
+            # add and reduce to force the kernel and then block on the result.
+            probe = torch.zeros(1, device=device)
+            _ = (probe + 1).sum().item()
+            torch.cuda.synchronize(probe.device)
+            ok = True
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "CUDA reports a usable device but torch cannot run a kernel on %s "
+            "(the installed torch build likely lacks a kernel image for this "
+            "GPU's compute capability); falling back to CPU. Reinstall a torch "
+            "build that matches this GPU (see scripts/install-gpu.sh, e.g. a "
+            "newer CUDA tag such as cu124/cu128) or set VTSEARCH_DEVICE=cpu to "
+            "silence this warning.",
+            device,
+            exc_info=True,
+        )
+        ok = False
+
+    _cuda_runnable[device] = ok
+    return ok
+
+
 def resolve_device() -> str:
     """Resolve :data:`DEVICE` to a concrete ``torch.device`` string.
 
     Imports torch lazily so that simply importing this module does not pull
     torch in.  Returns ``"cpu"`` if torch is unavailable.
+
+    Whether ``DEVICE`` is ``"auto"`` or an explicit ``"cuda"``/``"cuda:N"``,
+    the chosen CUDA device is smoke-tested via :func:`_cuda_can_run` before it
+    is returned; a device that cannot actually execute a kernel (wrong/missing
+    kernel image for the GPU) falls back to ``"cpu"`` so the app degrades
+    gracefully instead of crashing on every train.
     """
-    if DEVICE != "auto":
-        return DEVICE
     try:
         import torch  # noqa: PLC0415
-
-        if torch.cuda.is_available():
-            return "cuda"
-        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            return "mps"
-        return "cpu"
     except ImportError:
         return "cpu"
+
+    if DEVICE != "auto":
+        # Honour an explicit pin, but still refuse a CUDA device the wheel
+        # can't run on - a hard crash helps nobody, and CPU keeps the app up.
+        if DEVICE.startswith("cuda") and not _cuda_can_run(DEVICE):
+            return "cpu"
+        return DEVICE
+
+    if torch.cuda.is_available() and _cuda_can_run("cuda"):
+        return "cuda"
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 # Server-side file access is governed by the active login provider, not a

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -144,7 +144,7 @@ when one is in scope). Tests rely on this: they override
 | Constant                 | Default | Override env var              | Meaning                                                                                                          |
 |--------------------------|---------|-------------------------------|------------------------------------------------------------------------------------------------------------------|
 | `TORCH_THREADS`          | `1`     | `VTSEARCH_TORCH_THREADS`      | Native thread count for OpenMP / MKL / `torch.set_num_threads`. Default 1 keeps RSS low in constrained envs.     |
-| `DEVICE`                 | `"auto"`| `VTSEARCH_DEVICE`             | Preferred compute device. `"auto"` resolves at call time; explicit `"cuda"`, `"cuda:0"`, `"cpu"`, `"mps"` pass through. |
+| `DEVICE`                 | `"auto"`| `VTSEARCH_DEVICE`             | Preferred compute device. `"auto"` resolves at call time; explicit `"cuda"`, `"cuda:0"`, `"cpu"`, `"mps"` are honoured, but a CUDA device the installed torch wheel can't actually run on falls back to `"cpu"`. |
 | `MAX_UPLOAD_MB`          | `0`     | `VTSEARCH_MAX_UPLOAD_MB`      | HTTP body cap in megabytes. `0` = unlimited (Flask's out-of-the-box behaviour).                                  |
 | `TRAIN_EPOCHS`           | `200`   | `VTSEARCH_TRAIN_EPOCHS`       | Upper bound on MLP training epochs. `vtscore.training.mlp.train_model` may early-stop sooner.                    |
 | `TRAIN_PATIENCE`         | `10`    | `VTSEARCH_TRAIN_PATIENCE`     | Epochs the training loss must fail to improve before early-stop fires. `0` disables early-stop.                  |
@@ -155,23 +155,33 @@ when one is in scope). Tests rely on this: they override
 
 ### `resolve_device()`
 
-Defined at `vtscore/config.py:45-62`. Returns the concrete device
-string this host will actually use:
+Returns the concrete device string this host will actually use:
 
 ```python
 from vtscore.config import resolve_device
 
 torch_device = resolve_device()
-# "cuda" if CUDA is visible
+# "cuda" if CUDA is visible AND torch can run a kernel on it
 # "mps" on Apple Silicon
 # "cpu" otherwise
 ```
 
 Imports `torch` lazily so simply importing `vtscore.config` does not
 pull torch into the process. Returns `"cpu"` if torch isn't installed
-at all. When `DEVICE` is anything other than `"auto"`, the env var's
-value is returned unchanged - this is how you pin to `"cuda:1"` or
-`"mps"` for a specific run.
+at all.
+
+**CUDA is smoke-tested, not just probed for availability.**
+`torch.cuda.is_available()` returns `True` whenever a driver and device
+are visible, even when the installed torch wheel was built without a
+kernel image for that GPU's compute capability - in which case every real
+op raises `cudaErrorNoKernelImageForDevice`. `resolve_device()` therefore
+launches one tiny kernel (`_cuda_can_run()`, cached per device per process)
+before committing to CUDA; if it can't run, the host falls back to `"cpu"`
+with a one-time warning instead of crash-looping. This holds for an
+explicit `VTSEARCH_DEVICE=cuda`/`cuda:N` pin too: the pin is honoured when
+it works and falls back to CPU when it doesn't, so one install runs across
+a heterogeneous GPU fleet. To actually use a newer GPU, reinstall a torch
+build whose CUDA tag covers its arch (see `scripts/install-gpu.sh`).
 
 ## Server-path access
 


### PR DESCRIPTION
## Problem

Running a Train on a host whose GPU isn't covered by the installed torch wheel produced an endless 500 loop on `GET /api/labeling-status` (and any train):

```
torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device
```

`resolve_device()` trusted `torch.cuda.is_available()`, which returns `True` whenever a driver + CUDA device are visible — even when the wheel was compiled without a kernel image for that GPU's compute capability (`cudaErrorNoKernelImageForDevice`). So the device resolved to `cuda`, and the first real op inside `train_model` (`torch.where(...).to(device)`) blew up. Because the frontend polls labeling-status every ~2s, it 500-looped.

## Fix

VTSearch is now resilient to whatever GPU it lands on, rather than tied to a specific one:

- **`_cuda_can_run()`** (`vtscore/config.py`) launches + synchronizes one tiny kernel, cached per device per process. `resolve_device()` calls it before committing to CUDA — under `auto` *and* under an explicit `VTSEARCH_DEVICE=cuda`/`cuda:N` pin. If the kernel can't run, the host falls back to `cpu` with a one-time actionable warning instead of crash-looping. One install now runs across a heterogeneous GPU fleet.
- **`scripts/install-gpu.sh`**: default CUDA tag bumped `cu118` → `cu124`, with guidance on matching the tag to the GPU arch (Ampere/Ada `cu118`+, Hopper `cu121`+, Blackwell `cu128`+). The runtime fallback degrades gracefully, but you only get GPU *acceleration* with a matching wheel.
- Docs updated (`docs/SETUP.md`, `vtscore/docs/packages/config.md`).

## Tests

Added coverage in `tests_lib/core/test_torch_config.py`: auto + explicit-pin fallback when the kernel can't run, the probe swallowing/caching a launch error, and the no-CUDA path. Full suite green (4991 passed). Also reformatted a pre-existing ruff-format violation in `test_embedding_matrix.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFRSoC1g6r5hRvuAwP9k2u)_