### PR TITLE
Zoneless Phase 5: migrate remaining specs to the zoneless TestBed and drop zone.js

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -1,18 +1,22 @@
 # Zoneless change detection — detailed migration plan
 
-Status: **Phases 0–4 COMPLETE. Production is zoneless (Phase 3 shipped). Phase 4
+Status: **Phases 0–5 COMPLETE. Production is zoneless (Phase 3 shipped). Phase 4
 browser QA was run live against the GRID instance via Chrome MCP (2026-06-22) and
 PASSED — no staleness bugs on any interactive surface, zero console errors; see
-"Phase 4 — results" below. Phase 5 cleanup is underway: the no-op `NgZone.run`
-wrappers in `browse-canvas` + `panel-resize.directive` are removed, and the
-`vitest-patch` bridge is dropped (all 43 fakeAsync occurrences migrated to native
-`async` + Vitest fake timers; `zone.js/testing` + `vitest-patch` removed from the
-`build:test` polyfills). Base `zone.js` stays in the test build until the
-remaining default-TestBed specs adopt the zoneless `TestBed`. The other Phase 5
-items (per-component zoneless `TestBed` spec migration, explicit `OnPush`) stay
-optional. One unrelated
-pre-existing bug surfaced during QA — `vt-modal` only closes on `Esc` when focus
-is inside it (the `(keydown)` Esc handler lives on the never-focused
+"Phase 4 — results" below. Phase 5 cleanup is DONE: the no-op `NgZone.run`
+wrappers in `browse-canvas` + `panel-resize.directive` were removed; the
+`vitest-patch` bridge was dropped (all 43 fakeAsync occurrences migrated to native
+`async` + Vitest fake timers); and **all remaining default-TestBed specs were
+migrated to the zoneless `TestBed`, so `zone.js` is now dropped end to end** — the
+`build:test` polyfills array is empty and the `package.json` dependency is gone
+(it remains only as `@angular/core`'s optional peer, never bundled or loaded). The
+final 14 specs (9 fixture-creating contract/container specs + 5 service/guard
+specs that transitively inject NgZone services) now run under
+`provideZonelessChangeDetection()`. `./run-tests.sh frontend` is green (858 tests,
+0 errors). The only remaining (optional) Phase 5 item is explicit
+`ChangeDetectionStrategy.OnPush` annotations (documentation/intent only). One
+unrelated pre-existing bug surfaced during QA — `vt-modal` only closes on `Esc`
+when focus is inside it (the `(keydown)` Esc handler lives on the never-focused
 `.modal-backdrop`); tracked under "Open follow-ups", not a zoneless regression.**
 
 Detailed history: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
@@ -803,15 +807,49 @@ unrelated to zoneless — see Open follow-ups.
   real macrotask flush (`await new Promise(r => setTimeout(r))`). `zone.js/testing`
   and `zone.js/plugins/vitest-patch` are removed from the `build:test` polyfills,
   and the ProxyZone-bridge note in `src/test-setup.ts` is gone. Full Vitest suite
-  green (854 passed / 91 files). **`zone.js` itself stays** (in the `build:test`
-  polyfills and `package.json`): the ~36 spec files that still create a component
-  fixture on the **default zone-based TestBed** need `NgZone` to exist —
-  empirically, emptying the test polyfills fails 31 tests across 15 files
-  (NG0205/CD errors). So the final `zone.js` drop is blocked on the
-  TestBed-migration follow-up below, not on the fakeAsync work, which is finished.
+  green (854 passed / 91 files).
+- **Migrate the remaining default-TestBed specs to the zoneless `TestBed` and
+  drop `zone.js` entirely. ✅ DONE.** The last 14 specs that needed `NgZone` from
+  a default zone-based TestBed were migrated to `provideZonelessChangeDetection()`
+  (via the `provideZoneless()` / `configureZoneless()` helpers): the 9
+  fixture-creating contract/container specs (`app.component`, `center-panel`,
+  `document-viewer`, `image-viewer`, `dashboard`, `label-view`, `left-panel`,
+  `media-list`, `right-panel`) plus the 5 service/guard specs that transitively
+  inject NgZone services (`keyboard.service`, `browse-prep.service`,
+  `context-switch.service`, `active-context-watcher.service`,
+  `active-context.guard`). With every fixture-creating spec on the zoneless
+  TestBed, `zone.js` was removed from the `build:test` polyfills (now `[]`) and
+  from `package.json` (it remains only as `@angular/core`'s optional peer, never
+  bundled or loaded). `./run-tests.sh frontend` green (858 tests, 0 errors).
+  Conversion patterns learned (these contract/container specs are paired with the
+  Phase-1/2 `.zoneless.spec.ts` canaries, so the goal here was zone.js removal,
+  not turning them into staleness oracles):
+  - **Initial render:** `fixture.detectChanges()` → `TestBed.tick()` (the
+    scheduled CD mechanism; no autoDetect race). For rxResource-backed init keep
+    the existing `TestBed.tick()` + `settleResource()` (a loading resource
+    deadlocks `whenStable()`).
+  - **Re-render after a change:** under zoneless `TestBed.tick()` only re-checks
+    *dirty* views, so a post-init change must mark the host dirty first — drive
+    `@Input()` changes through `fixture.componentRef.setInput(...)` and internal
+    state changes through the real bound `(event)` (e.g. clicking a tab button).
+    For BehaviorSubject-backed state read non-reactively (dashboard ↔
+    `DatasetStateService`), `fixture.changeDetectorRef.markForCheck()` + `tick()`.
+  - **Dev-only NG0100:** the three `center-panel` image-media tests keep
+    `fixture.detectChanges(false)` to skip the check-no-changes verify pass for
+    the `imageViewer` ViewChild that settles mid-first-pass.
+  - **Zoneless async leaks:** without zone.js the framework no longer auto-cleans
+    the app's timers/microtasks; an SSE poller's `timer(0, N)` first emission or a
+    root-singleton rxResource reload can fire on a macrotask *after* teardown and
+    throw NG0205 through the destroyed injector. label-view's `afterEach` now
+    destroys the fixture, stops `VoteStateService` polling, and drains one
+    macrotask (while the injector is still alive) to absorb the straggler. A
+    *global* drain in `test-setup.ts` was tried first but rejected: it let a
+    pending autoDetect re-check teardown-state leaf components (audio/video-player
+    with `media` undefined) and crash their templates.
 - Adopt `ChangeDetectionStrategy.OnPush` explicitly on components for clarity
   (under zoneless they already behave OnPush-like; this is documentation/intent,
-  not a functional change).
+  not a functional change). **Still optional / not done** — the only remaining
+  Phase 5 item.
 
 ### Open follow-ups
 
@@ -847,8 +885,10 @@ unrelated to zoneless — see Open follow-ups.
     from the zoneless work.
   - **Migrate the remaining specs to the zoneless `TestBed`** + DOM-after-
     `whenStable()` assertions and delete the manual `fixture.detectChanges()`
-    pumps. **In progress — the tractable leaf/modal/list specs are DONE (22 spec
-    files migrated in one pass).** Migrated to `provideZoneless()` +
+    pumps. **✅ DONE — all fixture-creating specs now run under the zoneless
+    TestBed and `zone.js` is dropped end to end (empty `build:test` polyfills +
+    removed from `package.json`).** First the tractable leaf/modal/list specs (22
+    spec files) migrated to `provideZoneless()` +
     `settleZoneless()`/`setInput()`/`TestBed.tick()` (no manual `detectChanges`):
     `progress-bar`, `select-mode`, `inclusion-slider`, `stripe-overview`,
     `label-sort`, `media-item`, `audio-player`, `video-player`, `text-viewer`,
@@ -870,23 +910,27 @@ unrelated to zoneless — see Open follow-ups.
     (`examples`/`loading`/`saving`), `combine-datasets-modal`
     (`mediaTypes`/`submitting`/`error`), and `label-list.sortedEntries` (rebuilt
     from the `metadataCache.version$` subscribe).
-    **Still remaining (the hard classes, untouched):**
-    - **Contract specs** deliberately kept on the default TestBed (paired with a
-      `.zoneless.spec.ts` canary): `label-view.component` (16),
-      `center-panel.component` (10), `image-viewer.component` (1).
-    - **Heavy containers** that deadlock `whenStable()` via their child
-      rxResources and need stubbed/lightweight harnesses: `app.component` (10),
-      `right-panel.component` (8), `left-panel.component` (7), `media-list` (5),
-      `dashboard.component` (3).
-    **This is also the last blocker on removing `zone.js` entirely:** those
-    fixture-creating specs need `NgZone` from the default TestBed, so the test
-    polyfills cannot drop base `zone.js` until they move to the zoneless TestBed.
+    **Then the hard classes (now also DONE):** the contract specs paired with a
+    `.zoneless.spec.ts` canary (`label-view`, `center-panel`, `image-viewer`),
+    the heavy containers (`app.component`, `right-panel`, `left-panel`,
+    `media-list`, `dashboard`), the `document-viewer` contract spec, and the 5
+    service/guard specs that transitively inject NgZone services
+    (`keyboard.service`, `browse-prep.service`, `context-switch.service`,
+    `active-context-watcher.service`, `active-context.guard`). Since these are
+    contract/container specs (the canaries are the staleness oracles), they use
+    `TestBed.tick()`/`setInput()`/bound-event/`markForCheck()` to drive renders
+    rather than a strict DOM-after-`whenStable()` rewrite. See the Phase 5
+    section above for the full conversion-pattern notes (initial render,
+    re-render-after-change, dev-only NG0100, zoneless async leaks). **With this
+    done, `zone.js` was removed from the `build:test` polyfills and
+    `package.json` — the migration is complete.**
   - **Drop the `vitest-patch` bridge. ✅ DONE.** Converted all 43 fakeAsync
     occurrences (11 files) to native `async` + Vitest fake timers and removed
     `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
-    polyfills. Base `zone.js` is **not yet** removed (from `build:test` polyfills
-    or `package.json`): the default-TestBed specs above still need it — emptying
-    the test polyfills fails 31 tests / 15 files (NG0205). Full Vitest suite green.
+    polyfills. Base `zone.js` has now **also** been removed (from both the
+    `build:test` polyfills and `package.json`) — see the TestBed-migration item
+    above; it survives only as `@angular/core`'s optional peer. Full Vitest suite
+    green.
   - **Adopt explicit `ChangeDetectionStrategy.OnPush`** on components for intent
     (redundant under zoneless; documentation only).
 - **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 + 2.4 + 2.5 shipped; Phases 2.6–9 shipped; Phase 3 shipped.**
@@ -968,11 +1012,13 @@ unrelated to zoneless — see Open follow-ups.
   `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
   polyfills and finally `zone.js` from `package.json`. Angular's recommended
   long-term direction; separable, no prod impact.
-- **Adopt the zoneless `TestBed` per component.** `provideZoneless()` /
-  `configureZoneless()` and `settleZoneless()` exist but are used only by the
-  reference spec. Each migrated component (Phases 1–2) must switch its spec to
-  them, delete the manual `fixture.detectChanges()` pumps, and add a canary
-  (0.4). 188 `detectChanges()` calls across 39 files still to convert.
+- **Adopt the zoneless `TestBed` per component. ✅ DONE.** `provideZoneless()` /
+  `configureZoneless()` and `settleZoneless()` are now used across the whole
+  suite: every fixture-creating spec runs under the zoneless TestBed and the
+  default-TestBed `fixture.detectChanges()` pumps are gone (only three
+  `detectChanges(false)` calls remain in `center-panel` to skip a dev-only
+  ViewChild NG0100). The Phase-1/2 interactive components are each paired with a
+  `.zoneless.spec.ts` canary (0.4). zone.js is dropped end to end.
 
 ---
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -83,18 +83,20 @@
               // production build (which dropped zone.js entirely at the Phase 3
               // zoneless flip — see docs/plans/zoneless-migration.md).
               //
-              // The fakeAsync/tick bridge (zone.js/testing + the Angular
-              // vitest-patch plugin) was removed in Phase 5: every spec now uses
-              // native async + Vitest fake timers, so no spec needs ProxyZone.
-              // Base "zone.js" stays only because the spec files that have not
-              // yet adopted the zoneless TestBed still rely on zone-based change
-              // detection in the default TestBed (manual fixture.detectChanges()
-              // alone is fine, but the default TestBed requires NgZone to exist).
-              // It drops once those specs migrate (plan Phase 5).
+              // The polyfills array is now EMPTY: Phase 5 finished migrating
+              // every fixture-creating spec to the zoneless `TestBed`
+              // (`provideZonelessChangeDetection()` via the `provideZoneless()`
+              // helper), so no spec relies on zone-based change detection or
+              // needs `NgZone` from the default TestBed any more. The
+              // fakeAsync/tick bridge (zone.js/testing + the Angular
+              // vitest-patch plugin) was already removed earlier in Phase 5 —
+              // every spec uses native async + Vitest fake timers. zone.js is
+              // gone from the app end to end (prod build, test build, and
+              // package.json).
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true,
-              "polyfills": ["zone.js"]
+              "polyfills": []
             }
           },
           "defaultConfiguration": "production"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,8 +17,7 @@
         "@angular/router": "^21.2.17",
         "marked": "^14.1.4",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.16.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.2.16",
@@ -15045,7 +15044,9 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
       "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,8 +27,7 @@
     "@angular/router": "^21.2.17",
     "marked": "^14.1.4",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.16.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.2.16",

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -6,12 +6,14 @@ import { AppComponent } from './app.component';
 import { provideRouter } from '@angular/router';
 import { MediaStateService } from './services/media-state.service';
 import { DatasetStateService } from './services/dataset-state.service';
+import { provideZoneless } from './testing/zoneless-testbed';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [
+        ...provideZoneless(),
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -33,7 +35,7 @@ describe('AppComponent', () => {
 
   it('should render header with title', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const compiled = fixture.nativeElement as HTMLElement;
     // Branding is rendered as the logo image (alt text), not an <h1>.
     const logo = compiled.querySelector('header .header-logo') as HTMLImageElement;
@@ -42,7 +44,7 @@ describe('AppComponent', () => {
 
   it('should render logo in header', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const compiled = fixture.nativeElement as HTMLElement;
     const logo = compiled.querySelector('header .header-logo') as HTMLImageElement;
     expect(logo).toBeTruthy();
@@ -52,7 +54,7 @@ describe('AppComponent', () => {
 
   it('should render main content area with router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.main-content')).toBeTruthy();
   });
@@ -64,7 +66,7 @@ describe('AppComponent', () => {
 
   it('should toggle menu open on burger button click', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const btn = fixture.nativeElement.querySelector('.burger-btn') as HTMLElement;
     btn.click();
     expect(fixture.componentInstance.menuOpen).toBe(true);
@@ -72,7 +74,7 @@ describe('AppComponent', () => {
 
   it('should toggle menu closed on second burger button click', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const btn = fixture.nativeElement.querySelector('.burger-btn') as HTMLElement;
     btn.click();
     btn.click();
@@ -81,7 +83,7 @@ describe('AppComponent', () => {
 
   it('should close menu on document click', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     fixture.componentInstance.menuOpen = true;
     fixture.componentInstance.onDocumentClick(new Event('click'));
     expect(fixture.componentInstance.menuOpen).toBe(false);
@@ -89,7 +91,7 @@ describe('AppComponent', () => {
 
   it('should render all menu items', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     const items = fixture.nativeElement.querySelectorAll('.burger-item');
     expect(items.length).toBe(4);
     expect(items[0].textContent).toContain('Dashboard');
@@ -101,7 +103,7 @@ describe('AppComponent', () => {
   it('should disable dataset-dependent items when not on label view', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.componentInstance.isOnLabelView.set(false);
-    fixture.detectChanges();
+    TestBed.tick();
     const items = fixture.nativeElement.querySelectorAll('.burger-item');
     // Only Dashboard is dataset-dependent and gets disabled off the label view.
     expect(items[0].classList).toContain('disabled');
@@ -114,7 +116,7 @@ describe('AppComponent', () => {
   it('should enable dataset-dependent items when on label view', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.componentInstance.isOnLabelView.set(true);
-    fixture.detectChanges();
+    TestBed.tick();
     const items = fixture.nativeElement.querySelectorAll('.burger-item');
     expect(items[0].classList).not.toContain('disabled');
     expect(items[1].classList).not.toContain('disabled');
@@ -143,7 +145,7 @@ describe('AppComponent', () => {
 
   it('should close menu on Escape keydown', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
+    TestBed.tick();
     fixture.componentInstance.menuOpen = true;
     const dropdown = fixture.nativeElement.querySelector('.burger-dropdown') as HTMLElement;
     const event = new KeyboardEvent('keydown', { key: 'Escape' });

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { CenterPanelComponent } from './center-panel.component';
 import { EmbedderInfo, Media } from '../../models/api.models';
 import { RegionBox } from './image-viewer/image-viewer.component';
+import { provideZoneless } from '../../testing/zoneless-testbed';
 
 describe('CenterPanelComponent', () => {
   let component: CenterPanelComponent;
@@ -21,7 +22,7 @@ describe('CenterPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CenterPanelComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
     fixture = TestBed.createComponent(CenterPanelComponent);
     component = fixture.componentInstance;
@@ -37,13 +38,13 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should show placeholder when no media selected', () => {
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.textContent).toContain('Select a media item to view');
   });
 
   it('should show audio player for audio media', () => {
     component.media = mockMedia;
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-audio-player')).toBeTruthy();
   });
 
@@ -61,13 +62,13 @@ describe('CenterPanelComponent', () => {
 
   it('should show video player for video media', () => {
     component.media = { ...mockMedia, media_type: 'video' };
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-video-player')).toBeTruthy();
   });
 
   it('should show text viewer for text media', () => {
     component.media = { ...mockMedia, media_type: 'text' };
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-text-viewer')).toBeTruthy();
     // The rendered text-viewer fetches its paragraph on init; flush it so the
     // afterEach httpMock.verify() sees no dangling request.
@@ -76,19 +77,19 @@ describe('CenterPanelComponent', () => {
 
   it('should show document viewer for document media', () => {
     component.media = { ...mockMedia, media_type: 'document' };
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-document-viewer')).toBeTruthy();
   });
 
   it('should show voting overlay when media is selected', () => {
     component.media = mockMedia;
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-voting-overlay')).toBeTruthy();
   });
 
   it('should display metadata', () => {
     component.media = mockMedia;
-    fixture.detectChanges();
+    TestBed.tick();
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('test.wav');
     expect(text).toContain('MD5');
@@ -98,7 +99,7 @@ describe('CenterPanelComponent', () => {
   it('should send vote request on castVote', () => {
     component.media = mockMedia;
     component.showAnimations.set(false);
-    fixture.detectChanges();
+    TestBed.tick();
 
     let emitted: { id: number; vote: string } | undefined;
     component.mediaVoted.subscribe((e: { id: number; vote: string }) => (emitted = e));
@@ -119,7 +120,7 @@ describe('CenterPanelComponent', () => {
   it('should prevent double voting', () => {
     component.media = mockMedia;
     component.showAnimations.set(false);
-    fixture.detectChanges();
+    TestBed.tick();
     component.isVoting.set(true);
     component.castVote('good');
     httpMock.expectNone('/api/medias/1/vote');
@@ -136,7 +137,7 @@ describe('CenterPanelComponent', () => {
 
   it('should clear swipe class when media changes', () => {
     component.media = mockMedia;
-    fixture.detectChanges();
+    TestBed.tick();
     // Simulate swipe ending
     component.swipeClass.set('swipe-right');
 

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -4,6 +4,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { DocumentViewerComponent } from './document-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('DocumentViewerComponent', () => {
   let component: DocumentViewerComponent;
@@ -20,7 +21,7 @@ describe('DocumentViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DocumentViewerComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(DocumentViewerComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -3,6 +3,7 @@ import { ElementRef } from '@angular/core';
 import { ImageViewerComponent, RegionBox } from './image-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { Media } from '../../../models/api.models';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
@@ -19,7 +20,7 @@ describe('ImageViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ImageViewerComponent],
-      providers: [ActiveContextService],
+      providers: [...provideZoneless(), ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(ImageViewerComponent);
     component = fixture.componentInstance;
@@ -102,7 +103,7 @@ describe('ImageViewerComponent', () => {
   it('should render image element', () => {
     component.media = mockMedia;
     component.imageSrc = '/api/medias/2/image';
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('img')).toBeTruthy();
   });
 

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -5,6 +5,7 @@ import { provideRouter } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
 import { LabelSessionService } from '../../services/label-session.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
+import { provideZoneless } from '../../testing/zoneless-testbed';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -14,7 +15,7 @@ describe('DashboardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DashboardComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);
@@ -53,7 +54,7 @@ describe('DashboardComponent', () => {
     detectors: any[] = [],
     importers: any[] = [],
   ): void {
-    fixture.detectChanges();
+    TestBed.tick();
     httpMock.expectOne('/api/datasets/registry').flush({ datasets });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors });
     httpMock.expectOne('/api/dataset/all-importers').flush({ importers, tabs: [] });
@@ -448,7 +449,7 @@ describe('DashboardComponent', () => {
 
   it('should render empty state when no datasets', () => {
     flushInitialRequests();
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     const empty = el.querySelector('.empty-state');
     expect(empty).toBeTruthy();
@@ -458,7 +459,7 @@ describe('DashboardComponent', () => {
   it('should render dataset table when datasets exist', () => {
     const datasets = [{ id: 'd1', name: 'Test', media_type: 'audio', num_items: 5 }];
     flushInitialRequests(datasets);
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.dash-table')).toBeTruthy();
   });

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -449,6 +449,11 @@ describe('DashboardComponent', () => {
 
   it('should render empty state when no datasets', () => {
     flushInitialRequests();
+    // DatasetStateService is BehaviorSubject-backed, so the registry flush
+    // updates the dashboard's view state through plain (non-signal) reads that
+    // don't dirty the host under zoneless. markForCheck() marks it dirty so the
+    // subsequent tick repaints over the now-settled state in one clean pass.
+    fixture.changeDetectorRef.markForCheck();
     TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     const empty = el.querySelector('.empty-state');
@@ -459,6 +464,7 @@ describe('DashboardComponent', () => {
   it('should render dataset table when datasets exist', () => {
     const datasets = [{ id: 'd1', name: 'Test', media_type: 'audio', num_items: 5 }];
     flushInitialRequests(datasets);
+    fixture.changeDetectorRef.markForCheck();
     TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.dash-table')).toBeTruthy();

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -78,7 +78,7 @@ describe('LabelViewComponent', () => {
     );
   }
 
-  afterEach(() => {
+  afterEach(async () => {
     component.ngOnDestroy();
     // Kill the shared VoteStateService poll explicitly. Under zoneless (no
     // zone.js patching test timers) a leftover `timer(0, N)` poll keeps firing
@@ -95,11 +95,20 @@ describe('LabelViewComponent', () => {
     httpMock.match(() => true).forEach(req => {
       if (!req.cancelled) req.flush([]);
     });
-    // Destroy the fixture so the component injector — and the medias/settings
-    // rxResource loaders bound to it — are disposed. Without this a pending
-    // resource reload can fire an HTTP request after the next spec resets the
-    // TestBed, whose interceptor then runs in a destroyed injector (NG0205).
+    // Destroy the fixture so the component view + its child views are gone (no
+    // template can be re-checked) and the component injector — with the
+    // medias/settings rxResource loaders bound to it — is disposed.
     fixture.destroy();
+    // Drain one macrotask while the TestBed injector is still alive. Without
+    // zone.js the framework no longer tracks the app's timers/microtasks, so the
+    // SSE pollers' `timer(0, N)` first emissions and root-singleton rxResource
+    // reloads fire on a macrotask AFTER this teardown; letting them land now
+    // (injector alive, the reset happens in the next spec's beforeEach) turns
+    // what would be a post-reset NG0205 into a harmless unflushed request.
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    httpMock.match(() => true).forEach(req => {
+      if (!req.cancelled) req.flush([]);
+    });
   });
 
   it('should create', () => {

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -9,6 +9,7 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { settleResource } from '../../testing/settle-resource';
+import { provideZoneless } from '../../testing/zoneless-testbed';
 
 describe('LabelViewComponent', () => {
   let component: LabelViewComponent;
@@ -19,6 +20,7 @@ describe('LabelViewComponent', () => {
     await TestBed.configureTestingModule({
       imports: [LabelViewComponent],
       providers: [
+        ...provideZoneless(),
         provideHttpClient(),
         provideHttpClientTesting(),
         provideRouter([]),
@@ -38,7 +40,7 @@ describe('LabelViewComponent', () => {
   // after the synchronous test body returns, so they are NOT flushed here —
   // they are drained by `afterEach`'s catch-all instead.
   function flushInitialRequests(): void {
-    fixture.detectChanges();
+    TestBed.tick();
     // The medias and settings reads ride `rxResource`, whose loader runs in a
     // root effect rather than synchronously during `detectChanges()`; tick so
     // the GETs are actually issued before we match them.
@@ -109,7 +111,7 @@ describe('LabelViewComponent', () => {
 
   it('should render 3-panel layout', () => {
     flushInitialRequests();
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.panel-left')).toBeTruthy();
     expect(el.querySelector('.panel-center')).toBeTruthy();
@@ -237,14 +239,14 @@ describe('LabelViewComponent', () => {
 
   it('should render center panel component', () => {
     flushInitialRequests();
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('vt-center-panel')).toBeTruthy();
   });
 
   it('should render right panel component', () => {
     flushInitialRequests();
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('vt-right-panel')).toBeTruthy();
   });
@@ -325,7 +327,7 @@ describe('LabelViewComponent', () => {
 
     // Now trigger init which loads medias. The medias GET rides an rxResource
     // loader effect, so tick to issue it before flushing.
-    fixture.detectChanges();
+    TestBed.tick();
     TestBed.tick();
     httpMock.match('/api/medias/ids').forEach(req =>
       req.flush([{ id: 1, media_type: 'audio' }]),
@@ -377,7 +379,7 @@ describe('LabelViewComponent', () => {
     // Load a dataset whose media were embedded by a vision-only encoder
     // (DINOv3, supports_text=false) so the text-support checks resolve false.
     function loadNoTextDataset(): void {
-      fixture.detectChanges();
+      TestBed.tick();
       TestBed.tick();
       httpMock.match('/api/medias/ids').forEach(req =>
         req.flush([{ id: 1, media_type: 'image', embedder: 'dinov3' }]),
@@ -445,16 +447,16 @@ describe('LabelViewComponent', () => {
 
     // Activate autopilot → good phase
     autopilot.activate();
-    fixture.detectChanges();
+    TestBed.tick();
 
     // Transition good → bad
     autopilot.checkPhaseTransition(3, 0);
-    fixture.detectChanges();
+    TestBed.tick();
     expect(autopilot.state.phase).toBe('bad');
 
     // Transition bad → hard: should trigger learned sort
     autopilot.checkPhaseTransition(3, 4);
-    fixture.detectChanges();
+    TestBed.tick();
     expect(autopilot.state.phase).toBe('hard');
     expect(sortState.selectMode).toBe('hard');
     expect(sortState.sortMode).toBe('learned');
@@ -484,11 +486,11 @@ describe('LabelViewComponent', () => {
 
     // Activate and advance to new phase
     autopilot.activate();
-    fixture.detectChanges();
+    TestBed.tick();
     autopilot.checkPhaseTransition(3, 0); // good → bad
-    fixture.detectChanges();
+    TestBed.tick();
     autopilot.checkPhaseTransition(3, 4); // bad → hard
-    fixture.detectChanges();
+    TestBed.tick();
     // Flush learned sort from hard transition
     httpMock.expectOne('/api/learned-sort').flush({
       status: 'done',
@@ -505,7 +507,7 @@ describe('LabelViewComponent', () => {
       span: { status: 'yellow' },
     });
     autopilot.checkPhaseTransition(10, 10); // hard → new
-    fixture.detectChanges();
+    TestBed.tick();
     expect(autopilot.state.phase).toBe('new');
     expect(sortState.selectMode).toBe('new');
 
@@ -519,7 +521,7 @@ describe('LabelViewComponent', () => {
       span: { status: 'yellow' },
     });
     autopilot.checkPhaseTransition(12, 12); // new → hard
-    fixture.detectChanges();
+    TestBed.tick();
     expect(autopilot.state.phase).toBe('hard');
     expect(sortState.selectMode).toBe('hard');
     expect(sortState.sortMode).toBe('learned');
@@ -677,7 +679,7 @@ describe('LabelViewComponent', () => {
 
     // Creating a new label-view should clear stale state
     const freshFixture = TestBed.createComponent(LabelViewComponent);
-    freshFixture.detectChanges();
+    TestBed.tick();
 
     // After init, autopilot should be in 'good' phase (cleared then re-activated
     // by the child autopilot panel), NOT stuck in 'bad' from the old session
@@ -705,7 +707,7 @@ describe('LabelViewComponent', () => {
     // Creating a new label-view should clear stale votes before autopilot
     // activates, so it starts in 'good' phase (NOT 'hard'/Refine Boundary)
     const freshFixture = TestBed.createComponent(LabelViewComponent);
-    freshFixture.detectChanges();
+    TestBed.tick();
 
     expect(voteState.goodVotes.size).toBe(0);
     expect(voteState.badVotes.size).toBe(0);

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -80,6 +80,11 @@ describe('LabelViewComponent', () => {
 
   afterEach(() => {
     component.ngOnDestroy();
+    // Kill the shared VoteStateService poll explicitly. Under zoneless (no
+    // zone.js patching test timers) a leftover `timer(0, N)` poll keeps firing
+    // real macrotasks across spec boundaries; once the TestBed injector is reset
+    // its next tick issues an HTTP request through a destroyed injector (NG0205).
+    TestBed.inject(VoteStateService).stopPolling();
     // Drain any outstanding polling requests from right-panel or label-view
     // (the timer-driven /api/votes and /api/labeling-status pollers, the
     // metadata-batch fetch from selectMedia, plus anything a test left in
@@ -90,6 +95,11 @@ describe('LabelViewComponent', () => {
     httpMock.match(() => true).forEach(req => {
       if (!req.cancelled) req.flush([]);
     });
+    // Destroy the fixture so the component injector — and the medias/settings
+    // rxResource loaders bound to it — are disposed. Without this a pending
+    // resource reload can fire an HTTP request after the next spec resets the
+    // TestBed, whose interceptor then runs in a destroyed injector (NG0205).
+    fixture.destroy();
   });
 
   it('should create', () => {
@@ -687,6 +697,7 @@ describe('LabelViewComponent', () => {
 
     freshFixture.componentInstance.ngOnDestroy();
     httpMock.match(() => true);
+    freshFixture.destroy();
   });
 
   it('should clear stale vote state so autopilot starts in good phase', () => {
@@ -715,5 +726,6 @@ describe('LabelViewComponent', () => {
 
     freshFixture.componentInstance.ngOnDestroy();
     httpMock.match(() => true);
+    freshFixture.destroy();
   });
 });

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -8,6 +8,7 @@ import { SimpleChange } from '@angular/core';
 import { LeftPanelComponent } from './left-panel.component';
 import type { Media } from '../../models/api.models';
 import { settleResource } from '../../testing/settle-resource';
+import { provideZoneless } from '../../testing/zoneless-testbed';
 
 describe('LeftPanelComponent', () => {
   let component: LeftPanelComponent;
@@ -16,12 +17,12 @@ describe('LeftPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LeftPanelComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LeftPanelComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    TestBed.tick();
   });
 
   it('should create', () => {
@@ -36,7 +37,7 @@ describe('LeftPanelComponent', () => {
     const fresh = TestBed.createComponent(LeftPanelComponent);
     const comp = fresh.componentInstance;
     vi.spyOn(comp.autopilotStart, 'emit');
-    fresh.detectChanges();
+    TestBed.tick();
     expect(comp.autopilotStart.emit).toHaveBeenCalled();
   });
 
@@ -50,7 +51,7 @@ describe('LeftPanelComponent', () => {
     const comp = fresh.componentInstance;
     comp.autopilotEnabled = false;
     vi.spyOn(comp.autopilotStart, 'emit');
-    fresh.detectChanges();
+    TestBed.tick();
     expect(comp.activeTab).toBe('manual');
     expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
   });
@@ -60,7 +61,7 @@ describe('LeftPanelComponent', () => {
     const comp = fresh.componentInstance;
     comp.autopilotDisabled = true;
     vi.spyOn(comp.autopilotStart, 'emit');
-    fresh.detectChanges();
+    TestBed.tick();
     expect(comp.activeTab).toBe('manual');
     expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
   });
@@ -88,7 +89,7 @@ describe('LeftPanelComponent', () => {
 
   it('should disable the autopilot tab button when autopilotDisabled', () => {
     component.autopilotDisabled = true;
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     const tabs = el.querySelectorAll<HTMLButtonElement>('.left-tab');
     // Second tab is Autopilot.
@@ -103,7 +104,7 @@ describe('LeftPanelComponent', () => {
 
   it('should render manual tab content when switched', () => {
     component.setTab('manual');
-    fixture.detectChanges();
+    TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.tab-panel-manual')).toBeTruthy();
     expect(el.querySelector('.tab-panel-autopilot')).toBeNull();
@@ -117,7 +118,7 @@ describe('LeftPanelComponent', () => {
     expect(tabs[1].classList.contains('active')).toBe(true);
 
     component.setTab('manual');
-    fixture.detectChanges();
+    TestBed.tick();
     const tabsAfter = el.querySelectorAll('.left-tab');
     expect(tabsAfter[0].classList.contains('active')).toBe(true);
     expect(tabsAfter[1].classList.contains('active')).toBe(false);

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -88,7 +88,10 @@ describe('LeftPanelComponent', () => {
   });
 
   it('should disable the autopilot tab button when autopilotDisabled', () => {
-    component.autopilotDisabled = true;
+    // setInput fires ngOnChanges and marks the host dirty so the tick repaints
+    // consistently (a direct field write leaves derived tab state unsettled,
+    // which under zoneless surfaces as an NG0100 in the verify pass).
+    fixture.componentRef.setInput('autopilotDisabled', true);
     TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
     const tabs = el.querySelectorAll<HTMLButtonElement>('.left-tab');
@@ -103,21 +106,25 @@ describe('LeftPanelComponent', () => {
   });
 
   it('should render manual tab content when switched', () => {
-    component.setTab('manual');
-    TestBed.tick();
+    // Drive the switch through the tab button's (click) — a bound listener that
+    // marks the view dirty — so the panel repaints cleanly under zoneless
+    // (calling setTab() directly leaves the host undirtied and the tab
+    // conditional unsettled across the verify pass).
     const el = fixture.nativeElement as HTMLElement;
+    (el.querySelectorAll<HTMLButtonElement>('.left-tab')[0]).click(); // Manual
+    TestBed.tick();
     expect(el.querySelector('.tab-panel-manual')).toBeTruthy();
     expect(el.querySelector('.tab-panel-autopilot')).toBeNull();
   });
 
   it('should show active class on selected tab', () => {
     const el = fixture.nativeElement as HTMLElement;
-    const tabs = el.querySelectorAll('.left-tab');
+    const tabs = el.querySelectorAll<HTMLButtonElement>('.left-tab');
     // Default: autopilot is active (second tab)
     expect(tabs[0].classList.contains('active')).toBe(false);
     expect(tabs[1].classList.contains('active')).toBe(true);
 
-    component.setTab('manual');
+    tabs[0].click(); // Manual
     TestBed.tick();
     const tabsAfter = el.querySelectorAll('.left-tab');
     expect(tabsAfter[0].classList.contains('active')).toBe(true);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -93,7 +93,11 @@ describe('MediaListComponent', () => {
   });
 
   it('should show empty message when no medias', () => {
-    component.medias = [];
+    // Drive the input through setInput so ngOnChanges rebuilds the ordered-items
+    // cache to empty (a direct field write leaves the cache stale, which under
+    // zoneless surfaces as an NG0100 during the verify pass) and the host view
+    // is marked dirty so the tick repaints.
+    fixture.componentRef.setInput('medias', []);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('.empty-list')?.textContent).toContain('No media loaded');
   });

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -5,6 +5,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MediaListComponent } from './media-list.component';
 import { Media } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('MediaListComponent', () => {
   let component: MediaListComponent;
@@ -19,13 +20,13 @@ describe('MediaListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaListComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MediaListComponent);
     component = fixture.componentInstance;
     component.medias = mockMedias;
-    fixture.detectChanges();
+    TestBed.tick();
   });
 
   it('should create', () => {
@@ -51,7 +52,7 @@ describe('MediaListComponent', () => {
     component.ngOnChanges({
       sortOrder: new SimpleChange(null, component.sortOrder, false),
     });
-    fixture.detectChanges();
+    TestBed.tick();
     const items = component.cachedOrderedItems;
     expect(items[0].media.id).toBe(3);
     expect(items[1].media.id).toBe(1);
@@ -69,7 +70,7 @@ describe('MediaListComponent', () => {
       sortOrder: new SimpleChange(null, component.sortOrder, false),
       threshold: new SimpleChange(null, component.threshold, false),
     });
-    fixture.detectChanges();
+    TestBed.tick();
     const items = component.cachedOrderedItems;
     // Threshold is at 0.4, so item with score 0.2 should have showThreshold
     expect(items[0].showThreshold).toBe(false);
@@ -93,7 +94,7 @@ describe('MediaListComponent', () => {
 
   it('should show empty message when no medias', () => {
     component.medias = [];
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('.empty-list')?.textContent).toContain('No media loaded');
   });
 
@@ -107,7 +108,7 @@ describe('MediaListComponent', () => {
       sortOrder: new SimpleChange(null, component.sortOrder, false),
       threshold: new SimpleChange(null, component.threshold, false),
     });
-    fixture.detectChanges();
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('.media-threshold-line')).toBeTruthy();
   });
 

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { RightPanelComponent } from './right-panel.component';
 import { VoteStateService } from '../../services/vote-state.service';
+import { provideZoneless } from '../../testing/zoneless-testbed';
 
 describe('RightPanelComponent', () => {
   let component: RightPanelComponent;
@@ -12,7 +13,7 @@ describe('RightPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RightPanelComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RightPanelComponent);
@@ -29,7 +30,7 @@ describe('RightPanelComponent', () => {
   }
 
   async function flushInit(): Promise<void> {
-    fixture.detectChanges();
+    TestBed.tick();
     // Allow the votes poll's `timer(0, …)` first emission to fire on a real
     // macrotask (and drain microtasks) so its GET is issued.
     await new Promise<void>((resolve) => setTimeout(resolve));
@@ -59,7 +60,7 @@ describe('RightPanelComponent', () => {
   // the value commits. See docs/plans/httpresource-migration.md.
   it('should load view mode from settings on init', async () => {
     component.medias = [{ id: 1, media_type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
-    fixture.detectChanges();
+    TestBed.tick();
     TestBed.tick(); // run the rxResource loader effect so the GET is issued
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     // Drain the resource's promise-based value commit, then flush effects so the
@@ -74,7 +75,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should default viewMode to grid when not in settings', async () => {
-    fixture.detectChanges();
+    TestBed.tick();
     await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
@@ -84,7 +85,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should poll for votes on init', async () => {
-    fixture.detectChanges();
+    TestBed.tick();
     await new Promise<void>((resolve) => setTimeout(resolve));
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
     httpMock.expectOne('/api/settings').flush({ volume: 1 });
@@ -150,7 +151,7 @@ describe('RightPanelComponent', () => {
   it('should render detector context bar when trainMode set', async () => {
     component.trainMode = { model: { name: 'Test Detector', registry_id: 'r1' } };
     await flushInit();
-    fixture.detectChanges();
+    TestBed.tick();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeTruthy();
@@ -160,7 +161,7 @@ describe('RightPanelComponent', () => {
   it('should not render detector context bar when trainMode is null', async () => {
     component.trainMode = null;
     await flushInit();
-    fixture.detectChanges();
+    TestBed.tick();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.train-context-bar')).toBeFalsy();
@@ -169,7 +170,7 @@ describe('RightPanelComponent', () => {
 
   it('should render both good and bad label lists', async () => {
     await flushInit();
-    fixture.detectChanges();
+    TestBed.tick();
 
     const el = fixture.nativeElement as HTMLElement;
     const labelLists = el.querySelectorAll('vt-label-list');
@@ -179,7 +180,7 @@ describe('RightPanelComponent', () => {
 
   it('should render label sort dropdown', async () => {
     await flushInit();
-    fixture.detectChanges();
+    TestBed.tick();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('vt-label-sort')).toBeTruthy();

--- a/frontend/src/app/guards/active-context.guard.spec.ts
+++ b/frontend/src/app/guards/active-context.guard.spec.ts
@@ -18,6 +18,7 @@ import { ContextSwitchService } from '../services/context-switch.service';
 import { DatasetStateService } from '../services/dataset-state.service';
 import { ToastService } from '../services/toast.service';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
+import { configureZoneless } from '../testing/zoneless-testbed';
 
 describe('activeContextGuard', () => {
   let router: Router;
@@ -64,7 +65,7 @@ describe('activeContextGuard', () => {
   }
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    configureZoneless({
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/frontend/src/app/services/active-context-watcher.service.spec.ts
+++ b/frontend/src/app/services/active-context-watcher.service.spec.ts
@@ -7,6 +7,7 @@ import { ActiveContextService } from './active-context.service';
 import { DatasetStateService } from './dataset-state.service';
 import { ToastService } from './toast.service';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
+import { configureZoneless } from '../testing/zoneless-testbed';
 
 describe('ActiveContextWatcherService', () => {
   let watcher: ActiveContextWatcherService;
@@ -34,7 +35,7 @@ describe('ActiveContextWatcherService', () => {
   }
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    configureZoneless({
       providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
     });
     watcher = TestBed.inject(ActiveContextWatcherService);

--- a/frontend/src/app/services/browse-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-prep.service.spec.ts
@@ -8,6 +8,7 @@ import { ActiveContextService } from './active-context.service';
 import { ContextSwitchService } from './context-switch.service';
 import { ProgressEventsService } from './progress-events.service';
 import { ProjectionApiService } from './projection-api.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
 import { LoadingTask } from '../models/api.models';
 import type { ProjectionBuildResponse, ProjectionMeta } from '../models/projection.models';
 
@@ -74,7 +75,7 @@ describe('BrowsePrepService', () => {
       build: (): Observable<ProjectionBuildResponse> => buildProvider(),
     };
 
-    TestBed.configureTestingModule({
+    configureZoneless({
       providers: [
         provideRouter([]),
         { provide: ContextSwitchService, useValue: contextSwitchStub },

--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -10,6 +10,7 @@ import { DatasetStateService } from './dataset-state.service';
 import { DatasetsRegistryApiService } from './datasets-registry-api.service';
 import { DetectorsRegistryApiService } from './detectors-registry-api.service';
 import { ProgressEventsService } from './progress-events.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
 import {
   DatasetRegistryEntry,
   DetectorRegistryEntry,
@@ -125,7 +126,7 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
       detectorLoadingTasks: (): LoadingTask[] => detectorLoadingTasks$.value,
     };
 
-    TestBed.configureTestingModule({
+    configureZoneless({
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/frontend/src/app/services/keyboard.service.spec.ts
+++ b/frontend/src/app/services/keyboard.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { KeyboardService, KeyboardAction } from './keyboard.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
 
 describe('KeyboardService', () => {
   let service: KeyboardService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    configureZoneless({});
     service = TestBed.inject(KeyboardService);
   });
 

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -89,11 +89,12 @@ const canvasContextStub = new Proxy(
 HTMLCanvasElement.prototype.getContext = (() =>
   canvasContextStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
-// --- no fakeAsync / ProxyZone bridge ---------------------------------------
+// --- no zone.js at all -----------------------------------------------------
 // The specs no longer use Angular's fakeAsync()/tick(); they drive time with
 // native async + Vitest fake timers (vi.useFakeTimers / advanceTimersByTimeAsync)
-// and real macrotask drains instead. So neither "zone.js/testing" nor the
-// "zone.js/plugins/vitest-patch" bridge is loaded any more (see the build:test
-// polyfills in angular.json and docs/plans/zoneless-migration.md, Phase 5).
-// Base "zone.js" stays in the test polyfills only for the specs that still use
-// the default zone-based TestBed; nothing in this setup file needs it.
+// and real macrotask drains instead. And as of Phase 5, every fixture-creating
+// spec runs under the zoneless `TestBed` (`provideZonelessChangeDetection()`),
+// so no spec needs `NgZone` from a default zone-based TestBed. zone.js is
+// therefore dropped entirely: the build:test polyfills array is empty and the
+// package.json dependency is removed (see docs/plans/zoneless-migration.md,
+// Phase 5). Nothing in this setup file needs it.

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -10,7 +10,7 @@
  */
 
 import { getTestBed } from '@angular/core/testing';
-import { afterEach as vitestAfterEach, beforeEach as vitestBeforeEach } from 'vitest';
+import { beforeEach as vitestBeforeEach } from 'vitest';
 
 // --- TestBed cascade guard --------------------------------------------------
 // The Angular TestBed is a module-level singleton reset by an afterEach hook.
@@ -31,22 +31,6 @@ vitestBeforeEach(() => {
     // A throwing teardown from the previous spec is itself a reported failure;
     // swallow it here so it cannot mask the upcoming test.
   }
-});
-
-// --- zoneless async-leak drain ----------------------------------------------
-// Without zone.js, the test framework no longer tracks/auto-cleans the timers
-// and microtasks the app schedules (the SSE pollers' `timer(0, N)` first
-// emissions, rxResource reloads, etc.). A straggler that fires *after* the next
-// spec's `beforeEach` resets the TestBed runs through a destroyed injector and
-// throws an unhandled NG0205 ("Injector has already been destroyed"), e.g. when
-// an HTTP poller's `switchMap` issues a request. This setup-file `afterEach`
-// registers FIRST, so it runs LAST (Vitest runs afterEach hooks in reverse
-// registration order) — after each spec's own teardown (ngOnDestroy /
-// fixture.destroy). Draining one macrotask here lets any such straggler fire
-// while the injector is still alive (the reset happens in the *next*
-// beforeEach), turning a post-reset NG0205 into a harmless unflushed request.
-vitestAfterEach(async () => {
-  await new Promise<void>((resolve) => setTimeout(resolve));
 });
 
 // --- EventSource (Server-Sent Events) --------------------------------------

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -10,7 +10,7 @@
  */
 
 import { getTestBed } from '@angular/core/testing';
-import { beforeEach as vitestBeforeEach } from 'vitest';
+import { afterEach as vitestAfterEach, beforeEach as vitestBeforeEach } from 'vitest';
 
 // --- TestBed cascade guard --------------------------------------------------
 // The Angular TestBed is a module-level singleton reset by an afterEach hook.
@@ -31,6 +31,22 @@ vitestBeforeEach(() => {
     // A throwing teardown from the previous spec is itself a reported failure;
     // swallow it here so it cannot mask the upcoming test.
   }
+});
+
+// --- zoneless async-leak drain ----------------------------------------------
+// Without zone.js, the test framework no longer tracks/auto-cleans the timers
+// and microtasks the app schedules (the SSE pollers' `timer(0, N)` first
+// emissions, rxResource reloads, etc.). A straggler that fires *after* the next
+// spec's `beforeEach` resets the TestBed runs through a destroyed injector and
+// throws an unhandled NG0205 ("Injector has already been destroyed"), e.g. when
+// an HTTP poller's `switchMap` issues a request. This setup-file `afterEach`
+// registers FIRST, so it runs LAST (Vitest runs afterEach hooks in reverse
+// registration order) — after each spec's own teardown (ngOnDestroy /
+// fixture.destroy). Draining one macrotask here lets any such straggler fire
+// while the injector is still alive (the reset happens in the *next*
+// beforeEach), turning a post-reset NG0205 into a harmless unflushed request.
+vitestAfterEach(async () => {
+  await new Promise<void>((resolve) => setTimeout(resolve));
 });
 
 // --- EventSource (Server-Sent Events) --------------------------------------


### PR DESCRIPTION
## Summary

Completes Phase 5 of `docs/plans/zoneless-migration.md`: migrates the last specs that still created fixtures on the default zone-based `TestBed` over to `provideZonelessChangeDetection()`, which unblocks removing **`zone.js` end to end** — the `build:test` polyfills array is now empty and the `package.json` dependency is gone (it survives only as `@angular/core`'s optional peer, never bundled or loaded).

Production was already zoneless (Phase 3); this is test-infra + config only — no app/runtime code changes.

## What changed

**14 specs migrated to the zoneless TestBed:**
- 9 fixture-creating contract/container specs: `app.component`, `center-panel`, `document-viewer`, `image-viewer`, `dashboard`, `label-view`, `left-panel`, `media-list`, `right-panel`.
- 5 service/guard specs that transitively inject NgZone services: `keyboard.service`, `browse-prep.service`, `context-switch.service`, `active-context-watcher.service`, `active-context.guard`.

**Config:**
- `angular.json` `build:test` polyfills → `[]`.
- `zone.js` removed from `package.json` dependencies.
- `test-setup.ts` comment updated.

## Conversion patterns (for reviewers)

These contract/container specs are paired with the Phase-1/2 `.zoneless.spec.ts` canaries (which are the staleness oracles), so the goal here was zone.js removal, not turning them into oracles:

- **Initial render:** `fixture.detectChanges()` → `TestBed.tick()` (the scheduled CD mechanism; no autoDetect race). rxResource-backed init keeps `TestBed.tick()` + `settleResource()` (a loading resource deadlocks `whenStable()`).
- **Re-render after a change:** under zoneless `TestBed.tick()` only re-checks *dirty* views, so a post-init change must mark the host dirty first — `@Input()` changes via `fixture.componentRef.setInput(...)`, internal state via the real bound `(event)` (e.g. clicking a tab), and BehaviorSubject-backed non-reactive reads (dashboard ↔ `DatasetStateService`) via `markForCheck()` + `tick()`.
- **Dev-only NG0100:** the three `center-panel` image-media tests keep `fixture.detectChanges(false)` to skip the verify pass for the `imageViewer` ViewChild that settles mid-first-pass.
- **Zoneless async leaks:** without zone.js the framework no longer auto-cleans the app's timers/microtasks; an SSE poller's `timer(0, N)` first emission or a root-singleton rxResource reload can fire on a macrotask *after* teardown and throw NG0205 through a destroyed injector. `label-view`'s `afterEach` now destroys the fixture, stops `VoteStateService` polling, and drains one macrotask while the injector is still alive. (A *global* drain in `test-setup.ts` was tried first and rejected — it let a pending autoDetect re-check teardown-state leaf components with `media` undefined and crash their templates.)

## Testing

`./run-tests.sh frontend` green: **858 Vitest tests, 0 errors**, `build:prod` clean, `npm audit` clean (0 prod vulns), plus ruff / codespell / deptry / pip-audit / pyright / OpenAPI snapshot / Dockerfile / docs checks all pass.

The only remaining (optional) Phase 5 item is explicit `ChangeDetectionStrategy.OnPush` annotations (documentation/intent only) — tracked in the plan's Open follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7f7N9FMG1FQFC4JQimKLY

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7f7N9FMG1FQFC4JQimKLY)_