### PR TITLE
Close out logical-bug audit: M29 (AudioContext) + M35 (one-vote eval metrics)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -50,6 +50,6 @@ it can't drift far. (Point-in-time UI review/audit reports live in
 ## Audits / tooling / methodology
 
 - [angular-21-upgrade.md](angular-21-upgrade.md): Angular 19→21 bump (clears npm-audit highs) + Vitest spec migration to restore runnable frontend tests (all phases shipped; kept as the migration reference for future bumps)
-- [logical-bug-audit.md](logical-bug-audit.md): codebase logical-bug audit (C/H shipped; ~12 M/L open)
+- [logical-bug-audit.md](logical-bug-audit.md): codebase logical-bug audit (all findings resolved; kept as the audit record)
 - [browser-vision-testing.md](browser-vision-testing.md): browser-vision testing playbook (first round ran; reusable)
 - [user-docs-screenshots.md](user-docs-screenshots.md): auto-refreshable screenshots for user docs — manifest + capture harness (proposed; no shots yet)

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1,11 +1,12 @@
 # Logical-Bug Audit: 2026-05
 
-**Status:** Mostly resolved; C1–C12 (critical) and H1–H34 (high) are
-shipped; the security trio M32–M34 and the data-integrity M21 shipped
-2026-06-24, and the L1–L9 low batch was triaged the same day (L7/L9 fixed,
-the rest closed as stale / hypothetical / by-design). Only **M29** (audio
-context cleanup) and **M35** (one-vote eval metrics) remain open. Resolved
-findings are marked as struck-through headings.
+**Status:** Resolved. C1–C12 (critical) and H1–H34 (high) are shipped; the
+security trio M32–M34 and the data-integrity M21 shipped 2026-06-24, and the
+L1–L9 low batch was triaged the same day (L7/L9 fixed, the rest closed as
+stale / hypothetical / by-design). The last two open mediums — **M29** (audio
+context cleanup) and **M35** (one-vote eval metrics) — shipped 2026-06-25. No
+open findings remain; this doc is kept as the audit record. Resolved findings
+are marked as struck-through headings.
 
 **Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
 interaction passes) of the entire VTSearch codebase, focused on
@@ -922,8 +923,19 @@ Cross-section interaction agents:
   `response.ok`, and logs the underlying error via `console.warn` instead of
   swallowing it. `AbortError` is suppressed so rapid swiping doesn't spam the
   console or overwrite the next media's canvas.
-- **M29.** `AudioContext` not cleaned up on rapid navigation → resource
-  exhaustion.
+- ~~**M29.** `AudioContext` not cleaned up on rapid navigation → resource
+  exhaustion.~~ **Shipped.** Root cause: both the audio player and the
+  audio-crop overlay spun up a full hardware `AudioContext` purely to decode
+  audio for a static waveform. Chrome caps live contexts at ~6 and `close()`
+  is async, so rapid media navigation could create them faster than they tear
+  down (`NotSupportedError: number of hardware contexts reached maximum`); the
+  crop overlay additionally leaked its context whenever `decodeAudioData`
+  threw (the `catch` never called `close()`). Both now decode via a shared
+  `decodeAudioBuffer` helper (`frontend/src/app/utils/decode-audio.ts`) backed
+  by a throwaway `OfflineAudioContext`, which is purely computational — no
+  hardware allocation, no per-page cap, nothing to clean up. The audio
+  player's persistent `audioCtx` field and its `ngOnDestroy` close were
+  dropped.
 - ~~**M30.** Autopilot phase transitions can oscillate
   (`hard → new → hard → new`) when smart/stable status flickers.~~
   **Won't fix.** Evaluated and closed. The current derivation in
@@ -970,8 +982,15 @@ Cross-section interaction agents:
 
 ### Eval / exporters
 
-- **M35.** `voting_iterations.py` reports F1/FPR with one good + one bad vote
-  as if reliable.
+- ~~**M35.** `voting_iterations.py` reports F1/FPR with one good + one bad vote
+  as if reliable.~~ **Shipped.** `simulate_voting_iterations` emits a metrics
+  row as soon as ≥1 good and ≥1 bad vote exist, but that 1-vs-1 row was
+  indistinguishable from a 50-vs-50 row in the output. Rather than silently
+  drop early rows (lossy), each row now carries `n_good`/`n_bad` (the per-class
+  vote counts behind it, summing to `t`), threaded through both DataFrame
+  builders and documented in `vtscore/docs/packages/eval.md`, so downstream
+  analysis can filter or weight by sample size. Test coverage in
+  `tests_lib/detectors/test_eval_voting_iterations.py`.
 
 ---
 

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { decodeAudioBuffer } from '../../../utils/decode-audio';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,7 +24,6 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
 
   audioSrc = '';
 
-  private audioCtx: AudioContext | null = null;
   private waveformAbort: AbortController | null = null;
   private viewReady = false;
   // See ImageViewerComponent.lastMediaId: the `media` input reference changes
@@ -61,9 +61,6 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
       audio.pause();
       audio.removeAttribute('src');
       audio.load();
-    }
-    if (this.audioCtx && this.audioCtx.state !== 'closed') {
-      this.audioCtx.close();
     }
   }
 
@@ -152,10 +149,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
       const arrayBuffer = await response.arrayBuffer();
       if (abort.signal.aborted) return;
 
-      if (!this.audioCtx || this.audioCtx.state === 'closed') {
-        this.audioCtx = new AudioContext();
-      }
-      const audioBuffer = await this.audioCtx.decodeAudioData(arrayBuffer);
+      const audioBuffer = await decodeAudioBuffer(arrayBuffer);
       if (abort.signal.aborted) return;
 
       const channelData = audioBuffer.getChannelData(0);

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
@@ -9,6 +9,7 @@ import {
   output,
   ViewChild,
 } from '@angular/core';
+import { decodeAudioBuffer } from '../../../utils/decode-audio';
 
 
 export interface AudioCropResult {
@@ -55,17 +56,13 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
     }
     try {
       const arrayBuffer = await audioFile.arrayBuffer();
-      const AudioCtx = (window.AudioContext ||
-        (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext);
-      const ctx = new AudioCtx();
-      const buffer = await ctx.decodeAudioData(arrayBuffer);
+      const buffer = await decodeAudioBuffer(arrayBuffer);
       this.duration = buffer.duration;
       this.start = 0;
       this.end = this.duration;
       this.peaks = this.computePeaks(buffer, 600);
       this.loading = false;
       requestAnimationFrame(() => this.draw());
-      ctx.close();
     } catch (e) {
       this.errorMsg = 'Could not decode audio waveform; you can still crop by dragging.';
       this.loading = false;
@@ -76,7 +73,8 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    // No persistent resources beyond the AudioContext (already closed).
+    // No persistent resources to release: decoding uses a throwaway
+    // OfflineAudioContext (see decodeAudioBuffer) that needs no teardown.
   }
 
   /** Set duration from the <audio> element when it becomes available. */

--- a/frontend/src/app/utils/decode-audio.ts
+++ b/frontend/src/app/utils/decode-audio.ts
@@ -1,0 +1,24 @@
+/**
+ * Decode compressed/encoded audio bytes into an `AudioBuffer` for waveform
+ * rendering, using an `OfflineAudioContext`.
+ *
+ * Why offline rather than a live `AudioContext`: decoding is the only thing we
+ * need here (the actual playback runs through a plain `<audio>` element). A live
+ * `AudioContext` allocates a hardware audio thread and counts against the
+ * browser's per-page cap (~6 in Chrome); since `close()` is async, rapid media
+ * navigation could create contexts faster than they tear down and exhaust that
+ * budget (`NotSupportedError: number of hardware contexts reached maximum`).
+ * `OfflineAudioContext` is purely computational — no hardware allocation, no
+ * cap, and nothing to clean up — so callers never have to track its lifecycle.
+ *
+ * `decodeAudioData` resamples to the context's sample rate; 44.1 kHz mono is
+ * fine for peak/waveform display. The 1-frame length is irrelevant because we
+ * never call `startRendering()`.
+ */
+export async function decodeAudioBuffer(data: ArrayBuffer): Promise<AudioBuffer> {
+  const OfflineCtx =
+    window.OfflineAudioContext ||
+    (window as unknown as { webkitOfflineAudioContext: typeof OfflineAudioContext }).webkitOfflineAudioContext;
+  const ctx = new OfflineCtx(1, 1, 44100);
+  return ctx.decodeAudioData(data);
+}

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -167,9 +167,38 @@ class TestSimulateVotingIterations:
             seed=42,
             dataset_name="test_ds",
         )
-        expected_keys = {"seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"}
+        expected_keys = {
+            "seed",
+            "dataset",
+            "category",
+            "t",
+            "n_good",
+            "n_bad",
+            "cost",
+            "fpr",
+            "fnr",
+            "elapsed_seconds",
+        }
         for row in rows:
             assert set(row.keys()) == expected_keys
+
+    def test_vote_counts_reported(self):
+        """Each row carries the good/bad vote counts the model was trained on.
+
+        The first scored row reflects the 1-good + 1-bad minimum, and the
+        counts never exceed the votes seen so far (t).
+        """
+        medias = _make_separable_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(medias, "alpha", seed=42)
+        assert rows  # at least one scored step
+        first = rows[0]
+        assert first["n_good"] >= 1
+        assert first["n_bad"] >= 1
+        assert min(first["n_good"], first["n_bad"]) == 1  # earliest trainable step
+        for row in rows:
+            assert row["n_good"] + row["n_bad"] == row["t"]
+            assert row["n_good"] >= 1
+            assert row["n_bad"] >= 1
 
     def test_seed_determinism(self):
         medias = _make_separable_clips(n_per_cat=10)
@@ -267,7 +296,18 @@ class TestRunVotingIterationsEval:
             categories={"ds1": ["alpha"]},
         )
         assert isinstance(df, pd.DataFrame)
-        assert list(df.columns) == ["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"]
+        assert list(df.columns) == [
+            "seed",
+            "dataset",
+            "category",
+            "t",
+            "n_good",
+            "n_bad",
+            "cost",
+            "fpr",
+            "fnr",
+            "elapsed_seconds",
+        ]
 
     def test_multiple_seeds(self):
         medias = _make_separable_clips(n_per_cat=10)

--- a/vtscore/docs/packages/eval.md
+++ b/vtscore/docs/packages/eval.md
@@ -251,10 +251,16 @@ Returns a list of row dicts:
 ```python
 {
     "seed": 0, "dataset": "esc50_s", "category": "dog",
-    "t": 7, "cost": 0.124, "fpr": 0.05, "fnr": 0.21,
+    "t": 7, "n_good": 3, "n_bad": 4,
+    "cost": 0.124, "fpr": 0.05, "fnr": 0.21,
     "elapsed_seconds": 12.4,
 }
 ```
+
+`n_good`/`n_bad` are the good/bad vote counts the row's model was trained
+on (they sum to `t`). The first scored step has only one of each, so its
+metrics are very noisy; carry these counts through so analysis can filter or
+weight rows by sample size instead of treating a 1-vs-1 model as reliable.
 
 Honours the same threshold knobs as the runner. When
 `safe_thresholds=True`, the GMM blend uses scores over the simulation
@@ -266,7 +272,7 @@ calibration.
 `vtscore/eval/voting_iterations.py:250`. Sweep
 `simulate_voting_iterations` over `(seed × dataset × category)` and
 return a `pandas.DataFrame` with columns `seed, dataset, category, t,
-cost, fpr, fnr, elapsed_seconds`. When `categories` is `None` or a
+n_good, n_bad, cost, fpr, fnr, elapsed_seconds`. When `categories` is `None` or a
 dataset is missing from the dict, every unique category in that
 dataset is used.
 

--- a/vtscore/eval/visualize.py
+++ b/vtscore/eval/visualize.py
@@ -326,8 +326,8 @@ def plot_voting_iterations(
 
     Args:
         df: :class:`pandas.DataFrame` with columns
-            ``seed, dataset, category, t, cost, fpr, fnr`` as returned
-            by :func:`run_voting_iterations_eval`.
+            ``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr`` as
+            returned by :func:`run_voting_iterations_eval`.
         output_dir: Directory to write PNG files into (created if needed).
 
     Returns:

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -13,7 +13,14 @@ For each combination of seed *s*, dataset *d*, and target category *c*:
    (``fpr_weight * FPR + fnr_weight * FNR``).
 
 The result is a :class:`pandas.DataFrame` with columns
-``seed, dataset, category, t, cost, fpr, fnr``.
+``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr``.
+
+``n_good``/``n_bad`` are the number of good/bad votes the model was trained
+on for that row. The very first scored step has only one of each, so its
+``cost``/``fpr``/``fnr`` are extremely noisy; these counts let downstream
+analysis filter or weight rows by how many votes actually informed them
+rather than treating a 1-vs-1 model as if it were as reliable as a 50-vs-50
+one.
 """
 
 from __future__ import annotations
@@ -148,8 +155,10 @@ def simulate_voting_iterations(
             calibration in each split (default 0.5).
 
     Returns:
-        List of row dicts with keys
-        ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``.
+        List of row dicts with keys ``seed, dataset, category, t, n_good,
+        n_bad, cost, fpr, fnr, elapsed_seconds``. ``n_good``/``n_bad`` report
+        the vote counts behind each row so callers can tell apart metrics
+        learned from a 1-vs-1 model and a many-vs-many one.
     """
     import numpy as np  # noqa: PLC0415
     import torch  # noqa: PLC0415
@@ -235,6 +244,8 @@ def simulate_voting_iterations(
                 "dataset": dataset_name,
                 "category": target_category,
                 "t": t,
+                "n_good": len(good_votes),
+                "n_bad": len(bad_votes),
                 **metrics,
                 "elapsed_seconds": round(time.monotonic() - start_time, 3),
             }
@@ -278,8 +289,8 @@ def run_voting_iterations_eval(
             calibration in each split (default 0.5).
 
     Returns:
-        A :class:`~pandas.DataFrame` with columns
-        ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``.
+        A :class:`~pandas.DataFrame` with columns ``seed, dataset, category,
+        t, n_good, n_bad, cost, fpr, fnr, elapsed_seconds``.
     """
     import pandas as pd  # noqa: PLC0415
 
@@ -309,7 +320,9 @@ def run_voting_iterations_eval(
 
     return pd.DataFrame(
         all_rows,
-        columns=pd.Index(["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"]),
+        columns=pd.Index(
+            ["seed", "dataset", "category", "t", "n_good", "n_bad", "cost", "fpr", "fnr", "elapsed_seconds"]
+        ),
     )
 
 
@@ -339,7 +352,8 @@ def run_voting_iterations_eval_from_pickles(
 
     Returns:
         A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
-        (columns: ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``).
+        (columns: ``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr,
+        elapsed_seconds``).
     """
     from vtscore.datasets.loader import load_dataset_from_pickle
 


### PR DESCRIPTION
Closes the last two open findings in `docs/plans/logical-bug-audit.md`, marking the audit fully resolved.

## M29 — AudioContext not cleaned up on rapid navigation

Both the audio player and the audio-crop overlay spun up a full **hardware** `AudioContext` purely to decode audio for a static waveform. Chrome caps live contexts at ~6 per page and `close()` is async, so rapid media navigation could create them faster than they tear down (`NotSupportedError: number of hardware contexts reached maximum`). The crop overlay additionally **leaked** its context whenever `decodeAudioData` threw — the `catch` never called `close()`.

Both now decode via a shared `decodeAudioBuffer` helper (`frontend/src/app/utils/decode-audio.ts`) backed by a throwaway `OfflineAudioContext`: purely computational, no hardware allocation, no per-page cap, nothing to clean up. The audio player's persistent `audioCtx` field and its `ngOnDestroy` close were dropped.

## M35 — voting-iterations metrics reported as if reliable

`simulate_voting_iterations` emits a metrics row as soon as ≥1 good and ≥1 bad vote exist, but that 1-vs-1 row was indistinguishable from a 50-vs-50 row in the output. Rather than silently drop early rows (lossy), each row now carries `n_good`/`n_bad` (the per-class vote counts behind it, summing to `t`), threaded through both DataFrame builders and documented in `vtscore/docs/packages/eval.md`, so downstream analysis can filter or weight by sample size.

## Plan/index bookkeeping
- `logical-bug-audit.md`: M29/M35 struck through; status header updated to "Resolved".
- `docs/plans/README.md`: audit entry updated to "all findings resolved".

## Testing
- `./run-tests.sh frontend` — green (build OK, 860 Vitest tests pass, audit clean, pyright 0 errors).
- `./run-tests.sh detectors` — 1271 passed, including new `n_good`/`n_bad` assertions in `tests_lib/detectors/test_eval_voting_iterations.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0146vZc1yUYDvmCo5mPppNpd)_