### PR TITLE
Per-detector primary embedder (design + implementation)

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -1,11 +1,14 @@
 # Patch-based Image Embedder - Design
 
-**Status:** V1 shipped, V2 shipped, **V3 in progress.** The design
+**Status:** V1 shipped, V2 shipped, **V3 trio shipped end-to-end.** The design
 body below is the living spec for the shipped V1/V2 behaviour; the *V1 - DONE*
-and *V2 - DONE* closeouts are collapsed to struck-through lists. **Remaining
-work** is *V3* (one text + one patch embedder per dataset); see
-"V3 - implementation status" under "V3 work plan" for what's landed and the
-ordered phases that remain.
+and *V2 - DONE* closeouts are collapsed to struck-through lists. The V3
+text/patch/structural trio (dict-keyed `media["embeddings"]`, role binding,
+dataset-level score routing, create-time picker) is shipped - see
+"V3 - implementation status". **Remaining design-in-progress work** is
+*per-detector primary embedder* (each detector picks its own scoring space,
+superseding the dataset-level score precedence for detector operations); see
+"Per-detector primary embedder (design)".
 
 ## Status of related work
 
@@ -759,7 +762,10 @@ above it.  **Status: Phases 2a-2c shipped (the singular mirror is gone;
 binding slot + routing role shipped, and the create-time trio picker shipped
 (additive variant — see "Phase 3" below).  A real text + patch + structural
 dataset can now be created end-to-end.  Remaining work is the smaller
-follow-ups under "Open follow-ups".**
+follow-ups under "Open follow-ups" plus the **per-detector primary embedder**
+design (each detector picks its own scoring space, superseding the
+dataset-level score precedence for detector operations) — see
+"Per-detector primary embedder (design)" below.**
 
 **Shipped:**
 
@@ -962,8 +968,248 @@ follow-ups under "Open follow-ups".**
   in "Loader / exporter / importer impact" lands with the create-time
   multi-embed path that would populate it.
 
+## Per-detector primary embedder (design)
+
+**Status: design-in-progress.** Supersedes the *dataset-level* score
+precedence that shipped in V3 (Phases 2b.4 / 2b.5 / 2d) for **detector**
+operations.  Nothing here is implemented yet; the shipped routing table
+above is what's live today.
+
+### Motivation
+
+Shipped V3 resolves the "score embedder" - the single vector space the
+detector MLP trains and scores against - as a **dataset-level** property,
+by precedence (`routed_embedder("score")` = structural ▸ patch ▸ text).
+Every detector run against a given dataset therefore scores in the *same*
+space, whichever the precedence picks.  On the rare multi-embedder (trio)
+dataset that's wrong: the whole point of binding more than one embedder is
+that **different detectors want different spaces**.  A "find this exact
+logo" detector wants the structural embedder; a "pictures with a sunset
+mood" detector on the same dataset wants the text/patch embedder.  Forcing
+both through one dataset-wide precedence defeats the trio.
+
+So the choice moves from the dataset to the **detector**: each detector
+picks **one primary embedder** at creation, and training + scoring *that
+detector* run in *that* space.  The same dataset hosts many detectors, each
+with its own primary.  We will hardly ever bind the full trio, but when we
+do, this is what makes it useful.
+
+### The model
+
+- **A detector binds exactly one primary embedder**, chosen explicitly at
+  create time (see "How the primary is chosen").  It is the vector space the
+  detector's MLP is trained and scored in - nothing more, nothing less.
+- **Training detector D uses only D's primary.**  `_build_vote_xy`,
+  `_score_all_media`, the safe-threshold scoring pass, Auto-Find scoring,
+  the labelset embed name, and the diversity/positives-browse view *for that
+  detector* all route through `D.primary_embedder` instead of the active
+  dataset's `routed_embedder("score")`.
+- **Text sort is unaffected.**  `POST /api/sort` (text query) always runs
+  against the dataset's **text** slot (`routed_embedder("text")`),
+  independent of which primary the active detector picked.  A text query has
+  no meaning in a non-text space, and the dataset - not the detector - owns
+  the text encoder.  This is the one operation that stays dataset-routed.
+- **Multiple detectors, multiple primaries, one dataset.**  The dataset
+  keeps all its bound embedders' vectors side-by-side in
+  `media["embeddings"]` (already the V3 schema).  Detector A scoring in
+  `dinov3_patch` and detector B scoring in `sift_vlad` read different keys of
+  the same dict; nothing on disk is shared between them beyond the medias.
+
+### Schema change
+
+The choice is a persisted **name**, not a vector or MLP, so it's fully
+compatible with CLAUDE.md's "No Persisted Vectors or MLPs" rule.
+
+- **Detector JSON** (`data/detectors/<name>.json`, written by
+  `vtsearch/routes/detectors/crud.py::create_detector` /
+  `_write_detector`) gains a top-level `primary_embedder: str` field next to
+  `media_type` / `examples`.  Absent on legacy files → resolved at load by the
+  migration below.
+- **`DetectorCreateRequestSchema`** (`vtsearch/schemas/detectors.py`) gains
+  `primary_embedder = fields.String(load_default="")`.  Empty means "let the
+  server pick" (single-embedder dataset, or legacy clients); a concrete name
+  is validated against the active dataset's bound embedders.
+- **`DetectorContext.embedder`** stops being a *derived marker* stamped from
+  the dataset precedence and becomes the *authoritative* per-detector primary,
+  loaded from the JSON field.  Its slot, type (`str`), and role as the
+  `(detector, dataset, embedder)` MLP cache key are unchanged - only its
+  *source* changes (explicit field vs. `score_marker_embedder(first)`).
+
+### How the primary is chosen
+
+**Explicit at create time.**  No auto-default-by-precedence; the precedence
+only survives as the *legacy migration* fallback (below) and as the implicit
+single-option case.
+
+- On a **single-embedder dataset** (the overwhelmingly common case) there is
+  exactly one bound embedder, so the create flow auto-selects it - the picker
+  is hidden, or shown pre-filled and disabled.  Zero friction; identical UX to
+  today.
+- On a **multi-embedder dataset** the new-detector modal shows a required
+  picker listing the dataset's bound embedder names (the keys of
+  `media["embeddings"]`, equivalently every name role-typed by
+  `derive_binding_from_names`, **including** single-vector embedders like
+  `dinov2_single` that fill no role slot - they are still valid scoring
+  spaces).  The user must pick one; submission is rejected if the pick isn't
+  one of the dataset's bound embedders.
+
+The eligible set is "every embedder this dataset actually has vectors for",
+which is broader than the three *role* slots: the role slots are
+capability-typed (text/patch/structural), but a detector's primary is just
+"which vector space do I score in", and any bound embedder qualifies.
+
+### Routing
+
+| Operation | Embedder used (NEW) | vs. shipped V3 |
+|---|---|---|
+| Text sort (`POST /api/sort`) | dataset `text` slot | unchanged |
+| Detector MLP train + score | **active detector's `primary_embedder`** | was dataset score precedence |
+| Learned-sort / Auto-Find / safe-threshold scoring | active detector's primary | was dataset score precedence |
+| Positives-browse / diversity view *of a detector* | active detector's primary | was dataset score precedence |
+| Region similarity / region voting | dataset `patch` slot | unchanged (patch role is dataset-owned) |
+| Geometric verification | dataset `structural` slot | unchanged |
+| Example / by-id cosine sort, **no active detector** | dataset score precedence | unchanged |
+| Diversity tree of the **raw dataset** (no detector) | dataset score precedence | unchanged |
+
+The single substantive change is that the detector-scoped scoring paths read
+`det_ctx.embedder` (now the explicit primary) instead of calling
+`get_active_context().routed_embedder("score")`.  Because
+`det_ctx.embedder` is fed straight into the same embedder-aware matrix layer,
+and a name equal to the dataset's primary still collapses to the cached
+primary path, **every single-embedder dataset is byte-for-byte unchanged** -
+the detector's primary *is* the dataset's only embedder there.
+
+### MLP keying simplifies
+
+The `(detector, dataset, embedder)` key and the invalidation machinery
+(`invalidate_detector_model_on_embedder_mismatch`,
+`_maybe_clear_cache_on_embedder_switch`, `maybe_start_label_reembed`) are
+unchanged in shape, but their `embedder` component gets *simpler*:
+
+- The marker is now just `det_ctx.embedder` (the explicit primary), not the
+  resolved `score_marker_embedder(first)` (dataset precedence over the snap).
+- `update_det_ctx_with_trained_model` (`learned_sort.py`) and
+  `workflow.apply_and_retrain` stop *computing* the marker from the snap and
+  instead **read** it off the detector - the primary is decided at create
+  time, not re-derived every train.
+- `score_marker_embedder` / `score_marker_embedder_for_snap` survive only for
+  the legacy-migration fallback and the cross-dataset cold-train path
+  (`model_loading.resolve_or_train_detector`), which still works in the
+  primary vector space of the medias it's about to score.
+
+The invalidation semantics are exactly right under this model: when the
+active dataset can't supply the detector's primary embedder (it isn't among
+that dataset's `media["embeddings"]` keys), `det_ctx.embedder` ≠ what the
+dataset offers, so the cached MLP is dropped and the detector either
+re-embeds its labelset against the dataset (if its origins resolve) or is
+gated only where the space matches - same cross-space safety the marker
+provides today.
+
+### Cross-dataset reuse
+
+A detector stays portable across datasets, exactly as today, but the
+compatibility rule sharpens: **a detector runs against any dataset that binds
+its `primary_embedder`.**  A `sift_vlad`-primary detector works on every
+dataset that has `sift_vlad` vectors and is gated (greyed "Sort by Learned")
+on datasets that don't, instead of silently scoring in whatever the new
+dataset's precedence happened to pick.  Votes remain embedder-agnostic
+(`(media_id, label, region_box?)`), so switching the *dataset* under a
+detector re-derives the MLP from the same vote pile in the detector's primary
+space.
+
+### Migration / back-compat
+
+One-shot, read-time, per detector:
+
+1. Load a legacy detector JSON with **no** `primary_embedder` field.
+2. Resolve its primary as `score_marker_embedder` would have today: the active
+   dataset's score precedence (structural ▸ patch ▸ text, else the dataset's
+   single embedder name).  This is **exactly** the space a legacy detector was
+   already training in, so no behavior changes for any existing detector.
+3. Stamp that name on `DetectorContext.embedder`; the next `_write_detector`
+   (rename, vote-sync, or any save) persists the explicit field.
+
+After first save the field is authoritative and the precedence is never
+consulted for that detector again.  Per CLAUDE.md "Backwards Compatibility",
+we don't keep a parallel precedence-derived mirror once the field exists.
+
+### Validation
+
+- The create request's `primary_embedder`, when non-empty, must be one of the
+  active dataset's bound embedder names (else 400, "embedder X is not bound to
+  this dataset").
+- Empty `primary_embedder` is resolved server-side: the sole bound embedder on
+  a single-embedder dataset; rejected with 400 on a multi-embedder dataset
+  (the client must pick - there's no safe default once more than one space
+  exists).
+- No capability typing on the primary (unlike the role slots): any bound
+  embedder is a legal scoring space.
+
+### Frontend
+
+- **New-detector modal**: a "Detector embedder" picker, populated from the
+  active dataset's bound embedder list (surfaced on the medias payload's
+  `embedders` array, already shipped in Phase 3).  Hidden/disabled when the
+  list has one entry; required when it has more than one.  The license-notice
+  chip (`license_notice`) surfaces on whichever option carries one, reusing the
+  Phase-3 chip.
+- **Nested-modal back button**: if the picker becomes its own inner step,
+  follow the `← Back` rule in CLAUDE.md ("Nested-modal back buttons").
+- Everything downstream (sort bar's text-sort gate, region overlays, marquee)
+  already reads the dataset-level capability flags and is unchanged - the
+  detector's primary doesn't alter what the *dataset* supports.
+
+### Backend integration points
+
+- `create_detector` / `_write_detector` / `DetectorCreateRequestSchema`:
+  accept + persist `primary_embedder`, validate against the active dataset's
+  bound set, resolve the single-embedder default.
+- `DetectorContext.embedder`: loaded from the JSON field at detector load
+  (the labelset-load path), not stamped from the snap at train time.
+- The detector-scoped scoring callsites that today read
+  `routed_embedder("score")` (`scoring.py`, `positives_browse.py`, the
+  diversity/projection paths *when a detector is active*) switch to
+  `det_ctx.embedder`.  The **no-detector** seed paths (`example-sort`, raw
+  diversity tree) keep `routed_embedder("score")`.
+- `update_det_ctx_with_trained_model` / `workflow.apply_and_retrain`: read the
+  primary off the detector instead of computing `score_marker_embedder`.
+
+### Tests
+
+- Create a detector with an explicit `primary_embedder` on a (synthetic)
+  multi-embedder dataset; assert it persists to JSON and reloads onto
+  `DetectorContext.embedder`.
+- Two detectors on one dataset with different primaries train/score in their
+  respective spaces (different MLP cache keys; no cross-contamination).
+- Single-embedder dataset: empty `primary_embedder` auto-resolves to the only
+  embedder; behavior byte-for-byte identical to pre-change (golden scores).
+- Multi-embedder dataset: empty `primary_embedder` → 400; unbound name → 400.
+- Legacy detector (no field) loads, resolves its primary via the precedence
+  fallback, and persists the explicit field on next save.
+- Text sort still routes to the dataset text slot regardless of the active
+  detector's primary.
+- Cross-dataset: a detector is gated on a dataset that doesn't bind its
+  primary, and re-derives its MLP from votes on one that does.
+
+### Out of scope / open questions
+
+- **Per-detector diversity tree.**  The diversity tree is currently a
+  dataset-level structure (one tree, score precedence).  Whether each detector
+  should get its *own* diversity tree in its primary space - or keep one
+  shared dataset tree - is left open; the table above keeps the raw-dataset
+  tree on the precedence and only routes the detector-scoped positives view to
+  the primary.  Decide when a real multi-primary dataset exists to test on.
+- **Changing a detector's primary after creation.**  Out of scope - same
+  spirit as "re-import to change a dataset's embedder".  A user who wants a
+  different primary creates a new detector (votes are embedder-agnostic and can
+  be re-imported into it).  No in-place "re-key this detector's space" flow.
+- **Multi-primary single detector** (one detector scoring in two spaces at
+  once).  Out of scope - this is the inverse of the trio's "one space per
+  detector" premise; the same exclusion as V3 open question #4.
+
 ## Phasing
 
 - **v1 (this plan):** six image embedders - single/patch pairs for DINOv2 (ungated default), DINOv3 (gated, premium), and real-EUPE (FAIR Noncommercial). `supports_patch_regions` + `license_notice` flags on `MediaEmbedder`; each `_patch` embedder populates `media["patch_regions"]` (HAC tree) and `media["patch_grid"]` (raw H × W × 768 fp16); the matching `_single` slug provides a fast/cheap CLS-only path on the same backbone for datasets that don't need region search. `PatchEmbedOutput` protocol; max-region similarity; region-aware MLP scoring; asymmetric training loss (Good = `BCE(mlp(full_image_vec), 1)` unchanged from today, Bad = `mean`-over-regions BCE) with image-level labels unchanged on disk; gallery-card region highlight; license-notice surfacing on the embedder picker. Text sort stays grey via the already-shipped `supports_text` gate. Pre-implementation experiments run on `caltech101_s` and inform `K`, `α`, and the EUPE-real attention path.
 - **v2:** region voting on image media via Shift-drag on the focus pane (single rectangular box, salient-area annotation on yes-votes only; binary fast path via `←`/`→` preserved); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export. Touch deferred.
 - **v3:** the **text / patch / structural trio** - up to one embedder per role bound on a single dataset (text queries → text embedder; region similarity / votes → patch embedder; instance retrieval + geometric re-rank → structural embedder), at least one slot filled.  Schema change to dict-keyed `media["embeddings"]` (one vector per bound embedder); `patch_regions` / `patch_grid` / `local_features` stay single-valued (one patch + one structural slot); legacy `media["embedding"]` is read-migrated then dropped on next save; MLPs become keyed by `(detector, dataset, embedder)` against the score embedder (structural ▸ patch ▸ text).  Designed in "V3 - design" above; **shipped** end-to-end (substrate Phases 2a–2b.5, the structural binding slot + routing in Phase 2d, and the additive create-time trio picker in Phase 3 — see "V3 - implementation status"; the picker deviated to an additive design, documented there).
+- **per-detector primary embedder (design-in-progress):** moves the scoring-space choice from the dataset (the V3 score precedence structural ▸ patch ▸ text) to the **detector** - each detector picks one `primary_embedder` at create time and trains/scores in that space, so different detectors on one multi-embedder dataset can use different spaces; text sort stays on the dataset text slot. Persisted as a name on the detector JSON (no vectors/MLPs persisted); legacy detectors read-migrate to their existing precedence-resolved space. Designed in "Per-detector primary embedder (design)" above; not yet implemented.

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -1,14 +1,15 @@
 # Patch-based Image Embedder - Design
 
-**Status:** V1 shipped, V2 shipped, **V3 trio shipped end-to-end.** The design
-body below is the living spec for the shipped V1/V2 behaviour; the *V1 - DONE*
-and *V2 - DONE* closeouts are collapsed to struck-through lists. The V3
-text/patch/structural trio (dict-keyed `media["embeddings"]`, role binding,
-dataset-level score routing, create-time picker) is shipped - see
-"V3 - implementation status". **Remaining design-in-progress work** is
-*per-detector primary embedder* (each detector picks its own scoring space,
-superseding the dataset-level score precedence for detector operations); see
-"Per-detector primary embedder (design)".
+**Status:** V1 shipped, V2 shipped, **V3 trio shipped end-to-end**, and the
+**per-detector primary embedder shipped**. The design body below is the living
+spec for the shipped V1/V2 behaviour; the *V1 - DONE* and *V2 - DONE* closeouts
+are collapsed to struck-through lists. The V3 text/patch/structural trio
+(dict-keyed `media["embeddings"]`, role binding, dataset-level score routing,
+create-time picker) is shipped - see "V3 - implementation status". The
+per-detector primary embedder (each detector picks its own scoring space at
+create time, overriding the dataset-level score precedence for that detector's
+training/scoring) is shipped - see "Per-detector primary embedder (design)" for
+the spec, "What shipped" / "Open follow-ups" there for the close-out.
 
 ## Status of related work
 
@@ -970,10 +971,11 @@ dataset-level score precedence for detector operations) — see
 
 ## Per-detector primary embedder (design)
 
-**Status: design-in-progress.** Supersedes the *dataset-level* score
+**Status: SHIPPED.** Each detector picks one primary embedder at create time
+and trains/scores in that space, overriding the *dataset-level* score
 precedence that shipped in V3 (Phases 2b.4 / 2b.5 / 2d) for **detector**
-operations.  Nothing here is implemented yet; the shipped routing table
-above is what's live today.
+operations.  See "What shipped" and "Open follow-ups" at the end of this
+section for the close-out and the deliberate deviation from the design below.
 
 ### Motivation
 
@@ -1207,9 +1209,68 @@ we don't keep a parallel precedence-derived mirror once the field exists.
   once).  Out of scope - this is the inverse of the trio's "one space per
   detector" premise; the same exclusion as V3 open question #4.
 
+### What shipped
+
+The choice is persisted as `primary_embedder` on the detector JSON (a *name*,
+no vectors/MLPs - CLAUDE.md-compliant), resolved + validated at create time
+against the active dataset's bound embedders (`resolve_detector_primary`):
+empty auto-resolves the sole embedder on a single-embedder dataset and is
+rejected on a multi-embedder one; a concrete name must be bound.  The new
+`DetectorRegistryCreateRequestSchema.primary_embedder` / `DetectorCreateRequestSchema.primary_embedder`
+carry it; both create routes plus combine persist it.  The new-detector modal
+shows a **Detector Embedder** picker (with the license-notice chip) only when
+the active dataset binds more than one embedder, threading the pick into the
+register payload.
+
+All detector-scoped training/scoring routes through one resolver,
+`keying_embedder_for_snap(det_ctx, snap)`: the detector's primary **when the
+active dataset supplies it**, else the dataset score precedence.  This is the
+single knob behind `detector_score_embedder` (vote-driven `train_and_score` /
+`_score_all_media` / `_build_vote_xy`), the labelset embed path
+(`labelset_training._detector_embedder`), the cold-train path
+(`model_loading`), Find scoring, Auto-Find (one matrix per distinct keyed
+embedder), and the cache-invalidation / re-embed comparisons
+(`dataset_sync._embedder_of_active_dataset`, `embedder_sync`).  Region
+max-pool in `_score_all_media` is now gated on the resolved space **being the
+patch slot**, so a text-primary detector on a text+patch dataset scores the
+text full-image vectors instead of the patch tree.
+
+**Deliberate deviation from the design.** The design said
+`DetectorContext.embedder` *becomes* the authoritative per-detector primary.
+We instead added a **separate** immutable `DetectorContext.primary_embedder`
+(loaded from the JSON) and kept `DetectorContext.embedder` as the *adaptive
+cache-space marker* it already was.  Reason: collapsing the two would have
+removed the cross-embedder portability the V3 cross-embedder-switch work
+relies on - a detector pointed at a dataset that doesn't bind its primary must
+still re-embed its labelset against that dataset's space (the design's own
+"re-embeds its labelset against the dataset (if its origins resolve)"), and
+the invalidation/re-embed machinery keys on the *current* cache space, not the
+preference.  `keying_embedder_for_snap` reads `primary_embedder` and falls
+back to the precedence exactly when the dataset can't supply the primary, so
+single-embedder datasets and every existing detector are byte-for-byte
+unchanged (their `primary_embedder` is empty → pure precedence).
+
+### Open follow-ups
+
+- **In-memory primary drift across A→B→A switches.** `DetectorContext.embedder`
+  (the adaptive cache marker) is re-stamped to the dataset's space when the
+  active dataset can't supply the detector's primary.  The persisted
+  `primary_embedder` (JSON) is untouched and re-loaded on the next detector
+  load, but within one in-memory session a multi-embedder-dataset → other-space
+  dataset → back sequence can leave the detector scoring the "back" dataset via
+  the *adapted* slot rather than its primary until reload.  Exotic (rare
+  multi-embedder datasets, A→B→A); revisit if it bites.
+- **Cross-dataset Find / CLI-chunk scoring** still resolve their embedder from
+  each media's primary, not the detector's `primary_embedder` (same follow-up
+  already tracked under "Open follow-ups (from 2b.4)").  Correct for every
+  single-embedder dataset; wire to the detector primary when cross-dataset Find
+  over a real multi-embedder dataset is exercised.
+- **Per-detector diversity tree** and **changing a detector's primary after
+  creation** remain out of scope (see "Out of scope / open questions" above).
+
 ## Phasing
 
 - **v1 (this plan):** six image embedders - single/patch pairs for DINOv2 (ungated default), DINOv3 (gated, premium), and real-EUPE (FAIR Noncommercial). `supports_patch_regions` + `license_notice` flags on `MediaEmbedder`; each `_patch` embedder populates `media["patch_regions"]` (HAC tree) and `media["patch_grid"]` (raw H × W × 768 fp16); the matching `_single` slug provides a fast/cheap CLS-only path on the same backbone for datasets that don't need region search. `PatchEmbedOutput` protocol; max-region similarity; region-aware MLP scoring; asymmetric training loss (Good = `BCE(mlp(full_image_vec), 1)` unchanged from today, Bad = `mean`-over-regions BCE) with image-level labels unchanged on disk; gallery-card region highlight; license-notice surfacing on the embedder picker. Text sort stays grey via the already-shipped `supports_text` gate. Pre-implementation experiments run on `caltech101_s` and inform `K`, `α`, and the EUPE-real attention path.
 - **v2:** region voting on image media via Shift-drag on the focus pane (single rectangular box, salient-area annotation on yes-votes only; binary fast path via `←`/`→` preserved); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export. Touch deferred.
 - **v3:** the **text / patch / structural trio** - up to one embedder per role bound on a single dataset (text queries → text embedder; region similarity / votes → patch embedder; instance retrieval + geometric re-rank → structural embedder), at least one slot filled.  Schema change to dict-keyed `media["embeddings"]` (one vector per bound embedder); `patch_regions` / `patch_grid` / `local_features` stay single-valued (one patch + one structural slot); legacy `media["embedding"]` is read-migrated then dropped on next save; MLPs become keyed by `(detector, dataset, embedder)` against the score embedder (structural ▸ patch ▸ text).  Designed in "V3 - design" above; **shipped** end-to-end (substrate Phases 2a–2b.5, the structural binding slot + routing in Phase 2d, and the additive create-time trio picker in Phase 3 — see "V3 - implementation status"; the picker deviated to an additive design, documented there).
-- **per-detector primary embedder (design-in-progress):** moves the scoring-space choice from the dataset (the V3 score precedence structural ▸ patch ▸ text) to the **detector** - each detector picks one `primary_embedder` at create time and trains/scores in that space, so different detectors on one multi-embedder dataset can use different spaces; text sort stays on the dataset text slot. Persisted as a name on the detector JSON (no vectors/MLPs persisted); legacy detectors read-migrate to their existing precedence-resolved space. Designed in "Per-detector primary embedder (design)" above; not yet implemented.
+- **per-detector primary embedder (SHIPPED):** moves the scoring-space choice from the dataset (the V3 score precedence structural ▸ patch ▸ text) to the **detector** - each detector picks one `primary_embedder` at create time and trains/scores in that space, so different detectors on one multi-embedder dataset can use different spaces; text sort stays on the dataset text slot. Persisted as a name on the detector JSON (no vectors/MLPs persisted); legacy detectors fall back to the precedence-resolved space. All detector-scoped routing funnels through `keying_embedder_for_snap` (primary when the dataset supplies it, else precedence), so single-embedder datasets stay byte-for-byte unchanged. Shipped with a separate immutable `DetectorContext.primary_embedder` field (deviation from the design's "reuse `DetectorContext.embedder`", to preserve cross-embedder portability) - see "Per-detector primary embedder (design)" → "What shipped" / "Open follow-ups".

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1718,6 +1718,10 @@
             "minLength": 1,
             "type": "string"
           },
+          "primary_embedder": {
+            "default": "",
+            "type": "string"
+          },
           "text_query": {
             "default": "",
             "type": "string"
@@ -1814,6 +1818,9 @@
             "type": "string"
           },
           "name": {
+            "type": "string"
+          },
+          "primary_embedder": {
             "type": "string"
           },
           "text_query": {
@@ -2017,6 +2024,10 @@
             "minLength": 1,
             "type": "string"
           },
+          "primary_embedder": {
+            "default": "",
+            "type": "string"
+          },
           "text_query": {
             "default": "",
             "type": "string"
@@ -2102,6 +2113,9 @@
           },
           "num_training": {
             "type": "integer"
+          },
+          "primary_embedder": {
+            "type": "string"
           },
           "readers": {
             "items": {
@@ -5247,6 +5261,9 @@
           },
           "num_labels": {
             "type": "integer"
+          },
+          "primary_embedder": {
+            "type": "string"
           },
           "text_query": {
             "type": "string"

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -267,6 +267,29 @@
         />
       </div>
 
+      @if (tab === 'blank' && showEmbedderPicker) {
+        <div class="form-group">
+          <label class="col-label" for="detector-embedder"
+            title="The embedder this detector trains and scores in. This dataset binds more than one, so pick the vector space for this detector.">
+            Detector Embedder
+          </label>
+          <select
+            id="detector-embedder"
+            class="form-select"
+            name="detectorEmbedder"
+            [ngModel]="primaryEmbedder()"
+            (ngModelChange)="onPrimaryEmbedderChange($event)"
+          >
+            @for (embedder of embedderOptions; track embedder.name) {
+              <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
+            }
+          </select>
+          @if (primaryLicenseNotice; as notice) {
+            <div class="license-warning" role="note">⚠ {{ notice }}</div>
+          }
+        </div>
+      }
+
       @if (error()) {
         <p class="error-text">{{ error() }}</p>
       }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -333,3 +333,16 @@
     font-weight: var(--weight-semibold);
   }
 }
+
+// License-notice chip for the Detector Embedder picker, shown when the chosen
+// embedder carries a restrictive licence. Mirrors the import-advanced chip.
+.license-warning {
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 196, 0, 0.12);
+  border: 1px solid rgba(255, 196, 0, 0.4);
+  color: var(--text-warning);
+  font-size: var(--font-sm);
+  line-height: 1.35;
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -13,11 +13,14 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { EmbedderCapabilityService } from '../../../services/embedder-capability.service';
+import { MediaStateService } from '../../../services/media-state.service';
 import {
   DemoDataset,
+  EmbedderInfo,
   ImporterField,
   ImporterInfo,
   ImporterPickerTab,
+  Media,
   MediaTypeInfo,
 } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
@@ -51,6 +54,7 @@ export class NewDetectorModalComponent implements OnInit {
   private labelImportersApi = inject(LabelImportersApiService);
   private settingsState = inject(SettingsStateService);
   private embedderCaps = inject(EmbedderCapabilityService);
+  private mediaState = inject(MediaStateService);
 
   /** Media type of the currently active dataset, if any. */
   @Input() defaultMediaType = '';
@@ -86,6 +90,12 @@ export class NewDetectorModalComponent implements OnInit {
   readonly mediaTypeInfos = signal<MediaTypeInfo[]>([]);
   readonly submitting = signal(false);
   readonly error = signal('');
+
+  /** The detector's chosen primary embedder (its scoring vector space). Only
+   *  meaningful when the active dataset binds more than one embedder; on the
+   *  common single-embedder dataset the server auto-resolves it and the picker
+   *  is hidden. Empty until the user picks (or there is nothing to pick). */
+  readonly primaryEmbedder = signal('');
   mediaTypeDropdownOpen = false;
   /** True when the media-type field is locked to the active dataset's type.
    *  Set on init whenever `defaultMediaType` is provided; cleared when the
@@ -211,6 +221,7 @@ export class NewDetectorModalComponent implements OnInit {
 
   ngOnInit(): void {
     this.embedderCaps.ensureLoaded();
+    this.ensurePrimaryEmbedderDefault();
     this.datasetsListingsApi.getMediaTypes().subscribe({
       next: (res) => {
         this.mediaTypeInfos.set(res.media_types || []);
@@ -357,8 +368,61 @@ export class NewDetectorModalComponent implements OnInit {
     return !!this.pendingText().trim();
   }
 
+  /** Embedder names the active dataset has vectors for (the keys of each
+   *  media's ``embeddings`` dict, surfaced as the ``embedders`` array). These
+   *  are the detector's eligible primary spaces. Falls back to the single
+   *  ``datasetEmbedder`` when the medias haven't loaded an array. */
+  get boundEmbedderNames(): string[] {
+    const medias = this.mediaState.mediasSignal() as Media[];
+    const first = medias.length > 0 ? medias[0] : null;
+    const names = first?.embedders ?? (first?.embedder ? [first.embedder] : []);
+    if (names.length > 0) return names;
+    return this.datasetEmbedder ? [this.datasetEmbedder] : [];
+  }
+
+  /** Show the embedder picker only when the active dataset binds more than one
+   *  embedder — otherwise the single space is the unambiguous default and the
+   *  server resolves it without a pick. */
+  get showEmbedderPicker(): boolean {
+    return this.boundEmbedderNames.length > 1;
+  }
+
+  /** Capability metadata for each bound embedder, for option labels + the
+   *  license-notice chip. Unknown names still render (by name) so a freshly
+   *  added embedder is never unpickable. */
+  get embedderOptions(): EmbedderInfo[] {
+    const infos = this.embedderCaps.infos() ?? [];
+    return this.boundEmbedderNames.map(
+      (name) => infos.find((e) => e.name === name) ?? ({ name } as EmbedderInfo),
+    );
+  }
+
+  embedderLabel(info: EmbedderInfo): string {
+    return info.display_name || info.name;
+  }
+
+  /** License notice of the currently-selected primary embedder, or null. */
+  get primaryLicenseNotice(): string | null {
+    const sel = this.primaryEmbedder();
+    if (!sel) return null;
+    return (this.embedderCaps.infos() ?? []).find((e) => e.name === sel)?.license_notice ?? null;
+  }
+
+  onPrimaryEmbedderChange(name: string): void {
+    this.primaryEmbedder.set(name);
+  }
+
+  /** Default the picker to the first bound embedder the first time it becomes
+   *  relevant, so a multi-embedder dataset lands on a valid pick. */
+  private ensurePrimaryEmbedderDefault(): void {
+    if (this.showEmbedderPicker && !this.primaryEmbedder()) {
+      this.primaryEmbedder.set(this.boundEmbedderNames[0]);
+    }
+  }
+
   get canSubmitBlank(): boolean {
-    return !!this.name().trim() && this.hasExample && !this.submitting();
+    const embedderOk = !this.showEmbedderPicker || !!this.primaryEmbedder();
+    return !!this.name().trim() && this.hasExample && embedderOk && !this.submitting();
   }
 
   get canSubmitTrained(): boolean {
@@ -917,6 +981,10 @@ export class NewDetectorModalComponent implements OnInit {
         text_query: textQuery,
         media_example: mediaExample,
         examples: examplesPayload,
+        // Empty when there's a single (or no) bound embedder — the server
+        // auto-resolves the only space; a concrete name on a multi-embedder
+        // dataset selects the detector's scoring space.
+        primary_embedder: this.showEmbedderPicker ? this.primaryEmbedder() : '',
       })
       .subscribe({
         next: (resp: any) => {

--- a/tests/detectors/test_per_detector_primary.py
+++ b/tests/detectors/test_per_detector_primary.py
@@ -1,0 +1,177 @@
+"""Per-detector primary embedder: create-time validation, persistence, reload.
+
+A detector binds one *primary* embedder at create time (its scoring vector
+space).  These cover the route + state plumbing:
+
+* a single-embedder active dataset auto-resolves the empty pick;
+* a multi-embedder active dataset rejects an empty / unbound pick and accepts a
+  bound one, persisting it on the detector JSON;
+* loading a detector stamps ``DetectorContext.primary_embedder`` from the JSON;
+* a legacy detector with no field loads fine (empty primary).
+
+See docs/plans/patch-embedder.md → "Per-detector primary embedder".
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import numpy as np
+import pytest
+
+from vtsearch.settings import get_detectors_dir
+
+
+@pytest.fixture(autouse=True)
+def clean_detectors_dir():
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+    yield
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+
+
+def _basis(i: int) -> np.ndarray:
+    return np.eye(4, dtype=np.float32)[i]
+
+
+def _activate_dataset(embedder_names: list[str]):
+    """Register + thread-activate a dataset whose one media binds *embedder_names*.
+
+    The test client injects this context's id as ``X-Dataset-Id`` on each call,
+    so ``get_active_context()`` in the create route sees these bound embedders.
+    """
+    from vtscore.state.core import (
+        DatasetContext,
+        register_context,
+        set_thread_dataset_context,
+    )
+
+    ctx = DatasetContext("ds-primary-route")
+    ctx.medias[1] = {
+        "id": 1,
+        "media_type": "image",
+        "embedder": embedder_names[0] if embedder_names else "",
+        "embeddings": {name: _basis(0) for name in embedder_names},
+    }
+    register_context(ctx)
+    set_thread_dataset_context(ctx)
+    return ctx
+
+
+def _read_detector_json(name: str) -> dict:
+    from vtscore.detectors.store import _detector_path, _read_detector
+
+    return _read_detector(_detector_path(name)) or {}
+
+
+class TestCreateValidation:
+    def test_single_embedder_auto_resolves(self, client):
+        _activate_dataset(["clap"])
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "single-emb", "media_type": "image", "text_query": "x"},
+        )
+        assert res.status_code == 201, res.get_json()
+        assert _read_detector_json("single-emb")["primary_embedder"] == "clap"
+
+    def test_multi_embedder_empty_pick_rejected(self, client):
+        _activate_dataset(["siglip", "dinov3_patch"])
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "multi-empty", "media_type": "image", "text_query": "x"},
+        )
+        assert res.status_code == 400
+        assert "multiple" in res.get_json()["message"].lower()
+
+    def test_multi_embedder_unbound_pick_rejected(self, client):
+        _activate_dataset(["siglip", "dinov3_patch"])
+        res = client.post(
+            "/api/detectors/registry",
+            json={
+                "name": "multi-bad",
+                "media_type": "image",
+                "text_query": "x",
+                "primary_embedder": "not_bound",
+            },
+        )
+        assert res.status_code == 400
+        assert "not bound" in res.get_json()["message"].lower()
+
+    def test_multi_embedder_explicit_pick_persists(self, client):
+        _activate_dataset(["siglip", "dinov3_patch"])
+        res = client.post(
+            "/api/detectors/registry",
+            json={
+                "name": "multi-ok",
+                "media_type": "image",
+                "text_query": "x",
+                "primary_embedder": "dinov3_patch",
+            },
+        )
+        assert res.status_code == 201, res.get_json()
+        assert _read_detector_json("multi-ok")["primary_embedder"] == "dinov3_patch"
+
+    def test_crud_route_also_persists(self, client):
+        _activate_dataset(["siglip", "dinov3_patch"])
+        res = client.post(
+            "/api/detectors",
+            json={
+                "name": "crud-ok",
+                "media_type": "image",
+                "text_query": "x",
+                "primary_embedder": "siglip",
+            },
+        )
+        assert res.status_code == 201, res.get_json()
+        assert _read_detector_json("crud-ok")["primary_embedder"] == "siglip"
+
+
+class TestReloadStampsPrimary:
+    def test_loaded_context_carries_primary(self, client):
+        from tests import load_detector_and_wait
+        from vtscore.detectors.registry import find_by_name
+        from vtscore.state.core import get_detector_context
+
+        _activate_dataset(["siglip", "dinov3_patch"])
+        client.post(
+            "/api/detectors/registry",
+            json={
+                "name": "reload-primary",
+                "media_type": "image",
+                "text_query": "x",
+                "primary_embedder": "dinov3_patch",
+            },
+        )
+        entry = find_by_name("reload-primary")
+        assert entry is not None
+        load_detector_and_wait(client, entry["id"])
+        ctx = get_detector_context(entry["id"])
+        assert ctx is not None
+        assert ctx.primary_embedder == "dinov3_patch"
+
+    def test_legacy_detector_without_field_loads(self, client):
+        """A detector JSON with no ``primary_embedder`` loads with empty primary."""
+        from tests import load_detector_and_wait
+        from vtscore.detectors.registry import register_detector, reset_for_tests
+        from vtscore.detectors.store import _detector_path, _write_detector
+        from vtscore.state.core import get_detector_context
+
+        reset_for_tests()
+        _write_detector(
+            _detector_path("legacy-det"),
+            {
+                "name": "legacy-det",
+                "text_query": "",
+                "media_type": "image",
+                "examples": [],
+                "labelset": {"labels": []},
+            },
+        )
+        entry = register_detector(name="legacy-det", media_type="image")
+        load_detector_and_wait(client, entry["id"])
+        ctx = get_detector_context(entry["id"])
+        assert ctx is not None
+        assert ctx.primary_embedder == ""

--- a/tests_lib/detectors/test_per_detector_primary.py
+++ b/tests_lib/detectors/test_per_detector_primary.py
@@ -1,0 +1,192 @@
+"""Per-detector primary embedder routing (docs/plans/patch-embedder.md).
+
+A detector binds one *primary* embedder - the vector space it trains and
+scores in - independent of the dataset-level score precedence.  These cover
+the pure resolvers that route training/scoring through that choice:
+
+* ``keying_embedder_for_snap`` - the primary when the snap supplies it, else
+  the dataset score precedence (the legacy / cross-dataset-portability fallback).
+* ``detector_score_embedder`` - the scoring-space name handed to the matrix
+  layer (delegates to keying).
+* ``_score_all_media`` region gating - region max-pool only when the detector
+  scores in the dataset's *patch* slot, so a text-primary detector on a
+  text+patch dataset scores text full-image vectors, not the patch tree.
+* ``resolve_detector_primary`` - create-time validation against the active
+  dataset's bound embedders.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from vtscore.detectors.training import _score_all_media, detector_score_embedder
+from vtscore.embedding.binding import keying_embedder_for_snap
+from vtscore.media.patch_embed import RegionVector
+
+DIM = 4
+
+
+def _basis(i: int) -> np.ndarray:
+    return np.eye(DIM, dtype=np.float32)[i]
+
+
+def _dual_snap() -> dict[int, dict]:
+    """Two image medias bound to both a text (siglip) and a patch (dinov3) embedder.
+
+    media 1's siglip vector is e1, media 2's is e2; both share a dinov3 patch
+    region vector e3.  The recorded primary is the patch embedder.
+    """
+    snap: dict[int, dict] = {}
+    for cid in (1, 2):
+        snap[cid] = {
+            "id": cid,
+            "media_type": "image",
+            "embedder": "dinov3_patch",
+            "embeddings": {"siglip": _basis(cid), "dinov3_patch": _basis(0)},
+            "patch_regions": [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=_basis(3))],
+        }
+    return snap
+
+
+def _det(primary: str = "") -> SimpleNamespace:
+    return SimpleNamespace(primary_embedder=primary, embedder="")
+
+
+class TestKeyingEmbedder:
+    def test_primary_used_when_snap_supplies_it(self):
+        snap = _dual_snap()
+        # The detector's chosen text primary is bound on the dataset → used.
+        assert keying_embedder_for_snap(_det("siglip"), snap) == "siglip"
+        # A patch primary is likewise honoured.
+        assert keying_embedder_for_snap(_det("dinov3_patch"), snap) == "dinov3_patch"
+
+    def test_falls_back_to_precedence_when_primary_absent(self):
+        snap = _dual_snap()
+        # "clap" isn't bound here → precedence (structural ▸ patch ▸ text) picks
+        # the patch slot.
+        assert keying_embedder_for_snap(_det("clap"), snap) == "dinov3_patch"
+
+    def test_no_primary_is_precedence(self):
+        snap = _dual_snap()
+        assert keying_embedder_for_snap(_det(""), snap) == "dinov3_patch"
+        assert keying_embedder_for_snap(None, snap) == "dinov3_patch"
+
+    def test_empty_snap_is_empty_string(self):
+        assert keying_embedder_for_snap(_det("siglip"), {}) == ""
+        assert keying_embedder_for_snap(_det("siglip"), None) == ""
+
+    def test_single_embedder_dataset_returns_that_embedder(self):
+        snap = {1: {"id": 1, "embedder": "clap", "embeddings": {"clap": _basis(0)}}}
+        # No chosen primary → precedence names the one (text-capable) embedder
+        # only if it's role-typed; clap is text-capable so it fills the text slot.
+        # Either way a single-embedder dataset never diverges the detector's space.
+        assert keying_embedder_for_snap(_det(""), snap) in ("clap", "")
+
+
+class TestDetectorScoreEmbedder:
+    def test_delegates_to_keying(self):
+        snap = _dual_snap()
+        assert detector_score_embedder(_det("siglip"), snap) == "siglip"
+        assert detector_score_embedder(_det("dinov3_patch"), snap) == "dinov3_patch"
+
+    def test_empty_snap_is_none(self):
+        assert detector_score_embedder(_det("siglip"), {}) is None
+
+
+class TestRegionGating:
+    """``_score_all_media`` region max-pool is gated on the *patch* slot."""
+
+    def _model(self) -> nn.Module:
+        # Linear that fires on e1 (media 1's text vector) and not on e3 (the
+        # shared patch region), so the chosen space changes which media wins.
+        torch.manual_seed(0)
+        m = nn.Sequential(nn.Linear(DIM, 1)).eval()
+        with torch.no_grad():
+            m[0].weight.copy_(torch.tensor([[10.0, 0.0, 0.0, -10.0]]))
+            m[0].bias.zero_()
+        return m
+
+    def test_text_primary_scores_text_vectors_no_region(self):
+        snap = _dual_snap()
+        model = cast(nn.Sequential, self._model())
+        # Scoring in the text space: media 1 (e1) beats media 2 (e2); the patch
+        # tree is bypassed, so no best_region is produced.
+        all_ids, scores, best_region = _score_all_media(model, snap, "siglip")
+        assert set(all_ids) == {1, 2}
+        s = dict(zip(all_ids, scores))
+        assert s[1] > s[2]
+        # All winning regions are 0 (single full-image row per media; no tree).
+        assert set(best_region) == {0}
+
+    def test_patch_primary_uses_region_tree(self):
+        snap = _dual_snap()
+        model = cast(nn.Sequential, self._model())
+        # Scoring in the patch space: every media's region vector is e3, so the
+        # region path runs (one region row per media) and the scores tie.
+        all_ids, scores, _best = _score_all_media(model, snap, "dinov3_patch")
+        assert set(all_ids) == {1, 2}
+        assert abs(scores[0] - scores[1]) < 1e-6
+
+    def test_none_embedder_is_legacy_region_detection(self):
+        # No explicit embedder → any patch_regions takes the region path
+        # (byte-for-byte the pre-per-detector behaviour).
+        snap = _dual_snap()
+        model = cast(nn.Sequential, self._model())
+        all_ids, scores, _best = _score_all_media(model, snap)
+        assert set(all_ids) == {1, 2}
+        assert abs(scores[0] - scores[1]) < 1e-6
+
+
+class TestResolveDetectorPrimary:
+    """Create-time resolution / validation against the active dataset."""
+
+    def _activate(self, embedder_names: list[str]):
+        from vtscore.state.core import DatasetContext, thread_dataset_context
+
+        ctx = DatasetContext("ds-primary-test")
+        ctx.medias[1] = {
+            "id": 1,
+            "media_type": "image",
+            "embedder": embedder_names[0] if embedder_names else "",
+            "embeddings": {name: _basis(0) for name in embedder_names},
+        }
+        return thread_dataset_context(ctx)
+
+    def test_single_embedder_auto_resolves(self):
+        from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+        with self._activate(["clap"]):
+            primary, err = resolve_detector_primary("")
+        assert err is None
+        assert primary == "clap"
+
+    def test_multi_embedder_requires_pick(self):
+        from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+        with self._activate(["siglip", "dinov3_patch"]):
+            primary, err = resolve_detector_primary("")
+        assert primary == ""
+        assert err is not None and "multiple" in err.lower()
+
+    def test_explicit_pick_validated(self):
+        from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+        with self._activate(["siglip", "dinov3_patch"]):
+            primary, err = resolve_detector_primary("dinov3_patch")
+            assert err is None and primary == "dinov3_patch"
+
+            bad, bad_err = resolve_detector_primary("not_bound")
+        assert bad == ""
+        assert bad_err is not None and "not bound" in bad_err.lower()
+
+    def test_no_active_dataset_leaves_empty(self):
+        from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+        # No active dataset → can't validate, leave empty (resolved at first train).
+        primary, err = resolve_detector_primary("")
+        assert primary == "" and err is None

--- a/tests_lib/detectors/test_per_detector_primary.py
+++ b/tests_lib/detectors/test_per_detector_primary.py
@@ -105,11 +105,11 @@ class TestRegionGating:
         # Linear that fires on e1 (media 1's text vector) and not on e3 (the
         # shared patch region), so the chosen space changes which media wins.
         torch.manual_seed(0)
-        m = nn.Sequential(nn.Linear(DIM, 1)).eval()
+        linear = nn.Linear(DIM, 1)
         with torch.no_grad():
-            m[0].weight.copy_(torch.tensor([[10.0, 0.0, 0.0, -10.0]]))
-            m[0].bias.zero_()
-        return m
+            linear.weight.copy_(torch.tensor([[10.0, 0.0, 0.0, -10.0]]))
+            linear.bias.zero_()
+        return nn.Sequential(linear).eval()
 
     def test_text_primary_scores_text_vectors_no_region(self):
         snap = _dual_snap()

--- a/tests_lib/detectors/test_per_detector_primary.py
+++ b/tests_lib/detectors/test_per_detector_primary.py
@@ -107,7 +107,10 @@ class TestRegionGating:
         torch.manual_seed(0)
         linear = nn.Linear(DIM, 1)
         with torch.no_grad():
-            linear.weight.copy_(torch.tensor([[10.0, 0.0, 0.0, -10.0]]))
+            # Fires on e1 (dim 1, media 1's text vector); zero on e2 (dim 2) and
+            # e3 (dim 3, the shared patch region) → the scored space decides the
+            # winner.
+            linear.weight.copy_(torch.tensor([[0.0, 10.0, 0.0, 0.0]]))
             linear.bias.zero_()
         return nn.Sequential(linear).eval()
 
@@ -184,9 +187,11 @@ class TestResolveDetectorPrimary:
         assert bad == ""
         assert bad_err is not None and "not bound" in bad_err.lower()
 
-    def test_no_active_dataset_leaves_empty(self):
+    def test_no_bound_embedders_leaves_empty(self):
         from vtscore.detectors.primary_embedder import resolve_detector_primary
 
-        # No active dataset → can't validate, leave empty (resolved at first train).
-        primary, err = resolve_detector_primary("")
+        # A dataset with no bound embedders (nothing to vectorise against) →
+        # can't validate, leave empty (resolved at first train via migration).
+        with self._activate([]):
+            primary, err = resolve_detector_primary("")
         assert primary == "" and err is None

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -214,23 +214,24 @@ def invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder: str) -
     return True
 
 
-def _embedder_of_active_dataset() -> str:
-    """Return the active dataset's model-keying marker embedder, or ``""``.
+def _embedder_of_active_dataset(det_ctx=None) -> str:
+    """Return the active dataset's model-keying marker for *det_ctx*, or ``""``.
 
-    The **score** embedder (patch-else-text; the v3 routing table) the
-    detector MLP is trained and scored against - not the per-media primary,
-    which differs from the scored space on a dual-embedder dataset.  Matches
-    what the training paths stamp on ``DetectorContext.embedder`` so the
-    invalidation compare is apples-to-apples.  See ``score_marker_embedder``
-    and patch-embedder.md Phase 2b.5.
+    Under the per-detector primary model the marker is the detector's own
+    primary whenever the active dataset can supply it (so a valid cached model
+    survives a dataset switch), else the dataset score precedence (so a genuine
+    mismatch invalidates).  See :func:`keying_embedder_for_snap` and
+    patch-embedder.md → "Per-detector primary embedder".  For a single-embedder
+    dataset the primary *is* that one embedder, so this returns it unchanged -
+    byte-for-byte the pre-per-detector behaviour.
     """
-    from vtscore.embedding.binding import score_marker_embedder_for_snap
+    from vtscore.embedding.binding import keying_embedder_for_snap
     from vtscore.state.core import get_active_context
 
     ds_ctx = get_active_context()
     if not ds_ctx.dataset_id or not ds_ctx.medias:
         return ""
-    return score_marker_embedder_for_snap(ds_ctx.medias)
+    return keying_embedder_for_snap(det_ctx, ds_ctx.medias)
 
 
 def ensure_detector_model_matches_active_embedder() -> None:
@@ -254,7 +255,7 @@ def ensure_detector_model_matches_active_embedder() -> None:
     det_ctx = get_active_detector_context()
     if not det_ctx.detector_id:
         return
-    new_embedder = _embedder_of_active_dataset()
+    new_embedder = _embedder_of_active_dataset(det_ctx)
     invalidate_detector_model_on_embedder_mismatch(det_ctx, new_embedder)
 
 

--- a/vtscore/detectors/embedder_sync.py
+++ b/vtscore/detectors/embedder_sync.py
@@ -28,19 +28,21 @@ from typing import Any, Callable
 SpawnFn = Callable[..., Any]
 
 
-def active_dataset_embedder_name() -> str:
-    """Return the active dataset's model-keying marker embedder, or ``""``.
+def active_dataset_embedder_name(det_ctx=None) -> str:
+    """Return the active dataset's model-keying marker for *det_ctx*, or ``""``.
 
-    The **score** embedder (patch-else-text; the v3 routing table) the
-    detector's label cache is built against - matching what the training
-    paths stamp on ``DetectorContext.embedder`` so the re-embed mismatch
-    check here agrees with the model-invalidation check.  See
-    ``score_marker_embedder`` and patch-embedder.md Phase 2b.5.
+    Under the per-detector primary model the marker is the detector's own
+    primary whenever the active dataset can supply it (so the cache survives a
+    dataset switch and no re-embed fires), else the dataset score precedence (so
+    a genuine mismatch schedules a re-embed against the new dataset).  This
+    agrees with the model-invalidation check in ``dataset_sync``.  See
+    :func:`keying_embedder_for_snap` and patch-embedder.md → "Per-detector
+    primary embedder".
     """
-    from vtscore.embedding.binding import score_marker_embedder_for_snap
+    from vtscore.embedding.binding import keying_embedder_for_snap
     from vtscore.state import snapshot_medias
 
-    return score_marker_embedder_for_snap(snapshot_medias())
+    return keying_embedder_for_snap(det_ctx, snapshot_medias())
 
 
 def embedder_display_name(embedder_name: str) -> str:
@@ -65,7 +67,7 @@ def maybe_start_label_reembed(det_ctx, entry: dict, *, spawn: SpawnFn) -> str | 
     *spawn* starts the background worker (see :data:`SpawnFn`); it must replay
     the caller's execution context into the new thread.
     """
-    new_embedder = active_dataset_embedder_name()
+    new_embedder = active_dataset_embedder_name(det_ctx)
     if not new_embedder or not det_ctx.embedder or new_embedder == det_ctx.embedder:
         return None
 

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -46,6 +46,23 @@ def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     return score_marker_embedder_for_snap(snap)
 
 
+def _detector_embedder(det_ctx, snap: dict[int, dict[str, Any]] | None) -> str:
+    """The embedder a *detector* resolves and embeds its labels in.
+
+    The detector's explicit per-detector primary (``det_ctx.embedder``, chosen
+    at create time) wins; absent (legacy / pre-first-train) it falls back to
+    the active dataset's score precedence via
+    :func:`_embedder_for_active_dataset` - the legacy-migration default, which
+    on a single-embedder dataset names that one embedder.  Keeping a detector's
+    label cache keyed to its own primary means switching the active dataset
+    under the detector no longer invalidates the cache as long as the new
+    dataset supplies that primary.  See ``docs/plans/patch-embedder.md`` →
+    "Per-detector primary embedder".
+    """
+    primary = getattr(det_ctx, "embedder", "") or ""
+    return primary or _embedder_for_active_dataset(snap)
+
+
 def _patch_pooled_from_file(
     file_path: Path,
     *,
@@ -195,7 +212,10 @@ def _resolve_uncached_embedding(
         if cid is not None and cid in snap:
             media = snap[cid]
             pooled = pool_box_from_media(media, elem.region_box)
-            emb = pooled if pooled is not None else media_embedding(media)
+            # Read the in-dataset vector from the detector's primary space (the
+            # same space the cross-dataset path embeds into), not the media's
+            # generic primary - they diverge on a multi-embedder dataset.
+            emb = pooled if pooled is not None else media_embedding(media, embedder_name or None)
             if emb is not None:
                 return np.asarray(emb)
 
@@ -235,7 +255,7 @@ def populate_label_embeddings(
     """
     from vtscore.detectors.labelset_elements import stable_element_id
 
-    embedder_name = _embedder_for_active_dataset(snap)
+    embedder_name = _detector_embedder(det_ctx, snap)
     _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name)
     cache: dict[str, np.ndarray] = det_ctx.label_embeddings
     region_cache: dict[str, tuple[float, float, float, float] | None] = det_ctx.label_embedding_regions
@@ -372,7 +392,7 @@ def populate_label_local_features(
     """
     from vtscore.detectors.labelset_elements import stable_element_id
 
-    embedder_name = _embedder_for_active_dataset(snap)
+    embedder_name = _detector_embedder(det_ctx, snap)
     embedder = None
     if embedder_name:
         from vtscore.media import get_embedder
@@ -499,7 +519,9 @@ def train_from_labelset(
 
     from vtscore.detectors.training import train_and_threshold
 
-    mlp, threshold = train_and_threshold(X_list, y_list, snap=snap)
+    # populate_label_embeddings stamped det_ctx.embedder with the space the
+    # labels were embedded in; score the safe-threshold pass in that same space.
+    mlp, threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name=det_ctx.embedder or None)
     det_ctx.model = mlp
     det_ctx.threshold = threshold
     return True

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -49,18 +49,19 @@ def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
 def _detector_embedder(det_ctx, snap: dict[int, dict[str, Any]] | None) -> str:
     """The embedder a *detector* resolves and embeds its labels in.
 
-    The detector's explicit per-detector primary (``det_ctx.embedder``, chosen
-    at create time) wins; absent (legacy / pre-first-train) it falls back to
-    the active dataset's score precedence via
-    :func:`_embedder_for_active_dataset` - the legacy-migration default, which
-    on a single-embedder dataset names that one embedder.  Keeping a detector's
-    label cache keyed to its own primary means switching the active dataset
-    under the detector no longer invalidates the cache as long as the new
-    dataset supplies that primary.  See ``docs/plans/patch-embedder.md`` →
-    "Per-detector primary embedder".
+    The detector's chosen primary (``det_ctx.primary_embedder``) wins when the
+    active dataset supplies it; otherwise the dataset's score precedence (the
+    legacy-migration default and the cross-dataset portability fallback -
+    re-embed against whatever space the new dataset uses).  This is
+    :func:`keying_embedder_for_snap`, so it agrees with the model-invalidation
+    and re-embed checks.  Keeping a detector's label cache keyed to its own
+    primary means switching the active dataset under the detector no longer
+    invalidates the cache as long as the new dataset supplies that primary.  See
+    ``docs/plans/patch-embedder.md`` → "Per-detector primary embedder".
     """
-    primary = getattr(det_ctx, "embedder", "") or ""
-    return primary or _embedder_for_active_dataset(snap)
+    from vtscore.embedding.binding import keying_embedder_for_snap
+
+    return keying_embedder_for_snap(det_ctx, snap)
 
 
 def _patch_pooled_from_file(

--- a/vtscore/detectors/learned_sort.py
+++ b/vtscore/detectors/learned_sort.py
@@ -102,13 +102,16 @@ def update_det_ctx_with_trained_model(det_ctx, model, threshold, labelset, train
         det_ctx.training_medias = training
     if snap:
         first = next(iter(snap.values()), {})
-        # Stamp the model-keying marker (score embedder, patch-else-text) the
-        # MLP was trained against - not the per-media primary, which differs
-        # from the scored space on a dual-embedder dataset.  See
-        # ``score_marker_embedder`` and patch-embedder.md Phase 2b.5.
-        from vtscore.embedding.binding import score_marker_embedder
+        # The detector's primary embedder (``det_ctx.embedder``) is authoritative
+        # once set - chosen at create time, loaded from the detector JSON. Only
+        # stamp the dataset score-precedence marker when it's still empty (a
+        # legacy detector with no persisted primary): that one-shot migration
+        # records the space the detector was already training in.  See
+        # patch-embedder.md → "Per-detector primary embedder".
+        if not det_ctx.embedder:
+            from vtscore.embedding.binding import score_marker_embedder
 
-        det_ctx.embedder = score_marker_embedder(first)
+            det_ctx.embedder = score_marker_embedder(first)
         det_ctx.media_type = first.get("media_type", "")
 
 

--- a/vtscore/detectors/learned_sort.py
+++ b/vtscore/detectors/learned_sort.py
@@ -102,16 +102,14 @@ def update_det_ctx_with_trained_model(det_ctx, model, threshold, labelset, train
         det_ctx.training_medias = training
     if snap:
         first = next(iter(snap.values()), {})
-        # The detector's primary embedder (``det_ctx.embedder``) is authoritative
-        # once set - chosen at create time, loaded from the detector JSON. Only
-        # stamp the dataset score-precedence marker when it's still empty (a
-        # legacy detector with no persisted primary): that one-shot migration
-        # records the space the detector was already training in.  See
-        # patch-embedder.md → "Per-detector primary embedder".
-        if not det_ctx.embedder:
-            from vtscore.embedding.binding import score_marker_embedder
+        # Stamp the *cache-space* marker with the space the MLP was actually
+        # trained in: the detector's chosen primary when this dataset supplies
+        # it, else the dataset score precedence (keying_embedder_for_snap).  For
+        # a legacy detector with no chosen primary this is the precedence,
+        # byte-for-byte the pre-per-detector behaviour.
+        from vtscore.embedding.binding import keying_embedder_for_snap
 
-            det_ctx.embedder = score_marker_embedder(first)
+        det_ctx.embedder = keying_embedder_for_snap(det_ctx, snap)
         det_ctx.media_type = first.get("media_type", "")
 
 

--- a/vtscore/detectors/model_loading.py
+++ b/vtscore/detectors/model_loading.py
@@ -48,12 +48,14 @@ def resolve_or_train_detector(  # noqa: C901
         # Defense against H5: scoring Auto-Find detectors iterates contexts
         # that aren't the active one, so the before_request hook can't
         # have invalidated their stale MLPs.  Drop them here so the next
-        # branch trains fresh against *snap*'s embedder.  Compare the
-        # score-embedder marker (patch-else-text), matching what training
-        # stamps - the per-media primary diverges on a dual dataset.
-        from vtscore.embedding.binding import score_marker_embedder_for_snap
+        # branch trains fresh against the detector's primary.  The keying
+        # marker returns the detector's primary when the active dataset can
+        # supply it (so a valid cached model survives), else the dataset score
+        # precedence (so a genuine mismatch invalidates).  See patch-embedder.md
+        # → "Per-detector primary embedder".
+        from vtscore.embedding.binding import keying_embedder_for_snap
 
-        snap_embedder = score_marker_embedder_for_snap(snap)
+        snap_embedder = keying_embedder_for_snap(det_ctx, snap)
         invalidate_detector_model_on_embedder_mismatch(det_ctx, snap_embedder)
     if det_ctx is not None and det_ctx.model is not None:
         return det_ctx.model, det_ctx.threshold, None
@@ -77,18 +79,26 @@ def resolve_or_train_detector(  # noqa: C901
     from vtscore.detectors.resolver import resolve_label_embeddings
     from vtscore.detectors.training import train_and_threshold
 
+    # The detector's primary embedder (the explicit per-detector scoring space),
+    # persisted on the detector JSON.  Both the in-snap vectors and the
+    # origin-resolved label vectors are read/embedded in this one space so the
+    # cold-trained MLP never mixes embedder outputs.  Empty for a legacy
+    # detector / single-embedder dataset, where it falls back to the snap's
+    # primary embedder (byte-for-byte the pre-per-detector behaviour).
+    primary = (det_data.get("primary_embedder", "") or "") if det_data else ""
+
     X_list: list = []
     y_list: list[float] = []
     md5_to_emb = {}
     if snap:
-        md5_to_emb = {c["md5"]: media_embedding(c) for c in snap.values()}
+        md5_to_emb = {c["md5"]: media_embedding(c, primary or None) for c in snap.values()}
 
-    # Match origin-resolved label vectors to the snap's embedder space so
+    # Match origin-resolved label vectors to the detector's primary space so
     # the two paths don't produce a mixed-space training set (silently
     # garbage MLP).  Empty when the snap is empty or untyped, which falls
     # back to the media type's default embedder.
-    dataset_embedder = ""
-    if snap:
+    dataset_embedder = primary
+    if not dataset_embedder and snap:
         dataset_embedder = next(iter(snap.values()), {}).get("embedder", "") or ""
 
     unresolved: list[dict] = []
@@ -146,7 +156,9 @@ def resolve_or_train_detector(  # noqa: C901
             step=progress_step,
             total_steps=progress_total_steps,
         )
-        trained_mlp, threshold = train_and_threshold(X_list, y_list, snap=snap)
+        trained_mlp, threshold = train_and_threshold(
+            X_list, y_list, snap=snap, embedder_name=primary or None
+        )
         return trained_mlp, threshold, None
 
     diagnostic: dict = {

--- a/vtscore/detectors/model_loading.py
+++ b/vtscore/detectors/model_loading.py
@@ -162,9 +162,7 @@ def resolve_or_train_detector(  # noqa: C901
             step=progress_step,
             total_steps=progress_total_steps,
         )
-        trained_mlp, threshold = train_and_threshold(
-            X_list, y_list, snap=snap, embedder_name=cold_embedder or None
-        )
+        trained_mlp, threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name=cold_embedder or None)
         return trained_mlp, threshold, None
 
     diagnostic: dict = {

--- a/vtscore/detectors/model_loading.py
+++ b/vtscore/detectors/model_loading.py
@@ -79,25 +79,31 @@ def resolve_or_train_detector(  # noqa: C901
     from vtscore.detectors.resolver import resolve_label_embeddings
     from vtscore.detectors.training import train_and_threshold
 
-    # The detector's primary embedder (the explicit per-detector scoring space),
-    # persisted on the detector JSON.  Both the in-snap vectors and the
+    # The space to cold-train the MLP in: the detector's chosen primary when
+    # this snap supplies it, else the dataset score precedence (the legacy /
+    # cross-dataset-portability fallback).  Both the in-snap vectors and the
     # origin-resolved label vectors are read/embedded in this one space so the
-    # cold-trained MLP never mixes embedder outputs.  Empty for a legacy
-    # detector / single-embedder dataset, where it falls back to the snap's
-    # primary embedder (byte-for-byte the pre-per-detector behaviour).
+    # cold-trained MLP never mixes embedder outputs.  ``keying_embedder_for_snap``
+    # is fed a throwaway carrier for the detector's primary because an unloaded
+    # detector has no live context.
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+
     primary = (det_data.get("primary_embedder", "") or "") if det_data else ""
+    cold_embedder = keying_embedder_for_snap(SimpleNamespace(primary_embedder=primary), snap)
 
     X_list: list = []
     y_list: list[float] = []
     md5_to_emb = {}
     if snap:
-        md5_to_emb = {c["md5"]: media_embedding(c, primary or None) for c in snap.values()}
+        md5_to_emb = {c["md5"]: media_embedding(c, cold_embedder or None) for c in snap.values()}
 
-    # Match origin-resolved label vectors to the detector's primary space so
-    # the two paths don't produce a mixed-space training set (silently
-    # garbage MLP).  Empty when the snap is empty or untyped, which falls
-    # back to the media type's default embedder.
-    dataset_embedder = primary
+    # Match origin-resolved label vectors to the cold-train space so the two
+    # paths don't produce a mixed-space training set (silently garbage MLP).
+    # Empty when the snap is empty or untyped, which falls back to the media
+    # type's default embedder.
+    dataset_embedder = cold_embedder
     if not dataset_embedder and snap:
         dataset_embedder = next(iter(snap.values()), {}).get("embedder", "") or ""
 
@@ -157,7 +163,7 @@ def resolve_or_train_detector(  # noqa: C901
             total_steps=progress_total_steps,
         )
         trained_mlp, threshold = train_and_threshold(
-            X_list, y_list, snap=snap, embedder_name=primary or None
+            X_list, y_list, snap=snap, embedder_name=cold_embedder or None
         )
         return trained_mlp, threshold, None
 

--- a/vtscore/detectors/primary_embedder.py
+++ b/vtscore/detectors/primary_embedder.py
@@ -1,0 +1,63 @@
+"""Resolve and validate a detector's per-detector *primary* embedder.
+
+A detector binds exactly one **primary embedder** at create time - the single
+vector space its MLP is trained and scored in (see
+``docs/plans/patch-embedder.md`` → "Per-detector primary embedder").  It is a
+persisted *name* on the detector JSON, never a vector or MLP, so it satisfies
+the "No Persisted Vectors or MLPs" rule.
+
+This module holds the pure resolution / validation used by the detector-create
+routes.  It is library-tier (no Flask): the route turns a returned error string
+into an HTTP 400.
+"""
+
+from __future__ import annotations
+
+
+def active_dataset_bound_embedders() -> list[str]:
+    """Return the active dataset's bound embedder names, or ``[]``.
+
+    The eligible primaries for a detector are exactly the embedders the active
+    dataset has vectors for - the keys of ``media["embeddings"]`` - which is
+    broader than the three role slots: a single-vector embedder (e.g.
+    ``dinov2_single``) fills no role slot but is still a valid scoring space.
+    Empty when no dataset is loaded (the create flow then can't validate, and
+    leaves the choice to first-train migration).
+    """
+    from vtscore.embedding.media_vectors import media_embedder_names
+    from vtscore.state.core import get_active_context
+
+    ctx = get_active_context()
+    if not ctx.dataset_id or not ctx.medias:
+        return []
+    first = next(iter(ctx.medias.values()), {})
+    return media_embedder_names(first)
+
+
+def resolve_detector_primary(requested: str) -> tuple[str, str | None]:
+    """Resolve the primary embedder to persist for a new detector.
+
+    Returns ``(primary, error)`` - *error* is ``None`` on success, else a
+    message the route surfaces as HTTP 400.  Validation/resolution against the
+    active dataset's bound embedders:
+
+    * non-empty *requested* → must be one of the active dataset's bound
+      embedders (when a dataset is loaded), else an error;
+    * empty *requested* on a single-embedder dataset → that one embedder
+      (zero-friction default, identical UX to today);
+    * empty *requested* on a multi-embedder dataset → an error (the client must
+      choose: there is no safe default once more than one space exists);
+    * empty *requested* with no active dataset → ``("", None)``: left empty and
+      resolved at first train via the legacy score precedence (migration).
+    """
+    requested = (requested or "").strip()
+    bound = active_dataset_bound_embedders()
+    if requested:
+        if bound and requested not in bound:
+            return "", f"embedder '{requested}' is not bound to this dataset"
+        return requested, None
+    if len(bound) == 1:
+        return bound[0], None
+    if len(bound) > 1:
+        return "", "This dataset has multiple embedders; choose one as the detector's embedder"
+    return "", None

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -46,6 +46,38 @@ def _score_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | No
     return structural or patch or text
 
 
+def detector_score_embedder(det_ctx: Any, snap: dict[int, dict[str, Any]] | None) -> str | None:
+    """Embedder a *detector* trains and scores in.
+
+    The per-detector primary (``det_ctx.embedder``, the explicit space chosen
+    at create time) wins; absent (a legacy / pre-first-train context, or no
+    detector at all) it falls back to the dataset score precedence
+    (:func:`_score_embedder_for_snap`) - the legacy-migration default, which on
+    a single-embedder dataset names that one embedder.  Returns a concrete name
+    (collapsed to the cached primary path by the matrix layer when it equals
+    the dataset's primary), or ``None`` for a slot-less single-vector dataset
+    with no explicit primary, where the matrix layer reads each media's primary
+    vector.  See ``docs/plans/patch-embedder.md`` → "Per-detector primary
+    embedder".
+    """
+    primary = (getattr(det_ctx, "embedder", "") or "") if det_ctx is not None else ""
+    if primary:
+        return primary
+    return _score_embedder_for_snap(snap)
+
+
+def _patch_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | None:
+    """Resolve the patch-slot embedder name for *snap*'s medias, or ``None``."""
+    if not snap:
+        return None
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
+
+    first = next(iter(snap.values()), {})
+    _text, patch, _structural = derive_binding_from_names(media_embedder_names(first))
+    return patch
+
+
 def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
     """Check that *y_list* contains at least one good and one bad label.
 
@@ -63,6 +95,7 @@ def train_and_threshold(
     X_list: list,
     y_list: list[float],
     snap: dict | None = None,
+    embedder_name: str | None = None,
 ) -> tuple[Any, float]:
     """Train an MLP and compute a calibrated threshold.
 
@@ -83,6 +116,10 @@ def train_and_threshold(
         X_list: Embedding vectors (list of numpy arrays).
         y_list: Binary labels (1.0 = good, 0.0 = bad).
         snap: Optional media snapshot for safe-threshold scoring.
+        embedder_name: The detector's primary embedder, used so the
+            safe-threshold scoring pass reads vectors from the same space the
+            ``X_list`` were built in.  ``None`` falls back to the dataset score
+            precedence for *snap* (the pre-per-detector behaviour).
 
     Returns:
         ``(model, threshold)``
@@ -129,7 +166,8 @@ def train_and_threshold(
         # `safe` is only True when `snap` is truthy (see assignment above),
         # so the narrowing is real even though pyright can't track it.
         assert snap is not None
-        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, _score_embedder_for_snap(snap))
+        score_emb = embedder_name if embedder_name is not None else _score_embedder_for_snap(snap)
+        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, score_emb)
         X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             X_all = X_all.to(next(model.parameters()).device)
@@ -200,6 +238,7 @@ def _build_vote_xy(
     good_votes: dict[int, None],
     bad_votes: dict[int, None],
     region_boxes: dict[int, tuple[float, float, float, float]],
+    embedder_name: str | None = None,
 ) -> tuple[list[np.ndarray], list[float]]:
     """Build ``(X_list, y_list)`` from filtered votes.
 
@@ -208,12 +247,16 @@ def _build_vote_xy(
     embedding.  Returns the raw lists - the caller
     (:func:`_train_and_score_xy`) enforces the ≥2-samples / ≥1-good /
     ≥1-bad guard.
+
+    *embedder_name* is the detector's primary embedder; when ``None`` the
+    dataset score precedence for *clips_dict* is used (the pre-per-detector
+    behaviour).  Either way the MLP trains in the same space
+    :func:`_score_all_media` scores against.
     """
     from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
 
-    # Train against the dataset's score embedder so the MLP shares the space
-    # _score_all_media scores against (the v3 routing table).
-    embedder_name = _score_embedder_for_snap(clips_dict)
+    if embedder_name is None:
+        embedder_name = _score_embedder_for_snap(clips_dict)
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     for cid in good_votes:
@@ -230,6 +273,7 @@ def _build_vote_xy(
 def _score_all_media(
     model: nn.Sequential,
     clips_dict: dict[int, dict[str, Any]],
+    embedder_name: str | None = None,
 ) -> tuple[list[int], list[float], list[int]]:
     """Score every media in *clips_dict* with the trained MLP.
 
@@ -238,6 +282,14 @@ def _score_all_media(
     running a single forward pass, then max-pooling per media - so the
     winning region's index can be surfaced for UI overlays.  Plain
     datasets fall back to the cached embedding matrix.
+
+    *embedder_name* is the detector's primary embedder (the space the MLP was
+    trained in).  When it is given, region max-pooling is used **only** if that
+    primary is the dataset's patch-slot embedder - a detector scoring in the
+    text or structural space of a multi-embedder dataset must score against
+    that space's full-image vectors, not the patch tree.  When ``None`` (the
+    pre-per-detector behaviour) any media carrying ``patch_regions`` takes the
+    region path, matching the dataset-level score precedence.
 
     Returns ``(all_ids, scores_per_media, best_region_index_per_media)``.
     """
@@ -248,7 +300,13 @@ def _score_all_media(
         get_region_matrix_for_snap,
     )
 
+    resolved = embedder_name if embedder_name is not None else _score_embedder_for_snap(clips_dict)
     has_regions = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
+    if has_regions and embedder_name is not None:
+        # Explicit per-detector primary: region-pool only when scoring in the
+        # patch space (the patch tree lives in the patch embedder's vectors).
+        patch = _patch_embedder_for_snap(clips_dict)
+        has_regions = patch is not None and resolved == patch
     if has_regions:
         # One row per (media, region) pair, built once and cached on the
         # dataset context (the region vectors never change between votes -
@@ -256,7 +314,7 @@ def _score_all_media(
         # a multi-hundred-thousand-row matrix on every vote.
         all_ids, X_np, media_index_per_row, region_index_per_row = get_region_matrix_for_snap(clips_dict)
     else:
-        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict, _score_embedder_for_snap(clips_dict))
+        all_ids, X_np = get_embedding_matrix_for_snap(clips_dict, resolved)
         n = len(all_ids)
         media_index_per_row = np.arange(n, dtype=np.int64)
         region_index_per_row = np.zeros(n, dtype=np.int64)
@@ -346,6 +404,7 @@ def _format_results(
 def score_media_with_model(
     model: nn.Sequential,
     clips_dict: dict[int, dict[str, Any]],
+    embedder_name: str | None = None,
 ) -> list[dict[str, Any]]:
     """Score every media in *clips_dict* with an already-trained *model*.
 
@@ -357,8 +416,11 @@ def score_media_with_model(
     best-match highlight is populated regardless of which entry point ran the
     scoring.  Plain single-vector datasets are scored via the cached embedding
     matrix and gain no ``best_region`` field, exactly as before.
+
+    *embedder_name* is the detector's primary embedder, so the scoring space
+    matches the one the *model* was trained in (the per-detector primary).
     """
-    all_ids, scores, best_region = _score_all_media(model, clips_dict)
+    all_ids, scores, best_region = _score_all_media(model, clips_dict, embedder_name)
     return _format_results(all_ids, scores, best_region, clips_dict)
 
 
@@ -399,6 +461,11 @@ def _train_and_score_xy(
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
         return [], 0.5, None
 
+    # The detector's primary embedder (the explicit space it scores in), or the
+    # dataset score precedence when the detector has no primary yet.  Scoring
+    # reads vectors from this same space the X_list were assembled in.
+    score_emb = detector_score_embedder(det_ctx, clips_dict)
+
     X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
@@ -427,7 +494,7 @@ def _train_and_score_xy(
     # per labelled media, mirroring the "vote on whole images" rule.
     model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
 
-    all_ids, scores, best_region = _score_all_media(model, clips_dict)
+    all_ids, scores, best_region = _score_all_media(model, clips_dict, score_emb)
 
     if safe_thresholds:
         threshold = calculate_safe_threshold(threshold, scores, len(X_list))
@@ -488,7 +555,9 @@ def train_and_score(
           training was not possible).
     """
     region_boxes = vote_region_boxes or {}
-    X_list, y_list = _build_vote_xy(clips_dict, good_votes, bad_votes, region_boxes)
+    X_list, y_list = _build_vote_xy(
+        clips_dict, good_votes, bad_votes, region_boxes, detector_score_embedder(det_ctx, clips_dict)
+    )
     results, threshold, model = _train_and_score_xy(
         X_list,
         y_list,

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -49,21 +49,19 @@ def _score_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | No
 def detector_score_embedder(det_ctx: Any, snap: dict[int, dict[str, Any]] | None) -> str | None:
     """Embedder a *detector* trains and scores in.
 
-    The per-detector primary (``det_ctx.embedder``, the explicit space chosen
-    at create time) wins; absent (a legacy / pre-first-train context, or no
-    detector at all) it falls back to the dataset score precedence
-    (:func:`_score_embedder_for_snap`) - the legacy-migration default, which on
-    a single-embedder dataset names that one embedder.  Returns a concrete name
-    (collapsed to the cached primary path by the matrix layer when it equals
-    the dataset's primary), or ``None`` for a slot-less single-vector dataset
-    with no explicit primary, where the matrix layer reads each media's primary
-    vector.  See ``docs/plans/patch-embedder.md`` → "Per-detector primary
-    embedder".
+    The detector's chosen primary (``det_ctx.primary_embedder``) wins **when the
+    snap supplies it**; otherwise the dataset score precedence - the
+    legacy-migration default and the cross-dataset portability fallback (a
+    detector pointed at a dataset that lacks its primary re-embeds against that
+    dataset's space).  This is exactly :func:`keying_embedder_for_snap`.
+    Returns a concrete name (collapsed to the cached primary path by the matrix
+    layer when it equals the dataset's primary), or ``None`` when there is
+    nothing to resolve (empty snap).  See ``docs/plans/patch-embedder.md`` →
+    "Per-detector primary embedder".
     """
-    primary = (getattr(det_ctx, "embedder", "") or "") if det_ctx is not None else ""
-    if primary:
-        return primary
-    return _score_embedder_for_snap(snap)
+    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+
+    return keying_embedder_for_snap(det_ctx, snap) or None
 
 
 def _patch_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | None:

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -164,13 +164,15 @@ def apply_and_retrain(  # noqa: C901
                     training[cid] = snap[cid]
             det_ctx.training_medias = training
             first = next(iter(snap.values()), {})
-            # Stamp the model-keying marker (score embedder, patch-else-text)
-            # the MLP was trained against, not the per-media primary - they
-            # differ on a dual-embedder dataset.  See ``score_marker_embedder``
-            # and patch-embedder.md Phase 2b.5.
-            from vtscore.embedding.binding import score_marker_embedder
+            # The detector's primary embedder is authoritative once set (chosen
+            # at create time, loaded from the detector JSON); only stamp the
+            # dataset score-precedence marker for a legacy detector that has no
+            # persisted primary yet (one-shot migration).  See patch-embedder.md
+            # → "Per-detector primary embedder".
+            if not det_ctx.embedder:
+                from vtscore.embedding.binding import score_marker_embedder
 
-            det_ctx.embedder = score_marker_embedder(first)
+                det_ctx.embedder = score_marker_embedder(first)
             det_ctx.media_type = first.get("media_type", "")
             from vtscore.detectors.registry import record_detector_embedder
 

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -164,15 +164,14 @@ def apply_and_retrain(  # noqa: C901
                     training[cid] = snap[cid]
             det_ctx.training_medias = training
             first = next(iter(snap.values()), {})
-            # The detector's primary embedder is authoritative once set (chosen
-            # at create time, loaded from the detector JSON); only stamp the
-            # dataset score-precedence marker for a legacy detector that has no
-            # persisted primary yet (one-shot migration).  See patch-embedder.md
-            # → "Per-detector primary embedder".
-            if not det_ctx.embedder:
-                from vtscore.embedding.binding import score_marker_embedder
+            # Stamp the *cache-space* marker with the space the MLP was actually
+            # trained in: the detector's chosen primary when this dataset
+            # supplies it, else the dataset score precedence
+            # (keying_embedder_for_snap).  Legacy detectors (no chosen primary)
+            # get the precedence, byte-for-byte the pre-per-detector behaviour.
+            from vtscore.embedding.binding import keying_embedder_for_snap
 
-                det_ctx.embedder = score_marker_embedder(first)
+            det_ctx.embedder = keying_embedder_for_snap(det_ctx, snap)
             det_ctx.media_type = first.get("media_type", "")
             from vtscore.detectors.registry import record_detector_embedder
 

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -158,11 +158,12 @@ def keying_embedder_for_snap(det_ctx: Any, snap: dict[int, dict[str, Any]] | Non
     * no explicit primary yet (legacy / pre-first-train ``det_ctx``) → the
       score precedence, the legacy-migration default.
 
-    For every single-embedder dataset the primary *is* that one embedder and is
-    always present, so this returns the primary unchanged - byte-for-byte the
-    pre-per-detector behaviour, where the marker equalled the precedence.
+    For a legacy detector with no chosen primary (``primary_embedder`` empty)
+    this is exactly the dataset score precedence - byte-for-byte the
+    pre-per-detector behaviour - so a single-embedder dataset and every existing
+    detector are unaffected.
     """
-    primary = (getattr(det_ctx, "embedder", "") or "") if det_ctx is not None else ""
+    primary = (getattr(det_ctx, "primary_embedder", "") or "") if det_ctx is not None else ""
     if primary and snap:
         first = next(iter(snap.values()), {})
         if primary in media_embedder_names(first):

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -138,6 +138,38 @@ def score_marker_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> st
     return score_marker_embedder(next(iter(snap.values()), {}))
 
 
+def keying_embedder_for_snap(det_ctx: Any, snap: dict[int, dict[str, Any]] | None) -> str:
+    """The marker to compare against ``det_ctx.embedder`` for cache invalidation.
+
+    Under the *per-detector primary embedder* model (see
+    ``docs/plans/patch-embedder.md`` → "Per-detector primary embedder"), a
+    detector scores in its **own** explicit primary (``det_ctx.embedder``),
+    not the dataset's score precedence.  So the model/label caches stay valid
+    as long as the active dataset can still *supply* that primary embedder:
+
+    * primary set **and** present among the snap's bound embedders → return
+      the primary unchanged, so the compare against ``det_ctx.embedder`` is
+      equal and nothing is invalidated (no per-request retrain thrash on a
+      multi-embedder dataset whose precedence differs from the primary);
+    * primary set but **absent** from the snap (the dataset can't score this
+      detector) → return the snap's score precedence, which differs from the
+      primary and so invalidates the stale cache (the cold path then re-embeds
+      the labelset against the new dataset, or the detector is gated);
+    * no explicit primary yet (legacy / pre-first-train ``det_ctx``) → the
+      score precedence, the legacy-migration default.
+
+    For every single-embedder dataset the primary *is* that one embedder and is
+    always present, so this returns the primary unchanged - byte-for-byte the
+    pre-per-detector behaviour, where the marker equalled the precedence.
+    """
+    primary = (getattr(det_ctx, "embedder", "") or "") if det_ctx is not None else ""
+    if primary and snap:
+        first = next(iter(snap.values()), {})
+        if primary in media_embedder_names(first):
+            return primary
+    return score_marker_embedder_for_snap(snap)
+
+
 def validate_binding(
     text_embedder: str | None,
     patch_embedder: str | None,

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -480,7 +480,19 @@ class DetectorContext:
         "detector_id",
         "name",
         "media_type",
+        # The space the label cache / MLP is *currently* built in (an adaptive
+        # marker, re-stamped when the active dataset's space changes).  Distinct
+        # from ``primary_embedder``: on a dataset that can't supply the primary,
+        # this tracks whatever space the labels were re-embedded into so the
+        # cache-invalidation compare stays honest.
         "embedder",
+        # The detector's *chosen* primary embedder - the vector space it prefers
+        # to train/score in, persisted on the detector JSON and loaded here at
+        # detector load.  Immutable in memory (never re-stamped).  Empty for a
+        # legacy detector, where routing falls back to the dataset score
+        # precedence.  See ``docs/plans/patch-embedder.md`` → "Per-detector
+        # primary embedder".
+        "primary_embedder",
         # Vote state
         "good_votes",
         "bad_votes",
@@ -578,11 +590,20 @@ class DetectorContext:
         "calibration_cache",  # tuple[Any, tuple[list, float | None]] | None
     )
 
-    def __init__(self, detector_id: str = "", *, name: str = "", media_type: str = "", embedder: str = "") -> None:
+    def __init__(
+        self,
+        detector_id: str = "",
+        *,
+        name: str = "",
+        media_type: str = "",
+        embedder: str = "",
+        primary_embedder: str = "",
+    ) -> None:
         self.detector_id: str = detector_id
         self.name: str = name
         self.media_type: str = media_type
         self.embedder: str = embedder
+        self.primary_embedder: str = primary_embedder
         # Vote state
         self.good_votes: dict[int, None] = {}
         self.bad_votes: dict[int, None] = {}
@@ -832,6 +853,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "name", "")
         object.__setattr__(self, "media_type", "")
         object.__setattr__(self, "embedder", "")
+        object.__setattr__(self, "primary_embedder", "")
         object.__setattr__(self, "good_votes", _FrozenDict("detector"))
         object.__setattr__(self, "bad_votes", _FrozenDict("detector"))
         object.__setattr__(self, "label_history", _FrozenList("detector"))

--- a/vtsearch/routes/detectors/crud.py
+++ b/vtsearch/routes/detectors/crud.py
@@ -89,6 +89,7 @@ def _list_all() -> list[dict]:
                 "examples": data.get("examples", []),
                 "num_labels": len(labels),
                 "created_at": data.get("created_at", 0),
+                "primary_embedder": data.get("primary_embedder", "") or "",
             }
         )
     return detectors
@@ -139,6 +140,12 @@ def create_detector(body: dict):
     if path.exists():
         abort(409, message=f"A detector named '{name}' already exists")
 
+    from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+    primary_embedder, primary_err = resolve_detector_primary(body.get("primary_embedder", ""))
+    if primary_err:
+        abort(400, message=primary_err)
+
     # Build examples list; if text_query/media_example provided without
     # explicit examples, create a single example from it for backward compat.
     if examples is None and text_query:
@@ -153,6 +160,7 @@ def create_detector(body: dict):
         "media_type": media_type,
         "examples": examples or [],
         "created_at": time.time(),
+        "primary_embedder": primary_embedder,
         "labelset": {"labels": []},
     }
     _write_detector(path, detector_data)
@@ -388,6 +396,12 @@ def combine_detectors(body: dict):  # noqa: C901
                 text_query = s["text_query"]
                 break
 
+    # Inherit the primary embedder only when every source agrees on it; a
+    # disagreement (or any source without one) leaves it empty, resolved at
+    # first train against a dataset.
+    source_primaries = {(s.get("primary_embedder", "") or "") for s in sources}
+    combined_primary = next(iter(source_primaries)) if len(source_primaries) == 1 else ""
+
     new_data = {
         "name": new_name,
         "text_query": text_query,
@@ -395,6 +409,7 @@ def combine_detectors(body: dict):  # noqa: C901
         "media_type": media_type,
         "examples": merged_examples,
         "created_at": time.time(),
+        "primary_embedder": combined_primary,
         "labelset": merged.to_dict(),
         "combined_from": list(names),
     }

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -435,13 +435,13 @@ def load_detector_route(body: dict):  # noqa: C901
                         )
                         det_data = _read_detector(_detector_path(det_name))
                         if det_data:
-                            # The detector's primary embedder is authoritative
-                            # (chosen at create time): load it onto the context
-                            # before any training so the label-embed / score
-                            # paths use it instead of the dataset precedence.
-                            # Empty for a legacy detector → resolved at first
-                            # train via migration.
-                            det_ctx.embedder = det_data.get("primary_embedder", "") or ""
+                            # The detector's chosen primary embedder (immutable;
+                            # set at create time): load it so the label-embed /
+                            # score / invalidation paths prefer it over the
+                            # dataset precedence whenever the active dataset
+                            # supplies it.  Empty for a legacy detector → routing
+                            # falls back to the precedence.
+                            det_ctx.primary_embedder = det_data.get("primary_embedder", "") or ""
                             _restore_labels_from_detector(det_data)
 
                             tracker.check_cancelled()

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -145,6 +145,12 @@ def register_detector_route(body: dict):
     if not media_type or media_type == "any":
         abort(400, message="media_type is required (must be a specific type, not 'any')")
 
+    from vtscore.detectors.primary_embedder import resolve_detector_primary
+
+    primary_embedder, primary_err = resolve_detector_primary(body.get("primary_embedder", ""))
+    if primary_err:
+        abort(400, message=primary_err)
+
     det_path = _detector_path(name)
     if not det_path.exists():
         examples = body.get("examples") or []
@@ -159,6 +165,7 @@ def register_detector_route(body: dict):
             "media_type": media_type,
             "examples": examples,
             "created_at": time.time(),
+            "primary_embedder": primary_embedder,
             "labelset": {"labels": []},
         }
         _write_detector(det_path, detector_data)
@@ -428,6 +435,13 @@ def load_detector_route(body: dict):  # noqa: C901
                         )
                         det_data = _read_detector(_detector_path(det_name))
                         if det_data:
+                            # The detector's primary embedder is authoritative
+                            # (chosen at create time): load it onto the context
+                            # before any training so the label-embed / score
+                            # paths use it instead of the dataset precedence.
+                            # Empty for a legacy detector → resolved at first
+                            # train via migration.
+                            det_ctx.embedder = det_data.get("primary_embedder", "") or ""
                             _restore_labels_from_detector(det_data)
 
                             tracker.check_cancelled()
@@ -886,11 +900,12 @@ def get_detector_stats(detector_id: str):
     # Embedder: the loaded context's live value wins (it reflects the space
     # the labels are currently resolved against); otherwise the registry's
     # persisted stamp.
+    persisted_primary = data.get("primary_embedder", "") or ""
     if detector_id in get_loaded_detector_ids():
         ctx = get_detector_context(detector_id)
-        embedder = (ctx.embedder if ctx is not None else "") or entry.get("embedder", "") or ""
+        embedder = (ctx.embedder if ctx is not None else "") or persisted_primary or entry.get("embedder", "") or ""
     else:
-        embedder = entry.get("embedder", "") or ""
+        embedder = persisted_primary or entry.get("embedder", "") or ""
 
     input_spec = data.get("input_spec") or {}
     raw_clipper = (input_spec.get("clipper", "") if isinstance(input_spec, dict) else "") or ""
@@ -928,14 +943,19 @@ def get_detector_stats(detector_id: str):
 # ---------------------------------------------------------------------------
 
 
-def _detector_browse_embedder(entry: dict, media_type: str) -> str:
+def _detector_browse_embedder(entry: dict, data: dict, media_type: str) -> str:
     """The embedder to project a detector's positives with.
 
-    The detector's own recorded embedder wins — browsing a detector must not
-    depend on whatever dataset is incidentally selected on the dashboard.
-    Falls back to the media type's default embedder when the detector has
-    never recorded one (e.g. never trained against a dataset).
+    The detector's own primary embedder wins — browsing a detector must not
+    depend on whatever dataset is incidentally selected on the dashboard.  The
+    persisted per-detector primary (``data["primary_embedder"]``) is preferred;
+    the registry's recorded embedder is the fallback for a legacy detector that
+    has no primary yet but has trained.  Falls back to the media type's default
+    embedder when neither is set (e.g. a brand-new detector).
     """
+    primary = (data.get("primary_embedder", "") or "") if data else ""
+    if primary:
+        return primary
     recorded = entry.get("embedder", "") or ""
     if recorded:
         return recorded
@@ -1039,7 +1059,7 @@ def browse_detector_positives(detector_id: str):
     if not any(el.label == "good" for el in labelset.elements):
         abort(409, message="This detector has no positive labels to browse.")
 
-    embedder_name = _detector_browse_embedder(entry, media_type)
+    embedder_name = _detector_browse_embedder(entry, data, media_type)
 
     # Reuse the loaded detector's cached label vectors only when they were built
     # in the same space we're about to project in; otherwise re-embed fresh.

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -165,13 +165,18 @@ def find_label(body: dict):  # noqa: C901
     # Highlight overlay can outline it - matching the learned-sort path.  Plain
     # single-vector datasets take the cached embedding-matrix path inside and
     # gain no ``best_region`` field.
-    from vtscore.detectors.training import score_media_with_model
+    from types import SimpleNamespace
 
-    # Score in the detector's primary embedder space (the one the MLP was
-    # trained in); falls back to the dataset score precedence for a legacy
-    # detector with no persisted primary.
+    from vtscore.detectors.training import score_media_with_model
+    from vtscore.embedding.binding import keying_embedder_for_snap
+
+    # Score in the same space the MLP was trained in: the detector's chosen
+    # primary when this dataset supplies it, else the dataset score precedence
+    # (keying_embedder_for_snap) - matching resolve_or_train_detector's cold
+    # path and the learned-sort cache-space marker.
     primary = (det_data or {}).get("primary_embedder", "") or ""
-    results = score_media_with_model(mlp, snap, embedder_name=primary or None)
+    score_emb = keying_embedder_for_snap(SimpleNamespace(primary_embedder=primary), snap)
+    results = score_media_with_model(mlp, snap, embedder_name=score_emb or None)
     update_find_progress(
         "running",
         f"Scoring {n_total} items…",
@@ -626,13 +631,19 @@ def auto_detect(body: dict):
     # Each detector scores in its own primary embedder space, so build one
     # matrix per distinct embedder the Auto-Find detectors call for (collapsing
     # to a single shared matrix on the common single-embedder dataset, where
-    # every primary resolves to the same name).  A detector with no persisted
-    # primary falls back to the dataset score precedence.
+    # every primary resolves to the same name).  A detector whose chosen primary
+    # this dataset can't supply (or a legacy detector) falls back to the dataset
+    # score precedence, matching resolve_or_train_detector's cold-train space.
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+
     default_score = get_active_context().routed_embedder("score")
     det_embedders: dict[str, str | None] = {}
     for dname, ddata, _entry in detectors_to_run:
         primary = (ddata.get("primary_embedder", "") or "") if ddata else ""
-        det_embedders[dname] = primary or default_score
+        keyed = keying_embedder_for_snap(SimpleNamespace(primary_embedder=primary), snap)
+        det_embedders[dname] = keyed or default_score
     matrices: dict[str | None, tuple[list[int], Any]] = {}
     for emb in set(det_embedders.values()):
         ids, embs = get_embedding_matrix_for_snap(snap, emb)

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -679,7 +679,7 @@ def auto_detect(body: dict):
     if results:
         from vtsearch.achievements import record_find  # noqa: PLC0415
 
-        record_find(len(all_ids) * len(results))
+        record_find(len(default_ids) * len(results))
 
     response = {
         "media_type": media_type,

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -167,7 +167,11 @@ def find_label(body: dict):  # noqa: C901
     # gain no ``best_region`` field.
     from vtscore.detectors.training import score_media_with_model
 
-    results = score_media_with_model(mlp, snap)
+    # Score in the detector's primary embedder space (the one the MLP was
+    # trained in); falls back to the dataset score precedence for a legacy
+    # detector with no persisted primary.
+    primary = (det_data or {}).get("primary_embedder", "") or ""
+    results = score_media_with_model(mlp, snap, embedder_name=primary or None)
     update_find_progress(
         "running",
         f"Scoring {n_total} items…",
@@ -619,19 +623,40 @@ def auto_detect(body: dict):
     from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
     from vtscore.state.core import get_active_context  # noqa: PLC0415
 
-    all_ids, all_embs = get_embedding_matrix_for_snap(snap, get_active_context().routed_embedder("score"))
-    X_all = torch.from_numpy(all_embs)
+    # Each detector scores in its own primary embedder space, so build one
+    # matrix per distinct embedder the Auto-Find detectors call for (collapsing
+    # to a single shared matrix on the common single-embedder dataset, where
+    # every primary resolves to the same name).  A detector with no persisted
+    # primary falls back to the dataset score precedence.
+    default_score = get_active_context().routed_embedder("score")
+    det_embedders: dict[str, str | None] = {}
+    for dname, ddata, _entry in detectors_to_run:
+        primary = (ddata.get("primary_embedder", "") or "") if ddata else ""
+        det_embedders[dname] = primary or default_score
+    matrices: dict[str | None, tuple[list[int], Any]] = {}
+    for emb in set(det_embedders.values()):
+        ids, embs = get_embedding_matrix_for_snap(snap, emb)
+        matrices[emb] = (ids, torch.from_numpy(embs))
 
-    embed_dim = int(all_embs.shape[1]) if all_embs.ndim > 1 else 0
+    default_ids, default_X = matrices[default_score]
+    embed_dim = int(default_X.shape[1]) if default_X.ndim > 1 else 0
     worker_cap = cap_workers_by_memory(
-        len(all_ids),
+        len(default_ids),
         embed_dim,
         max_workers=min(len(detectors_to_run), 8),
     )
     results: dict[str, dict] = {}
     with ThreadPoolExecutor(max_workers=worker_cap) as pool:
         futures = [
-            pool.submit(_score_detector_for_auto_detect, name, data, entry, media_type, snap, all_ids, X_all)
+            pool.submit(
+                _score_detector_for_auto_detect,
+                name,
+                data,
+                entry,
+                media_type,
+                snap,
+                *matrices[det_embedders[name]],
+            )
             for name, data, entry in detectors_to_run
         ]
         for future in futures:

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -109,6 +109,10 @@ class _DetectorSummarySchema(Schema):
     examples = fields.List(fields.Dict())
     num_labels = fields.Integer(required=True)
     created_at = fields.Float(required=True)
+    # The detector's primary embedder (the vector space it trains/scores in),
+    # chosen at create time.  Empty for a legacy detector (resolved at first
+    # train).  See patch-embedder.md → "Per-detector primary embedder".
+    primary_embedder = fields.String()
 
 
 class DetectorsListResponseSchema(Schema):
@@ -138,6 +142,7 @@ class DetectorDetailSchema(Schema):
     media_type = fields.String()
     examples = fields.List(fields.Dict())
     created_at = fields.Float()
+    primary_embedder = fields.String()
     labelset = fields.Nested(_LabelSetSchema)
     combined_from = fields.List(fields.String())
 
@@ -161,6 +166,11 @@ class DetectorCreateRequestSchema(Schema):
     text_query = fields.String(load_default="")
     media_example = fields.String(load_default="")
     examples = fields.List(fields.Dict(), load_default=None, allow_none=True)
+    # The detector's primary embedder (its scoring vector space).  Empty lets
+    # the server pick: the sole embedder on a single-embedder dataset, or a 400
+    # on a multi-embedder dataset (the client must choose).  A concrete name is
+    # validated against the active dataset's bound embedders.
+    primary_embedder = fields.String(load_default="")
 
 
 class DetectorCreateResponseSchema(Schema):
@@ -287,6 +297,10 @@ class DetectorRegistryEntrySchema(Schema):
     # load the detector.  Loaded contexts override the persisted value
     # when present.  Empty string for detectors that have never trained.
     embedder = fields.String()
+    # The detector's per-detector primary embedder (its scoring vector space),
+    # chosen at create time and persisted on the detector JSON.  See
+    # patch-embedder.md → "Per-detector primary embedder".
+    primary_embedder = fields.String()
 
     class Meta:
         # Registry entries may carry extension keys (e.g. future per-row
@@ -314,6 +328,11 @@ class DetectorRegistryCreateRequestSchema(Schema):
     media_example = fields.String(load_default="")
     trainable = fields.Boolean(load_default=False)
     examples = fields.List(fields.Dict(), load_default=None, allow_none=True)
+    # The detector's primary embedder (its scoring vector space).  Empty lets
+    # the server pick (sole embedder on a single-embedder dataset, else 400 on a
+    # multi-embedder dataset).  Validated against the active dataset's bound
+    # embedders.  See patch-embedder.md → "Per-detector primary embedder".
+    primary_embedder = fields.String(load_default="")
 
 
 class DetectorRegistryCreateResponseSchema(Schema):


### PR DESCRIPTION
## What

Implements the **per-detector primary embedder**: each detector picks one embedder (its scoring vector space) at create time and trains/scores in that space, overriding the dataset-level V3 score precedence (structural ▸ patch ▸ text) for that detector's operations. (This PR started as the docs-only design and now carries the full implementation.)

## Why

Shipped V3 resolves the scoring space at the **dataset** level, so *every* detector on a dataset scores in the same space. On a multi-embedder (trio) dataset that defeats the point — a "find this exact logo" detector wants the structural embedder; a "sunset mood" detector wants text/patch. The choice now lives on the **detector**.

## How

- **Persisted as a name** on the detector JSON (`primary_embedder`) — no vectors/MLPs persisted (CLAUDE.md-compliant). Resolved + validated at create time against the active dataset's bound embedders (`resolve_detector_primary`): empty auto-resolves the sole embedder on a single-embedder dataset, is rejected on a multi-embedder one; a concrete name must be bound.
- **One resolver, `keying_embedder_for_snap(det_ctx, snap)`**, drives every detector-scoped path: the detector's primary **when the active dataset supplies it**, else the dataset score precedence. Behind `detector_score_embedder` (vote-driven train/score, `_build_vote_xy`, `_score_all_media`), the labelset embed path, the cold-train path (`model_loading`), Find scoring, Auto-Find (one matrix per distinct keyed embedder), and the cache-invalidation / re-embed comparisons.
- **Region max-pool is gated on the patch slot**, so a text-primary detector on a text+patch dataset scores text full-image vectors, not the patch tree.
- **Text sort is unaffected** — always routes to the dataset's `text` slot.
- **Frontend**: the new-detector modal shows a **Detector Embedder** picker (with the license-notice chip) only when the active dataset binds more than one embedder.

## Deliberate deviation from the design

The design said `DetectorContext.embedder` *becomes* the authoritative primary. Instead, a **separate immutable** `DetectorContext.primary_embedder` (from the JSON) was added, keeping `DetectorContext.embedder` as the *adaptive cache-space marker* it already was. Collapsing them would have removed the cross-embedder portability the V3 cross-embedder-switch work relies on (a detector on a dataset that lacks its primary must re-embed its labelset against that dataset's space). `keying_embedder_for_snap` falls back to the precedence exactly when the dataset can't supply the primary, so **single-embedder datasets and every existing detector are byte-for-byte unchanged** (empty primary → pure precedence). Documented in the plan's "What shipped" / "Open follow-ups".

## Tests

New library-tier (`tests_lib/detectors/test_per_detector_primary.py`) covering `keying_embedder_for_snap`, `detector_score_embedder`, the region gate, and `resolve_detector_primary`; new app-tier (`tests/detectors/test_per_detector_primary.py`) covering create validation/persistence and reload onto `DetectorContext.primary_embedder`. The existing cross-embedder-switch suite passes unchanged. OpenAPI snapshot regenerated. Full `./run-tests.sh` green (5169 Python + 860 Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KdUuHLD5zKWa58egWWMA