### PR TITLE
Fix DemoDatasets import UI: inline checkbox, eager dataset-name, archive label

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -20,7 +20,7 @@
     [selectedDemoName]="selectedDemo?.name || ''"
     (demoSelected)="selectDemo($event)"
     [sfPathInputValue]="sfPathInputValue"
-    (sfPathInputValueChange)="sfPathInputValue = $event"
+    (sfPathInputValueChange)="sfOnPathInput($event)"
     (sfPathApplied)="sfApplyPathInput()"
     [lfPickerKind]="lfPickerKind"
     [lfFiles]="lfFiles"
@@ -136,7 +136,7 @@
             [ngModel]="sfDigArchives"
             (ngModelChange)="sfDigArchives = $event"
           />
-          Dig into archives
+          Include archives' contents
         </label>
       </div>
 
@@ -294,6 +294,22 @@
                 <p class="form-hint">{{ field.hint }}</p>
               }
             }
+          } @else if (field.field_type === 'checkbox') {
+          <div class="form-group">
+            <label class="form-label" [for]="'field-' + field.key"
+              [title]="field.description || field.label || field.key">
+              <input
+                [id]="'field-' + field.key"
+                type="checkbox"
+                [checked]="formValues[field.key] === true || formValues[field.key] === 'true'"
+                (change)="formValues[field.key] = $any($event.target).checked ? 'true' : 'false'"
+              />
+              {{ field.label || field.key }}
+              @if (field.hint) {
+                <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
+              }
+            </label>
+          </div>
           } @else {
           <div class="form-group">
             <label class="form-label" [for]="'field-' + field.key"
@@ -321,13 +337,6 @@
                 class="form-input"
                 [accept]="field.accept || ''"
                 (change)="onFileSelected($event, field.key)"
-              />
-            } @else if (field.field_type === 'checkbox') {
-              <input
-                [id]="'field-' + field.key"
-                type="checkbox"
-                [checked]="formValues[field.key] === true || formValues[field.key] === 'true'"
-                (change)="formValues[field.key] = $any($event.target).checked ? 'true' : 'false'"
               />
             } @else if (field.field_type === 'select') {
               <select

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1664,6 +1664,30 @@ export class DatasetImporterModalComponent implements OnInit {
    *  ``sfFolderPath`` for the submit + detection helpers to consume. */
   sfPathInputValue = '';
 
+  /** Called on every keystroke in the absolute-path input.  Commits the
+   *  typed value to ``sfFolderPath`` (so the Import button enables and the
+   *  Dataset Name auto-derives live, without the user having to blur the
+   *  field first) but defers the server-side media-type detection to
+   *  :meth:`sfApplyPathInput` on blur/enter so we don't fire a request per
+   *  keystroke. */
+  sfOnPathInput(value: string): void {
+    this.sfPathInputValue = value;
+    const raw = (value || '').trim();
+    if (!raw) {
+      this.sfFolderPath = '';
+      this.sfBrowseError.set('');
+      this.sfDetection.set(null);
+      if (!this.sfDatasetNameDirty) {
+        this.sfDatasetName = '';
+      }
+      return;
+    }
+    this.sfFolderPath = raw.replace(/\/+$/, '') || '/';
+    if (!this.sfDatasetNameDirty) {
+      this.sfDatasetName = this.sfDerivedDatasetName();
+    }
+  }
+
   /** Apply the value typed into the absolute-path input. The path is not
    *  verified here - the server validates it on submit. */
   sfApplyPathInput(): void {

--- a/vtscore/datasets/importers/server_folder/__init__.py
+++ b/vtscore/datasets/importers/server_folder/__init__.py
@@ -158,7 +158,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
         ),
         PluginField(
             key="dig_archives",
-            label="Dig into archives",
+            label="Include archives' contents",
             field_type="checkbox",
             description=(
                 "When enabled, archives (.zip, .tar, .rar …) found inside the chosen "


### PR DESCRIPTION
## Summary

Fixes three UX issues in the **Add Dataset** modal's Files importers (Folder + Manifest).

### 1. Malformed checkbox in the Manifest form
Generic-form `checkbox` fields rendered their label *above* the input (the standard label-then-field layout), leaving the box floating in the middle of the row. They now render inline — the checkbox sits to the left of its label, matching the server-folder checkboxes (e.g. "Reference files in place"). This fixes the Manifest > "Reference files in place (don't copy)" box.

### 2. Dataset Name no longer requires a click to populate / enable Import
In the **Folder** flow the typed server path only committed on `blur`, so the Import button stayed disabled and the Dataset Name stayed empty until the user clicked elsewhere (e.g. into the name field). The path input now commits live on each keystroke, so:
- the **Import** button enables as soon as a path is typed, and
- the **Dataset Name** auto-derives from the path immediately.

Server-side media-type detection is still deferred to `blur`/`Enter` so we don't fire a detection request per keystroke. Leaving the name blank remains valid — the importer falls back to its default display name. (The Manifest form already derived the name live via its file-browser input; this brings the Folder flow to parity.)

### 3. Checkbox label wording
"Dig into archives" → **"Include archives' contents"** (both the hardcoded server-folder label and the backend `server_folder` field label).

## Testing
- `./run-tests.sh frontend` — build OK, 860 Vitest tests pass, audit clean.
- `./run-tests.sh io` — 783 backend importer/IO tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKc5gA1yFvTquevoz9DSho)_