### PR TITLE
Fix audio demo import with a clipper: defer embedding + CLAP 10s crash

### DIFF
--- a/tests_lib/downloads/test_gtzan_download.py
+++ b/tests_lib/downloads/test_gtzan_download.py
@@ -331,6 +331,55 @@ class TestLoadDemoSourceGtzan:
         categories_seen = {c["category"] for c in clips.values()}
         assert categories_seen == {"blues", "rock"}
 
+    def test_skip_embedding_defers_to_clipper(self, tmp_path):
+        """skip_embedding=True keeps every media with a deferred-embed placeholder.
+
+        Regression: a clipper-driven demo import must not embed (or drop) the
+        full parent recordings. Even when the embedder would return None for a
+        parent (e.g. a recording longer than CLAP's window), the media must
+        survive with ``embeddings={}`` so the clipper can re-embed its clips.
+        """
+        from vtscore.datasets import downloader as dl_module
+        from vtscore.datasets import loader as loader_module
+        from vtscore.media.audio.media_type import AudioMediaType
+
+        fake_metadata = {
+            "blues/blues.00001.wav": {"category": "blues", "path": tmp_path / "blues.00001.wav"},
+            "rock/rock.00001.wav": {"category": "rock", "path": tmp_path / "rock.00001.wav"},
+        }
+        for meta in fake_metadata.values():
+            meta["path"].write_bytes(b"RIFF" + b"\x00" * 40)
+
+        mt = AudioMediaType()
+        mt.load_media_data = MagicMock(return_value={"media_bytes": b"", "duration": 1.0})
+        mock_emb = self._make_mock_embedder()
+        # Simulate the full-parent embed failing; with skip_embedding it must
+        # never be called, so no media is dropped.
+        mock_emb.embed_media = MagicMock(return_value=None)
+        mock_emb.load_models = MagicMock()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_gtzan", return_value=tmp_path),
+            patch.object(loader_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="gtzan",
+                categories=["blues", "rock"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+                skip_embedding=True,
+            )
+
+        assert len(clips) == 2
+        mock_emb.embed_media.assert_not_called()
+        for clip in clips.values():
+            assert clip["embeddings"] == {}
+            assert clip["embedder"] == "clap"
+
     def test_gtzan_slice_is_applied(self, tmp_path):
         """slice_start/slice_end limits files per category."""
         from vtscore.datasets import downloader as dl_module

--- a/tests_lib/gpu/test_gpu.py
+++ b/tests_lib/gpu/test_gpu.py
@@ -528,7 +528,7 @@ class TestCLAPEmbeddingGPU:
             return_tensors="pt",
             padding="max_length",
             max_length=480000,
-            truncation=True,
+            truncation="rand_trunc",
         )
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -229,6 +229,18 @@ def load_demo_dataset(  # noqa: C901
     slice_frac_end = dataset_info.get("slice_frac_end")
 
     medias.clear()
+
+    # When a real (non-default) clipper is configured, the clipper stage below
+    # splits every loaded media into sub-clips and re-embeds each clip from its
+    # own bytes. Embedding the full parent during load would then be wasted work
+    # whose result is immediately discarded - and for audio it actively breaks:
+    # a parent recording longer than the embedder's window (e.g. CLAP's 10 s)
+    # could fail to embed and be dropped before the clipper ever cuts it down to
+    # an embeddable clip. So defer embedding to the clipper: load the parents
+    # with a deferred-embed placeholder and let _apply_clipper produce the
+    # vectors. Mirrors the regular import pipeline, which skips parent embedding
+    # whenever a clipper is specified.
+    clipper_applied = bool(_effective_clipper(clipper_name, media_type_id))
     external_dir = mt.load_demo_source(
         source=source,
         categories=categories,
@@ -239,6 +251,7 @@ def load_demo_dataset(  # noqa: C901
         embedder=embedder,
         slice_frac_start=slice_frac_start,
         slice_frac_end=slice_frac_end,
+        skip_embedding=clipper_applied,
     )
 
     # Stamp the demo origin on all medias
@@ -262,7 +275,6 @@ def load_demo_dataset(  # noqa: C901
     # parent's category/metadata.  Skipped for the pre-selected default
     # clipper (a no-op).  Runs after any converter so it operates on the
     # final media type.
-    clipper_applied = bool(_effective_clipper(clipper_name, media_type_id))
     if clipper_applied:
         from vtscore.datasets.stages.clipper import _apply_clipper
 

--- a/vtscore/media/audio/_clap_shared.py
+++ b/vtscore/media/audio/_clap_shared.py
@@ -24,6 +24,16 @@ from typing import Any, Optional
 import numpy as np
 
 from vtscore.config import CLAP_SAMPLE_RATE
+
+# CLAP embeds a single 10 s window (480000 samples at 48 kHz). The feature
+# extractor only knows how to *truncate* longer audio via "rand_trunc" (a
+# random crop) or "fusion" (4-channel, fusion checkpoints only) - and the
+# unfused HTSAT checkpoints we load support neither cleanly. A random crop
+# would also make re-embedding the same file non-deterministic, which breaks
+# the origin -> embedding rederivation contract. So we truncate to exactly
+# CLAP_MAX_SAMPLES ourselves (deterministic first window); the feature
+# extractor then takes its equal-length branch and never crops.
+CLAP_MAX_SAMPLES = 480000
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
@@ -132,8 +142,8 @@ class _ClapBase(MediaEmbedder):
             sampling_rate=CLAP_SAMPLE_RATE,
             return_tensors="pt",
             padding="max_length",
-            max_length=480000,
-            truncation=True,
+            max_length=CLAP_MAX_SAMPLES,
+            truncation="rand_trunc",
         )
         self._on_progress("loading", f"Warming up {self.label} pipeline: running model…", 3, 3)
         device = next(self._model.parameters()).device
@@ -183,13 +193,19 @@ class _ClapBase(MediaEmbedder):
                 assert file_path is not None  # narrowed by the path_str check above
                 source = file_path
             audio_data, _sr = librosa.load(source, sr=CLAP_SAMPLE_RATE, mono=True)
+            # Deterministic truncation to a single 10 s window: drop everything
+            # past CLAP_MAX_SAMPLES so the feature extractor never reaches its
+            # random-crop ("rand_trunc") path. The explicit truncation string is
+            # a valid defensive value; it is not actually exercised here.
+            if audio_data.shape[0] > CLAP_MAX_SAMPLES:
+                audio_data = audio_data[:CLAP_MAX_SAMPLES]
             inputs = self._processor(
                 audio=audio_data,
                 sampling_rate=CLAP_SAMPLE_RATE,
                 return_tensors="pt",
                 padding="max_length",
-                max_length=480000,
-                truncation=True,
+                max_length=CLAP_MAX_SAMPLES,
+                truncation="rand_trunc",
             )
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -617,6 +617,7 @@ class AudioMediaType(MediaType):
         embedder=None,
         slice_frac_start=None,
         slice_frac_end=None,
+        skip_embedding=False,
         **kwargs,
     ):
         import hashlib  # noqa: PLC0415
@@ -644,8 +645,9 @@ class AudioMediaType(MediaType):
             on_progress,
         )
 
-        # Load models
-        if getattr(embedder, "_model", None) is None:
+        # Load models (skipped when a clipper will re-embed every clip - see
+        # skip_embedding in load_demo_dataset).
+        if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading audio embedding model…", 0, 0)
             original_cb = embedder._on_progress
             embedder._on_progress = on_progress
@@ -656,17 +658,23 @@ class AudioMediaType(MediaType):
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(audio_files)
-        on_progress("embedding", f"Starting embedding for {total} audio files...", 0, total)
+        status = "loading" if skip_embedding else "embedding"
+        verb = "Loading" if skip_embedding else "Embedding"
+        on_progress(status, f"{verb} {total} audio files...", 0, total)
         demo_origin: dict = {"importer": "demo", "params": {}}
 
         from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
         for i, (audio_path, meta) in enumerate(audio_files):
             rel_name = f"{meta['category']}/{audio_path.name}"
-            on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
-            embedding = embedder.embed_media(media_from_path(audio_path))
-            if embedding is None:
-                continue
+            if skip_embedding:
+                on_progress("loading", f"Loading {rel_name}", i + 1, total)
+                embedding = None
+            else:
+                on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
+                embedding = embedder.embed_media(media_from_path(audio_path))
+                if embedding is None:
+                    continue
 
             with open(audio_path, "rb") as f:
                 wav_bytes = f.read()
@@ -679,7 +687,7 @@ class AudioMediaType(MediaType):
                 "duration": media_fields["duration"],
                 "file_size": len(wav_bytes),
                 "md5": hashlib.md5(wav_bytes).hexdigest(),
-                "embeddings": {embedder.name: embedding},
+                "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": wav_bytes,
                 "thumbnail_bytes": media_fields.get("thumbnail_bytes"),
                 "filename": rel_name,

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -373,6 +373,12 @@ class MediaType(ABC):
             clips: Dict to populate in-place.  The caller has already cleared
                 it.  Keys should be sequential integer clip IDs starting at 1.
             on_progress: Optional progress callback.
+            skip_embedding: When ``True`` (passed via ``**kwargs``), populate
+                each media with a deferred-embed placeholder (``embeddings={}``)
+                instead of embedding it here.  The demo loader sets this when a
+                clipper will split + re-embed every clip, so embedding the full
+                parent would be wasted (and, for audio, can fail on parents
+                longer than the embedder window before the clipper trims them).
 
         Returns:
             An optional external media directory path (absolute string) to

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -743,25 +743,32 @@ def _ensure_image_embedder_loaded(embedder, on_progress) -> None:
             embedder._on_progress = original_cb
 
 
-def _embed_file_images(selected, clips, embedder, on_progress, demo_origin) -> None:
+def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (img_path, category) tuples into ``clips``."""
     import hashlib  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
-    _ensure_image_embedder_loaded(embedder, on_progress)
+    if not skip_embedding:
+        _ensure_image_embedder_loaded(embedder, on_progress)
 
     clip_id = max(clips.keys(), default=0) + 1
     total = len(selected)
-    on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+    status = "loading" if skip_embedding else "embedding"
+    verb = "Loading" if skip_embedding else "Embedding"
+    on_progress(status, f"{verb} {total} images...", 0, total)
 
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
     for i, (img_path, category) in enumerate(selected):
-        on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
-        embedding = embedder.embed_media(media_from_path(img_path))
-        if embedding is None:
-            continue
+        if skip_embedding:
+            on_progress("loading", f"Loading {category}/{img_path.name}", i + 1, total)
+            embedding = None
+        else:
+            on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
+            embedding = embedder.embed_media(media_from_path(img_path))
+            if embedding is None:
+                continue
         with open(img_path, "rb") as f:
             image_bytes = f.read()
         try:
@@ -776,7 +783,7 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin) -> N
             "duration": 0,
             "file_size": len(image_bytes),
             "md5": hashlib.md5(image_bytes).hexdigest(),
-            "embeddings": {embedder.name: embedding},
+            "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
             "filename": f"{category}/{img_path.name}",
@@ -789,22 +796,29 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin) -> N
         clip_id += 1
 
 
-def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin) -> None:
+def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (page_name, PIL.Image, category) tuples into ``clips``."""
     import hashlib  # noqa: PLC0415
     import io as _io  # noqa: PLC0415
 
-    _ensure_image_embedder_loaded(embedder, on_progress)
+    if not skip_embedding:
+        _ensure_image_embedder_loaded(embedder, on_progress)
 
     clip_id = max(clips.keys(), default=0) + 1
     total = len(selected_pages)
-    on_progress("embedding", f"Starting embedding for {total} document pages...", 0, total)
+    status = "loading" if skip_embedding else "embedding"
+    verb = "Loading" if skip_embedding else "Embedding"
+    on_progress(status, f"{verb} {total} document pages...", 0, total)
 
     for i, (page_name, pil_image, category) in enumerate(selected_pages):
-        on_progress("embedding", f"Embedding {page_name}", i + 1, total)
-        embedding = cast(Any, embedder).embed_pil_image(pil_image)
-        if embedding is None:
-            continue
+        if skip_embedding:
+            on_progress("loading", f"Loading {page_name}", i + 1, total)
+            embedding = None
+        else:
+            on_progress("embedding", f"Embedding {page_name}", i + 1, total)
+            embedding = cast(Any, embedder).embed_pil_image(pil_image)
+            if embedding is None:
+                continue
         img_buffer = _io.BytesIO()
         pil_image.save(img_buffer, format="PNG")
         image_bytes = img_buffer.getvalue()
@@ -816,7 +830,7 @@ def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin) 
             "duration": 0,
             "file_size": len(image_bytes),
             "md5": hashlib.md5(image_bytes).hexdigest(),
-            "embeddings": {embedder.name: embedding},
+            "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
             "filename": f"{rel_name}.png",
@@ -829,28 +843,34 @@ def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin) 
         clip_id += 1
 
 
-def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin) -> None:
+def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (image_array, category) tuples into ``clips``."""
     import hashlib  # noqa: PLC0415
     import io as _io  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
-    _ensure_image_embedder_loaded(embedder, on_progress)
+    if not skip_embedding:
+        _ensure_image_embedder_loaded(embedder, on_progress)
 
     clip_id = max(clips.keys(), default=0) + 1
     total = len(selected)
-    on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+    status = "loading" if skip_embedding else "embedding"
+    verb = "Loading" if skip_embedding else "Embedding"
+    on_progress(status, f"{verb} {total} images...", 0, total)
 
     for i, (image_array, category) in enumerate(selected):
-        on_progress("embedding", f"Embedding {category}", i + 1, total)
+        on_progress(status, f"{verb} {category}", i + 1, total)
         img = Image.fromarray(image_array.astype("uint8"), "RGB")
         img_buffer = _io.BytesIO()
         img.save(img_buffer, format="PNG")
         image_bytes = img_buffer.getvalue()
-        embedding = cast(Any, embedder).embed_pil_image(img)
-        if embedding is None:
-            continue
+        if skip_embedding:
+            embedding = None
+        else:
+            embedding = cast(Any, embedder).embed_pil_image(img)
+            if embedding is None:
+                continue
         fname = f"{category}/{category}_{clip_id}.png"
         clips[clip_id] = {
             "id": clip_id,
@@ -859,7 +879,7 @@ def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin) -> 
             "duration": 0,
             "file_size": len(image_bytes),
             "md5": hashlib.md5(image_bytes).hexdigest(),
-            "embeddings": {embedder.name: embedding},
+            "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
             "filename": fname,
@@ -892,7 +912,7 @@ def _normalize_regions(pixel_regions, width, height) -> list:
     return out
 
 
-def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin) -> None:
+def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed Visual Genome images, stamping multi-label categories + regions.
 
     ``selected`` is a list of ``(img_path, positive_categories, pixel_regions)``.
@@ -906,18 +926,25 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin) -> Non
 
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
-    _ensure_image_embedder_loaded(embedder, on_progress)
+    if not skip_embedding:
+        _ensure_image_embedder_loaded(embedder, on_progress)
 
     clip_id = max(clips.keys(), default=0) + 1
     total = len(selected)
-    on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+    status = "loading" if skip_embedding else "embedding"
+    verb = "Loading" if skip_embedding else "Embedding"
+    on_progress(status, f"{verb} {total} images...", 0, total)
 
     for i, (img_path, positive_categories, pixel_regions) in enumerate(selected):
         primary = positive_categories[0]
-        on_progress("embedding", f"Embedding {primary}/{img_path.name}", i + 1, total)
-        embedding = embedder.embed_media(media_from_path(img_path))
-        if embedding is None:
-            continue
+        if skip_embedding:
+            on_progress("loading", f"Loading {primary}/{img_path.name}", i + 1, total)
+            embedding = None
+        else:
+            on_progress("embedding", f"Embedding {primary}/{img_path.name}", i + 1, total)
+            embedding = embedder.embed_media(media_from_path(img_path))
+            if embedding is None:
+                continue
         with open(img_path, "rb") as f:
             image_bytes = f.read()
         try:
@@ -932,7 +959,7 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin) -> Non
             "duration": 0,
             "file_size": len(image_bytes),
             "md5": hashlib.md5(image_bytes).hexdigest(),
-            "embeddings": {embedder.name: embedding},
+            "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
             "filename": img_path.name,
@@ -972,6 +999,11 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             raise ValueError(f"No embedders registered for media type {_MEDIA_TYPE_ID!r}")
         embedder = avail[0]
 
+    # When a clipper will re-embed every produced crop, skip embedding the full
+    # parent images here (the result would be discarded) - see skip_embedding in
+    # load_demo_dataset.
+    skip_embedding = bool(kwargs.get("skip_embedding", False))
+
     demo_origin: dict = {"importer": "demo", "params": {}}
     slice_args = (slice_start, slice_end, slice_frac_start, slice_frac_end)
 
@@ -982,6 +1014,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -992,6 +1025,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1002,6 +1036,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1012,6 +1047,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1022,6 +1058,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1032,6 +1069,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1042,6 +1080,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 
@@ -1052,6 +1091,7 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
             embedder,
             on_progress,
             demo_origin,
+            skip_embedding=skip_embedding,
         )
         return None
 

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -539,6 +539,7 @@ class TextMediaType(MediaType):
         embedder=None,
         slice_frac_start=None,
         slice_frac_end=None,
+        skip_embedding=False,
         **kwargs,
     ):
         import hashlib  # noqa: PLC0415
@@ -566,7 +567,9 @@ class TextMediaType(MediaType):
             on_progress,
         )
 
-        if getattr(embedder, "_model", None) is None:
+        # Load models (skipped when a clipper will re-embed every clip - see
+        # skip_embedding in load_demo_dataset).
+        if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading text embedding model…", 0, 0)
             original_cb = embedder._on_progress
             embedder._on_progress = on_progress
@@ -577,21 +580,26 @@ class TextMediaType(MediaType):
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(selected_texts)
-        on_progress("embedding", f"Starting embedding for {total} paragraphs...", 0, total)
+        status = "loading" if skip_embedding else "embedding"
+        verb = "Loading" if skip_embedding else "Embedding"
+        on_progress(status, f"{verb} {total} paragraphs...", 0, total)
         demo_origin_template: dict = {"importer": "demo", "params": {}}
 
         for i, (text_content, category) in enumerate(zip(selected_texts, selected_categories)):
-            on_progress("embedding", f"Embedding {category}", i + 1, total)
+            on_progress(status, f"{verb} {category}", i + 1, total)
             text_content = text_content[:1000].strip()
             if not text_content:
                 continue
-            try:
-                embedding = cast(Any, embedder).embed_text_passage(text_content)
-            except Exception:
-                logging.getLogger(__name__).exception("Error embedding paragraph")
-                continue
-            if embedding is None:
-                continue
+            if skip_embedding:
+                embedding = None
+            else:
+                try:
+                    embedding = cast(Any, embedder).embed_text_passage(text_content)
+                except Exception:
+                    logging.getLogger(__name__).exception("Error embedding paragraph")
+                    continue
+                if embedding is None:
+                    continue
             word_count = len(text_content.split())
             character_count = len(text_content)
             text_bytes = text_content.encode("utf-8")
@@ -603,7 +611,7 @@ class TextMediaType(MediaType):
                 "duration": 0,
                 "file_size": len(text_bytes),
                 "md5": hashlib.md5(text_bytes).hexdigest(),
-                "embeddings": {embedder.name: embedding},
+                "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": None,
                 "media_string": text_content,
                 "filename": fname,

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -695,6 +695,7 @@ class VideoMediaType(MediaType):
         embedder=None,
         slice_frac_start=None,
         slice_frac_end=None,
+        skip_embedding=False,
         **kwargs,
     ):
         import hashlib  # noqa: PLC0415
@@ -740,7 +741,9 @@ class VideoMediaType(MediaType):
                 )
             )
 
-        if getattr(embedder, "_model", None) is None:
+        # Load models (skipped when a clipper will re-embed every clip - see
+        # skip_embedding in load_demo_dataset).
+        if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading video embedding model\u2026", 0, 0)
             original_cb = embedder._on_progress
             embedder._on_progress = on_progress
@@ -751,17 +754,23 @@ class VideoMediaType(MediaType):
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(video_files)
-        on_progress("embedding", f"Starting embedding for {total} video files...", 0, total)
+        status = "loading" if skip_embedding else "embedding"
+        verb = "Loading" if skip_embedding else "Embedding"
+        on_progress(status, f"{verb} {total} video files...", 0, total)
         demo_origin_template: dict = {"importer": "demo", "params": {}}
 
         from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
         for i, (video_path, meta) in enumerate(video_files):
             rel_name = f"{meta['category']}/{video_path.name}"
-            on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
-            embedding = embedder.embed_media(media_from_path(video_path))
-            if embedding is None:
-                continue
+            if skip_embedding:
+                on_progress("loading", f"Loading {rel_name}", i + 1, total)
+                embedding = None
+            else:
+                on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
+                embedding = embedder.embed_media(media_from_path(video_path))
+                if embedding is None:
+                    continue
             with open(video_path, "rb") as f:
                 video_bytes = f.read()
             media_fields = self.load_media_data(video_path)
@@ -772,7 +781,7 @@ class VideoMediaType(MediaType):
                 "duration": media_fields["duration"],
                 "file_size": len(video_bytes),
                 "md5": hashlib.md5(video_bytes).hexdigest(),
-                "embeddings": {embedder.name: embedding},
+                "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": video_bytes,
                 "thumbnail_bytes": media_fields.get("thumbnail_bytes"),
                 "filename": rel_name,

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -684,7 +684,7 @@ class VideoMediaType(MediaType):
         "kth": "download_kth",
     }
 
-    def load_demo_source(
+    def load_demo_source(  # noqa: C901 - flat per-item embed/defer branching
         self,
         source,
         categories,


### PR DESCRIPTION
## Symptom

Importing an audio demo dataset (TUT sound events) **with a clipper set to cut to 10s** failed with `ValueError: Import produced no medias.` Every file errored during embedding:

```
NotImplementedError: data_truncating True not implemented
  .../transformers/models/clap/feature_extraction_clap.py", line 237, in _get_input_mel
```

The user correctly noted the clips should never have exceeded 10s — so why was the embedder choking on full ~30s files? Two distinct problems.

## Problem 1 — the embedder was seeing the *full parent* files, not the clips

The demo loaders embed each media during load (`load_demo_source`), and the clipper runs *afterward*. So the full ~30s parent recordings were embedded first. Worse, the audio demo loader **drops** any media whose embedding returns `None` (`if embedding is None: continue`) — so when CLAP crashed on every full file, every media was dropped and the import produced zero medias.

**Fix:** thread a `skip_embedding` flag from `load_demo_dataset` (set when a real, non-default clipper is configured) through every media type's `load_demo_source` (audio, image, video, text). When set, parents are created with a deferred-embed placeholder (`embeddings={}`), model loading and per-item embedding are skipped, and `_apply_clipper` embeds the clips from their own bytes. This mirrors the regular import pipeline, which already skips parent embedding when a clipper is specified. The embedder now only ever sees the (≤ clip-length) clips.

## Problem 2 — CLAP crashes on any audio longer than its 10s window

Independently, the CLAP feature extractor in newer `transformers` rejects `truncation=True` for any waveform longer than the 10s (480000-sample) window. The only valid long-audio modes are `"rand_trunc"` (a **random** crop — non-deterministic, breaks the origin→embedding rederivation contract) or `"fusion"` (4-channel, fusion checkpoints only; our unfused HTSAT checkpoints can't use it).

**Fix:** truncate the waveform to exactly 10s ourselves (deterministic first window) before calling the processor, so the feature extractor takes its equal-length branch and never crops. `"rand_trunc"` is passed as a valid defensive value but is never exercised. Applied to the embed path, the warmup call, and the GPU test that mirrors the call. This keeps full-file audio embedding working for the no-clipper case (`sound_default`).

## Testing

- New regression test (`test_skip_embedding_defers_to_clipper`): a clipper-driven demo import keeps every media with `embeddings={}` and never calls the parent embedder, even when embedding would have returned `None`.
- `./run-tests.sh` — all tests pass (5167 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)