### PR TITLE
Progress UX: flow SSE during long ops, dedup toasts, sync header on Load

### DIFF
--- a/app.py
+++ b/app.py
@@ -247,7 +247,16 @@ def _set_user_context():
 # spinner feed) from piling up behind a long lock-holder and exhausting
 # the worker's threads (2026-06-19: one stuck job parked 23 threads on
 # the futex and froze the whole UI).
-_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active",)
+#
+# `/api/events` is the SSE progress stream: a long-lived, read-only request
+# that only subscribes to the *global* progress trackers and yields their
+# snapshots. It needs no per-request vote rehydration, and gating it on
+# `_state_lock` is self-defeating — while a long Find/load holds the worker
+# busy, the EventSource's reconnect would block in this hook on the very
+# lock the long job contends, so progress events never reach the client and
+# the bar sits indeterminate. Exempting it keeps progress flowing during
+# exactly the long operations the bar exists to report.
+_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active", "/api/events")
 
 
 @app.before_request

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -568,4 +568,61 @@ describe('DashboardComponent', () => {
     // startProgressPolling subscribes to the SSE channel; no further HTTP
     // is issued until a loading-task event arrives, so nothing else to flush.
   });
+
+  describe('loadDataset / loadDetector → active context', () => {
+    // Loading from a dashboard card should make the item the active context
+    // so the top-bar selector reflects it — but only *after* the load
+    // settles (the SSE task reaches idle without error), never before, so we
+    // don't reintroduce the H25 race where the interceptor tags requests
+    // with an id the backend hasn't finished loading.
+
+    it('promotes the loaded dataset to active only after the load settles', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'image' }];
+      flushInitialRequests(datasets);
+
+      const activeCtx = component['activeContext'];
+      const setActive = vi.spyOn(activeCtx, 'setActivePair');
+      // Capture the completion callback instead of running the real SSE poll.
+      let onComplete: (() => void) | undefined;
+      vi.spyOn(component['loadingTasksSvc'], 'startProgressPolling').mockImplementation(
+        (_taskId?: string, cb?: () => void) => {
+          onComplete = cb;
+        },
+      );
+
+      component.loadDataset(datasets[0] as any);
+      httpMock.expectOne('/api/datasets/registry/d1/load').flush({ task_id: 't1' });
+
+      // Still not active mid-load.
+      expect(setActive).not.toHaveBeenCalled();
+      expect(onComplete).toBeTypeOf('function');
+
+      onComplete!();
+      expect(setActive).toHaveBeenCalledWith('d1', '');
+    });
+
+    it('promotes the loaded detector to active (preserving the dataset half) after settle', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'image', loaded: true }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'image' }];
+      flushInitialRequests(datasets, models);
+
+      const activeCtx = component['activeContext'];
+      // A dataset is already active; loading a detector must keep it.
+      activeCtx.setActivePair('d1', '');
+      const setActive = vi.spyOn(activeCtx, 'setActivePair');
+      let onComplete: (() => void) | undefined;
+      vi.spyOn(component['loadingTasksSvc'], 'startDetectorProgressPolling').mockImplementation(
+        (cb?: () => void) => {
+          onComplete = cb;
+        },
+      );
+
+      component.loadDetector(models[0] as any);
+      httpMock.expectOne('/api/detectors/registry/load').flush({ task_id: 't2' });
+
+      expect(setActive).not.toHaveBeenCalled();
+      onComplete!();
+      expect(setActive).toHaveBeenCalledWith('d1', 'm1');
+    });
+  });
 });

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -823,7 +823,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   loadDataset(dataset: DatasetRegistryEntry): void {
     this.datasetsRegistryApi.loadRegistered(dataset.id).subscribe({
-      next: (response) => this.loadingTasksSvc.startProgressPolling(response.task_id),
+      next: (response) =>
+        this.loadingTasksSvc.startProgressPolling(response.task_id, () =>
+          // Promote to active once the load has settled (never before, per
+          // the H25 intent/active ordering), keeping any active detector
+          // half, so the top-bar dataset selector reflects what was just
+          // loaded instead of staying on "Select a dataset".
+          this.activeContext.setActivePair(dataset.id, this.activeContext.modelId),
+        ),
     });
   }
 
@@ -859,7 +866,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   loadDetector(model: DetectorRegistryEntry): void {
     this.detectorsRegistryApi.loadDetector(model.id).subscribe({
-      next: () => this.loadingTasksSvc.startDetectorProgressPolling(),
+      next: () =>
+        this.loadingTasksSvc.startDetectorProgressPolling(() =>
+          // Promote to active once the detector load settles (per the H25
+          // ordering), keeping the active dataset half, so the top-bar
+          // detector selector reflects what was just loaded.
+          this.activeContext.setActivePair(this.activeContext.datasetId, model.id),
+        ),
     });
   }
 

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -1,5 +1,19 @@
 <div class="toast-stack" aria-live="assertive" aria-atomic="false">
-  @for (t of (toastService.toasts$ | async) ?? []; track trackById($index, t)) {
+  @if (((toastService.toasts$ | async) ?? []); as toasts) {
+    @if (toasts.length > 1) {
+      <div class="toast-stack__controls">
+        <button
+          type="button"
+          class="toast-stack__dismiss-all"
+          (click)="dismissAll()"
+          title="Dismiss all notifications"
+          aria-label="Dismiss all notifications"
+        >
+          Dismiss all ({{ toasts.length }})
+        </button>
+      </div>
+    }
+    @for (t of toasts; track trackById($index, t)) {
     <div class="toast" [class.toast--success]="t.level === 'success'" role="alert">
       <div class="toast__main">
         @if (t.level === 'success') {
@@ -75,5 +89,6 @@
         </div>
       }
     </div>
+    }
   }
 </div>

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -12,6 +12,30 @@
   pointer-events: none;
 }
 
+.toast-stack__controls {
+  pointer-events: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.toast-stack__dismiss-all {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  padding: var(--space-2xs) var(--space-md);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--error);
+    background: var(--bad-bg);
+  }
+}
+
 .toast {
   pointer-events: auto;
   min-width: min(420px, calc(100vw - 24px));

--- a/frontend/src/app/components/toast-container/toast-container.component.spec.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.spec.ts
@@ -50,4 +50,27 @@ describe('ToastContainerComponent', () => {
     await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
   });
+
+  it('shows a Dismiss-all control only when more than one toast is stacked', async () => {
+    toast.error({ message: 'First' });
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.toast-stack__dismiss-all')).toBeNull();
+
+    toast.error({ message: 'Second' });
+    await settleZoneless(fixture);
+    const btn = fixture.nativeElement.querySelector('.toast-stack__dismiss-all');
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toContain('Dismiss all (2)');
+  });
+
+  it('clears the whole stack when Dismiss all is clicked', async () => {
+    toast.error({ message: 'First' });
+    toast.error({ message: 'Second' });
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelectorAll('.toast').length).toBe(2);
+
+    fixture.nativeElement.querySelector('.toast-stack__dismiss-all').click();
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelectorAll('.toast').length).toBe(0);
+  });
 });

--- a/frontend/src/app/components/toast-container/toast-container.component.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.ts
@@ -42,6 +42,13 @@ export class ToastContainerComponent implements OnDestroy {
     this.toastService.dismiss(t.id);
   }
 
+  /** Clear the whole stack at once. Surfaced only when more than one toast
+   *  is showing, so a burst of errors (e.g. one backend condition surfacing
+   *  from several endpoints) doesn't force the user to close them one by one. */
+  dismissAll(): void {
+    this.toastService.dismissAll();
+  }
+
   /** Fire a toast's action button. The toast is dismissed regardless of
    *  whether the handler throws so the user never sees a stuck toast
    *  with a clicked action. */

--- a/frontend/src/app/interceptors/error.interceptor.ts
+++ b/frontend/src/app/interceptors/error.interceptor.ts
@@ -32,9 +32,13 @@ export const SKIP_ERROR_TOAST = new HttpContextToken<boolean>(() => false);
  * response with the active dataset/detector IDs and the server-side
  * request_id (from the response body and/or ``X-Request-Id`` header).
  *
- * Repeating the same endpoint+status (e.g. a retry loop hammering a
- * broken backend) replaces the existing toast via dedup key rather
- * than stacking duplicates.
+ * Repeating the same error (e.g. a retry loop hammering a broken
+ * backend, or one backend condition surfacing from several in-flight
+ * endpoints at once) replaces the existing toast via dedup key rather
+ * than stacking duplicates. The key is the status + human message, not
+ * the endpoint URL: a single condition like "Dataset is not loaded" can
+ * be returned by several endpoints simultaneously, and the user should
+ * see it once, not once per endpoint that happened to be in flight.
  *
  * This interceptor is also the chokepoint for the connection circuit
  * breaker ({@link ConnectionStateService}): it feeds every outcome to the
@@ -112,7 +116,10 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         message: errorCtx.message,
         detail: errorCtx.detail,
         errorContext: errorCtx,
-        dedupKey: `http:${req.method}:${url}:${err.status}`,
+        // Dedup on status + message (not the endpoint URL): the same
+        // backend condition often surfaces from multiple endpoints at
+        // once, and the user wants one toast for it, not one per URL.
+        dedupKey: `http:${err.status}:${errorCtx.message}`,
       });
       return throwError(() => err);
     }),

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -336,3 +336,48 @@ class TestEventsRoute:
             assert any(t["task_id"] == "evt_test" for t in payload)
         finally:
             loading_tasks.remove_task("evt_test")
+
+
+class TestEventsStateSyncExemption:
+    """`/api/events` must skip the lock-taking ``before_request`` state-sync.
+
+    The SSE stream is read-only — it only subscribes to the *global*
+    progress trackers and yields their snapshots — so it never needs the
+    per-request vote rehydration. Gating its (re)connect on ``_state_lock``
+    is self-defeating: while a long Find/load holds the worker busy, the
+    EventSource reconnect would block on the very lock the long job
+    contends, and the progress events the bar needs would never arrive.
+    So it is exempt exactly like the jobs/active spinner poll.
+    """
+
+    def _spy_state_sync(self, monkeypatch) -> list[str]:
+        """Replace the two before_request state-sync helpers with recorders.
+
+        ``_set_request_context`` imports them from
+        ``vtscore.detectors.dataset_sync`` at call time, so patching the
+        source module is what the hook actually sees.
+        """
+        calls: list[str] = []
+        import vtscore.detectors.dataset_sync as ds
+
+        monkeypatch.setattr(ds, "ensure_votes_match_active_dataset", lambda: calls.append("votes"))
+        monkeypatch.setattr(ds, "ensure_detector_model_matches_active_embedder", lambda: calls.append("embedder"))
+        return calls
+
+    def test_events_skips_lock_taking_state_sync(self, client, monkeypatch):
+        calls = self._spy_state_sync(monkeypatch)
+        resp = client.get("/api/events", buffered=False)
+        try:
+            assert resp.status_code == 200
+        finally:
+            resp.close()
+        # Exempt prefix → the lock-taking rehydrate never ran for this request.
+        assert calls == []
+
+    def test_non_exempt_endpoint_still_runs_state_sync(self, client, monkeypatch):
+        """Control: a normal (non-exempt) endpoint still triggers the sync,
+        proving the empty result above is the exemption, not a dead spy."""
+        calls = self._spy_state_sync(monkeypatch)
+        resp = client.get("/api/version")
+        assert resp.status_code == 200
+        assert "votes" in calls and "embedder" in calls


### PR DESCRIPTION
While exercising the new multi-step weighted progress bars by hand (driving a live VTSearch on the GRID), I found that the *rendering* is solid — dataset/detector loads show the staged `Loading … · step S/T · phase` bar with subtitle + ETA exactly as designed. The rough edges were around it. This PR fixes three.

## 1. SSE starvation — the real cause of the indeterminate scoring bar
The "Scoring with detector…" bar sat as an indeterminate barber-pole for 45s+ on the GRID. It turned out the scoring/load progress **is** fully instrumented (`find_label` emits `step`/`total_steps` + weighted `overall`); the events just weren't reaching the client. `/api/events` (the SSE progress stream) was **not** exempt from the lock-taking `before_request` state-sync, so while a long Find/load held the worker busy, the EventSource reconnect blocked on the very `_state_lock` the long job contended — starving the progress stream the bar reports.

Fix: add `/api/events` to `_STATE_SYNC_EXEMPT_PREFIXES`, exactly like `/api/jobs/active` already is. The SSE handler is read-only (it only subscribes to the global progress trackers), so it never needs per-request vote rehydration.

## 2. Toasts: dedup duplicates + Dismiss-all
A single backend condition ("Dataset is not loaded") surfaced from several in-flight endpoints at once produced **5 stacked, identical toasts**, each needing an individual dismiss. The interceptor already deduped — but keyed on `method:url:status`, so same-message/different-URL didn't collapse. Re-key on `status:message`, and add a "Dismiss all" control when more than one toast is stacked.

## 3. Header active-context desync after a dashboard Load
After "Load dataset"/"Load detector" from a dashboard card, both loaded but the top bar still read "Select a dataset / Select a detector". Promote the loaded item to the active context **once its load settles** (never before, preserving the H25 intent/active ordering), keeping the other half.

## Tests
- `tests/api/test_events_sse.py`: new `TestEventsStateSyncExemption` (events skips the lock-taking sync; non-exempt control still runs it).
- `toast-container.component.spec.ts`: Dismiss-all shows only when >1 toast; clears the stack.
- `dashboard.component.spec.ts`: dataset/detector promoted to active only after the load settles, preserving the other half.

Full Python suite (5021 passed), frontend `build:prod` (clean), and frontend Vitest (858 passed) all green.

### Out of scope
`./run-tests.sh`'s `pip-audit` gate flags a newly-disclosed CVE in **msgpack 1.1.2** (a transitive dep, unpinned by VTSearch and identically present on `dev`) — unrelated to this change and with no pin to bump here. I ran the suites directly to validate; the msgpack bump belongs in its own dependency-maintenance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)