### PR TITLE
fix(gpu): pin torch from CUDA index + GPU-tag/module SLURM docs

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -51,9 +51,16 @@ COPY pyproject.toml ./
 COPY vtsearch/ vtsearch/
 
 # Pre-install numpy/scipy as binary-only wheels so the PyTorch extra-index
-# cannot pull in source tarballs that require g++.
+# cannot pull in source tarballs that require g++. Then pin torch from the CUDA
+# index with --index-url (NOT --extra-index-url): otherwise PyPI stays a
+# candidate and a newer PyPI torch overrides the cu121 build with a wrong-arch
+# wheel (cudaErrorNoKernelImageForDevice at runtime on unsupported GPUs).
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir --only-binary :all: numpy scipy && \
+    pip install --no-cache-dir \
+        --index-url https://download.pytorch.org/whl/cu121 \
+        --prefer-binary \
+        torch torchvision torchaudio && \
     pip install --no-cache-dir \
         --extra-index-url https://download.pytorch.org/whl/cu121 \
         --prefer-binary \

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -192,17 +192,23 @@ bash scripts/install-cpu.sh
 **For GPU** (NVIDIA CUDA-compatible systems):
 
 ```bash
-bash scripts/install-gpu.sh          # defaults to CUDA 12.4 (cu124)
+bash scripts/install-gpu.sh          # defaults to CUDA 12.4 (cu124; spans Volta..Hopper)
 bash scripts/install-gpu.sh cu118    # for CUDA 11.8 (older drivers)
-bash scripts/install-gpu.sh cu128    # for CUDA 12.8 (Blackwell GPUs)
+bash scripts/install-gpu.sh cu128    # for CUDA 12.8 (Blackwell; drops Volta)
 ```
 
 The CUDA tag picks a torch wheel that only ships kernels for certain GPU
-architectures, so match it to your hardware: Ampere/Ada on `cu118`+, Hopper
-(H100) on `cu121`+, Blackwell on `cu128`+. A mismatched wheel imports fine
-and then raises `cudaErrorNoKernelImageForDevice` on the first GPU op;
-VTSearch detects this at runtime and falls back to CPU (with a warning)
-rather than crashing, but you only get GPU acceleration with a matching wheel.
+architectures, so match it to your hardware. There's a **floor** — newer GPUs
+need newer tags: Ampere/Ada on `cu118`+, Hopper (H100) on `cu121`+, Blackwell
+on `cu128`+ — and a **ceiling**: the newest wheels *drop* the oldest
+architectures, so "just use the latest tag" is wrong for old hardware. For
+example, `cu128` dropped Volta (`sm_70`), so a **Tesla V100 needs `cu124`**
+(or `cu121`/`cu118`), not `cu128`. Rule of thumb: pick the oldest tag your
+driver supports that still covers your GPU; `cu124` is a safe default spanning
+Volta through Hopper. A mismatched wheel imports fine and then raises
+`cudaErrorNoKernelImageForDevice` on the first GPU op; VTSearch detects this at
+runtime and falls back to CPU (with a warning) rather than crashing, but you
+only get GPU acceleration with a matching wheel.
 
 Both scripts run `pip install -r requirements/{base,gpu}.txt`, which
 installs every runtime + dev dep and editable-installs the `vtsearch`
@@ -440,6 +446,28 @@ with a shared filesystem.
    The scripts default to a venv named `.venv` in the project dir; override with
    `VTS_VENV` if yours differs.
 
+   > **Module-based Python (e.g. the HLTCOE Grid).** Many clusters ship Python
+   > only via environment modules, and the system `python3` may be too old
+   > (VTSearch needs 3.10+). Load a recent one first, and build the venv with
+   > the **versioned** interpreter name so a `pyenv` shim on your `PATH` can't
+   > shadow it:
+   >
+   > ```bash
+   > module avail python                 # find an available 3.10+ module
+   > module load python/3.12.3
+   > which python3.12                     # should be the module's, not a pyenv shim
+   > python3.12 -m venv .venv
+   > source .venv/bin/activate
+   > python --version                     # confirm 3.12.x before installing
+   > bash scripts/install-gpu.sh cu124
+   > ```
+   >
+   > A venv built this way is **not** self-contained — its `python` needs the
+   > module's `libpython` at runtime — so the launcher must load the module
+   > before activating the venv. Set `VTS_MODULE` (see
+   > [Tuning](#tuning-the-allocation)) so `vtsearch` does this for you:
+   > `VTS_MODULE="python/3.12.3" vtsearch` (or `export` it in `~/.bashrc`).
+
 3. **Build the frontend** (needs Node.js 22+; see [Building the
    frontend](#building-the-frontend)):
 
@@ -530,6 +558,7 @@ inline, e.g. `VTS_MEM=64G VTS_GPU=a100 vtsearch`:
 |----------|---------|---------|
 | `VTS_DIR` | `/exp/$USER/projects/VTSearch` | Path to the VTSearch checkout on the cluster |
 | `VTS_VENV` | `.venv` | Virtualenv to activate (relative to `VTS_DIR`, or absolute) |
+| `VTS_MODULE` | (none) | Environment module(s) to `module load` before activating the venv (space-separated). Needed when your venv is built from a module-provided Python, e.g. `VTS_MODULE="python/3.12.3"` |
 | `VTS_PART` | `gpu` | SLURM partition |
 | `VTS_GPU` | `l40s` | GPU type requested via `--gres=gpu:<type>:1` |
 | `VTS_CPUS` | `8` | CPU cores |
@@ -546,8 +575,11 @@ inline, e.g. `VTS_MEM=64G VTS_GPU=a100 vtsearch`:
 | `VTS_PORT` | (cluster-computed) | Forwarded port; defaults to the same per-user value the launcher binds. Set it only if you overrode `VTS_PORT` on the cluster too |
 
 Adjust `VTS_GPU`, `VTS_PART`, and the CUDA wheel in `install-gpu.sh` to match
-your cluster's hardware. Check what's available with `sinfo` and your cluster's
-documentation.
+your cluster's hardware. To find the exact GPU type string for `VTS_GPU`, check
+a node's gres: `scontrol show node <node> | grep -i Gres` (e.g. `Gres=gpu:v100:8`
+→ use `VTS_GPU=v100`) or list partition gres with `sinfo -o '%P %G'`. Note
+`VTS_GPU` takes just the type (`v100`), not the full `gpu:v100:8` spec — the
+launcher adds the `gpu:` prefix and `:1` count itself.
 
 ## Running the tests
 

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -1,9 +1,10 @@
 # VTSearch: GPU dependencies (CUDA)
 #
 # Used by docker/Dockerfile.gpu (which pins cu121 at install time) and
-# scripts/install-gpu.sh (which passes the chosen CUDA tag's
-# --extra-index-url on the pip command line). Like requirements/base.txt
-# this forwards to pyproject.toml; `[project.dependencies]` plus the
-# `dev` extra.
+# scripts/install-gpu.sh. Both first install torch/torchvision/torchaudio
+# from the chosen CUDA tag's index with --index-url (so PyPI can't override
+# the build with a mismatched-arch wheel), then install the rest of this file
+# with --extra-index-url. Like requirements/base.txt this forwards to
+# pyproject.toml; `[project.dependencies]` plus the `dev` extra.
 
 -e .[dev]

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -41,7 +41,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=_progress.sh
 source "$SCRIPT_DIR/_progress.sh"
 
-vts_progress_init 4 "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})"
+vts_progress_init 5 "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})"
 
 vts_progress_step "Checking Python version (>= 3.10)"
 source "$SCRIPT_DIR/_check-python.sh"
@@ -56,7 +56,23 @@ pip install --only-binary :all: \
   "scipy" \
   --progress-bar on
 
-vts_progress_step "Installing all dependencies via ${EXTRA_INDEX} (this may take several minutes)"
+# Pin torch/torchvision/torchaudio to the chosen CUDA index with --index-url
+# (NOT --extra-index-url). With --extra-index-url, PyPI stays in the candidate
+# set, and when PyPI ships a *newer* torch than this CUDA index tops out at
+# (e.g. cu124 caps at 2.6.0 while PyPI has 2.7.x, a cu126 build), pip prefers
+# the higher version and silently installs the wrong-arch wheel -- which then
+# fails with cudaErrorNoKernelImageForDevice on older GPUs. Installing from the
+# CUDA index alone forces the matching +${CUDA_TAG} build; the PyTorch index
+# mirrors torch's dependency closure, so a sole --index-url resolves cleanly.
+vts_progress_step "Installing CUDA torch from ${CUDA_TAG} index (pinned so PyPI can't substitute a mismatched build)"
+pip install --index-url "$EXTRA_INDEX" \
+  --prefer-binary \
+  torch torchvision torchaudio \
+  --progress-bar on
+
+# Install everything else. torch is already satisfied by the pinned build above,
+# so this --extra-index-url pass won't replace it (no --upgrade).
+vts_progress_step "Installing remaining dependencies via ${EXTRA_INDEX} (this may take several minutes)"
 pip install --extra-index-url "$EXTRA_INDEX" \
   --prefer-binary \
   -r "$REPO_ROOT/requirements/gpu.txt" \

--- a/scripts/install-gpu.sh
+++ b/scripts/install-gpu.sh
@@ -10,19 +10,27 @@ set -euo pipefail
 #
 # The CUDA tag selects which prebuilt torch wheel you get, and each wheel
 # only ships kernel images for a fixed set of GPU architectures. Pick a tag
-# that covers your GPU's compute capability, or torch will import fine and
-# then raise `cudaErrorNoKernelImageForDevice` on the first real op. Newer
-# GPUs need newer tags: Ampere/Ada work on cu118+, Hopper (H100) on cu121+,
-# Blackwell (B100/B200, RTX 50xx) on cu128+. When in doubt, prefer a recent
-# tag. (VTSearch also smoke-tests CUDA at runtime and falls back to CPU if the
+# whose wheel covers your GPU's compute capability, or torch will import fine
+# and then raise `cudaErrorNoKernelImageForDevice` on the first real op.
+#
+# There is a floor AND a ceiling. Newer GPUs need newer tags: Ampere/Ada work
+# on cu118+, Hopper (H100) on cu121+, Blackwell (B100/B200, RTX 50xx) on
+# cu128+. But the newest wheels also DROP the oldest architectures, so "just
+# use the latest tag" is wrong for old hardware: cu128 dropped Volta (sm_70),
+# so a Tesla V100 needs cu124 (or cu121/cu118), NOT cu128. Rule of thumb: use
+# the oldest tag your driver supports that still covers your GPU. cu124 is a
+# safe default that spans Volta through Hopper.
+#
+# (VTSearch also smoke-tests CUDA at runtime and falls back to CPU if the
 # installed wheel can't run on the GPU, so a mismatch degrades instead of
 # crashing - but you only get GPU acceleration with a matching wheel.)
 #
 # Usage:
-#   bash scripts/install-gpu.sh              # defaults to cu124
+#   bash scripts/install-gpu.sh              # defaults to cu124 (spans Volta..Hopper)
 #   bash scripts/install-gpu.sh cu118        # for CUDA 11.8 (older drivers)
 #   bash scripts/install-gpu.sh cu121        # for CUDA 12.1
-#   bash scripts/install-gpu.sh cu128        # for CUDA 12.8 (Blackwell)
+#   bash scripts/install-gpu.sh cu124        # for CUDA 12.4 (V100/Volta, A100, H100)
+#   bash scripts/install-gpu.sh cu128        # for CUDA 12.8 (Blackwell; drops Volta)
 
 CUDA_TAG="${1:-cu124}"
 EXTRA_INDEX="https://download.pytorch.org/whl/${CUDA_TAG}"

--- a/scripts/slurm/README.md
+++ b/scripts/slurm/README.md
@@ -24,6 +24,13 @@ cp scripts/slurm/vtsearch-slurm.sh ~/.local/bin/vtsearch && chmod +x ~/.local/bi
 vtsearch          # allocates a GPU node and starts the app; leave it running
 ```
 
+> On clusters whose Python comes from environment modules (e.g. the HLTCOE
+> Grid), set `VTS_MODULE` so the launcher loads it before activating the venv,
+> e.g. `VTS_MODULE="python/3.12.3" vtsearch`. See
+> [`docs/SETUP.md`](../../docs/SETUP.md#running-on-a-slurm-gpu-cluster) for the
+> full module-based setup. Pick the CUDA wheel to match your GPU — older cards
+> like the V100 need `cu124`, *not* the newest `cu128` (which drops Volta).
+
 On your local machine (after adding a `cluster` host to `~/.ssh/config`):
 
 ```bash

--- a/scripts/slurm/vtsearch-slurm.sh
+++ b/scripts/slurm/vtsearch-slurm.sh
@@ -23,6 +23,13 @@ set -u
 DIR=${VTS_DIR:-/exp/$USER/projects/VTSearch}
 # Path (relative to $DIR, or absolute) to the Python virtualenv to activate.
 VENV=${VTS_VENV:-.venv}
+# Optional environment module(s) to `module load` before activating the venv.
+# Needed on clusters whose Python comes from `module load python/X.Y` -- a venv
+# built from a module interpreter is NOT self-contained (its python needs the
+# module's libpython/LD_LIBRARY_PATH at runtime), so the module must be loaded
+# in the job shell too. Space-separated; empty = don't touch modules.
+# e.g.  VTS_MODULE="python/3.12.3" vtsearch
+MODULE=${VTS_MODULE:-}
 PART=${VTS_PART:-gpu}       # SLURM partition
 GPU=${VTS_GPU:-l40s}        # GPU type for --gres=gpu:<type>:1
 CPUS=${VTS_CPUS:-8}         # CPU cores
@@ -39,7 +46,7 @@ echo ">>> (this may queue; once it lands, VTSearch starts and prints its node + 
 
 # Export the resolved dir/venv/port so they survive into the srun child shell.
 # app.py reads VTSEARCH_PORT for the dev server's bind port.
-export VTS_DIR="$DIR" VTS_VENV="$VENV" VTSEARCH_PORT="$PORT"
+export VTS_DIR="$DIR" VTS_VENV="$VENV" VTS_MODULE="$MODULE" VTSEARCH_PORT="$PORT"
 
 exec srun --job-name=vtsearch --pty \
     -p "$PART" --gres=gpu:${GPU}:1 -c "$CPUS" --mem "$MEM" -t "$TIME" \
@@ -48,6 +55,9 @@ exec srun --job-name=vtsearch --pty \
         # letting child processes (python) take the default SIGINT and die.
         trap ":" INT
         cd "$VTS_DIR" || { echo "project dir missing: $VTS_DIR (set VTS_DIR)"; exit 1; }
+        # Load environment modules first if requested: a venv built from a
+        # module-provided python needs that module loaded at runtime too.
+        [ -n "$VTS_MODULE" ] && { module load $VTS_MODULE || { echo "module load failed: $VTS_MODULE (set VTS_MODULE)"; exit 1; }; }
         source "$VTS_VENV/bin/activate" || { echo "venv missing: $VTS_VENV (set VTS_VENV)"; exit 1; }
         node=$(hostname)
         echo


### PR DESCRIPTION
## What & why

Fixes that surfaced bringing VTSearch up on a **V100-based SLURM cluster** (HLTCOE Grid). The headline is a real installer bug; the rest is supporting docs/launcher work.

### 1. Installer pulled the wrong-arch torch wheel (the real bug)
`install-gpu.sh cu124` and `docker/Dockerfile.gpu` used `pip install --extra-index-url .../cuXXX`, which leaves **PyPI in the candidate set**. When PyPI ships a *newer* torch than the chosen CUDA index tops out at — cu124 caps at `2.6.0`, but PyPI has `2.7.x` (a **cu126** build) — pip prefers the higher version and silently installs a **wrong-arch wheel**. On a Tesla V100 (Volta `sm_70`) that wheel has no kernel image and raises `cudaErrorNoKernelImageForDevice` at runtime, so `cu124` *looked* broken even though it's the correct tag.

**Fix:** two-phase install. First pin `torch torchvision torchaudio` from the CUDA index with **`--index-url`** (sole index → forces the matching `+cuXXX` build), then install the rest with `--extra-index-url` (torch already satisfied, so it isn't replaced). The PyTorch wheel index mirrors torch's dependency closure, so a sole `--index-url` resolves cleanly. Applied to both `install-gpu.sh` and `Dockerfile.gpu`.

### 2. CUDA-tag guidance had a floor but no ceiling
Docs only said "newer GPUs need newer tags." But the newest **cu128/cu126 wheels drop Volta (`sm_70`)**, so a **V100 needs `cu124`, not the latest tag**. Documented the ceiling + the V100→`cu124` data point in `install-gpu.sh` and `docs/SETUP.md`.

### 3. SLURM launcher had no hook for environment modules
A venv built from a `module load python/X.Y` interpreter isn't self-contained (its `python` needs the module's `libpython` at runtime). Added a **`VTS_MODULE`** env var to `vtsearch-slurm.sh` (`module load`s before activating the venv), and documented the module-based setup (incl. the `pyenv`-shim shadowing gotcha and finding the gres type for `VTS_GPU`).

## Files
- `scripts/install-gpu.sh` — two-phase pinned-torch install + tag-guidance comment
- `docker/Dockerfile.gpu` — same two-phase pinned-torch install
- `requirements/gpu.txt` — comment updated to describe the install flow
- `docs/SETUP.md` — GPU tag ceiling, module-based cluster setup, `VTS_MODULE` row, gres-name hint
- `scripts/slurm/vtsearch-slurm.sh` — `VTS_MODULE` knob + `module load` before venv activation
- `scripts/slurm/README.md` — pointer for module-based clusters + V100 tag caveat

## Testing
Verified live on the Grid: pinning torch to `2.6.0+cu124` puts `sm_70` back in `torch.cuda.get_arch_list()` and the V100 runs kernels (no more CPU fallback). Shell changes: `bash -n` clean; `codespell` clean on all edited files. No Python/TS changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)