### PR TITLE
test(zoneless): migrate tractable specs to the zoneless TestBed (Phase 5)

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -847,13 +847,39 @@ unrelated to zoneless — see Open follow-ups.
     from the zoneless work.
   - **Migrate the remaining specs to the zoneless `TestBed`** + DOM-after-
     `whenStable()` assertions and delete the manual `fixture.detectChanges()`
-    pumps (still ~188 across ~39 files). The conversions are compile-verified and
-    a handful of canaries exist, but most specs still run on the default (zoned)
-    TestBed with `detectChanges`, so they are not yet staleness oracles. (Heavy
-    containers — left-panel, dashboard, right-panel, app — deadlock `whenStable()`
-    via their child rxResources; those need stubbed/lightweight harnesses.)
-    **This is now also the last blocker on removing `zone.js` entirely:** those
-    ~36 fixture-creating specs need `NgZone` from the default TestBed, so the test
+    pumps. **In progress — the tractable leaf/modal/list specs are DONE (22 spec
+    files migrated in one pass).** Migrated to `provideZoneless()` +
+    `settleZoneless()`/`setInput()`/`TestBed.tick()` (no manual `detectChanges`):
+    `progress-bar`, `select-mode`, `inclusion-slider`, `stripe-overview`,
+    `label-sort`, `media-item`, `audio-player`, `video-player`, `text-viewer`,
+    `progress-indicators`, `detector-context-bar`, `modal`, `sort-bar`,
+    `autopilot-panel`, `dataset-card`, `detector-card`, `load-sort-modal`,
+    `autodetect-results-modal`, `autodetect-progress-modal`, `settings-modal`,
+    `export-modal`, `progress-modal`, `new-detector-modal`, `examples-editor-modal`,
+    `combine-datasets-modal`, `dataset-importer-modal`, `label-list`. Pattern notes:
+    drive `@Input`/signal inputs through `componentRef.setInput()` (a CD trigger,
+    so a plain field write on a top-level fixture host won't schedule CD — the
+    `modal` host uses signals); plain `ngOnInit` HTTP subscribes don't block
+    `whenStable()` so `settleZoneless()` works, but **rxResource-backed init must
+    use `TestBed.tick()` + `settleResource()`** (a loading resource holds the app
+    unstable and deadlocks `whenStable()`). This pass also surfaced and **fixed
+    five real zoneless staleness bugs** the oracle exposed — plain fields written
+    from HTTP `.subscribe()` callbacks yet read in the template, now signals
+    (Recipe B): `text-viewer.text`, `autodetect-results-modal`
+    (`exporters`/`selectedExporter`/`exporterFields`), `examples-editor-modal`
+    (`examples`/`loading`/`saving`), `combine-datasets-modal`
+    (`mediaTypes`/`submitting`/`error`), and `label-list.sortedEntries` (rebuilt
+    from the `metadataCache.version$` subscribe).
+    **Still remaining (the hard classes, untouched):**
+    - **Contract specs** deliberately kept on the default TestBed (paired with a
+      `.zoneless.spec.ts` canary): `label-view.component` (16),
+      `center-panel.component` (10), `image-viewer.component` (1).
+    - **Heavy containers** that deadlock `whenStable()` via their child
+      rxResources and need stubbed/lightweight harnesses: `app.component` (10),
+      `right-panel.component` (8), `left-panel.component` (7), `media-list` (5),
+      `dashboard.component` (3).
+    **This is also the last blocker on removing `zone.js` entirely:** those
+    fixture-creating specs need `NgZone` from the default TestBed, so the test
     polyfills cannot drop base `zone.js` until they move to the zoneless TestBed.
   - **Drop the `vitest-patch` bridge. ✅ DONE.** Converted all 43 fakeAsync
     occurrences (11 files) to native `async` + Vitest fake timers and removed

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('AudioPlayerComponent', () => {
   let component: AudioPlayerComponent;
@@ -18,7 +20,7 @@ describe('AudioPlayerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AudioPlayerComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(AudioPlayerComponent);
     component = fixture.componentInstance;
@@ -36,18 +38,16 @@ describe('AudioPlayerComponent', () => {
     expect(component.audioSrc).toBe('/api/medias/1/audio');
   });
 
-  it('should render canvas and audio elements', () => {
-    component.media = mockMedia;
-    component.audioSrc = '/api/medias/1/audio';
-    fixture.detectChanges();
+  it('should render canvas and audio elements', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('canvas')).toBeTruthy();
     expect(fixture.nativeElement.querySelector('audio')).toBeTruthy();
   });
 
-  it('should have controls on audio element', () => {
-    component.media = mockMedia;
-    component.audioSrc = '/api/medias/1/audio';
-    fixture.detectChanges();
+  it('should have controls on audio element', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
     const audio = fixture.nativeElement.querySelector('audio');
     expect(audio.hasAttribute('controls')).toBe(true);
     expect(audio.hasAttribute('loop')).toBe(true);

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.html
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.html
@@ -1,1 +1,1 @@
-<div class="text-content">{{ text }}</div>
+<div class="text-content">{{ text() }}</div>

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -3,6 +3,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TextViewerComponent } from './text-viewer.component';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('TextViewerComponent', () => {
   let component: TextViewerComponent;
@@ -20,7 +22,7 @@ describe('TextViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TextViewerComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
     fixture = TestBed.createComponent(TextViewerComponent);
     component = fixture.componentInstance;
@@ -35,45 +37,40 @@ describe('TextViewerComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display loading initially', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    fixture.detectChanges();
+  it('should display loading initially', async () => {
+    // setInput drives ngOnChanges (the real channel), which kicks off the fetch.
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.textContent).toContain('Loading...');
-    // ngOnChanges kicks off the text fetch; flush the in-flight request so the
-    // afterEach httpMock.verify() sees no dangling request. The loading-state
-    // assertion above is checked before the response arrives.
+    // Flush the in-flight request so afterEach httpMock.verify() sees none
+    // dangling. The loading-state assertion above runs before the response.
     httpMock.expectOne('/api/medias/4/text').flush({ content: 'done' });
   });
 
-  it('should load and display text', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    fixture.detectChanges();
+  // Zoneless staleness path: `text` is written from an HTTP `.subscribe()`
+  // callback (not a CD trigger). It is a signal, so the response repaints the
+  // DOM with no manual detectChanges.
+  it('should load and display text', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
 
     const req = httpMock.expectOne('/api/medias/4/text');
     req.flush({ content: 'Hello world', word_count: 2, character_count: 11 });
-    fixture.detectChanges();
+    await settleZoneless(fixture);
 
-    expect(component.text).toBe('Hello world');
+    expect(component.text()).toBe('Hello world');
     expect(fixture.nativeElement.textContent).toContain('Hello world');
   });
 
-  it('should show error on failure', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    fixture.detectChanges();
+  it('should show error on failure', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
 
     const req = httpMock.expectOne('/api/medias/4/text');
     req.error(new ProgressEvent('error'));
-    fixture.detectChanges();
+    await settleZoneless(fixture);
 
-    expect(component.text).toContain('Error');
+    expect(component.text()).toContain('Error');
+    expect(fixture.nativeElement.textContent).toContain('Error');
   });
 });

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { Media } from '../../../models/api.models';
@@ -14,7 +14,9 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
 
   @Input() media!: Media;
 
-  text = 'Loading...';
+  // Signal so the HTTP response (written from a `.subscribe()` callback, which is
+  // not on the zoneless CD-notification path) repaints the view.
+  readonly text = signal('Loading...');
   private sub: Subscription | null = null;
   // See ImageViewerComponent.lastMediaId; avoid re-fetching the text payload
   // every time the metadata cache hydrates a new reference for the same id.
@@ -33,13 +35,13 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
 
   private loadText(): void {
     this.sub?.unsubscribe();
-    this.text = 'Loading...';
+    this.text.set('Loading...');
     this.sub = this.mediasApi.getText(this.media.id).subscribe({
       next: (data) => {
-        this.text = data.content || '';
+        this.text.set(data.content || '');
       },
       error: () => {
-        this.text = 'Error loading text content.';
+        this.text.set('Error loading text content.');
       },
     });
   }

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('VideoPlayerComponent', () => {
   let component: VideoPlayerComponent;
@@ -19,7 +21,7 @@ describe('VideoPlayerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [VideoPlayerComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(VideoPlayerComponent);
     component = fixture.componentInstance;
@@ -37,10 +39,9 @@ describe('VideoPlayerComponent', () => {
     expect(component.videoSrc).toBe('/api/medias/3/video');
   });
 
-  it('should render video element', () => {
-    component.media = mockMedia;
-    component.videoSrc = '/api/medias/3/video';
-    fixture.detectChanges();
+  it('should render video element', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
     const video = fixture.nativeElement.querySelector('video');
     expect(video).toBeTruthy();
     expect(video.hasAttribute('controls')).toBe(true);

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -19,7 +19,7 @@
           class="name-input"
           [(ngModel)]="name"
           placeholder="Combined dataset name"
-          [disabled]="submitting"
+          [disabled]="submitting()"
         />
       </label>
 
@@ -83,21 +83,21 @@
         </p>
       }
 
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
+      @if (error()) {
+        <p class="error-text">{{ error() }}</p>
       }
     }
   </div>
 
   <div class="form-actions" modal-footer>
-    <button class="btn btn--secondary" (click)="close()" [disabled]="submitting">Cancel</button>
+    <button class="btn btn--secondary" (click)="close()" [disabled]="submitting()">Cancel</button>
     <button
       class="btn btn--primary"
       (click)="submit()"
-      [disabled]="submitting || !canCombine"
+      [disabled]="submitting() || !canCombine"
       [title]="disabledReason || 'Combine these datasets into a new one'"
     >
-      @if (submitting) {
+      @if (submitting()) {
         Combining...
       } @else {
         Combine

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
@@ -3,6 +3,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { CombineDatasetsModalComponent } from './combine-datasets-modal.component';
 import { DatasetRegistryEntry } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('CombineDatasetsModalComponent', () => {
   let component: CombineDatasetsModalComponent;
@@ -27,7 +29,7 @@ describe('CombineDatasetsModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CombineDatasetsModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CombineDatasetsModalComponent);
@@ -39,55 +41,52 @@ describe('CombineDatasetsModalComponent', () => {
     httpMock.verify();
   });
 
-  function flushMediaTypes() {
+  // Set the datasets input, settle to run ngOnInit (builds rows + issues the
+  // media-types GET), then flush it.
+  async function init(datasets: DatasetRegistryEntry[]): Promise<void> {
+    fixture.componentRef.setInput('datasets', datasets);
+    await settleZoneless(fixture);
     httpMock.expectOne('/api/media-types').flush(mockMediaTypes);
+    await settleZoneless(fixture);
   }
 
-  it('builds rows from input datasets, filtering out entries with no pkl_path', () => {
-    component.datasets = [
+  it('builds rows from input datasets, filtering out entries with no pkl_path', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/data/a.pkl'),
       ds('b', 'Bravo', 'audio', 20, ''),
       ds('c', 'Charlie', 'audio', 30, '/data/c.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     expect(component.rows.length).toBe(2);
     expect(component.rows.map((r) => r.id)).toEqual(['a', 'c']);
     expect(component.totalItems).toBe(40);
   });
 
-  it('canCombine is true only when ≥2 rows share a single media type', () => {
-    component.datasets = [
+  it('canCombine is true only when ≥2 rows share a single media type', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
       ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     expect(component.canCombine).toBe(true);
     expect(component.disabledReason).toBe('');
   });
 
-  it('canCombine is false when media types differ', () => {
-    component.datasets = [
+  it('canCombine is false when media types differ', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
       ds('b', 'Bravo', 'image', 20, '/x/b.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     expect(component.canCombine).toBe(false);
     expect(component.disabledReason).toContain('share a media type');
   });
 
-  it('canCombine is false when fewer than two rows remain after removal', () => {
-    component.datasets = [
+  it('canCombine is false when fewer than two rows remain after removal', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
       ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     component.removeRow('b');
     expect(component.rows.length).toBe(1);
@@ -95,13 +94,11 @@ describe('CombineDatasetsModalComponent', () => {
     expect(component.disabledReason).toContain('at least two');
   });
 
-  it('submit posts the pkl paths to /api/dataset/combine and emits combineStarted', () => {
-    component.datasets = [
+  it('submit posts the pkl paths to /api/dataset/combine and emits combineStarted', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
       ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     let started = false;
     component.combineStarted.subscribe(() => { started = true; });
@@ -113,16 +110,14 @@ describe('CombineDatasetsModalComponent', () => {
     req.flush({ ok: true });
 
     expect(started).toBe(true);
-    expect(component.submitting).toBe(false);
+    expect(component.submitting()).toBe(false);
   });
 
-  it('submit surfaces backend errors without emitting combineStarted', () => {
-    component.datasets = [
+  it('submit surfaces backend errors without emitting combineStarted', async () => {
+    await init([
       ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
       ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
-    ];
-    fixture.detectChanges();
-    flushMediaTypes();
+    ]);
 
     let started = false;
     component.combineStarted.subscribe(() => { started = true; });
@@ -132,14 +127,12 @@ describe('CombineDatasetsModalComponent', () => {
     req.flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
 
     expect(started).toBe(false);
-    expect(component.error).toBe('boom');
-    expect(component.submitting).toBe(false);
+    expect(component.error()).toBe('boom');
+    expect(component.submitting()).toBe(false);
   });
 
-  it('submit is a no-op when canCombine is false', () => {
-    component.datasets = [ds('a', 'Alpha', 'audio', 10, '/x/a.pkl')];
-    fixture.detectChanges();
-    flushMediaTypes();
+  it('submit is a no-op when canCombine is false', async () => {
+    await init([ds('a', 'Alpha', 'audio', 10, '/x/a.pkl')]);
 
     component.submit();
     httpMock.expectNone('/api/dataset/combine');

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject, output } from '@angular/core';
+import { Component, Input, OnInit, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -33,9 +33,11 @@ export class CombineDatasetsModalComponent implements OnInit {
   readonly combineStarted = output<void>();
 
   rows: CombineRow[] = [];
-  mediaTypes: MediaTypeInfo[] = [];
-  submitting = false;
-  error = '';
+  // Signals: written from the media-types / combine subscribes (async, not a
+  // zoneless CD trigger) yet read in the template, so they must repaint on emit.
+  readonly mediaTypes = signal<MediaTypeInfo[]>([]);
+  readonly submitting = signal(false);
+  readonly error = signal('');
   name = '';
 
   ngOnInit(): void {
@@ -53,7 +55,7 @@ export class CombineDatasetsModalComponent implements OnInit {
 
     this.datasetsListingsApi.getMediaTypes().subscribe({
       next: (res) => {
-        this.mediaTypes = res.media_types || [];
+        this.mediaTypes.set(res.media_types || []);
       },
     });
   }
@@ -92,12 +94,12 @@ export class CombineDatasetsModalComponent implements OnInit {
   }
 
   mediaTypeLabel(typeId: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    const mt = this.mediaTypes().find((m) => m.type_id === typeId);
     return mt?.name || typeId;
   }
 
   mediaTypeIcon(typeId: string): string {
-    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    const mt = this.mediaTypes().find((m) => m.type_id === typeId);
     return mt?.icon || '';
   }
 
@@ -107,18 +109,18 @@ export class CombineDatasetsModalComponent implements OnInit {
 
   submit(): void {
     if (!this.canCombine) return;
-    this.submitting = true;
-    this.error = '';
+    this.submitting.set(true);
+    this.error.set('');
     const paths = this.rows.map((r) => r.pkl_path);
     const name = (this.name || '').trim() || this.defaultName();
     this.datasetsCrudApi.combineDatasets({ datasets: paths, name }).subscribe({
       next: () => {
-        this.submitting = false;
+        this.submitting.set(false);
         this.combineStarted.emit();
       },
       error: (err) => {
-        this.submitting = false;
-        this.error = (err?.error?.error as string) || 'Combine failed';
+        this.submitting.set(false);
+        this.error.set((err?.error?.error as string) || 'Combine failed');
       },
     });
   }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatasetCardComponent } from './dataset-card.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('DatasetCardComponent', () => {
   let component: DatasetCardComponent;
@@ -18,16 +20,17 @@ describe('DatasetCardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DatasetCardComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DatasetCardComponent);
     component = fixture.componentInstance;
-    component.dataset = { ...mockDataset };
+    fixture.componentRef.setInput('dataset', { ...mockDataset });
     // The card only renders middle columns listed in columnOrder; the
     // dashboard supplies this ordering. Provide a representative set so the
     // media-type and item-count cells render.
-    component.columnOrder = ['media_type', 'num_items', 'created_at'];
-    fixture.detectChanges();
+    fixture.componentRef.setInput('columnOrder', ['media_type', 'num_items', 'created_at']);
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -55,18 +58,18 @@ describe('DatasetCardComponent', () => {
     expect(el.querySelector('.load-btn')).toBeFalsy();
   });
 
-  it('should show the load button when not loaded', () => {
-    component.dataset = { ...mockDataset, loaded: false };
-    fixture.detectChanges();
+  it('should show the load button when not loaded', async () => {
+    fixture.componentRef.setInput('dataset', { ...mockDataset, loaded: false });
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.load-btn')).toBeTruthy();
   });
 
-  it('should enter rename mode on rename button click', () => {
+  it('should enter rename mode on rename button click', async () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     expect(component.editing).toBe(true);
     expect(component.editName).toBe('Test Dataset');
     expect(el.querySelector('.inline-edit')).toBeTruthy();
@@ -76,9 +79,10 @@ describe('DatasetCardComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
-    fixture.detectChanges();
-    // Drain the focus setTimeout queued when editing mode opens.
-    await new Promise<void>((resolve) => setTimeout(resolve));
+    // Settle renders the .inline-edit input; the focus setTimeout queued in
+    // beginRename() then runs against the live element.
+    await settleZoneless(fixture);
+    await settleZoneless(fixture);
     const input = el.querySelector('.inline-edit') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
   });
@@ -126,9 +130,9 @@ describe('DatasetCardComponent', () => {
     expect(component.browse.emit).toHaveBeenCalled();
   });
 
-  it('should emit browse for non-audio datasets too', () => {
-    component.dataset = { ...mockDataset, media_type: 'image' };
-    fixture.detectChanges();
+  it('should emit browse for non-audio datasets too', async () => {
+    fixture.componentRef.setInput('dataset', { ...mockDataset, media_type: 'image' });
+    await settleZoneless(fixture);
     vi.spyOn(component.browse, 'emit');
     const el = fixture.nativeElement as HTMLElement;
     const browseBtn = el.querySelector('.browse-btn') as HTMLButtonElement;
@@ -143,9 +147,9 @@ describe('DatasetCardComponent', () => {
     expect(component.formatDate(0)).toBe('-');
   });
 
-  it('should apply selected class via host binding', () => {
-    component.selected = true;
-    fixture.detectChanges();
+  it('should apply selected class via host binding', async () => {
+    fixture.componentRef.setInput('selected', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.classList.contains('selected')).toBe(true);
   });
 });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { DatasetImporterModalComponent } from './dataset-importer-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('DatasetImporterModalComponent', () => {
   let component: DatasetImporterModalComponent;
@@ -129,7 +131,7 @@ describe('DatasetImporterModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DatasetImporterModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DatasetImporterModalComponent);
@@ -161,7 +163,7 @@ describe('DatasetImporterModalComponent', () => {
   }
 
   function flushImporters(): void {
-    fixture.detectChanges();
+    TestBed.tick(); // run ngOnInit under zoneless (issues the init GETs)
     httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters, tabs: mockTabs });
     flushInitRequests();
   }
@@ -215,9 +217,9 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importers().length).toBe(7);
   });
 
-  it('should start with no top-level tab selected and a blank content area', () => {
+  it('should start with no top-level tab selected and a blank content area', async () => {
     flushImporters();
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     expect(component.activeImporterTab()).toBe('');
     expect(component.selectedImporter()).toBeNull();
     const el = fixture.nativeElement as HTMLElement;
@@ -236,9 +238,9 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.activeImporterTab()).toBe('');
   });
 
-  it('should always render the Services tab even when no importers populate it', () => {
+  it('should always render the Services tab even when no importers populate it', async () => {
     flushImporters();
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     const tabLabels = Array.from(el.querySelectorAll('.importer-tab')).map(
       (b) => (b.textContent || '').trim(),
@@ -250,10 +252,10 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importersForActiveTab.length).toBe(0);
   });
 
-  it('should render inner importer sub-tabs for the active category', () => {
+  it('should render inner importer sub-tabs for the active category', async () => {
     flushImporters();
     component.selectImporterTab('local');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     const subtabs = el.querySelectorAll('.importer-subtab');
     expect(subtabs.length).toBe(2);
@@ -264,7 +266,7 @@ describe('DatasetImporterModalComponent', () => {
     // clears the prior importer selection so the user must click again.
     component.selectImporterTab('server');
     expect(component.selectedImporter()).toBeNull();
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const serverSubtabs = el.querySelectorAll('.importer-subtab');
     expect(serverSubtabs.length).toBe(2);
     expect(serverSubtabs[0].textContent).toContain('Folder');
@@ -272,7 +274,7 @@ describe('DatasetImporterModalComponent', () => {
   });
 
   it('should hide importers marked hidden_from_picker', () => {
-    fixture.detectChanges();
+    TestBed.tick();
     const importersWithHidden = [
       ...mockImporters,
       { name: 'recaller', display_name: 'ReCaller', hidden_from_picker: true, fields: [] },
@@ -586,11 +588,11 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should hide the demo tab bar in favor of a dropdown above the grid', () => {
+  it('should hide the demo tab bar in favor of a dropdown above the grid', async () => {
     flushImporters();
     openAndFlushDemoPicker();
 
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
 
     // The inner media-type tabs are replaced by a <vt-import-config>
@@ -603,7 +605,7 @@ describe('DatasetImporterModalComponent', () => {
 
     // Switching to the 'image' tab swaps in that tab's single row.
     selectDemoTabAndFlush('image', mockImageEmbedders);
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     expect(el.querySelectorAll('.demo-row').length).toBe(1);
   });
 

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectorCardComponent } from './detector-card.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('DetectorCardComponent', () => {
   let component: DetectorCardComponent;
@@ -18,16 +20,17 @@ describe('DetectorCardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DetectorCardComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DetectorCardComponent);
     component = fixture.componentInstance;
-    component.detector = { ...mockDetector };
+    fixture.componentRef.setInput('detector', { ...mockDetector });
     // The card only renders middle columns listed in columnOrder; the
     // dashboard supplies this ordering. Provide a representative set so the
     // media-type and training-count cells render.
-    component.columnOrder = ['media_type', 'num_training', 'last_trained_at'];
-    fixture.detectChanges();
+    fixture.componentRef.setInput('columnOrder', ['media_type', 'num_training', 'last_trained_at']);
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -50,11 +53,11 @@ describe('DetectorCardComponent', () => {
     expect(el.textContent).toContain('50');
   });
 
-  it('should enter rename mode on rename button click', () => {
+  it('should enter rename mode on rename button click', async () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     expect(component.editing).toBe(true);
     expect(el.querySelector('.inline-edit')).toBeTruthy();
   });
@@ -63,9 +66,8 @@ describe('DetectorCardComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
-    fixture.detectChanges();
-    // Drain the focus setTimeout queued when editing mode opens.
-    await new Promise<void>((resolve) => setTimeout(resolve));
+    await settleZoneless(fixture);
+    await settleZoneless(fixture);
     const input = el.querySelector('.inline-edit') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
   });
@@ -99,9 +101,9 @@ describe('DetectorCardComponent', () => {
     expect(component.formatDate(null)).toBe('-');
   });
 
-  it('should apply selected class via host binding', () => {
-    component.selected = true;
-    fixture.detectChanges();
+  it('should apply selected class via host binding', async () => {
+    fixture.componentRef.setInput('selected', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.classList.contains('selected')).toBe(true);
   });
 });

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { NewDetectorModalComponent } from './new-detector-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('NewDetectorModalComponent', () => {
   let component: NewDetectorModalComponent;
@@ -11,13 +12,13 @@ describe('NewDetectorModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NewDetectorModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NewDetectorModalComponent);
     component = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
+    TestBed.tick(); // run ngOnInit under zoneless (issues the init GETs)
 
     // Flush the media types request from ngOnInit
     httpMock.expectOne('/api/media-types').flush({
@@ -227,14 +228,14 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NewDetectorModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NewDetectorModalComponent);
     component = fixture.componentInstance;
     component.defaultMediaType = 'image';
     httpMock = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
+    TestBed.tick(); // run ngOnInit under zoneless (issues the init GETs)
 
     httpMock.expectOne('/api/media-types').flush({
       media_types: [

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AutopilotPanelComponent } from './autopilot-panel.component';
 import { AutopilotStateService } from '../../../services/autopilot-state.service';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('AutopilotPanelComponent', () => {
   let component: AutopilotPanelComponent;
@@ -10,12 +12,13 @@ describe('AutopilotPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AutopilotPanelComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutopilotPanelComponent);
     component = fixture.componentInstance;
     autopilotState = TestBed.inject(AutopilotStateService);
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   afterEach(() => {
@@ -31,12 +34,12 @@ describe('AutopilotPanelComponent', () => {
     expect(component.running).toBe(true);
   });
 
-  it('should emit started on init', () => {
+  it('should emit started on init', async () => {
     autopilotState.clear();
     const fresh = TestBed.createComponent(AutopilotPanelComponent);
     const comp = fresh.componentInstance;
     vi.spyOn(comp.started, 'emit');
-    fresh.detectChanges();
+    await settleZoneless(fresh);
     expect(comp.started.emit).toHaveBeenCalled();
   });
 
@@ -166,7 +169,6 @@ describe('AutopilotPanelComponent', () => {
     autopilotState.checkPhaseTransition(10, 10);
     expect(component.state.phase).toBe('new');
 
-    fixture.detectChanges();
     const steps = component.steps;
     const newStep = steps.find((s: any) => s.phase === 'new');
     // The diversity (new) phase runs after smart + stable are already green,
@@ -243,9 +245,9 @@ describe('AutopilotPanelComponent', () => {
     expect(stepLabels[3].title).toContain('Diversity exploration');
   });
 
-  it('should show phase intent tooltip on each collapsed-step dot', () => {
+  it('should show phase intent tooltip on each collapsed-step dot', async () => {
     fixture.componentRef.setInput('collapsed', true);
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const dots = fixture.nativeElement.querySelectorAll('.collapsed-step');
     expect(dots.length).toBe(5);
     expect(dots[0].title).toContain('Phase 1');
@@ -256,32 +258,32 @@ describe('AutopilotPanelComponent', () => {
     expect(dots[2].title).toContain('uncertain items');
   });
 
-  it('should emit refocus when clicking the active step', () => {
+  it('should emit refocus when clicking the active step', async () => {
     vi.spyOn(component.refocus, 'emit');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const activeStep = fixture.nativeElement.querySelector('.ap-step.active');
     activeStep.click();
     expect(component.refocus.emit).toHaveBeenCalled();
   });
 
-  it('should not emit refocus when clicking a future step', () => {
+  it('should not emit refocus when clicking a future step', async () => {
     vi.spyOn(component.refocus, 'emit');
-    fixture.detectChanges();
+    await settleZoneless(fixture);
     const futureSteps = fixture.nativeElement.querySelectorAll('.ap-step.future');
     futureSteps[0].click();
     expect(component.refocus.emit).not.toHaveBeenCalled();
   });
 
-  it('activate without labelset labels should not enter retrain mode', () => {
+  it('activate without labelset labels should not enter retrain mode', async () => {
     autopilotState.clear();
     const fresh = TestBed.createComponent(AutopilotPanelComponent);
     fresh.componentInstance.labelsetGoodCount = 0;
     fresh.componentInstance.labelsetBadCount = 0;
-    fresh.detectChanges();
+    await settleZoneless(fresh);
     expect(fresh.componentInstance.state.retrainMode).toBe(false);
   });
 
-  it('activate with detector labels from another dataset should enter retrain mode', () => {
+  it('activate with detector labels from another dataset should enter retrain mode', async () => {
     autopilotState.clear();
     const fresh = TestBed.createComponent(AutopilotPanelComponent);
     // Simulate "trained on DatasetA, switched to DatasetB with 0 votes here":
@@ -290,7 +292,7 @@ describe('AutopilotPanelComponent', () => {
     fresh.componentInstance.labelsetBadCount = 4;
     fresh.componentInstance.goodVotes = new Set();
     fresh.componentInstance.badVotes = new Set();
-    fresh.detectChanges();
+    await settleZoneless(fresh);
     expect(fresh.componentInstance.state.retrainMode).toBe(true);
     // Still in 'good' phase since current-dataset votes are below threshold.
     expect(fresh.componentInstance.state.phase).toBe('good');

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.spec.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { InclusionSliderComponent } from './inclusion-slider.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('InclusionSliderComponent', () => {
   let component: InclusionSliderComponent;
@@ -8,11 +10,12 @@ describe('InclusionSliderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [InclusionSliderComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(InclusionSliderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaItemComponent } from './media-item.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('MediaItemComponent', () => {
   let component: MediaItemComponent;
@@ -18,13 +20,13 @@ describe('MediaItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaItemComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MediaItemComponent);
     component = fixture.componentInstance;
-    component.media = mockMedia;
-    fixture.detectChanges();
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -51,21 +53,21 @@ describe('MediaItemComponent', () => {
     expect(component.select.emit).toHaveBeenCalledWith(1);
   });
 
-  it('should add active class when active', () => {
-    component.active = true;
-    fixture.detectChanges();
+  it('should add active class when active', async () => {
+    fixture.componentRef.setInput('active', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.media-item.active')).toBeTruthy();
   });
 
-  it('should add labeled-good class when vote is good', () => {
-    component.voteLabel = 'good';
-    fixture.detectChanges();
+  it('should add labeled-good class when vote is good', async () => {
+    fixture.componentRef.setInput('voteLabel', 'good');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.media-item.labeled-good')).toBeTruthy();
   });
 
-  it('should add labeled-bad class when vote is bad', () => {
-    component.voteLabel = 'bad';
-    fixture.detectChanges();
+  it('should add labeled-bad class when vote is bad', async () => {
+    fixture.componentRef.setInput('voteLabel', 'bad');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.media-item.labeled-bad')).toBeTruthy();
   });
 
@@ -99,15 +101,15 @@ describe('MediaItemComponent', () => {
     expect(component.thumbnailUrl).toBe('/api/medias/2/thumbnail');
   });
 
-  it('should show score when provided', () => {
-    component.score = 0.85;
-    fixture.detectChanges();
+  it('should show score when provided', async () => {
+    fixture.componentRef.setInput('score', 0.85);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.media-score')).toBeTruthy();
   });
 
-  it('should not show score when null', () => {
-    component.score = null;
-    fixture.detectChanges();
+  it('should not show score when null', async () => {
+    fixture.componentRef.setInput('score', null);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.media-score')).toBeNull();
   });
 });

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProgressIndicatorsComponent } from './progress-indicators.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('ProgressIndicatorsComponent', () => {
   let component: ProgressIndicatorsComponent;
@@ -8,11 +10,12 @@ describe('ProgressIndicatorsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProgressIndicatorsComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProgressIndicatorsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -39,7 +42,6 @@ describe('ProgressIndicatorsComponent', () => {
       stable: { status: 'yellow' },
       span: { status: '' },
     };
-    fixture.detectChanges();
     expect(component.smartStatus).toBe('green');
     expect(component.stableStatus).toBe('yellow');
     expect(component.spanStatus).toBe('');
@@ -92,25 +94,25 @@ describe('ProgressIndicatorsComponent', () => {
     expect(component.spanSubtext).toBe('3/4');
   });
 
-  it('should show sort overlay when sortBusy is true', () => {
-    component.sortBusy = true;
-    component.sortStatus = 'Sorting...';
-    fixture.detectChanges();
+  it('should show sort overlay when sortBusy is true', async () => {
+    fixture.componentRef.setInput('sortBusy', true);
+    fixture.componentRef.setInput('sortStatus', 'Sorting...');
+    await settleZoneless(fixture);
     const overlay = fixture.nativeElement.querySelector('.sort-overlay');
     expect(overlay).toBeTruthy();
     expect(overlay.textContent).toContain('Sorting...');
     expect(fixture.nativeElement.querySelector('.labeling-indicator')).toBeNull();
   });
 
-  it('should show progress bar inside sort overlay when busy', () => {
-    component.sortBusy = true;
-    fixture.detectChanges();
+  it('should show progress bar inside sort overlay when busy', async () => {
+    fixture.componentRef.setInput('sortBusy', true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.sort-overlay vt-progress-bar')).toBeTruthy();
   });
 
-  it('should show indicators when sortBusy is false', () => {
-    component.sortBusy = false;
-    fixture.detectChanges();
+  it('should show indicators when sortBusy is false', async () => {
+    fixture.componentRef.setInput('sortBusy', false);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.sort-overlay')).toBeNull();
     expect(fixture.nativeElement.querySelectorAll('.labeling-indicator').length).toBe(3);
   });
@@ -160,16 +162,16 @@ describe('ProgressIndicatorsComponent', () => {
     expect(buttons[2].getAttribute('title')).toContain('Diverse: your votes cover the dataset broadly.');
   });
 
-  it('should set data-status attribute on indicators', () => {
-    component.labelingStatus = {
+  it('should set data-status attribute on indicators', async () => {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'yellow' },
       span: { status: 'red' },
-    };
-    fixture.detectChanges();
+    });
+    await settleZoneless(fixture);
     const buttons = fixture.nativeElement.querySelectorAll('.labeling-indicator');
     expect(buttons[0].getAttribute('data-status')).toBe('green');
     expect(buttons[1].getAttribute('data-status')).toBe('yellow');

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.spec.ts
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectModeComponent } from './select-mode.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('SelectModeComponent', () => {
   let component: SelectModeComponent;
@@ -8,11 +10,12 @@ describe('SelectModeComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SelectModeComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SelectModeComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -34,9 +37,9 @@ describe('SelectModeComponent', () => {
     expect(component.selectModeChange.emit).toHaveBeenCalledWith('hard');
   });
 
-  it('should mark active radio with active class', () => {
-    component.selectMode = 'hard';
-    fixture.detectChanges();
+  it('should mark active radio with active class', async () => {
+    fixture.componentRef.setInput('selectMode', 'hard');
+    await settleZoneless(fixture);
     const labels = fixture.nativeElement.querySelectorAll('.sort-radio');
     expect(labels[1].classList.contains('active')).toBe(true);
   });

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SortBarComponent } from './sort-bar.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('SortBarComponent', () => {
   let component: SortBarComponent;
@@ -8,11 +10,12 @@ describe('SortBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SortBarComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SortBarComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -23,21 +26,21 @@ describe('SortBarComponent', () => {
     expect(component.sortMode).toBe('text');
   });
 
-  it('should show text input when in text mode', () => {
-    component.sortMode = 'text';
-    fixture.detectChanges();
+  it('should show text input when in text mode', async () => {
+    fixture.componentRef.setInput('sortMode', 'text');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.text-sort-input')).toBeTruthy();
   });
 
-  it('should show learned sort wrap when in learned mode', () => {
-    component.sortMode = 'learned';
-    fixture.detectChanges();
+  it('should show learned sort wrap when in learned mode', async () => {
+    fixture.componentRef.setInput('sortMode', 'learned');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.learned-sort-wrap')).toBeTruthy();
   });
 
-  it('should show load sort wrap when in load mode', () => {
-    component.sortMode = 'load';
-    fixture.detectChanges();
+  it('should show load sort wrap when in load mode', async () => {
+    fixture.componentRef.setInput('sortMode', 'load');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.load-sort-wrap')).toBeTruthy();
   });
 
@@ -79,35 +82,33 @@ describe('SortBarComponent', () => {
     expect(component.textSort.emit).not.toHaveBeenCalled();
   });
 
-  it('should render a Search button alongside the text input', () => {
-    component.sortMode = 'text';
-    fixture.detectChanges();
+  it('should render a Search button alongside the text input', async () => {
+    fixture.componentRef.setInput('sortMode', 'text');
+    await settleZoneless(fixture);
     const btn = fixture.nativeElement.querySelector('.text-sort-btn');
     expect(btn).toBeTruthy();
     expect(btn.textContent).toContain('Search');
   });
 
   it('should disable Search button when query is empty or whitespace', () => {
-    component.sortMode = 'text';
+    // searchDisabled is a getter over the internal textQuery field; no render.
     component.textQuery = '   ';
-    fixture.detectChanges();
     expect(component.searchDisabled).toBe(true);
     component.textQuery = 'cats';
-    fixture.detectChanges();
     expect(component.searchDisabled).toBe(false);
   });
 
-  it('should show hint when learned is disabled', () => {
-    component.sortMode = 'learned';
-    component.learnedSortAvailable = false;
-    fixture.detectChanges();
+  it('should show hint when learned is disabled', async () => {
+    fixture.componentRef.setInput('sortMode', 'learned');
+    fixture.componentRef.setInput('learnedSortAvailable', false);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.sort-hint')?.textContent).toContain('Need at least');
   });
 
-  it('should show load sort label', () => {
-    component.sortMode = 'load';
-    component.loadSortLabel = 'Detector A';
-    fixture.detectChanges();
+  it('should show load sort label', async () => {
+    fixture.componentRef.setInput('sortMode', 'load');
+    fixture.componentRef.setInput('loadSortLabel', 'Detector A');
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.sort-desc')?.textContent).toContain('Detector A');
   });
 });

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.spec.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StripeOverviewComponent } from './stripe-overview.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('StripeOverviewComponent', () => {
   let component: StripeOverviewComponent;
@@ -8,11 +10,12 @@ describe('StripeOverviewComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [StripeOverviewComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StripeOverviewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {

--- a/frontend/src/app/components/modal/modal.component.spec.ts
+++ b/frontend/src/app/components/modal/modal.component.spec.ts
@@ -1,19 +1,29 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ModalComponent } from './modal.component';
+import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
 
 @Component({
   standalone: true,
   imports: [ModalComponent],
   template: `
-    <vt-modal [title]="'Test Modal'" [open]="isOpen" (closed)="onClose()">
+    <vt-modal
+      [title]="'Test Modal'"
+      [open]="isOpen()"
+      [showCloseButton]="showCloseButton()"
+      (closed)="onClose()"
+    >
       <p>Body content</p>
       <button modal-footer>Footer button</button>
     </vt-modal>
   `,
 })
 class TestHostComponent {
-  isOpen = false;
+  // Signals so the host drives the modal through the zoneless CD path (a plain
+  // field write on the top-level host would not schedule change detection).
+  readonly isOpen = signal(false);
+  readonly showCloseButton = signal(true);
   closeCalled = false;
   onClose(): void {
     this.closeCalled = true;
@@ -27,63 +37,62 @@ describe('ModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
   });
 
-  it('should not render when closed', () => {
-    host.isOpen = false;
-    fixture.detectChanges();
+  it('should not render when closed', async () => {
+    host.isOpen.set(false);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeNull();
   });
 
-  it('should render when open', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should render when open', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeTruthy();
     expect(fixture.nativeElement.querySelector('.modal-header h2')?.textContent).toContain('Test Modal');
   });
 
-  it('should project body content', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should project body content', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.modal-body p')?.textContent).toContain('Body content');
   });
 
-  it('should emit closed on close button click', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should emit closed on close button click', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     fixture.nativeElement.querySelector('.modal-close').click();
     expect(host.closeCalled).toBe(true);
   });
 
-  it('should emit closed on backdrop click', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should emit closed on backdrop click', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     fixture.nativeElement.querySelector('.modal-backdrop').click();
     expect(host.closeCalled).toBe(true);
   });
 
-  it('should not close on content click', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should not close on content click', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     fixture.nativeElement.querySelector('.modal-content').click();
     expect(host.closeCalled).toBe(false);
   });
 
-  it('should hide close button when showCloseButton is false', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
-    const modal = fixture.debugElement.children[0].componentInstance as ModalComponent;
-    modal.showCloseButton = false;
-    fixture.detectChanges();
+  it('should hide close button when showCloseButton is false', async () => {
+    host.isOpen.set(true);
+    host.showCloseButton.set(false);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.modal-close')).toBeNull();
   });
 
-  it('should show close button by default', () => {
-    host.isOpen = true;
-    fixture.detectChanges();
+  it('should show close button by default', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.modal-close')).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AutoDetectProgressModalComponent } from './autodetect-progress-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('AutoDetectProgressModalComponent', () => {
   let component: AutoDetectProgressModalComponent;
@@ -8,21 +10,22 @@ describe('AutoDetectProgressModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AutoDetectProgressModalComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutoDetectProgressModalComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display progress percentage', () => {
-    component.progress = 75;
-    component.statusText = 'Running detector 2 of 3...';
-    fixture.detectChanges();
+  it('should display progress percentage', async () => {
+    fixture.componentRef.setInput('progress', 75);
+    fixture.componentRef.setInput('statusText', 'Running detector 2 of 3...');
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('75%');
     expect(el.textContent).toContain('Running detector 2 of 3');

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -69,14 +69,14 @@
     </div>
 
     <div class="export-row">
-      <select class="form-select" [(ngModel)]="selectedExporter" (ngModelChange)="onExporterChange()" title="Choose export destination">
-        @for (exp of exporters; track exp.name) {
+      <select class="form-select" [ngModel]="selectedExporter()" (ngModelChange)="selectedExporter.set($event); onExporterChange()" title="Choose export destination">
+        @for (exp of exporters(); track exp.name) {
           <option [value]="exp.name">{{ exp.display_name || exp.name }}</option>
         }
       </select>
     </div>
 
-    @for (field of exporterFields; track field.key) {
+    @for (field of exporterFields(); track field.key) {
       <div class="form-group">
         <label class="form-label">{{ field.label || field.key }}{{ field.required ? ' *' : '' }}</label>
         @if (field.field_type === 'select') {

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AutoDetectResultsModalComponent } from './autodetect-results-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('AutoDetectResultsModalComponent', () => {
   let component: AutoDetectResultsModalComponent;
@@ -27,58 +29,61 @@ describe('AutoDetectResultsModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AutoDetectResultsModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutoDetectResultsModalComponent);
     component = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
-    component.data = mockData as any;
+    fixture.componentRef.setInput('data', mockData as any);
   });
 
   afterEach(() => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
-    fixture.detectChanges();
+  // Settle runs ngOnInit (issues GET /api/exporters), flush the response, settle
+  // again so the exporter signals repaint. No manual detectChanges.
+  async function flushInit(): Promise<void> {
+    await settleZoneless(fixture);
     httpMock.expectOne('/api/exporters').flush([
       { name: 'json', label: 'JSON', fields: [] },
       { name: 'csv', label: 'CSV', fields: [{ key: 'path', field_type: 'text', label: 'Path' }] },
     ]);
+    await settleZoneless(fixture);
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should count good and bad hits', () => {
-    flushInit();
+  it('should count good and bad hits', async () => {
+    await flushInit();
     expect(component.goodCount).toBe(2);
     expect(component.badCount).toBe(1);
   });
 
-  it('should display good hits by default', () => {
-    flushInit();
+  it('should display good hits by default', async () => {
+    await flushInit();
     component.exportSides = 'good';
     expect(component.displayHits.length).toBe(2);
   });
 
-  it('should display bad hits when selected', () => {
-    flushInit();
+  it('should display bad hits when selected', async () => {
+    await flushInit();
     component.exportSides = 'bad';
     expect(component.displayHits.length).toBe(1);
   });
 
-  it('should display all hits when both selected', () => {
-    flushInit();
+  it('should display all hits when both selected', async () => {
+    await flushInit();
     component.exportSides = 'both';
     expect(component.displayHits.length).toBe(3);
   });
 
-  it('should format origin with params', () => {
-    flushInit();
+  it('should format origin with params', async () => {
+    await flushInit();
     const hit = {
       md5: 'x',
       origin: { importer: 'folder', params: { path: '/data' } },
@@ -86,35 +91,40 @@ describe('AutoDetectResultsModalComponent', () => {
     expect(component.formatOrigin(hit)).toBe('folder(/data)');
   });
 
-  it('should format origin without params', () => {
-    flushInit();
+  it('should format origin without params', async () => {
+    await flushInit();
     expect(component.formatOrigin({ md5: 'x', origin: { importer: 'folder' } })).toBe('folder');
     expect(component.formatOrigin({ md5: 'x' })).toBe('');
   });
 
-  it('should load exporters on init', () => {
-    flushInit();
-    expect(component.exporters.length).toBe(2);
-    expect(component.selectedExporter).toBe('json');
+  // Zoneless canary: exporters/selectedExporter are written from the
+  // getExporters() subscribe (not a CD trigger) — as signals they repaint the
+  // dropdown.
+  it('should load exporters on init and render the dropdown options', async () => {
+    await flushInit();
+    expect(component.exporters().length).toBe(2);
+    expect(component.selectedExporter()).toBe('json');
+    const options = fixture.nativeElement.querySelectorAll('.export-row select option');
+    expect(options.length).toBe(2);
+    expect(options[0].getAttribute('value')).toBe('json');
   });
 
-  it('should update exporter fields when exporter changes', () => {
-    flushInit();
-    component.selectedExporter = 'csv';
+  it('should update exporter fields when exporter changes', async () => {
+    await flushInit();
+    component.selectedExporter.set('csv');
     component.onExporterChange();
-    expect(component.exporterFields.length).toBe(1);
+    expect(component.exporterFields().length).toBe(1);
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render results table', () => {
-    flushInit();
-    fixture.detectChanges();
+  it('should render results table', async () => {
+    await flushInit();
     const el = fixture.nativeElement as HTMLElement;
     const rows = el.querySelectorAll('.results-table tbody tr');
     expect(rows.length).toBe(2); // good hits by default

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject, output } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, inject, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -30,9 +30,11 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   readonly closed = output<void>();
 
   exportSides: 'good' | 'bad' | 'both' = 'good';
-  exporters: ExporterEntry[] = [];
-  selectedExporter = '';
-  exporterFields: ImporterField[] = [];
+  // Signals: these are written from the getExporters() subscribe callback (not a
+  // zoneless CD trigger) yet read in the template, so they must repaint on emit.
+  readonly exporters = signal<ExporterEntry[]>([]);
+  readonly selectedExporter = signal('');
+  readonly exporterFields = signal<ImporterField[]>([]);
   exportFieldValues: Record<string, string> = {};
 
   /** Columns offered by the shared clipboard control (single-column list mode). */
@@ -49,9 +51,9 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
       next: (list) => {
-        this.exporters = list;
+        this.exporters.set(list);
         if (list.length > 0) {
-          this.selectedExporter = list[0].name;
+          this.selectedExporter.set(list[0].name);
           this.updateExporterFields();
         }
       },
@@ -121,10 +123,11 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   }
 
   private updateExporterFields(): void {
-    const exp = this.exporters.find((e) => e.name === this.selectedExporter);
-    this.exporterFields = (exp?.fields ?? []) as ImporterField[];
+    const exp = this.exporters().find((e) => e.name === this.selectedExporter());
+    const fields = (exp?.fields ?? []) as ImporterField[];
+    this.exporterFields.set(fields);
     this.exportFieldValues = {};
-    for (const field of this.exporterFields) {
+    for (const field of fields) {
       if (field.default) {
         this.exportFieldValues[field.key] = field.default;
       }

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
@@ -1,12 +1,12 @@
 <vt-modal title="Edit Examples" [open]="true" (closed)="close()">
-  @if (loading) {
+  @if (loading()) {
     <p class="empty-state">Loading examples...</p>
   } @else {
     <div class="examples-sections">
       <div class="examples-section">
         <h3>Good Examples ({{ goodExamples.length }})</h3>
         <div class="examples-grid">
-          @for (ex of examples; track $index; let i = $index) {
+          @for (ex of examples(); track $index; let i = $index) {
             @if (ex.type === 'good') {
               <div class="example-card">
                 <span class="example-label">{{ ex.label || 'Example ' + (i + 1) }}</span>
@@ -24,7 +24,7 @@
       <div class="examples-section">
         <h3>Bad Examples ({{ badExamples.length }})</h3>
         <div class="examples-grid">
-          @for (ex of examples; track $index; let i = $index) {
+          @for (ex of examples(); track $index; let i = $index) {
             @if (ex.type === 'bad') {
               <div class="example-card">
                 <span class="example-label">{{ ex.label || 'Example ' + (i + 1) }}</span>
@@ -50,8 +50,8 @@
 
   <div class="editor-actions" modal-footer>
     <button class="btn btn--secondary" (click)="close()">Cancel</button>
-    <button class="btn btn--primary" (click)="save()" [disabled]="saving">
-      {{ saving ? 'Saving...' : 'Save' }}
+    <button class="btn btn--primary" (click)="save()" [disabled]="saving()">
+      {{ saving() ? 'Saving...' : 'Save' }}
     </button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExamplesEditorModalComponent } from './examples-editor-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('ExamplesEditorModalComponent', () => {
   let component: ExamplesEditorModalComponent;
@@ -17,49 +19,56 @@ describe('ExamplesEditorModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ExamplesEditorModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExamplesEditorModalComponent);
     component = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
-    component.modelName = 'test-model';
+    fixture.componentRef.setInput('modelName', 'test-model');
   });
 
   afterEach(() => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
-    fixture.detectChanges();
+  // Settle runs ngOnInit (issues the GET), flush, settle again so the loaded
+  // examples repaint. No manual detectChanges.
+  async function flushInit(): Promise<void> {
+    await settleZoneless(fixture);
     httpMock.expectOne('/api/detectors/test-model').flush({ examples: mockExamples });
+    await settleZoneless(fixture);
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should load examples on init', () => {
-    flushInit();
-    expect(component.examples.length).toBe(3);
-    expect(component.loading).toBe(false);
+  // Zoneless canary: `examples`/`loading` are written from the load subscribe (an
+  // unpatched callback). As signals they repaint the grid, so the loaded cards
+  // render with no manual detectChanges.
+  it('should load examples on init and render the cards', async () => {
+    await flushInit();
+    expect(component.examples().length).toBe(3);
+    expect(component.loading()).toBe(false);
+    expect(fixture.nativeElement.querySelectorAll('.example-card').length).toBe(3);
   });
 
-  it('should count good and bad examples', () => {
-    flushInit();
+  it('should count good and bad examples', async () => {
+    await flushInit();
     expect(component.goodExamples.length).toBe(2);
     expect(component.badExamples.length).toBe(1);
   });
 
-  it('should remove an example', () => {
-    flushInit();
+  it('should remove an example', async () => {
+    await flushInit();
     component.removeExample(0);
-    expect(component.examples.length).toBe(2);
+    expect(component.examples().length).toBe(2);
   });
 
-  it('should save examples', () => {
-    flushInit();
+  it('should save examples', async () => {
+    await flushInit();
     vi.spyOn(component.saved, 'emit');
     component.save();
 
@@ -67,12 +76,14 @@ describe('ExamplesEditorModalComponent', () => {
     expect(req.request.method).toBe('PUT');
     req.flush({});
 
-    expect(component.saving).toBe(false);
+    expect(component.saving()).toBe(false);
     expect(component.saved.emit).toHaveBeenCalled();
+    // Cancel the queued auto-close timer so it cannot leak past the test.
+    component.close();
   });
 
-  it('should show error on save failure', () => {
-    flushInit();
+  it('should show error on save failure', async () => {
+    await flushInit();
     component.save();
     httpMock
       .expectOne('/api/detectors/test-model/examples')
@@ -80,23 +91,24 @@ describe('ExamplesEditorModalComponent', () => {
     expect(component.error()).toBe('Save failed');
   });
 
-  it('should handle empty model name', () => {
-    component.modelName = '';
-    fixture.detectChanges();
-    expect(component.loading).toBe(false);
+  it('should handle empty model name', async () => {
+    fixture.componentRef.setInput('modelName', '');
+    await settleZoneless(fixture);
+    expect(component.loading()).toBe(false);
   });
 
-  it('should handle load error', () => {
-    fixture.detectChanges();
+  it('should handle load error', async () => {
+    await settleZoneless(fixture);
     httpMock
       .expectOne('/api/detectors/test-model')
       .flush({}, { status: 500, statusText: 'Error' });
-    expect(component.loading).toBe(false);
+    await settleZoneless(fixture);
+    expect(component.loading()).toBe(false);
     expect(component.error()).toBe('Failed to load examples');
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -23,67 +23,65 @@ export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
   readonly closed = output<void>();
   readonly saved = output<void>();
 
-  examples: Example[] = [];
-  loading = true;
-  saving = false;
-  // Written from the load/save subscribes (async); template-bound.
+  // Signals: all written from the load/save subscribes (async, not a zoneless CD
+  // trigger) and read in the template, so they must repaint on emit.
+  readonly examples = signal<Example[]>([]);
+  readonly loading = signal(true);
+  readonly saving = signal(false);
   readonly error = signal('');
   readonly status = signal('');
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit(): void {
     if (!this.modelName) {
-      this.loading = false;
+      this.loading.set(false);
       return;
     }
     this.detectorsCrudApi.get(this.modelName).subscribe({
       next: (data: any) => {
-        this.examples = data.examples || [];
-        this.loading = false;
+        this.examples.set(data.examples || []);
+        this.loading.set(false);
       },
       error: () => {
-        this.loading = false;
+        this.loading.set(false);
         this.error.set('Failed to load examples');
       },
     });
   }
 
   get goodExamples(): Example[] {
-    return this.examples.filter((e) => e.type === 'good');
+    return this.examples().filter((e) => e.type === 'good');
   }
 
   get badExamples(): Example[] {
-    return this.examples.filter((e) => e.type === 'bad');
+    return this.examples().filter((e) => e.type === 'bad');
   }
 
   removeExample(index: number): void {
-    this.examples.splice(index, 1);
+    this.examples.update((list) => list.filter((_, i) => i !== index));
   }
 
   onFileSelected(event: Event, type: 'good' | 'bad'): void {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) return;
     const file = input.files[0];
-    this.examples.push({
-      type,
-      label: file.name,
-    });
+    this.examples.update((list) => [...list, { type, label: file.name }]);
     input.value = '';
   }
 
   save(): void {
-    this.saving = true;
+    this.saving.set(true);
     this.error.set('');
     this.status.set('');
-    this.detectorsCrudApi.setExamples(this.modelName, this.examples).subscribe({
+    this.detectorsCrudApi.setExamples(this.modelName, this.examples()).subscribe({
       next: () => {
-        this.saving = false;
+        this.saving.set(false);
         this.status.set('Saved.');
         this.saved.emit();
         this.closeTimer = setTimeout(() => this.close(), 600);
       },
       error: (err) => {
-        this.saving = false;
+        this.saving.set(false);
         this.error.set(err.error?.error || 'Failed to save');
       },
     });

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExportModalComponent } from './export-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource } from '../../../testing/settle-resource';
 
 describe('ExportModalComponent', () => {
@@ -25,7 +26,7 @@ describe('ExportModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ExportModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExportModalComponent);
@@ -42,7 +43,10 @@ describe('ExportModalComponent', () => {
   // `detectChanges()`; tick to issue the GETs (the labels read also waits for
   // `ngOnInit` to set the input-derived filter), then settle before asserting.
   async function flushInit(): Promise<void> {
-    fixture.detectChanges();
+    // Zoneless + rxResource: TestBed.tick() runs ngOnInit and the resource
+    // loader effects to issue the GETs. whenStable() can't be used — a loading
+    // rxResource holds the app unstable — so the rxResource specs drive CD with
+    // tick()/settleResource() and never call detectChanges().
     TestBed.tick();
     // The eager status/exporter GETs fire on the tick; the labels GET is
     // released by `ngOnInit`'s signal flip a microtask later, so settle first

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LoadSortModalComponent } from './load-sort-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('LoadSortModalComponent', () => {
   let component: LoadSortModalComponent;
@@ -11,7 +13,7 @@ describe('LoadSortModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LoadSortModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoadSortModalComponent);
@@ -23,8 +25,8 @@ describe('LoadSortModalComponent', () => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
-    fixture.detectChanges();
+  async function flushInit(): Promise<void> {
+    await settleZoneless(fixture);
     httpMock.expectOne('/api/server-media-files').flush({
       files: [
         { name: 'example', filename: 'example.wav', path: '/data/example.wav', size_bytes: 1000 },
@@ -37,15 +39,16 @@ describe('LoadSortModalComponent', () => {
         { id: 'm2', name: 'Untrained', media_type: 'audio', num_training: 0 },
       ],
     });
+    await settleZoneless(fixture);
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should load server files and registry models on init', () => {
-    flushInit();
+  it('should load server files and registry models on init', async () => {
+    await flushInit();
     expect(component.serverMediaFiles().length).toBe(2);
     expect(component.serverMediaFiles()[0].filename).toBe('example.wav');
     expect(component.registryModels().length).toBe(1);
@@ -53,8 +56,8 @@ describe('LoadSortModalComponent', () => {
     expect(component.loading()).toBe(false);
   });
 
-  it('should emit modelSelected and close when a registry model is loaded', () => {
-    flushInit();
+  it('should emit modelSelected and close when a registry model is loaded', async () => {
+    await flushInit();
     vi.spyOn(component.modelSelected, 'emit');
     vi.spyOn(component.closed, 'emit');
 
@@ -64,8 +67,8 @@ describe('LoadSortModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should load server media and emit', () => {
-    flushInit();
+  it('should load server media and emit', async () => {
+    await flushInit();
     vi.spyOn(component.exampleSortStarted, 'emit');
     vi.spyOn(component.closed, 'emit');
 
@@ -76,16 +79,15 @@ describe('LoadSortModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render file lists', () => {
-    flushInit();
-    fixture.detectChanges();
+  it('should render file lists', async () => {
+    await flushInit();
     const el = fixture.nativeElement as HTMLElement;
     const items = el.querySelectorAll('.file-item');
     expect(items.length).toBe(3); // 1 trained model + 2 media files
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ProgressModalComponent } from './progress-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('ProgressModalComponent', () => {
   let component: ProgressModalComponent;
@@ -11,7 +12,7 @@ describe('ProgressModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProgressModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProgressModalComponent);
@@ -43,7 +44,8 @@ describe('ProgressModalComponent', () => {
     vi.useFakeTimers();
     try {
       component.metric = 'smart';
-      fixture.detectChanges();
+      // TestBed.tick() runs ngOnInit (kicks off the train POST) under zoneless.
+      TestBed.tick();
       expect(component.analyzing).toBe(true);
 
       // Progress now arrives over the `eval` SSE channel, not via HTTP polling.

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { SettingsModalComponent } from './settings-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('SettingsModalComponent', () => {
   let component: SettingsModalComponent;
@@ -33,7 +35,7 @@ describe('SettingsModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SettingsModalComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SettingsModalComponent);
@@ -45,8 +47,11 @@ describe('SettingsModalComponent', () => {
     httpMock.verify();
   });
 
-  function flushInit(): void {
-    fixture.detectChanges();
+  // Settle runs ngOnInit, whose forkJoin issues the four parallel GETs (plain
+  // HTTP subscribes don't hold the app unstable, so whenStable resolves before
+  // the flush). Settle again afterwards so the resolved signals repaint.
+  async function flushInit(): Promise<void> {
+    await settleZoneless(fixture);
     // forkJoin makes all requests in parallel: settings, media types,
     // embedders, and version.
     const settingsReq = httpMock.expectOne('/api/settings');
@@ -59,27 +64,28 @@ describe('SettingsModalComponent', () => {
     mediaTypesReq.flush(mockMediaTypes);
     embeddersReq.flush({ embedders: [] });
     versionReq.flush({ version: '2026-05-07T00:00:00Z' });
+    await settleZoneless(fixture);
   }
 
-  it('should create', () => {
-    flushInit();
+  it('should create', async () => {
+    await flushInit();
     expect(component).toBeTruthy();
   });
 
-  it('should load settings on init', () => {
-    flushInit();
+  it('should load settings on init', async () => {
+    await flushInit();
     expect(component.settings().theme).toBe('dark');
     expect(component.loading()).toBe(false);
   });
 
-  it('should load media types and set active view tab', () => {
-    flushInit();
+  it('should load media types and set active view tab', async () => {
+    await flushInit();
     expect(component.mediaTypes().length).toBe(2);
     expect(component.activeViewTab()).toBe('audio');
   });
 
-  it('should update theme and save', () => {
-    flushInit();
+  it('should update theme and save', async () => {
+    await flushInit();
     component.onThemeChange('light');
     expect(component.settings().theme).toBe('light');
     // onThemeChange persists twice: ThemeService.setTheme issues its own
@@ -89,36 +95,36 @@ describe('SettingsModalComponent', () => {
     reqs.forEach((r) => r.flush(mockSettings));
   });
 
-  it('should toggle boolean setting and save', () => {
-    flushInit();
+  it('should toggle boolean setting and save', async () => {
+    await flushInit();
     component.onToggle('show_animations', false);
     expect(component.settings().show_animations).toBe(false);
     httpMock.expectOne('/api/settings').flush(mockSettings);
   });
 
-  it('should update number setting and save', () => {
-    flushInit();
+  it('should update number setting and save', async () => {
+    await flushInit();
     component.onNumberChange('calibrate_count', 100);
     expect(component.settings().calibrate_count).toBe(100);
     httpMock.expectOne('/api/settings').flush(mockSettings);
   });
 
-  it('should update per-media-type view mode and save', () => {
-    flushInit();
+  it('should update per-media-type view mode and save', async () => {
+    await flushInit();
     component.onViewModeChange('view_mode_left', 'audio', 'grid');
     const dict = component.settings().view_mode_left as Record<string, string>;
     expect(dict['audio']).toBe('grid');
     httpMock.expectOne('/api/settings').flush(mockSettings);
   });
 
-  it('should get view mode for a media type', () => {
-    flushInit();
+  it('should get view mode for a media type', async () => {
+    await flushInit();
     expect(component.getViewMode('view_mode_left', 'audio')).toBe('list');
     expect(component.getViewMode('view_mode_right', 'audio')).toBe('grid');
   });
 
   it('should reset to defaults after confirmation', async () => {
-    flushInit();
+    await flushInit();
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
     component.resetDefaults();
     // Drain the confirm() promise continuation that issues the GET.
@@ -133,41 +139,41 @@ describe('SettingsModalComponent', () => {
   });
 
   it('should not reset when confirmation is declined', async () => {
-    flushInit();
+    await flushInit();
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(false));
     component.resetDefaults();
     await new Promise<void>((resolve) => setTimeout(resolve));
     httpMock.expectNone('/api/settings/defaults');
   });
 
-  it('should use preselectedViewTab when valid', () => {
-    component.preselectedViewTab = 'image';
-    flushInit();
+  it('should use preselectedViewTab when valid', async () => {
+    fixture.componentRef.setInput('preselectedViewTab', 'image');
+    await flushInit();
     expect(component.activeViewTab()).toBe('image');
     expect(component.activeSettingsTab()).toBe('appearance');
   });
 
-  it('should ignore preselectedViewTab when not in mediaTypes', () => {
-    component.preselectedViewTab = 'video';
-    flushInit();
+  it('should ignore preselectedViewTab when not in mediaTypes', async () => {
+    fixture.componentRef.setInput('preselectedViewTab', 'video');
+    await flushInit();
     expect(component.activeViewTab()).toBe('audio');
   });
 
-  it('should ignore empty preselectedViewTab', () => {
-    component.preselectedViewTab = '';
-    flushInit();
+  it('should ignore empty preselectedViewTab', async () => {
+    fixture.componentRef.setInput('preselectedViewTab', '');
+    await flushInit();
     expect(component.activeViewTab()).toBe('audio');
   });
 
-  it('should emit closed on close', () => {
-    flushInit();
+  it('should emit closed on close', async () => {
+    await flushInit();
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should handle init error gracefully', () => {
-    fixture.detectChanges();
+  it('should handle init error gracefully', async () => {
+    await settleZoneless(fixture);
     const settingsReq = httpMock.expectOne('/api/settings');
     const mediaTypesReq = httpMock.expectOne('/api/media-types');
     const embeddersReq = httpMock.expectOne('/api/embedders');

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProgressBarComponent } from './progress-bar.component';
+import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
 
 describe('ProgressBarComponent', () => {
   let component: ProgressBarComponent;
@@ -8,6 +10,7 @@ describe('ProgressBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProgressBarComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
     fixture = TestBed.createComponent(ProgressBarComponent);
     component = fixture.componentInstance;
@@ -35,30 +38,32 @@ describe('ProgressBarComponent', () => {
     expect(component.percentage).toBe(0);
   });
 
-  it('should render progressbar role', () => {
-    fixture.detectChanges();
+  // Zoneless: drive inputs via `setInput` (a CD trigger) and assert the rendered
+  // DOM after `whenStable()` — no manual `detectChanges`.
+  it('should render progressbar role', async () => {
+    await settleZoneless(fixture);
     const track = fixture.nativeElement.querySelector('.progress-track');
     expect(track.getAttribute('role')).toBe('progressbar');
   });
 
-  it('should set width style from percentage', () => {
-    component.value = 75;
-    component.max = 100;
-    fixture.detectChanges();
+  it('should set width style from percentage', async () => {
+    fixture.componentRef.setInput('value', 75);
+    fixture.componentRef.setInput('max', 100);
+    await settleZoneless(fixture);
     const fill = fixture.nativeElement.querySelector('.progress-fill') as HTMLElement;
     expect(fill.style.width).toBe('75%');
   });
 
-  it('should apply indeterminate class', () => {
-    component.indeterminate = true;
-    fixture.detectChanges();
+  it('should apply indeterminate class', async () => {
+    fixture.componentRef.setInput('indeterminate', true);
+    await settleZoneless(fixture);
     const fill = fixture.nativeElement.querySelector('.progress-fill');
     expect(fill.classList).toContain('indeterminate');
   });
 
-  it('should not have aria-valuenow when indeterminate', () => {
-    component.indeterminate = true;
-    fixture.detectChanges();
+  it('should not have aria-valuenow when indeterminate', async () => {
+    fixture.componentRef.setInput('indeterminate', true);
+    await settleZoneless(fixture);
     const track = fixture.nativeElement.querySelector('.progress-track');
     expect(track.getAttribute('aria-valuenow')).toBeNull();
   });

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectorContextBarComponent } from './detector-context-bar.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('DetectorContextBarComponent', () => {
   let component: DetectorContextBarComponent;
@@ -8,51 +10,52 @@ describe('DetectorContextBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DetectorContextBarComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DetectorContextBarComponent);
     component = fixture.componentInstance;
   });
 
-  it('should create', () => {
-    fixture.detectChanges();
+  it('should create', async () => {
+    await settleZoneless(fixture);
     expect(component).toBeTruthy();
   });
 
-  it('should not render when visible is false', () => {
-    component.visible = false;
-    fixture.detectChanges();
+  it('should not render when visible is false', async () => {
+    fixture.componentRef.setInput('visible', false);
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeFalsy();
   });
 
-  it('should render when visible is true', () => {
-    component.visible = true;
-    component.detectorName = 'My Detector';
-    fixture.detectChanges();
+  it('should render when visible is true', async () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('detectorName', 'My Detector');
+    await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeTruthy();
     expect(el.querySelector('.train-context-name')?.textContent).toContain('My Detector');
   });
 
   it('should enter editing mode on startRename', async () => {
-    component.visible = true;
-    component.detectorName = 'Old Name';
-    fixture.detectChanges();
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('detectorName', 'Old Name');
+    await settleZoneless(fixture);
 
     component.startRename();
-    // Drain the focus setTimeout queued by startRename().
-    await new Promise<void>((resolve) => setTimeout(resolve));
-    fixture.detectChanges();
+    // Drain the focus setTimeout queued by startRename(), then settle so the
+    // editing input renders.
+    await settleZoneless(fixture);
 
     expect(component.editing).toBe(true);
     expect(component.editValue).toBe('Old Name');
   });
 
-  it('should not start rename if detectorName is empty', () => {
-    component.visible = true;
-    component.detectorName = '';
-    fixture.detectChanges();
+  it('should not start rename if detectorName is empty', async () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('detectorName', '');
+    await settleZoneless(fixture);
 
     component.startRename();
     expect(component.editing).toBe(false);

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -11,7 +11,7 @@
     <ng-content select="[list-actions]"></ng-content>
   </div>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth() + 'px'" #voteListContainer>
-    @for (entry of sortedEntries; track trackById($index, entry)) {
+    @for (entry of sortedEntries(); track trackById($index, entry)) {
       <div
         class="vote-entry"
         [class.vote-entry-grid]="isGrid"

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { LabelListComponent, LabelEntry } from './label-list.component';
+import { LabelListComponent } from './label-list.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('LabelListComponent', () => {
   let component: LabelListComponent;
@@ -13,26 +15,32 @@ describe('LabelListComponent', () => {
     { id: 3, media_type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },
   ];
 
+  // Set any number of inputs via setInput (a CD trigger) then settle so
+  // ngOnChanges rebuilds the lookup map and the sortedEntries signal.
+  async function setInputs(inputs: Record<string, unknown>): Promise<void> {
+    for (const [k, v] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(k, v);
+    }
+    await settleZoneless(fixture);
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LabelListComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LabelListComponent);
     component = fixture.componentInstance;
   });
 
-  it('should create', () => {
-    fixture.detectChanges();
+  it('should create', async () => {
+    await settleZoneless(fixture);
     expect(component).toBeTruthy();
   });
 
-  it('should display correct label heading and count', () => {
-    component.label = 'good';
-    component.ids = [1, 2];
-    component.medias = sampleMedias;
-    fixture.detectChanges();
+  it('should display correct label heading and count', async () => {
+    await setInputs({ label: 'good', ids: [1, 2], medias: sampleMedias });
 
     const el = fixture.nativeElement as HTMLElement;
     const heading = el.querySelector('h3');
@@ -41,11 +49,8 @@ describe('LabelListComponent', () => {
     expect(heading?.classList.contains('good')).toBe(true);
   });
 
-  it('should display bad label heading', () => {
-    component.label = 'bad';
-    component.ids = [3];
-    component.medias = sampleMedias;
-    fixture.detectChanges();
+  it('should display bad label heading', async () => {
+    await setInputs({ label: 'bad', ids: [3], medias: sampleMedias });
 
     const el = fixture.nativeElement as HTMLElement;
     const heading = el.querySelector('h3');
@@ -55,96 +60,74 @@ describe('LabelListComponent', () => {
 
   describe('sorting', () => {
     beforeEach(() => {
-      component.label = 'good';
-      component.ids = [1, 2, 3];
-      component.medias = sampleMedias;
-      component.clickTimes = { '1': 3, '2': 1, '3': 2 };
-      component.learnedScores = { '1': 0.9, '2': 0.5, '3': 0.7 };
+      // Batch the base inputs; each test adds sortMode then settles once.
+      fixture.componentRef.setInput('label', 'good');
+      fixture.componentRef.setInput('ids', [1, 2, 3]);
+      fixture.componentRef.setInput('medias', sampleMedias);
+      fixture.componentRef.setInput('clickTimes', { '1': 3, '2': 1, '3': 2 });
+      fixture.componentRef.setInput('learnedScores', { '1': 0.9, '2': 0.5, '3': 0.7 });
     });
 
-    it('should sort by time-desc (newest first)', () => {
-      component.sortMode = 'time-desc';
-      fixture.detectChanges();
-      expect(component.sortedEntries.map(e => e.id)).toEqual([1, 3, 2]);
+    it('should sort by time-desc (newest first)', async () => {
+      await setInputs({ sortMode: 'time-desc' });
+      expect(component.sortedEntries().map(e => e.id)).toEqual([1, 3, 2]);
     });
 
-    it('should sort by time-asc (oldest first)', () => {
-      component.sortMode = 'time-asc';
-      fixture.detectChanges();
-      expect(component.sortedEntries.map(e => e.id)).toEqual([2, 3, 1]);
+    it('should sort by time-asc (oldest first)', async () => {
+      await setInputs({ sortMode: 'time-asc' });
+      expect(component.sortedEntries().map(e => e.id)).toEqual([2, 3, 1]);
     });
 
-    it('should sort by name-asc', () => {
-      component.sortMode = 'name-asc';
-      fixture.detectChanges();
-      const names = component.sortedEntries.map(e => e.name);
+    it('should sort by name-asc', async () => {
+      await setInputs({ sortMode: 'name-asc' });
+      const names = component.sortedEntries().map(e => e.name);
       expect(names).toEqual(['clip.mp4', 'photo.jpg', 'song.wav']);
     });
 
-    it('should sort by name-desc', () => {
-      component.sortMode = 'name-desc';
-      fixture.detectChanges();
-      const names = component.sortedEntries.map(e => e.name);
+    it('should sort by name-desc', async () => {
+      await setInputs({ sortMode: 'name-desc' });
+      const names = component.sortedEntries().map(e => e.name);
       expect(names).toEqual(['song.wav', 'photo.jpg', 'clip.mp4']);
     });
 
-    it('should sort by confidence-desc', () => {
-      component.sortMode = 'confidence-desc';
-      fixture.detectChanges();
-      expect(component.sortedEntries.map(e => e.id)).toEqual([1, 3, 2]);
+    it('should sort by confidence-desc', async () => {
+      await setInputs({ sortMode: 'confidence-desc' });
+      expect(component.sortedEntries().map(e => e.id)).toEqual([1, 3, 2]);
     });
 
-    it('should sort by confidence-asc', () => {
-      component.sortMode = 'confidence-asc';
-      fixture.detectChanges();
-      expect(component.sortedEntries.map(e => e.id)).toEqual([2, 3, 1]);
+    it('should sort by confidence-asc', async () => {
+      await setInputs({ sortMode: 'confidence-asc' });
+      expect(component.sortedEntries().map(e => e.id)).toEqual([2, 3, 1]);
     });
 
-    it('should sort by id-asc', () => {
-      component.sortMode = 'id-asc';
-      fixture.detectChanges();
-      expect(component.sortedEntries.map(e => e.id)).toEqual([1, 2, 3]);
+    it('should sort by id-asc', async () => {
+      await setInputs({ sortMode: 'id-asc' });
+      expect(component.sortedEntries().map(e => e.id)).toEqual([1, 2, 3]);
     });
   });
 
   describe('confidence calculation', () => {
-    it('should use score directly for good label', () => {
-      component.label = 'good';
-      component.ids = [1];
-      component.medias = sampleMedias;
-      component.learnedScores = { '1': 0.8 };
-      fixture.detectChanges();
-
-      expect(component.sortedEntries[0].confidence).toBeCloseTo(0.8);
+    it('should use score directly for good label', async () => {
+      await setInputs({ label: 'good', ids: [1], medias: sampleMedias, learnedScores: { '1': 0.8 } });
+      expect(component.sortedEntries()[0].confidence).toBeCloseTo(0.8);
     });
 
-    it('should use 1-score for bad label', () => {
-      component.label = 'bad';
-      component.ids = [1];
-      component.medias = sampleMedias;
-      component.learnedScores = { '1': 0.3 };
-      fixture.detectChanges();
-
-      expect(component.sortedEntries[0].confidence).toBeCloseTo(0.7);
+    it('should use 1-score for bad label', async () => {
+      await setInputs({ label: 'bad', ids: [1], medias: sampleMedias, learnedScores: { '1': 0.3 } });
+      expect(component.sortedEntries()[0].confidence).toBeCloseTo(0.7);
     });
 
-    it('should set confidence to -1 when no score', () => {
-      component.label = 'good';
-      component.ids = [1];
-      component.medias = sampleMedias;
-      component.learnedScores = {};
-      fixture.detectChanges();
-
-      expect(component.sortedEntries[0].confidence).toBe(-1);
+    it('should set confidence to -1 when no score', async () => {
+      await setInputs({ label: 'good', ids: [1], medias: sampleMedias, learnedScores: {} });
+      expect(component.sortedEntries()[0].confidence).toBe(-1);
     });
   });
 
   describe('view modes and thumbnails', () => {
-    beforeEach(() => {
-      component.medias = sampleMedias;
-      // ngOnInit builds the media-id → media lookup map from `medias`;
-      // detectChanges() runs it so thumbnailUrl()/hasThumbnailUrl() resolve.
-      fixture.detectChanges();
+    beforeEach(async () => {
+      // setInput builds the media-id → media lookup map (in ngOnChanges) so
+      // thumbnailUrl()/hasThumbnailUrl() resolve.
+      await setInputs({ medias: sampleMedias });
     });
 
     it('should have thumbnail URL for images', () => {
@@ -165,28 +148,28 @@ describe('LabelListComponent', () => {
       expect(component.thumbnailUrl(3)).toBe('/api/medias/3/thumbnail');
     });
 
-    it('should be in grid mode when viewMode is grid', () => {
-      component.viewMode = 'grid';
+    it('should be in grid mode when viewMode is grid', async () => {
+      await setInputs({ viewMode: 'grid' });
       expect(component.isGrid).toBe(true);
     });
 
-    it('should not be in grid mode when viewMode is list', () => {
-      component.viewMode = 'list';
+    it('should not be in grid mode when viewMode is list', async () => {
+      await setInputs({ viewMode: 'list' });
       expect(component.isGrid).toBe(false);
     });
 
-    it('should not show placeholder icon for audio in grid mode (has thumbnail)', () => {
-      component.viewMode = 'grid';
+    it('should not show placeholder icon for audio in grid mode (has thumbnail)', async () => {
+      await setInputs({ viewMode: 'grid' });
       expect(component.placeholderIcon(1)).toBeNull();
     });
 
-    it('should not show placeholder icon for image in grid mode', () => {
-      component.viewMode = 'grid';
+    it('should not show placeholder icon for image in grid mode', async () => {
+      await setInputs({ viewMode: 'grid' });
       expect(component.placeholderIcon(2)).toBeNull();
     });
 
-    it('should not show placeholder icon in list mode', () => {
-      component.viewMode = 'list';
+    it('should not show placeholder icon in list mode', async () => {
+      await setInputs({ viewMode: 'list' });
       expect(component.placeholderIcon(1)).toBeNull();
     });
   });
@@ -215,25 +198,18 @@ describe('LabelListComponent', () => {
     expect(component.mediaSelected.emit).not.toHaveBeenCalled();
   });
 
-  it('should use filename for entry name', () => {
-    component.ids = [1];
-    component.medias = sampleMedias;
-    fixture.detectChanges();
-    expect(component.sortedEntries[0].name).toBe('song.wav');
+  it('should use filename for entry name', async () => {
+    await setInputs({ ids: [1], medias: sampleMedias });
+    expect(component.sortedEntries()[0].name).toBe('song.wav');
   });
 
-  it('should fallback to Clip #ID when no media found', () => {
-    component.ids = [999];
-    component.medias = sampleMedias;
-    fixture.detectChanges();
-    expect(component.sortedEntries[0].name).toBe('Clip #999');
+  it('should fallback to Clip #ID when no media found', async () => {
+    await setInputs({ ids: [999], medias: sampleMedias });
+    expect(component.sortedEntries()[0].name).toBe('Clip #999');
   });
 
-  it('should render vote entries in the DOM', () => {
-    component.label = 'good';
-    component.ids = [1, 2];
-    component.medias = sampleMedias;
-    fixture.detectChanges();
+  it('should render vote entries in the DOM', async () => {
+    await setInputs({ label: 'good', ids: [1, 2], medias: sampleMedias });
 
     const el = fixture.nativeElement as HTMLElement;
     const entries = el.querySelectorAll('.vote-entry');

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy, inject, input, output } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -60,7 +60,10 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
 
   @ViewChild('voteListContainer') voteListContainer?: ElementRef<HTMLDivElement>;
 
-  sortedEntries: LabelEntry[] = [];
+  // Signal: rebuilt from the metadataCache version$ subscribe (an unpatched
+  // callback, not a zoneless CD trigger) as well as from ngOnChanges, and read in
+  // the template, so it must repaint when the cache hydrates.
+  readonly sortedEntries = signal<LabelEntry[]>([]);
   private pendingScrollPct: number | null = null;
   /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
   private mediaMap = new Map<number, Media>();
@@ -69,12 +72,12 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   ngOnInit(): void {
     this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
     this.metadataCache.ensureLoaded(this.ids);
-    this.sortedEntries = this.buildSortedEntries();
+    this.sortedEntries.set(this.buildSortedEntries());
     // Re-render entry names when the cache hydrates voted items.
     this.metadataCache.version$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
-        this.sortedEntries = this.buildSortedEntries();
+        this.sortedEntries.set(this.buildSortedEntries());
       });
   }
 
@@ -90,7 +93,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     if (changes['ids']) {
       this.metadataCache.ensureLoaded(this.ids);
     }
-    this.sortedEntries = this.buildSortedEntries();
+    this.sortedEntries.set(this.buildSortedEntries());
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LabelSortComponent, LabelSortMode } from './label-sort.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 
 describe('LabelSortComponent', () => {
   let component: LabelSortComponent;
@@ -8,11 +10,12 @@ describe('LabelSortComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LabelSortComponent],
+      providers: [...provideZoneless()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LabelSortComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await settleZoneless(fixture);
   });
 
   it('should create', () => {
@@ -44,9 +47,9 @@ describe('LabelSortComponent', () => {
     expect(values).toContain('id-asc');
   });
 
-  it('should accept mode input', () => {
-    component.mode = 'confidence-desc';
-    fixture.detectChanges();
+  it('should accept mode input', async () => {
+    fixture.componentRef.setInput('mode', 'confidence-desc');
+    await settleZoneless(fixture);
     expect(component.mode).toBe('confidence-desc');
   });
 });


### PR DESCRIPTION
## What & why

Continues the zoneless Angular 21 migration (`docs/plans/zoneless-migration.md`, Phase 5). Production has been zoneless since Phase 3; the remaining work is converting the unit specs from the default (zoned) `TestBed` + manual `fixture.detectChanges()` to `provideZonelessChangeDetection()` with DOM-after-`settleZoneless()` assertions, so the headless suite becomes a genuine zoneless-staleness oracle (and to eventually unblock dropping `zone.js` entirely).

This PR migrates **all 22 tractable leaf/modal/list specs** and, because the migrated specs actually catch staleness, **fixes 5 real zoneless staleness bugs** they surfaced.

## Specs migrated (22)

`progress-bar`, `select-mode`, `inclusion-slider`, `stripe-overview`, `label-sort`, `media-item`, `audio-player`, `video-player`, `text-viewer`, `progress-indicators`, `detector-context-bar`, `modal`, `sort-bar`, `autopilot-panel`, `dataset-card`, `detector-card`, `load-sort-modal`, `autodetect-results-modal`, `autodetect-progress-modal`, `settings-modal`, `export-modal`, `progress-modal`, `new-detector-modal`, `examples-editor-modal`, `combine-datasets-modal`, `dataset-importer-modal`, `label-list`.

Each now uses `provideZoneless()` + `settleZoneless()`/`setInput()`/`TestBed.tick()` and asserts the rendered DOM instead of force-rendering with `detectChanges()`.

## Real staleness bugs fixed (plain field written from an HTTP `.subscribe()`, read in the template → would not repaint under zoneless; now a signal, Recipe B)

- **`text-viewer`** — `text` (file-content fetch).
- **`autodetect-results-modal`** — `exporters` / `selectedExporter` / `exporterFields` (the exporter dropdown wouldn't populate); `[(ngModel)]` split into `[ngModel]`/`(ngModelChange)`.
- **`examples-editor-modal`** — `examples` / `loading` / `saving` (the example grid + Loading state); array mutations made immutable.
- **`combine-datasets-modal`** — `mediaTypes` / `submitting` / `error` (type labels/icons, the Combining… button, error text).
- **`label-list`** — `sortedEntries`, rebuilt from the `metadataCache.version$` subscribe (the labeled-vote list wouldn't repaint on metadata hydration).

## Pattern notes (for the next contributor)

- Drive `@Input`/signal inputs through `componentRef.setInput()` (a CD trigger). A plain field write on a **top-level** fixture host won't schedule CD — the `modal` test host uses signals instead.
- Plain `ngOnInit` HTTP subscribes don't block `whenStable()`, so `settleZoneless()` works. **rxResource-backed init must use `TestBed.tick()` + `settleResource()`** — a loading resource holds the app unstable and deadlocks `whenStable()`.

## Deferred (documented in the plan's Open follow-ups)

Two hard classes, untouched here:
- **Contract specs** deliberately kept on the default TestBed (paired with a `.zoneless.spec.ts` canary): `label-view.component`, `center-panel.component`, `image-viewer.component`.
- **Heavy containers** that deadlock `whenStable()` via child rxResources and need stubbed/lightweight harnesses: `app.component`, `right-panel.component`, `left-panel.component`, `media-list`, `dashboard.component`.

These remain the last blocker on removing base `zone.js` from the test polyfills.

## Testing

`./run-tests.sh frontend` green: `build:prod` clean (0 warnings), `npm audit` OK, **Vitest 858 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUvpmejToksvnmi5GDqx7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUvpmejToksvnmi5GDqx7u)_