### PR TITLE
Apply Clipper during demo-dataset import (with params)

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -230,6 +230,14 @@ POST /api/dataset/load-demo
 
 **Body:** `{"name": "esc50_animals"}`
 
+Optional fields: `embedder`, `clipper`, `clipper_params`, `converter`,
+`dataset_name`, `build_projection`. When `clipper` names a real (non-default)
+clipper, every loaded media is split into sub-clips at load time and the clips
+are re-embedded; `clipper_params` (e.g. `{"duration": 5.0}`) overrides the
+clipper's defaults. The pre-selected default clipper for a media type is a
+no-op. Clipped clips inherit their parent media's category. Example:
+`{"name": "tut_sound_events_2017_a", "clipper": "sound_tiling", "clipper_params": {"duration": 5.0}}`.
+
 → `{"ok": true, "message": "Loading started"}`
 
 **From importer:**

--- a/docs/plans/clipper-chain.md
+++ b/docs/plans/clipper-chain.md
@@ -271,3 +271,37 @@ describe only the last clipper step. A chain of two clippers (e.g.
 unless the consumer reads `clipper_chain`. Phase 4 will replace the
 legacy keys; for Phase 1 this is acceptable because the resolver uses
 the JSON trail.
+
+## Demo-dataset clipping (GUI) — shipped
+
+The demo importer already exposed a clipper "Details" button in the picker,
+but `load_demo_dataset` only recorded the chosen clipper name in the pickle
+meta and never applied it. It now runs the selected clipper (with params) at
+load time via the shared `_apply_clipper` machinery, so clips inherit their
+parent's category and are re-embedded with the demo's embedder. The demo path
+sends `clipper` + `clipper_params` only when the pick is a real (non-default)
+clipper — `_effective_clipper` (backend) and `effectiveDemoClipper()`
+(frontend) share the "default = empty / `*_default` / first-in-list" rule so
+the pre-selected default stays a no-op. The single per-dataset pickle records
+the effective clipper + params; a later load with a different clipper/params
+rebuilds it. Motivating case: the long-form `tut_sound_events_2017_*` demos,
+which are meant to be cut by hand.
+
+### Open follow-ups (demo clipping)
+
+- **Params-blind status.** `GET /api/dataset/demo-list` only receives the
+  clipper *name*, so a params-only change (e.g. `duration` 2→5 on the same
+  clipper) shows "ready" until the load itself detects the drift and rebuilds.
+  Making status params-aware means threading `clipper_params` to the status
+  endpoint and into `_downgrade_for_mismatch`.
+- **One cached config.** Only a single pickle is kept per demo dataset, so
+  switching clipper/params re-embeds rather than caching each config (mirrors
+  the existing embedder-mismatch behaviour). A clipper-signature cache key
+  (like the converter's `{name}__{converter}`) would cache multiple configs at
+  the cost of status accuracy.
+- **Origin reload.** Each clip's `origin.params` carries the clipper trail, but
+  the demo importer's `reload_from_origin` only restores `name`/`converter`,
+  not the clipper. Saved clipped demos work (their clip bytes ride in the
+  pickle); re-deriving a single clip purely from its origin would not re-clip.
+- **Multi-embedder trio.** When the create-time embedder trio is used, clip
+  re-embedding uses the primary embedder only.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1105,6 +1105,13 @@
             "default": "",
             "type": "string"
           },
+          "clipper_params": {
+            "additionalProperties": {},
+            "default": null,
+            "description": "Optional parameter overrides for `clipper` (e.g. `{\"duration\": 5.0}`). Only applied when `clipper` names a real, non-default clipper.",
+            "nullable": true,
+            "type": "object"
+          },
           "converter": {
             "default": "",
             "type": "string"

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1009,13 +1009,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
       embedder?: string;
       embedders?: string[];
       clipper?: string;
+      clipper_params?: Record<string, number | string>;
       dataset_name?: string;
       build_projection?: boolean;
     };
-    const params: Record<string, string | string[]> = {};
+    const params: Record<string, string | string[] | Record<string, number | string>> = {};
     if (extras.embedder) params['embedder'] = extras.embedder;
     if (extras.embedders && extras.embedders.length > 0) params['embedders'] = extras.embedders;
-    if (extras.clipper) params['clipper'] = extras.clipper;
+    if (extras.clipper) {
+      params['clipper'] = extras.clipper;
+      if (extras.clipper_params && Object.keys(extras.clipper_params).length > 0) {
+        params['clipper_params'] = extras.clipper_params;
+      }
+    }
     const userName = (extras.dataset_name || '').trim();
     if (userName) params['dataset_name'] = userName;
     if (extras.build_projection) params['build_projection'] = 'true';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -71,7 +71,7 @@
             (selectedStructuralEmbedderChange)="selectedDemoStructuralEmbedder.set($event)"
             [lockedEmbedder]="lockedEmbedderFor(activeTab(), demoEmbedders())"
             [selectedClipper]="selectedDemoClipper()"
-            [selectedClipperParams]="{}"
+            [selectedClipperParams]="demoClipperParamValues()"
             (clipperChooserRequested)="openClipperChooser('demo')"
             [buildProjection]="buildProjection"
             (buildProjectionChange)="buildProjection = $event"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -91,6 +91,7 @@ export class DatasetImporterModalComponent implements OnInit {
   demoEmbedder = '';
   readonly demoClippers = signal<ClipperInfo[]>([]);
   readonly selectedDemoClipper = signal('');
+  readonly demoClipperParamValues = signal<Record<string, number | string>>({});
   /** Optional user-supplied dataset name for demo imports.  Empty means
    *  "use the demo entry's label". */
   demoDatasetName = '';
@@ -1022,6 +1023,7 @@ export class DatasetImporterModalComponent implements OnInit {
       this.selectedDemoEmbedder.set('');
       this.demoClippers.set([]);
       this.selectedDemoClipper.set('');
+      this.demoClipperParamValues.set({});
       return;
     }
     this.datasetsListingsApi.getEmbedders(mediaType).subscribe({
@@ -1033,7 +1035,7 @@ export class DatasetImporterModalComponent implements OnInit {
         // The initial demo fetch had no embedder/clipper context, so re-fetch
         // with the now-known defaults for authoritative status values.
         if (this.selectedDemoEmbedder()) {
-          this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.selectedDemoClipper());
+          this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.effectiveDemoClipper());
         }
       },
     });
@@ -1041,21 +1043,34 @@ export class DatasetImporterModalComponent implements OnInit {
       next: (clippers) => {
         this.demoClippers.set(clippers);
         this.selectedDemoClipper.set(clippers.length > 0 ? clippers[0].name : '');
+        this.demoClipperParamValues.set({});
       },
     });
+  }
+
+  /** The demo clipper the user actually chose, or ``''`` when it is the
+   *  pre-selected no-op default.  Mirrors the backend's
+   *  ``_effective_clipper`` and the form path's ``isDefaultClipper`` rule so
+   *  status checks and the load request agree on when clipping happens. */
+  private effectiveDemoClipper(): string {
+    const name = this.selectedDemoClipper();
+    const clippers = this.demoClippers();
+    const isDefault =
+      !name || name.endsWith('_default') || (clippers.length > 0 && clippers[0].name === name);
+    return isDefault ? '' : name;
   }
 
   onDemoEmbedderChange(embedder: string): void {
     this.selectedDemoEmbedder.set(embedder);
     this.demoEmbedder = embedder;
     this.updateDemoStatuses();
-    this.refetchDemoStatuses(embedder, this.selectedDemoClipper());
+    this.refetchDemoStatuses(embedder, this.effectiveDemoClipper());
   }
 
   onDemoClipperChange(clipper: string): void {
     this.selectedDemoClipper.set(clipper);
     this.updateDemoStatuses();
-    this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.selectedDemoClipper());
+    this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.effectiveDemoClipper());
   }
 
   /**
@@ -1069,7 +1084,7 @@ export class DatasetImporterModalComponent implements OnInit {
    */
   private updateDemoStatuses(): void {
     const emb = this.selectedDemoEmbedder();
-    const clip = this.selectedDemoClipper();
+    const clip = this.effectiveDemoClipper();
     for (const demo of this.demos()) {
       if (demo.media_type !== this.activeTab()) continue;
       if (demo.status === 'needs_download') continue;
@@ -1260,11 +1275,12 @@ export class DatasetImporterModalComponent implements OnInit {
       this.selectedDemoPatchEmbedder(),
       this.selectedDemoStructuralEmbedder(),
     );
+    const effClipper = this.effectiveDemoClipper();
     this.demoSelected.emit({
       ...demo,
       embedder: this.selectedDemoEmbedder(),
       ...(demoEmbedders ? { embedders: demoEmbedders } : {}),
-      clipper: this.selectedDemoClipper(),
+      ...(effClipper ? { clipper: effClipper, clipper_params: { ...this.demoClipperParamValues() } } : {}),
       dataset_name: userName,
       build_projection: this.buildProjection,
     } as any);
@@ -2016,8 +2032,9 @@ export class DatasetImporterModalComponent implements OnInit {
       this.clipperParamValues.set({ ...selection.params });
     } else if (ctx === 'demo') {
       this.selectedDemoClipper.set(selection.name);
+      this.demoClipperParamValues.set({ ...selection.params });
       this.updateDemoStatuses();
-      this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.selectedDemoClipper());
+      this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.effectiveDemoClipper());
     } else if (ctx === 'sf') {
       this.sfSelectedClipper.set(selection.name);
       this.sfClipperParamValues.set({ ...selection.params });
@@ -2039,8 +2056,9 @@ export class DatasetImporterModalComponent implements OnInit {
       this.resetClipperParams();
     } else if (ctx === 'demo') {
       this.selectedDemoClipper.set(defaultName);
+      this.demoClipperParamValues.set({});
       this.updateDemoStatuses();
-      this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.selectedDemoClipper());
+      this.refetchDemoStatuses(this.selectedDemoEmbedder(), this.effectiveDemoClipper());
     } else if (ctx === 'sf') {
       this.sfSelectedClipper.set(defaultName);
       this.sfResetClipperParams();

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -127,7 +127,10 @@ export class DatasetsCrudApiService {
     return this.http.post<DatasetLoadStartedResponse>('/api/dataset/import-local-files', formData);
   }
 
-  loadDemo(name: string, params?: Record<string, string | string[]>): Observable<DatasetLoadStartedResponse> {
+  loadDemo(
+    name: string,
+    params?: Record<string, string | string[] | Record<string, number | string>>,
+  ): Observable<DatasetLoadStartedResponse> {
     const body: DatasetLoadDemoRequest = { name, ...params };
     return loadDemoDatasetRoute(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));
   }

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1038,6 +1038,173 @@ class TestDemoCacheEmbedderMismatch:
         assert 1 in medias
 
 
+class TestEffectiveClipper:
+    """`_effective_clipper` normalises the pre-selected default clipper to ''."""
+
+    def test_empty_and_default_normalise_to_blank(self):
+        from vtscore.datasets.loader_demo import _effective_clipper
+
+        assert _effective_clipper("", "audio") == ""
+        # sound_default ends with _default → the explicit "import as-is" no-op.
+        assert _effective_clipper("sound_default", "audio") == ""
+
+    def test_first_clipper_in_list_is_treated_as_default(self):
+        from vtscore.datasets.loader_demo import _effective_clipper
+        from vtscore.media import clippers_for_type
+
+        first = clippers_for_type("audio")[0].name
+        assert _effective_clipper(first, "audio") == ""
+
+    def test_real_clipper_passes_through(self):
+        from vtscore.datasets.loader_demo import _effective_clipper
+
+        assert _effective_clipper("sound_tiling", "audio") == "sound_tiling"
+
+
+class TestDemoClipperApplied:
+    """A real (non-default) clipper selected for a demo is actually applied at
+    load time, with its params and the demo's embedder; the default is a no-op."""
+
+    FAKE_INFO = {
+        "media_type": "audio",
+        "source": "fake",
+        "categories": ["a"],
+        "slice_start": 0,
+        "slice_end": None,
+    }
+
+    def _run(self, tmp_path, clipper_name, clipper_params=None):
+        from unittest.mock import MagicMock, patch
+
+        from vtscore.datasets.loader import load_demo_dataset
+
+        embeddings_dir = tmp_path / "embeddings"
+        embeddings_dir.mkdir()
+
+        fake_embedder = MagicMock()
+        fake_embedder.name = "clap"
+
+        mock_mt = MagicMock()
+        mock_mt.dir_key = "audio_dir"
+
+        def fake_load(**kwargs):
+            clips = kwargs["clips"]
+            clips[1] = {"id": 1, "media_type": "audio", "category": "a", "embeddings": {}}
+            return "/fake/dir"
+
+        mock_mt.load_demo_source.side_effect = fake_load
+
+        demo_name = "fake_audio_demo"
+        medias: dict = {}
+        with (
+            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: self.FAKE_INFO}),
+            patch("vtscore.media.embedders_for_type", return_value=[fake_embedder]),
+            patch("vtscore.media.get", return_value=mock_mt),
+            patch("vtscore.datasets.stages.clipper._apply_clipper") as mock_clip,
+        ):
+            load_demo_dataset(demo_name, medias, clipper_name=clipper_name, clipper_params=clipper_params)
+        return mock_clip, fake_embedder
+
+    def test_real_clipper_is_applied_with_params_and_embedder(self, tmp_path):
+        mock_clip, fake_embedder = self._run(
+            tmp_path, "sound_tiling", clipper_params={"duration": 5.0}
+        )
+        mock_clip.assert_called_once()
+        args, kwargs = mock_clip.call_args
+        # _apply_clipper(medias, name, params, on_progress=..., embedder=...)
+        assert args[1] == "sound_tiling"
+        assert args[2] == {"duration": 5.0}
+        assert kwargs["embedder"] is fake_embedder
+
+    def test_default_clipper_is_a_noop(self, tmp_path):
+        from vtscore.media import clippers_for_type
+
+        first = clippers_for_type("audio")[0].name
+        mock_clip, _ = self._run(tmp_path, first)
+        mock_clip.assert_not_called()
+
+
+class TestDemoCacheClipperMismatch:
+    """The pickle cache is rebuilt when the requested clipper / params differ
+    from the cached one, and reused when they match."""
+
+    def _write_cache(self, embeddings_dir, demo_name, clipper, clipper_params):
+        import pickle
+
+        from vtscore.datasets.container import write_container
+
+        pkl_file = embeddings_dir / f"{demo_name}.pkl"
+        pkl_bytes = pickle.dumps({"name": demo_name, "medias": {1: {"embedding": [0.1]}}})
+        write_container(
+            pkl_file,
+            pkl_bytes,
+            {
+                "format_version": 1,
+                "embedder": "clap",
+                "clipper": clipper,
+                "clipper_params": clipper_params,
+                "media_type": "audio",
+            },
+        )
+
+    def test_clipper_param_change_busts_cache(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from vtscore.datasets.loader import load_demo_dataset
+
+        embeddings_dir = tmp_path / "embeddings"
+        embeddings_dir.mkdir()
+        demo_name = "fake_audio_demo"
+        self._write_cache(embeddings_dir, demo_name, "sound_tiling", {"duration": 2.0})
+
+        fake_embedder = MagicMock()
+        fake_embedder.name = "clap"
+        mock_mt = MagicMock()
+        mock_mt.dir_key = "audio_dir"
+        mock_mt.load_demo_source.return_value = "/fake/dir"
+
+        with (
+            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: TestDemoClipperApplied.FAKE_INFO}),
+            patch("vtscore.media.embedders_for_type", return_value=[fake_embedder]),
+            patch("vtscore.media.get", return_value=mock_mt),
+            patch("vtscore.datasets.stages.clipper._apply_clipper"),
+        ):
+            load_demo_dataset(
+                demo_name, {}, clipper_name="sound_tiling", clipper_params={"duration": 5.0}
+            )
+            # Param drift → cache discarded → re-embed via load_demo_source.
+            mock_mt.load_demo_source.assert_called_once()
+
+    def test_matching_clipper_uses_cache(self, tmp_path):
+        from unittest.mock import patch
+
+        import numpy as np
+
+        from vtscore.datasets.loader import load_demo_dataset
+
+        embeddings_dir = tmp_path / "embeddings"
+        embeddings_dir.mkdir()
+        demo_name = "fake_audio_demo"
+        self._write_cache(embeddings_dir, demo_name, "sound_tiling", {"duration": 2.0})
+
+        def fake_load(path, m):
+            m[1] = {"embedding": np.array([0.1]), "media_type": "audio"}
+
+        with (
+            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: TestDemoClipperApplied.FAKE_INFO}),
+            patch("vtscore.datasets.loader.load_dataset_from_pickle", side_effect=fake_load),
+        ):
+            medias: dict = {}
+            load_demo_dataset(
+                demo_name, medias, clipper_name="sound_tiling", clipper_params={"duration": 2.0}
+            )
+
+        assert 1 in medias
+
+
 class TestCaltech101Download:
     """Verify download_caltech101 handles the nested zip→tar.gz structure."""
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1107,9 +1107,7 @@ class TestDemoClipperApplied:
         return mock_clip, fake_embedder
 
     def test_real_clipper_is_applied_with_params_and_embedder(self, tmp_path):
-        mock_clip, fake_embedder = self._run(
-            tmp_path, "sound_tiling", clipper_params={"duration": 5.0}
-        )
+        mock_clip, fake_embedder = self._run(tmp_path, "sound_tiling", clipper_params={"duration": 5.0})
         mock_clip.assert_called_once()
         args, kwargs = mock_clip.call_args
         # _apply_clipper(medias, name, params, on_progress=..., embedder=...)
@@ -1171,9 +1169,7 @@ class TestDemoCacheClipperMismatch:
             patch("vtscore.media.get", return_value=mock_mt),
             patch("vtscore.datasets.stages.clipper._apply_clipper"),
         ):
-            load_demo_dataset(
-                demo_name, {}, clipper_name="sound_tiling", clipper_params={"duration": 5.0}
-            )
+            load_demo_dataset(demo_name, {}, clipper_name="sound_tiling", clipper_params={"duration": 5.0})
             # Param drift → cache discarded → re-embed via load_demo_source.
             mock_mt.load_demo_source.assert_called_once()
 
@@ -1198,9 +1194,7 @@ class TestDemoCacheClipperMismatch:
             patch("vtscore.datasets.loader.load_dataset_from_pickle", side_effect=fake_load),
         ):
             medias: dict = {}
-            load_demo_dataset(
-                demo_name, medias, clipper_name="sound_tiling", clipper_params={"duration": 2.0}
-            )
+            load_demo_dataset(demo_name, medias, clipper_name="sound_tiling", clipper_params={"duration": 2.0})
 
         assert 1 in medias
 

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -443,7 +443,7 @@ class TestApplyClipperBackwardsCompat:
 
         calls: dict[str, int] = {"fixup": 0, "thumb": 0}
 
-        def fake_fixup(clips, recompute, media_type, on_progress=None):
+        def fake_fixup(clips, recompute, media_type, on_progress=None, embedder=None):
             calls["fixup"] += 1
 
         def fake_thumb(clips, recompute, media_type):

--- a/vtscore/datasets/importers/demo/__init__.py
+++ b/vtscore/datasets/importers/demo/__init__.py
@@ -90,6 +90,7 @@ class DemoDatasetImporter(ImporterBase):
         embedder_name = field_values.get("embedder", "") or ""
         converter_name = field_values.get("converter", "") or ""
         clipper_name = field_values.get("clipper", "") or ""
+        clipper_params = field_values.get("clipper_params") or None
 
         load_demo_dataset(
             dataset_name,
@@ -97,6 +98,7 @@ class DemoDatasetImporter(ImporterBase):
             embedder_name=embedder_name,
             converter_name=converter_name,
             clipper_name=clipper_name,
+            clipper_params=clipper_params,
         )
 
     def origin_display(self, origin: dict[str, Any]) -> str:

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -24,6 +24,30 @@ from vtscore.datasets.loader import (
 )
 
 
+def _effective_clipper(clipper_name: str, media_type_id: str) -> str:
+    """Return *clipper_name* if it is a real (non-default) clipper, else ``""``.
+
+    The demo UI always sends *a* clipper name (the first one in the
+    media-type's list is pre-selected), but the conventional "default"
+    choice is a no-op that should not split the media.  Mirrors the
+    frontend's ``isDefaultClipper`` rule so that the two sides agree on
+    when clipping actually happens: a clipper is a no-op when it is empty,
+    ends with ``_default``, or is the first clipper registered for the
+    media type (the pre-selected default).  Normalising to ``""`` here also
+    means legacy pickles that recorded the pre-selected default name (e.g.
+    ``"sound_auto"``) compare equal to "no clipper" and don't trigger a
+    needless re-embed.
+    """
+    if not clipper_name or clipper_name.endswith("_default"):
+        return ""
+    from vtscore.media import clippers_for_type  # noqa: PLC0415
+
+    clippers = clippers_for_type(media_type_id)
+    if clippers and clippers[0].name == clipper_name:
+        return ""
+    return clipper_name
+
+
 def _stamp_demo_origin(
     medias: dict[int, dict[str, Any]],
     dataset_name: str,
@@ -72,6 +96,7 @@ def load_demo_dataset(  # noqa: C901
     embedder_name: str = "",
     converter_name: str = "",
     clipper_name: str = "",
+    clipper_params: dict[str, Any] | None = None,
 ) -> None:
     """Load a named demo dataset into the medias dict, downloading and embedding as needed.
 
@@ -102,8 +127,14 @@ def load_demo_dataset(  # noqa: C901
         converter_name: Optional name of a converter (e.g. ``"video2image"``).
             When given, the demo is loaded in its native type and then
             converted.
-        clipper_name: Optional name of a registered clipper.  Recorded in
-            the container metadata for status tracking.
+        clipper_name: Optional name of a registered clipper.  When it names
+            a real (non-default) clipper, every loaded media is split into
+            sub-clips via the shared clipper machinery and the clips are
+            re-embedded; the clipped clips inherit their parent's category
+            (and other metadata) by construction.  Recorded in the container
+            metadata so a later load with a different clipper re-derives.
+        clipper_params: Optional parameter overrides for *clipper_name*
+            (e.g. ``{"duration": 5.0}`` for a tiling clipper).
 
     Raises:
         ValueError: If ``dataset_name`` is not in ``DEMO_DATASETS``, or if the
@@ -135,8 +166,21 @@ def load_demo_dataset(  # noqa: C901
 
         cached_meta = read_meta(pkl_file)
         cached_embedder = cached_meta.get("embedder") or ""
-        if embedder_name and cached_embedder and embedder_name != cached_embedder:
-            on_progress("loading", f"Re-embedding {dataset_name} with {embedder_name}...", 0, 0)
+        embedder_mismatch = bool(embedder_name) and bool(cached_embedder) and embedder_name != cached_embedder
+        # A cached pickle built with a different clipper (or different clipper
+        # params) no longer reflects the requested split, so rebuild it.  Both
+        # names are normalised through _effective_clipper so the pre-selected
+        # default ("" vs e.g. "sound_auto") never counts as a mismatch.
+        requested_clipper = _effective_clipper(clipper_name, media_type_id)
+        cached_clipper = _effective_clipper(cached_meta.get("clipper") or "", media_type_id)
+        requested_params = clipper_params or {}
+        cached_params = cached_meta.get("clipper_params") or {}
+        clipper_mismatch = requested_clipper != cached_clipper or (
+            bool(requested_clipper) and requested_params != cached_params
+        )
+        if embedder_mismatch or clipper_mismatch:
+            reason = f"with {embedder_name}" if embedder_mismatch else "with new clipper"
+            on_progress("loading", f"Re-embedding {dataset_name} {reason}...", 0, 0)
             pkl_file.unlink()
         else:
             on_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
@@ -212,16 +256,51 @@ def load_demo_dataset(  # noqa: C901
             on_progress=on_progress,
         )
 
+    # --- Apply clipper if requested ---
+    # Splits each loaded media into sub-clips (re-embedding them) via the same
+    # machinery the regular import pipeline uses, so clips inherit their
+    # parent's category/metadata.  Skipped for the pre-selected default
+    # clipper (a no-op).  Runs after any converter so it operates on the
+    # final media type.
+    clipper_applied = bool(_effective_clipper(clipper_name, media_type_id))
+    if clipper_applied:
+        from vtscore.datasets.stages.clipper import _apply_clipper
+
+        def _clip_progress(current: int, total: int, phase: str) -> None:
+            if phase == "clipping":
+                msg = "Clipping media…"
+            elif phase == "converting":
+                msg = "Converting media…"
+            elif phase == "embedding":
+                msg = "Embedding clips…"
+            else:
+                # A loading/warmup message forwarded verbatim from the embedder.
+                msg = phase
+            on_progress("loading", msg, current, total)
+
+        _clip_progress(0, 0, "clipping")
+        _apply_clipper(
+            medias,
+            _effective_clipper(clipper_name, media_type_id),
+            clipper_params,
+            on_progress=_clip_progress,
+            embedder=embedder,
+        )
+
     # Build the pickle cache payload
     # For types with external media dirs (audio, video), exclude media_bytes
     # from the pickle and store the dir path so reloading can find the files.
     # When a converter was applied, external_dir is no longer relevant (the
-    # converted medias carry their own bytes/strings).
+    # converted medias carry their own bytes/strings).  Likewise when a clipper
+    # split the media: each clip is a *slice* of its source file, not the whole
+    # file the external dir resolves by name, so its bytes must ride in the
+    # pickle (dataset pickles are the one place persisted bytes are allowed).
     # Local import avoids a circular import at module load (loader imports
     # loader_demo before this helper is defined).
     from vtscore.datasets.loader import _embeddings_dict_for_pickle
 
-    if external_dir is not None and not converter_name:
+    store_external = external_dir is not None and not converter_name and not clipper_applied
+    if store_external:
         pkl_data: dict[str, Any] = {
             "name": dataset_name,
             "medias": {
@@ -254,14 +333,18 @@ def load_demo_dataset(  # noqa: C901
 
     resolved_name = getattr(embedder, "name", "") if embedder is not None else ""
     extra_pickle_keys: dict[str, Any] = {}
-    if external_dir is not None and not converter_name:
+    if store_external:
         extra_pickle_keys[mt.dir_key] = external_dir
 
     medias_pkl_bytes = pickle.dumps(pkl_data, protocol=5)
     meta = {
         "format_version": 1,
         "embedder": resolved_name,
-        "clipper": clipper_name,
+        # Store the *effective* clipper (normalised default -> "") plus its
+        # params so a later load can tell whether the cache still matches the
+        # requested split.
+        "clipper": _effective_clipper(clipper_name, media_type_id),
+        "clipper_params": (clipper_params or {}) if clipper_applied else {},
         "media_type": media_type_id,
         "name": dataset_name,
     }

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -26,6 +26,7 @@ def _apply_clipper(  # noqa: C901
     clipper_params: dict | None = None,
     on_progress: Callable[[int, int, str], None] | None = None,
     chain_steps: list[dict] | None = None,
+    embedder=None,
 ) -> None:
     """Apply a clipper (or full chain) to all medias in *clips_dict*, in place.
 
@@ -52,6 +53,12 @@ def _apply_clipper(  # noqa: C901
     Args:
         on_progress: Optional callback ``(current, total, phase)`` invoked
             during clipping and re-embedding so callers can report progress.
+        embedder: Optional embedder used to re-embed the produced clips.
+            When ``None`` (the default), the first registered embedder for
+            the final media type is used.  Callers that loaded the parent
+            media with a specific embedder (e.g. the demo loader honouring a
+            user-chosen embedder) pass it here so clips are embedded with the
+            same model the parents were.
     """
     from vtscore.datasets.clipper_chain import apply_chain_to_clips, normalise_chain
 
@@ -116,7 +123,7 @@ def _apply_clipper(  # noqa: C901
     final_type, needs_recompute = result
 
     clips_list = list(clips_dict.values())
-    _fixup_clip_md5_and_embeddings(clips_list, needs_recompute, final_type, on_progress=on_progress)
+    _fixup_clip_md5_and_embeddings(clips_list, needs_recompute, final_type, on_progress=on_progress, embedder=embedder)
     _regenerate_clip_thumbnails(clips_list, needs_recompute, final_type)
 
     # Update `media_type` on every clip so downstream code sees the final type
@@ -278,6 +285,7 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
     needs_recompute: list[bool],
     media_type: str,
     on_progress: Callable[[int, int, str], None] | None = None,
+    embedder=None,
 ) -> None:
     """Recompute MD5 and embeddings for clips that need it.
 
@@ -341,7 +349,7 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
     if on_progress:
         on_progress(0, total_clips, "embedding")
 
-    embedder = _resolve_clip_embedder(media_type)
+    embedder = embedder or _resolve_clip_embedder(media_type)
     if embedder is None:
         return
 

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -331,6 +331,22 @@ def import_local_files():
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
 
+def _apply_demo_media_type_fields(field_values: dict, converter_name: str, demo_info: dict) -> None:
+    """Set ``media_type`` (and ``converter``) on *field_values* for a demo load.
+
+    With a converter the resulting dataset has the converter's *target* type,
+    not the demo's original type; without one it keeps the demo's native type.
+    """
+    if not converter_name:
+        field_values["media_type"] = demo_info.get("media_type", "")
+        return
+    from vtscore.converters import get_converter  # noqa: PLC0415
+
+    conv = get_converter(converter_name)
+    field_values["media_type"] = conv.target_type if conv is not None else demo_info.get("media_type", "")
+    field_values["converter"] = converter_name
+
+
 @datasets_load_bp.route("/api/dataset/load-demo", methods=["POST"])
 @datasets_load_bp.arguments(DatasetLoadDemoRequestSchema)
 @datasets_load_bp.response(200, DatasetLoadStartedResponseSchema)
@@ -366,19 +382,7 @@ def load_demo_dataset_route(body: dict):
         field_values["build_projection"] = "true"
     # Inject media_type so the loading task exposes it to the frontend,
     # allowing the "guessed type" logic to consider in-progress loads.
-    if converter_name:
-        # When a converter is used, the resulting dataset has the converter's
-        # target type, not the demo's original type.
-        from vtscore.converters import get_converter  # noqa: PLC0415
-
-        conv = get_converter(converter_name)
-        if conv is not None:
-            field_values["media_type"] = conv.target_type
-        else:
-            field_values["media_type"] = demo_info.get("media_type", "")
-        field_values["converter"] = converter_name
-    else:
-        field_values["media_type"] = demo_info.get("media_type", "")
+    _apply_demo_media_type_fields(field_values, converter_name, demo_info)
     if clipper_name:
         field_values["clipper"] = clipper_name
         if clipper_params:

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -347,6 +347,7 @@ def load_demo_dataset_route(body: dict):
     dataset_name = body.get("name")
     embedder_name = body.get("embedder", "")
     clipper_name = body.get("clipper", "")
+    clipper_params = body.get("clipper_params")
     converter_name = body.get("converter", "")
     user_dataset_name = (body.get("dataset_name") or "").strip()
 
@@ -380,6 +381,8 @@ def load_demo_dataset_route(body: dict):
         field_values["media_type"] = demo_info.get("media_type", "")
     if clipper_name:
         field_values["clipper"] = clipper_name
+        if clipper_params:
+            field_values["clipper_params"] = clipper_params
     if embedder_name:
         field_values["embedder"] = embedder_name
     demo_embedders = body.get("embedders")

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -357,7 +357,7 @@ class DatasetLoadDemoRequestSchema(Schema):
         load_default=None,
         metadata={
             "description": (
-                "Optional parameter overrides for `clipper` (e.g. `{\"duration\": 5.0}`). "
+                'Optional parameter overrides for `clipper` (e.g. `{"duration": 5.0}`). '
                 "Only applied when `clipper` names a real, non-default clipper."
             )
         },

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -353,6 +353,15 @@ class DatasetLoadDemoRequestSchema(Schema):
         },
     )
     clipper = fields.String(load_default="")
+    clipper_params = fields.Dict(
+        load_default=None,
+        metadata={
+            "description": (
+                "Optional parameter overrides for `clipper` (e.g. `{\"duration\": 5.0}`). "
+                "Only applied when `clipper` names a real, non-default clipper."
+            )
+        },
+    )
     converter = fields.String(load_default="")
     dataset_name = fields.String(load_default="")
     build_projection = fields.String(


### PR DESCRIPTION
## What & why

We added long-form audio demos (e.g. `tut_sound_events_2017_*`, "long-form audio for hands-on clipping"), but there was no way to actually clip them. The demo importer's clipper **Details** button was wired end-to-end through the UI and backend — yet `load_demo_dataset` only recorded the chosen clipper name in the pickle meta and **never applied it** (the converter, right next to it, *is* applied via `apply_converter_to_demo`). So selecting a clipper on a demo changed nothing.

This makes the existing button real: a non-default clipper picked for a demo is now run at load time via the shared `_apply_clipper` machinery. Each loaded media is split into sub-clips that **inherit their parent's category** (and other metadata) and are re-embedded. This is the `mediaX2mediaX` clipper only — converters (`mediaX2mediaY`) are untouched, since each demo is locked to its media type.

## Changes

- **`loader_demo.py`**: apply the clipper after load/convert; store clip bytes in the pickle (clips are *slices*, not whole files, so the external-dir form would break reload); record the effective clipper + params in meta and rebuild the cache when either changes (mirrors the embedder-mismatch check).
- **`stages/clipper.py`**: `_apply_clipper` / `_fixup_clip_md5_and_embeddings` accept an optional `embedder` override so clips embed with the same model the parent media did (default behaviour unchanged).
- **Default = no-op**: the demo path sends `clipper` + `clipper_params` only for a real pick. Backend `_effective_clipper` and frontend `effectiveDemoClipper()` share the *empty / `*_default` / first-in-list* rule, so the pre-selected default stays a no-op **and** legacy pickles that recorded the default name don't needlessly rebuild.
- **Params plumbing**: demo clipper-params signal + chooser wiring, request schema (`clipper_params`), route, OpenAPI snapshot, generated-client param type.
- **Tests**: clipper applied with params + embedder; default is a no-op; cache busts on clipper/param change and reuses on match; `_effective_clipper` unit tests.
- **Docs**: `docs/api/datasets.md` load-demo body; "Demo-dataset clipping (GUI) — shipped" + open follow-ups in `docs/plans/clipper-chain.md`.

## Known follow-ups (recorded in the plan file)

Params-blind demo-list status (load is authoritative and rebuilds), a single cached config per demo, no clipper in the demo `reload_from_origin` (saved clipped demos still work — clip bytes ride in the pickle), and clip re-embed uses the primary embedder when the trio is selected.

## Backwards compatibility

A previously-cached audio demo whose meta stored the old default clipper name normalises to "no clipper", so it won't rebuild. A demo cached with a *real* clipper rebuilds once if you load it with a different clipper/params — expected.

## Testing

`./run-tests.sh` — all 5148 pass (ruff, format, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, frontend build + Vitest, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZGqkqfwddi5rkoukhfzrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZGqkqfwddi5rkoukhfzrU)_