### PR TITLE
Add "reference files in place" (no-copy) import option for server importers

### DIFF
--- a/docs/plans/server-dedup-references.md
+++ b/docs/plans/server-dedup-references.md
@@ -1,0 +1,117 @@
+# Reference (no-copy) dataset import
+
+Status: **Phase 1 shipped.** Whole-file references for the two server
+importers (`server_folder`, `server_files`) are wired end-to-end. Phase 2
+(lazy clips **and** lazy converter output) is deferred — see *Open
+follow-ups*.
+
+## Problem
+
+Importing a server-side folder or manifest copies every file's bytes into
+the dataset: full mode inlines `media_bytes` into each media dict, and those
+bytes get baked into the registry pickle. For large collections this
+duplicates storage that already lives on the server. When the source files
+are reliable and will persist, that duplication is pure waste.
+
+## Mechanism: thin mode, surfaced as an import option
+
+The library already had **thin mode** (`thin=True`): the loader stores a
+`media_path` reference instead of loading `media_bytes`, and
+`MediaType._resolve_media_bytes` (`vtscore/media/base.py`) reads bytes lazily
+on demand (`media_bytes → media_path → media_url`). It was previously only
+reachable from the CLI autodetect path (`vtscore/cli.py`).
+
+**We did not add symlinks.** The server importers already reference files in
+place (they never copy into a managed directory), so the only duplication is
+the inlined bytes in the pickle. A plain `media_path` reference removes that;
+a symlink would add inodes + cleanup for no benefit, and breaks across
+machines exactly as badly as an absolute path. References win.
+
+## What shipped (Phase 1)
+
+- **`reference_files` import option** (`field_type="checkbox"`,
+  `include_in_origin=False`) on `server_folder` and `server_files`. Kept out
+  of the persisted origin: reference-vs-copy is a storage choice, not part of
+  the data source's identity, so it must not perturb dedup / reload matching.
+- **Threaded as `thin`** in `load_pipeline._run_importer_in_background`: the
+  flag is popped from `field_values` and passed to
+  `importer.run(...) / run_chunked(...)` as `thin=`. Other importers never
+  receive the field, so they always run in copy mode (unchanged).
+- **Full-mode pickle load now honors `media_path`**
+  (`loader_pickle._convert_one_pickle_media`). Reopening a saved dataset from
+  the dashboard loads the registry pickle in *full* mode, which previously
+  ignored `media_path` and **dropped** every media that had no inline bytes.
+  It now falls back to the stored `media_path` (when the file still exists)
+  and loads that media lazily, so a reference dataset survives the
+  registry-save → full-mode-reopen round-trip. This also rescues both disk
+  *and* RAM: the reopened dataset stays references, not re-inlined bytes.
+- **Frontend**: a `checkbox` branch was added to the generic importer form
+  (it had none — a checkbox field would have rendered as a text input), so
+  `server_files` / Manifest shows the option; and the custom `server_folder`
+  picker got the checkbox + `sfReferenceFiles` state + `reference_files`
+  submit param.
+
+### Accepted brittleness
+
+A reference dataset depends on its source files staying put. Moving or
+deleting them breaks the dataset (medias whose `media_path` no longer
+resolves are dropped on reopen, exactly like a missing companion file
+today). This is the explicit trade the option exists to make.
+
+### Deliberately *not* in scope for Phase 1
+
+- **Browser-upload importers** (`local_folder`, `local_files`) stage uploads
+  into a temp dir that is deleted after import, so references would dangle.
+  The option is not offered there.
+- **Clippers and converters** still materialize bytes (see below).
+
+## Open follow-ups (Phase 2: lazy clips AND lazy converter output)
+
+Phase 1 only avoids duplication for media imported **as-is**. Two transforms
+still copy bytes into the dataset, and both should learn a lazy/reference
+form. Treat them together — they share the same shape (reference the
+original + a recipe, resolve on demand) and the same set of downstream
+consumers to update.
+
+1. **Lazy clips.** Clippers (`vtscore/media/audio/clipper.py`,
+   `vtscore/media/video/clipper.py`, text clippers) eagerly slice real bytes
+   into each clip's `media_bytes` (e.g. `_wav_slice`). A clip already records
+   `clip_start` / `clip_end`, so the data model is half-built. A *lazy clip*
+   would set `media_bytes=None`, keep the original `media_path` + range, and
+   have the byte-resolution path slice on demand.
+
+2. **Lazy converter output.** Converters (`vtscore/converters/`, e.g.
+   document→image, video→frame) similarly produce derived media with
+   materialized bytes via `run_converters_on_folder`. The reference form
+   would store the source `media_path` + the converter name/params and
+   re-run the conversion (or a cached slice) on demand. PDF page expansion
+   (`load_pdf_images_into`) is the same pattern.
+
+### Phase 2 design notes / ripple points
+
+Both lazy clips and lazy converters need the same machinery, so build it
+once:
+
+- A way to mark a media as "derived/virtual" carrying `(source ref,
+  recipe)` where recipe is a clip range or a converter+params.
+- **Byte resolution** (`MediaType._resolve_media_bytes` /
+  `_resolve_media_string`) must detect a virtual media and produce bytes by
+  resolving the source then applying the recipe (slice / convert), ideally
+  with a small process-scoped cache (per the no-persisted-bytes rule — never
+  serialize the materialized result).
+- **Embedding** pulls bytes through the same resolution path, so it works for
+  free once resolution does — but verify the embed stage doesn't assume
+  inline bytes.
+- **Origin → re-embed rederivation** (`vtscore/detectors/resolver.py`)
+  currently resolves an origin to the *whole* original file; for virtual
+  media it must re-apply the clip range / converter to reproduce the exact
+  derived bytes the embedding was trained on.
+- **HTTP serving** and **exporters** (anything that streams `media_bytes`)
+  go through resolution, so confirm each consumer tolerates on-demand
+  materialization (latency, partial-range requests for audio/video scrub).
+- **Pickle round-trip**: the same full-mode-honors-reference fix applies, but
+  the recipe must serialize too (it's not a vector or an MLP, so it's allowed
+  to persist).
+
+These are deferred; Phase 1 delivers the bulk of the storage win for
+un-clipped, un-converted server datasets.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5981,6 +5981,9 @@
           "paths_file": {
             "type": "string"
           },
+          "reference_files": {
+            "default": null
+          },
           "source_specs": {
             "default": null,
             "nullable": true
@@ -6037,6 +6040,9 @@
             "type": "string"
           },
           "recursive": {
+            "default": null
+          },
+          "reference_files": {
             "default": null
           },
           "source_specs": {
@@ -6483,6 +6489,9 @@
           "paths_file": {
             "type": "string"
           },
+          "reference_files": {
+            "default": null
+          },
           "source_specs": {
             "default": null,
             "nullable": true
@@ -6519,6 +6528,9 @@
             "type": "string"
           },
           "recursive": {
+            "default": null
+          },
+          "reference_files": {
             "default": null
           },
           "source_specs": {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -141,6 +141,18 @@
       </div>
 
       <div class="form-group">
+        <label class="form-label" for="sf-reference-files" title="When enabled, the dataset stores a path reference to each original file on the server instead of copying its bytes in. Saves storage, but the dataset depends on the source files staying put — moving or deleting them breaks it.">
+          <input
+            id="sf-reference-files"
+            type="checkbox"
+            [ngModel]="sfReferenceFiles"
+            (ngModelChange)="sfReferenceFiles = $event"
+          />
+          Reference files in place (don't copy)
+        </label>
+      </div>
+
+      <div class="form-group">
         <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
         <input
           id="sf-dataset-name"
@@ -309,6 +321,13 @@
                 class="form-input"
                 [accept]="field.accept || ''"
                 (change)="onFileSelected($event, field.key)"
+              />
+            } @else if (field.field_type === 'checkbox') {
+              <input
+                [id]="'field-' + field.key"
+                type="checkbox"
+                [checked]="formValues[field.key] === true || formValues[field.key] === 'true'"
+                (change)="formValues[field.key] = $any($event.target).checked ? 'true' : 'false'"
               />
             } @else if (field.field_type === 'select') {
               <select

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -177,6 +177,9 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Whether archives inside the picked folder are extracted and imported.
    *  Also enables pointing the folder path directly at a single archive. */
   sfDigArchives = false;
+  /** Whether the dataset references the original files in place instead of
+   *  copying their bytes in (maps onto the loader's thin mode). */
+  sfReferenceFiles = false;
   /** Optional user-supplied dataset name for server-folder imports. */
   sfDatasetName = '';
   /** Whether the user has manually edited :prop:`sfDatasetName`. */
@@ -1613,6 +1616,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfSubmitting.set(false);
     this.sfRecursive = this.readRecursiveDefault(this.selectedImporter());
     this.sfDigArchives = false;
+    this.sfReferenceFiles = false;
     this.sfDatasetName = '';
     this.sfDatasetNameDirty = false;
     this.sfPathInputValue = '';
@@ -2055,6 +2059,7 @@ export class DatasetImporterModalComponent implements OnInit {
       media_type: this.sfMediaType(),
       recursive: this.sfRecursive,
       dig_archives: this.sfDigArchives,
+      reference_files: this.sfReferenceFiles,
     };
     const sfName = (this.sfDatasetName || '').trim();
     if (sfName) {

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -173,6 +173,65 @@ class TestThinLoadFromPickle:
         assert medias[1]["media_bytes"] is not None
 
 
+class TestFullModeMediaPathReference:
+    """Full-mode pickle load must honor a stored ``media_path`` reference.
+
+    A reference dataset (imported with ``reference_files`` / thin) is saved to
+    the registry pickle with ``media_bytes=None`` and a ``media_path`` pointing
+    at the original file.  Reopening from the dashboard loads that pickle in
+    *full* mode, which historically ignored ``media_path`` and dropped every
+    such media.  It must instead fall back to the reference and load it lazily,
+    so the reference dataset survives the save → reopen round-trip.
+    """
+
+    def _make_reference_pickle(self, tmp_path: Path, media_path: str | None) -> Path:
+        """Pickle one audio media with no inline bytes and a ``media_path``."""
+        wav_bytes = _make_wav_bytes()
+        media: dict[str, Any] = {
+            "id": 1,
+            "media_type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "embedding": np.zeros(512).tolist(),
+            "embedder": "clap",
+            "filename": "test.wav",
+            "category": "test",
+            "media_bytes": None,
+            "media_path": media_path,
+        }
+        pkl_path = tmp_path / "ref.pkl"
+        from vtscore.datasets.container import write_container
+
+        write_container(pkl_path, pickle.dumps({"medias": {1: media}}), {"format_version": 1})
+        return pkl_path
+
+    def test_full_mode_keeps_media_when_path_exists(self, tmp_path):
+        src = _make_wav_file(tmp_path, "test.wav")
+        pkl_path = self._make_reference_pickle(tmp_path, str(src))
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert len(medias) == 1
+        # Loaded lazily: no bytes in RAM, but the reference resolves on disk.
+        assert medias[1]["media_bytes"] is None
+        assert medias[1]["media_path"] == str(src)
+        assert Path(medias[1]["media_path"]).exists()
+        assert isinstance(media_embedding(medias[1]), np.ndarray)
+
+    def test_full_mode_drops_media_when_path_missing(self, tmp_path, capsys):
+        pkl_path = self._make_reference_pickle(tmp_path, str(tmp_path / "gone.wav"))
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert medias == {}
+        assert "1 media files missing" in capsys.readouterr().out
+
+    def test_full_mode_drops_media_when_no_path(self, tmp_path):
+        pkl_path = self._make_reference_pickle(tmp_path, None)
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert medias == {}
+
+
 class TestPickleNullEmbedding:
     """Skip-on-None pickle entries (audit M8 / M12).
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -887,9 +887,7 @@ class TestLocalArchiveImport:
         assert str(ref.default).lower() == "false"
         # Storage choice, not source identity: must stay out of the origin.
         assert ref.include_in_origin is False
-        origin = IMPORTER.build_origin(
-            {"path": "/data/audio", "media_type": "audio", "reference_files": "true"}
-        )
+        origin = IMPORTER.build_origin({"path": "/data/audio", "media_type": "audio", "reference_files": "true"})
         assert "reference_files" not in origin["params"]
 
     def test_server_folder_run_cli_rejects_missing_path(self):

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -878,6 +878,20 @@ class TestLocalArchiveImport:
         assert dig.field_type == "checkbox"
         assert str(dig.default).lower() == "false"
 
+    def test_server_folder_has_reference_files_field(self):
+        from vtscore.datasets.importers.server_folder import IMPORTER
+
+        ref = next((f for f in IMPORTER.fields if f.key == "reference_files"), None)
+        assert ref is not None
+        assert ref.field_type == "checkbox"
+        assert str(ref.default).lower() == "false"
+        # Storage choice, not source identity: must stay out of the origin.
+        assert ref.include_in_origin is False
+        origin = IMPORTER.build_origin(
+            {"path": "/data/audio", "media_type": "audio", "reference_files": "true"}
+        )
+        assert "reference_files" not in origin["params"]
+
     def test_server_folder_run_cli_rejects_missing_path(self):
         from vtscore.datasets.importers.server_folder import IMPORTER
 

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -167,6 +167,16 @@ class TestImporterMetadata:
             "params": {"paths_file": "/a/list.txt", "media_type": "audio"},
         }
 
+    def test_reference_files_field_excluded_from_origin(self):
+        """``reference_files`` is a storage choice, not part of source identity."""
+        imp = ServerFilesDatasetImporter()
+        keys = {f.key for f in imp.fields}
+        assert "reference_files" in keys
+        origin = imp.build_origin(
+            {"paths_file": "/a/list.txt", "media_type": "audio", "reference_files": "true"}
+        )
+        assert "reference_files" not in origin["params"]
+
     def test_resolve_file_returns_origin_name_when_file_exists(self, tmp_path):
         f = tmp_path / "real.wav"
         f.write_bytes(b"x")

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -172,9 +172,7 @@ class TestImporterMetadata:
         imp = ServerFilesDatasetImporter()
         keys = {f.key for f in imp.fields}
         assert "reference_files" in keys
-        origin = imp.build_origin(
-            {"paths_file": "/a/list.txt", "media_type": "audio", "reference_files": "true"}
-        )
+        origin = imp.build_origin({"paths_file": "/a/list.txt", "media_type": "audio", "reference_files": "true"})
         assert "reference_files" not in origin["params"]
 
     def test_resolve_file_returns_origin_name_when_file_exists(self, tmp_path):

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -228,6 +228,23 @@ class ServerFilesDatasetImporter(DatasetImporter):
             ),
             accept=".txt,.list,.npz",
         ),
+        ImporterField(
+            key="reference_files",
+            label="Reference files in place (don't copy)",
+            field_type="checkbox",
+            description=(
+                "When enabled, the dataset stores a path reference to each listed "
+                "file on the server instead of copying its bytes in.  Saves storage, "
+                "but the dataset depends on the listed files staying put — moving or "
+                "deleting them breaks it."
+            ),
+            default="false",
+            required=False,
+            # Reference mode is a storage choice, not part of the data source's
+            # identity (see server_folder for the rationale); keep it out of the
+            # persisted origin.
+            include_in_origin=False,
+        ),
     ]
 
     def __init__(self) -> None:

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -168,6 +168,24 @@ class ServerFolderDatasetImporter(DatasetImporter):
             default="false",
             required=False,
         ),
+        ImporterField(
+            key="reference_files",
+            label="Reference files in place (don't copy)",
+            field_type="checkbox",
+            description=(
+                "When enabled, the dataset stores a path reference to each original "
+                "file on the server instead of copying its bytes in.  Saves storage, "
+                "but the dataset depends on the source files staying put — moving or "
+                "deleting them breaks it."
+            ),
+            default="false",
+            required=False,
+            # Reference mode is a storage choice, not part of the data source's
+            # identity: the same folder referenced or copied resolves to the same
+            # files, so it must not pollute the persisted origin (which drives
+            # dedup / reload matching).
+            include_in_origin=False,
+        ),
     ]
 
     def __init__(self) -> None:

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -582,6 +582,11 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     field_values = wrap_cli_file_fields(importer.fields, field_values)
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
+    # Reference mode (server importers): store path references instead of
+    # copying media bytes.  Maps onto the loader's ``thin`` flag.  Popped so
+    # it isn't forwarded into the importer's field_values (run() takes ``thin``
+    # as a parameter, not a field).
+    reference_files = _parse_bool(field_values.pop("reference_files", None))
     clipper_name = field_values.pop("clipper", "") or ""
     clipper_params = field_values.pop("clipper_params", None)
     chain_steps = _parse_chain_field(field_values.pop("clipper_chain", None))
@@ -606,9 +611,9 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
 
     def _load(target_medias):
         if use_chunked:
-            consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size))
+            consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size, thin=reference_files))
         else:
-            importer.run(field_values, target_medias)
+            importer.run(field_values, target_medias, thin=reference_files)
 
     return _run_origin_load_in_background(
         _load,

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -240,6 +240,15 @@ def _convert_one_pickle_media(
         dir_keys,
     )
     if media_bytes is None:
+        # Reference dataset (imported with reference_files / thin): the pickle
+        # carries no inline bytes, but a stored ``media_path`` may still point
+        # at the original file on disk.  Keep the media lazy (load it thin)
+        # rather than dropping it, so a reference dataset survives the
+        # registry save → full-mode reopen round-trip.  ``_resolve_media_bytes``
+        # reads the bytes on demand from ``media_path`` at serve/embed time.
+        ref_path = _resolve_thin_media_path(media_type, media_info, data, dir_keys)
+        if ref_path and Path(ref_path).exists():
+            return _build_pickle_thin_media(new_id, media_info, media_type, ref_path, extra_fields), False
         return None, missing
     return (
         _build_pickle_full_media(

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -249,6 +249,11 @@ def _convert_one_pickle_media(
         ref_path = _resolve_thin_media_path(media_type, media_info, data, dir_keys)
         if ref_path and Path(ref_path).exists():
             return _build_pickle_thin_media(new_id, media_info, media_type, ref_path, extra_fields), False
+        # A reference whose file has gone counts as missing so the load-time
+        # warning fires, even when there is no companion dir for
+        # ``_load_pickle_media_payload`` to flag it against.
+        if media_info.get("media_path"):
+            return None, True
         return None, missing
     return (
         _build_pickle_full_media(


### PR DESCRIPTION
## What & why

Importing a server folder or manifest currently copies every file's bytes into the dataset (full mode inlines `media_bytes`, which then gets baked into the registry pickle). When the source files are reliable and will persist, that duplicates storage that already lives on the server.

This surfaces the library's existing **thin mode** as a per-import **"Reference files in place (don't copy)"** checkbox on the two server importers (`server_folder`, `server_files`). With it on, the dataset stores a `media_path` reference to each original file and resolves bytes lazily on demand, instead of copying.

**Symlinks were considered and rejected:** the server importers already reference files in place (they never copy into a managed dir), so the only duplication is the inlined pickle bytes. A plain path reference removes that; a symlink would add inodes + cleanup for no benefit and breaks across machines just as badly. References win.

## What's in Phase 1

- **`reference_files` checkbox** (`include_in_origin=False`) on `server_folder` and `server_files`. Kept out of the persisted origin — reference-vs-copy is a storage choice, not part of the data source's identity, so it must not perturb dedup / reload matching.
- **Threaded as `thin`** in `load_pipeline._run_importer_in_background` (popped from `field_values`, passed to `run` / `run_chunked`). Other importers never receive the field, so they stay in copy mode.
- **Full-mode pickle load now honors a stored `media_path`** (`loader_pickle`). Reopening a saved dataset loads the registry pickle in *full* mode, which previously ignored `media_path` and **dropped** every media without inline bytes. It now falls back to the reference (loading it lazily) when the file still exists, and counts it as missing when it's gone. This is what lets a reference dataset survive the registry-save → reopen round-trip.
- **Frontend**: added a `checkbox` branch to the generic importer form (it had none — a checkbox field rendered as a text input), so the Manifest importer shows the option; plus the checkbox/state/submit param in the custom `server_folder` picker.
- **Tests**: importers declare the field and keep it out of the origin; full-mode load keeps a still-resolvable reference (lazy) and drops + counts a dangling one.
- OpenAPI snapshot regenerated.

### Accepted brittleness
A reference dataset depends on its source files staying put — moving/deleting them breaks it (dangling references are dropped on reopen, like a missing companion file today). That's the explicit trade this option exists to make. Browser-upload importers (`local_folder`/`local_files`) stage into temp dirs that are deleted after import, so the option is intentionally not offered there.

## Deferred (Phase 2) — see `docs/plans/server-dedup-references.md`
Clippers **and** converters still materialize bytes. Phase 2 makes both lazy (reference original + recipe, resolve on demand), sharing one mechanism and the same downstream consumers (byte resolution, embedding, origin re-embed rederivation, serving, exporters).

## Testing
`./run-tests.sh` (full): **5043 passed, 1 skipped**. Frontend gate: build OK, Vitest **860 passed**. ruff / pyright / deptry / codespell / pip-audit / OpenAPI drift all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmNeFb3dcwbGPq45RQvtkv)_