### PR TITLE
zoneless: adopt explicit OnPush on all components + fix vt-modal Esc-to-close

### DIFF
--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -12,12 +12,29 @@ migrated to the zoneless `TestBed`, so `zone.js` is now dropped end to end** —
 (it remains only as `@angular/core`'s optional peer, never bundled or loaded). The
 final 14 specs (9 fixture-creating contract/container specs + 5 service/guard
 specs that transitively inject NgZone services) now run under
-`provideZonelessChangeDetection()`. `./run-tests.sh frontend` is green (858 tests,
-0 errors). The only remaining (optional) Phase 5 item is explicit
-`ChangeDetectionStrategy.OnPush` annotations (documentation/intent only). One
-unrelated pre-existing bug surfaced during QA — `vt-modal` only closes on `Esc`
-when focus is inside it (the `(keydown)` Esc handler lives on the never-focused
-`.modal-backdrop`); tracked under "Open follow-ups", not a zoneless regression.**
+`provideZonelessChangeDetection()`. `./run-tests.sh frontend` is green (860 tests,
+0 errors).
+
+**Phase 5 is now fully shipped, including the last two items:**
+- **Explicit `ChangeDetectionStrategy.OnPush` on all 86 components. ✅ DONE.**
+  This turned out *not* to be documentation-only: it exposed that two hot
+  services were still `BehaviorSubject`-backed and read non-reactively in the
+  dashboard template (`DatasetStateService` → `datasets`/`loading`/`loaded`/…;
+  `DashboardLoadingTasksService` → `loadingTasks`/`orphanLoadingTasks`/
+  `inlineTaskMap`). Under the old default (CheckAlways) strategy they got "free"
+  repaints on any CD pass; under OnPush the host only re-checks when dirtied, so
+  both services were signalized (Recipe B: private `signal` + value-returning
+  getter that is *tracked* when read in templates, mirroring the Phase-2.5
+  SortState/VoteState pattern). `DatasetStateService` keeps its `$` observables as
+  `toObservable` bridges so the RxJS consumers (context-pulldown, app.component,
+  active-context-watcher, the route guards) are unchanged; `toObservable` emits
+  on the next CD pass rather than synchronously, so four spec files were updated
+  to `TestBed.tick()` past the bridge. `DashboardLoadingTasksService`'s unused
+  `$` observables were dropped.
+- **`vt-modal` `Esc`-to-close fixed. ✅ DONE.** Replaced the never-firing
+  backdrop-scoped `(keydown)` with `@HostListener('document:keydown.escape')`
+  (guarded by `open()`), mirroring the `context-menu` / `browse-bin-popup`
+  pattern, so Esc closes a button-opened modal regardless of focus.**
 
 Detailed history: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
 (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
@@ -846,10 +863,23 @@ unrelated to zoneless — see Open follow-ups.
     *global* drain in `test-setup.ts` was tried first but rejected: it let a
     pending autoDetect re-check teardown-state leaf components (audio/video-player
     with `media` undefined) and crash their templates.
-- Adopt `ChangeDetectionStrategy.OnPush` explicitly on components for clarity
-  (under zoneless they already behave OnPush-like; this is documentation/intent,
-  not a functional change). **Still optional / not done** — the only remaining
-  Phase 5 item.
+- Adopt `ChangeDetectionStrategy.OnPush` explicitly on components. **✅ DONE —
+  all 86 components.** Expected to be documentation/intent, but it surfaced a
+  real gap: components reading a *non-signal* `BehaviorSubject` service getter
+  directly in their template (the dashboard ↔ `DatasetStateService` /
+  `DashboardLoadingTasksService`) relied on the default CheckAlways strategy for
+  "free" repaints. Under OnPush the host only re-checks when dirtied, so those
+  two services were signalized (Recipe B; private `signal` + value-returning
+  getter, which is tracked when read during template evaluation — the same
+  getter-signal trick proven for SortState/VoteState in Phase 2.5). The blanket
+  add was mechanical (`changeDetection: ChangeDetectionStrategy.OnPush` as the
+  first `@Component` property + the `@angular/core` import). `DatasetStateService`
+  retained its `$` observables as `toObservable` bridges (RxJS consumers
+  unchanged); since `toObservable` emits on the next CD pass rather than
+  synchronously like a `BehaviorSubject`, the dashboard / active-context-watcher /
+  active-context-guard / dataset-state service specs gained `TestBed.tick()`
+  calls past the bridge. Full suite green (`./run-tests.sh` 5026 passed;
+  `./run-tests.sh frontend` 860 tests).
 
 ### Open follow-ups
 
@@ -871,18 +901,19 @@ unrelated to zoneless — see Open follow-ups.
     CD on their own. The `NgZone` injection **stays** in both — still used by the
     `runOutsideAngular` perf wrappers, which are kept. `build:prod` clean (initial
     489.34 kB < 500 kB budget); full Vitest suite green (854 passed / 91 files).
-  - **`vt-modal` `Esc`-to-close is focus-scoped (pre-existing, NOT zoneless).**
-    Surfaced during Phase 4 QA: opening any `vt-modal` from a button leaves focus
-    on that button, and the modal's `Esc` handler is a plain `(keydown)` on the
-    `.modal-backdrop` div (`modal/modal.component.html`), which is never
-    programmatically focused on open (it has `tabindex="-1"` but no autofocus). So
-    `Esc` does nothing until the user clicks/tabs into the modal — even though the
-    keyboard-help sheet advertises "Esc — Close modal or dropdown". Affects all
-    button-opened modals (settings, stats, help, …). It is a focus/event-routing
-    bug, independent of change detection (`(keydown)` is a bound listener). Fix
-    option: focus the backdrop (or first focusable) on open, or move the handler
-    to `@HostListener('document:keydown.escape')` on `ModalComponent`. Separable
-    from the zoneless work.
+  - **`vt-modal` `Esc`-to-close is focus-scoped (pre-existing, NOT zoneless).
+    ✅ FIXED.** Surfaced during Phase 4 QA: opening any `vt-modal` from a button
+    leaves focus on that button, and the modal's `Esc` handler was a plain
+    `(keydown)` on the `.modal-backdrop` div, which is never programmatically
+    focused on open — so `Esc` did nothing until the user clicked/tabbed into the
+    modal. Fixed by moving the handler to `@HostListener('document:keydown.escape')`
+    on `ModalComponent` (guarded by `open()`), mirroring the existing
+    `context-menu` / `browse-bin-popup` `document:keydown.escape` pattern; the
+    backdrop `(keydown)` was removed so it can't double-emit `closed`. The
+    focus-the-backdrop alternative was rejected because several modals use
+    `autofocus` / programmatic input focus that it would fight. Two regression
+    canaries added to `modal.component.spec.ts` (Esc dispatched at `document`
+    level closes an open modal; Esc is inert when closed).
   - **Migrate the remaining specs to the zoneless `TestBed`** + DOM-after-
     `whenStable()` assertions and delete the manual `fixture.detectChanges()`
     pumps. **✅ DONE — all fixture-creating specs now run under the zoneless

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, HostListener, inject, signal } from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { combineLatest } from 'rxjs';
@@ -39,6 +39,7 @@ import type { RecentSession } from './generated/api-client/models/recent-session
 import { isPairCompatible } from './utils/context-compat';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-root',
   imports: [
     CommonModule,

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IconComponent } from '../icon/icon.component';
 
@@ -13,6 +13,7 @@ import { IconComponent } from '../icon/icon.component';
  * The base symbol comes from the existing vt-icon set via *iconType*.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-achievement-badge',
   standalone: true,
   imports: [CommonModule, IconComponent],

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementsService } from '../../services/achievements.service';
 import { ToastService } from '../../services/toast.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-achievement-unlock-host',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, OnDestroy, OnInit } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -26,6 +26,7 @@ interface AchievementRow extends AchievementEntry {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-achievements-tab',
   standalone: true,
   imports: [FormsModule, AchievementBadgeComponent],

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostListener, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
@@ -81,6 +81,7 @@ const HOVER_EXTENT_PER_RADIUS = 3;
  * visible window so large bins stay responsive.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-bin-popup',
   standalone: true,
   imports: [CommonModule, ScrollingModule, ViewControlsComponent],

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, effect, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -48,6 +48,7 @@ export interface BrowseContextMenuEvent {
 const HOVER_RADIUS_SCALE = 1.38;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-canvas',
   standalone: true,
   templateUrl: './browse-canvas.component.html',

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -1,9 +1,10 @@
-import { Component, ElementRef, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, input, OnChanges, OnDestroy, signal, SimpleChanges, ViewChild } from '@angular/core';
 
 import { ActiveContextService } from '../../services/active-context.service';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-hover-preview',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/browse-legend/browse-legend.component.ts
+++ b/frontend/src/app/components/browse-legend/browse-legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnDestroy, OnInit, signal } from '@angular/core';
 import {
   gradientStops,
   resolveColormap,
@@ -28,6 +28,7 @@ interface LegendTick {
  * the canvas is painting — Heat, Ocean, or Grayscale, light or dark.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-legend',
   standalone: true,
   template: `

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostBinding, Input, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, inject, Input, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { BrowseViewportService, ViewportBounds } from '../../services/browse-viewport.service';
@@ -32,6 +32,7 @@ export const MINIMAP_MAX_HEIGHT = 450;
  * main canvas has already fetched and never holds its own copy.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-minimap',
   standalone: true,
   imports: [IconComponent],

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -35,6 +35,7 @@ interface SelectionEntry {
  * stays in step with the Find right panel.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-selection-panel',
   standalone: true,
   imports: [CommonModule, FormsModule, ViewControlsComponent],

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, OnDestroy, NgZone, ViewChild, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -39,6 +39,7 @@ import type { AppSettings } from '../../generated/api-client/models/app-settings
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-view',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -1,8 +1,9 @@
-import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, AfterViewInit, inject, input, output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-audio-player',
   standalone: true,
   templateUrl: './audio-player.component.html',

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, effect, inject, input, output, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, Input, input, OnChanges, OnDestroy, output, signal, SimpleChanges, untracked, ViewChild } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
@@ -17,6 +17,7 @@ import { VotingOverlayComponent } from './voting-overlay/voting-overlay.componen
 import { prefersReducedMotion } from '../../utils/reduced-motion';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-center-panel',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-document-viewer',
   standalone: true,
   templateUrl: './document-viewer.component.html',

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, OnChanges, OnDestroy, output, signal, SimpleChanges, ViewChild } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -15,6 +15,7 @@ type DragMode =
 const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a stray click
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-image-viewer',
   standalone: true,
   imports: [NgStyle],

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, OnDestroy, signal, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { Media } from '../../../models/api.models';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-text-viewer',
   standalone: true,
   templateUrl: './text-viewer.component.html',

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,9 +1,10 @@
-import { Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
 
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-video-player',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnDestroy, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnDestroy, output, signal } from '@angular/core';
 import { IconComponent } from '../../icon/icon.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-voting-overlay',
   standalone: true,
   imports: [IconComponent],

--- a/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
+++ b/frontend/src/app/components/clipboard-copy/clipboard-copy.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnDestroy, SimpleChanges, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnChanges, OnDestroy, signal, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -27,6 +27,7 @@ interface DelimiterOption {
  * component stays agnostic about the source model (LabeledElement, hit, …).
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-clipboard-copy',
   standalone: true,
   imports: [FormsModule],

--- a/frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/frontend/src/app/components/context-menu/context-menu.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, ElementRef, HostListener, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, input, output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 export interface ContextMenuItem {
@@ -20,6 +20,7 @@ export interface ContextMenuItem {
  * (`vt-label-view`) and the dashboard grids.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-context-menu',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, inject, input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ interface PulldownRow {
  * ArrowDown to navigate, Enter to pick, Escape to close.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-context-pulldown',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 
 import { Router } from '@angular/router';
 import { Subject, combineLatest } from 'rxjs';
@@ -18,6 +18,7 @@ import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.mo
  * just renders the explanation given the current active pair.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-incompatible-pair-explainer',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, SimpleChanges, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnChanges, output, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -10,6 +10,7 @@ export interface ClipperSelection {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-clipper-chooser',
   standalone: true,
   imports: [FormsModule, ModalComponent],

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -16,6 +16,7 @@ interface CombineRow {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-combine-datasets-modal',
   standalone: true,
   imports: [CommonModule, FormsModule, ModalComponent, IconComponent],

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -13,6 +13,7 @@ interface SourceRow {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-combine-detectors-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent],

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -58,9 +58,15 @@ describe('DashboardComponent', () => {
     httpMock.expectOne('/api/datasets/registry').flush({ datasets });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors });
     httpMock.expectOne('/api/dataset/all-importers').flush({ importers, tabs: [] });
-    // Auto-selecting a single dataset synchronously kicks off an embedder
-    // preload; drain it (and any usage polls already in flight) here so
-    // tests that don't assert on them stay clean.
+    // DatasetStateService is signal-backed and exposes `datasets$`/`detectors$`
+    // as `toObservable` bridges, which emit on the next change-detection pass
+    // (not synchronously when the signal is set). Tick once more so the
+    // dashboard's `datasets$`/`detectors$` subscriptions (registry auto-select)
+    // run before the test asserts on the resulting selection state.
+    TestBed.tick();
+    // Auto-selecting a single dataset kicks off an embedder preload; drain it
+    // (and any usage polls already in flight) here so tests that don't assert
+    // on them stay clean.
     drainBackgroundRequests();
   }
 
@@ -112,6 +118,8 @@ describe('DashboardComponent', () => {
       ],
     });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
+    // Let the `datasets$` bridge deliver the new registry to the auto-select sub.
+    TestBed.tick();
 
     expect(component.selectedDatasetIds.has('d1')).toBe(false);
     expect(component.selectedDatasetIds.has('d2')).toBe(true);
@@ -131,6 +139,8 @@ describe('DashboardComponent', () => {
         { id: 'm2', name: 'Second' },
       ],
     });
+    // Let the `detectors$` bridge deliver the new registry to the auto-select sub.
+    TestBed.tick();
 
     // Adding items after the initial load clears the prior selection and
     // selects only the new ones (same behavior as datasets above).

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, OnDestroy, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, HostListener, inject, OnDestroy, OnInit, signal } from '@angular/core';
 
 import { NavigationCancel, NavigationEnd, NavigationError, Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
@@ -51,6 +51,7 @@ import { IconComponent } from '../icon/icon.component';
 import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dashboard',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges, ViewChild, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, input, OnChanges, output, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -15,6 +15,7 @@ import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/contex
 import { buildDatasetCardMenuItems } from '../card-context-menu-items';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dataset-card',
   standalone: true,
   imports: [CommonModule, FormsModule, ProgressBarComponent, ContextMenuComponent],

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, HostListener, Input, OnInit, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, inject, Input, input, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -19,6 +19,7 @@ import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeI
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dataset-importer-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, ClipperChooserComponent, ImportAdvancedComponent, ImportConfigComponent, SourcePickerComponent, FieldHintIconComponent, FileBrowserComponent, FolderBrowserComponent],

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -24,6 +24,7 @@ import { SourceSpecsPickerComponent } from '../source-specs-picker/source-specs-
  *  emits :prop:`clipperChooserRequested` and the parent opens it.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-import-advanced',
   standalone: true,
   imports: [FormsModule, SourceSpecsPickerComponent],

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, Input, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, Input, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -23,6 +23,7 @@ import { IconComponent } from '../../../icon/icon.component';
  *  cannot host markup.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-import-config',
   standalone: true,
   imports: [FormsModule, IconComponent],

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -45,6 +45,7 @@ import { ManagedColumns } from '../../../../utils/managed-columns';
  *    the local-folder / local-files flows.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-source-picker',
   standalone: true,
   imports: [CommonModule, FormsModule, IconComponent, DropZoneComponent],

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, SimpleChanges, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnChanges, output, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -16,6 +16,7 @@ import { ClipperInfo, ConverterInfo, SourceSpec } from '../../../../models/api.m
  *  importer's "Advanced" section, so a nested "Advanced" label here
  *  would read as "Advanced inside Advanced". */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-source-specs-picker',
   standalone: true,
   imports: [FormsModule],

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges, ViewChild, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, input, OnChanges, output, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -14,6 +14,7 @@ import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/contex
 import { buildDetectorCardMenuItems } from '../card-context-menu-items';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-detector-card',
   standalone: true,
   imports: [CommonModule, FormsModule, ProgressBarComponent, ContextMenuComponent],

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, Input, OnInit, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, inject, Input, input, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -34,6 +34,7 @@ type ModalTab = 'blank' | 'trained';
 type TrainedSubView = 'picker' | 'form';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-new-detector-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, FieldHintIconComponent],

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 export interface UsageBytes {
   total: number;
@@ -7,6 +7,7 @@ export interface UsageBytes {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-usage-bar',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/dialog-host/dialog-host.component.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../modal/modal.component';
@@ -6,6 +6,7 @@ import { IconComponent } from '../icon/icon.component';
 import { VtDialogService } from '../../services/dialog.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dialog-host',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent],

--- a/frontend/src/app/components/drop-zone/drop-zone.component.ts
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.ts
@@ -1,7 +1,8 @@
-import { Component, ElementRef, Input, ViewChild, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, input, output, ViewChild } from '@angular/core';
 
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-drop-zone',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -1,9 +1,10 @@
 
-import { Component, ElementRef, HostListener, signal, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, input, signal } from '@angular/core';
 
 const HOVER_DELAY_MS = 500;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-field-hint-icon',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { map } from 'rxjs/operators';
@@ -17,6 +17,7 @@ import {
  *  controls open/close state and binds a ``/api/browse``-backed
  *  ``browseFn`` to the unified browser. */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-file-browser',
   standalone: true,
   imports: [FormsModule, FolderBrowserComponent],

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit, computed, effect, inject, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
@@ -35,6 +35,7 @@ import {
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-find-view',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -1,16 +1,17 @@
 
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   HostListener,
+  input,
   OnChanges,
   OnDestroy,
   OnInit,
+  output,
   SimpleChanges,
   ViewChild,
-  input,
-  output
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
@@ -71,6 +72,7 @@ const TYPEAHEAD_RESET_MS = 800;
  *  ``/api/browse-media-files``, ...).  The component never imports an
  *  API service directly. */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-folder-browser',
   standalone: true,
   imports: [IconComponent],

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnChanges, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, input, OnChanges } from '@angular/core';
 
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
@@ -75,6 +75,7 @@ function emojiToType(icon: string): string {
 const sanitizedCache = new Map<string, SafeHtml>();
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-icon',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, ViewChild, AfterViewInit, effect, inject, signal, untracked } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, ViewChild } from '@angular/core';
 
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -41,6 +41,7 @@ import { LabelViewPanelStateService } from './label-view-panel-state.service';
 import { buildMediaContextMenuItems } from './media-context-menu-items';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-view',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
 
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
@@ -30,6 +30,7 @@ export interface StepDisplay {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autopilot-panel',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
@@ -1,7 +1,8 @@
-import { Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-inclusion-slider',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,16 +1,17 @@
 import {
+  ChangeDetectionStrategy,
   Component,
-  Input,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-  ViewChild,
   computed,
   effect,
   inject,
+  Input,
   input,
+  OnChanges,
+  OnInit,
   output,
-  signal
+  signal,
+  SimpleChanges,
+  ViewChild,
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -32,6 +33,7 @@ import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.serv
 export type { SortMode, SelectMode, SortedItem };
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-left-panel',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnChanges, SimpleChanges, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-media-item',
   standalone: true,
   imports: [CommonModule],

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ElementRef, ViewChild, AfterViewChecked, ChangeDetectorRef, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges, computed, inject, input, output } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, ElementRef, inject, Input, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
 
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subject } from 'rxjs';
@@ -55,6 +55,7 @@ interface OrderedItem {
 type GridRow = { kind: 'items'; items: OrderedItem[] } | { kind: 'threshold' };
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-media-list',
   standalone: true,
   imports: [ScrollingModule, MediaItemComponent, SkeletonComponent],

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
 
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import {
@@ -9,6 +9,7 @@ import {
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-progress-indicators',
   standalone: true,
   imports: [ProgressBarComponent],

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
 
 import { SelectMode } from '../left-panel.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-select-mode',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input, OnInit, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input, OnInit, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { SortMode } from '../left-panel.component';
 import { LoadSortModalComponent } from '../../modals/load-sort-modal/load-sort-modal.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-sort-bar',
   standalone: true,
   imports: [FormsModule, LoadSortModalComponent],

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnChanges, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input, OnChanges, output } from '@angular/core';
 
 import { SortedItem } from '../left-panel.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-stripe-overview',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,9 +1,10 @@
-import { Component, inject, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-login',
   standalone: true,
   imports: [FormsModule],

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -2,7 +2,6 @@
 <div
   class="modal-backdrop"
   (click)="onBackdropClick($event)"
-  (keydown)="onKeydown($event)"
   role="dialog"
   aria-modal="true"
   [attr.aria-label]="title()"

--- a/frontend/src/app/components/modal/modal.component.spec.ts
+++ b/frontend/src/app/components/modal/modal.component.spec.ts
@@ -83,6 +83,23 @@ describe('ModalComponent', () => {
     expect(host.closeCalled).toBe(false);
   });
 
+  it('should close on Escape dispatched at document level (focus not in the modal)', async () => {
+    // Regression: modals open from a button, so focus stays on the button and a
+    // backdrop-scoped (keydown) never fired. The document-level handler must
+    // close an open modal regardless of where focus is.
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(host.closeCalled).toBe(true);
+  });
+
+  it('should ignore Escape when the modal is closed', async () => {
+    host.isOpen.set(false);
+    await settleZoneless(fixture);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(host.closeCalled).toBe(false);
+  });
+
   it('should hide close button when showCloseButton is false', async () => {
     host.isOpen.set(true);
     host.showCloseButton.set(false);

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-modal',
   standalone: true,
   templateUrl: './modal.component.html',

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, Input, input, output } from '@angular/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,8 +23,17 @@ export class ModalComponent {
     this.closed.emit();
   }
 
-  onKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Escape') {
+  /**
+   * Close on Escape. Listening on `document` (not the backdrop) is required
+   * because opening a modal from a button leaves focus on that button, so a
+   * `(keydown)` bound to the never-focused backdrop never fired — Esc did
+   * nothing until the user clicked into the modal. The `open()` guard ensures
+   * only a currently-open modal reacts. Mirrors the `context-menu` /
+   * `browse-bin-popup` `document:keydown.escape` pattern.
+   */
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.open()) {
       this.close();
     }
   }

--- a/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
+++ b/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
@@ -1,8 +1,9 @@
-import { Component, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { AchievementsTabComponent } from '../../achievements-tab/achievements-tab.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-achievements-modal',
   standalone: true,
   imports: [ModalComponent, AchievementsTabComponent],

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autodetect-progress-modal',
   standalone: true,
   imports: [ModalComponent, ProgressBarComponent],

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -17,6 +17,7 @@ import {
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autodetect-results-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, ClipboardCopyComponent],

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
@@ -6,6 +6,7 @@ import type { DatasetRegistryStatsResponse } from '../../../generated/api-client
 import { formatTimestamp as formatTs } from '../../../utils/format-date';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dataset-stats-modal',
   standalone: true,
   imports: [CommonModule, ModalComponent],

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsRegistryApiService } from '../../../services/detectors-registry-api.service';
@@ -11,6 +11,7 @@ import { formatTimestamp as formatTs } from '../../../utils/format-date';
  *  detector's creation/provenance metadata. Counts only — no embeddings
  *  or MLP weights are read (see the "No Persisted Vectors" rule). */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-detector-stats-modal',
   standalone: true,
   imports: [CommonModule, ModalComponent],

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
 
@@ -10,6 +10,7 @@ interface Example {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-examples-editor-modal',
   standalone: true,
   imports: [ModalComponent],

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -1,12 +1,13 @@
 import {
+  ChangeDetectionStrategy,
   Component,
-  OnInit,
   computed,
   effect,
   inject,
-  signal,
   input,
-  output
+  OnInit,
+  output,
+  signal,
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -36,6 +37,7 @@ export interface ColumnDef {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-export-modal',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsFindApiService } from '../../../services/detectors-find-api.service';
@@ -20,6 +20,7 @@ interface ChartPoint {
  * See docs/plans/find-verification-workflow.md.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-find-stats-modal',
   standalone: true,
   imports: [CommonModule, ModalComponent],

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit, SecurityContext, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, output, SecurityContext, signal } from '@angular/core';
 
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -41,6 +41,7 @@ const THEME_VARIANT_RE = /\.(light|dark)\.(png|jpe?g|webp|gif|avif)$/i;
 const ABSOLUTE_SRC_RE = /^([a-z]+:)?\/\//i;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-keyboard-help-modal',
   standalone: true,
   imports: [ModalComponent],

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, inject, signal, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, Input, input, output, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
@@ -7,6 +7,7 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-exporter-modal',
   standalone: true,
   imports: [ModalComponent, IconComponent],

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -1,13 +1,14 @@
 import {
+  ChangeDetectionStrategy,
   Component,
-  ElementRef,
-  OnDestroy,
-  ViewChild,
   computed,
+  ElementRef,
   inject,
   input,
+  OnDestroy,
   output,
   signal,
+  ViewChild,
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
@@ -24,6 +25,7 @@ import type { LabelImporterEntry } from '../../../generated/api-client/models/la
 type ModalView = 'picker' | 'form';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-importer-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -23,6 +23,7 @@ interface BrowseItem {
 type MediaPickerView = 'sources' | 'browse-items' | 'file-browser';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-load-sort-modal',
   standalone: true,
   imports: [CommonModule, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent],

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
@@ -1,12 +1,13 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
-  OnDestroy,
-  ViewChild,
   input,
-  output
+  OnDestroy,
+  output,
+  ViewChild,
 } from '@angular/core';
 
 
@@ -20,6 +21,7 @@ type DragMode = 'none' | 'start' | 'end' | 'move';
 const HANDLE_HIT_PX = 12;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-audio-crop-overlay',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
@@ -1,10 +1,11 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
-  ViewChild,
   input,
-  output
+  output,
+  ViewChild,
 } from '@angular/core';
 
 
@@ -18,6 +19,7 @@ type DragMode = 'none' | 'move' | 'tl' | 'tr' | 'bl' | 'br' | 'l' | 'r' | 't' | 
 const HANDLE_HIT_RADIUS = 12;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-image-crop-overlay',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnDestroy, OnInit, output } from '@angular/core';
 
 import { ModalComponent } from '../../modal/modal.component';
 import { ImageCropOverlayComponent, ImageCropResult } from './image-crop-overlay.component';
@@ -14,6 +14,7 @@ export interface MediaCropResult {
 type View = 'confirm' | 'cropping';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-media-crop-modal',
   standalone: true,
   imports: [ModalComponent, ImageCropOverlayComponent, AudioCropOverlayComponent],

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnDestroy, OnInit, output, ViewChild } from '@angular/core';
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,6 +17,7 @@ import type { EvalTrainAndScoreResponse } from '../../../generated/api-client/mo
 export type ProgressMetric = 'smart' | 'stable' | 'diverse';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-progress-modal',
   standalone: true,
   imports: [ModalComponent, ProgressBarComponent],

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, input, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -23,6 +23,7 @@ export interface ResortResult {
 type ModalView = 'prompt' | 'media-picker';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-resort-prompt-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent],

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, computed, inject, signal, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnDestroy, output, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
@@ -13,6 +13,7 @@ import type { RunSettingsExportResponse } from '../../../generated/api-client/mo
 type ModalView = 'picker' | 'form';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-settings-exporter-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, computed, inject, signal, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnDestroy, output, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
@@ -12,6 +12,7 @@ import type { SettingsImporterEntry } from '../../../generated/api-client/models
 type ModalView = 'picker' | 'form';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-settings-importer-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnDestroy, OnInit, output, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -42,6 +42,7 @@ export interface AutoFindExporterChange {
  *     `autofind_exporter` / `autofind_exporter_field_values`.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-auto-find-settings',
   standalone: true,
   imports: [FormsModule, IconComponent],

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -31,6 +31,7 @@ import {
  *  Edits are emitted as a full :type:`ImportDefaultsByMediaType` map so
  *  the parent can persist them with the rest of the settings dict. */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-import-defaults-settings',
   standalone: true,
   imports: [FormsModule, IconComponent, SourceSpecsPickerComponent, ClipperChooserComponent],

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { forkJoin, Subject } from 'rxjs';
@@ -29,6 +29,7 @@ import {
 } from '../../browse-canvas/hex-render.util';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-settings-modal',
   standalone: true,
   imports: [FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, ImportDefaultsSettingsComponent, FieldHintIconComponent, AutoFindSettingsComponent],

--- a/frontend/src/app/components/offline-banner/offline-banner.component.ts
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ConnectionStateService } from '../../services/connection-state.service';
 
 /**
@@ -10,6 +10,7 @@ import { ConnectionStateService } from '../../services/connection-state.service'
  * the SSE stream stay paused until the user reconnects.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-offline-banner',
   standalone: true,
   imports: [],

--- a/frontend/src/app/components/progress-bar/progress-bar.component.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-progress-bar',
   standalone: true,
   templateUrl: './progress-bar.component.html',

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
@@ -1,8 +1,9 @@
-import { Component, ElementRef, Input, ViewChild, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, output, ViewChild } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-detector-context-bar',
   standalone: true,
   imports: [FormsModule],

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy, inject, input, output, signal } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, OnInit, output, signal, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -16,6 +16,7 @@ export interface LabelEntry {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-list',
   standalone: true,
   imports: [CommonModule],

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 export type LabelSortMode =
@@ -11,6 +11,7 @@ export type LabelSortMode =
   | 'id-asc';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-sort',
   standalone: true,
   imports: [FormsModule],

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Component, ElementRef, OnChanges, SimpleChanges, ViewChild, inject, input, output } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, Component, ElementRef, inject, input, OnChanges, output, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
@@ -9,6 +9,7 @@ interface SortedElement extends DetectorLabelView {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-labelset-list',
   standalone: true,
   imports: [CommonModule],

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, computed, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, Input, input, OnChanges, OnDestroy, OnInit, output, signal, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -25,6 +25,7 @@ export interface TrainModeContext {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-right-panel',
   standalone: true,
   imports: [

--- a/frontend/src/app/components/skeleton/skeleton.component.ts
+++ b/frontend/src/app/components/skeleton/skeleton.component.ts
@@ -1,7 +1,8 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { NgStyle } from '@angular/common';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-skeleton',
   standalone: true,
   imports: [NgStyle],

--- a/frontend/src/app/components/toast-container/toast-container.component.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, signal } from '@angular/core';
 
 import { AsyncPipe } from '@angular/common';
 import { Toast, ToastService } from '../../services/toast.service';
@@ -10,6 +10,7 @@ import { Toast, ToastService } from '../../services/toast.service';
  * info actions (preserves the old global-error-banner UX).
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-toast-container',
   standalone: true,
   imports: [AsyncPipe],

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, SimpleChanges, effect, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 import { SettingsStateService } from '../../services/settings-state.service';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
@@ -9,6 +9,7 @@ const ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL'] as const;
 type IconSize = (typeof ICON_SIZES)[number];
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-view-controls',
   standalone: true,
   imports: [IconComponent],

--- a/frontend/src/app/guards/active-context.guard.spec.ts
+++ b/frontend/src/app/guards/active-context.guard.spec.ts
@@ -38,13 +38,18 @@ describe('activeContextGuard', () => {
     detectors: DetectorRegistryEntry[],
   ): void {
     const ds = datasetState as unknown as {
-      datasetsSubject: { next: (v: unknown) => void };
-      detectorsSubject: { next: (v: unknown) => void };
-      loadedSubject: { next: (v: unknown) => void };
+      _datasets: { set: (v: unknown) => void };
+      _detectors: { set: (v: unknown) => void };
+      _loaded: { set: (v: unknown) => void };
     };
-    ds.datasetsSubject.next(datasets);
-    ds.detectorsSubject.next(detectors);
-    ds.loadedSubject.next(true);
+    ds._datasets.set(datasets);
+    ds._detectors.set(detectors);
+    ds._loaded.set(true);
+    // `loaded$` is a `toObservable` bridge over the `_loaded` signal: its
+    // backing effect pushes the new value into the replayed stream on the next
+    // change-detection pass. Tick so the guard's `loaded$` subscription replays
+    // `true` synchronously when it subscribes below.
+    TestBed.tick();
   }
 
   function runGuard(datasetId: string, detectorId: string): MaybeAsync<GuardResult> {

--- a/frontend/src/app/services/active-context-watcher.service.spec.ts
+++ b/frontend/src/app/services/active-context-watcher.service.spec.ts
@@ -23,15 +23,21 @@ describe('ActiveContextWatcherService', () => {
     return { id, name, media_type: 'audio' } as DetectorRegistryEntry;
   }
 
+  // DatasetStateService is signal-backed; `datasets$`/`detectors$` are
+  // `toObservable` bridges whose backing effects push into the stream on the
+  // next change-detection pass. Set the private signal, then tick so the
+  // watcher's `combineLatest` observes the new value before the test asserts
+  // (mirrors the old synchronous BehaviorSubject `.next()`).
   function setDatasets(entries: DatasetRegistryEntry[]): void {
-    // BehaviorSubject is private; cast through any for test setup.
-    (datasetState as unknown as { datasetsSubject: { next: (v: unknown) => void } })
-      .datasetsSubject.next(entries);
+    (datasetState as unknown as { _datasets: { set: (v: unknown) => void } })._datasets.set(entries);
+    TestBed.tick();
   }
 
   function setDetectors(entries: DetectorRegistryEntry[]): void {
-    (datasetState as unknown as { detectorsSubject: { next: (v: unknown) => void } })
-      .detectorsSubject.next(entries);
+    (datasetState as unknown as { _detectors: { set: (v: unknown) => void } })._detectors.set(
+      entries,
+    );
+    TestBed.tick();
   }
 
   beforeEach(() => {
@@ -47,6 +53,9 @@ describe('ActiveContextWatcherService', () => {
 
   it('does not toast when the registry is empty (initial-load state)', () => {
     activeContext.setActivePair('d1', 'm1');
+    // Flush the (empty) registry bridges so combineLatest fires; the active
+    // ids were never seen in the registry, so no phantom deletion toast.
+    TestBed.tick();
     // Registry still empty; could just be loading.
     expect(toast.toasts.length).toBe(0);
     expect(activeContext.datasetId).toBe('d1');

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Injectable, inject, signal } from '@angular/core';
+import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { LoadingTask } from '../models/api.models';
 import { AchievementsService } from './achievements.service';
@@ -37,11 +37,12 @@ export class DashboardLoadingTasksService {
   private datasetState = inject(DatasetStateService);
   private achievements = inject(AchievementsService);
 
-  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
-  private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
-
-  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
-  readonly detectorLoadingTasks$ = this.detectorLoadingTasksSubject.asObservable();
+  // Signals (not BehaviorSubjects) so the dashboard's template reads of
+  // `loadingTasks`/`orphanLoadingTasks`/`inlineTaskMap` repaint under zoneless
+  // OnPush change detection: a `.set()` from the SSE-driven poller schedules CD
+  // because the value is read (through getters) during template evaluation.
+  private readonly _loadingTasks = signal<LoadingTask[]>([]);
+  private readonly _detectorLoadingTasks = signal<LoadingTask[]>([]);
 
   private polling$ = new Subject<void>();
   private detectorPolling$ = new Subject<void>();
@@ -79,17 +80,17 @@ export class DashboardLoadingTasksService {
     this.completedModelTaskIds.clear();
     this.datasetPollingActive = false;
     this.detectorPollingActive = false;
-    this.loadingTasksSubject.next([]);
-    this.detectorLoadingTasksSubject.next([]);
+    this._loadingTasks.set([]);
+    this._detectorLoadingTasks.set([]);
     this.datasetState.setLoading(false);
   }
 
   get loadingTasks(): LoadingTask[] {
-    return this.loadingTasksSubject.value;
+    return this._loadingTasks();
   }
 
   get detectorLoadingTasks(): LoadingTask[] {
-    return this.detectorLoadingTasksSubject.value;
+    return this._detectorLoadingTasks();
   }
 
   /** Map dataset_id → LoadingTask for tasks that match an existing dataset row. */
@@ -152,7 +153,7 @@ export class DashboardLoadingTasksService {
           const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
           const failed = errored.filter((t) => t.error !== 'Cancelled');
 
-          this.loadingTasksSubject.next([...active, ...failed]);
+          this._loadingTasks.set([...active, ...failed]);
 
           // Detect tasks that just completed successfully so we can
           // refresh the registry immediately (not only when ALL finish).
@@ -201,7 +202,7 @@ export class DashboardLoadingTasksService {
           const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
           const failed = errored.filter((t) => t.error !== 'Cancelled');
 
-          this.detectorLoadingTasksSubject.next([...active, ...failed]);
+          this._detectorLoadingTasks.set([...active, ...failed]);
 
           // Detect tasks that just completed successfully
           const justFinished = tasks.filter(
@@ -234,7 +235,7 @@ export class DashboardLoadingTasksService {
   }
 
   dismissLoadingTask(taskId: string): void {
-    this.loadingTasksSubject.next(this.loadingTasks.filter((t) => t.task_id !== taskId));
+    this._loadingTasks.set(this.loadingTasks.filter((t) => t.task_id !== taskId));
   }
 
   cancelDetectorLoadingTask(taskId: string): void {
@@ -242,7 +243,7 @@ export class DashboardLoadingTasksService {
   }
 
   dismissDetectorLoadingTask(taskId: string): void {
-    this.detectorLoadingTasksSubject.next(
+    this._detectorLoadingTasks.set(
       this.detectorLoadingTasks.filter((t) => t.task_id !== taskId),
     );
   }

--- a/frontend/src/app/services/dataset-state.service.spec.ts
+++ b/frontend/src/app/services/dataset-state.service.spec.ts
@@ -108,13 +108,16 @@ describe('DatasetStateService', () => {
   });
 
   it('refresh should record error on registry fetch failure and clear on retry success', () => {
+    // `error` is signal-backed; sample it after each step (the `error$`
+    // `toObservable` bridge emits asynchronously, so polling the synchronous
+    // getter is the deterministic way to capture the state transitions).
     const errors: (string | null)[] = [];
-    service.error$.subscribe((e) => errors.push(e));
 
     service.refresh();
     // forkJoin cancels the sibling detectors request when datasets errors.
     httpMock.expectOne('/api/detectors/registry');
     httpMock.expectOne('/api/datasets/registry').error(new ProgressEvent('Network error'));
+    errors.push(service.error);
     expect(service.error).toBe("Couldn't load datasets and detectors.");
 
     // A second refresh after the failure should still work; the
@@ -122,9 +125,10 @@ describe('DatasetStateService', () => {
     service.refresh();
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [{ id: '1', name: 'ok' }] });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
+    errors.push(service.error);
     expect(service.datasets.length).toBe(1);
     expect(service.error).toBeNull();
-    // Sanity: we saw both error and success emissions.
+    // Sanity: we saw both the error and the cleared (success) state.
     expect(errors).toContain("Couldn't load datasets and detectors.");
     expect(errors[errors.length - 1]).toBeNull();
   });

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, OnDestroy, inject } from '@angular/core';
-import { BehaviorSubject, Subject, forkJoin, of } from 'rxjs';
+import { Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subject, forkJoin, of } from 'rxjs';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
 import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
 import { DatasetsRegistryApiService } from './datasets-registry-api.service';
@@ -10,30 +11,37 @@ export class DatasetStateService implements OnDestroy {
   private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private detectorsRegistryApi = inject(DetectorsRegistryApiService);
 
-  private readonly datasetsSubject = new BehaviorSubject<DatasetRegistryEntry[]>([]);
-  private readonly detectorsSubject = new BehaviorSubject<DetectorRegistryEntry[]>([]);
-  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
-  private readonly progressMessageSubject = new BehaviorSubject<string>('');
+  // Signals (not BehaviorSubjects) so direct template reads of the value
+  // getters (`datasets`/`loading`/`loaded`/…) repaint under zoneless OnPush
+  // change detection: reading a signal through a getter during template
+  // evaluation is tracked, so a `.set()` from the registry fetch schedules CD.
+  // The `$` observables are kept as `toObservable` bridges so the remaining
+  // RxJS consumers (context-pulldown, app.component, the route guards,
+  // active-context-watcher) work unchanged.
+  private readonly _datasets = signal<DatasetRegistryEntry[]>([]);
+  private readonly _detectors = signal<DetectorRegistryEntry[]>([]);
+  private readonly _loading = signal(false);
+  private readonly _progressMessage = signal('');
   /** Last registry-fetch error, or null if the most recent fetch
    *  succeeded. Surfaced inline in the context-pulldowns so the user can
    *  retry without leaving their current view. */
-  private readonly errorSubject = new BehaviorSubject<string | null>(null);
+  private readonly _error = signal<string | null>(null);
   /** Flips to `true` the first time the registry returns from the
    *  server, success or empty. Used by the active-context route guard
    *  to know when it's safe to validate a URL pair against the
    *  registry; on a deep-link cold start, the guard may run before the
    *  initial fetch lands. */
-  private readonly loadedSubject = new BehaviorSubject<boolean>(false);
+  private readonly _loaded = signal(false);
   private readonly destroy$ = new Subject<void>();
   /** Emits whenever a refresh is requested; switchMap ensures only the latest response is used. */
   private readonly refreshTrigger$ = new Subject<void>();
 
-  readonly datasets$ = this.datasetsSubject.asObservable();
-  readonly detectors$ = this.detectorsSubject.asObservable();
-  readonly loading$ = this.loadingSubject.asObservable();
-  readonly progressMessage$ = this.progressMessageSubject.asObservable();
-  readonly error$ = this.errorSubject.asObservable();
-  readonly loaded$ = this.loadedSubject.asObservable();
+  readonly datasets$ = toObservable(this._datasets);
+  readonly detectors$ = toObservable(this._detectors);
+  readonly loading$ = toObservable(this._loading);
+  readonly progressMessage$ = toObservable(this._progressMessage);
+  readonly error$ = toObservable(this._error);
+  readonly loaded$ = toObservable(this._loaded);
 
   constructor() {
     // Single subscription that uses switchMap to cancel in-flight requests
@@ -53,18 +61,18 @@ export class DatasetStateService implements OnDestroy {
       .subscribe({
         next: (res) => {
           if (res === null) {
-            this.errorSubject.next("Couldn't load datasets and detectors.");
+            this._error.set("Couldn't load datasets and detectors.");
             // A failed fetch still resolves the "have we tried?" question,
             // so the route guard doesn't hang forever.
-            if (!this.loadedSubject.value) this.loadedSubject.next(true);
+            if (!this._loaded()) this._loaded.set(true);
             return;
           }
-          this.datasetsSubject.next(
+          this._datasets.set(
             (res.datasets.datasets || []) as unknown as DatasetRegistryEntry[],
           );
-          this.detectorsSubject.next(res.detectors.detectors || []);
-          if (this.errorSubject.value !== null) this.errorSubject.next(null);
-          if (!this.loadedSubject.value) this.loadedSubject.next(true);
+          this._detectors.set(res.detectors.detectors || []);
+          if (this._error() !== null) this._error.set(null);
+          if (!this._loaded()) this._loaded.set(true);
         },
       });
   }
@@ -75,35 +83,35 @@ export class DatasetStateService implements OnDestroy {
   }
 
   get datasets(): DatasetRegistryEntry[] {
-    return this.datasetsSubject.value;
+    return this._datasets();
   }
 
   get detectors(): DetectorRegistryEntry[] {
-    return this.detectorsSubject.value;
+    return this._detectors();
   }
 
   get loading(): boolean {
-    return this.loadingSubject.value;
+    return this._loading();
   }
 
   get progressMessage(): string {
-    return this.progressMessageSubject.value;
+    return this._progressMessage();
   }
 
   get error(): string | null {
-    return this.errorSubject.value;
+    return this._error();
   }
 
   get loaded(): boolean {
-    return this.loadedSubject.value;
+    return this._loaded();
   }
 
   setLoading(loading: boolean): void {
-    this.loadingSubject.next(loading);
+    this._loading.set(loading);
   }
 
   setProgressMessage(message: string): void {
-    this.progressMessageSubject.next(message);
+    this._progressMessage.set(message);
   }
 
   refresh(): void {
@@ -111,11 +119,11 @@ export class DatasetStateService implements OnDestroy {
   }
 
   clear(): void {
-    this.datasetsSubject.next([]);
-    this.detectorsSubject.next([]);
-    this.loadingSubject.next(false);
-    this.progressMessageSubject.next('');
-    this.errorSubject.next(null);
-    this.loadedSubject.next(false);
+    this._datasets.set([]);
+    this._detectors.set([]);
+    this._loading.set(false);
+    this._progressMessage.set('');
+    this._error.set(null);
+    this._loaded.set(false);
   }
 }


### PR DESCRIPTION
Finishes the last two open items of the zoneless migration (`docs/plans/zoneless-migration.md`, Phase 5).

## 1. Explicit `ChangeDetectionStrategy.OnPush` on all 86 components

The plan expected this to be documentation-only ("under zoneless they already behave OnPush-like"), but it surfaced a real gap: a couple of components still read **non-signal `BehaviorSubject` service getters directly in their templates** and relied on the default CheckAlways strategy for "free" repaints on any CD pass. Under OnPush a host only re-checks when it's dirtied, so those services had to be signalized:

- **`DatasetStateService`** — `datasets`/`detectors`/`loading`/`progressMessage`/`error`/`loaded` are now private `signal`s exposed via value-returning getters (tracked when read during template evaluation, the same getter-signal trick proven for SortState/VoteState in Phase 2.5). The `$` observables are kept as `toObservable` bridges, so the RxJS consumers (context-pulldown, app.component, active-context-watcher, the route guards) are unchanged.
- **`DashboardLoadingTasksService`** — `loadingTasks`/`detectorLoadingTasks` signalized the same way; its unused `$` observables were dropped.

The OnPush add itself was mechanical: `changeDetection: ChangeDetectionStrategy.OnPush` as the first `@Component` property + the `@angular/core` import.

Because `toObservable` emits on the next CD pass rather than synchronously like a `BehaviorSubject`, four spec files gained `TestBed.tick()` calls to step past the bridge (dashboard, active-context-watcher, active-context-guard, dataset-state service). No production behavior change — registry data arrives async in real life regardless.

## 2. `vt-modal` Esc-to-close fix

Pre-existing bug found during Phase 4 QA (not a zoneless regression): opening a modal from a button leaves focus on the button, and the modal's `Esc` handler was a `(keydown)` bound to the never-focused `.modal-backdrop`, so Esc did nothing until you clicked into the modal. Moved it to `@HostListener('document:keydown.escape')` (guarded by `open()`), mirroring the existing `context-menu` / `browse-bin-popup` pattern; removed the backdrop `(keydown)` so it can't double-emit `closed`. The focus-the-backdrop alternative was rejected because several modals use `autofocus` / programmatic input focus that it would fight. Two regression canaries added.

## Testing

- `./run-tests.sh` — **5026 passed**, 1 skipped.
- `./run-tests.sh frontend` — **860 tests** passed; `build:prod` clean (0 warnings); `npm audit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDBtHNnhE6szWdrWucCPwK)_