### PR TITLE
Lazy clips for reference datasets (server-dedup Phase 2a)

### DIFF
--- a/docs/plans/server-dedup-references.md
+++ b/docs/plans/server-dedup-references.md
@@ -1,9 +1,10 @@
 # Reference (no-copy) dataset import
 
-Status: **Phase 1 shipped.** Whole-file references for the two server
-importers (`server_folder`, `server_files`) are wired end-to-end. Phase 2
-(lazy clips **and** lazy converter output) is deferred — see *Open
-follow-ups*.
+Status: **Phase 1 + Phase 2a shipped.** Whole-file references for the two
+server importers (`server_folder`, `server_files`) are wired end-to-end
+(Phase 1). **Lazy clips** for audio and image now let reference datasets be
+clipped without duplicating bytes (Phase 2a). **Lazy converter output**
+(Phase 2b) is deferred — see *Open follow-ups*.
 
 ## Problem
 
@@ -65,53 +66,85 @@ today). This is the explicit trade the option exists to make.
   The option is not offered there.
 - **Clippers and converters** still materialize bytes (see below).
 
-## Open follow-ups (Phase 2: lazy clips AND lazy converter output)
+## What shipped (Phase 2a: lazy clips)
 
-Phase 1 only avoids duplication for media imported **as-is**. Two transforms
-still copy bytes into the dataset, and both should learn a lazy/reference
-form. Treat them together — they share the same shape (reference the
-original + a recipe, resolve on demand) and the same set of downstream
-consumers to update.
+Reference (thin) datasets can now be **clipped** without duplicating bytes.
+Before this, a reference import that also chose a clipper silently produced
+*no* clips: audio/image clippers early-return the media unchanged when
+`media_bytes` is absent, so the clipper stage was a no-op on thin parents.
 
-1. **Lazy clips.** Clippers (`vtscore/media/audio/clipper.py`,
-   `vtscore/media/video/clipper.py`, text clippers) eagerly slice real bytes
-   into each clip's `media_bytes` (e.g. `_wav_slice`). A clip already records
-   `clip_start` / `clip_end`, so the data model is half-built. A *lazy clip*
-   would set `media_bytes=None`, keep the original `media_path` + range, and
-   have the byte-resolution path slice on demand.
+- **`vtscore/media/lazy_clip.py`** — a *lazy clip* carries no `media_bytes`;
+  it keeps `media_path` (the source file) plus a *recipe* read from
+  `origin.params` (`clip_start`/`clip_end` for audio, `clip_box` for image)
+  and reproduces its bytes on demand. A small process-scoped LRU cache holds
+  resolved slices (never persisted, per the no-persisted-bytes rule). Only
+  audio and image participate — they're the types whose clippers actually
+  re-slice bytes.
+- **`MediaType._resolve_media_bytes`** (`vtscore/media/base.py`) consults
+  `lazy_clip_bytes` before the plain `media_path` read, so HTTP serving,
+  exporters, and any other byte consumer transparently get the sliced clip.
+- **Clipper stage** (`vtscore/datasets/stages/clipper.py`) gained
+  `_hydrate_reference_parents` (transiently load a thin parent's bytes so the
+  clipper can compute boundaries and the existing MD5/embed/thumbnail fixup
+  runs unchanged) and `_relazify_reference_clips_stage` (strip the
+  materialized bytes back off the derived clips). The re-lazify step runs in
+  `load_pipeline` **after** the embed/drop-none stages, so the embed-missing
+  safety net never mis-embeds a clip's *whole* source file behind its path.
+- **Cross-dataset re-embed** needed no change: `resolver.py` already
+  re-derives clips from the source file + recipe; lazy clips just make the
+  in-dataset path match.
+- **Pickle round-trip** works because the recipe lives in `origin.params`
+  (which already round-trips) and `media_path` is serialized; reopening a
+  reference clip stays lazy and resolves on demand.
 
-2. **Lazy converter output.** Converters (`vtscore/converters/`, e.g.
+Text clips stay materialized (a sliced string is tiny — no storage win and
+re-splitting from source is fragile). Video clips are already metadata-only
+(they share the parent's bytes; the player seeks via `clip_start`/`clip_end`),
+so they don't duplicate bytes and need no recipe slicing. A converter anywhere
+in the chain disables lazification (the output is no longer a slice of the
+source) — that's Phase 2b.
+
+## Open follow-ups (Phase 2b: lazy converter output)
+
+Phase 1 + 2a avoid duplication for media imported **as-is** and for
+audio/image **clips**. One transform still copies bytes into the dataset:
+
+1. **Lazy converter output.** Converters (`vtscore/converters/`, e.g.
    document→image, video→frame) similarly produce derived media with
    materialized bytes via `run_converters_on_folder`. The reference form
    would store the source `media_path` + the converter name/params and
    re-run the conversion (or a cached slice) on demand. PDF page expansion
    (`load_pdf_images_into`) is the same pattern.
 
-### Phase 2 design notes / ripple points
+### Phase 2b design notes / ripple points
 
-Both lazy clips and lazy converters need the same machinery, so build it
-once:
+Lazy converter output reuses the same shape Phase 2a built for clips
+(reference the source + a recipe, resolve on demand), but the recipe is a
+converter name+params rather than a clip range, and the open problems are
+harder:
 
-- A way to mark a media as "derived/virtual" carrying `(source ref,
-  recipe)` where recipe is a clip range or a converter+params.
-- **Byte resolution** (`MediaType._resolve_media_bytes` /
-  `_resolve_media_string`) must detect a virtual media and produce bytes by
-  resolving the source then applying the recipe (slice / convert), ideally
-  with a small process-scoped cache (per the no-persisted-bytes rule — never
-  serialize the materialized result).
-- **Embedding** pulls bytes through the same resolution path, so it works for
-  free once resolution does — but verify the embed stage doesn't assume
-  inline bytes.
-- **Origin → re-embed rederivation** (`vtscore/detectors/resolver.py`)
-  currently resolves an origin to the *whole* original file; for virtual
-  media it must re-apply the clip range / converter to reproduce the exact
-  derived bytes the embedding was trained on.
-- **HTTP serving** and **exporters** (anything that streams `media_bytes`)
-  go through resolution, so confirm each consumer tolerates on-demand
-  materialization (latency, partial-range requests for audio/video scrub).
-- **Pickle round-trip**: the same full-mode-honors-reference fix applies, but
-  the recipe must serialize too (it's not a vector or an MLP, so it's allowed
-  to persist).
+- **Recipe channel.** Phase 2a reads the clip recipe from `origin.params`
+  (`clip_start`/`clip_end`/`clip_box`), which already round-trips. A converter
+  recipe (converter name + params + which sub-output) would ride the same
+  `origin.params` / `clipper_chain` trail, but the byte-resolution detection in
+  `vtscore.media.lazy_clip` would need a converter branch (and a way to pick
+  the right sub-output, à la `clipper_chain._select_chain_output`).
+- **Byte resolution cost.** A clip slice is cheap (a `_wav_slice` / PIL crop).
+  Re-running document→image or video→frame on every cold `media_bytes` fetch is
+  expensive, and partial-range/scrub requests amplify it. The process-scoped
+  cache in `lazy_clip.py` helps within a process but the latency story needs
+  real thought (pre-warm? larger cache? bounded by bytes not count?).
+- **Embedding** already works for clips because the clipper-stage fixup embeds
+  from the materialized bytes before re-lazification; a converter path would
+  follow the same "hydrate → convert → embed → re-lazify" ordering. Verify the
+  embed-missing safety net (which reads `media_path` as the *whole* file) is
+  never reached for a converted media — same hazard Phase 2a dodged by
+  re-lazifying after the embed stages.
+- **Origin → re-embed rederivation** (`vtscore/detectors/resolver.py`) already
+  re-applies converters for cross-dataset training, so that path is reusable.
+- **HTTP serving** and **exporters** stream through `_resolve_media_bytes`, so
+  they get converter output for free once resolution learns the converter
+  branch — modulo the latency concern above.
 
-These are deferred; Phase 1 delivers the bulk of the storage win for
-un-clipped, un-converted server datasets.
+Phase 2b is deferred; Phase 1 + 2a deliver the storage win for un-converted
+server datasets, clipped or not.

--- a/tests_lib/datasets/test_lazy_clips.py
+++ b/tests_lib/datasets/test_lazy_clips.py
@@ -11,7 +11,6 @@ See ``docs/plans/server-dedup-references.md``.
 
 from __future__ import annotations
 
-import types
 import wave
 from pathlib import Path
 from typing import Any
@@ -85,7 +84,11 @@ def _stub_clip_fixup(monkeypatch):
 
 
 def _relazify(clips: dict) -> None:
-    clipper_stage._relazify_reference_clips_stage(types.SimpleNamespace(medias=clips))
+    from vtscore.state import DatasetContext  # noqa: PLC0415
+
+    ctx = DatasetContext("_test_lazy_clips")
+    ctx.medias = clips
+    clipper_stage._relazify_reference_clips_stage(ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/datasets/test_lazy_clips.py
+++ b/tests_lib/datasets/test_lazy_clips.py
@@ -1,0 +1,344 @@
+"""Tests for lazy clips: reference (thin) datasets that store clip recipes.
+
+A reference import keeps a ``media_path`` reference instead of copying bytes
+(Phase 1).  Phase 2 (this module) makes *clippers* honour that contract: when a
+reference parent is tiled/sliced, the derived clips store no ``media_bytes`` of
+their own - just the source path plus the clip boundaries in ``origin.params``
+- and reproduce their bytes on demand via ``_resolve_media_bytes``.
+
+See ``docs/plans/server-dedup-references.md``.
+"""
+
+from __future__ import annotations
+
+import types
+import wave
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from vtscore.datasets.stages import clipper as clipper_stage
+from vtscore.media.audio.clipper import _wav_slice
+from vtscore.media.lazy_clip import clip_recipe, lazy_clip_bytes
+
+from helpers import make_png_bytes, make_wav_bytes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_wav(tmp_path: Path, name: str = "src.wav", duration: float = 1.0) -> Path:
+    p = tmp_path / name
+    p.write_bytes(make_wav_bytes(frequency=440.0, duration=duration))
+    return p
+
+
+def _thin_audio_media(path: Path) -> dict[str, Any]:
+    """Build a thin (reference) audio media - no bytes, just a path."""
+    return {
+        "id": 1,
+        "media_type": "audio",
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": str(path),
+        "duration": 0,
+        "file_size": path.stat().st_size,
+        "md5": "deadbeef",
+        "filename": path.name,
+        "category": "custom",
+        "origin": {"importer": "server_folder", "params": {"path": str(path.parent)}},
+        "origin_name": path.name,
+    }
+
+
+def _thin_image_media(path: Path) -> dict[str, Any]:
+    return {
+        "id": 1,
+        "media_type": "image",
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": str(path),
+        "duration": 0,
+        "file_size": path.stat().st_size,
+        "md5": "deadbeef",
+        "filename": path.name,
+        "category": "custom",
+        "origin": {"importer": "server_folder", "params": {"path": str(path.parent)}},
+        "origin_name": path.name,
+    }
+
+
+@pytest.fixture
+def _stub_clip_fixup(monkeypatch):
+    """Skip the per-clip MD5/embedding/thumbnail fixup (no embedder needed).
+
+    The lazy-clip mechanism under test (hydrate -> clip -> re-lazify -> resolve)
+    is independent of embedding, so we stub the fixup the same way the existing
+    clipper-chain tests do.
+    """
+    monkeypatch.setattr(clipper_stage, "_fixup_clip_md5_and_embeddings", lambda *a, **k: None)
+    monkeypatch.setattr(clipper_stage, "_regenerate_clip_thumbnails", lambda *a, **k: None)
+
+
+def _relazify(clips: dict) -> None:
+    clipper_stage._relazify_reference_clips_stage(types.SimpleNamespace(medias=clips))
+
+
+# ---------------------------------------------------------------------------
+# clip_recipe
+# ---------------------------------------------------------------------------
+
+
+class TestClipRecipe:
+    def test_audio_recipe_from_origin_params(self):
+        media = {"media_type": "audio", "origin": {"params": {"clip_start": "0.5", "clip_end": "1.5"}}}
+        assert clip_recipe(media) == ("audio", 0.5, 1.5)
+
+    def test_image_recipe_from_origin_params_string(self):
+        media = {"media_type": "image", "origin": {"params": {"clip_box": "0,0,16,16"}}}
+        assert clip_recipe(media) == ("image", (0, 0, 16, 16))
+
+    def test_image_recipe_from_list(self):
+        media = {"media_type": "image", "origin": {"params": {"clip_box": [1, 2, 3, 4]}}}
+        assert clip_recipe(media) == ("image", (1, 2, 3, 4))
+
+    def test_no_recipe_without_boundaries(self):
+        media = {"media_type": "audio", "origin": {"params": {}}}
+        assert clip_recipe(media) is None
+
+    def test_text_and_video_never_lazy(self):
+        assert clip_recipe({"media_type": "text", "origin": {"params": {"clip_index": "2"}}}) is None
+        assert clip_recipe({"media_type": "video", "origin": {"params": {"clip_start": "0", "clip_end": "1"}}}) is None
+
+    def test_malformed_box_is_none(self):
+        media = {"media_type": "image", "origin": {"params": {"clip_box": "0,0,16"}}}
+        assert clip_recipe(media) is None
+
+
+# ---------------------------------------------------------------------------
+# lazy_clip_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestLazyClipBytes:
+    def test_audio_slice_matches_wav_slice(self, tmp_path):
+        src = _write_wav(tmp_path, duration=1.0)
+        media = {
+            "media_type": "audio",
+            "media_path": str(src),
+            "origin": {"params": {"clip_start": "0.2", "clip_end": "0.6"}},
+        }
+        got = lazy_clip_bytes(media)
+        expected = _wav_slice(src.read_bytes(), 0.2, 0.6)
+        assert got == expected
+        # And the slice is genuinely shorter than the source.
+        with wave.open(__import__("io").BytesIO(got), "rb") as wf:
+            assert wf.getnframes() < wave.open(str(src), "rb").getnframes()
+
+    def test_image_crop(self, tmp_path):
+        src = tmp_path / "src.png"
+        src.write_bytes(make_png_bytes(width=32, height=32, color=(10, 20, 30)))
+        media = {
+            "media_type": "image",
+            "media_path": str(src),
+            "origin": {"params": {"clip_box": "0,0,16,16"}},
+        }
+        got = lazy_clip_bytes(media)
+        assert got is not None
+        from PIL import Image
+        import io as _io
+
+        with Image.open(_io.BytesIO(got)) as img:
+            assert img.size == (16, 16)
+
+    def test_no_recipe_returns_none(self, tmp_path):
+        src = _write_wav(tmp_path)
+        media = {"media_type": "audio", "media_path": str(src), "origin": {"params": {}}}
+        assert lazy_clip_bytes(media) is None
+
+    def test_missing_source_returns_none(self, tmp_path):
+        media = {
+            "media_type": "audio",
+            "media_path": str(tmp_path / "nope.wav"),
+            "origin": {"params": {"clip_start": "0", "clip_end": "0.5"}},
+        }
+        assert lazy_clip_bytes(media) is None
+
+    def test_cache_returns_identical_object(self, tmp_path):
+        src = _write_wav(tmp_path, duration=1.0)
+        media = {
+            "media_type": "audio",
+            "media_path": str(src),
+            "origin": {"params": {"clip_start": "0.1", "clip_end": "0.4"}},
+        }
+        first = lazy_clip_bytes(media)
+        second = lazy_clip_bytes(media)
+        assert first is second  # served from the process-scoped cache
+
+
+# ---------------------------------------------------------------------------
+# _resolve_media_bytes integration (serve path)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMediaBytes:
+    def test_audio_media_type_resolves_lazy_clip(self, tmp_path):
+        import vtscore.media as media_registry
+
+        src = _write_wav(tmp_path, duration=1.0)
+        media = {
+            "media_type": "audio",
+            "media_bytes": None,
+            "media_path": str(src),
+            "origin": {"params": {"clip_start": "0.3", "clip_end": "0.7"}},
+        }
+        resolved = media_registry.get("audio")._resolve_media_bytes(media)
+        assert resolved == _wav_slice(src.read_bytes(), 0.3, 0.7)
+
+    def test_inline_bytes_take_precedence(self, tmp_path):
+        import vtscore.media as media_registry
+
+        src = _write_wav(tmp_path)
+        media = {
+            "media_type": "audio",
+            "media_bytes": b"inline",
+            "media_path": str(src),
+            "origin": {"params": {"clip_start": "0", "clip_end": "0.1"}},
+        }
+        assert media_registry.get("audio")._resolve_media_bytes(media) == b"inline"
+
+    def test_whole_file_thin_media_unaffected(self, tmp_path):
+        import vtscore.media as media_registry
+
+        src = _write_wav(tmp_path)
+        media = {"media_type": "audio", "media_bytes": None, "media_path": str(src), "origin": {"params": {}}}
+        assert media_registry.get("audio")._resolve_media_bytes(media) == src.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: clipper stage produces lazy clips for reference parents
+# ---------------------------------------------------------------------------
+
+
+class TestClipperStageLazyClips:
+    def test_thin_audio_tiling_produces_lazy_clips(self, tmp_path, _stub_clip_fixup):
+        src = _write_wav(tmp_path, duration=1.2)
+        clips = {1: _thin_audio_media(src)}
+
+        clipper_stage._apply_clipper(clips, "sound_tiling", {"duration": 0.3})
+        assert len(clips) > 1  # actually tiled
+
+        # Before re-lazify: clips carry the marker + materialized bytes.
+        for clip in clips.values():
+            assert clip.get("_lazy_source") == str(src)
+            assert clip["media_bytes"] is not None
+
+        _relazify(clips)
+
+        for clip in clips.values():
+            assert "_lazy_source" not in clip
+            assert clip["media_bytes"] is None
+            assert clip["media_path"] == str(src)
+            params = clip["origin"]["params"]
+            assert "clip_start" in params and "clip_end" in params
+            # Resolution reproduces the exact slice.
+            import vtscore.media as media_registry
+
+            resolved = media_registry.get("audio")._resolve_media_bytes(clip)
+            expected = _wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
+            assert resolved == expected
+
+    def test_thin_image_tiling_produces_lazy_clips(self, tmp_path, _stub_clip_fixup):
+        src = tmp_path / "src.png"
+        src.write_bytes(make_png_bytes(width=16, height=48, color=(5, 10, 15)))
+        clips = {1: _thin_image_media(src)}
+
+        clipper_stage._apply_clipper(clips, "image_tiling", None)
+        assert len(clips) > 1
+
+        _relazify(clips)
+
+        import vtscore.media as media_registry
+
+        for clip in clips.values():
+            assert clip["media_bytes"] is None
+            assert clip["media_path"] == str(src)
+            assert "clip_box" in clip["origin"]["params"]
+            resolved = media_registry.get("image")._resolve_media_bytes(clip)
+            assert resolved is not None
+            from PIL import Image
+            import io as _io
+
+            with Image.open(_io.BytesIO(resolved)) as img:
+                assert img.size == (16, 16)  # square tile from the 16x48 source
+
+    def test_full_mode_audio_not_relazified(self, tmp_path, _stub_clip_fixup):
+        """A non-reference parent (bytes present) keeps materialized clip bytes."""
+        src = _write_wav(tmp_path, duration=1.2)
+        media = _thin_audio_media(src)
+        media["media_bytes"] = src.read_bytes()  # full mode
+        clips = {1: media}
+
+        clipper_stage._apply_clipper(clips, "sound_tiling", {"duration": 0.3})
+        assert len(clips) > 1
+        for clip in clips.values():
+            assert "_lazy_source" not in clip  # never marked
+            assert clip["media_bytes"] is not None
+
+        _relazify(clips)  # no markers -> no-op
+        for clip in clips.values():
+            assert clip["media_bytes"] is not None
+
+    def test_converter_chain_not_lazified(self, tmp_path):
+        """A chain containing a converter changes media type, so its output is
+        no longer a slice of the source file; such parents must NOT be
+        hydrated/marked for re-lazification."""
+        src = _write_wav(tmp_path)
+        clips = {1: _thin_audio_media(src)}
+        steps = [{"kind": "converter", "name": "audio2image", "params": {}}]
+        marked = clipper_stage._hydrate_reference_parents(clips, steps)
+        assert marked is False
+        assert "_lazy_source" not in clips[1]
+
+
+# ---------------------------------------------------------------------------
+# Pickle round-trip: lazy clips survive save -> reopen and still resolve
+# ---------------------------------------------------------------------------
+
+
+class TestPickleRoundTrip:
+    def test_lazy_clip_survives_round_trip(self, tmp_path, _stub_clip_fixup):
+        from vtscore.datasets.loader import export_dataset_to_file, load_dataset_from_pickle
+
+        src = _write_wav(tmp_path, duration=1.2)
+        clips = {1: _thin_audio_media(src)}
+        clipper_stage._apply_clipper(clips, "sound_tiling", {"duration": 0.3})
+        _relazify(clips)
+
+        # Attach embeddings so the loader keeps the entries (a clip with no
+        # usable vector is dropped on load).
+        rng = np.random.default_rng(0)
+        for clip in clips.values():
+            clip["embeddings"] = {"stub": rng.standard_normal(8).astype(np.float32)}
+            clip["embedder"] = "stub"
+
+        pkl = tmp_path / "ds.pkl"
+        pkl.write_bytes(export_dataset_to_file(clips, media_type="audio"))
+
+        reopened: dict = {}
+        load_dataset_from_pickle(pkl, reopened)
+        assert len(reopened) == len(clips)
+
+        import vtscore.media as media_registry
+
+        for clip in reopened.values():
+            assert clip["media_bytes"] is None
+            assert clip["media_path"] == str(src)
+            params = clip["origin"]["params"]
+            resolved = media_registry.get("audio")._resolve_media_bytes(clip)
+            expected = _wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
+            assert resolved == expected

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -42,7 +42,7 @@ from vtscore.datasets.stages._common import (
     _TOTAL_LOAD_STEPS,
     _origin_to_str,
 )
-from vtscore.datasets.stages.clipper import _apply_clipper_stage
+from vtscore.datasets.stages.clipper import _apply_clipper_stage, _relazify_reference_clips_stage
 from vtscore.datasets.stages.embedding import embed_missing, _embed_missing_stage
 from vtscore.datasets.stages.finalize import (
     _build_diversity_tree_stage,
@@ -484,6 +484,10 @@ def _run_origin_load_in_background(
                     _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
                     _embed_missing_stage(ctx, tracker, embedders if embedders else [embedder])
                     _drop_none_embeddings_stage(ctx, tracker)
+                    # Re-lazify clips from reference (thin) parents now that
+                    # embedding is done: strip their materialized bytes so the
+                    # dataset stores recipes, not duplicated clip payloads.
+                    _relazify_reference_clips_stage(ctx, tracker)
                     _collapse_duplicates_stage(ctx, tracker)
                     _build_diversity_tree_stage(ctx, tracker)
                     tracker.check_cancelled()

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -100,6 +100,16 @@ def _apply_clipper(  # noqa: C901
     if not steps:
         return
 
+    # Reference (thin) parents carry no bytes, so audio/image clippers - which
+    # read ``media_bytes`` to compute boundaries and slice - would early-return
+    # the media unchanged.  Transiently hydrate those parents from their source
+    # files so clipping (and the per-clip MD5/embed/thumbnail fixup below) runs
+    # exactly as it does in full mode.  Each hydrated parent is tagged with a
+    # ``_lazy_source`` marker that rides into its clips; those clips are
+    # re-lazified by ``_relazify_reference_clips_stage`` after the embed stages
+    # so the dataset never stores duplicated clip bytes.
+    _hydrate_reference_parents(clips_dict, steps)
+
     result = apply_chain_to_clips(clips_dict, steps, on_progress=on_progress)
     if result is None:
         return
@@ -113,6 +123,85 @@ def _apply_clipper(  # noqa: C901
     # (converter chains change the media_type of the carriers).
     for clip in clips_dict.values():
         clip["media_type"] = final_type
+
+
+def _hydrate_reference_parents(clips_dict: dict, steps: list[dict]) -> bool:
+    """Materialize bytes on reference (thin) parents so clippers can run.
+
+    A *reference* media carries ``media_path`` but no ``media_bytes`` /
+    ``media_string`` (it was imported with ``reference_files`` / ``thin``).
+    Audio and image clippers need the actual bytes to compute clip boundaries
+    and slice, so we load the source via the media type's ``load_media_data``
+    (which also fills ``duration`` / ``width`` / ``height`` / ``thumbnail``,
+    skipped at thin-import time) and tag the parent with a ``_lazy_source``
+    marker.  The marker rides along into every derived clip via the clipper's
+    ``dict(media)`` copy, so :func:`_relazify_reference_clips` can later strip
+    those clips back to references.
+
+    Lazy clips only apply to pure same-type clipper chains; a chain containing
+    a converter changes media type, so the clip's bytes are no longer a slice
+    of the original source file.  Such chains are left fully materialized
+    (lazy converter output is out of scope - see
+    ``docs/plans/server-dedup-references.md``).
+
+    Returns ``True`` if at least one parent was hydrated.
+    """
+    from vtscore.media.lazy_clip import LAZY_CLIP_TYPES  # noqa: PLC0415
+
+    if any(step.get("kind") == "converter" for step in steps):
+        return False
+
+    import vtscore.media as media_registry  # noqa: PLC0415
+
+    any_hydrated = False
+    for media in clips_dict.values():
+        if media.get("media_bytes") is not None or media.get("media_string") is not None:
+            continue
+        media_type = media.get("media_type")
+        if media_type not in LAZY_CLIP_TYPES:
+            continue
+        path = media.get("media_path")
+        if not path or not Path(path).exists():
+            continue
+        try:
+            mt = media_registry.get(media_type)
+            media.update(mt.load_media_data(Path(path)))
+        except Exception:
+            import logging as _logging  # noqa: PLC0415
+
+            _logging.getLogger(__name__).warning(
+                "lazy clip: failed to hydrate reference parent %s; clipping it as-is", path, exc_info=True
+            )
+            continue
+        media["_lazy_source"] = path
+        any_hydrated = True
+    return any_hydrated
+
+
+def _relazify_reference_clips_stage(ctx: DatasetContext, tracker=None) -> None:
+    """Strip materialized bytes from clips descended from a reference parent.
+
+    Each such clip carries the ``_lazy_source`` marker (inherited from its
+    hydrated parent in :func:`_hydrate_reference_parents`).  We drop its
+    ``media_bytes`` / ``media_string`` and point ``media_path`` back at the
+    source file; ``_resolve_media_bytes`` reproduces the clip's bytes on demand
+    from the recipe stored in ``origin.params`` (sliced clip) or by reading the
+    whole file (a pass-through clip the clipper returned unchanged).  The
+    per-clip MD5, embedding, and thumbnail were already computed from the real
+    bytes in the clipper stage, so the reference clip is byte-for-byte
+    equivalent without the stored payload.
+
+    Runs after the embed / drop-none stages so the embed-missing safety net
+    sees real bytes (a clip's ``media_path`` points at the *whole* source file,
+    not the slice, so embedding it lazily would embed the wrong content).
+    """
+    for clip in ctx.medias.values():
+        source = clip.pop("_lazy_source", None)
+        if source is None:
+            continue
+        clip["media_path"] = source
+        clip["media_bytes"] = None
+        clip["media_string"] = None
 
 
 def _regenerate_clip_thumbnails(  # noqa: C901

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -421,12 +421,21 @@ class MediaType(ABC):
         Resolution order:
 
         1. ``media_bytes`` - already in memory.
-        2. ``media_path`` - local file on disk (thin mode).
-        3. ``media_url`` - remote URL (URL-backed media, e.g. PullWrest).
+        2. *lazy clip* - a derived sub-media that carries a clip recipe in
+           ``origin.params`` instead of materialized bytes; its bytes are
+           sliced/cropped from the source on demand (see
+           :mod:`vtscore.media.lazy_clip`).
+        3. ``media_path`` - local file on disk (thin mode).
+        4. ``media_url`` - remote URL (URL-backed media, e.g. PullWrest).
         """
         media_bytes = media.get("media_bytes")
         if media_bytes is not None:
             return media_bytes
+        from vtscore.media.lazy_clip import lazy_clip_bytes  # noqa: PLC0415
+
+        clipped = lazy_clip_bytes(media)
+        if clipped is not None:
+            return clipped
         media_path = media.get("media_path")
         if media_path:
             path = Path(media_path)

--- a/vtscore/media/lazy_clip.py
+++ b/vtscore/media/lazy_clip.py
@@ -1,0 +1,185 @@
+"""Lazy clip resolution: derive a clip's bytes from its source on demand.
+
+A *lazy clip* is a derived sub-media that stores **no** materialized
+``media_bytes`` of its own.  Instead it keeps a reference to the original
+source file (``media_path``) plus a *recipe* (the clip boundaries recorded in
+``origin.params``) and reproduces its bytes on demand by slicing/cropping the
+source.  This is how reference (thin) imports avoid duplicating the source
+bytes once per clip in the dataset pickle: a 5-minute recording tiled into 30
+clips stores the recipe 30 times (a few bytes each) instead of 30 copies of
+the audio.
+
+Only the media types whose clippers actually *re-slice bytes* participate:
+
+* **audio** - ``clip_start`` / ``clip_end`` seconds, sliced via
+  :func:`~vtscore.media.audio.clipper._wav_slice`.
+* **image** - ``clip_box`` pixel box, cropped via Pillow.
+
+Text clips keep their (tiny) ``media_string`` materialized, and video clips are
+already metadata-only (they share the parent's bytes and the player seeks via
+``clip_start`` / ``clip_end``), so neither needs lazy resolution.
+
+Resolved bytes are held in a small process-scoped LRU cache.  Per the
+no-persisted-bytes rule, this cache is purely in-memory: nothing here writes a
+materialized clip back to disk or into a pickle.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = ["LAZY_CLIP_TYPES", "clip_recipe", "lazy_clip_bytes"]
+
+#: Media types whose clippers re-slice bytes and therefore support lazy clips.
+LAZY_CLIP_TYPES = ("audio", "image")
+
+# Process-scoped LRU of resolved clip bytes, keyed by (source, recipe).  Bounded
+# by entry count; clip payloads are small (one tile / crop) so a few hundred
+# entries stays well within memory.  Never persisted.
+_CACHE_MAX = 256
+_cache: "OrderedDict[tuple, bytes]" = OrderedDict()
+_cache_lock = threading.Lock()
+
+
+def _parse_box(raw: Any) -> tuple[int, int, int, int] | None:
+    """Parse a ``clip_box`` into a 4-int pixel tuple, or ``None`` if malformed.
+
+    Accepts the ``"x1,y1,x2,y2"`` string stored in ``origin.params`` as well
+    as a native list/tuple (the in-memory form on a freshly clipped media).
+    """
+    if isinstance(raw, (list, tuple)):
+        parts = list(raw)
+    elif isinstance(raw, str):
+        parts = [p for p in raw.split(",") if p != ""]
+    else:
+        return None
+    if len(parts) != 4:
+        return None
+    try:
+        return (int(float(parts[0])), int(float(parts[1])), int(float(parts[2])), int(float(parts[3])))
+    except (TypeError, ValueError):
+        return None
+
+
+def clip_recipe(media: dict[str, Any]) -> tuple | None:
+    """Return a hashable recipe describing *media*'s clip, or ``None``.
+
+    The recipe is read from ``origin.params`` (the channel that survives the
+    pickle round-trip), not the top-level ``clip_*`` fields, so it resolves
+    identically for a freshly clipped media and one reopened from disk.
+
+    Returns one of:
+
+    * ``("audio", clip_start, clip_end)`` - seconds, both floats.
+    * ``("image", (x1, y1, x2, y2))`` - integer pixel box.
+
+    or ``None`` when *media* is not a recognised lazy clip (no recipe, or a
+    media type that doesn't re-slice bytes).
+    """
+    media_type = media.get("media_type")
+    origin = media.get("origin")
+    params = origin.get("params", {}) if isinstance(origin, dict) else {}
+
+    if media_type == "audio":
+        cs = params.get("clip_start")
+        ce = params.get("clip_end")
+        if cs is None or ce is None:
+            return None
+        try:
+            return ("audio", float(cs), float(ce))
+        except (TypeError, ValueError):
+            return None
+
+    if media_type == "image":
+        box = _parse_box(params.get("clip_box"))
+        if box is None:
+            return None
+        return ("image", box)
+
+    return None
+
+
+def _apply_recipe(source_bytes: bytes, recipe: tuple) -> bytes | None:
+    """Reproduce a clip's bytes by applying *recipe* to *source_bytes*."""
+    kind = recipe[0]
+    if kind == "audio":
+        from vtscore.media.audio.clipper import _wav_slice  # noqa: PLC0415
+
+        return _wav_slice(source_bytes, recipe[1], recipe[2])
+    if kind == "image":
+        from PIL import Image  # noqa: PLC0415
+
+        box = recipe[1]
+        with Image.open(io.BytesIO(source_bytes)) as img:
+            fmt = img.format or "PNG"
+            cropped = img.crop(box)
+            buf = io.BytesIO()
+            cropped.save(buf, format=fmt)
+        return buf.getvalue()
+    return None
+
+
+def _read_source_bytes(media: dict[str, Any]) -> bytes | None:
+    """Read the whole source file (or URL) backing a lazy clip."""
+    media_path = media.get("media_path")
+    if media_path:
+        path = Path(media_path)
+        if path.exists():
+            return path.read_bytes()
+    media_url = media.get("media_url")
+    if media_url:
+        from vtscore.media.base import _fetch_media_url  # noqa: PLC0415
+
+        return _fetch_media_url(media_url)
+    return None
+
+
+def lazy_clip_bytes(media: dict[str, Any]) -> bytes | None:
+    """Return *media*'s clip bytes derived from its source, or ``None``.
+
+    ``None`` means "not a lazy clip" (no recipe) or "source unavailable" - in
+    both cases the caller falls back to its existing resolution order
+    (``media_path`` whole-file read, then ``media_url``).  A media that already
+    carries inline ``media_bytes`` is never lazy, so callers should check that
+    first; this function does not.
+    """
+    recipe = clip_recipe(media)
+    if recipe is None:
+        return None
+
+    source_key = media.get("media_path") or media.get("media_url")
+    cache_key = (source_key, recipe) if source_key else None
+
+    if cache_key is not None:
+        with _cache_lock:
+            hit = _cache.get(cache_key)
+            if hit is not None:
+                _cache.move_to_end(cache_key)
+                return hit
+
+    source = _read_source_bytes(media)
+    if source is None:
+        return None
+
+    try:
+        out = _apply_recipe(source, recipe)
+    except Exception:
+        log.warning("lazy_clip: failed to apply recipe %r to %s", recipe, source_key, exc_info=True)
+        return None
+    if out is None:
+        return None
+
+    if cache_key is not None:
+        with _cache_lock:
+            _cache[cache_key] = out
+            _cache.move_to_end(cache_key)
+            while len(_cache) > _CACHE_MAX:
+                _cache.popitem(last=False)
+    return out


### PR DESCRIPTION
## What & why

Phase 2a of `docs/plans/server-dedup-references.md`: **lazy clips**. After Phase 1, a reference (thin) import that *also* chose a clipper silently produced **no clips** — audio/image clippers early-return the media unchanged when `media_bytes` is absent, so the clipper stage was a no-op on thin parents. This makes clipping work for reference datasets *without* re-duplicating the bytes the reference was meant to avoid: a 5-minute recording tiled into 30 clips now stores the recipe 30 times (a few bytes each) instead of 30 copies of the audio.

Scope was confirmed as **lazy clips only**; lazy converter output is deferred to Phase 2b (its on-demand-conversion latency/caching story is genuinely harder). See the plan doc.

## How

- **`vtscore/media/lazy_clip.py`** (new) — a lazy clip carries no `media_bytes`; it keeps `media_path` (the source file) plus a *recipe* read from `origin.params` (`clip_start`/`clip_end` for audio, `clip_box` for image) and reproduces its bytes on demand. A small process-scoped LRU cache holds resolved slices (never persisted, per the no-persisted-bytes rule). Only audio and image participate — they're the types whose clippers actually re-slice bytes.
- **`MediaType._resolve_media_bytes`** (`vtscore/media/base.py`) consults `lazy_clip_bytes` before the plain `media_path` read, so HTTP serving, exporters, and every other byte consumer transparently get the sliced clip.
- **Clipper stage** (`vtscore/datasets/stages/clipper.py`) — `_hydrate_reference_parents` transiently loads a thin parent's bytes so the clipper computes boundaries and the existing MD5/embed/thumbnail fixup runs unchanged; `_relazify_reference_clips_stage` then strips the materialized bytes back off the derived clips.
- **`vtscore/datasets/load_pipeline.py`** runs the re-lazify stage **after** the embed/drop-none stages, so the embed-missing safety net (which reads `media_path` as the *whole* file) never mis-embeds a clip's full source behind its path.

Cross-dataset re-embed needed no change — `resolver.py` already re-derives clips from source + recipe. Pickle round-trip works because the recipe lives in `origin.params` (which already round-trips) and `media_path` is serialized; reopening a reference clip stays lazy.

Text clips stay materialized (a sliced string is tiny). Video clips are already metadata-only (shared parent bytes; player seeks via `clip_start`/`clip_end`). A converter anywhere in the chain disables lazification — that's Phase 2b.

## Backwards compatibility

No breaking changes. Full-mode (non-reference) imports are untouched: parents with bytes are never marked, and the re-lazify stage is a no-op without markers.

## Tests

New `tests_lib/datasets/test_lazy_clips.py` (19 tests): recipe extraction, on-demand audio slice / image crop + caching, `_resolve_media_bytes` integration, end-to-end thin-audio and thin-image tiling, full-mode-unaffected guard, converter-chain-not-lazified guard, and a pickle save→reopen→resolve round-trip. Full `./run-tests.sh` green (ruff/format/codespell/deptry/pip-audit/pyright/frontend build + 5095 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoonizHW3JwAwYL3jgfTMe)_