### PR TITLE
docs: refresh plans README + collapse PluginField aliases (Theme F)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -467,10 +467,9 @@ and media sources) share a common `PluginBase` / `PluginField` /
 
 1. **Base class** (`PluginBase`) defines `name`, `display_name`, `fields`,
    and an abstract `run()`/`export()`/`load()`/`save()` method.
-2. **Field dataclass** (`PluginField`, aliased as `ImporterField`,
-   `ExporterField`, `LabelImporterField`, `SettingsImporterField`, etc.)
-   describes each user-configurable input with type, label, default,
-   validation, and placeholder.
+2. **Field dataclass** (`PluginField`, re-exported by every family's base
+   module) describes each user-configurable input with type, label,
+   default, validation, and placeholder.
 3. **Auto-discovery** via `PluginRegistry` scans sub-packages using
    direct filesystem scanning for a sentinel attribute (`IMPORTER`,
    `EXPORTER`, `LABEL_IMPORTER`, `SETTINGS_IMPORTER`, `SETTINGS_EXPORTER`,

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -36,8 +36,8 @@ architecture built on two base classes in `vtscore/plugins/__init__.py`:
 ### PluginField
 
 A dataclass describing a single user-configurable input. All plugin
-families use the same field type (aliased as `ImporterField`,
-`ExporterField`, `LabelImporterField`, `SettingsImporterField`, etc.).
+families share this one field type; each family's base module re-exports
+`PluginField` so you can import it alongside the family's base class.
 
 | Parameter     | Type        | Default  | Description                                             |
 |---------------|-------------|----------|---------------------------------------------------------|
@@ -194,7 +194,7 @@ Expose a module-level `IMPORTER` instance.
 ```python
 # vtscore/datasets/importers/s3/__init__.py
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, PluginField
 from vtscore.media import all_folder_names
 
 
@@ -205,14 +205,14 @@ class S3Importer(DatasetImporter):
     icon = "☁️"
 
     fields = [
-        ImporterField(
+        PluginField(
             key="bucket",
             label="Bucket Name",
             field_type="text",
             description="The S3 bucket name.",
             required=True,
         ),
-        ImporterField(
+        PluginField(
             key="prefix",
             label="Key Prefix",
             field_type="text",
@@ -220,7 +220,7 @@ class S3Importer(DatasetImporter):
             required=False,
             default="",
         ),
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Media Type",
             field_type="select",
@@ -233,7 +233,7 @@ class S3Importer(DatasetImporter):
         """Download files from S3, then load them into the dataset.
 
         Args:
-            field_values: Maps each ImporterField.key to the user's input.
+            field_values: Maps each PluginField.key to the user's input.
                 - "file" fields arrive as werkzeug FileStorage objects.
                 - All other fields arrive as plain strings.
             medias: The global medias dict.  Populate it **in-place**; do not
@@ -537,9 +537,9 @@ fields it depends on in `depends_on`.  Then implement
 class ReCallerImporter(DatasetImporter):
     name = "recaller"
     fields = [
-        ImporterField("media_type", "Media Type", "select",
+        PluginField("media_type", "Media Type", "select",
                       options=all_folder_names(), default="audio"),
-        ImporterField(
+        PluginField(
             "query_id", "Query ID", "select",
             dynamic_options=True,
             depends_on=["media_type"],   # re-fetch when media_type changes
@@ -648,8 +648,8 @@ loops `effective_source_specs()` and calls you once per spec.
 class DXImporter(DatasetImporter):
     name = "dx"
     fields = [
-        ImporterField(key="media_type", label="Output Media Type", field_type="select", ...),
-        ImporterField(key="dataset_id", ..., required=True),
+        PluginField(key="media_type", label="Output Media Type", field_type="select", ...),
+        PluginField(key="dataset_id", ..., required=True),
     ]
 
     def fetch_source_media(self, spec, field_values, thin=False):
@@ -826,7 +826,7 @@ Subclass `LabelsetExporter` from `vtscore.exporters.base`.
 ```python
 # vtscore/exporters/sftp/__init__.py
 
-from vtscore.exporters.base import LabelsetExporter, ExporterField
+from vtscore.exporters.base import LabelsetExporter, PluginField
 
 
 class SftpLabelsetExporter(LabelsetExporter):
@@ -835,10 +835,10 @@ class SftpLabelsetExporter(LabelsetExporter):
     description = "Upload results JSON to a remote SFTP server."
     icon = "📡"
     fields = [
-        ExporterField("host", "Hostname", "text"),
-        ExporterField("user", "Username", "text"),
-        ExporterField("password", "Password", "password"),
-        ExporterField(
+        PluginField("host", "Hostname", "text"),
+        PluginField("user", "Username", "text"),
+        PluginField("password", "Password", "password"),
+        PluginField(
             "path", "Remote Path", "text",
             default="/results/autodetect.json",
         ),
@@ -861,7 +861,7 @@ class SftpLabelsetExporter(LabelsetExporter):
                         }
                     }
                 }
-            field_values: Mapping of ExporterField.key to user-supplied value.
+            field_values: Mapping of PluginField.key to user-supplied value.
 
         Returns:
             A dict with a "message" key (shown as confirmation to the user).
@@ -1001,7 +1001,7 @@ Subclass `LabelImporter` from `vtscore.labels.importers.base`. The
 ```python
 # vtscore/labels/importers/postgres/__init__.py
 
-from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
 class PostgresLabelImporter(LabelImporter):
@@ -1010,9 +1010,9 @@ class PostgresLabelImporter(LabelImporter):
     description = "Import labels from a PostgreSQL database query."
     icon = "🐘"
     fields = [
-        LabelImporterField("host", "Hostname", "text"),
-        LabelImporterField("database", "Database", "text"),
-        LabelImporterField(
+        PluginField("host", "Hostname", "text"),
+        PluginField("database", "Database", "text"),
+        PluginField(
             "query", "SQL Query", "text",
             description="Must return md5 and label columns.",
         ),
@@ -1108,7 +1108,7 @@ The `run()` method must return a dict of settings key-value pairs.
 ```python
 # vtsearch/settings_io/importers/s3/__init__.py
 
-from vtsearch.settings_io.importers.base import SettingsImporter, SettingsImporterField
+from vtsearch.settings_io.importers.base import SettingsImporter, PluginField
 
 
 class S3SettingsImporter(SettingsImporter):
@@ -1117,8 +1117,8 @@ class S3SettingsImporter(SettingsImporter):
     description = "Import settings from an S3 object."
     icon = "☁️"
     fields = [
-        SettingsImporterField("bucket", "S3 Bucket", "text"),
-        SettingsImporterField("key", "Object Key", "text"),
+        PluginField("bucket", "S3 Bucket", "text"),
+        PluginField("key", "Object Key", "text"),
     ]
 
     def run(self, field_values: dict) -> dict:
@@ -1180,7 +1180,7 @@ dict with a `"message"` key.
 ```python
 # vtsearch/settings_io/exporters/s3/__init__.py
 
-from vtsearch.settings_io.exporters.base import SettingsExporter, SettingsExporterField
+from vtsearch.settings_io.exporters.base import SettingsExporter, PluginField
 
 
 class S3SettingsExporter(SettingsExporter):
@@ -1189,8 +1189,8 @@ class S3SettingsExporter(SettingsExporter):
     description = "Export settings to an S3 object."
     icon = "☁️"
     fields = [
-        SettingsExporterField("bucket", "S3 Bucket", "text"),
-        SettingsExporterField("key", "Object Key", "text"),
+        PluginField("bucket", "S3 Bucket", "text"),
+        PluginField("key", "Object Key", "text"),
     ]
 
     def export(self, settings_data: dict, field_values: dict) -> dict:

--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -10,9 +10,10 @@ wins** (the "shim" rename and the `labelset_ops` facade), and several
 `UserSettingsStore`; the `load_pipeline.py` stage extraction; the `app.py`
 CLI + port-preflight extraction; and the `importers/base.py` split into a
 `base/` package with a thin `ImporterBase` and the rich `DatasetImporter` —
-see the Theme B section). For the details of what landed, see the git
-history / merged PRs on `dev`. **Everything below is the remaining planned
-work.**
+see the Theme B section), and the **Theme F `PluginField` alias collapse**
+(the seven per-family `*Field` aliases removed; see Theme F). For the
+details of what landed, see the git history / merged PRs on `dev`.
+**Everything below is the remaining planned work.**
 
 This review asks: where have design decisions that were right at small scale
 been outgrown, and what is worth streamlining, abstracting, or reorganizing?
@@ -175,8 +176,13 @@ below is still open.)
 - **`SyncSource[LoadT, SaveT]`** (`vtscore/sync/`) has two subclasses, each
   with one concrete implementation. Don't add more indirection here until a
   third consumer appears.
-- **`PluginField` aliases.** Six no-op aliases (`ImporterField = PluginField`
-  …) imply field types differ per family. Collapse to `PluginField`.
+- ~~**`PluginField` aliases.** Six no-op aliases (`ImporterField = PluginField`
+  …) imply field types differ per family. Collapse to `PluginField`.~~
+  **Shipped.** Removed all seven per-family aliases (`ImporterField`,
+  `ExporterField`, `LabelImporterField`, `LabelsetSourceField`,
+  `SettingsSourceField`, `SettingsImporterField`, `SettingsExporterField`);
+  every plugin/test now uses `PluginField` directly, re-exported from each
+  family's base module. Docs updated to match.
 - **`loader.py` façade** re-exports its three sibling loaders without adding
   abstraction.
 
@@ -204,8 +210,8 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
    below) and the two frontend components.
 2. **Theme D** — converge frontend types onto the generated client.
 3. **Theme E** — `MediaSource` / `DatasetImporter` ingestion-concept overlap.
-4. **Theme F** — collapse `PluginField` aliases; revisit `SyncSource` if a
-   third consumer appears.
+4. **Theme F** — ~~collapse `PluginField` aliases~~ (shipped); revisit
+   `SyncSource` if a third consumer appears.
 5. **Theme C remaining** — state-proxy registry table; image single/patch
    base; downloaders base.
 6. **Theme B (deferred)** — `DetectorContext` sub-context split (~346 call

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -146,8 +146,6 @@ class DatasetImporter(PluginBase):
     conversion and ingestion for hooks 1–3; subclasses never call
     `get_converter()`."""
 
-ImporterField = PluginField
-"""Alias kept for clarity at import sites; identical to vtscore.plugins.PluginField."""
 
 def get_importer(name: str) -> DatasetImporter:
     """Look up a registered importer by its `name` attribute; raises KeyError."""
@@ -407,9 +405,6 @@ class LabelsetSource(SyncSource[LabelSet, LabelSet]):
     """Bidirectional sync target for a detector's labelset. Implements
     `load(field_values) -> LabelSet` and `save(labelset, field_values) -> None`,
     with optional `load_full()` for richer detector metadata."""
-
-LabelImporterField = PluginField
-LabelsetSourceField = PluginField
 
 def get_label_importer(name: str) -> LabelImporter: ...
 def list_label_importers() -> list[LabelImporter]: ...
@@ -1151,8 +1146,6 @@ class LabelsetExporter(PluginBase):
     `supports_streaming = True` and implementing
     `export_cli_streaming(header, records, field_values)`. See
     EXTENDING-plugins.md and docs/plans/cli-stream-massive-images.md."""
-
-ExporterField = PluginField  # backwards-compat alias
 
 def get_exporter(name: str) -> LabelsetExporter: ...
 def list_exporters() -> list[LabelsetExporter]: ...

--- a/tests/datasets/test_creation_info.py
+++ b/tests/datasets/test_creation_info.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from vtscore.datasets.importers import get_importer
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, PluginField
 from vtscore.datasets.loader import export_dataset_to_file, load_dataset_from_pickle
 
 
@@ -17,8 +17,8 @@ class _DummyImporter(DatasetImporter):
     display_name = "Test Dummy"
     description = "A dummy importer for testing."
     fields = [
-        ImporterField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
-        ImporterField("path", "Folder", "folder"),
+        PluginField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
+        PluginField("path", "Folder", "folder"),
     ]
 
     def run(self, field_values, medias):
@@ -45,7 +45,7 @@ class TestBuildCliArgs:
             name = "file_test"
             display_name = "File Test"
             description = "test"
-            fields = [ImporterField("upload", "Upload", "file", accept=".pkl")]
+            fields = [PluginField("upload", "Upload", "file", accept=".pkl")]
 
             def run(self, _fv, _c):
                 pass

--- a/tests/datasets/test_origin_labelset.py
+++ b/tests/datasets/test_origin_labelset.py
@@ -356,16 +356,16 @@ class TestLabelSet:
 
 class TestBuildOrigin:
     def test_build_origin_from_fields(self):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
         class TestImporter(DatasetImporter):
             name = "test"
             display_name = "Test"
             description = "Test importer."
             fields = [
-                ImporterField("path", "Path", "folder"),
-                ImporterField("media_type", "Media Type", "select", options=["audio", "image"]),
-                ImporterField("file", "File", "file"),  # Should be excluded
+                PluginField("path", "Path", "folder"),
+                PluginField("media_type", "Media Type", "select", options=["audio", "image"]),
+                PluginField("file", "File", "file"),  # Should be excluded
             ]
 
             def run(self, field_values, medias):
@@ -376,15 +376,15 @@ class TestBuildOrigin:
         assert origin == {"importer": "test", "params": {"path": "/data/audio", "media_type": "audio"}}
 
     def test_build_origin_excludes_empty_values(self):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
         class TestImporter(DatasetImporter):
             name = "t"
             display_name = "T"
             description = "T"
             fields = [
-                ImporterField("path", "Path", "folder"),
-                ImporterField("opt", "Opt", "text", required=False),
+                PluginField("path", "Path", "folder"),
+                PluginField("opt", "Opt", "text", required=False),
             ]
 
             def run(self, field_values, medias):

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -346,7 +346,7 @@ class TestDynamicImporterDispatch:
 
     def test_custom_importer_resolve_file_is_called(self, tmp_path):
         """A custom importer registered at runtime has its resolve_file called."""
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
         marker_file = tmp_path / "custom_media.wav"
         marker_file.write_bytes(b"custom_audio")
@@ -355,7 +355,7 @@ class TestDynamicImporterDispatch:
             name = "test_custom"
             display_name = "Test Custom"
             description = "A test importer"
-            fields = [ImporterField(key="path", label="Path", field_type="text")]
+            fields = [PluginField(key="path", label="Path", field_type="text")]
 
             def resolve_file(self, origin, origin_name="", filename="", **kw):
                 p = origin.get("params", {}).get("path", "")

--- a/tests/io/test_chunked_web_flow.py
+++ b/tests/io/test_chunked_web_flow.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import numpy as np
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, PluginField
 from vtscore.datasets.load_pipeline import auto_chunk_size, consume_chunks_into
 
 
@@ -88,7 +88,7 @@ class _DummyChunkedImporter(DatasetImporter):
     display_name = "Dummy Chunked"
     description = "Test importer"
     icon = ""
-    fields: list[ImporterField] = []
+    fields: list[PluginField] = []
 
     def __init__(self) -> None:
         super().__init__()
@@ -122,7 +122,7 @@ class _DummyNonChunkedImporter(DatasetImporter):
     display_name = "Dummy Non-Chunked"
     description = "Test importer (no chunked support)"
     icon = ""
-    fields: list[ImporterField] = []
+    fields: list[PluginField] = []
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/io/test_dataset_importer_media.py
+++ b/tests/io/test_dataset_importer_media.py
@@ -60,7 +60,7 @@ class _VectorAndMD5Importer:
 
     @staticmethod
     def create(folder: Path, vectors: dict[str, Any], md5s: dict[str, str]):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
         from vtscore.datasets.loader import load_dataset_from_folder
 
         class Importer(DatasetImporter):
@@ -68,8 +68,8 @@ class _VectorAndMD5Importer:
             display_name = "Test Vector+MD5"
             description = "Test importer providing vectors and MD5s."
             fields = [
-                ImporterField("media_type", "Media Type", "text", default="audio"),
-                ImporterField("path", "Path", "text"),
+                PluginField("media_type", "Media Type", "text", default="audio"),
+                PluginField("path", "Path", "text"),
             ]
 
             def run(self, field_values, medias, thin=False):
@@ -329,7 +329,7 @@ class TestImporterCustomMetadataMD5:
 
     def test_custom_metadata_md5_used_as_media_md5(self, tmp_path):
         """When custom_metadata_map has an 'md5' key, it should be used as the media's MD5."""
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
         from vtscore.datasets.loader import load_dataset_from_folder
 
         class MetadataMD5Importer(DatasetImporter):
@@ -337,8 +337,8 @@ class TestImporterCustomMetadataMD5:
             display_name = "Test CM MD5"
             description = "Test importer using custom_metadata_map for MD5."
             fields = [
-                ImporterField("media_type", "Media Type", "text", default="audio"),
-                ImporterField("path", "Path", "text"),
+                PluginField("media_type", "Media Type", "text", default="audio"),
+                PluginField("path", "Path", "text"),
             ]
 
             def run(self, field_values, medias, thin=False):
@@ -605,7 +605,7 @@ class TestImporterCustomMetadataEmbedding:
 
     def test_importer_custom_metadata_embedding_end_to_end(self, tmp_path):
         """A DatasetImporter providing embedding via custom_metadata_map should work end-to-end."""
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
         from vtscore.datasets.loader import load_dataset_from_folder
 
         rng = np.random.default_rng(77)
@@ -617,8 +617,8 @@ class TestImporterCustomMetadataEmbedding:
             display_name = "Test CM Embedding"
             description = "Test importer using custom_metadata_map for embedding."
             fields = [
-                ImporterField("media_type", "Media Type", "text", default="audio"),
-                ImporterField("path", "Path", "text"),
+                PluginField("media_type", "Media Type", "text", default="audio"),
+                PluginField("path", "Path", "text"),
             ]
 
             def run(self, field_values, medias, thin=False):

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import pytest
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter
 from vtscore.plugins import PluginField
 
 
@@ -26,8 +26,8 @@ class _StubImporter(DatasetImporter):
     display_name = "Stub Dynamic"
     description = "Test importer with dynamic-options field."
     fields = [
-        ImporterField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
-        ImporterField(
+        PluginField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
+        PluginField(
             "query_id",
             "Query",
             "select",

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -1,7 +1,7 @@
 """Tests for the Labelset Exporter abstraction.
 
 Covers:
-- ExporterField and LabelsetExporter base classes
+- PluginField and LabelsetExporter base classes
 - Auto-discovery registry
 - Built-in exporters: gui, server_json_file, server_csv_file, email_smtp
 - Flask API routes: GET /api/exporters, POST /api/exporters/export
@@ -73,15 +73,15 @@ def _multi_user_provider(user_dir: Path):
 
 
 # ---------------------------------------------------------------------------
-# ExporterField
+# PluginField
 # ---------------------------------------------------------------------------
 
 
 class TestExporterField:
     def test_to_dict_contains_required_keys(self):
-        from vtscore.exporters.base import ExporterField
+        from vtscore.exporters.base import PluginField
 
-        f = ExporterField(key="fp", label="File Path", field_type="text")
+        f = PluginField(key="fp", label="File Path", field_type="text")
         d = f.to_dict()
         assert d["key"] == "fp"
         assert d["label"] == "File Path"
@@ -93,9 +93,9 @@ class TestExporterField:
         assert "placeholder" in d
 
     def test_defaults(self):
-        from vtscore.exporters.base import ExporterField
+        from vtscore.exporters.base import PluginField
 
-        f = ExporterField(key="x", label="X", field_type="text")
+        f = PluginField(key="x", label="X", field_type="text")
         assert f.required is True
         assert f.default == ""
         assert f.placeholder == ""
@@ -103,9 +103,9 @@ class TestExporterField:
         assert f.description == ""
 
     def test_custom_values(self):
-        from vtscore.exporters.base import ExporterField
+        from vtscore.exporters.base import PluginField
 
-        f = ExporterField(
+        f = PluginField(
             key="mode",
             label="Mode",
             field_type="select",
@@ -135,14 +135,14 @@ class TestLabelsetExporterBase:
             exp.export({}, {})
 
     def test_to_dict_contains_standard_keys(self):
-        from vtscore.exporters.base import ExporterField, LabelsetExporter
+        from vtscore.exporters.base import PluginField, LabelsetExporter
 
         class Dummy(LabelsetExporter):
             name = "dummy"
             display_name = "Dummy"
             description = "A test exporter."
             icon = "🧪"
-            fields = [ExporterField(key="k", label="K", field_type="text")]
+            fields = [PluginField(key="k", label="K", field_type="text")]
 
             def export(self, results, field_values):
                 return {"message": "ok"}

--- a/tests/io/test_label_importers.py
+++ b/tests/io/test_label_importers.py
@@ -1,7 +1,7 @@
 """Tests for the Label Importer abstraction.
 
 Covers:
-- LabelImporterField and LabelImporter base classes
+- PluginField and LabelImporter base classes
 - Auto-discovery registry (list_label_importers, get_label_importer)
 - GET /api/label-importers endpoint
 - Built-in importers: server_json_file, server_csv_file
@@ -17,15 +17,15 @@ import app as app_module
 
 
 # ---------------------------------------------------------------------------
-# LabelImporterField
+# PluginField
 # ---------------------------------------------------------------------------
 
 
 class TestLabelImporterField:
     def test_to_dict_contains_required_keys(self):
-        from vtscore.labels.importers.base import LabelImporterField
+        from vtscore.labels.importers.base import PluginField
 
-        f = LabelImporterField(key="file", label="My File", field_type="file")
+        f = PluginField(key="file", label="My File", field_type="file")
         d = f.to_dict()
         assert d["key"] == "file"
         assert d["label"] == "My File"
@@ -38,9 +38,9 @@ class TestLabelImporterField:
         assert "placeholder" in d
 
     def test_defaults(self):
-        from vtscore.labels.importers.base import LabelImporterField
+        from vtscore.labels.importers.base import PluginField
 
-        f = LabelImporterField(key="x", label="X", field_type="text")
+        f = PluginField(key="x", label="X", field_type="text")
         assert f.required is True
         assert f.default == ""
         assert f.placeholder == ""
@@ -49,9 +49,9 @@ class TestLabelImporterField:
         assert f.accept == ""
 
     def test_custom_values(self):
-        from vtscore.labels.importers.base import LabelImporterField
+        from vtscore.labels.importers.base import PluginField
 
-        f = LabelImporterField(
+        f = PluginField(
             key="mode",
             label="Mode",
             field_type="select",
@@ -124,13 +124,13 @@ class TestLabelImporterBase:
         assert Custom().to_dict()["icon"] == "🔖"
 
     def test_validate_cli_field_values_raises_on_missing_required(self):
-        from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+        from vtscore.labels.importers.base import LabelImporter, PluginField
 
         class Imp(LabelImporter):
             name = "t"
             display_name = "T"
             description = "T"
-            fields = [LabelImporterField("filepath", "File", "text", required=True)]
+            fields = [PluginField("filepath", "File", "text", required=True)]
 
             def run(self, field_values):
                 return []
@@ -140,13 +140,13 @@ class TestLabelImporterBase:
             imp.validate_cli_field_values({})
 
     def test_validate_cli_field_values_passes_when_provided(self):
-        from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+        from vtscore.labels.importers.base import LabelImporter, PluginField
 
         class Imp(LabelImporter):
             name = "t"
             display_name = "T"
             description = "T"
-            fields = [LabelImporterField("filepath", "File", "text", required=True)]
+            fields = [PluginField("filepath", "File", "text", required=True)]
 
             def run(self, field_values):
                 return []
@@ -173,13 +173,13 @@ class TestLabelImporterBase:
     def test_add_cli_arguments_adds_text_field(self):
         import argparse
 
-        from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+        from vtscore.labels.importers.base import LabelImporter, PluginField
 
         class Imp(LabelImporter):
             name = "t"
             display_name = "T"
             description = "T"
-            fields = [LabelImporterField("server", "Server", "text", description="DB host")]
+            fields = [PluginField("server", "Server", "text", description="DB host")]
 
             def run(self, field_values):
                 return []
@@ -192,13 +192,13 @@ class TestLabelImporterBase:
     def test_add_cli_arguments_select_adds_choices(self):
         import argparse
 
-        from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+        from vtscore.labels.importers.base import LabelImporter, PluginField
 
         class Imp(LabelImporter):
             name = "t"
             display_name = "T"
             description = "T"
-            fields = [LabelImporterField("mode", "Mode", "select", options=["a", "b"], default="a")]
+            fields = [PluginField("mode", "Mode", "select", options=["a", "b"], default="a")]
 
             def run(self, field_values):
                 return []

--- a/tests_lib/datasets/test_build_origin.py
+++ b/tests_lib/datasets/test_build_origin.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
 
 def _make_importer(
     *,
     name: str = "fake",
-    fields: list[ImporterField] | None = None,
+    fields: list[PluginField] | None = None,
     extra_origin_keys: tuple[str, ...] = (),
     origin_suppressed: bool = False,
 ) -> DatasetImporter:
@@ -44,13 +44,13 @@ def _make_importer(
 class TestOriginSuppressed:
     def test_returns_empty_params_when_suppressed(self):
         imp = _make_importer(
-            fields=[ImporterField("k", "K", "text")],
+            fields=[PluginField("k", "K", "text")],
             origin_suppressed=True,
         )
         assert imp.build_origin({"k": "v"}) == {"importer": "fake", "params": {}}
 
     def test_default_is_not_suppressed(self):
-        imp = _make_importer(fields=[ImporterField("k", "K", "text")])
+        imp = _make_importer(fields=[PluginField("k", "K", "text")])
         assert imp.build_origin({"k": "v"})["params"] == {"k": "v"}
 
 
@@ -58,8 +58,8 @@ class TestFieldTypeDefaults:
     def test_password_field_is_excluded_by_default(self):
         imp = _make_importer(
             fields=[
-                ImporterField("user", "User", "text"),
-                ImporterField("password", "Password", "password"),
+                PluginField("user", "User", "text"),
+                PluginField("password", "Password", "password"),
             ],
         )
         params = imp.build_origin({"user": "alice", "password": "hunter2"})["params"]
@@ -68,8 +68,8 @@ class TestFieldTypeDefaults:
     def test_file_field_is_excluded_by_default(self):
         imp = _make_importer(
             fields=[
-                ImporterField("name", "Name", "text"),
-                ImporterField("upload", "Upload", "file"),
+                PluginField("name", "Name", "text"),
+                PluginField("upload", "Upload", "file"),
             ],
         )
         params = imp.build_origin({"name": "x", "upload": "/should/not/leak"})["params"]
@@ -78,7 +78,7 @@ class TestFieldTypeDefaults:
     def test_include_in_origin_overrides_default(self):
         imp = _make_importer(
             fields=[
-                ImporterField("debug_token", "Debug", "password", include_in_origin=True),
+                PluginField("debug_token", "Debug", "password", include_in_origin=True),
             ],
         )
         params = imp.build_origin({"debug_token": "ok-to-persist"})["params"]
@@ -87,8 +87,8 @@ class TestFieldTypeDefaults:
     def test_include_in_origin_can_omit_a_text_field(self):
         imp = _make_importer(
             fields=[
-                ImporterField("keep", "Keep", "text"),
-                ImporterField("drop", "Drop", "text", include_in_origin=False),
+                PluginField("keep", "Keep", "text"),
+                PluginField("drop", "Drop", "text", include_in_origin=False),
             ],
         )
         params = imp.build_origin({"keep": "a", "drop": "b"})["params"]
@@ -99,7 +99,7 @@ class TestOriginSerializer:
     def test_list_field_is_comma_joined_via_serializer(self):
         imp = _make_importer(
             fields=[
-                ImporterField(
+                PluginField(
                     "datasets",
                     "Datasets",
                     "text",
@@ -113,7 +113,7 @@ class TestOriginSerializer:
     def test_serializer_ignored_when_value_empty(self):
         imp = _make_importer(
             fields=[
-                ImporterField("k", "K", "text", origin_serializer=lambda v: f"!{v}!"),
+                PluginField("k", "K", "text", origin_serializer=lambda v: f"!{v}!"),
             ],
         )
         # Empty value is skipped before the serializer runs.
@@ -123,7 +123,7 @@ class TestOriginSerializer:
         # Without an origin_serializer, list/dict values are JSON-encoded so
         # they round-trip through the string-only origin contract.
         imp = _make_importer(
-            fields=[ImporterField("payload", "Payload", "text")],
+            fields=[PluginField("payload", "Payload", "text")],
         )
         params = imp.build_origin({"payload": [{"a": 1}]})["params"]
         assert params == {"payload": '[{"a": 1}]'}
@@ -132,7 +132,7 @@ class TestOriginSerializer:
 class TestExtraOriginKeys:
     def test_extra_origin_keys_copy_from_field_values(self):
         imp = _make_importer(
-            fields=[ImporterField("a", "A", "text")],
+            fields=[PluginField("a", "A", "text")],
             extra_origin_keys=("transient",),
         )
         params = imp.build_origin({"a": "1", "transient": "abc"})["params"]
@@ -162,8 +162,8 @@ class TestCheckboxStillSerialised:
     def test_checkbox_emits_true_false_strings(self):
         imp = _make_importer(
             fields=[
-                ImporterField("on", "On", "checkbox", default="false"),
-                ImporterField("off", "Off", "checkbox", default="false"),
+                PluginField("on", "On", "checkbox", default="false"),
+                PluginField("off", "Off", "checkbox", default="false"),
             ],
         )
         params = imp.build_origin({"on": True, "off": False})["params"]
@@ -171,7 +171,7 @@ class TestCheckboxStillSerialised:
 
     def test_checkbox_default_when_missing(self):
         imp = _make_importer(
-            fields=[ImporterField("on", "On", "checkbox", default="true")],
+            fields=[PluginField("on", "On", "checkbox", default="true")],
         )
         # Field absent from field_values; falls back to declared default.
         assert imp.build_origin({})["params"] == {"on": "true"}
@@ -187,8 +187,8 @@ class TestSubclassOverrideWins:
             display_name = "Overriding"
             description = ""
             fields = [
-                ImporterField("password", "Password", "password"),
-                ImporterField("user", "User", "text"),
+                PluginField("password", "Password", "password"),
+                PluginField("user", "User", "text"),
             ]
 
             def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:

--- a/tests_lib/datasets/test_chunked_loading.py
+++ b/tests_lib/datasets/test_chunked_loading.py
@@ -436,14 +436,14 @@ class TestBaseImporterChunkedDefault:
     delegates to run/run_cli and yields one chunk."""
 
     def test_default_run_chunked_yields_one_chunk(self, tmp_path):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
         class DummyImporter(DatasetImporter):
             name = "dummy"
             display_name = "Dummy"
             description = "Test"
             icon = ""
-            fields: list[ImporterField] = []
+            fields: list[PluginField] = []
 
             def run(self, field_values, medias, thin=False):
                 medias[1] = {"id": 1, "media_type": "audio", "embedder": "clap", "embeddings": {"clap": np.zeros(4)}}

--- a/tests_lib/datasets/test_phase_c.py
+++ b/tests_lib/datasets/test_phase_c.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 from vtscore.converters.base import MediaConverter
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter
 from vtscore.plugins import PluginField
 from vtscore.plugins.uploads import (
     BytesIOUploadedFile,
@@ -192,7 +192,7 @@ class _FileImporter(DatasetImporter):
     name = "_file_importer"
     display_name = "_file_importer"
     description = ""
-    fields = [ImporterField(key="file", label="F", field_type="file")]
+    fields = [PluginField(key="file", label="F", field_type="file")]
 
     last_value: Any = None
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -360,14 +360,14 @@ class TestImporterDatasetName:
         from vtscore.datasets.importers.base import (
             DATASET_NAME_FIELD_KEY,
             DatasetImporter,
-            ImporterField,
+            PluginField,
         )
 
         class Imp(DatasetImporter):
             name = "imp"
             display_name = "Imp"
             description = "."
-            fields = [ImporterField("path", "Path", "text")]
+            fields = [PluginField("path", "Path", "text")]
 
             def run(self, field_values, medias):
                 pass
@@ -381,13 +381,13 @@ class TestImporterDatasetName:
     def test_class_fields_attribute_unchanged_by_to_dict(self):
         """to_dict() appends dataset_name only on the serialised payload;
         the class-level ``fields`` attribute remains as the developer wrote it."""
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
         class Imp(DatasetImporter):
             name = "imp2"
             display_name = "Imp"
             description = "."
-            fields = [ImporterField("path", "Path", "text")]
+            fields = [PluginField("path", "Path", "text")]
 
             def run(self, field_values, medias):
                 pass
@@ -1238,16 +1238,14 @@ class TestIngestSpecStreamMediaType:
     @staticmethod
     def _make_importer(records: list[dict]):
         """Return a DatasetImporter subclass that yields *records* for any spec."""
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 
         class _Imp(DatasetImporter):
             name = "test_stamp"
             display_name = "Test"
             description = "Test importer."
             fields = [
-                ImporterField(
-                    "media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"
-                ),
+                PluginField("media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"),
             ]
 
             def fetch_source_media(self, spec: SourceSpec, field_values: dict, thin: bool = False):
@@ -1379,16 +1377,14 @@ class TestIngestSpecStreamRequiredFields:
 
     @staticmethod
     def _make_importer(records: list[dict]):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 
         class _Imp(DatasetImporter):
             name = "test_fields"
             display_name = "Test"
             description = "Test importer."
             fields = [
-                ImporterField(
-                    "media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"
-                ),
+                PluginField("media_type", "Media Type", "select", options=["image", "video", "audio"], default="image"),
             ]
 
             def fetch_source_media(self, spec: SourceSpec, field_values: dict, thin: bool = False):
@@ -1524,14 +1520,14 @@ class TestConverterOutputEndToEnd:
 
     @staticmethod
     def _make_importer(records: list[dict]):
-        from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+        from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 
         class _Imp(DatasetImporter):
             name = "test_e2e"
             display_name = "Test"
             description = "Test importer."
             fields = [
-                ImporterField(
+                PluginField(
                     "media_type",
                     "Media Type",
                     "select",

--- a/vtscore/datasets/__init__.py
+++ b/vtscore/datasets/__init__.py
@@ -9,7 +9,7 @@ from vtscore.datasets.downloader import (
     download_ucf101_subset,
 )
 from vtscore.datasets.importers import get_importer, list_importers
-from vtscore.datasets.importers.base import DatasetImporter, ImporterBase, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, ImporterBase, PluginField
 from vtscore.datasets.labelset import LabelSet, LabeledElement
 from vtscore.datasets.loader import (
     export_dataset_to_file,
@@ -37,7 +37,7 @@ __all__ = [
     # Importer registry
     "DatasetImporter",
     "ImporterBase",
-    "ImporterField",
+    "PluginField",
     "get_importer",
     "list_importers",
     # Downloader functions

--- a/vtscore/datasets/importers/base/__init__.py
+++ b/vtscore/datasets/importers/base/__init__.py
@@ -35,7 +35,7 @@ The base is split across submodules:
 Example – a minimal SFTP importer skeleton::
 
     # vtsearch/datasets/importers/sftp/__init__.py
-    from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+    from vtscore.datasets.importers.base import DatasetImporter, PluginField
 
     from vtscore.media import all_folder_names
 
@@ -44,11 +44,11 @@ Example – a minimal SFTP importer skeleton::
         display_name = "SFTP Server"
         description  = "Download media files from an SFTP server."
         fields = [
-            ImporterField("host",       "Hostname",    "text"),
-            ImporterField("user",       "Username",    "text"),
-            ImporterField("password",   "Password",    "password"),
-            ImporterField("path",       "Remote Path", "text"),
-            ImporterField(
+            PluginField("host",       "Hostname",    "text"),
+            PluginField("user",       "Username",    "text"),
+            PluginField("password",   "Password",    "password"),
+            PluginField("path",       "Remote Path", "text"),
+            PluginField(
                 "media_type", "Media Type", "select",
                 options=all_folder_names(),
                 default="audio",
@@ -77,14 +77,11 @@ from .dataset_importer import DatasetImporter
 from .origin import DATASET_NAME_FIELD_KEY
 from .specs import PickerView, SourceSpec
 
-# Backward-compatible alias; existing plugins import ``ImporterField``.
-ImporterField = PluginField
-
 __all__ = [
     "DATASET_NAME_FIELD_KEY",
     "DatasetImporter",
     "ImporterBase",
-    "ImporterField",
     "PickerView",
+    "PluginField",
     "SourceSpec",
 ]

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -273,7 +273,7 @@ class ImporterBase(PluginBase):
           convenience hooks.
 
         Args:
-            field_values: Mapping of :attr:`ImporterField.key` → value.
+            field_values: Mapping of :attr:`PluginField.key` → value.
                 Fields with ``field_type="file"`` receive an
                 :class:`~vtscore.plugins.uploads.UploadedFile` (Flask
                 requests pass a Werkzeug ``FileStorage`` straight

--- a/vtscore/datasets/importers/base/dataset_importer.py
+++ b/vtscore/datasets/importers/base/dataset_importer.py
@@ -93,7 +93,7 @@ class DatasetImporter(ImporterBase):
         media dict did not already set one.
 
         Args:
-            field_values: Mapping of :attr:`ImporterField.key` → value.
+            field_values: Mapping of :attr:`PluginField.key` → value.
                 Fields with ``field_type="file"`` receive an
                 :class:`~vtscore.plugins.uploads.UploadedFile` (Flask
                 requests pass a Werkzeug ``FileStorage`` straight

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -10,7 +10,7 @@ import gc
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
-from vtscore.datasets.importers.base import ImporterBase, ImporterField
+from vtscore.datasets.importers.base import ImporterBase, PluginField
 
 
 def _get_progress():
@@ -126,7 +126,7 @@ class CombineDatasetsImporter(ImporterBase):
     ui_mode = "custom"
     hidden_from_picker = True
     fields = [
-        ImporterField(
+        PluginField(
             key="datasets",
             label="Dataset Files",
             field_type="text",
@@ -137,7 +137,7 @@ class CombineDatasetsImporter(ImporterBase):
             # comma-joined form ``_parse_dataset_paths`` already accepts.
             origin_serializer=lambda v: ",".join(v) if isinstance(v, list) else str(v),
         ),
-        ImporterField(
+        PluginField(
             key="name",
             label="Name",
             field_type="text",

--- a/vtscore/datasets/importers/demo/__init__.py
+++ b/vtscore/datasets/importers/demo/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from vtscore.datasets.importers.base import ImporterBase, ImporterField
+from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.datasets.loader import load_demo_dataset
 
 
@@ -37,13 +37,13 @@ class DemoDatasetImporter(ImporterBase):
     category = "demo"
 
     fields = [
-        ImporterField(
+        PluginField(
             key="name",
             label="Dataset",
             field_type="select",
             description="Which demo dataset to load.",
         ),
-        ImporterField(
+        PluginField(
             key="embedder",
             label="Embedder",
             field_type="text",
@@ -51,7 +51,7 @@ class DemoDatasetImporter(ImporterBase):
             required=False,
             include_in_origin=False,
         ),
-        ImporterField(
+        PluginField(
             key="converter",
             label="Converter",
             field_type="text",

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -29,7 +29,7 @@ from uuid import uuid4
 from vtscore.config import DATA_DIR
 from vtscore.datasets.archive import extract_archive, is_archive_path, load_archive_into
 from vtscore.datasets.downloader import download_file_with_progress
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder
 
 ProgressCallback = Callable[[str, str, int, int], None]
@@ -113,7 +113,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     icon = "\U0001f310"
     hidden_from_picker = True
     fields = [
-        ImporterField(
+        PluginField(
             key="url",
             label="Path or URL",
             field_type="url",
@@ -123,7 +123,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 "Supported archive formats: .zip, .tar, .tar.gz / .tgz, .tar.bz2, .rar."
             ),
         ),
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Dataset MediaType",
             field_type="select",

--- a/vtscore/datasets/importers/local_folder/__init__.py
+++ b/vtscore/datasets/importers/local_folder/__init__.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtscore.datasets.importers.base import ImporterBase, ImporterField
+from vtscore.datasets.importers.base import ImporterBase, PluginField
 
 
 class LocalFolderDatasetImporter(ImporterBase):
@@ -44,7 +44,7 @@ class LocalFolderDatasetImporter(ImporterBase):
     picker_view = "local_folder"
     category = "local"
     fields = [
-        ImporterField(
+        PluginField(
             key="recursive",
             label="Include subfolders",
             field_type="checkbox",

--- a/vtscore/datasets/importers/pickle/__init__.py
+++ b/vtscore/datasets/importers/pickle/__init__.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
-from vtscore.datasets.importers.base import ImporterBase, ImporterField
+from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.datasets.loader import load_dataset_from_pickle, load_dataset_from_pickle_chunked
 
 
@@ -36,7 +36,7 @@ class PickleDatasetImporter(ImporterBase):
     ui_mode = "file_upload"
     hidden_from_picker = True
     fields = [
-        ImporterField(
+        PluginField(
             key="file",
             label="Upload a file",
             field_type="file",

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 from typing import Any, Iterator
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.media import all_folder_names
 
 
@@ -186,7 +186,7 @@ class ReCallerDatasetImporter(DatasetImporter):
     # contentID); the dataset-level origin carries no actionable identity.
     origin_suppressed = True
     fields = [
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Output Media Type",
             field_type="select",
@@ -195,7 +195,7 @@ class ReCallerDatasetImporter(DatasetImporter):
             description="The media type this dataset will hold.  Source-type rows below specify which ReCaller record types to pull in and how to convert them to this output type.",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="query_id",
             label="Query ID",
             field_type="select",

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.datasets.importers._npz_vectors import read_npz_embedder_name, read_npz_filenames_and_vectors
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 
 logger = logging.getLogger(__name__)
@@ -202,7 +202,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
     picker_view = "form"
     category = "server"
     fields = [
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Dataset MediaType",
             field_type="select",
@@ -214,7 +214,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
             default="audio",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="paths_file",
             label="Paths file",
             field_type="server_path",
@@ -228,7 +228,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
             ),
             accept=".txt,.list,.npz",
         ),
-        ImporterField(
+        PluginField(
             key="reference_files",
             label="Reference files in place (don't copy)",
             field_type="checkbox",

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -41,7 +41,7 @@ from vtscore.datasets.archive import (
     iter_archive_chunks,
     load_archive_into,
 )
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
+from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 from vtscore.datasets.pdf import load_pdf_images_into
 
@@ -128,7 +128,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
     picker_view = "server_folder"
     category = "server"
     fields = [
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Dataset MediaType",
             field_type="select",
@@ -136,7 +136,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
             default="audio",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="path",
             label="Folder or archive",
             field_type="folder",
@@ -145,7 +145,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 "archive file (.zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar)."
             ),
         ),
-        ImporterField(
+        PluginField(
             key="recursive",
             label="Include subfolders",
             field_type="checkbox",
@@ -156,7 +156,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
             default="true",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="dig_archives",
             label="Dig into archives",
             field_type="checkbox",
@@ -168,7 +168,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
             default="false",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="reference_files",
             label="Reference files in place (don't copy)",
             field_type="checkbox",

--- a/vtscore/datasets/importers/synthetic/__init__.py
+++ b/vtscore/datasets/importers/synthetic/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.config import DATA_DIR
-from vtscore.datasets.importers.base import ImporterBase, ImporterField
+from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.datasets.loader import load_dataset_from_folder
 
 _SUPPORTED_MEDIA_TYPES = ["image", "audio", "video"]
@@ -42,7 +42,7 @@ class SyntheticDatasetImporter(ImporterBase):
     category = "demo"
 
     fields = [
-        ImporterField(
+        PluginField(
             key="media_type",
             label="Dataset MediaType",
             field_type="select",
@@ -51,7 +51,7 @@ class SyntheticDatasetImporter(ImporterBase):
             default="image",
             required=False,
         ),
-        ImporterField(
+        PluginField(
             key="size",
             label="Size",
             field_type="number",

--- a/vtscore/docs/extending/README.md
+++ b/vtscore/docs/extending/README.md
@@ -78,10 +78,9 @@ sync at the model layer.
 These cut across every family and apply to both in-tree and
 third-party plugins.
 
-**Declare inputs as `PluginField`s.** Each plugin family re-exports
-`PluginField` under a friendlier alias (`ImporterField`,
-`ExporterField`, `LabelImporterField`, …) which is a literal `=
-PluginField`. The frontend renders a form from `fields`, the CLI
+**Declare inputs as `PluginField`s.** Each plugin family's base module
+re-exports `PluginField` so you can import it alongside the family's
+base class. The frontend renders a form from `fields`, the CLI
 derives `argparse` flags from `fields`, and the marshmallow schema
 builder validates POST bodies against `fields`. See [`vtscore/plugins/__init__.py:71`](../../plugins/__init__.py)
 for the full dataclass and the [plugins package doc](../packages/plugins.md#pluginfield)

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -307,7 +307,7 @@ from typing import Any
 
 import numpy as np
 
-from vtscore.datasets.importers.base import DatasetImporter, ImporterField
+from vtscore.datasets.importers.base import DatasetImporter, PluginField
 from vtscore.security.url_validation import validate_url
 
 
@@ -317,7 +317,7 @@ class CatalogueImporter(DatasetImporter):
     description = "Import audio clips from a remote JSON-line catalogue."
     icon = "\U0001f5c3"  # card-index
     fields = [
-        ImporterField(
+        PluginField(
             key="catalogue_url",
             label="Catalogue URL",
             field_type="url",

--- a/vtscore/docs/extending/label-importers.md
+++ b/vtscore/docs/extending/label-importers.md
@@ -120,7 +120,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
 class RedisStreamLabelImporter(LabelImporter):
@@ -131,21 +131,21 @@ class RedisStreamLabelImporter(LabelImporter):
     description = "Import labels from a Redis stream of JSON entries."
     icon = "\U0001f5c4"  # file cabinet
     fields = [
-        LabelImporterField(
+        PluginField(
             key="redis_url",
             label="Redis URL",
             field_type="url",
             description="redis:// or rediss:// URL.",
             required=True,
         ),
-        LabelImporterField(
+        PluginField(
             key="stream_name",
             label="Stream name",
             field_type="text",
             default="vtsearch:labels",
             required=True,
         ),
-        LabelImporterField(
+        PluginField(
             key="count",
             label="Max entries",
             field_type="number",

--- a/vtscore/docs/extending/labelset-sources.md
+++ b/vtscore/docs/extending/labelset-sources.md
@@ -183,7 +183,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from vtscore.labels.sources.base import LabelsetSource, LabelsetSourceField
+from vtscore.labels.sources.base import LabelsetSource, PluginField
 from vtscore.security.path_validation import sanitize_template_value
 
 if TYPE_CHECKING:
@@ -213,13 +213,13 @@ class S3LabelsetSource(LabelsetSource):
     description = "Sync detector labels with a JSON object in an S3 bucket."
     icon = "☁️"  # cloud
     fields = [
-        LabelsetSourceField(
+        PluginField(
             key="bucket",
             label="S3 Bucket",
             field_type="text",
             required=True,
         ),
-        LabelsetSourceField(
+        PluginField(
             key="key",
             label="Object Key",
             field_type="text",

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -204,7 +204,7 @@ from typing import Any
 
 import requests
 
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 from vtscore.security.url_validation import validate_url
 
 
@@ -216,14 +216,14 @@ class SignedWebhookExporter(LabelsetExporter):
     description = "POST labels JSON to a URL with an HMAC-SHA256 signature."
     icon = "\U0001f510"  # closed lock with key
     fields = [
-        ExporterField(
+        PluginField(
             key="url",
             label="Webhook URL",
             field_type="url",
             description="The URL to POST labels to.",
             required=True,
         ),
-        ExporterField(
+        PluginField(
             key="hmac_secret",
             label="HMAC secret",
             field_type="password",

--- a/vtscore/docs/packages/exporters.md
+++ b/vtscore/docs/packages/exporters.md
@@ -22,7 +22,7 @@ external source) are not here; they live in
 - [Registry and accessors](#registry-and-accessors)
 - [`LabelsetExporter` ABC](#labelsetexporter-abc)
 - [The export contract](#the-export-contract)
-- [`ExporterField`](#exporterfield)
+- [`PluginField`](#exporterfield)
 - [Built-in exporters](#built-in-exporters)
 - [Template variables in path fields](#template-variables-in-path-fields)
 - [Writing a custom exporter](#writing-a-custom-exporter)
@@ -72,14 +72,14 @@ the standard `PluginBase` class attributes (`name`, `display_name`,
 `"\U0001f4e4"` (outbox tray).
 
 ```python
-from vtscore.exporters.base import LabelsetExporter, ExporterField
+from vtscore.exporters.base import LabelsetExporter, PluginField
 
 
 class MyExporter(LabelsetExporter):
     name = "my_exporter"
     display_name = "My Exporter"
     description = "..."
-    fields = [ExporterField("path", "Path", "server_path")]
+    fields = [PluginField("path", "Path", "server_path")]
 
     def export(self, results: dict, field_values: dict) -> dict:
         ...
@@ -152,19 +152,18 @@ delegating to `export()`. Override it when CLI invocation needs a
 different behaviour - the GUI exporter does this so it can print to
 stdout instead of asking the (nonexistent) frontend to render.
 
-## `ExporterField`
+## `PluginField`
 
-A backwards-compatibility alias for `PluginField`:
+`vtscore/exporters/base.py` re-exports `PluginField` so exporters can
+import it alongside `LabelsetExporter`:
 
 ```python
-# vtscore/exporters/base.py:54
-ExporterField = PluginField
+from vtscore.exporters.base import LabelsetExporter, PluginField
 ```
 
-Use whichever name reads better at the call site; the two are
-literally identical. Field semantics - `field_type` literals,
-`dynamic_options`, `depends_on`, number-field type inference - are
-documented in detail in [`plugins.md#pluginfield`](plugins.md#pluginfield).
+Field semantics - `field_type` literals, `dynamic_options`,
+`depends_on`, number-field type inference - are documented in detail in
+[`plugins.md#pluginfield`](plugins.md#pluginfield).
 
 ## Built-in exporters
 
@@ -246,7 +245,7 @@ from typing import Any
 
 import paramiko
 
-from vtscore.exporters.base import LabelsetExporter, ExporterField
+from vtscore.exporters.base import LabelsetExporter, PluginField
 
 
 class SftpLabelsetExporter(LabelsetExporter):
@@ -255,10 +254,10 @@ class SftpLabelsetExporter(LabelsetExporter):
     description = "Upload the results JSON to a remote SFTP server."
     icon = "\U0001f4e1"
     fields = [
-        ExporterField("host",     "Hostname",    "text"),
-        ExporterField("user",     "Username",    "text"),
-        ExporterField("password", "Password",    "password"),
-        ExporterField(
+        PluginField("host",     "Hostname",    "text"),
+        PluginField("user",     "Username",    "text"),
+        PluginField("password", "Password",    "password"),
+        PluginField(
             "path", "Remote Path", "text",
             default="/results/autodetect.json",
         ),

--- a/vtscore/docs/packages/labels.md
+++ b/vtscore/docs/packages/labels.md
@@ -18,7 +18,7 @@ auto-discovers them.
 
 ```python
 from vtscore.labels.importers import (
-    LabelImporter, LabelImporterField,
+    LabelImporter, PluginField,
     get_label_importer, list_label_importers,
 )
 
@@ -52,16 +52,16 @@ collisions.
 
 ```python
 # my_pkg/postgres_label_importer.py
-from vtscore.labels.importers import LabelImporter, LabelImporterField
+from vtscore.labels.importers import LabelImporter, PluginField
 
 class PostgresLabelImporter(LabelImporter):
     name = "postgres"
     display_name = "PostgreSQL Query"
     description = "Import labels from a PostgreSQL query."
     fields = [
-        LabelImporterField("host",     "Host",     "text"),
-        LabelImporterField("database", "Database", "text"),
-        LabelImporterField("query",    "Query",    "text",
+        PluginField("host",     "Host",     "text"),
+        PluginField("database", "Database", "text"),
+        PluginField("query",    "Query",    "text",
                            description="Must return md5 and label columns."),
     ]
 
@@ -141,15 +141,15 @@ resolve a path for a non-active detector (notably detector rename).
 ```python
 # my_pkg/redis_labelset_source.py
 from vtscore.datasets.labelset import LabelSet
-from vtscore.labels.sources import LabelsetSource, LabelsetSourceField
+from vtscore.labels.sources import LabelsetSource, PluginField
 
 class RedisLabelsetSource(LabelsetSource):
     name = "redis"
     display_name = "Redis Key"
     description = "Sync detector labels with a Redis key."
     fields = [
-        LabelsetSourceField("host", "Host", "text", default="localhost"),
-        LabelsetSourceField("key",  "Key",  "text",
+        PluginField("host", "Host", "text", default="localhost"),
+        PluginField("key",  "Key",  "text",
                             description="Supports {detector_id} and {detector_name}."),
     ]
 

--- a/vtscore/docs/packages/plugins.md
+++ b/vtscore/docs/packages/plugins.md
@@ -58,9 +58,8 @@ user-configurable input on a plugin. Each plugin declares its inputs as
 `fields: list[PluginField]` on the class; the frontend renders a form
 from those, the CLI derives flags from those, and the marshmallow
 schema builder validates POST bodies against those. The same dataclass
-is used by every family; each family re-exports it under a friendlier
-alias (`ImporterField`, `ExporterField`, `LabelImporterField`,
-`LabelsetSourceField`, …) which is a literal `= PluginField` assignment.
+is used by every family; each family's base module re-exports
+`PluginField` so plugins can import it alongside their base class.
 
 ### Constructor parameters
 
@@ -419,7 +418,7 @@ from __future__ import annotations
 from typing import Any
 import json
 
-from vtscore.exporters.base import LabelsetExporter, ExporterField
+from vtscore.exporters.base import LabelsetExporter, PluginField
 
 
 class StdoutLabelsetExporter(LabelsetExporter):
@@ -428,7 +427,7 @@ class StdoutLabelsetExporter(LabelsetExporter):
     description = "Print the labelset as JSON to stdout."
     icon = "\U0001f4dd"
     fields = [
-        ExporterField(
+        PluginField(
             key="indent",
             label="Indent",
             field_type="number",

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -21,7 +21,7 @@ set: set :attr:`~LabelsetExporter.supports_streaming` to ``True`` and implement
 Example – a minimal SFTP exporter skeleton::
 
     # vtsearch/exporters/sftp/__init__.py
-    from vtscore.exporters.base import LabelsetExporter, ExporterField
+    from vtscore.exporters.base import LabelsetExporter, PluginField
 
     class SftpLabelsetExporter(LabelsetExporter):
         name         = "sftp"
@@ -29,10 +29,10 @@ Example – a minimal SFTP exporter skeleton::
         description  = "Upload results JSON to a remote SFTP server."
         icon         = "📡"
         fields = [
-            ExporterField("host",     "Hostname",    "text"),
-            ExporterField("user",     "Username",    "text"),
-            ExporterField("password", "Password",    "password"),
-            ExporterField("path",     "Remote Path", "text",
+            PluginField("host",     "Hostname",    "text"),
+            PluginField("user",     "Username",    "text"),
+            PluginField("password", "Password",    "password"),
+            PluginField("path",     "Remote Path", "text",
                           default="/results/autodetect.json"),
         ]
 
@@ -56,10 +56,7 @@ from typing import Any, Iterator
 
 from vtscore.plugins import PluginBase, PluginField
 
-# Backward-compatible alias - existing plugins import ``ExporterField``.
-ExporterField = PluginField
-
-__all__ = ["ExporterField", "LabelsetExporter"]
+__all__ = ["LabelsetExporter", "PluginField"]
 
 
 class LabelsetExporter(PluginBase):
@@ -106,7 +103,7 @@ class LabelsetExporter(PluginBase):
                            }
                          }
 
-            field_values: Mapping of :attr:`ExporterField.key` → value string
+            field_values: Mapping of :attr:`PluginField.key` → value string
                 supplied by the user.
 
         Returns:
@@ -178,7 +175,7 @@ class LabelsetExporter(PluginBase):
                 (NOT globally sorted by score).  Each *hit* is the dict from
                 :func:`vtscore.utils.hits.build_media_hit` plus a ``"label"``
                 key (``"good"`` for above-threshold, ``"bad"`` otherwise).
-            field_values: Mapping of :attr:`ExporterField.key` → value.
+            field_values: Mapping of :attr:`PluginField.key` → value.
 
         Returns:
             A status dict with a ``"message"`` key (and optionally

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -16,7 +16,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 
 # Pragmatic address check: a non-empty local part, a single ``@``, and a
 # dotted domain, none of which may contain whitespace.  Not full RFC 5322
@@ -109,7 +109,7 @@ class EmailLabelsetExporter(LabelsetExporter):
     description = "Email the results summary to any address."
     icon = "📧"
     fields = [
-        ExporterField(
+        PluginField(
             key="from",
             label="Sender Email",
             field_type="email",
@@ -117,7 +117,7 @@ class EmailLabelsetExporter(LabelsetExporter):
             hint=("Must be on a domain you control - most MX hosts reject mail from non-existent domains."),
             placeholder="vtsearch@your-domain.example",
         ),
-        ExporterField(
+        PluginField(
             key="to",
             label="Recipient Email",
             field_type="email",

--- a/vtscore/exporters/holder/__init__.py
+++ b/vtscore/exporters/holder/__init__.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 
 
 # ---------------------------------------------------------------------------
@@ -125,10 +125,10 @@ class HolderLabelsetExporter(LabelsetExporter):
     description = "Create a Holder package with Good/Bad folders of contentIDs."
     icon = "\U0001f4e6"  # package
     hidden_from_picker = True  # flip to False once API clients are implemented
-    fields: list[ExporterField] = [
+    fields: list[PluginField] = [
         # No user-supplied fields - a new package is created automatically.
         # Add Holder auth/URL fields here when needed:
-        # ExporterField(key="holder_url", label="Holder API URL", field_type="text"),
+        # PluginField(key="holder_url", label="Holder API URL", field_type="text"),
     ]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 from vtscore.io import atomic_write_text
 
 _DEFAULT_CSV_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
@@ -62,7 +62,7 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
     description = "Write the results to a CSV file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        ExporterField(
+        PluginField(
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 from vtscore.io import atomic_write_json
 
 _DEFAULT_JSON_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.json"
@@ -42,7 +42,7 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
     description = "Write the results to a JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        ExporterField(
+        PluginField(
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",

--- a/vtscore/exporters/webhook/__init__.py
+++ b/vtscore/exporters/webhook/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import requests
 
-from vtscore.exporters.base import ExporterField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter
 
 
 class WebhookLabelsetExporter(LabelsetExporter):
@@ -25,14 +25,14 @@ class WebhookLabelsetExporter(LabelsetExporter):
     description = "POST the results as JSON to a URL."
     icon = "\U0001f310"
     fields = [
-        ExporterField(
+        PluginField(
             key="url",
             label="Webhook URL",
             field_type="url",
             description="The URL to POST the results JSON to.",
             placeholder="https://example.com/webhook",
         ),
-        ExporterField(
+        PluginField(
             key="auth_header",
             label="Authorization Header",
             field_type="password",

--- a/vtscore/labels/importers/base.py
+++ b/vtscore/labels/importers/base.py
@@ -25,7 +25,7 @@ where ``label`` is ``"good"`` or ``"bad"``.
 Example – a minimal database label importer skeleton::
 
     # vtsearch/labels/importers/postgres/__init__.py
-    from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+    from vtscore.labels.importers.base import LabelImporter, PluginField
 
     class PostgresLabelImporter(LabelImporter):
         name         = "postgres"
@@ -33,9 +33,9 @@ Example – a minimal database label importer skeleton::
         description  = "Import labels from a PostgreSQL database query."
         icon         = "🐘"
         fields = [
-            LabelImporterField("host",     "Hostname", "text"),
-            LabelImporterField("database", "Database", "text"),
-            LabelImporterField("query",    "SQL Query", "text",
+            PluginField("host",     "Hostname", "text"),
+            PluginField("database", "Database", "text"),
+            PluginField("query",    "SQL Query", "text",
                                description="Must return md5 and label columns."),
         ]
 
@@ -62,10 +62,7 @@ from typing import Any
 
 from vtscore.plugins import PluginBase, PluginField
 
-# Backward-compatible alias - existing plugins import ``LabelImporterField``.
-LabelImporterField = PluginField
-
-__all__ = ["LabelImporter", "LabelImporterField"]
+__all__ = ["LabelImporter", "PluginField"]
 
 
 class LabelImporter(PluginBase):
@@ -107,7 +104,7 @@ class LabelImporter(PluginBase):
         """Perform the import and return a list of label dicts.
 
         Args:
-            field_values: Mapping of :attr:`LabelImporterField.key` → value.
+            field_values: Mapping of :attr:`PluginField.key` → value.
                 Fields with ``field_type="file"`` receive an
                 :class:`~vtscore.plugins.uploads.UploadedFile` (Flask
                 requests pass a Werkzeug ``FileStorage`` straight

--- a/vtscore/labels/importers/holder/__init__.py
+++ b/vtscore/labels/importers/holder/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class HolderLabelImporter(LabelImporter):
     icon = "\U0001f4e6"  # package
     hidden_from_picker = True  # flip to False once API clients are implemented
     fields = [
-        LabelImporterField(
+        PluginField(
             key="holder_id",
             label="Holder ID",
             field_type="text",

--- a/vtscore/labels/importers/server_csv_file/__init__.py
+++ b/vtscore/labels/importers/server_csv_file/__init__.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.config import DATA_DIR
-from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
 class ServerCsvLabelImporter(LabelImporter):
@@ -35,7 +35,7 @@ class ServerCsvLabelImporter(LabelImporter):
     description = "Import labels from a CSV file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        LabelImporterField(
+        PluginField(
             key="filepath",
             label="Path or URL",
             field_type="server_path",

--- a/vtscore/labels/importers/server_json_file/__init__.py
+++ b/vtscore/labels/importers/server_json_file/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from vtscore.config import DATA_DIR
 from vtscore.io import read_server_json
-from vtscore.labels.importers.base import LabelImporter, LabelImporterField
+from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
 class ServerJsonLabelImporter(LabelImporter):
@@ -34,7 +34,7 @@ class ServerJsonLabelImporter(LabelImporter):
     description = "Import labels from a VTSearch-format JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        LabelImporterField(
+        PluginField(
             key="filepath",
             label="Path or URL",
             field_type="server_path",

--- a/vtscore/labels/sources/base.py
+++ b/vtscore/labels/sources/base.py
@@ -22,9 +22,7 @@ if TYPE_CHECKING:
     # noqa suppresses an otherwise-correct F401.
     from vtscore.datasets.labelset import LabelSet  # noqa: F401
 
-LabelsetSourceField = PluginField
-
-__all__ = ["LabelsetSource", "LabelsetSourceField"]
+__all__ = ["LabelsetSource", "PluginField"]
 
 
 class LabelsetSource(SyncSource[list[dict[str, str]], "LabelSet"]):

--- a/vtscore/labels/sources/server_json_file/__init__.py
+++ b/vtscore/labels/sources/server_json_file/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from vtscore.config import DATA_DIR
 from vtscore.io import atomic_write_json, read_server_json
-from vtscore.labels.sources.base import LabelsetSource, LabelsetSourceField
+from vtscore.labels.sources.base import LabelsetSource, PluginField
 
 if TYPE_CHECKING:
     from vtscore.datasets.labelset import LabelSet
@@ -25,7 +25,7 @@ class ServerFileLabelsetSource(LabelsetSource):
     description = "Sync detector labels with a JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        LabelsetSourceField(
+        PluginField(
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",

--- a/vtsearch/settings_io/exporters/base.py
+++ b/vtsearch/settings_io/exporters/base.py
@@ -15,9 +15,7 @@ from typing import Any
 
 from vtscore.plugins import PluginBase, PluginField
 
-SettingsExporterField = PluginField
-
-__all__ = ["SettingsExporter", "SettingsExporterField"]
+__all__ = ["PluginField", "SettingsExporter"]
 
 
 class SettingsExporter(PluginBase):

--- a/vtsearch/settings_io/exporters/server_json_file/__init__.py
+++ b/vtsearch/settings_io/exporters/server_json_file/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.io import atomic_write_json
-from vtsearch.settings_io.exporters.base import SettingsExporter, SettingsExporterField
+from vtsearch.settings_io.exporters.base import SettingsExporter, PluginField
 
 
 class ServerFileSettingsExporter(SettingsExporter):
@@ -21,7 +21,7 @@ class ServerFileSettingsExporter(SettingsExporter):
     description = "Write settings to a JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        SettingsExporterField(
+        PluginField(
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",

--- a/vtsearch/settings_io/importers/base.py
+++ b/vtsearch/settings_io/importers/base.py
@@ -15,9 +15,7 @@ from typing import Any
 
 from vtscore.plugins import PluginBase, PluginField
 
-SettingsImporterField = PluginField
-
-__all__ = ["SettingsImporter", "SettingsImporterField"]
+__all__ = ["PluginField", "SettingsImporter"]
 
 
 class SettingsImporter(PluginBase):

--- a/vtsearch/settings_io/importers/local_json_file/__init__.py
+++ b/vtsearch/settings_io/importers/local_json_file/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from vtsearch.settings_io.importers.base import SettingsImporter, SettingsImporterField
+from vtsearch.settings_io.importers.base import SettingsImporter, PluginField
 
 
 class LocalFileSettingsImporter(SettingsImporter):
@@ -20,7 +20,7 @@ class LocalFileSettingsImporter(SettingsImporter):
     description = "Import settings from a JSON file on your computer."
     icon = "\U0001f4c1"  # file folder
     fields = [
-        SettingsImporterField(
+        PluginField(
             key="file",
             label="Upload a file",
             field_type="file",

--- a/vtsearch/settings_io/importers/server_json_file/__init__.py
+++ b/vtsearch/settings_io/importers/server_json_file/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from vtscore.io import read_server_json
-from vtsearch.settings_io.importers.base import SettingsImporter, SettingsImporterField
+from vtsearch.settings_io.importers.base import SettingsImporter, PluginField
 
 
 class ServerFileSettingsImporter(SettingsImporter):
@@ -20,7 +20,7 @@ class ServerFileSettingsImporter(SettingsImporter):
     description = "Import settings from a JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        SettingsImporterField(
+        PluginField(
             key="filepath",
             label="Path or URL",
             field_type="server_path",

--- a/vtsearch/settings_io/sources/base.py
+++ b/vtsearch/settings_io/sources/base.py
@@ -16,9 +16,7 @@ from typing import Any
 from vtscore.plugins import PluginField
 from vtscore.sync import SyncSource
 
-SettingsSourceField = PluginField
-
-__all__ = ["SettingsSource", "SettingsSourceField"]
+__all__ = ["PluginField", "SettingsSource"]
 
 
 class SettingsSource(SyncSource[dict[str, Any], dict[str, Any]]):

--- a/vtsearch/settings_io/sources/server_json_file/__init__.py
+++ b/vtsearch/settings_io/sources/server_json_file/__init__.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.io import atomic_write_json, read_server_json
-from vtsearch.settings_io.sources.base import SettingsSource, SettingsSourceField
+from vtsearch.settings_io.sources.base import SettingsSource, PluginField
 
 
 class ServerFileSettingsSource(SettingsSource):
@@ -22,7 +22,7 @@ class ServerFileSettingsSource(SettingsSource):
     description = "Sync settings with a JSON file on the server filesystem."
     icon = "\U0001f5a5"  # desktop computer
     fields = [
-        SettingsSourceField(
+        PluginField(
             key="filepath",
             label="Save to (server path)",
             field_type="server_path",


### PR DESCRIPTION
Started as a stale-index cleanup; while re-checking the "what next?" candidates against current `dev`, picked up the Theme F refactor from `code-structure-review.md`.

## 1. Plans README refresh

The `docs/plans/README.md` index had drifted:

- **Removed** the `vtsbrowse-audit-fixes.md` entry — that file was deleted in `714ab086` after fully shipping.
- **Added** six plan files that existed on disk but weren't indexed: `auto-find-settings-tab`, `code-structure-review`, `dataset-import-archives`, `httpresource-migration`, `server-dedup-references`, `zoneless-migration`.
- **Refreshed stale status notes**: `structural-embedder` (V1 + Stage-2 + Find re-rank shipped, no longer "not started"), `user-docs-screenshots` (shipped 2026-06-10), `server-dedup-references` (Phase 2b landed in `98a8f0f4`), `scalability-plan` (Phase 2.2 label-sync debounce shipped).
- **Added a "Frontend migrations" group** for the Angular-21 / zoneless / rxResource docs.

## 2. Collapse PluginField aliases (Theme F)

The plugin field dataclass was re-exported under seven per-family no-op aliases (`ImporterField`, `ExporterField`, `LabelImporterField`, `LabelsetSourceField`, `SettingsSourceField`, `SettingsImporterField`, `SettingsExporterField`), each a literal `= PluginField`. The renamed aliases falsely implied field types differ per plugin family.

- Removed all seven aliases. Every plugin and test now uses `PluginField` directly.
- Each family's base module still re-exports `PluginField` (via its existing `from vtscore.plugins import PluginField`), so the ergonomic `from <family>.base import PluginField, <BaseClass>` import still works.
- Docs updated to teach `PluginField` directly (EXTENDING-plugins, ARCHITECTURE, package + extending guides, API sketch).
- Marked the Theme F alias item shipped in `docs/plans/code-structure-review.md`.

**Backwards-incompatible**: external plugins importing the old alias names must switch to `PluginField`.

## Testing

`./run-tests.sh` — all 5141 tests pass (ruff, format, codespell, deptry, frontend build all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdVHXGUMb8bYg6sFwwGAoi)_