### PR TITLE
v3 Phase 2b.5 (MLP keying) + reconcile the text/patch/structural trio plan

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -680,8 +680,8 @@ plumbing, not modelling.
 V3 lands as a sequence of behavior-preserving substrate phases (so each
 commit is reviewable and the single-embedder world keeps working) followed by
 the user-visible binding.  Ordering is by dependency: each phase needs the one
-above it.  **Status: Phases 2a-2b.4 shipped; 2b.5 (MLP keying) and 2c (drop
-the singular mirror) remain, then the create-time dual-picker.**
+above it.  **Status: Phases 2a-2b.5 shipped; 2c (drop the singular mirror)
+remains, then the create-time dual-picker.**
 
 **Shipped:**
 
@@ -757,10 +757,38 @@ the singular mirror) remain, then the create-time dual-picker.**
   against the text embedder's full-image vectors, not the patch tree.  See "Open
   follow-ups" for the cross-dataset Find / CLI-chunk scoring still on primary.
 
+- **Phase 2b.5 - MLP keying.** The cached detector MLP (`DetectorContext.model`)
+  is now keyed to the **score embedder** (patch-else-text; the v3 routing table),
+  not the per-media singular `media["embedder"]` mirror.  A single canonical
+  marker resolver - `vtscore.embedding.binding.score_marker_embedder` (and its
+  `*_for_snap` sibling) - returns `patch or text or primary`, where the primary
+  *name* is the slot-less single-vector fallback so the marker is always a
+  concrete string to stamp on / compare against `DetectorContext.embedder`.
+  Every site that writes the marker (`learned_sort.update_det_ctx_with_trained_model`,
+  `workflow.apply_and_retrain`, `labelset_training.populate_label_embeddings`,
+  `embedder_sync`) and every site that computes the "new embedder" to compare it
+  against (`dataset_sync._embedder_of_active_dataset`, `model_loading`'s
+  Auto-Find defensive check, `embedder_sync.active_dataset_embedder_name`) now
+  routes through that one helper, so `invalidate_detector_model_on_embedder_mismatch`,
+  `_maybe_clear_cache_on_embedder_switch`, and `maybe_start_label_reembed` all
+  compare apples-to-apples.  **Effect:** keying by the embedder *name* (which
+  fully determines the vector space; votes re-derive from the dataset-agnostic
+  labelset) is sufficient for the `(detector, dataset, embedder)` key - a stale
+  cross-space MLP is dropped and retrained on any switch where the score
+  embedder changes.  Byte-for-byte unchanged for every single-embedder dataset
+  (there score-marker == primary); the only behavior change is on a dual
+  dataset, where the primary mirror (text) and the scored space (patch) differ -
+  previously the stale text-keyed MLP would survive a switch onto the patch
+  scoring space.  The cross-dataset Find / cold-train path
+  (`model_loading.resolve_or_train_detector`, lines that build `md5_to_emb` from
+  the primary `c["embedding"]`) is deliberately left on the primary vector - it
+  pairs both the in-snap vectors and the origin-resolved vectors in the same
+  primary space, so it stays self-consistent; wiring it to the score embedder is
+  the cross-dataset-Find follow-up already tracked under "Open follow-ups (from
+  2b.4)".
+
 **Remaining, in order:**
 
-- **Phase 2b.5 - MLP keying.** Key MLPs by `(detector, dataset, embedder)`.
-  See "Detector MLP keying".
 - **Phase 2c - drop the singular mirror.** Once every read site routes through
   the accessor with an explicit embedder, remove the `media["embedding"]`
   primary mirror (read-time re-key on load handles old pickles).

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -329,13 +329,14 @@ Today a dataset is bound to **one** embedder, set at creation. The dataset's cap
 
 The dataset surface gains two getters that just delegate: `dataset.supports_text` and `dataset.supports_patch_regions`, computed from the bound embedder. The frontend's `ActiveContextService` already routes `X-Dataset-Id`; the sort-bar and (eventually) the region-vote affordance read the two capability flags off the dataset metadata response.
 
-### Future: one text embedder + one patch embedder per dataset
+### Future: the text / patch / structural trio per dataset
 
 Tracked in "V3 - design" below.  v1/v2 picked the field names
 (`media["embedding"]`, `media["patch_regions"]`, `media["patch_grid"]`)
 so that they collapse cleanly into the v3 dict schema - no rewrite of
 the v1/v2 storage decisions is needed; v3 is purely additive at the
-schema level.
+schema level.  The structural role's `media["local_features"]`
+(structural-embedder.md) slots into the same additive model.
 
 ## Backend integration points
 
@@ -465,29 +466,49 @@ fallback box is suppressed (same rule as the gallery outline). Frontend-only.
 
 ## V3 - design
 
-V3 lets a dataset bind **up to one text-capable embedder + up to one
-patch-capable embedder** instead of exactly one embedder.  Text sort
-runs against the text embedder; region similarity, region voting, and
-the detector MLP run against the patch embedder; both live side-by-
-side in the pickle.  No dataset is forced to take two embedders - a
-single-embedder dataset still works, and a dataset that doesn't
-benefit from one of the two roles simply leaves that slot empty.
+V3 lets a dataset bind **up to one embedder per role across three
+role types** - a text-capable embedder, a patch-capable embedder, and
+a structural (geometric-verification) embedder - instead of exactly
+one embedder.  Text sort runs against the text embedder; region
+similarity, region voting, and region-aware MLP scoring run against
+the patch embedder; instance retrieval + geometric re-rank run against
+the structural embedder; all bound embedders live side-by-side in the
+pickle.  No dataset is forced to take more than one - a single-embedder
+dataset still works, and a dataset that doesn't benefit from a given
+role simply leaves that slot empty (the only hard rule is that **at
+least one of the three** is set, or there's nothing to sort/search
+against).
 
 The point is to **stop forcing the user to choose** between "good
-text queries" (SigLIP/CLIP) and "good region voting + visual quality"
-(DINOv3 patch).  Today those are mutually exclusive because the
-dataset has exactly one embedder; in v3 they coexist on the same
-pickle.
+text queries" (SigLIP/CLIP), "good region voting + visual quality"
+(DINOv3 patch), and "find this exact instance" (SIFT/VLAD structural).
+Today those are mutually exclusive because the dataset has exactly one
+embedder; in v3 they coexist on the same pickle.  The three roles are
+type-distinct because they ride three independent capability flags -
+`supports_text`, `supports_patch_regions`, and
+`supports_geometric_verification` - and each populates its own per-media
+storage (full-image vectors / `patch_regions` + `patch_grid` /
+`local_features`).
 
 ### Schema change
 
 The on-disk per-media fields become dicts keyed by embedder name:
 
 ```python
-media["embeddings"]    = {"siglip": ndarray, "dinov3_patch": ndarray}   # fp16, L2-normalised, one entry per bound embedder
-media["patch_regions"] = {"dinov3_patch": [RegionVector, ...]}          # only the patch embedder(s) populate this
-media["patch_grid"]    = {"dinov3_patch": ndarray}                      # (H, W, D) fp16 per patch embedder
+media["embeddings"]     = {"siglip": ndarray, "dinov3_patch": ndarray, "sift_vlad": ndarray}  # fp16, L2-normalised, one entry per bound embedder (incl. the structural VLAD vector)
+media["patch_regions"]  = [RegionVector, ...]   # the patch embedder's HAC tree (one patch slot, so single-valued)
+media["patch_grid"]     = ndarray               # (H, W, D) fp16, the patch embedder's grid
+media["local_features"] = StructuralFeatures(...)  # the structural embedder's keypoints + descriptors (one structural slot, so single-valued)
 ```
+
+`media["embeddings"]` is the genuinely multi-valued field (one vector per
+bound embedder, including the structural embedder's Stage-1 VLAD vector).
+`patch_regions` / `patch_grid` / `local_features` stay **single-valued**:
+the binding allows at most one patch and one structural embedder, so keying
+them by name would be a perpetually ≤1-entry dict.  Each is owned by its
+role's bound embedder; dict-keying them is deferred to if "more than one
+patch (or structural) embedder per dataset" ever comes off the non-goals
+list.
 
 The legacy `media["embedding"]` (singular, scalar value) is **dropped
 from the on-disk format** in v3.  Loaders that read an older pickle
@@ -495,63 +516,81 @@ re-key it on the fly:
 
 ```python
 media["embeddings"] = {legacy_embedder_name: media.pop("embedding")}
-if legacy_embedder_supports_patch and "patch_regions" in media:
-    media["patch_regions"] = {legacy_embedder_name: media.pop("patch_regions")}
-    media["patch_grid"]    = {legacy_embedder_name: media.pop("patch_grid")}
+# patch_regions / patch_grid / local_features stay single-valued and in place;
+# they were already owned by the (single) legacy embedder, which now fills the
+# matching role slot, so there is nothing to re-key.
 ```
 
 This is a one-shot read-time migration, not a runtime compat shim.
-After the first save under v3, the legacy fields are gone.  Per
-CLAUDE.md ("Backwards Compatibility"), we don't keep a parallel
-`media["embedding"]` mirror.
+After the first save under v3, the legacy singular `media["embedding"]`
+is gone (`embeddings` replaces it).  Per CLAUDE.md ("Backwards
+Compatibility"), we don't keep a parallel `media["embedding"]` mirror.
 
 ### Dataset binding
 
-Two new fields on the dataset header (the part of the pickle that
-describes the dataset, not the per-media list):
+Three new fields on the dataset header (the part of the pickle that
+describes the dataset, not the per-media list) - one per role type:
 
 ```python
-dataset.text_embedder:  str | None   # e.g. "siglip" or "e5" or None
-dataset.patch_embedder: str | None   # e.g. "dinov3_patch" or None
+dataset.text_embedder:       str | None   # e.g. "siglip" or "e5" or None
+dataset.patch_embedder:      str | None   # e.g. "dinov3_patch" or None
+dataset.structural_embedder: str | None   # e.g. "sift_vlad" or None
 ```
 
 Constraints:
 
-- At least one of the two must be set (otherwise no sort/search/vote
-  works).
+- **At least one of the three must be set** (otherwise no
+  sort/search/vote works).  The dataset-create flow enforces this; the
+  per-slot type checks below don't.
 - `text_embedder` must point at an embedder with
   `supports_text == True`.
 - `patch_embedder` must point at an embedder with
-  `supports_patch_regions == True`.  Slots are role-typed; a
-  single-vector embedder (e.g. `dinov3_single`) is not eligible for
-  the patch slot.
-- Both slots may be filled - that's the new capability v3 unlocks.
-  The two embedders run independently at load time; their outputs
-  share nothing.
+  `supports_patch_regions == True`.
+- `structural_embedder` must point at an embedder with
+  `supports_geometric_verification == True`.
+- Slots are role-typed; a single-vector embedder (e.g.
+  `dinov2_single`) is eligible for **no** slot (it drives cosine sort /
+  the detector MLP via its primary vector, read directly rather than
+  through a role slot - see Phase 2b.4).
+- A single embedder may legitimately fill more than one slot if it
+  advertises more than one capability (a hypothetical text+patch
+  backbone fills both); each role independently takes the first bound
+  name that advertises that capability.
+- Any combination of the three slots may be filled - that's the new
+  capability v3 unlocks.  The bound embedders run independently at load
+  time; their outputs share nothing on disk.
 
 `dataset.supports_text` becomes `text_embedder is not None`;
-`dataset.supports_patch_regions` becomes `patch_embedder is not None`.
-The existing `MediaEmbedder.supports_text` /
-`supports_patch_regions` flags stay - they describe an embedder's
+`dataset.supports_patch_regions` becomes `patch_embedder is not None`;
+`dataset.supports_geometric_verification` becomes
+`structural_embedder is not None`.  The existing
+`MediaEmbedder.supports_*` flags stay - they describe an embedder's
 *capabilities*; the dataset slots record which embedder is *bound* to
 which role.
 
 ### Routing rules
 
+The shared **score embedder** (the single vector space the detector MLP,
+diversity tree, and example/by-id cosine sort run against) resolves by
+precedence: **`structural_embedder` if set, else `patch_embedder` if
+set, else `text_embedder`** (`None` for a slot-less single-vector
+dataset, where the matrix layer reads each media's primary vector).  The
+dedicated text / patch / structural roles each use their own slot:
+
 | Operation | Embedder used | Behaviour when slot empty |
 |---|---|---|
 | Text sort (`POST /api/sort`) | `text_embedder` | HTTP 400 + `supports_text: false` (already the v1 behaviour) |
-| Cosine example sort (`POST /api/example-sort`) | `patch_embedder` if set, else `text_embedder` | HTTP 400 if neither is set |
-| Region similarity (`POST /api/find-label`, etc.) | `patch_embedder` | HTTP 400 if `patch_embedder` is None |
-| Region voting / `region_box` on `LabeledElement` | `patch_embedder` | UI hides Shift-drag affordance if `patch_embedder` is None |
-| Diversity tree | `patch_embedder` if set, else `text_embedder` | One tree per dataset; rebuilt when the bound embedder changes |
-| Detector MLP scoring | `patch_embedder` if set, else `text_embedder` | Region max-pool applies only when scoring against `patch_embedder` |
+| Cosine example sort (`POST /api/example-sort`) | score embedder (structural ▸ patch ▸ text) | HTTP 400 if all three are empty |
+| Region similarity / region voting / `region_box` | `patch_embedder` | UI hides Shift-drag region affordance if None |
+| Geometric (instance) verification + Stage-2 re-rank | `structural_embedder` | re-rank skipped (coarse VLAD retrieval only) if None |
+| Diversity tree | score embedder | One tree per dataset; rebuilt when the bound score embedder changes |
+| Detector MLP scoring | score embedder | Region max-pool when score == `patch_embedder`; two-stage verify when score == `structural_embedder` |
 | Detector MLP training | same embedder as scoring (must match) | - |
-| Gallery `best_region` overlay | `patch_embedder` | Outline absent when `patch_embedder` is None (v1 behaviour) |
+| Gallery `best_region` overlay | `patch_embedder` or `structural_embedder` (whichever drove the score) | Outline absent when neither is set |
 
-The example-sort fallback to `text_embedder` is **only** for image
-uploads - text sort never falls back to the patch embedder, because
-patch embedders don't have a text encoder.  The
+The example-sort fallback chain is **only** for image
+uploads - text sort never falls back to the patch/structural embedder,
+because those have no text encoder.  The
 `MediaEmbedder.supports_text` gate already enforces this at request
 time.
 
@@ -560,54 +599,71 @@ time.
 Today an MLP is keyed by `(detector_id, dataset_id)` and trained on
 whatever vectors the dataset's single embedder produced.  In v3:
 
-- An MLP is keyed by `(detector_id, dataset_id, embedder_name)`.
+- An MLP is keyed by `(detector_id, dataset_id, embedder_name)`, where
+  `embedder_name` is the **score** embedder (structural ▸ patch ▸ text)
+  the model was trained against - **not** the per-media primary mirror,
+  which diverges from the scored space on a multi-embedder dataset.
+  (Shipped in Phase 2b.5 via the canonical `score_marker_embedder`; see
+  "V3 - implementation status".)
 - A detector that ran against `siglip` on a v2-era dataset stays
   valid post-migration - its embedder_name is the pre-migration
   embedder.
-- Switching `dataset.patch_embedder` from `None` to `dinov3_patch`
-  doesn't invalidate existing `text_embedder`-keyed MLPs; the new
-  patch-keyed MLP is trained fresh from the existing votes the next
+- Switching the bound score embedder (e.g. adding a `patch_embedder` or
+  `structural_embedder` to a previously text-only dataset) doesn't
+  invalidate existing MLPs keyed to the old embedder; the new
+  embedder-keyed MLP is trained fresh from the existing votes the next
   time the user runs Learned sort.  Votes are embedder-agnostic
   (they're `(media_id, label, region_box?)`), so they re-use cleanly.
+- A structural-keyed detector carries **two** learned objects (the
+  Stage-1 retrieval MLP on VLAD vectors + the match-statistic
+  verification classifier); both are re-derived from votes and never
+  persisted, exactly as in the structural-embedder v1 design.
 
 ### Loader / exporter / importer impact
 
 - **Pickle loaders** (`loader_pickle.py`, `loader_folder.py`) run
-  both bound embedders during ingest.  Each one writes into its own
-  key under `media["embeddings"]` / `media["patch_regions"]` /
-  `media["patch_grid"]`.  The two passes share dataset I/O (one file
-  open per media) but run their forwards independently.
+  every bound embedder during ingest (already generalised to a set in
+  Phase 2b.3).  Each writes its own vector into `media["embeddings"]`;
+  the patch embedder additionally writes `patch_regions` / `patch_grid`,
+  and the structural embedder writes `local_features`.  The passes share
+  dataset I/O (one file open per media) but run their forwards
+  independently.
 - **`ConcurrencyGate`** (`load_pipeline.py`) gates embed work; v3's
-  two embedders count as two embed phases for the same dataset.  Net
-  effect: a two-embedder dataset takes longer to ingest than a
-  single-embedder one, gated under the same `_embed_gate` limit.
+  bound embedders count as that many embed phases for the same dataset.
+  Net effect: a multi-embedder dataset takes proportionally longer to
+  ingest, gated under the same `_embed_gate` limit.
 - **Dataset pickle schema version** bumps.  Old pickles still load
   via the read-time re-key; saving from v3 always writes the new
   schema.
 - **NPZ paths-file (server_files importer)** today carries one
   `vectors` array per media.  In v3 it grows an optional
   `vectors_<embedder_name>` per-embedder layout; the existing
-  single-`vectors` layout maps to the dataset's `text_embedder` slot
-  (or `patch_embedder` if no text slot is set).
+  single-`vectors` layout maps to the dataset's score-role slot
+  (structural ▸ patch ▸ text).
 - **Combine Datasets importer**: input pickles must have identical
-  `(text_embedder, patch_embedder)` pairs to combine.  We refuse the
-  combine with a clear error otherwise - no partial-overlap
-  reconciliation in v3.
+  `(text_embedder, patch_embedder, structural_embedder)` triples to
+  combine.  We refuse the combine with a clear error otherwise - no
+  partial-overlap reconciliation in v3.
 
 ### Frontend
 
-- **Dataset-create flow**: today's single embedder picker becomes a
-  pair of pickers ("Text embedder" + "Patch embedder"), each
-  defaulted to None and filtered by the role-typed capability list.
-  The license-notice chip surfaces on whichever picker shows an
-  embedder with one.
+- **Dataset-create flow**: today's single embedder picker becomes
+  **three independent pickers** - "Text embedder", "Patch embedder",
+  and "Structural embedder" - each defaulted to None and filtered by
+  its role-typed capability list (`supports_text` /
+  `supports_patch_regions` / `supports_geometric_verification`).  The
+  user may pick one (or leave empty) per picker; the form rejects
+  submission only when **all three are empty**.  The license-notice
+  chip surfaces on whichever picker shows an embedder with one.
 - **Sort bar** continues to read `dataset.supports_text` /
-  `supports_patch_regions` - no per-component change.
+  `supports_patch_regions` (+ now `supports_geometric_verification`) -
+  no per-component change.
 - **Embedder picker page** (admin-ish): no shape change; embedder
-  cards already list `supports_text` and `supports_patch_regions`.
+  cards already list the three `supports_*` capability flags.
 - **Region-vote UI**: unchanged from v2 once the routing wires up;
-  Shift-drag continues to work whenever `dataset.patch_embedder` is
-  set.
+  Shift-drag continues to work whenever `dataset.patch_embedder` **or**
+  `dataset.structural_embedder` is set (for structural the box defines
+  the match template - see structural-embedder.md).
 
 ### Migration
 
@@ -616,12 +672,11 @@ v3:
 
 1. Read legacy `dataset.embedder: str` and `media["embedding"]:
    ndarray`.
-2. If the legacy embedder is `supports_text=True` →
-   `dataset.text_embedder = legacy_name`,
-   `dataset.patch_embedder = None`.
-   If it's `supports_patch_regions=True` →
-   `dataset.patch_embedder = legacy_name`,
-   `dataset.text_embedder = None`.
+2. Role-type the legacy embedder into its matching slot, leaving the
+   others `None`: `supports_text` → `text_embedder`,
+   `supports_patch_regions` → `patch_embedder`,
+   `supports_geometric_verification` → `structural_embedder`.  (A
+   dual-capability legacy embedder fills every slot it qualifies for.)
 3. Re-key per-media fields as in "Schema change".
 4. Mark the dataset as v3-schema in memory; the next save writes the
    new format.
@@ -634,10 +689,13 @@ inconsistency window.
 
 ### Out of scope for v3
 
-- **>1 text or >1 patch embedder per dataset.**  A user wanting two
-  text embedders re-imports under a separate dataset.  The schema
-  (dict keyed by name) is forward-compatible with this, but the
-  binding rules (`text_embedder: str | None`) intentionally aren't.
+- **>1 embedder of the same role per dataset** (two text, two patch, or
+  two structural embedders).  A user wanting two text embedders
+  re-imports under a separate dataset.  The schema (`embeddings` dict
+  keyed by name) is forward-compatible with this, but the binding rules
+  (`text_embedder: str | None`, etc.) intentionally aren't.  Binding
+  one of *each* role (text + patch + structural) **is** in scope - that
+  is the trio v3 unlocks.
 - **In-place add-an-embedder on a loaded dataset.**  Same re-import
   rule as v1.
 - **Cross-embedder MLP transfer.**  An MLP trained against `siglip`
@@ -650,30 +708,46 @@ inconsistency window.
 
 ### Open questions (v3)
 
-1. **Where in the dataset header do `text_embedder` /
-   `patch_embedder` live?**  Today's single `dataset.embedder` field
-   probably can't just be renamed without breaking labelset sync.
-   Most likely: keep the legacy field as an alias to whichever slot
-   is filled (read-only, computed) for one release, then drop it.
-   To be confirmed during impl.
-2. **Combine Datasets ergonomics.**  Strict "embedder pair must
+1. **Where in the dataset header do the three slots live?**  Today's
+   single `dataset.embedder` field probably can't just be renamed
+   without breaking labelset sync.  Most likely: keep the legacy field
+   as an alias to whichever slot the score role resolves to (read-only,
+   computed) for one release, then drop it.  To be confirmed during
+   impl.
+2. **Combine Datasets ergonomics.**  Strict "embedder triple must
    match" is the v3 rule, but if it bites enough users in practice
    we may want a "combine on the text slot only" variant.  Punt
    until we see real demand.
-3. **Diversity-tree backbone preference.**  The routing table picks
-   `patch_embedder` over `text_embedder` when both are set, on the
-   theory that patch backbones (DINO/EUPE) cluster images more
-   semantically than text-trained backbones (SigLIP).  Worth a
-   sanity check on a mixed dataset before we lock the preference
-   in.
+3. **Diversity-tree + score backbone preference (patch vs structural).**
+   The routing table resolves the shared score role as structural ▸
+   patch ▸ text.  Patch-over-text rests on patch backbones (DINO/EUPE)
+   clustering images more semantically than text backbones (SigLIP);
+   **structural-over-patch is the less obvious call** - a structural
+   embedder is a deliberate specialist pick, so if it's bound we treat
+   instance verification as the intended detector behaviour, but its
+   Stage-1 VLAD vector may cluster *worse* than patch for the diversity
+   tree.  Two sub-decisions to validate on a real patch+structural
+   dataset before locking in: (a) does the detector default to the
+   structural two-stage pipeline when both are bound, and (b) should the
+   diversity tree use a *different* preference (patch ▸ structural)
+   than the detector?  Until then, both use the single score precedence
+   above.
+4. **Patch + structural coexistence at score time.**  Storage and the
+   per-role routing already support binding both; the open piece is
+   whether a single detector can ever run *both* visual pipelines at
+   once (region max-pool MLP *and* geometric verify) rather than
+   choosing one via the score precedence.  Out of scope for the first
+   trio cut; the score precedence picks exactly one.
 
 ### V3 work plan (sketch)
 
 Filled in when we start, just like the v2 plan was a punchlist
 during impl.  Rough size estimate: backend ~2× v2 (schema +
-loader + per-embedder MLP keying), frontend ~0.5× v2 (just the
-dual-picker on dataset-create).  No new ML algorithms - v3 is
-plumbing, not modelling.
+loader + per-embedder MLP keying), frontend ~0.5× v2 (the three
+role pickers on dataset-create).  No new ML algorithms - v3 is
+plumbing, not modelling (the structural pipeline itself already
+shipped per structural-embedder.md; v3 only adds its third binding
+slot + routing).
 
 ### V3 - implementation status
 
@@ -681,7 +755,8 @@ V3 lands as a sequence of behavior-preserving substrate phases (so each
 commit is reviewable and the single-embedder world keeps working) followed by
 the user-visible binding.  Ordering is by dependency: each phase needs the one
 above it.  **Status: Phases 2a-2b.5 shipped; 2c (drop the singular mirror)
-remains, then the create-time dual-picker.**
+remains, then the create-time picker that binds the text / patch / structural
+trio (three role pickers; at least one slot filled).**
 
 **Shipped:**
 
@@ -801,9 +876,9 @@ remains, then the create-time dual-picker.**
   subsets - neither is the active `DatasetContext`, so they keep building the
   matrix from each media's primary vector (no `routed_embedder` call).  This is
   correct for every single-embedder dataset (primary == score embedder) and
-  only matters once a dual-embedder dataset can be created and Find-scored; wire
-  a binding derived from those medias' own embedder names when the create-time
-  dual path lands.
+  only matters once a multi-embedder (trio) dataset can be created and
+  Find-scored; wire a binding derived from those medias' own embedder names when
+  the create-time three-role picker lands.
 - **Region-less media in a region matrix fall back to the primary vector.**
   `matrix._build_region_arrays` sources a region-less media's single row from
   `media["embedding"]` (primary), not the patch embedder's vector.  On a real
@@ -812,23 +887,27 @@ remains, then the create-time dual-picker.**
 
 ### Open follow-ups (from 2b.3)
 
-- **No create-time path to bind two embedders yet.** 2b.3 makes the loader,
-  exporter, and pickle reader multi-embedder-*correct* (and exercises it via
-  the embed driver + persistence round-trip), but the standard create flow
-  still passes one `embedder` field, so production datasets remain
-  single-embedder until the frontend dual-picker (under "Frontend" in the v3
-  design) threads a `(text_embedder, patch_embedder)` pair into the load
-  pipeline.  Wire that alongside or after routing (2b.4).
-- **`patch_regions` / `patch_grid` stay singular.** The binding allows at most
-  one patch embedder, so these remain single-valued (owned by that embedder)
-  rather than dict-keyed.  Only revisit if "more than one patch embedder per
-  dataset" ever comes off the v3 non-goals list.
-- **Combine Datasets pair-match guard not added.** `combine_datasets` still
-  guards only on media type, not on the `(text_embedder, patch_embedder)`
-  pair (a pre-existing latitude — it never checked the single `embedder`
-  either).  Since nothing can create a two-embedder dataset yet, this is
-  harmless today; add the strict pair-match refusal (v3 design open question
-  #2) when the dual-picker lands.
+- **No create-time path to bind multiple embedders yet.** 2b.3 makes the
+  loader, exporter, and pickle reader multi-embedder-*correct* (and exercises
+  it via the embed driver + persistence round-trip), but the standard create
+  flow still passes one `embedder` field, so production datasets remain
+  single-embedder until the frontend **three-role picker** (under "Frontend"
+  in the v3 design) threads a `(text_embedder, patch_embedder,
+  structural_embedder)` triple into the load pipeline.  Wire that alongside or
+  after routing (2b.4).  Note the structural slot also needs the binding model
+  + `routed_embedder` to grow a `structural` role and the score precedence to
+  become structural ▸ patch ▸ text (today the code knows only text/patch).
+- **`patch_regions` / `patch_grid` / `local_features` stay singular.** The
+  binding allows at most one patch and one structural embedder, so these remain
+  single-valued (owned by that role's embedder) rather than dict-keyed.  Only
+  revisit if "more than one patch (or structural) embedder per dataset" ever
+  comes off the v3 non-goals list.
+- **Combine Datasets triple-match guard not added.** `combine_datasets` still
+  guards only on media type, not on the `(text_embedder, patch_embedder,
+  structural_embedder)` triple (a pre-existing latitude — it never checked the
+  single `embedder` either).  Since nothing can create a multi-embedder dataset
+  yet, this is harmless today; add the strict triple-match refusal (v3 design
+  open question #2) when the picker lands.
 - **NPZ per-embedder layout (`vectors_<name>`) not added.** The `server_files`
   NPZ importer still carries a single `vectors` array; the per-embedder layout
   in "Loader / exporter / importer impact" lands with the create-time
@@ -838,4 +917,4 @@ remains, then the create-time dual-picker.**
 
 - **v1 (this plan):** six image embedders - single/patch pairs for DINOv2 (ungated default), DINOv3 (gated, premium), and real-EUPE (FAIR Noncommercial). `supports_patch_regions` + `license_notice` flags on `MediaEmbedder`; each `_patch` embedder populates `media["patch_regions"]` (HAC tree) and `media["patch_grid"]` (raw H × W × 768 fp16); the matching `_single` slug provides a fast/cheap CLS-only path on the same backbone for datasets that don't need region search. `PatchEmbedOutput` protocol; max-region similarity; region-aware MLP scoring; asymmetric training loss (Good = `BCE(mlp(full_image_vec), 1)` unchanged from today, Bad = `mean`-over-regions BCE) with image-level labels unchanged on disk; gallery-card region highlight; license-notice surfacing on the embedder picker. Text sort stays grey via the already-shipped `supports_text` gate. Pre-implementation experiments run on `caltech101_s` and inform `K`, `α`, and the EUPE-real attention path.
 - **v2:** region voting on image media via Shift-drag on the focus pane (single rectangular box, salient-area annotation on yes-votes only; binary fast path via `←`/`→` preserved); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export. Touch deferred.
-- **v3:** one text embedder + one patch embedder per dataset (text queries → text embedder; region similarity / votes → patch embedder).  Schema change to dict-keyed `media["embeddings"]` / `media["patch_regions"]` / `media["patch_grid"]`; legacy `media["embedding"]` is read-migrated then dropped on next save; MLPs become keyed by `(detector, dataset, embedder)`.  Designed in "V3 - design" above; work plan filled in when impl starts.
+- **v3:** the **text / patch / structural trio** - up to one embedder per role bound on a single dataset (text queries → text embedder; region similarity / votes → patch embedder; instance retrieval + geometric re-rank → structural embedder), at least one slot filled.  Schema change to dict-keyed `media["embeddings"]` (one vector per bound embedder); `patch_regions` / `patch_grid` / `local_features` stay single-valued (one patch + one structural slot); legacy `media["embedding"]` is read-migrated then dropped on next save; MLPs become keyed by `(detector, dataset, embedder)` against the score embedder (structural ▸ patch ▸ text).  Designed in "V3 - design" above; substrate Phases 2a–2b.5 shipped (see "V3 - implementation status").

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -20,8 +20,9 @@ geometric re-rank); **SIFT for v1 with a pluggable matching backend** so learned
 local features drop in later; **the full vote-trained detector ships in v1** (both
 the example/region similarity flow and the match-statistic verification classifier,
 just like patch); **planar-only** matching; **image-only v1 with audio as the next
-media target**; **dual-embedder coexistence deferred** to patch v3 (one structural
-embedder per dataset for now); **a fixed, shipped VLAD vocabulary** for v1 (no
+media target**; **multi-embedder coexistence is the third role of the active patch
+v3 trio** (text + patch + structural; one structural embedder per dataset until the
+v3 create-time picker lands); **a fixed, shipped VLAD vocabulary** for v1 (no
 per-dataset codebook fit); **similarity-transform** geometric matching (4 DoF:
 translation, rotation, uniform scale — no shear, no perspective).
 
@@ -297,22 +298,34 @@ Structural embedders set `supports_text = False`, `is_default = False`
   structural datasets the copy nudges "box the pattern you want to match."
 - **No new region-vote affordance** beyond what patch v2 already ships.
 
-## Single embedder per dataset (dual-embedder deferred)
+## Single embedder per dataset today; the third v3 role next
 
-For now a structural embedder is **one embedder per dataset**, exactly like patch:
-the dataset is bound to it at creation, and both the example/region similarity
-flow and the vote-trained detector run against that single embedder. This is the
-whole v1/v2 scope — no coexistence with a text embedder.
+**Today** a structural embedder is **one embedder per dataset**, exactly like
+patch: the dataset is bound to it at creation, and both the example/region
+similarity flow and the vote-trained detector run against that single embedder.
+This is the whole v1/v2 scope — no coexistence with a text embedder yet.
 
-`supports_text = False` does mean a structural dataset can be seeded *only* by
-example/region, never by a text query. That's an accepted limitation for now, the
-same way a `dinov*_patch` dataset has no text sort today. The longer-term fix —
-binding a text-capable embedder (SigLIP) *and* a structural embedder on the same
-dataset so text-seeded discovery and instance matching coexist — is patch
-v3's **dual-embedder** territory (a structural embedder would slot in as a third
-role-type alongside `text_embedder` / `patch_embedder`). **Deferred; we'll take it
-up when patch v3 lands.** Nothing in v1/v2 forecloses it: the per-media `embedding`
-field collapses cleanly into the v3 dict-keyed schema, just as the patch fields do.
+`supports_text = False` means a *structural-only* dataset can be seeded *only* by
+example/region, never by a text query — the same way a `dinov*_patch` dataset has
+no text sort today. The fix is now an **active part of patch v3**, not a vague
+"someday": structural is the **third role** in the v3 **text / patch / structural
+trio**. A dataset binds up to one embedder per role (`text_embedder` /
+`patch_embedder` / `structural_embedder`), so SigLIP-text-seeded discovery and
+SIFT/VLAD instance matching coexist on one dataset. The structural slot routes
+the geometric-verification role; it also participates in the shared **score**
+role at precedence **structural ▸ patch ▸ text** (a structural embedder is a
+deliberate specialist pick, so when bound it's treated as the intended detector
+behaviour — see patch-embedder.md "Routing rules" and open question #3). Nothing
+in v1/v2 forecloses this: the per-media `embedding` field already collapses
+cleanly into the v3 dict-keyed `media["embeddings"]`, and `local_features` stays
+single-valued (one structural slot) just as `patch_regions` does for the one
+patch slot.
+
+The v3 substrate (`media["embeddings"]` dict, name-keyed MLPs) has shipped
+(patch-embedder.md Phases 2a–2b.5); what remains for the structural slot is the
+`structural_embedder` field on the binding, a `structural` routing role, and the
+create-time picker exposing it. See patch-embedder.md "V3 - implementation
+status" / "Open follow-ups (from 2b.3)".
 
 ## Non-goals
 
@@ -397,10 +410,14 @@ an interface rewrite. The capability flag is `supports_geometric_verification`
   `StructuralMatcher` protocol + `supports_geometric_verification` flag — the
   next media target, sequenced here because the image work proves out the
   abstraction it reuses.
-- **Later (deferred):** structural embedder as a third role in the patch-v3
-  dual-embedder schema (text + patch + structural slots per dataset), so a dataset
-  can offer text-seeded discovery *and* instance-matching detectors simultaneously.
-  Picked up when patch v3 lands; not scheduled here.
+- **Patch v3 (active):** structural embedder as the **third role** in the v3
+  **text / patch / structural trio** (one embedder per role bound on a single
+  dataset), so a dataset can offer text-seeded discovery *and* region voting
+  *and* instance-matching detectors simultaneously. The v3 substrate has shipped
+  (patch-embedder.md Phases 2a–2b.5: `media["embeddings"]` dict +
+  score-embedder-keyed MLPs); the remaining structural-specific work is the
+  `structural_embedder` binding slot, a `structural` routing role, and the
+  create-time picker exposing it. Tracked in patch-embedder.md, not here.
 
 ## Tests
 
@@ -626,5 +643,8 @@ entry point that stopped at coarse VLAD retrieval (CPU-tested in
 - Keep the `StructuralMatcher` protocol media-agnostic from day one so the audio
   (constellation-fingerprint) backend — the next media target — lands in v2 without
   reshaping the interface.
-- Dual-embedder coexistence (structural + text on one dataset) is deferred to patch
-  v3; not scheduled here.
+- Multi-embedder coexistence (structural alongside text and/or patch on one
+  dataset) is the **third role of the active v3 trio**, tracked in
+  patch-embedder.md ("V3 - design" / "Open follow-ups (from 2b.3)"): the v3
+  substrate has shipped; the structural binding slot + `structural` routing role
+  + create-time picker are what remain. Not scheduled in this doc.

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -13,7 +13,13 @@ import numpy as np
 import pytest
 
 from vtscore.embedding import binding as binding_mod
-from vtscore.embedding.binding import derive_binding, derive_binding_from_names, validate_binding
+from vtscore.embedding.binding import (
+    derive_binding,
+    derive_binding_from_names,
+    score_marker_embedder,
+    score_marker_embedder_for_snap,
+    validate_binding,
+)
 from vtscore.state.core import DatasetContext
 
 # embedder name -> (supports_text, supports_patch_regions)
@@ -208,6 +214,55 @@ class TestRoutedEmbedder:
         ctx = _ctx_with_embedder("faketext")
         with pytest.raises(ValueError, match="unknown embedder routing role"):
             ctx.routed_embedder("bogus")
+
+
+class TestScoreMarkerEmbedder:
+    """The v3 model-keying marker - the embedder component of the
+    ``(detector, dataset, embedder)`` MLP key (patch-embedder.md Phase 2b.5).
+
+    The marker must equal the **score** embedder (patch-else-text) the MLP is
+    trained/scored against, falling back to the primary *name* for a slot-less
+    single-vector dataset so it is always a concrete string to compare against
+    ``DetectorContext.embedder``.
+    """
+
+    def _media(self, primary: str, names: list[str]) -> dict:
+        return {
+            "embedder": primary,
+            "embedding": np.ones(4, dtype=np.float32),
+            "embeddings": {n: np.ones(4, dtype=np.float32) for n in names},
+        }
+
+    def test_text_only_marks_text(self, fake_caps):
+        assert score_marker_embedder(self._media("faketext", ["faketext"])) == "faketext"
+
+    def test_patch_only_marks_patch(self, fake_caps):
+        assert score_marker_embedder(self._media("fakepatch", ["fakepatch"])) == "fakepatch"
+
+    def test_dual_marks_patch_not_primary(self, fake_caps):
+        # The crux of Phase 2b.5: a dual dataset's primary mirror is the text
+        # embedder, but the MLP scores against the patch embedder.  The marker
+        # must follow the scored space (patch), not media["embedder"] (text),
+        # or a stale cross-space MLP survives a dataset switch.
+        media = self._media("faketext", ["faketext", "fakepatch"])
+        assert media["embedder"] == "faketext"
+        assert score_marker_embedder(media) == "fakepatch"
+
+    def test_single_vector_falls_back_to_primary_name(self, fake_caps):
+        # routed_embedder("score") is None here, but the marker is a concrete
+        # name (the primary) so the str-compare invalidation still works.
+        assert score_marker_embedder(self._media("fakesingle", ["fakesingle"])) == "fakesingle"
+
+    def test_no_embedder_marks_empty(self, fake_caps):
+        assert score_marker_embedder({}) == ""
+
+    def test_for_snap_empty(self):
+        assert score_marker_embedder_for_snap(None) == ""
+        assert score_marker_embedder_for_snap({}) == ""
+
+    def test_for_snap_uses_first_media(self, fake_caps):
+        snap = {7: self._media("faketext", ["faketext", "fakepatch"])}
+        assert score_marker_embedder_for_snap(snap) == "fakepatch"
 
 
 class TestRealRegisteredEmbedder:

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -215,14 +215,22 @@ def invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder: str) -
 
 
 def _embedder_of_active_dataset() -> str:
-    """Return the embedder name recorded on the active dataset's medias, or ``""``."""
+    """Return the active dataset's model-keying marker embedder, or ``""``.
+
+    The **score** embedder (patch-else-text; the v3 routing table) the
+    detector MLP is trained and scored against - not the per-media primary,
+    which differs from the scored space on a dual-embedder dataset.  Matches
+    what the training paths stamp on ``DetectorContext.embedder`` so the
+    invalidation compare is apples-to-apples.  See ``score_marker_embedder``
+    and patch-embedder.md Phase 2b.5.
+    """
+    from vtscore.embedding.binding import score_marker_embedder_for_snap
     from vtscore.state.core import get_active_context
 
     ds_ctx = get_active_context()
     if not ds_ctx.dataset_id or not ds_ctx.medias:
         return ""
-    first = next(iter(ds_ctx.medias.values()), {})
-    return first.get("embedder", "") or ""
+    return score_marker_embedder_for_snap(ds_ctx.medias)
 
 
 def ensure_detector_model_matches_active_embedder() -> None:

--- a/vtscore/detectors/embedder_sync.py
+++ b/vtscore/detectors/embedder_sync.py
@@ -29,14 +29,18 @@ SpawnFn = Callable[..., Any]
 
 
 def active_dataset_embedder_name() -> str:
-    """Return the embedder name recorded on the active dataset's medias, or ``""``."""
+    """Return the active dataset's model-keying marker embedder, or ``""``.
+
+    The **score** embedder (patch-else-text; the v3 routing table) the
+    detector's label cache is built against - matching what the training
+    paths stamp on ``DetectorContext.embedder`` so the re-embed mismatch
+    check here agrees with the model-invalidation check.  See
+    ``score_marker_embedder`` and patch-embedder.md Phase 2b.5.
+    """
+    from vtscore.embedding.binding import score_marker_embedder_for_snap
     from vtscore.state import snapshot_medias
 
-    snap = snapshot_medias()
-    if not snap:
-        return ""
-    first = next(iter(snap.values()), {})
-    return first.get("embedder", "") or ""
+    return score_marker_embedder_for_snap(snapshot_medias())
 
 
 def embedder_display_name(embedder_name: str) -> str:

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -32,22 +32,17 @@ ProgressCallback = Callable[[str, int, int], None]
 def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     """Return the embedder name to use for fresh resolve+embed work.
 
-    Prefers the **score** embedder (patch-else-text; the v3 routing table)
-    *derived from the medias in snap* so that newly embedded cross-dataset
-    vectors line up with the in-dataset vectors the MLP is scored against.
-    Derived from the snap's own embedder names rather than the active context
-    so a non-active snapshot resolves correctly.  Falls back to the recorded
-    primary embedder for a slot-less single-vector dataset (where the two
-    coincide), and ``""`` when *snap* is empty.
+    Thin alias for the canonical model-keying marker
+    :func:`vtscore.embedding.binding.score_marker_embedder_for_snap`: the
+    **score** embedder (patch-else-text; the v3 routing table) derived from
+    the medias in *snap* so newly embedded cross-dataset vectors line up with
+    the in-dataset vectors the MLP is scored against, falling back to the
+    recorded primary embedder for a slot-less single-vector dataset and ``""``
+    when *snap* is empty.
     """
-    if not snap:
-        return ""
-    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
-    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
+    from vtscore.embedding.binding import score_marker_embedder_for_snap  # noqa: PLC0415
 
-    first = next(iter(snap.values()), {})
-    text, patch = derive_binding_from_names(media_embedder_names(first))
-    return patch or text or first.get("embedder", "") or ""
+    return score_marker_embedder_for_snap(snap)
 
 
 def _patch_pooled_from_file(

--- a/vtscore/detectors/learned_sort.py
+++ b/vtscore/detectors/learned_sort.py
@@ -102,7 +102,13 @@ def update_det_ctx_with_trained_model(det_ctx, model, threshold, labelset, train
         det_ctx.training_medias = training
     if snap:
         first = next(iter(snap.values()), {})
-        det_ctx.embedder = first.get("embedder", "")
+        # Stamp the model-keying marker (score embedder, patch-else-text) the
+        # MLP was trained against - not the per-media primary, which differs
+        # from the scored space on a dual-embedder dataset.  See
+        # ``score_marker_embedder`` and patch-embedder.md Phase 2b.5.
+        from vtscore.embedding.binding import score_marker_embedder
+
+        det_ctx.embedder = score_marker_embedder(first)
         det_ctx.media_type = first.get("media_type", "")
 
 

--- a/vtscore/detectors/model_loading.py
+++ b/vtscore/detectors/model_loading.py
@@ -47,8 +47,12 @@ def resolve_or_train_detector(  # noqa: C901
         # Defense against H5: scoring Auto-Find detectors iterates contexts
         # that aren't the active one, so the before_request hook can't
         # have invalidated their stale MLPs.  Drop them here so the next
-        # branch trains fresh against *snap*'s embedder.
-        snap_embedder = next(iter(snap.values()), {}).get("embedder", "") or "" if snap else ""
+        # branch trains fresh against *snap*'s embedder.  Compare the
+        # score-embedder marker (patch-else-text), matching what training
+        # stamps - the per-media primary diverges on a dual dataset.
+        from vtscore.embedding.binding import score_marker_embedder_for_snap
+
+        snap_embedder = score_marker_embedder_for_snap(snap)
         invalidate_detector_model_on_embedder_mismatch(det_ctx, snap_embedder)
     if det_ctx is not None and det_ctx.model is not None:
         return det_ctx.model, det_ctx.threshold, None

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -164,7 +164,13 @@ def apply_and_retrain(  # noqa: C901
                     training[cid] = snap[cid]
             det_ctx.training_medias = training
             first = next(iter(snap.values()), {})
-            det_ctx.embedder = first.get("embedder", "")
+            # Stamp the model-keying marker (score embedder, patch-else-text)
+            # the MLP was trained against, not the per-media primary - they
+            # differ on a dual-embedder dataset.  See ``score_marker_embedder``
+            # and patch-embedder.md Phase 2b.5.
+            from vtscore.embedding.binding import score_marker_embedder
+
+            det_ctx.embedder = score_marker_embedder(first)
             det_ctx.media_type = first.get("media_type", "")
             from vtscore.detectors.registry import record_detector_embedder
 

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -25,6 +25,9 @@ capabilities" (and is therefore ineligible for either slot).
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
+
+from vtscore.embedding.media_vectors import media_embedder_names
 
 
 def _capabilities(embedder_name: str) -> tuple[bool, bool]:
@@ -82,6 +85,43 @@ def derive_binding_from_names(embedder_names: Iterable[str | None]) -> tuple[str
         if supports_patch and patch_embedder is None:
             patch_embedder = name
     return (text_embedder, patch_embedder)
+
+
+def score_marker_embedder(media: dict[str, Any]) -> str:
+    """Concrete embedder name a detector MLP is keyed to for *media*.
+
+    This is the v3 model-keying marker (the "embedder" component of the
+    ``(detector, dataset, embedder)`` MLP key in ``docs/plans/patch-embedder.md``).
+    It resolves to the **score** embedder (patch-else-text, the routing
+    table) when a role slot is bound, and falls back to *media*'s primary
+    embedder *name* for a slot-less single-vector dataset (e.g.
+    ``dinov2_single``).  ``""`` only when *media* carries no embedder at all.
+
+    Unlike :meth:`DatasetContext.routed_embedder`, which returns ``None`` for
+    a slot-less dataset so the matrix layer collapses to the cached primary
+    path, this always returns a concrete name so it can be stamped on and
+    compared against ``DetectorContext.embedder`` (a ``str``).  The two never
+    disagree about which vector space a model was trained against: for a
+    single-embedder dataset both name the same embedder; for a dual dataset
+    both pick the patch-else-text slot; only the slot-less fallback differs
+    (a name here vs ``None`` there), and that name *is* the primary the
+    matrix layer reads in that case.
+    """
+    text, patch = derive_binding_from_names(media_embedder_names(media))
+    return patch or text or media.get("embedder", "") or ""
+
+
+def score_marker_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str:
+    """:func:`score_marker_embedder` for the first media in a *snap* dict.
+
+    Returns ``""`` when *snap* is empty.  Used by the model-invalidation and
+    cross-dataset training paths, which derive the marker from the medias they
+    are about to score rather than from the active context's binding (a
+    non-active snapshot resolves correctly this way).
+    """
+    if not snap:
+        return ""
+    return score_marker_embedder(next(iter(snap.values()), {}))
 
 
 def validate_binding(text_embedder: str | None, patch_embedder: str | None) -> None:


### PR DESCRIPTION
Two commits, both in the triple-embedder (patch-embedder V3) line of work.

## 1. Phase 2b.5 — key the detector MLP by the score embedder, not the primary mirror

The cached detector MLP (`DetectorContext.model`) is keyed to which embedding space it was trained against (`DetectorContext.embedder`) and invalidated when the active dataset's embedder differs. That comparison read the per-media singular `media["embedder"]` mirror. For every single-embedder dataset that equals the score embedder, but on a **multi-embedder (text + patch + structural)** dataset they diverge: the primary mirror is the *text* embedder while the MLP trains/scores against the *patch* (or structural) embedder. So a stale text-keyed MLP could survive a switch onto a different scoring space (silent garbage scores, or an `nn.Linear` size-mismatch crash when dims differ).

- New canonical marker resolver `vtscore.embedding.binding.score_marker_embedder` (+ `score_marker_embedder_for_snap`): **patch-else-text**, falling back to the primary *name* for a slot-less single-vector dataset so the marker is always a concrete string to compare against `DetectorContext.embedder`.
- Routed every marker **write** (`learned_sort`, `workflow`, `labelset_training`, `embedder_sync`) and every **"new embedder" comparison** (`dataset_sync._embedder_of_active_dataset`, `model_loading`'s Auto-Find defensive check, `embedder_sync.active_dataset_embedder_name`) through that one helper.
- **Byte-for-byte unchanged for single-embedder datasets** (score-marker == primary); the only behavior change is on a multi-embedder dataset (which can't be created until the create-time picker lands).
- New `TestScoreMarkerEmbedder` in `tests_lib/core/test_dataset_binding.py`. Full suite green: **5026 passed, 1 skipped**.

## 2. Reconcile the plan docs to a coherent text / patch / structural **trio**

The plans disagreed: `patch-embedder.md` V3 framed the binding as a text+patch "dual" model and listed structural coexistence as out-of-scope, while `structural-embedder.md` said structural would slot in as a third role when patch v3 lands.

Both now describe one design: v3 binds **up to one embedder per role across three role types** (text / patch / structural), at least one slot filled, all coexisting — surfaced as **three independent role pickers** at create time. Updated: V3 intro, schema (`embeddings` dict multi-valued; `patch_regions`/`patch_grid`/`local_features` single-valued), dataset binding (`structural_embedder` slot + `supports_geometric_verification` + at-least-one constraint), routing table (structural role + score precedence **structural ▸ patch ▸ text**), MLP keying, loader/exporter/importer, frontend (three pickers), migration, out-of-scope, open questions (patch-vs-structural precedence + coexistence), phasing, status header, and the 2b.3/2b.4 follow-ups. `structural-embedder.md` reframes "dual-embedder deferred" → "third role of the active v3 trio".

Plan status now: **Phases 2a–2b.5 shipped; 2c (drop the singular mirror) remains, then the create-time three-role picker.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)