### PR TITLE
Phase 2b: lazy converter output for reference imports

### DIFF
--- a/docs/plans/server-dedup-references.md
+++ b/docs/plans/server-dedup-references.md
@@ -1,12 +1,15 @@
 # Reference (no-copy) dataset import
 
-Status: **Phase 1 + Phase 2a shipped; Phase 2b designed, not yet built.**
+Status: **Phase 1 + Phase 2a + Phase 2b shipped.**
 Whole-file references for the two server importers (`server_folder`,
 `server_files`) are wired end-to-end (Phase 1). **Lazy clips** for audio and
-image now let reference datasets be clipped without duplicating bytes
-(Phase 2a). **Lazy converter output** (Phase 2b) is the last transform that
-still copies bytes; the design is fully specified below under *Phase 2b
-design* and is ready to implement, but no Phase 2b code has shipped.
+image let reference datasets be clipped without duplicating bytes (Phase 2a).
+**Lazy converter output** (Phase 2b) now extends the same recipe-on-demand
+mechanism to the last duplicating transform: a converter (`document2image`,
+`video2image`, …) running in reference mode stores the source path plus a
+converter recipe instead of baking N rendered outputs into the pickle. The
+*Phase 2b design* below is the implementation spec; *What shipped (Phase 2b)*
+records what actually landed and the remaining fast-follows.
 
 ## Problem
 
@@ -105,6 +108,76 @@ re-splitting from source is fragile). Video clips are already metadata-only
 so they don't duplicate bytes and need no recipe slicing. A converter anywhere
 in the chain disables lazification (the output is no longer a slice of the
 source) — that's Phase 2b.
+
+## What shipped (Phase 2b: lazy converter output)
+
+Reference (thin) imports that run a **converter** (`server_folder` /
+`server_files` with a converter spec) no longer bake the rendered outputs into
+the pickle. Each output stores the *source* `media_path` plus a converter
+recipe in `origin.params` and re-renders on demand. This closes the last
+duplicating transform; un-converted media (Phase 1) and audio/image clips
+(Phase 2a) were already reference-clean.
+
+- **Importer stamp** (`vtscore/converters/runner.py`):
+  `_emit_converted_outputs` stamps three per-output disambiguators —
+  `converter_out_index`, `converter_n_out`, and `converter_content_hash` (a
+  12-hex md5 of the output bytes, via `clipper_chain._content_hash`). Each
+  output now gets its **own** origin dict (`_origin_with_disambiguators`)
+  rather than sharing one flat origin per source file. In reference (`thin`)
+  mode each output is tagged with `_lazy_source` and keeps its `media_bytes`
+  only for the embed stage. The disambiguators are stamped in *both* modes so
+  the cross-dataset resolver can re-select sub-outputs even for copy-mode
+  converter imports.
+- **Byte resolution** (`vtscore/media/lazy_clip.py`): `clip_recipe` learned a
+  converter branch (checked first, keyed by `converter` in `origin.params`, so
+  a `document2image` output with `media_type=image` resolves as a converter
+  output, not an image clip). `_apply_converter_recipe` re-runs the converter
+  on the source bytes and re-selects the recorded output by **delegating to
+  `clipper_chain._select_chain_output`** — identical content-hash-first,
+  drift-aware, refuse-to-guess semantics as the resolver. Returns `None`
+  (fall through, cache nothing) when nothing matches.
+- **Byte-bounded cache** (`vtscore/media/lazy_clip.py`): converter output uses
+  a new `_ByteBoundedLRU` (~256 MB ceiling) **separate** from Phase 2a's
+  count-bounded clip cache, because a rendered page / video frame is 1–8 MB and
+  varies by an order of magnitude (256 *entries* of those could be 1–2 GB). The
+  clip slice cache stays count-bounded.
+- **Re-lazify** (`vtscore/datasets/stages/clipper.py`):
+  `_relazify_reference_clips_stage` already strips any `_lazy_source`-tagged
+  media, so it covers converter outputs unchanged — only the docstring was
+  generalized. It runs after the embed / drop-none stages (existing
+  `load_pipeline` ordering), so the embed-missing safety net always sees the
+  real rendered bytes, never the source file behind the path.
+- **Cross-dataset re-embed** (`vtscore/detectors/resolver.py`): a flat
+  converter origin is normalized into a one-element chain
+  (`_converter_origin_to_chain`) and replayed through the existing
+  `replay_chain_on_file`, so a reference-converted label re-embeds the rendered
+  page/frame (not the raw source file) via a single shared replay path. Falls
+  back to a whole-file embed if the converter is gone.
+- **Pickle round-trip / HTTP serving / exporters** need no change: the recipe
+  lives in `origin.params` (round-trips), `media_path` is serialized, and
+  `_resolve_media_bytes` already consults `lazy_clip_bytes` before the
+  whole-file read.
+
+### Open follow-ups (Phase 2b)
+
+- **Demo converter path** (`apply_converter_to_demo` /
+  `_emit_converted_demo_outputs`) and **standalone PDF expansion**
+  (`load_pdf_images_into` in `vtscore/datasets/pdf.py`) do **not** yet stamp the
+  disambiguators or `_lazy_source`; they always materialize. Same recipe+resolve
+  shape — wire them through `_origin_with_disambiguators` (or share the emit
+  helper) when a reference path reaches them.
+- **Multi-step chains mixing a converter and a clipper** under reference mode
+  are still left fully materialized: `_hydrate_reference_parents` bails when a
+  chain contains a converter, and Phase 2b's first cut covers a *converter as
+  the sole reference transform*. Re-slicing converter output (converter →
+  clipper) is a later composition now that both lazy branches exist.
+- **Cache unification**: Phase 2a's clip cache and Phase 2b's converter cache
+  are two structures with two eviction policies. Migrating clips onto the
+  byte-bounded LRU (clips are just small, cheap-to-recompute entries) would
+  leave one cache; not required, noted so they don't drift.
+- **Pre-warm**: intentionally not done — re-converting on load defeats the
+  storage-only-cost trade. Revisit only if a real workload shows cold-fetch
+  latency is a problem.
 
 ## Phase 2b design: lazy converter output
 

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -510,6 +510,76 @@ class TestRunConvertersOnFolder:
         # All should have sequential IDs
         assert sorted(medias.keys()) == [1, 2, 3]
 
+    def test_stamps_sub_output_disambiguators(self, tmp_path):
+        """Every converter output records out_index / n_out / content_hash so
+        a lazy or cross-dataset replay can re-select the exact sub-output."""
+        from vtscore.datasets.clipper_chain import _content_hash
+        from vtscore.converters.runner import run_converters_on_folder
+
+        (tmp_path / "long_video.mp4").write_bytes(b"video-data")
+
+        fake_outputs = [
+            {"filename": f"frame_{i}.png", "media_bytes": _make_png_bytes(width=4 + i), "duration": 0} for i in range(3)
+        ]
+        mock_converter = self._mock_video2image_converter(convert_return=fake_outputs)
+
+        medias: dict = {}
+        with (
+            patch("vtscore.converters.get_converter", return_value=mock_converter),
+            patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
+        ):
+            run_converters_on_folder(
+                folder_path=tmp_path,
+                converter_specs=[SourceSpec(source_type="video", converter="video2image")],
+                target_media_type="image",
+                medias=medias,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(medias) == 3
+        for i, mid in enumerate(sorted(medias)):
+            params = medias[mid]["origin"]["params"]
+            assert params["converter_out_index"] == str(i)
+            assert params["converter_n_out"] == "3"
+            assert params["converter_content_hash"] == _content_hash(fake_outputs[i])
+        # Per-output origins must be distinct objects, not one shared dict.
+        assert medias[1]["origin"] is not medias[2]["origin"]
+        # Non-thin import keeps inline bytes and stamps no lazy marker.
+        assert "_lazy_source" not in medias[1]
+
+    def test_thin_mode_tags_lazy_source_and_keeps_bytes(self, tmp_path):
+        """Reference (thin) mode tags each output with _lazy_source (for the
+        re-lazify stage) while keeping media_bytes for the embed stage."""
+        from vtscore.converters.runner import run_converters_on_folder
+
+        (tmp_path / "long_video.mp4").write_bytes(b"video-data")
+
+        fake_outputs = [
+            {"filename": f"frame_{i}.png", "media_bytes": _make_png_bytes(), "duration": 0} for i in range(2)
+        ]
+        mock_converter = self._mock_video2image_converter(convert_return=fake_outputs)
+
+        medias: dict = {}
+        with (
+            patch("vtscore.converters.get_converter", return_value=mock_converter),
+            patch("vtscore.media.get_by_folder_name", return_value=self._mock_target_mt()),
+        ):
+            run_converters_on_folder(
+                folder_path=tmp_path,
+                converter_specs=[SourceSpec(source_type="video", converter="video2image")],
+                target_media_type="image",
+                medias=medias,
+                on_progress=lambda *a: None,
+                thin=True,
+            )
+
+        resolved_source = str((tmp_path / "long_video.mp4").resolve())
+        assert len(medias) == 2
+        for media in medias.values():
+            assert media["_lazy_source"] == resolved_source
+            assert media["media_bytes"] is not None  # kept for the embed stage
+            assert media["media_path"] == resolved_source
+
     def test_converter_failure_skips_file(self, tmp_path):
         """If converter.convert() raises, that file is skipped."""
         from vtscore.converters.runner import run_converters_on_folder

--- a/tests_lib/datasets/test_lazy_clips.py
+++ b/tests_lib/datasets/test_lazy_clips.py
@@ -18,9 +18,10 @@ from typing import Any
 import numpy as np
 import pytest
 
+from vtscore.datasets.clipper_chain import _content_hash
 from vtscore.datasets.stages import clipper as clipper_stage
 from vtscore.media.audio.clipper import _wav_slice
-from vtscore.media.lazy_clip import clip_recipe, lazy_clip_bytes
+from vtscore.media.lazy_clip import _ByteBoundedLRU, clip_recipe, lazy_clip_bytes
 
 from helpers import make_png_bytes, make_wav_bytes
 
@@ -345,3 +346,230 @@ class TestPickleRoundTrip:
             resolved = media_registry.get("audio")._resolve_media_bytes(clip)
             expected = _wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
             assert resolved == expected
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b: lazy converter output
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc2Image:
+    """A deterministic stand-in for a real converter (no heavy deps).
+
+    Produces one image output per "page", whose bytes are derived from the
+    source bytes so a test can predict the exact output for any out_index.
+    """
+
+    name = "doc2img"
+    source_type = "document"
+    target_type = "image"
+
+    def __init__(self, n_pages: int = 3) -> None:
+        self.n_pages = n_pages
+
+    def convert_normalized(self, media: dict[str, Any], params: dict[str, Any]) -> list[dict[str, Any]]:
+        src = media.get("media_bytes") or b""
+        n = int(params.get("pages", self.n_pages))
+        return [
+            {"filename": f"page_{i}.png", "media_bytes": src + f"|page{i}".encode(), "duration": 0} for i in range(n)
+        ]
+
+
+def _page_bytes(source: bytes, idx: int) -> bytes:
+    return source + f"|page{idx}".encode()
+
+
+def _converter_media(
+    source_path: Path,
+    *,
+    out_index: int,
+    n_out: int,
+    content_hash: str | None,
+    params: dict[str, Any] | None = None,
+    name: str = "doc2img",
+    target_type: str = "image",
+) -> dict[str, Any]:
+    """Build a byte-less reference-converted media (the re-lazified form)."""
+    p: dict[str, Any] = {
+        "converter": name,
+        "source_file": source_path.name,
+        "converter_out_index": str(out_index),
+        "converter_n_out": str(n_out),
+    }
+    if content_hash is not None:
+        p["converter_content_hash"] = content_hash
+    for k, v in (params or {}).items():
+        p[f"converter_param_{k}"] = str(v)
+    return {
+        "media_type": target_type,
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": str(source_path),
+        "filename": f"{source_path.stem}_page.png",
+        "origin": {"importer": "converter", "params": p},
+    }
+
+
+@pytest.fixture
+def _fake_converter(monkeypatch):
+    fake = _FakeDoc2Image(n_pages=3)
+    monkeypatch.setattr("vtscore.converters.get_converter", lambda name: fake if name == "doc2img" else None)
+    return fake
+
+
+class TestConverterRecipe:
+    def test_recipe_recognised_by_converter_param(self):
+        media = {
+            "media_type": "image",
+            "origin": {"params": {"converter": "doc2img", "converter_out_index": "1", "converter_n_out": "3"}},
+        }
+        recipe = clip_recipe(media)
+        assert recipe is not None
+        assert recipe[0] == "converter"
+        assert recipe[1] == "doc2img"
+        assert recipe[3] == 1  # out_index coerced to int
+
+    def test_converter_params_reconstructed(self):
+        media = {
+            "media_type": "text",
+            "origin": {
+                "params": {
+                    "converter": "doc2img",
+                    "converter_out_index": "0",
+                    "converter_param_pages": "5",
+                    "converter_param_dpi": "150",
+                }
+            },
+        }
+        recipe = clip_recipe(media)
+        assert recipe is not None
+        assert dict(recipe[2]) == {"pages": "5", "dpi": "150"}
+
+    def test_no_disambiguator_is_not_lazy(self):
+        # A converter origin with neither out_index nor content_hash can't be
+        # resolved back to a specific output, so it is treated as not-lazy.
+        media = {"media_type": "image", "origin": {"params": {"converter": "doc2img"}}}
+        assert clip_recipe(media) is None
+
+    def test_converter_branch_beats_image_clip_branch(self):
+        # A converted image carries media_type=image but is NOT an image clip
+        # (no clip_box); the converter branch must win.
+        media = {
+            "media_type": "image",
+            "origin": {"params": {"converter": "doc2img", "converter_out_index": "2", "converter_n_out": "3"}},
+        }
+        recipe = clip_recipe(media)
+        assert recipe is not None
+        assert recipe[0] == "converter"
+
+
+class TestLazyConverterBytes:
+    def test_resolves_correct_page(self, tmp_path, _fake_converter):
+        src = tmp_path / "doc.pdf"
+        src.write_bytes(b"PDFBYTES")
+        ch = _content_hash({"media_bytes": _page_bytes(b"PDFBYTES", 1)})
+        media = _converter_media(src, out_index=1, n_out=3, content_hash=ch, params={"pages": 3})
+        assert lazy_clip_bytes(media) == _page_bytes(b"PDFBYTES", 1)
+
+    def test_resolve_via_media_type(self, tmp_path, _fake_converter):
+        import vtscore.media as media_registry
+
+        src = tmp_path / "doc2.pdf"
+        src.write_bytes(b"OTHER")
+        ch = _content_hash({"media_bytes": _page_bytes(b"OTHER", 0)})
+        media = _converter_media(src, out_index=0, n_out=3, content_hash=ch, params={"pages": 3})
+        # _resolve_media_bytes consults lazy_clip before the whole-file read,
+        # so the serve path gets the rendered page, not the source PDF.
+        resolved = media_registry.get("image")._resolve_media_bytes(media)
+        assert resolved == _page_bytes(b"OTHER", 0)
+
+    def test_content_hash_survives_output_count_drift(self, tmp_path, monkeypatch):
+        # Recorded with n_out=3; converter now yields 5 outputs. The content
+        # hash still pins the right page (drift falls back to content match).
+        fake = _FakeDoc2Image(n_pages=5)
+        monkeypatch.setattr("vtscore.converters.get_converter", lambda name: fake if name == "doc2img" else None)
+        src = tmp_path / "drift.pdf"
+        src.write_bytes(b"DRIFT")
+        ch = _content_hash({"media_bytes": _page_bytes(b"DRIFT", 2)})
+        media = _converter_media(src, out_index=2, n_out=3, content_hash=ch, params={"pages": 5})
+        assert lazy_clip_bytes(media) == _page_bytes(b"DRIFT", 2)
+
+    def test_refuses_to_guess_on_drift_without_hash(self, tmp_path, monkeypatch):
+        # No content hash + output-count drift => positional pick is unsafe,
+        # so resolution returns None rather than the wrong page.
+        fake = _FakeDoc2Image(n_pages=5)
+        monkeypatch.setattr("vtscore.converters.get_converter", lambda name: fake if name == "doc2img" else None)
+        src = tmp_path / "drift2.pdf"
+        src.write_bytes(b"DRIFT2")
+        media = _converter_media(src, out_index=2, n_out=3, content_hash=None, params={"pages": 5})
+        assert lazy_clip_bytes(media) is None
+
+    def test_unknown_converter_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("vtscore.converters.get_converter", lambda name: None)
+        src = tmp_path / "x.pdf"
+        src.write_bytes(b"X")
+        media = _converter_media(src, out_index=0, n_out=1, content_hash=None)
+        assert lazy_clip_bytes(media) is None
+
+    def test_cache_returns_identical_object(self, tmp_path, _fake_converter):
+        src = tmp_path / "cache.pdf"
+        src.write_bytes(b"CACHEME")
+        ch = _content_hash({"media_bytes": _page_bytes(b"CACHEME", 0)})
+        media = _converter_media(src, out_index=0, n_out=3, content_hash=ch, params={"pages": 3})
+        first = lazy_clip_bytes(media)
+        second = lazy_clip_bytes(media)
+        assert first is second  # served from the byte-bounded converter cache
+
+
+class TestRelazifyConverterOutput:
+    def test_relazify_strips_converted_bytes(self, tmp_path, _fake_converter):
+        """A converter output tagged with _lazy_source is stripped to a
+        reference by the re-lazify stage, then resolves on demand."""
+        import vtscore.media as media_registry
+
+        src = tmp_path / "doc.pdf"
+        src.write_bytes(b"PDFBYTES")
+        ch = _content_hash({"media_bytes": _page_bytes(b"PDFBYTES", 2)})
+        media = _converter_media(src, out_index=2, n_out=3, content_hash=ch, params={"pages": 3})
+        # Simulate the pre-relazify state: bytes present + marker set.
+        media["media_bytes"] = _page_bytes(b"PDFBYTES", 2)
+        media["_lazy_source"] = str(src)
+
+        _relazify({1: media})
+
+        assert "_lazy_source" not in media
+        assert media["media_bytes"] is None
+        assert media["media_path"] == str(src)
+        resolved = media_registry.get("image")._resolve_media_bytes(media)
+        assert resolved == _page_bytes(b"PDFBYTES", 2)
+
+
+class TestByteBoundedLRU:
+    def test_evicts_oldest_until_under_ceiling(self):
+        cache = _ByteBoundedLRU(max_bytes=10)
+        cache.put(("a",), b"xxxxx")  # 5 bytes
+        cache.put(("b",), b"yyyyy")  # 10 total
+        assert cache.get(("a",)) == b"xxxxx"
+        cache.put(("c",), b"zzzzz")  # 15 -> evict oldest (b, since a was just touched)
+        assert cache.get(("b",)) is None
+        assert cache.get(("a",)) == b"xxxxx"
+        assert cache.get(("c",)) == b"zzzzz"
+
+    def test_keeps_single_oversized_entry(self):
+        cache = _ByteBoundedLRU(max_bytes=4)
+        big = b"0123456789"  # 10 bytes > ceiling
+        cache.put(("big",), big)
+        # The just-inserted entry is kept so the immediate fetch hits.
+        assert cache.get(("big",)) == big
+        # A later insert evicts the oversized entry.
+        cache.put(("small",), b"ab")
+        assert cache.get(("big",)) is None
+        assert cache.get(("small",)) == b"ab"
+
+    def test_update_existing_key_adjusts_total(self):
+        cache = _ByteBoundedLRU(max_bytes=10)
+        cache.put(("k",), b"xxxxx")
+        cache.put(("k",), b"yy")  # replace; total should be 2, not 7
+        cache.put(("j",), b"zzzzzzz")  # 2 + 7 = 9 <= 10, both fit
+        assert cache.get(("k",)) == b"yy"
+        assert cache.get(("j",)) == b"zzzzzzz"

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -464,3 +464,123 @@ class TestApplyClipperBackwardsCompat:
             assert "clipper_chain" in params
         assert calls["fixup"] == 1
         assert calls["thumb"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b: flat (run_converters_on_folder) converter origin replay
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc2Image:
+    """Deterministic converter stand-in: one image output per page."""
+
+    name = "doc2img"
+    source_type = "document"
+    target_type = "image"
+
+    def __init__(self, n_pages: int = 3) -> None:
+        self.n_pages = n_pages
+
+    def convert_normalized(self, media, params):
+        src = media.get("media_bytes") or b""
+        n = int(params.get("pages", self.n_pages))
+        return [
+            {"filename": f"page_{i}.png", "media_bytes": src + f"|page{i}".encode(), "duration": 0} for i in range(n)
+        ]
+
+
+class TestFlatConverterOriginToChain:
+    def test_builds_one_step_chain_with_disambiguators(self):
+        from vtscore.detectors.resolver import _converter_origin_to_chain
+
+        params = {
+            "converter": "doc2img",
+            "converter_param_pages": "3",
+            "converter_out_index": "2",
+            "converter_n_out": "3",
+            "converter_content_hash": "abc123def456",
+        }
+        chain = _converter_origin_to_chain(params)
+        assert chain == [
+            {
+                "kind": "converter",
+                "name": "doc2img",
+                "params": {"pages": "3"},
+                "out_index": 2,
+                "n_out": 3,
+                "content_hash": "abc123def456",
+            }
+        ]
+
+    def test_returns_none_without_converter(self):
+        from vtscore.detectors.resolver import _converter_origin_to_chain
+
+        assert _converter_origin_to_chain({"path": "/data"}) is None
+
+
+class TestEmbedResolvedLabelFlatConverter:
+    def test_replays_converter_and_embeds_right_page(self, tmp_path, monkeypatch):
+        """A flat converter origin re-runs the converter on the resolved
+        source file and embeds the recorded sub-output (the rendered page),
+        NOT the raw source file."""
+        from vtscore.datasets.clipper_chain import _content_hash
+        from vtscore.detectors import resolver as resolver_module
+        from vtscore.detectors.resolver import _embed_resolved_label
+
+        fake = _FakeDoc2Image(n_pages=3)
+        monkeypatch.setattr("vtscore.converters.get_converter", lambda name: fake if name == "doc2img" else None)
+
+        captured: dict = {}
+
+        def fake_embed_file(path, media_type, embedder_name=""):
+            captured["bytes"] = path.read_bytes()
+            captured["media_type"] = media_type
+            return np.ones(4, dtype=np.float32)
+
+        monkeypatch.setattr(resolver_module, "embed_file", fake_embed_file)
+
+        src = tmp_path / "doc.pdf"
+        src.write_bytes(b"PDF")
+        ch = _content_hash({"media_bytes": b"PDF|page2"})
+        origin = {
+            "importer": "converter",
+            "params": {
+                "converter": "doc2img",
+                "converter_out_index": "2",
+                "converter_n_out": "3",
+                "converter_content_hash": ch,
+                "converter_param_pages": "3",
+            },
+        }
+
+        embedding = _embed_resolved_label(src, "image", origin, "")
+        assert embedding is not None
+        # Embedded the rendered page, not the source PDF.
+        assert captured["bytes"] == b"PDF|page2"
+        assert captured["media_type"] == "image"
+
+    def test_falls_back_to_whole_file_when_replay_fails(self, tmp_path, monkeypatch):
+        """If the converter is gone, _embed_resolved_label falls back to a
+        whole-file embed rather than dropping the label."""
+        from vtscore.detectors import resolver as resolver_module
+        from vtscore.detectors.resolver import _embed_resolved_label
+
+        monkeypatch.setattr("vtscore.converters.get_converter", lambda name: None)
+
+        captured: dict = {}
+
+        def fake_embed_file(path, media_type, embedder_name=""):
+            captured["bytes"] = path.read_bytes()
+            return np.zeros(4, dtype=np.float32)
+
+        monkeypatch.setattr(resolver_module, "embed_file", fake_embed_file)
+
+        src = tmp_path / "doc.pdf"
+        src.write_bytes(b"RAWPDF")
+        origin = {
+            "importer": "converter",
+            "params": {"converter": "doc2img", "converter_out_index": "0", "converter_n_out": "1"},
+        }
+        embedding = _embed_resolved_label(src, "image", origin, "")
+        assert embedding is not None
+        assert captured["bytes"] == b"RAWPDF"  # whole-file fallback

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -155,6 +155,52 @@ def _run_converter_on_source(
         return None
 
 
+def _short_content_hash(output: dict[str, Any]) -> str | None:
+    """Return a 12-hex md5 of a converter output's payload, or ``None``.
+
+    Reuses :func:`vtscore.datasets.clipper_chain._content_hash` so the
+    converter recipe records the *same* authoritative disambiguator the
+    chain stage records, and the shared ``_select_chain_output`` selector
+    matches identically on replay.  This hashes bytes we are about to
+    embed (and, in reference mode, discard) - it does not persist them,
+    so it respects the no-persisted-bytes rule (the dataset MD5 already
+    stores a per-media content hash for the same reason).
+    """
+    from vtscore.datasets.clipper_chain import _content_hash  # noqa: PLC0415
+
+    return _content_hash(output)
+
+
+def _origin_with_disambiguators(
+    origin: dict[str, Any], out_index: int, n_out: int, output: dict[str, Any]
+) -> dict[str, Any]:
+    """Return a per-output copy of *origin* stamped with sub-output disambiguators.
+
+    ``run_converters_on_folder`` records a *flat* origin per source file, so
+    every output of one source would otherwise share one origin dict (and one
+    set of params).  Lazy converter resolution needs to re-run the converter
+    and pick *this* output back out, so each output carries:
+
+    - ``converter_out_index`` - this output's position in the converter's
+      returned list (page number - 1, frame segment index).
+    - ``converter_n_out`` - the output count at import time, so the resolver
+      can detect drift (source changed, library bumped) and fall back from
+      positional to content matching instead of returning the wrong page.
+    - ``converter_content_hash`` - the authoritative disambiguator: a short
+      md5 of the output bytes, preferred by ``_select_chain_output``.
+
+    All values are stored as strings, matching the ``converter_param_<key>``
+    round-trip convention; readers coerce as needed.
+    """
+    params = dict(origin.get("params", {}))
+    params["converter_out_index"] = str(out_index)
+    params["converter_n_out"] = str(n_out)
+    ch = _short_content_hash(output)
+    if ch is not None:
+        params["converter_content_hash"] = ch
+    return {**origin, "params": params}
+
+
 def _emit_converted_outputs(
     *,
     outputs: list[dict[str, Any]],
@@ -165,26 +211,39 @@ def _emit_converted_outputs(
     medias: dict[int, dict[str, Any]],
     start_id: int,
     category: str,
+    thin: bool = False,
 ) -> int:
     """Append each converter output to *medias*; return next media_id.
 
     Outputs leave with ``embedding=None``; the framework embed stage
     embeds them from ``media_bytes`` / ``media_string``.
+
+    In reference (*thin*) mode each output keeps its ``media_bytes`` for the
+    embed stage but is tagged with a ``_lazy_source`` marker carrying the
+    source file path.  ``_relazify_reference_clips_stage`` strips those bytes
+    after embedding so the saved dataset stores only the source path plus the
+    converter recipe (in ``origin.params``); the bytes are reproduced on demand
+    by :mod:`vtscore.media.lazy_clip`.
     """
     media_id = start_id
-    for output in outputs:
+    n_out = len(outputs)
+    resolved_source = str(source_path.resolve())
+    for out_index, output in enumerate(outputs):
         output_filename = output.get("filename", f"converted_{media_id}")
         origin_name = f"{source_rel}\u2192{output_filename}"
 
+        per_output_origin = _origin_with_disambiguators(origin, out_index, n_out, output)
         media_data = _build_converted_media_dict(
             media_id,
             output,
             target_type,
-            origin,
+            per_output_origin,
             origin_name,
-            str(source_path.resolve()),
+            resolved_source,
             category,
         )
+        if thin:
+            media_data["_lazy_source"] = resolved_source
         medias[media_id] = media_data
         media_id += 1
     return media_id
@@ -216,10 +275,15 @@ def run_converters_on_folder(
         target_media_type: The target media type identifier
             (e.g. ``"image"``).
         medias: The medias dict to append to (not cleared).
-        thin: When ``True``, store converter output in a temp directory
-            instead of holding bytes in memory.  Currently all converted
-            media is kept in-memory regardless, since converters produce
-            bytes directly.
+        thin: Reference mode.  When ``True``, each converted output is
+            tagged with a ``_lazy_source`` marker and keeps its
+            ``media_bytes`` only long enough for the framework embed stage;
+            ``_relazify_reference_clips_stage`` then strips those bytes so
+            the saved dataset stores the source path plus a converter recipe
+            (``converter`` / ``converter_param_*`` / ``converter_out_index``
+            / ``converter_n_out`` / ``converter_content_hash`` in
+            ``origin.params``) instead of N copies of the rendered output.
+            :mod:`vtscore.media.lazy_clip` reproduces the bytes on demand.
         on_progress: Optional progress callback.
         base_origin: The origin dict of the parent import (e.g.
             ``{"importer": "server_folder", "params": {"path": "..."}}``)
@@ -290,6 +354,7 @@ def run_converters_on_folder(
                 medias=medias,
                 start_id=media_id,
                 category="custom",
+                thin=thin,
             )
 
 

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -179,21 +179,29 @@ def _hydrate_reference_parents(clips_dict: dict, steps: list[dict]) -> bool:
 
 
 def _relazify_reference_clips_stage(ctx: DatasetContext, tracker=None) -> None:
-    """Strip materialized bytes from clips descended from a reference parent.
+    """Strip materialized bytes from reference-derived media (clips + converter output).
 
-    Each such clip carries the ``_lazy_source`` marker (inherited from its
-    hydrated parent in :func:`_hydrate_reference_parents`).  We drop its
-    ``media_bytes`` / ``media_string`` and point ``media_path`` back at the
-    source file; ``_resolve_media_bytes`` reproduces the clip's bytes on demand
-    from the recipe stored in ``origin.params`` (sliced clip) or by reading the
-    whole file (a pass-through clip the clipper returned unchanged).  The
-    per-clip MD5, embedding, and thumbnail were already computed from the real
-    bytes in the clipper stage, so the reference clip is byte-for-byte
-    equivalent without the stored payload.
+    Two producers tag media with the ``_lazy_source`` marker carrying the
+    source file path:
+
+    * **clips** descended from a hydrated reference parent (see
+      :func:`_hydrate_reference_parents`) - audio slices, image crops.
+    * **converter output** emitted in reference mode by
+      :func:`~vtscore.converters.runner.run_converters_on_folder` - rendered
+      PDF pages, extracted video frames.
+
+    For each, we drop its ``media_bytes`` / ``media_string`` and point
+    ``media_path`` back at the source file; ``_resolve_media_bytes`` reproduces
+    the bytes on demand from the recipe in ``origin.params`` (a clip slice, a
+    converter re-render) or by reading the whole file (a pass-through clip the
+    clipper returned unchanged).  The per-item MD5, embedding, and thumbnail
+    were already computed from the real bytes, so the reference media is
+    byte-for-byte equivalent without the stored payload.
 
     Runs after the embed / drop-none stages so the embed-missing safety net
-    sees real bytes (a clip's ``media_path`` points at the *whole* source file,
-    not the slice, so embedding it lazily would embed the wrong content).
+    sees real bytes: a derived item's ``media_path`` points at the *whole*
+    source file (the parent recording, the source PDF), not the slice/page, so
+    embedding it lazily would embed the wrong content.
     """
     for clip in ctx.medias.values():
         source = clip.pop("_lazy_source", None)

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -504,6 +504,46 @@ def _clip_to_bytes(file_path: Path, media_type: str, params: dict[str, Any]) -> 
     return None
 
 
+def _converter_origin_to_chain(params: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Normalize a flat ``run_converters_on_folder`` origin into a one-step chain.
+
+    The importer-level converter path (path 1 in
+    ``docs/plans/server-dedup-references.md``) stamps a *flat* origin -
+    ``converter`` / ``converter_param_<key>`` plus the Phase 2b sub-output
+    disambiguators ``converter_out_index`` / ``converter_n_out`` /
+    ``converter_content_hash`` - rather than the ``clipper_chain`` trail the
+    chain stage records.  Reshaping it into a single :class:`ChainStep` lets
+    the resolver reuse the one replay code path
+    (:func:`~vtscore.datasets.clipper_chain.replay_chain_on_file`) and the
+    shared sub-output selector, so a reference-converted label re-embeds from
+    the source file + recipe exactly like a chain-converted one.
+
+    Returns ``None`` when no ``converter`` is recorded.
+    """
+    converter = params.get("converter")
+    if not converter:
+        return None
+    prefix = "converter_param_"
+    conv_params = {k[len(prefix) :]: v for k, v in params.items() if k.startswith(prefix)}
+    entry: dict[str, Any] = {"kind": "converter", "name": str(converter), "params": conv_params}
+    out_index = params.get("converter_out_index")
+    if out_index is not None:
+        try:
+            entry["out_index"] = int(out_index)
+        except (TypeError, ValueError):
+            pass
+    n_out = params.get("converter_n_out")
+    if n_out is not None:
+        try:
+            entry["n_out"] = int(n_out)
+        except (TypeError, ValueError):
+            pass
+    content_hash = params.get("converter_content_hash")
+    if content_hash is not None:
+        entry["content_hash"] = content_hash
+    return [entry]
+
+
 def _replay_chain(file_path: Path, chain_raw: Any, embedder_name: str) -> tuple[np.ndarray, bytes | None] | None:
     """Replay a clipper chain on *file_path*.
 
@@ -654,6 +694,19 @@ def _embed_resolved_label(
             return None
         embedding, _clip_bytes = result
         return embedding
+    # Flat converter origin (run_converters_on_folder): re-run the converter on
+    # the resolved source file and re-select the recorded sub-output, so a
+    # reference-converted label embeds the rendered page/frame, not the raw
+    # source file.  Normalized into a one-step chain to reuse the chain replay.
+    if origin is not None and params.get("converter"):
+        chain = _converter_origin_to_chain(params)
+        if chain is not None:
+            result = _replay_chain(file_path, chain, embedder_name)
+            if result is not None:
+                embedding, _clip_bytes = result
+                return embedding
+        # Replay failed (converter gone, no output matched): fall through to a
+        # whole-file embed rather than dropping the label entirely.
     return embed_file(file_path, media_type, embedder_name)
 
 

--- a/vtscore/media/lazy_clip.py
+++ b/vtscore/media/lazy_clip.py
@@ -2,26 +2,39 @@
 
 A *lazy clip* is a derived sub-media that stores **no** materialized
 ``media_bytes`` of its own.  Instead it keeps a reference to the original
-source file (``media_path``) plus a *recipe* (the clip boundaries recorded in
-``origin.params``) and reproduces its bytes on demand by slicing/cropping the
-source.  This is how reference (thin) imports avoid duplicating the source
-bytes once per clip in the dataset pickle: a 5-minute recording tiled into 30
-clips stores the recipe 30 times (a few bytes each) instead of 30 copies of
-the audio.
+source file (``media_path``) plus a *recipe* (recorded in ``origin.params``)
+and reproduces its bytes on demand.  This is how reference (thin) imports avoid
+duplicating the source bytes once per derived item in the dataset pickle: a
+5-minute recording tiled into 30 clips stores the recipe 30 times (a few bytes
+each) instead of 30 copies of the audio.
 
-Only the media types whose clippers actually *re-slice bytes* participate:
+Two recipe families participate:
 
-* **audio** - ``clip_start`` / ``clip_end`` seconds, sliced via
-  :func:`~vtscore.media.audio.clipper._wav_slice`.
-* **image** - ``clip_box`` pixel box, cropped via Pillow.
+* **clip slices** - the media type's clipper re-slices the source bytes:
 
-Text clips keep their (tiny) ``media_string`` materialized, and video clips are
-already metadata-only (they share the parent's bytes and the player seeks via
-``clip_start`` / ``clip_end``), so neither needs lazy resolution.
+  * **audio** - ``clip_start`` / ``clip_end`` seconds, sliced via
+    :func:`~vtscore.media.audio.clipper._wav_slice`.
+  * **image** - ``clip_box`` pixel box, cropped via Pillow.
 
-Resolved bytes are held in a small process-scoped LRU cache.  Per the
-no-persisted-bytes rule, this cache is purely in-memory: nothing here writes a
-materialized clip back to disk or into a pickle.
+  Text clips keep their (tiny) ``media_string`` materialized, and video clips
+  are already metadata-only (they share the parent's bytes and the player
+  seeks via ``clip_start`` / ``clip_end``), so neither needs lazy resolution.
+
+* **converter output** - a converter (``document2image``, ``video2image``, …)
+  rendered a derived media (a PDF page PNG, an extracted video frame) from the
+  *source* file.  Keyed by the ``converter`` entry in ``origin.params`` (not by
+  target media type), the recipe re-runs the converter and re-selects the exact
+  sub-output recorded at import time (``converter_out_index`` /
+  ``converter_n_out`` / ``converter_content_hash``) via the shared
+  :func:`~vtscore.datasets.clipper_chain._select_chain_output` selector.
+
+Resolved bytes are held in process-scoped LRU caches.  Per the
+no-persisted-bytes rule, these caches are purely in-memory: nothing here writes
+a materialized clip back to disk or into a pickle.  Clip slices use a
+count-bounded cache (payloads are small and uniform - one tile / crop);
+converter output uses a *byte-bounded* cache (a rendered page or video frame is
+1-8 MB and varies by an order of magnitude, so a count bound that is safe for
+clips would be unsafe here).
 """
 
 from __future__ import annotations
@@ -38,6 +51,8 @@ log = logging.getLogger(__name__)
 __all__ = ["LAZY_CLIP_TYPES", "clip_recipe", "lazy_clip_bytes"]
 
 #: Media types whose clippers re-slice bytes and therefore support lazy clips.
+#: The converter branch is keyed by ``converter`` in ``origin.params`` instead,
+#: so it is *not* gated on this list (a converter can target any media type).
 LAZY_CLIP_TYPES = ("audio", "image")
 
 # Process-scoped LRU of resolved clip bytes, keyed by (source, recipe).  Bounded
@@ -46,6 +61,51 @@ LAZY_CLIP_TYPES = ("audio", "image")
 _CACHE_MAX = 256
 _cache: "OrderedDict[tuple, bytes]" = OrderedDict()
 _cache_lock = threading.Lock()
+
+
+class _ByteBoundedLRU:
+    """Process-scoped LRU bounded by *total held bytes*, not entry count.
+
+    Converter output (a rendered PDF page, a decoded video frame) is large and
+    non-uniform - 1-8 MB per entry, varying by an order of magnitude across
+    documents - so a count bound that keeps clip slices safe could hold 1-2 GB
+    here.  Bounding by summed payload size keeps memory predictable regardless
+    of output size.  Never persisted; purely an in-memory recompute cache.
+    """
+
+    def __init__(self, max_bytes: int) -> None:
+        self._max = max_bytes
+        self._d: "OrderedDict[tuple, bytes]" = OrderedDict()
+        self._total = 0
+        self._lock = threading.Lock()
+
+    def get(self, key: tuple) -> bytes | None:
+        with self._lock:
+            hit = self._d.get(key)
+            if hit is not None:
+                self._d.move_to_end(key)
+            return hit
+
+    def put(self, key: tuple, value: bytes) -> None:
+        with self._lock:
+            if key in self._d:
+                self._total -= len(self._d[key])
+            self._d[key] = value
+            self._d.move_to_end(key)
+            self._total += len(value)
+            # Evict oldest until under the ceiling, but never evict the entry we
+            # just inserted (a single output larger than the ceiling is kept so
+            # the immediate fetch still hits; it is dropped on the next insert).
+            while self._total > self._max and len(self._d) > 1:
+                _, evicted = self._d.popitem(last=False)
+                self._total -= len(evicted)
+
+
+#: Byte ceiling for the converter-output cache (~256 MB).  Large enough to keep
+#: a hot set of rendered pages / frames resident across HTTP range/scrub bursts
+#: without an unbounded memory risk.
+_CONV_CACHE_MAX_BYTES = 256 * 1024 * 1024
+_conv_cache = _ByteBoundedLRU(_CONV_CACHE_MAX_BYTES)
 
 
 def _parse_box(raw: Any) -> tuple[int, int, int, int] | None:
@@ -68,24 +128,75 @@ def _parse_box(raw: Any) -> tuple[int, int, int, int] | None:
         return None
 
 
+def _converter_recipe(params: dict[str, Any]) -> tuple | None:
+    """Build a converter recipe from ``origin.params``, or ``None``.
+
+    Returns ``("converter", name, params_items, out_index, n_out,
+    content_hash)`` where ``params_items`` is a hashable
+    ``tuple(sorted(...))`` of the reconstructed converter params (rebuilt
+    from the ``converter_param_<key>`` keys).  Requires at least one
+    sub-output disambiguator (``converter_out_index`` or
+    ``converter_content_hash``); without one, replay cannot pick the right
+    output, so it is treated as "not a lazy converter media" (``None``) and
+    the caller falls through to its normal resolution order.
+    """
+    name = params.get("converter")
+    if not name:
+        return None
+    out_index_raw = params.get("converter_out_index")
+    content_hash = params.get("converter_content_hash")
+    if out_index_raw is None and content_hash is None:
+        return None
+
+    prefix = "converter_param_"
+    conv_params = {k[len(prefix) :]: v for k, v in params.items() if k.startswith(prefix)}
+
+    def _as_int(raw: Any) -> int | None:
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+    return (
+        "converter",
+        str(name),
+        tuple(sorted(conv_params.items())),
+        _as_int(out_index_raw),
+        _as_int(params.get("converter_n_out")),
+        content_hash,
+    )
+
+
 def clip_recipe(media: dict[str, Any]) -> tuple | None:
-    """Return a hashable recipe describing *media*'s clip, or ``None``.
+    """Return a hashable recipe describing *media*'s derivation, or ``None``.
 
     The recipe is read from ``origin.params`` (the channel that survives the
     pickle round-trip), not the top-level ``clip_*`` fields, so it resolves
-    identically for a freshly clipped media and one reopened from disk.
+    identically for a freshly derived media and one reopened from disk.
 
     Returns one of:
 
+    * ``("converter", name, params_items, out_index, n_out, content_hash)`` -
+      a converter output re-rendered from the source file.
     * ``("audio", clip_start, clip_end)`` - seconds, both floats.
     * ``("image", (x1, y1, x2, y2))`` - integer pixel box.
 
-    or ``None`` when *media* is not a recognised lazy clip (no recipe, or a
+    or ``None`` when *media* is not a recognised lazy media (no recipe, or a
     media type that doesn't re-slice bytes).
+
+    The converter branch is checked first and is keyed by the ``converter``
+    param, not the target media type: a ``document2image`` output has
+    ``media_type == "image"`` but is a converter output, not an image *clip*.
     """
-    media_type = media.get("media_type")
     origin = media.get("origin")
     params = origin.get("params", {}) if isinstance(origin, dict) else {}
+
+    if params.get("converter"):
+        return _converter_recipe(params)
+
+    media_type = media.get("media_type")
 
     if media_type == "audio":
         cs = params.get("clip_start")
@@ -106,9 +217,11 @@ def clip_recipe(media: dict[str, Any]) -> tuple | None:
     return None
 
 
-def _apply_recipe(source_bytes: bytes, recipe: tuple) -> bytes | None:
-    """Reproduce a clip's bytes by applying *recipe* to *source_bytes*."""
+def _apply_recipe(source_bytes: bytes, recipe: tuple, media: dict[str, Any]) -> bytes | None:
+    """Reproduce a derived media's bytes by applying *recipe* to *source_bytes*."""
     kind = recipe[0]
+    if kind == "converter":
+        return _apply_converter_recipe(source_bytes, recipe, media)
     if kind == "audio":
         from vtscore.media.audio.clipper import _wav_slice  # noqa: PLC0415
 
@@ -123,6 +236,50 @@ def _apply_recipe(source_bytes: bytes, recipe: tuple) -> bytes | None:
             buf = io.BytesIO()
             cropped.save(buf, format=fmt)
         return buf.getvalue()
+    return None
+
+
+def _apply_converter_recipe(source_bytes: bytes, recipe: tuple, media: dict[str, Any]) -> bytes | None:
+    """Re-run a converter on the source file and re-select the recorded output.
+
+    Rebuilds the converter's ``params`` from the recipe, hands it a minimal
+    source-media dict (the whole source bytes plus filename / path), and
+    selects the exact sub-output via the shared
+    :func:`~vtscore.datasets.clipper_chain._select_chain_output` so the
+    content-hash-first, drift-aware, refuse-to-guess semantics match the
+    cross-dataset resolver.  Returns ``None`` (cache nothing, fall through)
+    when the converter is unknown or no output matches - the same "better no
+    bytes than wrong bytes" stance the clip branches take.
+    """
+    from vtscore.converters import get_converter  # noqa: PLC0415
+    from vtscore.datasets.clipper_chain import _select_chain_output  # noqa: PLC0415
+
+    _, converter_name, params_items, out_index, n_out, content_hash = recipe
+    conv = get_converter(converter_name)
+    if conv is None:
+        log.warning("lazy_clip: unknown converter %r; cannot resolve output", converter_name)
+        return None
+
+    source_path = media.get("media_path")
+    filename = Path(source_path).name if source_path else media.get("filename", "")
+    source_media: dict[str, Any] = {"media_bytes": source_bytes, "filename": filename}
+    if source_path:
+        source_media["media_path"] = source_path
+
+    outputs = conv.convert_normalized(source_media, dict(params_items))
+
+    entry: dict[str, Any] = {"kind": "converter", "name": converter_name, "out_index": out_index, "n_out": n_out}
+    if content_hash is not None:
+        entry["content_hash"] = content_hash
+    picked = _select_chain_output(outputs, entry)
+    if picked is None:
+        return None
+    payload = picked.get("media_bytes")
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload)
+    text = picked.get("media_string")
+    if isinstance(text, str):
+        return text.encode("utf-8")
     return None
 
 
@@ -154,22 +311,21 @@ def lazy_clip_bytes(media: dict[str, Any]) -> bytes | None:
     if recipe is None:
         return None
 
+    is_converter = recipe[0] == "converter"
     source_key = media.get("media_path") or media.get("media_url")
     cache_key = (source_key, recipe) if source_key else None
 
     if cache_key is not None:
-        with _cache_lock:
-            hit = _cache.get(cache_key)
-            if hit is not None:
-                _cache.move_to_end(cache_key)
-                return hit
+        hit = _conv_cache.get(cache_key) if is_converter else _count_cache_get(cache_key)
+        if hit is not None:
+            return hit
 
     source = _read_source_bytes(media)
     if source is None:
         return None
 
     try:
-        out = _apply_recipe(source, recipe)
+        out = _apply_recipe(source, recipe, media)
     except Exception:
         log.warning("lazy_clip: failed to apply recipe %r to %s", recipe, source_key, exc_info=True)
         return None
@@ -177,9 +333,26 @@ def lazy_clip_bytes(media: dict[str, Any]) -> bytes | None:
         return None
 
     if cache_key is not None:
-        with _cache_lock:
-            _cache[cache_key] = out
-            _cache.move_to_end(cache_key)
-            while len(_cache) > _CACHE_MAX:
-                _cache.popitem(last=False)
+        if is_converter:
+            _conv_cache.put(cache_key, out)
+        else:
+            _count_cache_put(cache_key, out)
     return out
+
+
+def _count_cache_get(cache_key: tuple) -> bytes | None:
+    """Look up a clip slice in the count-bounded LRU."""
+    with _cache_lock:
+        hit = _cache.get(cache_key)
+        if hit is not None:
+            _cache.move_to_end(cache_key)
+        return hit
+
+
+def _count_cache_put(cache_key: tuple, value: bytes) -> None:
+    """Insert a clip slice into the count-bounded LRU, evicting the oldest."""
+    with _cache_lock:
+        _cache[cache_key] = value
+        _cache.move_to_end(cache_key)
+        while len(_cache) > _CACHE_MAX:
+            _cache.popitem(last=False)


### PR DESCRIPTION
Implements **Phase 2b** of `docs/plans/server-dedup-references.md`: lazy converter output.

## What this does

Reference (thin) imports that run a **converter** (`server_folder` / `server_files` with a converter spec) no longer bake the rendered outputs into the dataset pickle. A 200-page PDF imported as a reference previously inlined 200 full-resolution page images; now each output stores the *source* `media_path` plus a converter recipe in `origin.params` and re-renders on demand. This closes the last duplicating transform — un-converted media (Phase 1) and audio/image clips (Phase 2a) were already reference-clean.

## How it works

- **`vtscore/converters/runner.py`** — `_emit_converted_outputs` stamps three per-output disambiguators (`converter_out_index`, `converter_n_out`, `converter_content_hash`, a 12-hex md5 reusing `clipper_chain._content_hash`), and each output now gets its **own** origin dict. In reference (`thin`) mode each output is tagged with `_lazy_source` and keeps `media_bytes` only for the embed stage. Disambiguators are stamped in both modes so the cross-dataset resolver can re-select sub-outputs for copy-mode imports too.
- **`vtscore/media/lazy_clip.py`** — `clip_recipe` learns a converter branch (checked first, keyed by the `converter` param so a `document2image` output with `media_type=image` resolves as a converter output, not an image clip). `_apply_converter_recipe` re-runs the converter on the source bytes and re-selects the recorded output by delegating to the shared `clipper_chain._select_chain_output` (identical content-hash-first, drift-aware, refuse-to-guess semantics). Adds a **byte-bounded** `_ByteBoundedLRU` (~256 MB) separate from the count-bounded clip cache, since rendered pages/frames are 1–8 MB and vary by an order of magnitude.
- **`vtscore/datasets/stages/clipper.py`** — `_relazify_reference_clips_stage` already strips any `_lazy_source`-tagged media, so it covers converter outputs unchanged (docstring generalized). It runs after the embed / drop-none stages so the embed-missing safety net always sees the real rendered bytes, never the source file behind the path.
- **`vtscore/detectors/resolver.py`** — a flat converter origin is normalized into a one-step chain (`_converter_origin_to_chain`) and replayed via the existing `replay_chain_on_file`, so a reference-converted label re-embeds the rendered page/frame, not the raw source file. Falls back to a whole-file embed if the converter is gone.

Pickle round-trip / HTTP serving / exporters need no change: the recipe lives in `origin.params` (round-trips), `media_path` is serialized, and `_resolve_media_bytes` already consults `lazy_clip_bytes` before the whole-file read.

## Tests

New coverage for runner stamping + thin marker, lazy converter resolution (incl. content-hash drift survival and refuse-on-drift-without-hash), the byte-bounded cache eviction, re-lazify of converted output, and resolver replay embedding the right page. Full `./run-tests.sh` suite green (5119 passed).

Remaining fast-follows (demo converter path, standalone PDF expansion, converter→clipper chains, cache unification) are recorded under *Open follow-ups (Phase 2b)* in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019n657vRzyFpouPH2HEXN7q

---
_Generated by [Claude Code](https://claude.ai/code/session_019n657vRzyFpouPH2HEXN7q)_