### PR TITLE
Zoneless Phase 5: drop the vitest-patch bridge (fakeAsync → native async)

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -4,9 +4,13 @@ Status: **Phases 0–4 COMPLETE. Production is zoneless (Phase 3 shipped). Phase
 browser QA was run live against the GRID instance via Chrome MCP (2026-06-22) and
 PASSED — no staleness bugs on any interactive surface, zero console errors; see
 "Phase 4 — results" below. Phase 5 cleanup is underway: the no-op `NgZone.run`
-wrappers in `browse-canvas` + `panel-resize.directive` are now removed; the
-remaining Phase 5 items (per-component zoneless `TestBed` spec migration, dropping
-the `vitest-patch` bridge, explicit `OnPush`) stay optional. One unrelated
+wrappers in `browse-canvas` + `panel-resize.directive` are removed, and the
+`vitest-patch` bridge is dropped (all 43 fakeAsync occurrences migrated to native
+`async` + Vitest fake timers; `zone.js/testing` + `vitest-patch` removed from the
+`build:test` polyfills). Base `zone.js` stays in the test build until the
+remaining default-TestBed specs adopt the zoneless `TestBed`. The other Phase 5
+items (per-component zoneless `TestBed` spec migration, explicit `OnPush`) stay
+optional. One unrelated
 pre-existing bug surfaced during QA — `vt-modal` only closes on `Esc` when focus
 is inside it (the `(keydown)` Esc handler lives on the never-focused
 `.modal-backdrop`); tracked under "Open follow-ups", not a zoneless regression.**
@@ -790,10 +794,21 @@ unrelated to zoneless — see Open follow-ups.
 
 ### Phase 5 — Cleanup / follow-ups
 
-- Migrate the residual fakeAsync/timer specs to native `async` + Vitest fake
-  timers and drop `zone.js/plugins/vitest-patch` (and finally `zone.js` from
-  `package.json`) — Angular's recommended long-term direction (Appendix C #7).
-  Optional, separable, no prod impact.
+- **Migrate the residual fakeAsync/timer specs to native `async` + Vitest fake
+  timers and drop `zone.js/plugins/vitest-patch`. ✅ DONE.** All 43 fakeAsync
+  occurrences (11 files) now use native `async` tests: timer-delay cases
+  (vote/browse-prep pollers, progress-modal's 50 ms) use `vi.useFakeTimers()` +
+  `vi.advanceTimersByTimeAsync(...)`; microtask/macrotask drains (dialog
+  promises, focus `setTimeout`s, the `timer(0,…)` poll first-emissions) use a
+  real macrotask flush (`await new Promise(r => setTimeout(r))`). `zone.js/testing`
+  and `zone.js/plugins/vitest-patch` are removed from the `build:test` polyfills,
+  and the ProxyZone-bridge note in `src/test-setup.ts` is gone. Full Vitest suite
+  green (854 passed / 91 files). **`zone.js` itself stays** (in the `build:test`
+  polyfills and `package.json`): the ~36 spec files that still create a component
+  fixture on the **default zone-based TestBed** need `NgZone` to exist —
+  empirically, emptying the test polyfills fails 31 tests across 15 files
+  (NG0205/CD errors). So the final `zone.js` drop is blocked on the
+  TestBed-migration follow-up below, not on the fakeAsync work, which is finished.
 - Adopt `ChangeDetectionStrategy.OnPush` explicitly on components for clarity
   (under zoneless they already behave OnPush-like; this is documentation/intent,
   not a functional change).
@@ -837,9 +852,15 @@ unrelated to zoneless — see Open follow-ups.
     TestBed with `detectChanges`, so they are not yet staleness oracles. (Heavy
     containers — left-panel, dashboard, right-panel, app — deadlock `whenStable()`
     via their child rxResources; those need stubbed/lightweight harnesses.)
-  - **Drop the `vitest-patch` bridge** (convert the 43 fakeAsync occurrences to
-    native `async` + Vitest fake timers, then remove `zone.js` from the
-    `build:test` polyfills and `package.json`).
+    **This is now also the last blocker on removing `zone.js` entirely:** those
+    ~36 fixture-creating specs need `NgZone` from the default TestBed, so the test
+    polyfills cannot drop base `zone.js` until they move to the zoneless TestBed.
+  - **Drop the `vitest-patch` bridge. ✅ DONE.** Converted all 43 fakeAsync
+    occurrences (11 files) to native `async` + Vitest fake timers and removed
+    `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
+    polyfills. Base `zone.js` is **not yet** removed (from `build:test` polyfills
+    or `package.json`): the default-TestBed specs above still need it — emptying
+    the test polyfills fails 31 tests / 15 files (NG0205). Full Vitest suite green.
   - **Adopt explicit `ChangeDetectionStrategy.OnPush`** on components for intent
     (redundant under zoneless; documentation only).
 - **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 + 2.4 + 2.5 shipped; Phases 2.6–9 shipped; Phase 3 shipped.**

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -125,9 +125,10 @@
             // `development`, so the test polyfills are decoupled from the
             // production build. The @angular/build:unit-test builder has no
             // `polyfills` option of its own; it inherits them from this
-            // buildTarget. Dropping "zone.js" from the base production polyfills
-            // (zoneless flip, Phase 3 of docs/plans/zoneless-migration.md) then
-            // cannot silently break fakeAsync, because build:test pins its own.
+            // buildTarget. The base production build dropped "zone.js" at the
+            // zoneless flip (Phase 3 of docs/plans/zoneless-migration.md); the
+            // test build still pins its own "zone.js" for the default-TestBed
+            // specs (Phase 5), so the two cannot drift.
             "buildTarget": "frontend:build:test",
             "runner": "vitest",
             "runnerConfig": "vitest.config.ts",

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -79,24 +79,22 @@
             },
             "test": {
               // Build configuration used only by the unit-test target. Mirrors
-              // `development` but pins its OWN polyfills so the fakeAsync bridge
-              // survives the Phase 3 removal of zone.js from the base production
-              // polyfills (see docs/plans/zoneless-migration.md, Phase 0.1).
-              // "zone.js/plugins/vitest-patch" is the Angular-maintained bridge
-              // that keeps fakeAsync/tick/waitForAsync working under the Vitest
-              // runner (zone.js's jest patch bails outside jest). It is
-              // explicitly transitional — the long-term direction is native
-              // async + Vitest fake timers (plan Phase 5).
+              // `development` but pins its OWN polyfills, decoupled from the base
+              // production build (which dropped zone.js entirely at the Phase 3
+              // zoneless flip — see docs/plans/zoneless-migration.md).
               //
-              // Order matters: vitest-patch needs ProxyZoneSpec/SyncTestZoneSpec
-              // (from "zone.js/testing") to exist at its load time, so testing
-              // is listed BEFORE it. The builder also auto-appends another
-              // "zone.js/testing" at the end, but that re-import is a no-op (ES
-              // modules execute once).
+              // The fakeAsync/tick bridge (zone.js/testing + the Angular
+              // vitest-patch plugin) was removed in Phase 5: every spec now uses
+              // native async + Vitest fake timers, so no spec needs ProxyZone.
+              // Base "zone.js" stays only because the spec files that have not
+              // yet adopted the zoneless TestBed still rely on zone-based change
+              // detection in the default TestBed (manual fixture.detectChanges()
+              // alone is fine, but the default TestBed requires NgZone to exist).
+              // It drops once those specs migrate (plan Phase 5).
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true,
-              "polyfills": ["zone.js", "zone.js/testing", "zone.js/plugins/vitest-patch"]
+              "polyfills": ["zone.js"]
             }
           },
           "defaultConfiguration": "production"

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
@@ -414,7 +414,7 @@ describe('DashboardComponent', () => {
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   });
 
-  it('should delete a dataset after confirmation', fakeAsync(() => {
+  it('should delete a dataset after confirmation', async () => {
     const datasets = [{ id: 'd1', name: 'ToDelete', media_type: 'audio' }];
     flushInitialRequests(datasets);
     component.selectedDatasetIds.add('d1');
@@ -423,7 +423,8 @@ describe('DashboardComponent', () => {
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
 
     component.deleteDataset(datasets[0]);
-    tick();
+    // Drain the confirm() promise continuation that issues the DELETE.
+    await new Promise<void>((resolve) => setTimeout(resolve));
 
     const req = httpMock.expectOne('/api/datasets/registry/d1');
     expect(req.request.method).toBe('DELETE');
@@ -433,7 +434,7 @@ describe('DashboardComponent', () => {
 
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
-  }));
+  });
 
   it('should open and close importer modal via NewThingFlowsService', () => {
     flushInitialRequests();

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatasetCardComponent } from './dataset-card.component';
 
 describe('DatasetCardComponent', () => {
@@ -72,15 +72,16 @@ describe('DatasetCardComponent', () => {
     expect(el.querySelector('.inline-edit')).toBeTruthy();
   });
 
-  it('should focus the rename input after clicking rename', fakeAsync(() => {
+  it('should focus the rename input after clicking rename', async () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
     fixture.detectChanges();
-    tick();
+    // Drain the focus setTimeout queued when editing mode opens.
+    await new Promise<void>((resolve) => setTimeout(resolve));
     const input = el.querySelector('.inline-edit') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
-  }));
+  });
 
   it('should emit rename on Enter key', () => {
     vi.spyOn(component.rename, 'emit');

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectorCardComponent } from './detector-card.component';
 
 describe('DetectorCardComponent', () => {
@@ -59,15 +59,16 @@ describe('DetectorCardComponent', () => {
     expect(el.querySelector('.inline-edit')).toBeTruthy();
   });
 
-  it('should focus the rename input after clicking rename', fakeAsync(() => {
+  it('should focus the rename input after clicking rename', async () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
     fixture.detectChanges();
-    tick();
+    // Drain the focus setTimeout queued when editing mode opens.
+    await new Promise<void>((resolve) => setTimeout(resolve));
     const input = el.querySelector('.inline-edit') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
-  }));
+  });
 
   it('should emit rename on confirm', () => {
     vi.spyOn(component.rename, 'emit');

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
@@ -34,9 +34,9 @@ describe('LabelViewComponent', () => {
   // `fixture.detectChanges()`. label-view's ngOnInit loads medias, votes,
   // settings, dataset status, inclusion; the left panel loads media-types
   // and embedders. The `/api/labeling-status` and polling `/api/votes`
-  // requests are driven by `timer(0, …)` and only fire after a `tick(…)`
-  // inside `fakeAsync`, so they are NOT flushed here — they are drained
-  // by `afterEach`'s catch-all instead.
+  // requests are driven by `timer(0, …)`, which only fires on a real macrotask
+  // after the synchronous test body returns, so they are NOT flushed here —
+  // they are drained by `afterEach`'s catch-all instead.
   function flushInitialRequests(): void {
     fixture.detectChanges();
     // The medias and settings reads ride `rxResource`, whose loader runs in a
@@ -80,8 +80,8 @@ describe('LabelViewComponent', () => {
     component.ngOnDestroy();
     // Drain any outstanding polling requests from right-panel or label-view
     // (the timer-driven /api/votes and /api/labeling-status pollers, the
-    // metadata-batch fetch from selectMedia, plus anything a fakeAsync test
-    // left in flight). ngOnDestroy unsubscribes the component's own streams,
+    // metadata-batch fetch from selectMedia, plus anything a test left in
+    // flight). ngOnDestroy unsubscribes the component's own streams,
     // which cancels their in-flight requests; cancelled requests can't be
     // flushed, so skip them. Flush an empty array so the metadata-batch
     // handler (which iterates the body) doesn't choke on a non-iterable.
@@ -133,7 +133,7 @@ describe('LabelViewComponent', () => {
     expect(component.sortState.threshold).toBe(0.5);
   });
 
-  it('should handle learned sort', fakeAsync(() => {
+  it('should handle learned sort', () => {
     flushInitialRequests();
     // Set votes via vote state service
     component.voteState.loadVotes();
@@ -151,7 +151,7 @@ describe('LabelViewComponent', () => {
 
     expect(component.sortState.sortBusy).toBe(false);
     expect(component.sortState.sortOrder!.length).toBe(2);
-  }));
+  });
 
   it('should not trigger learned sort without votes', () => {
     flushInitialRequests();
@@ -225,7 +225,7 @@ describe('LabelViewComponent', () => {
     expect(component.mediaState.selectedId()).toBe(1);
   });
 
-  it('should handle inclusion change', fakeAsync(() => {
+  it('should handle inclusion change', () => {
     flushInitialRequests();
     component.onInclusionChange(5);
     expect(component.sortState.inclusion).toBe(5);
@@ -233,7 +233,7 @@ describe('LabelViewComponent', () => {
     const req = httpMock.expectOne('/api/inclusion');
     expect(req.request.body).toEqual({ inclusion: 5 });
     req.flush({ inclusion: 5 });
-  }));
+  });
 
   it('should render center panel component', () => {
     flushInitialRequests();
@@ -433,7 +433,7 @@ describe('LabelViewComponent', () => {
     });
   });
 
-  it('should trigger learned sort when autopilot transitions from bad to hard', fakeAsync(() => {
+  it('should trigger learned sort when autopilot transitions from bad to hard', () => {
     flushInitialRequests();
 
     const autopilot = TestBed.inject(AutopilotStateService);
@@ -470,9 +470,9 @@ describe('LabelViewComponent', () => {
 
     expect(sortState.sortBusy).toBe(false);
     expect(sortState.threshold).toBe(0.5);
-  }));
+  });
 
-  it('should switch to hard select mode when bouncing from new back to hard', fakeAsync(() => {
+  it('should switch to hard select mode when bouncing from new back to hard', () => {
     flushInitialRequests();
 
     const autopilot = TestBed.inject(AutopilotStateService);
@@ -533,7 +533,7 @@ describe('LabelViewComponent', () => {
       threshold: 0.5,
     });
     expect(sortState.sortBusy).toBe(false);
-  }));
+  });
 
   it('should select hard items by index distance, not score distance', () => {
     flushInitialRequests();

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ProgressModalComponent } from './progress-modal.component';
@@ -39,27 +39,32 @@ describe('ProgressModalComponent', () => {
     expect(component.title).toContain('Diversity Coverage');
   });
 
-  it('should start in analyzing state', fakeAsync(() => {
-    component.metric = 'smart';
-    fixture.detectChanges();
-    expect(component.analyzing).toBe(true);
+  it('should start in analyzing state', async () => {
+    vi.useFakeTimers();
+    try {
+      component.metric = 'smart';
+      fixture.detectChanges();
+      expect(component.analyzing).toBe(true);
 
-    // Progress now arrives over the `eval` SSE channel, not via HTTP polling.
-    // The only HTTP call is the train-and-score POST, which returns a job
-    // envelope; on a cache hit (status=done) the component applies the data
-    // inline without polling.
-    const trainReq = httpMock.expectOne('/api/eval/train-and-score');
-    trainReq.flush({
-      job_id: 'abc',
-      status: 'done',
-      metric: 'smart',
-      error_cost: [{ num_labels: 5, error_cost: 0.5 }],
-    });
+      // Progress now arrives over the `eval` SSE channel, not via HTTP polling.
+      // The only HTTP call is the train-and-score POST, which returns a job
+      // envelope; on a cache hit (status=done) the component applies the data
+      // inline without polling.
+      const trainReq = httpMock.expectOne('/api/eval/train-and-score');
+      trainReq.flush({
+        job_id: 'abc',
+        status: 'done',
+        metric: 'smart',
+        error_cost: [{ num_labels: 5, error_cost: 0.5 }],
+      });
 
-    tick(50);
-    expect(component.analyzing).toBe(false);
-    expect(component.chartData.length).toBe(1);
-  }));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it('should emit closed on close', () => {
     vi.spyOn(component.closed, 'emit');

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { SettingsModalComponent } from './settings-modal.component';
@@ -117,11 +117,12 @@ describe('SettingsModalComponent', () => {
     expect(component.getViewMode('view_mode_right', 'audio')).toBe('grid');
   });
 
-  it('should reset to defaults after confirmation', fakeAsync(() => {
+  it('should reset to defaults after confirmation', async () => {
     flushInit();
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
     component.resetDefaults();
-    tick();
+    // Drain the confirm() promise continuation that issues the GET.
+    await new Promise<void>((resolve) => setTimeout(resolve));
     httpMock.expectOne('/api/settings/defaults').flush({ ...mockSettings, theme: 'light' });
     // Applying the defaults persists twice: ThemeService.setTheme PUTs the
     // new theme, and save() PUTs the full settings object.
@@ -129,15 +130,15 @@ describe('SettingsModalComponent', () => {
     expect(reqs.length).toBe(2);
     reqs.forEach((r) => r.flush(mockSettings));
     expect(component.settings().theme).toBe('light');
-  }));
+  });
 
-  it('should not reset when confirmation is declined', fakeAsync(() => {
+  it('should not reset when confirmation is declined', async () => {
     flushInit();
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(false));
     component.resetDefaults();
-    tick();
+    await new Promise<void>((resolve) => setTimeout(resolve));
     httpMock.expectNone('/api/settings/defaults');
-  }));
+  });
 
   it('should use preselectedViewTab when valid', () => {
     component.preselectedViewTab = 'image';

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectorContextBarComponent } from './detector-context-bar.component';
 
 describe('DetectorContextBarComponent', () => {
@@ -35,18 +35,19 @@ describe('DetectorContextBarComponent', () => {
     expect(el.querySelector('.train-context-name')?.textContent).toContain('My Detector');
   });
 
-  it('should enter editing mode on startRename', fakeAsync(() => {
+  it('should enter editing mode on startRename', async () => {
     component.visible = true;
     component.detectorName = 'Old Name';
     fixture.detectChanges();
 
     component.startRename();
-    tick();
+    // Drain the focus setTimeout queued by startRename().
+    await new Promise<void>((resolve) => setTimeout(resolve));
     fixture.detectChanges();
 
     expect(component.editing).toBe(true);
     expect(component.editValue).toBe('Old Name');
-  }));
+  });
 
   it('should not start rename if detectorName is empty', () => {
     component.visible = true;

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick, discardPeriodicTasks } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { RightPanelComponent } from './right-panel.component';
@@ -28,9 +28,11 @@ describe('RightPanelComponent', () => {
     httpMock.match(() => true); // discard any pending requests
   }
 
-  function flushInit(): void {
+  async function flushInit(): Promise<void> {
     fixture.detectChanges();
-    tick(); // Allow timer(0, ...) to fire
+    // Allow the votes poll's `timer(0, …)` first emission to fire on a real
+    // macrotask (and drain microtasks) so its GET is issued.
+    await new Promise<void>((resolve) => setTimeout(resolve));
     // Settings request
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({
@@ -46,16 +48,15 @@ describe('RightPanelComponent', () => {
     });
   }
 
-  it('should create', fakeAsync(() => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
     cleanup();
-  }));
+  });
 
-  // Real-async (not fakeAsync): the SettingsStateService rxResource has a
-  // promise-based loader whose value does not commit under fakeAsync's virtual
-  // clock, so a test that asserts a *settings-derived* value must drain real
-  // microtasks. See docs/plans/httpresource-migration.md.
+  // The SettingsStateService rxResource has a promise-based loader, so a test
+  // that asserts a *settings-derived* value must drain real microtasks before
+  // the value commits. See docs/plans/httpresource-migration.md.
   it('should load view mode from settings on init', async () => {
     component.medias = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
     fixture.detectChanges();
@@ -72,19 +73,19 @@ describe('RightPanelComponent', () => {
     cleanup();
   });
 
-  it('should default viewMode to grid when not in settings', fakeAsync(() => {
+  it('should default viewMode to grid when not in settings', async () => {
     fixture.detectChanges();
-    tick();
+    await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
     expect(component.viewMode()).toBe('grid');
     cleanup();
-  }));
+  });
 
-  it('should poll for votes on init', fakeAsync(() => {
+  it('should poll for votes on init', async () => {
     fixture.detectChanges();
-    tick();
+    await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
     httpMock.expectOne('/api/votes').flush({
@@ -99,26 +100,26 @@ describe('RightPanelComponent', () => {
     expect(component.clickTimes()).toEqual({ '1': 1, '2': 2, '3': 3 });
     expect(component.learnedScores()).toEqual({ '1': 0.9, '2': 0.8, '3': 0.1 });
     cleanup();
-  }));
+  });
 
-  it('should change sort mode', fakeAsync(() => {
-    flushInit();
+  it('should change sort mode', async () => {
+    await flushInit();
     component.onSortModeChange('name-asc');
     expect(component.sortMode).toBe('name-asc');
     cleanup();
-  }));
+  });
 
-  it('should emit mediaSelected', fakeAsync(() => {
-    flushInit();
+  it('should emit mediaSelected', async () => {
+    await flushInit();
     vi.spyOn(component.mediaSelected, 'emit');
     component.onMediaSelected(42);
     expect(component.mediaSelected.emit).toHaveBeenCalledWith(42);
     cleanup();
-  }));
+  });
 
-  it('should rename detector via detectors-registry-api', fakeAsync(() => {
+  it('should rename detector via detectors-registry-api', async () => {
     component.trainMode = { model: { name: 'Old', registry_id: 'r1' } };
-    flushInit();
+    await flushInit();
 
     component.onDetectorRenamed('New Name');
     const req = httpMock.expectOne('/api/detectors/registry/r1/rename');
@@ -128,60 +129,60 @@ describe('RightPanelComponent', () => {
 
     expect(component.trainMode.model.name).toBe('New Name');
     cleanup();
-  }));
+  });
 
-  it('should not rename if no registry_id', fakeAsync(() => {
+  it('should not rename if no registry_id', async () => {
     component.trainMode = { model: { name: 'Old' } };
-    flushInit();
+    await flushInit();
 
     component.onDetectorRenamed('New');
     cleanup();
-  }));
+  });
 
-  it('should not rename if no trainMode', fakeAsync(() => {
+  it('should not rename if no trainMode', async () => {
     component.trainMode = null;
-    flushInit();
+    await flushInit();
 
     component.onDetectorRenamed('New');
     cleanup();
-  }));
+  });
 
-  it('should render detector context bar when trainMode set', fakeAsync(() => {
+  it('should render detector context bar when trainMode set', async () => {
     component.trainMode = { model: { name: 'Test Detector', registry_id: 'r1' } };
-    flushInit();
+    await flushInit();
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeTruthy();
     cleanup();
-  }));
+  });
 
-  it('should not render detector context bar when trainMode is null', fakeAsync(() => {
+  it('should not render detector context bar when trainMode is null', async () => {
     component.trainMode = null;
-    flushInit();
+    await flushInit();
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeFalsy();
     cleanup();
-  }));
+  });
 
-  it('should render both good and bad label lists', fakeAsync(() => {
-    flushInit();
+  it('should render both good and bad label lists', async () => {
+    await flushInit();
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     const labelLists = el.querySelectorAll('vt-label-list');
     expect(labelLists.length).toBe(2);
     cleanup();
-  }));
+  });
 
-  it('should render label sort dropdown', fakeAsync(() => {
-    flushInit();
+  it('should render label sort dropdown', async () => {
+    await flushInit();
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('vt-label-sort')).toBeTruthy();
     cleanup();
-  }));
+  });
 });

--- a/frontend/src/app/services/browse-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-prep.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { Router, provideRouter } from '@angular/router';
 import { Observable, Subject, of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -100,25 +100,30 @@ describe('BrowsePrepService', () => {
     expect(service.preparing).toBe(false);
   });
 
-  it('builds the projection, polls until ready, then navigates', fakeAsync(() => {
-    // idle → build (building) → poll → ready
-    metaProvider = () => of(meta({ status: 'idle' }));
-    buildProvider = () => of({ status: 'building' });
+  it('builds the projection, polls until ready, then navigates', async () => {
+    vi.useFakeTimers();
+    try {
+      // idle → build (building) → poll → ready
+      metaProvider = () => of(meta({ status: 'idle' }));
+      buildProvider = () => of({ status: 'building' });
 
-    service.prepareAndBrowse(DS);
-    applyPair$.next();
+      service.prepareAndBrowse(DS);
+      applyPair$.next();
 
-    // After the build kicks off we are projecting and have not navigated.
-    expect(service.taskKind(DS)).toBe('projection');
-    expect(service.displayTask(DS)?.status).toBe('building');
-    expect(router.navigate).not.toHaveBeenCalled();
+      // After the build kicks off we are projecting and have not navigated.
+      expect(service.taskKind(DS)).toBe('projection');
+      expect(service.displayTask(DS)?.status).toBe('building');
+      expect(router.navigate).not.toHaveBeenCalled();
 
-    // Next poll reports the layout is ready.
-    metaProvider = () => of(meta({ status: 'ready', point_count: 7 }));
-    tick(1000);
+      // Next poll reports the layout is ready.
+      metaProvider = () => of(meta({ status: 'ready', point_count: 7 }));
+      await vi.advanceTimersByTimeAsync(1000);
 
-    expect(router.navigate).toHaveBeenCalledWith(['/browse', DS]);
-  }));
+      expect(router.navigate).toHaveBeenCalledWith(['/browse', DS]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it('surfaces a projection build failure inline without navigating', () => {
     metaProvider = () => of(meta({ status: 'idle' }));

--- a/frontend/src/app/services/dataset-state.service.spec.ts
+++ b/frontend/src/app/services/dataset-state.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { DatasetStateService } from './dataset-state.service';
@@ -63,16 +63,15 @@ describe('DatasetStateService', () => {
     expect(service.detectors[0].name).toBe('detector1');
   });
 
-  it('rapid refresh should cancel stale in-flight requests', fakeAsync(() => {
-    // First refresh; will be cancelled by the second
+  it('rapid refresh should cancel stale in-flight requests', () => {
+    // First refresh; will be cancelled by the second. The switchMap subscribes
+    // to the forkJoin synchronously, so both registry GETs register at once.
     service.refresh();
-    tick();
     const staleDs = httpMock.expectOne('/api/datasets/registry');
     const staleDetectors = httpMock.expectOne('/api/detectors/registry');
 
     // Second refresh; this one should win
     service.refresh();
-    tick();
     const freshDs = httpMock.expectOne('/api/datasets/registry');
     const freshDetectors = httpMock.expectOne('/api/detectors/registry');
 
@@ -86,7 +85,7 @@ describe('DatasetStateService', () => {
 
     expect(service.datasets.length).toBe(1);
     expect(service.datasets[0].name).toBe('fresh');
-  }));
+  });
 
   it('setLoading and setProgressMessage should update state', () => {
     service.setLoading(true);

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, tick, discardPeriodicTasks } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { VoteStateService } from './vote-state.service';
@@ -50,62 +50,73 @@ describe('VoteStateService', () => {
     expect(service.learnedScores).toEqual({ '1': 0.9 });
   });
 
-  it('startPolling should periodically fetch votes', fakeAsync(() => {
-    service.startPolling(1000);
+  it('startPolling should periodically fetch votes', async () => {
+    vi.useFakeTimers();
+    try {
+      service.startPolling(1000);
 
-    // First poll at t=0 (timer(0, …) emits on a macrotask; flush it).
-    tick(0);
-    httpMock.expectOne('/api/votes').flush(mockVotes);
-    expect(service.goodVotes.size).toBe(2);
+      // First poll at t=0 (timer(0, …) emits on a macrotask; flush it).
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/votes').flush(mockVotes);
+      expect(service.goodVotes.size).toBe(2);
 
-    // Second poll at t=1000
-    tick(1000);
-    httpMock.expectOne('/api/votes').flush({ good: [1], bad: [], click_times: {}, learned_scores: {} });
-    expect(service.goodVotes.size).toBe(1);
+      // Second poll at t=1000
+      await vi.advanceTimersByTimeAsync(1000);
+      httpMock.expectOne('/api/votes').flush({ good: [1], bad: [], click_times: {}, learned_scores: {} });
+      expect(service.goodVotes.size).toBe(1);
 
-    service.stopPolling();
-    discardPeriodicTasks();
-  }));
+      service.stopPolling();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-  it('stopPolling should stop periodic fetches', fakeAsync(() => {
-    service.startPolling(1000);
-    tick(0);
-    httpMock.expectOne('/api/votes').flush(mockVotes);
+  it('stopPolling should stop periodic fetches', async () => {
+    vi.useFakeTimers();
+    try {
+      service.startPolling(1000);
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/votes').flush(mockVotes);
 
-    service.stopPolling();
-    tick(1000);
-    httpMock.expectNone('/api/votes');
-
-    discardPeriodicTasks();
-  }));
+      service.stopPolling();
+      await vi.advanceTimersByTimeAsync(1000);
+      httpMock.expectNone('/api/votes');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   // Regression for logical-bug-audit H24: a single /api/votes failure
   // (502 from a proxy, stale X-Dataset-Id after a context switch, etc.)
   // used to terminate the entire polling chain and leave `polling` stuck
   // at true, freezing vote state for the rest of the session.
-  it('polling survives a transient /api/votes error and keeps polling', fakeAsync(() => {
-    service.startPolling(1000);
+  it('polling survives a transient /api/votes error and keeps polling', async () => {
+    vi.useFakeTimers();
+    try {
+      service.startPolling(1000);
 
-    // First tick: server is unreachable. Pre-fix this would tear the
-    // whole observable down.
-    tick(0);
-    httpMock.expectOne('/api/votes').flush(null, { status: 502, statusText: 'Bad Gateway' });
+      // First tick: server is unreachable. Pre-fix this would tear the
+      // whole observable down.
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/votes').flush(null, { status: 502, statusText: 'Bad Gateway' });
 
-    // Local state must NOT be clobbered to empty on a failed tick.
-    // (Without the EMPTY shortcut, an empty stub VotesResponse here
-    // would silently erase optimistic votes.)
-    service.applyOptimisticState(99, 'good');
-    expect(service.goodVotes.has(99)).toBe(true);
+      // Local state must NOT be clobbered to empty on a failed tick.
+      // (Without the EMPTY shortcut, an empty stub VotesResponse here
+      // would silently erase optimistic votes.)
+      service.applyOptimisticState(99, 'good');
+      expect(service.goodVotes.has(99)).toBe(true);
 
-    // Second tick: server is back. The chain must still be alive.
-    tick(1000);
-    httpMock.expectOne('/api/votes').flush(mockVotes);
-    expect(service.goodVotes.has(1)).toBe(true);
-    expect(service.goodVotes.has(2)).toBe(true);
+      // Second tick: server is back. The chain must still be alive.
+      await vi.advanceTimersByTimeAsync(1000);
+      httpMock.expectOne('/api/votes').flush(mockVotes);
+      expect(service.goodVotes.has(1)).toBe(true);
+      expect(service.goodVotes.has(2)).toBe(true);
 
-    service.stopPolling();
-    discardPeriodicTasks();
-  }));
+      service.stopPolling();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it('clear should reset all state', () => {
     service.loadVotes();

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -89,16 +89,11 @@ const canvasContextStub = new Proxy(
 HTMLCanvasElement.prototype.getContext = (() =>
   canvasContextStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
-// --- fakeAsync / ProxyZone bridge ------------------------------------------
-// Angular's fakeAsync()/tick() require each test to run inside a Zone forked
-// with a ProxyZoneSpec. zone.js/testing only auto-wires that for Jasmine,
-// Mocha and Jest — its jest patch bails with `typeof jest === 'undefined'`,
-// and Vitest is none of those — so without help every fakeAsync() spec throws
-// "Expected to be running in 'ProxyZone'".
-//
-// `zone.js/plugins/vitest-patch` (loaded ahead of this file via the test
-// target's polyfills in angular.json) is the Angular-maintained bridge that
-// wires Vitest's describe/it/hooks into the sync/proxy zones, replacing the
-// hand-rolled replica that used to live here. It is explicitly transitional;
-// the long-term direction is native async + Vitest fake timers (zoneless
-// migration Phase 5). Nothing further is needed here.
+// --- no fakeAsync / ProxyZone bridge ---------------------------------------
+// The specs no longer use Angular's fakeAsync()/tick(); they drive time with
+// native async + Vitest fake timers (vi.useFakeTimers / advanceTimersByTimeAsync)
+// and real macrotask drains instead. So neither "zone.js/testing" nor the
+// "zone.js/plugins/vitest-patch" bridge is loaded any more (see the build:test
+// polyfills in angular.json and docs/plans/zoneless-migration.md, Phase 5).
+// Base "zone.js" stays in the test polyfills only for the specs that still use
+// the default zone-based TestBed; nothing in this setup file needs it.


### PR DESCRIPTION
## What

Phase 5 cleanup of the zoneless migration (`docs/plans/zoneless-migration.md`): remove the `zone.js/plugins/vitest-patch` ProxyZone bridge by migrating every `fakeAsync`/`tick` spec to native `async` + Vitest fake timers.

- **Converted all 43 `fakeAsync` occurrences across 11 spec files** off Angular's `fakeAsync`/`tick`/`discardPeriodicTasks`:
  - **Timer-delay cases** (`vote-state` + `browse-prep` pollers, `progress-modal`'s 50 ms badge) → `vi.useFakeTimers()` + `await vi.advanceTimersByTimeAsync(N)`, wrapped in `try/finally` with `vi.useRealTimers()`.
  - **Microtask / macrotask drains** (dialog `confirm()` promises, focus `setTimeout`s, the `timer(0,…)` votes-poll first emission) → a real macrotask flush `await new Promise(r => setTimeout(r))`.
  - **Purely synchronous bodies** that were needlessly wrapped in `fakeAsync` (`label-view`, `dataset-state`) → plain sync/`async` tests.
- **Removed `zone.js/testing` + `zone.js/plugins/vitest-patch`** from the `build:test` polyfills in `angular.json`; deleted the ProxyZone-bridge note in `src/test-setup.ts` and refreshed the surrounding comments.

## What did NOT change (and why)

Base **`zone.js` stays** in the `build:test` polyfills and `package.json`. ~36 spec files still create a component fixture on the **default zone-based TestBed**, which requires `NgZone` to exist — emptying the test polyfills fails **31 tests across 15 files** (NG0205 / CD errors). The final `zone.js` drop is therefore blocked on the separate "migrate remaining specs to the zoneless TestBed" follow-up, not on this fakeAsync work. This is recorded in the plan's Phase 5 / Open follow-ups.

## Testing

`./run-tests.sh frontend` green: TypeScript build OK, `npm audit` clean, **854 Vitest tests passed (91 files)** with the vitest-patch bridge gone. All ruff/codespell/deptry/pyright/OpenAPI gates pass.

No production code changes — specs + test build config + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5jDeBv17Uf9sXmSc397xW

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5jDeBv17Uf9sXmSc397xW)_