### PR TITLE
Resolve logical-bug audit L1–L9 batch

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -2,9 +2,10 @@
 
 **Status:** Mostly resolved; C1–C12 (critical) and H1–H34 (high) are
 shipped; the security trio M32–M34 and the data-integrity M21 shipped
-2026-06-24; ~8 medium/low items remain open (M29, M35, L1–L9; M22–M28,
-M30–M31 shipped or closed as not-a-bug). Resolved findings are marked as
-struck-through headings.
+2026-06-24, and the L1–L9 low batch was triaged the same day (L7/L9 fixed,
+the rest closed as stale / hypothetical / by-design). Only **M29** (audio
+context cleanup) and **M35** (one-vote eval metrics) remain open. Resolved
+findings are marked as struck-through headings.
 
 **Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
 interaction passes) of the entire VTSearch codebase, focused on
@@ -976,24 +977,70 @@ Cross-section interaction agents:
 
 ## Low: latent / cosmetic / hypothetical
 
-- **L1.** `_run_pipeline` returns `None` silently in text mode (no "done"
-  signal).
-- **L2.** Pipeline-vs-server logic in `app.py` L792 is masked by `sys.exit()`
-  but breaks if the function is ever refactored to return.
-- **L3.** Frontend cross-pane settings: `getViewMode()` falls back to
-  hard-coded defaults when the per-media-type entry isn't loaded.
-- **L4.** `get_settings_source_config` reads cache without re-checking sync
-  state.
-- **L5.** Frontend `clip_box` exports: list-of-floats CSV-joined without
-  quote-protection (edge case).
-- **L6.** Empty `Origin.params` not always dropped consistently across
-  importers.
-- **L7.** `eval/metrics.py` returns F1=0 for empty test set without flagging
-  the degenerate case.
-- **L8.** Logging of vote-related events truncates achievement traceback for
-  UI display.
-- **L9.** `get_param` returns `""` for unknown keys; silently swallows
-  renamed parameters.
+Triaged 2026-06-24. Two carried real, low-risk fixes (L7, L9); the rest
+were stale line references, hypothetical, or already-correct-by-design and
+are closed with rationale below.
+
+- ~~**L1.** `_run_pipeline` returns `None` silently in text mode (no "done"
+  signal).~~ **Closed — not a bug.** Every `_run_pipeline` branch emits a
+  terminal signal: the live and streaming paths run an exporter, and
+  `_run_exporter` (`vtscore/cli.py`) always emits an `export_complete`
+  progress event (defaulting to `"Export complete."` when the exporter
+  returns no message); the dry-run path prints its plan. There is no silent
+  return.
+- ~~**L2.** Pipeline-vs-server logic in `app.py` L792 is masked by `sys.exit()`
+  but breaks if the function is ever refactored to return.~~ **Closed —
+  hypothetical, and the line reference is stale** (`app.py` was split; the
+  dispatch now lives in `vtsearch/cli_main.py:main`). That dispatch is a
+  plain `if args.autodetect: … else: _run_server(…)` with no shared
+  fall-through, and the early-exit helpers (`_maybe_list_plugins`,
+  `_maybe_run_pipeline`) correctly `sys.exit(0)`. Nothing breaks unless a
+  future edit deliberately removes those exits, which the `if/else` would
+  still contain.
+- ~~**L3.** Frontend cross-pane settings: `getViewMode()` falls back to
+  hard-coded defaults when the per-media-type entry isn't loaded.~~
+  **Closed — by design.** The `'list'`/`'grid'` fallbacks match the
+  server-side defaults, and the component is recreated on dataset switch, so
+  the unloaded window is a benign transient that resolves on the first
+  settings emission. No correctness impact.
+- ~~**L4.** `get_settings_source_config` reads cache without re-checking sync
+  state.~~ **Closed — by design.** The getter only returns the configured
+  source descriptor; it makes no claim about sync freshness.
+  `set_settings_source_config` is what owns sync state and already drops it
+  (`_store.drop_sync_state`) when the source is cleared, so there is no stale
+  "still synced" signal for the getter to re-check.
+- ~~**L5.** Frontend `clip_box` exports: list-of-floats CSV-joined without
+  quote-protection (edge case).~~ **Closed — already protected.** The
+  comma-joined `clip_box` cell is written through `csv.writer.writerow`
+  (`vtscore/exporters/server_csv_file`), which quotes any field containing a
+  comma (`QUOTE_MINIMAL`) and round-trips correctly through `csv.DictReader`.
+  The join is not hand-concatenated into the row.
+- ~~**L6.** Empty `Origin.params` not always dropped consistently across
+  importers.~~ **Closed — consistent by construction.** `Origin.to_dict`
+  always serialises `params` (an empty `{}` when unset) and `from_dict`
+  defaults to `{}`, so empty-vs-absent round-trips identically. The one real
+  hazard — sharing a single origin dict by reference across sibling clips —
+  is already handled where it matters (`load_pipeline.py` copies per media,
+  with an inline comment explaining the aliasing risk).
+- ~~**L7.** `eval/metrics.py` returns F1=0 for empty test set without flagging
+  the degenerate case.~~ **Shipped.**
+  `compute_binary_classification_metrics` now logs a warning when the
+  prediction set is empty (`total == 0`), so the all-zero tuple isn't
+  mistaken for a real 0%-accurate evaluation. Tests in
+  `tests_lib/detectors/test_eval.py::TestBinaryClassification`.
+- ~~**L8.** Logging of vote-related events truncates achievement traceback for
+  UI display.~~ **Closed — stale / non-existent.** No vote-event logging path
+  truncates a traceback: `vtsearch/routes/media/list.py` and
+  `routes/labels/vote.py` log via `logger.exception(...)` (full traceback),
+  and `achievements.py` never logs vote errors. The "truncation" in
+  `tests/core/test_votes.py` refers to vote-*step* history truncation, an
+  unrelated concept.
+- ~~**L9.** `get_param` returns `""` for unknown keys; silently swallows
+  renamed parameters.~~ **Shipped.** `MediaConverter.get_param` still returns
+  `""` for an undeclared key (historical contract), but now logs a warning
+  naming the key and converter, so a typo'd or renamed field surfaces instead
+  of reading as empty forever. Tests in
+  `tests/converters/test_converter_selection.py`.
 
 ---
 

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -913,6 +913,7 @@ class TestConverterAcceptsParams:
         from vtscore.converters import get_converter
 
         c = get_converter("video2image")
+        assert c is not None
         with caplog.at_level(logging.WARNING, logger="vtscore.converters.base"):
             c.get_param({}, "n_clips")
         assert not any("no field declares that key" in r.message for r in caplog.records)

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -894,6 +894,29 @@ class TestConverterAcceptsParams:
         # Default falls back to the field's declared default.
         assert c.get_param({}, "n_clips") == "10"
 
+    def test_get_param_unknown_key_returns_empty_and_warns(self, caplog):
+        """An undeclared key still returns "" (historical contract) but now
+        logs a warning so a renamed/typo'd field isn't swallowed silently (L9)."""
+        import logging
+
+        from vtscore.converters import get_converter
+
+        c = get_converter("video2image")
+        assert c is not None
+        with caplog.at_level(logging.WARNING, logger="vtscore.converters.base"):
+            assert c.get_param({}, "no_such_field") == ""
+        assert any("no field declares that key" in r.message for r in caplog.records)
+
+    def test_get_param_declared_key_does_not_warn(self, caplog):
+        import logging
+
+        from vtscore.converters import get_converter
+
+        c = get_converter("video2image")
+        with caplog.at_level(logging.WARNING, logger="vtscore.converters.base"):
+            c.get_param({}, "n_clips")
+        assert not any("no field declares that key" in r.message for r in caplog.records)
+
 
 class TestImportAPISourceSpecs:
     def test_import_endpoint_passes_source_specs(self, client):

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -144,6 +144,23 @@ class TestBinaryClassification:
         acc, prec, rec, f1 = compute_binary_classification_metrics([], [])
         assert acc == 0.0
 
+    def test_empty_logs_degenerate_warning(self, caplog):
+        """An empty prediction set returns all-zero metrics, but logs a warning
+        so the zeros aren't mistaken for a real evaluation (L7)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="vtscore.eval.metrics"):
+            acc, prec, rec, f1 = compute_binary_classification_metrics([], [])
+        assert (acc, prec, rec, f1) == (0.0, 0.0, 0.0, 0.0)
+        assert any("empty prediction set" in r.message for r in caplog.records)
+
+    def test_nonempty_does_not_warn(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="vtscore.eval.metrics"):
+            compute_binary_classification_metrics([1, 0], [1, 0])
+        assert not any("empty prediction set" in r.message for r in caplog.records)
+
 
 # =====================================================================
 # Metrics: compute_metrics (integration)

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -233,6 +234,17 @@ class MediaConverter(PluginBase, ABC):
         for f in self.fields:
             if f.key == key:
                 return f.default
+        # No field declares *key*. Returning "" keeps the historical contract,
+        # but a key that doesn't match any declared field is almost always a
+        # typo or a field that was renamed/removed out from under a caller —
+        # which would otherwise read as an empty string forever. Surface it
+        # (L9) instead of swallowing it silently.
+        logging.getLogger(__name__).warning(
+            "get_param(%r) on converter %r: no field declares that key; returning ''. "
+            "A renamed or removed field will silently read as empty.",
+            key,
+            self.name,
+        )
         return ""
 
     def to_dict(self) -> dict[str, Any]:

--- a/vtscore/eval/metrics.py
+++ b/vtscore/eval/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -212,6 +213,14 @@ def compute_binary_classification_metrics(
     tn = sum(p == 0 and gt == 0 for p, gt in zip(predictions, labels))
 
     total = tp + fp + fn + tn
+    if total == 0:
+        # Degenerate input: no predictions to score. The all-zero tuple below
+        # is not a real "0% accurate" result — flag it so a caller (or a log
+        # reader) doesn't treat the zeros as a meaningful evaluation (L7).
+        logging.getLogger(__name__).warning(
+            "compute_binary_classification_metrics called with an empty prediction set; "
+            "returning all-zero accuracy/precision/recall/F1, which are not meaningful."
+        )
     accuracy = (tp + tn) / total if total > 0 else 0.0
     precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
     recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0


### PR DESCRIPTION
Follow-up to #2027 (merged), which carried the M-item fixes (M21/M32/M33/M34). The L1–L9 commits landed on that branch *after* it merged, so they never made it into `dev` — this PR brings them over.

## Low batch (L1–L9), triaged 2026-06-24

Two carried real, low-risk fixes; the other seven were stale line references, hypothetical, or already correct by design (each closed with rationale in the audit doc):

- **L7 — fixed:** `compute_binary_classification_metrics` logs a warning on an empty prediction set so the all-zero tuple isn't read as a real evaluation.
- **L9 — fixed:** `MediaConverter.get_param` logs a warning when a key matches no declared field (still returns `""` for back-compat), surfacing typo'd/renamed fields.
- **L1 closed** (every pipeline branch emits `export_complete`), **L2 closed** (stale `app.py:792` ref; dispatch is a clean `if/else` in `cli_main.py`), **L3 closed** (defensive defaults match server, benign transient), **L4 closed** (getter returns config only; setter owns sync state), **L5 closed** (`csv.writer` already quotes the comma-joined `clip_box` cell), **L6 closed** (`Origin` round-trips empty params consistently; aliasing handled in `load_pipeline`), **L8 closed** (no such traceback-truncation code exists).

## Tests
- `tests_lib/detectors/test_eval.py::TestBinaryClassification` (L7)
- `tests/converters/test_converter_selection.py` (L9)

Full `./run-tests.sh` green: **ALL 5080 TESTS PASSED** (lint/format/codespell/deptry/pyright/frontend gates included). The audit doc is updated to strike every resolved L item; only **M29** (audio-context cleanup) and **M35** (one-vote eval metrics) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SakYxy2Aorn2eDpfM7Habf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SakYxy2Aorn2eDpfM7Habf)_