### PR TITLE
Audit noqa: C901 markers — remove inert ones, refactor the worst offenders

### DIFF
--- a/docs/plans/c901-complexity-cleanup.md
+++ b/docs/plans/c901-complexity-cleanup.md
@@ -1,0 +1,82 @@
+# C901 complexity-marker cleanup
+
+**Status:** First pass shipped (stale-marker removal + the McCabe ≥16 tier refactored). Remaining refactor candidates deferred; see Open follow-ups.
+
+## Background
+
+Every legacy hot-spot over the McCabe threshold (`max-complexity = 10`) carries a
+per-function `# noqa: C901`. This pass audited all of them to answer: *does each
+function genuinely need the exception, or is the marker hiding avoidable complexity?*
+
+Method: `ruff check --select C901 --ignore-noqa` reports the true McCabe number for
+each suppressed function. Each was then classified **stale** (already ≤10, marker
+inert), **justified** (intrinsic complexity — flat dispatch, coupled validation
+cascade, retry state machine, or nested-closure factory), or **refactorable** (a
+cohesive sub-block extracts cleanly into a helper, dropping the function under 10
+*and* reading better).
+
+## What shipped
+
+**Inert markers removed (5):** the four functions below were already ≤10 (simplified
+since the marker was added), and `scripts/**` is already C901-exempt via
+`per-file-ignores`, so its inline token was redundant.
+
+- `vtsearch/achievements.py` `_credit_vote`
+- `vtsearch/routes/detectors/scoring.py` `find_label`
+- `vtscore/datasets/archive.py` `extract_archive`
+- `vtscore/datasets/clipper_chain.py` `_select_chain_output`
+- `scripts/spike_structural_roxford.py` `main` (dropped the redundant `C901`, kept `PLR0915`)
+
+**Refactored below threshold (9), highest-complexity tier (McCabe ≥16):**
+
+| Function | Was | Helpers extracted |
+|---|---|---|
+| `stages/embedding.embed_missing` | 33 | `_resolve_embedder`, `_run_embed_pass`, `_run_backfill_pass`, `_missing_for_embedder`, `_needs_side_channel`, `_ensure_model_loaded`, `_noop_progress` |
+| `media/list.add_media_to_pile` | 20 | `_read_pile_upload`, `_resolve_embedder`, `_embed_upload`, `_make_pile_thumbnail`, `_insert_or_collide` |
+| `file_browser.browse` | 17 | `_entry_to_listing`, `_parse_allowed_exts` |
+| `detectors/registry.load_detector_route` | 17 | `_run_detector_load_task`, `_unload_active_detector` |
+| `loader_demo.load_demo_dataset` | 17 | `_try_load_cached`, `_resolve_demo_embedder`, `_write_demo_cache` |
+| `downloader/core._download_and_extract` | 17 | `_extract_archive` |
+| `detectors/labels.import_labels_into_detector` | 16 | `_merge_entries_into_labelset` |
+| `datasets/ingest.ingest_missing_medias` | 16 | `_ingest_via_importer` (mirrors existing `_ingest_via_source`/`_ingest_via_resolver`) |
+| `downloader/text.download_bbc_news` | 16 | `_ensure_bbc_extracted` |
+
+All behavior-preserving; full suite (5168 tests) green.
+
+## Justified — left as-is (noqa kept)
+
+These stay flagged because the complexity is intrinsic and extraction would *hurt*
+readability: flat one-branch-per-case dispatch (`_demo_sources.load_demo_source`,
+`replay_chain_on_file`, `resolver._resolve_with_stack`, `_export_autodetect`),
+coupled validation/guard cascades (`combine_detectors`, `load_pipeline_file`,
+`sync_from_labelset_source`, `resolve_or_train_detector`, `register_detector_from_labelset`,
+`load_registered_dataset`, `resolve_file`, `run_label_import`,
+`detect_media_types_in_folder`, `_stamp_origin`, `download_ucsf_documents`,
+`download_arxiv_abstracts`, `apply_chain_to_clips`, `_fixup_clip_md5_and_embeddings`),
+retry/resume state machines (`download_file_with_progress`), irreducible loop nests
+(`_build_node`, `run_label_curve_eval`), the train-first/rollback ordering in
+`apply_and_retrain`, and nested-closure factories whose McCabe is inflated by
+aggregated `def`s sharing captured state (`_make_per_side_setting`,
+`intercept_tqdm_progress`, `stream_progress_events`, `_resolve_context`,
+`_transcode_to_mp4`, `media_type.load_demo_source`).
+
+## Open follow-ups
+
+Refactorable but deferred (the audit found a clean extraction for each; not done in
+this pass). Each drops under 10 with the named helper:
+
+| Function | McCabe | Suggested extraction |
+|---|---|---|
+| `media/list._resolve_display_image` | 11 | `_MIMETYPE_BY_EXT` dict lookup |
+| `converters/video2image.convert` | 14 | `_compute_n_frames(...)` |
+| `concurrency/progress.list_tasks` | 14 | `_build_snapshot(task_id, entry)` (de-dup branches) |
+| `detectors/labeling_progress._ensure_cache` | 11 | `_resolve_step_model(...)` |
+| `detectors/labeling_progress._eval_cached_models` | 14 | `_score_step(...)` |
+| `detectors/label_restoration.restore_labels_from_detector` | 15 | `_resolve_unmatched(...)` |
+| `detectors/media_seeding.seed_good_votes_from_examples` | 14 | `_ensure_embedder(...)` |
+| `routes/labels/vote.fill_labels_from_sort` | 15 | `_partition_candidates(...)` |
+| `labels/importers/server_csv_file._parse_csv_bytes` | 13 | `_row_to_entry(...)` |
+| `datasets/stages/clipper._apply_clipper` | 12 | `_stamp_default_clipper(...)` |
+| `datasets/stages/clipper._regenerate_clip_thumbnails` | 14 | `_thumb_for(clip, media_type)` over one loop |
+| `downloader/images.download_caltech101` | 14 | `_extract_members(...)` |
+| `media/image/clipper.clip` | 14 | `_box_from_detection(det, w, h)` |

--- a/scripts/spike_structural_roxford.py
+++ b/scripts/spike_structural_roxford.py
@@ -85,7 +85,7 @@ def _compute_ap(ranked_ids: list[int], positives: set[int], junk: set[int]) -> f
     return ap / len(positives)
 
 
-def main() -> None:  # noqa: C901, PLR0915
+def main() -> None:  # noqa: PLR0915
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--max-db", type=int, default=0, help="Subsample the db to N images (0 = all).")
     parser.add_argument("--max-features", type=int, default=1024, help="SIFT keypoint cap per image.")

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -147,7 +147,7 @@ def _reject_traversal(extract_dir_resolved: Path, member_name: str) -> None:
         raise ValueError(f"Path traversal detected in archive: {member_name}")
 
 
-def extract_archive(  # noqa: C901
+def extract_archive(
     archive_path: Path,
     extract_dir: Path,
     on_progress: Optional[ProgressCallback] = None,

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -424,7 +424,7 @@ def _entry_has_disambiguators(entry: ChainStep) -> bool:
     return any(entry.get(k) is not None for k in ("clip_start", "clip_end", "clip_box", "clip_index", "content_hash"))
 
 
-def _select_chain_output(  # noqa: C901
+def _select_chain_output(
     outputs: list[dict[str, Any]],
     entry: ChainStep,
 ) -> dict[str, Any] | None:

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -380,7 +380,51 @@ def _move_tree_contents(src: Path, dst: Path) -> None:
                     shutil.copy2(child, target)
 
 
-def _download_and_extract(  # noqa: C901
+def _extract_archive(
+    archive_path: Path, archive_name: str, dest_dir: Path, dataset_name: str, on_progress: ProgressCallback
+) -> None:
+    """Extract *archive_path* into *dest_dir*, dispatching by filename suffix.
+
+    Supports ``.tar.gz`` / ``.tgz`` (gzip tar), ``.tar`` (uncompressed tar), and
+    ``.zip`` archives.  Tar members are extracted with ``filter="data"`` (which
+    rejects unsafe absolute/traversal paths); zip members are validated against
+    *dest_dir* to guard against path traversal (zip-slip).  Raises ``ValueError``
+    for an unsupported archive format.
+    """
+    suffix = archive_name.lower()
+    if suffix.endswith((".tar.gz", ".tgz", ".tar")):
+        # Iterate lazily instead of calling getmembers() - the latter must
+        # decompress the entire gzip stream just to read tar headers, then
+        # extraction decompresses it *again*.  Lazy iteration decompresses
+        # once and avoids a minutes-long stall on multi-GB archives.
+        # Use "r:*" for gzip tars to auto-detect compression - some CDNs (e.g.
+        # HuggingFace Xet) transparently decompress .tar.gz files during transfer.
+        mode = "r:" if suffix.endswith(".tar") else "r:*"
+        total_bytes = archive_path.stat().st_size
+        with open(archive_path, "rb") as raw_f:
+            with tarfile.open(fileobj=raw_f, mode=mode) as tar_ref:
+                for i, member in enumerate(tar_ref):
+                    if i % 100 == 0:
+                        on_progress("downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
+                    tar_ref.extract(member, dest_dir, filter="data")
+        on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
+    elif suffix.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zip_ref:
+            members = zip_ref.namelist()
+            total = len(members)
+            for i, member in enumerate(members):
+                if i % 100 == 0 or i == total - 1:
+                    on_progress("downloading", f"Extracting {dataset_name}...", i + 1, total)
+                # Guard against path traversal in zip entries
+                member_path = Path(dest_dir) / member
+                if not str(member_path.resolve()).startswith(str(Path(dest_dir).resolve())):
+                    raise ValueError(f"Path traversal detected in archive: {member}")
+                zip_ref.extract(member, dest_dir)
+    else:
+        raise ValueError(f"Unsupported archive format: {archive_name}")
+
+
+def _download_and_extract(
     *,
     url: str,
     archive_name: str,
@@ -436,45 +480,7 @@ def _download_and_extract(  # noqa: C901
         on_progress("downloading", f"Extracting {dataset_name}...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
 
-        suffix = archive_name.lower()
-        if suffix.endswith((".tar.gz", ".tgz")):
-            # Iterate lazily instead of calling getmembers() - the latter must
-            # decompress the entire gzip stream just to read tar headers, then
-            # extraction decompresses it *again*.  Lazy iteration decompresses
-            # once and avoids a minutes-long stall on multi-GB archives.
-            # Use "r:*" to auto-detect compression - some CDNs (e.g. HuggingFace
-            # Xet) transparently decompress .tar.gz files during transfer.
-            total_bytes = temp_archive.stat().st_size
-            with open(temp_archive, "rb") as raw_f:
-                with tarfile.open(fileobj=raw_f, mode="r:*") as tar_ref:
-                    for i, member in enumerate(tar_ref):
-                        if i % 100 == 0:
-                            on_progress("downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
-                        tar_ref.extract(member, temp_extract, filter="data")
-            on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
-        elif suffix.endswith(".tar"):
-            total_bytes = temp_archive.stat().st_size
-            with open(temp_archive, "rb") as raw_f:
-                with tarfile.open(fileobj=raw_f, mode="r:") as tar_ref:
-                    for i, member in enumerate(tar_ref):
-                        if i % 100 == 0:
-                            on_progress("downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
-                        tar_ref.extract(member, temp_extract, filter="data")
-            on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
-        elif suffix.endswith(".zip"):
-            with zipfile.ZipFile(temp_archive, "r") as zip_ref:
-                members = zip_ref.namelist()
-                total = len(members)
-                for i, member in enumerate(members):
-                    if i % 100 == 0 or i == total - 1:
-                        on_progress("downloading", f"Extracting {dataset_name}...", i + 1, total)
-                    # Guard against path traversal in zip entries
-                    member_path = Path(temp_extract) / member
-                    if not str(member_path.resolve()).startswith(str(Path(temp_extract).resolve())):
-                        raise ValueError(f"Path traversal detected in archive: {member}")
-                    zip_ref.extract(member, temp_extract)
-        else:
-            raise ValueError(f"Unsupported archive format: {archive_name}")
+        _extract_archive(temp_archive, archive_name, temp_extract, dataset_name, on_progress)
 
         # Another download may have finished while we were extracting.
         if check_path.exists():

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -118,7 +118,66 @@ def download_20newsgroups(
     return texts, labels, target_names
 
 
-def download_bbc_news(  # noqa: C901
+def _ensure_bbc_extracted(extract_dir: Path, on_progress: ProgressCallback) -> None:
+    """Download and extract the BBC News archive into *extract_dir* if absent.
+
+    Downloads ``bbc-fulltext.zip`` into a uniquely-named temp file, unzips it
+    with progress reporting, locates the directory holding the category
+    subfolders, and copies it into place.  Temp artifacts are always cleaned up.
+    No-op when *extract_dir* already exists (skip-if-exists semantics).
+    """
+    if extract_dir.exists():
+        return
+
+    unique_id = uuid.uuid4().hex[:8]
+    temp_archive = _core.DATA_DIR / f".dl_{unique_id}_bbc-fulltext.zip"
+    temp_extract = _core.DATA_DIR / f".extract_{unique_id}_bbc-fulltext"
+
+    try:
+        on_progress("downloading", "Starting BBC News download...", 0, 0)
+        _core.download_file_with_progress(
+            _core.BBC_NEWS_URL,
+            temp_archive,
+            _core.BBC_NEWS_DOWNLOAD_SIZE_MB * 1024 * 1024,
+            on_progress,
+        )
+
+        if not extract_dir.exists():
+            on_progress("downloading", "Extracting BBC News dataset...", 0, 0)
+            raw_dir = temp_extract / "raw"
+            raw_dir.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(temp_archive, "r") as zip_ref:
+                # The zip may contain a top-level folder (e.g. "bbc/"); extract
+                # all members and then locate category directories below.
+                members = zip_ref.namelist()
+                total = len(members)
+                for i, member in enumerate(members):
+                    if i % 100 == 0 or i == total - 1:
+                        on_progress(
+                            "downloading",
+                            "Extracting BBC News dataset...",
+                            i + 1,
+                            total,
+                        )
+                    zip_ref.extract(member, raw_dir)
+
+            # Find the directory that contains the category subfolders.
+            _bbc_root = _find_bbc_root(raw_dir)
+            if _bbc_root is None:
+                raise RuntimeError(f"Could not locate BBC News category directories inside {raw_dir}")
+
+            if not extract_dir.exists():
+                try:
+                    shutil.copytree(_bbc_root, extract_dir)
+                except FileExistsError:
+                    pass  # Another download finished first
+    finally:
+        temp_archive.unlink(missing_ok=True)
+        if temp_extract.exists():
+            shutil.rmtree(temp_extract, ignore_errors=True)
+
+
+def download_bbc_news(
     on_progress: Optional[ProgressCallback] = None,
 ) -> dict[str, list[str]]:
     """Download and prepare the BBC News full-text dataset.
@@ -144,53 +203,7 @@ def download_bbc_news(  # noqa: C901
     extract_dir = _core.DATA_DIR / "bbc-fulltext"
     _core.DATA_DIR.mkdir(exist_ok=True)
 
-    if not extract_dir.exists():
-        unique_id = uuid.uuid4().hex[:8]
-        temp_archive = _core.DATA_DIR / f".dl_{unique_id}_bbc-fulltext.zip"
-        temp_extract = _core.DATA_DIR / f".extract_{unique_id}_bbc-fulltext"
-
-        try:
-            on_progress("downloading", "Starting BBC News download...", 0, 0)
-            _core.download_file_with_progress(
-                _core.BBC_NEWS_URL,
-                temp_archive,
-                _core.BBC_NEWS_DOWNLOAD_SIZE_MB * 1024 * 1024,
-                on_progress,
-            )
-
-            if not extract_dir.exists():
-                on_progress("downloading", "Extracting BBC News dataset...", 0, 0)
-                raw_dir = temp_extract / "raw"
-                raw_dir.mkdir(parents=True, exist_ok=True)
-                with zipfile.ZipFile(temp_archive, "r") as zip_ref:
-                    # The zip may contain a top-level folder (e.g. "bbc/"); extract
-                    # all members and then locate category directories below.
-                    members = zip_ref.namelist()
-                    total = len(members)
-                    for i, member in enumerate(members):
-                        if i % 100 == 0 or i == total - 1:
-                            on_progress(
-                                "downloading",
-                                "Extracting BBC News dataset...",
-                                i + 1,
-                                total,
-                            )
-                        zip_ref.extract(member, raw_dir)
-
-                # Find the directory that contains the category subfolders.
-                _bbc_root = _find_bbc_root(raw_dir)
-                if _bbc_root is None:
-                    raise RuntimeError(f"Could not locate BBC News category directories inside {raw_dir}")
-
-                if not extract_dir.exists():
-                    try:
-                        shutil.copytree(_bbc_root, extract_dir)
-                    except FileExistsError:
-                        pass  # Another download finished first
-        finally:
-            temp_archive.unlink(missing_ok=True)
-            if temp_extract.exists():
-                shutil.rmtree(temp_extract, ignore_errors=True)
+    _ensure_bbc_extracted(extract_dir, on_progress)
 
     # Read articles grouped by category directory name.
     categories_articles: dict[str, list[str]] = {}

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -401,7 +401,96 @@ def _ingest_via_resolver(
     return ingested
 
 
-def ingest_missing_medias(  # noqa: C901
+def _wanted_keys(entries: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """Collect the ``origin_name`` and ``md5`` values we're looking for.
+
+    Returns ``(wanted_names, wanted_md5s)``; empty strings are skipped so a
+    media with a blank field can't match a blank wanted key.
+    """
+    wanted_names: set[str] = set()
+    wanted_md5s: set[str] = set()
+    for entry in entries:
+        name = entry.get("origin_name", "")
+        if name:
+            wanted_names.add(name)
+        md5 = entry.get("md5", "")
+        if md5:
+            wanted_md5s.add(md5)
+    return wanted_names, wanted_md5s
+
+
+def _normalize_temp_origins(temp_medias: dict[int, dict[str, Any]], origin_dict: dict[str, Any]) -> None:
+    """Backfill ``origin`` / ``origin_name`` on importer-produced medias.
+
+    Each media gets a fresh ``origin`` copy so a later mutation of one
+    media's ``origin.params`` cannot leak across siblings (and across pickle
+    round-trips).
+    """
+    for media in temp_medias.values():
+        if media.get("origin") is None:
+            media["origin"] = {
+                "importer": origin_dict.get("importer", ""),
+                "params": dict(origin_dict.get("params", {})),
+            }
+        if not media.get("origin_name"):
+            media["origin_name"] = media.get("filename", "")
+
+
+def _ingest_via_importer(
+    origin_dict: dict[str, Any],
+    entries: list[dict[str, Any]],
+    medias: dict[int, dict[str, Any]],
+) -> int:
+    """Try to ingest missing entries by running the full dataset importer.
+
+    Runs the importer for this origin into a temporary medias dict, then
+    cherry-picks the medias matching the wanted ``origin_name`` / ``md5``
+    sets and appends them to *medias* with fresh IDs.
+
+    Returns the number of successfully ingested medias, or -1 if no importer
+    is registered for this origin (the caller has no further fallback). A
+    failed importer run or zero matches counts as "applied" and returns 0.
+    """
+    from vtscore.datasets.importers import get_importer
+
+    importer_name = origin_dict.get("importer", "")
+    importer = get_importer(importer_name)
+    if importer is None:
+        return -1
+
+    params = origin_dict.get("params", {})
+    wanted_names, wanted_md5s = _wanted_keys(entries)
+
+    # Run the importer into a temporary medias dict
+    temp_medias: dict[int, dict[str, Any]] = {}
+    try:
+        importer.run_cli(params, temp_medias)
+    except Exception:
+        # If the importer fails (e.g. folder not found), skip this origin
+        return 0
+
+    _normalize_temp_origins(temp_medias, origin_dict)
+
+    ingested = 0
+
+    # Cherry-pick matching medias.  Allocate IDs and insert atomically
+    # under _state_lock so a concurrent ingest can't reuse the same ID.
+    # Snapshot the values up front: the importer may retain a reference to
+    # temp_medias and mutate it from a background thread.
+    for temp_clip in list(temp_medias.values()):
+        clip_origin_name = temp_clip.get("origin_name", "")
+        clip_md5 = temp_clip.get("md5", "")
+        if clip_origin_name in wanted_names or clip_md5 in wanted_md5s:
+            with _state_lock:
+                cid = next_media_id(medias)
+                temp_clip["id"] = cid
+                medias[cid] = temp_clip
+            ingested += 1
+
+    return ingested
+
+
+def ingest_missing_medias(
     missing_entries: list[dict[str, Any]],
     medias: dict[int, dict[str, Any]],
     on_progress: Optional[ProgressCallback] = None,
@@ -428,8 +517,6 @@ def ingest_missing_medias(  # noqa: C901
     Returns:
         The number of medias successfully ingested.
     """
-    from vtscore.datasets.importers import get_importer
-
     if on_progress is None:
         on_progress = _default_progress()
 
@@ -463,56 +550,10 @@ def ingest_missing_medias(  # noqa: C901
             continue
 
         # Legacy path: run the full importer
-        importer = get_importer(importer_name)
-        if importer is None:
+        importer_result = _ingest_via_importer(origin_dict, entries, medias)
+        if importer_result >= 0:
+            total_ingested += importer_result
             continue
-
-        params = origin_dict.get("params", {})
-
-        # Build a set of origin_names we're looking for
-        wanted_names: set[str] = set()
-        wanted_md5s: set[str] = set()
-        for entry in entries:
-            name = entry.get("origin_name", "")
-            if name:
-                wanted_names.add(name)
-            md5 = entry.get("md5", "")
-            if md5:
-                wanted_md5s.add(md5)
-
-        # Run the importer into a temporary medias dict
-        temp_medias: dict[int, dict[str, Any]] = {}
-        try:
-            importer.run_cli(params, temp_medias)
-        except Exception:
-            # If the importer fails (e.g. folder not found), skip this origin
-            continue
-
-        # Set origin on temp medias that don't have one.  Each media gets a
-        # fresh copy so a later mutation of one media's ``origin.params``
-        # cannot leak across siblings (and across pickle round-trips).
-        for media in temp_medias.values():
-            if media.get("origin") is None:
-                media["origin"] = {
-                    "importer": origin_dict.get("importer", ""),
-                    "params": dict(origin_dict.get("params", {})),
-                }
-            if not media.get("origin_name"):
-                media["origin_name"] = media.get("filename", "")
-
-        # Cherry-pick matching medias.  Allocate IDs and insert atomically
-        # under _state_lock so a concurrent ingest can't reuse the same ID.
-        # Snapshot the values up front: the importer may retain a reference to
-        # temp_medias and mutate it from a background thread.
-        for temp_clip in list(temp_medias.values()):
-            clip_origin_name = temp_clip.get("origin_name", "")
-            clip_md5 = temp_clip.get("md5", "")
-            if clip_origin_name in wanted_names or clip_md5 in wanted_md5s:
-                with _state_lock:
-                    cid = next_media_id(medias)
-                    temp_clip["id"] = cid
-                    medias[cid] = temp_clip
-                total_ingested += 1
 
     on_progress("idle", f"Ingested {total_ingested} media(s) from origins.", 0, 0)
     return total_ingested

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -89,7 +89,99 @@ def _stamp_media_type(
             media["media_type"] = expected
 
 
-def load_demo_dataset(  # noqa: C901
+def _try_load_cached(
+    pkl_file: Any,
+    dataset_name: str,
+    media_type_id: str,
+    medias: dict[int, dict[str, Any]],
+    on_progress: ProgressCallback,
+    embedder_name: str,
+    converter_name: str,
+    clipper_name: str,
+    clipper_params: dict[str, Any] | None,
+) -> bool:
+    """Try to satisfy the load from the cached ``.pkl`` file.
+
+    Returns ``True`` when the cache was a hit: *medias* has been populated,
+    origins/media-types stamped, and the final "Loaded" progress emitted, so
+    the caller should return immediately.  Returns ``False`` when the cache
+    was missing, stale (embedder/clipper mismatch), or empty on load; in that
+    case the stale pickle (if any) has been unlinked and the caller should
+    rebuild from scratch.
+    """
+    from vtscore.datasets import loader as _loader
+
+    if not pkl_file.exists():
+        return False
+
+    # If the caller explicitly requested an embedder, verify the cached
+    # pickle was produced by the same one.  When *embedder_name* is empty
+    # (meaning "use default"), accept whatever is cached.
+    from vtscore.datasets.container import read_meta
+
+    cached_meta = read_meta(pkl_file)
+    cached_embedder = cached_meta.get("embedder") or ""
+    embedder_mismatch = bool(embedder_name) and bool(cached_embedder) and embedder_name != cached_embedder
+    # A cached pickle built with a different clipper (or different clipper
+    # params) no longer reflects the requested split, so rebuild it.  Both
+    # names are normalised through _effective_clipper so the pre-selected
+    # default ("" vs e.g. "sound_tiling") never counts as a mismatch.
+    requested_clipper = _effective_clipper(clipper_name, media_type_id)
+    cached_clipper = _effective_clipper(cached_meta.get("clipper") or "", media_type_id)
+    requested_params = clipper_params or {}
+    cached_params = cached_meta.get("clipper_params") or {}
+    clipper_mismatch = requested_clipper != cached_clipper or (
+        bool(requested_clipper) and requested_params != cached_params
+    )
+    if embedder_mismatch or clipper_mismatch:
+        reason = f"with {embedder_name}" if embedder_mismatch else "with new clipper"
+        on_progress("loading", f"Re-embedding {dataset_name} {reason}...", 0, 0)
+        pkl_file.unlink()
+        return False
+
+    on_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
+    _loader.load_dataset_from_pickle(pkl_file, medias)
+
+    # Check if any medias were actually loaded
+    if len(medias) == 0:
+        # Pickle file exists but media files are missing, delete and re-embed
+        on_progress("loading", f"Media files missing, re-embedding {dataset_name}...", 0, 0)
+        pkl_file.unlink()
+        return False
+
+    # Stamp demo origin on cached medias so that cross-dataset
+    # resolution always has the dataset name in the origin params.
+    # Old pickles (created before origin stamping) may have empty
+    # params - this ensures they are corrected on load.
+    _stamp_demo_origin(medias, dataset_name, converter_name)
+    # Fill in missing media_type: old pkls may lack the field,
+    # causing every item to fall back to the "audio" default in
+    # load_dataset_from_pickle and the dataset to register with
+    # the wrong type.
+    _stamp_media_type(medias, media_type_id, converter_name)
+    on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)
+    return True
+
+
+def _resolve_demo_embedder(embedder_name: str, media_type_id: str) -> Any:
+    """Resolve the embedder to use for a demo load.
+
+    When *embedder_name* is given, look it up (raising ``ValueError`` for an
+    unknown name).  Otherwise fall back to the first registered embedder for
+    *media_type_id*, or ``None`` when the media type has none.
+    """
+    from vtscore.media import embedders_for_type, get_embedder
+
+    if embedder_name:
+        try:
+            return get_embedder(embedder_name)
+        except KeyError:
+            raise ValueError(f"Unknown embedder: {embedder_name}")
+    avail = embedders_for_type(media_type_id)
+    return avail[0] if avail else None
+
+
+def load_demo_dataset(
     dataset_name: str,
     medias: dict[int, dict[str, Any]],
     on_progress: Optional[ProgressCallback] = None,
@@ -158,66 +250,23 @@ def load_demo_dataset(  # noqa: C901
 
     # Check if already embedded
     pkl_file = _loader.EMBEDDINGS_DIR / f"{cache_key}.pkl"
-    if pkl_file.exists():
-        # If the caller explicitly requested an embedder, verify the cached
-        # pickle was produced by the same one.  When *embedder_name* is empty
-        # (meaning "use default"), accept whatever is cached.
-        from vtscore.datasets.container import read_meta
-
-        cached_meta = read_meta(pkl_file)
-        cached_embedder = cached_meta.get("embedder") or ""
-        embedder_mismatch = bool(embedder_name) and bool(cached_embedder) and embedder_name != cached_embedder
-        # A cached pickle built with a different clipper (or different clipper
-        # params) no longer reflects the requested split, so rebuild it.  Both
-        # names are normalised through _effective_clipper so the pre-selected
-        # default ("" vs e.g. "sound_tiling") never counts as a mismatch.
-        requested_clipper = _effective_clipper(clipper_name, media_type_id)
-        cached_clipper = _effective_clipper(cached_meta.get("clipper") or "", media_type_id)
-        requested_params = clipper_params or {}
-        cached_params = cached_meta.get("clipper_params") or {}
-        clipper_mismatch = requested_clipper != cached_clipper or (
-            bool(requested_clipper) and requested_params != cached_params
-        )
-        if embedder_mismatch or clipper_mismatch:
-            reason = f"with {embedder_name}" if embedder_mismatch else "with new clipper"
-            on_progress("loading", f"Re-embedding {dataset_name} {reason}...", 0, 0)
-            pkl_file.unlink()
-        else:
-            on_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
-            _loader.load_dataset_from_pickle(pkl_file, medias)
-
-            # Check if any medias were actually loaded
-            if len(medias) == 0:
-                # Pickle file exists but media files are missing, delete and re-embed
-                on_progress("loading", f"Media files missing, re-embedding {dataset_name}...", 0, 0)
-                pkl_file.unlink()
-            else:
-                # Stamp demo origin on cached medias so that cross-dataset
-                # resolution always has the dataset name in the origin params.
-                # Old pickles (created before origin stamping) may have empty
-                # params - this ensures they are corrected on load.
-                _stamp_demo_origin(medias, dataset_name, converter_name)
-                # Fill in missing media_type: old pkls may lack the field,
-                # causing every item to fall back to the "audio" default in
-                # load_dataset_from_pickle and the dataset to register with
-                # the wrong type.
-                _stamp_media_type(medias, media_type_id, converter_name)
-                on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)
-                return
+    if _try_load_cached(
+        pkl_file,
+        dataset_name,
+        media_type_id,
+        medias,
+        on_progress,
+        embedder_name,
+        converter_name,
+        clipper_name,
+        clipper_params,
+    ):
+        return
 
     # Resolve the embedder
-    from vtscore.media import embedders_for_type, get as media_get, get_embedder
+    from vtscore.media import get as media_get
 
-    embedder = None
-    if embedder_name:
-        try:
-            embedder = get_embedder(embedder_name)
-        except KeyError:
-            raise ValueError(f"Unknown embedder: {embedder_name}")
-    else:
-        avail = embedders_for_type(media_type_id)
-        if avail:
-            embedder = avail[0]
+    embedder = _resolve_demo_embedder(embedder_name, media_type_id)
 
     mt = media_get(media_type_id)
 
@@ -299,47 +348,68 @@ def load_demo_dataset(  # noqa: C901
             embedder=embedder,
         )
 
-    # Build the pickle cache payload
-    # For types with external media dirs (audio, video), exclude media_bytes
-    # from the pickle and store the dir path so reloading can find the files.
-    # When a converter was applied, external_dir is no longer relevant (the
-    # converted medias carry their own bytes/strings).  Likewise when a clipper
-    # split the media: each clip is a *slice* of its source file, not the whole
-    # file the external dir resolves by name, so its bytes must ride in the
-    # pickle (dataset pickles are the one place persisted bytes are allowed).
+    _write_demo_cache(
+        pkl_file=pkl_file,
+        dataset_name=dataset_name,
+        media_type_id=media_type_id,
+        medias=medias,
+        mt=mt,
+        embedder=embedder,
+        external_dir=external_dir,
+        converter_name=converter_name,
+        clipper_name=clipper_name,
+        clipper_params=clipper_params,
+        clipper_applied=clipper_applied,
+    )
+
+    on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)
+
+
+def _write_demo_cache(
+    *,
+    pkl_file: Any,
+    dataset_name: str,
+    media_type_id: str,
+    medias: dict[int, dict[str, Any]],
+    mt: Any,
+    embedder: Any,
+    external_dir: Any,
+    converter_name: str,
+    clipper_name: str,
+    clipper_params: dict[str, Any] | None,
+    clipper_applied: bool,
+) -> None:
+    """Serialize the freshly built demo dataset to its pickle container.
+
+    For types with external media dirs (audio, video), excludes media_bytes
+    from the pickle and stores the dir path so reloading can find the files.
+    When a converter was applied, external_dir is no longer relevant (the
+    converted medias carry their own bytes/strings).  Likewise when a clipper
+    split the media: each clip is a *slice* of its source file, not the whole
+    file the external dir resolves by name, so its bytes must ride in the
+    pickle (dataset pickles are the one place persisted bytes are allowed).
+    """
+    from vtscore.datasets import loader as _loader
+
     # Local import avoids a circular import at module load (loader imports
     # loader_demo before this helper is defined).
     from vtscore.datasets.loader import _embeddings_dict_for_pickle
 
     store_external = external_dir is not None and not converter_name and not clipper_applied
+
+    def _pickle_media(media: dict[str, Any]) -> dict[str, Any]:
+        return {
+            k: _embeddings_dict_for_pickle(v) if k == "embeddings" else (v.tolist() if isinstance(v, np.ndarray) else v)
+            for k, v in media.items()
+            if not (store_external and k in ("media_bytes", "thumbnail_bytes"))
+        }
+
+    pkl_data: dict[str, Any] = {
+        "name": dataset_name,
+        "medias": {cid: _pickle_media(media) for cid, media in medias.items()},
+    }
     if store_external:
-        pkl_data: dict[str, Any] = {
-            "name": dataset_name,
-            "medias": {
-                cid: {
-                    k: _embeddings_dict_for_pickle(v)
-                    if k == "embeddings"
-                    else (v.tolist() if isinstance(v, np.ndarray) else v)
-                    for k, v in media.items()
-                    if k not in ("media_bytes", "thumbnail_bytes")
-                }
-                for cid, media in medias.items()
-            },
-            mt.dir_key: external_dir,
-        }
-    else:
-        pkl_data = {
-            "name": dataset_name,
-            "medias": {
-                cid: {
-                    k: _embeddings_dict_for_pickle(v)
-                    if k == "embeddings"
-                    else (v.tolist() if isinstance(v, np.ndarray) else v)
-                    for k, v in media.items()
-                }
-                for cid, media in medias.items()
-            },
-        }
+        pkl_data[mt.dir_key] = external_dir
 
     _loader.EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -363,5 +433,3 @@ def load_demo_dataset(  # noqa: C901
     from vtscore.datasets.container import write_container
 
     write_container(pkl_file, medias_pkl_bytes, meta, extra_pickle_keys=extra_pickle_keys)
-
-    on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -53,7 +53,172 @@ def _first_stored_embedder(medias: dict[int, dict[str, Any]]) -> str:
     return ""
 
 
-def embed_missing(  # noqa: C901
+def _resolve_embedder(
+    medias: dict[int, dict[str, Any]],
+    embedder_name: str,
+    media_type: str,
+):
+    """Resolve the embedder for this load: explicit pick → stored → default.
+
+    Returns the resolved embedder, or ``None`` when no embedder is available.
+
+    An explicit *embedder_name* is looked up directly; if it resolves, that
+    wins.  Otherwise (only when no explicit name was given) we honour the
+    embedder the media were already embedded with (a pickle reload /
+    content-vector importer records it on the media) so a patch-embedded
+    dataset re-binds to its patch embedder rather than the single-vector
+    media-type default — the default would report
+    ``supports_patch_regions=False`` and silently skip the region back-fill.
+    Failing both, fall back to the first embedder registered for *media_type*.
+    """
+    from vtscore.media import embedders_for_type, get_embedder  # noqa: PLC0415
+
+    emb = None
+    if embedder_name:
+        try:
+            emb = get_embedder(embedder_name)
+        except KeyError:
+            emb = None
+    if emb is None and not embedder_name:
+        stored = _first_stored_embedder(medias)
+        if stored:
+            try:
+                emb = get_embedder(stored)
+            except KeyError:
+                emb = None
+    if emb is None:
+        avail = embedders_for_type(media_type)
+        emb = avail[0] if avail else None
+    return emb
+
+
+def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+    """Progress sink used when no ``on_progress`` callback was supplied."""
+    return None
+
+
+def _ensure_model_loaded(emb, on_progress: Callable[[str, str, int, int], None]) -> None:
+    """Load the embedder's models if not already loaded, announcing progress."""
+    if getattr(emb, "_model", None) is None:
+        on_progress("loading", "Loading embedding model…", 0, 0)
+        emb.load_models()
+
+
+def _missing_for_embedder(
+    medias: dict[int, dict[str, Any]],
+    emb,
+    embedder_name: str,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Return the ``(mid, media)`` items still needing *this* embedder's vector.
+
+    When the caller named an embedder explicitly (the bound-set driver and the
+    reload path both do), "missing" is keyed to that embedder's own per-media
+    entry, so a second bound embedder embeds items the first already covered
+    (their singular vector belongs to the first model).
+
+    When no embedder was named (bare default-resolution call), keep the legacy
+    contract: only items with *no* vector at all are embedded, so a dataset
+    already populated by some other source isn't re-embedded under the resolved
+    default.
+    """
+    if embedder_name:
+        return [(mid, m) for mid, m in medias.items() if media_embedding(m, emb.name) is None]
+    return [(mid, m) for mid, m in medias.items() if media_embedding(m) is None]
+
+
+def _needs_side_channel(m: dict[str, Any], embedder_name: str, key: str) -> bool:
+    """Whether *m* was embedded by *embedder_name* but lacks side-channel *key*.
+
+    The embedder must have produced a CLS/VLAD vector for the image (so we
+    never re-derive a side channel for an image it never embedded), keyed off
+    its own per-embedder entry rather than the singular mirror: in a
+    multi-embedder dataset the mirror may belong to a *different* model.
+    """
+    return media_embedding(m, embedder_name) is not None and m.get(key) is None
+
+
+def _run_embed_pass(
+    emb,
+    medias: dict[int, dict[str, Any]],
+    media_type: str,
+    missing: list[tuple[int, dict[str, Any]]],
+    on_progress: Callable[[str, str, int, int], None],
+    original_cb,
+) -> None:
+    """Bulk-embed the *missing* items and attach each non-``None`` vector.
+
+    Announces progress, routes the embedder's callback through *on_progress*
+    (restoring *original_cb* afterward), and on a bulk-embed failure logs and
+    attaches nothing (items stay at ``None`` for the drop-none stage).  Items
+    whose media vanished from *medias* during the call are skipped.
+    """
+    if not missing:
+        return
+    total = len(missing)
+    on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
+
+    inputs = [m for _, m in missing]
+    emb._on_progress = on_progress
+    try:
+        vectors = emb.embed_media_bulk(inputs)
+    except Exception:
+        logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
+        vectors = None
+    finally:
+        emb._on_progress = original_cb
+
+    if vectors is None:
+        return
+    embedder_id = emb.name
+    for (mid, _), vec in zip(missing, vectors):
+        if vec is None:
+            continue
+        media = medias.get(mid)
+        if media is None:
+            continue
+        set_media_embedding(media, embedder_id, vec)
+
+
+def _run_backfill_pass(
+    emb,
+    medias: dict[int, dict[str, Any]],
+    media_type: str,
+    on_progress: Callable[[str, str, int, int], None],
+    original_cb,
+    *,
+    needs: Callable[[dict[str, Any]], bool],
+    forward: Callable[[list[dict[str, Any]]], list],
+    attach: Callable[[dict[str, Any], Any], None],
+    fail_message: str,
+) -> None:
+    """Run one side-channel back-fill pass over every media still needing it.
+
+    Filters *medias* by *needs*, bulk-forwards them through *forward* (routing
+    progress through *on_progress* and restoring *original_cb* afterward), and
+    attaches each non-``None`` output via *attach*.  On a *forward* failure the
+    pass logs *fail_message* and attaches nothing (every output is treated as
+    ``None``).  Runs over every matching media, including ones that arrived
+    already-embedded — not only the items embedded in this load.
+    """
+    inputs = [m for m in medias.values() if needs(m)]
+    if not inputs:
+        return
+    emb._on_progress = on_progress
+    try:
+        outputs = forward(inputs)
+    except Exception:
+        logging.getLogger(__name__).exception(fail_message, media_type, len(inputs))
+        outputs = [None] * len(inputs)
+    finally:
+        emb._on_progress = original_cb
+
+    for media, out in zip(inputs, outputs):
+        if out is None:
+            continue
+        attach(media, out)
+
+
+def embed_missing(
     medias: dict[int, dict[str, Any]],
     embedder_name: str = "",
     on_progress: Callable[[str, str, int, int], None] | None = None,
@@ -87,49 +252,12 @@ def embed_missing(  # noqa: C901
     if not media_type:
         return
 
-    from vtscore.media import embedders_for_type, get_embedder  # noqa: PLC0415
-
-    emb = None
-    if embedder_name:
-        try:
-            emb = get_embedder(embedder_name)
-        except KeyError:
-            emb = None
-    if emb is None and not embedder_name:
-        # No explicit embedder for this load: honour the one the media were
-        # already embedded with (set on a pickle reload / content-vector
-        # importer) before falling back to the media-type default.  Without
-        # this a patch-embedded dataset reloaded with no embedder pick would
-        # resolve to the single-vector default and skip the patch-region
-        # back-fill below, so the best-match highlight and region voting have
-        # no region data to work with.
-        stored = _first_stored_embedder(medias)
-        if stored:
-            try:
-                emb = get_embedder(stored)
-            except KeyError:
-                emb = None
-    if emb is None:
-        avail = embedders_for_type(media_type)
-        emb = avail[0] if avail else None
+    emb = _resolve_embedder(medias, embedder_name, media_type)
     if emb is None:
         return
 
     # Which items still need *this* embedder's vector.
-    #
-    # When the caller named an embedder explicitly (the bound-set driver and
-    # the reload path both do), "missing" is keyed to that embedder's own
-    # per-media entry, so a second bound embedder embeds items the first
-    # already covered (their singular vector belongs to the first model).
-    #
-    # When no embedder was named (bare default-resolution call), keep the
-    # legacy contract: only items with *no* vector at all are embedded, so a
-    # dataset already populated by some other source isn't re-embedded under
-    # the resolved default.
-    if embedder_name:
-        missing = [(mid, m) for mid, m in medias.items() if media_embedding(m, emb.name) is None]
-    else:
-        missing = [(mid, m) for mid, m in medias.items() if media_embedding(m) is None]
+    missing = _missing_for_embedder(medias, emb, embedder_name)
 
     # Patch-capable embedders attach a per-image HAC region tree + patch grid
     # alongside the CLS ``embedding``.  That side-channel must exist for any
@@ -144,11 +272,7 @@ def embed_missing(  # noqa: C901
     patch_capable = getattr(emb, "supports_patch_regions", False) is True
 
     def _needs_patch(m: dict[str, Any]) -> bool:
-        # This embedder must have produced a CLS vector for the image (so we
-        # never re-pool regions for an image it never embedded), but key off
-        # its own per-embedder entry rather than the singular mirror: in a
-        # multi-embedder dataset the mirror may belong to a *different* model.
-        return media_embedding(m, emb.name) is not None and m.get("patch_regions") is None
+        return _needs_side_channel(m, emb.name, "patch_regions")
 
     # Structural embedders (SIFT/VLAD) attach a per-image keypoint+descriptor set
     # alongside the VLAD ``embedding``, on the same back-fill terms as patch
@@ -158,7 +282,7 @@ def embed_missing(  # noqa: C901
     structural_capable = getattr(emb, "supports_geometric_verification", False) is True
 
     def _needs_local_features(m: dict[str, Any]) -> bool:
-        return media_embedding(m, emb.name) is not None and m.get("local_features") is None
+        return _needs_side_channel(m, emb.name, "local_features")
 
     has_patch_backfill = patch_capable and any(_needs_patch(m) for m in medias.values())
     has_structural_backfill = structural_capable and any(_needs_local_features(m) for m in medias.values())
@@ -167,87 +291,45 @@ def embed_missing(  # noqa: C901
         return
 
     if on_progress is None:
-
-        def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-            return None
-
         on_progress = _noop_progress
 
-    if getattr(emb, "_model", None) is None:
-        on_progress("loading", "Loading embedding model…", 0, 0)
-        emb.load_models()
+    _ensure_model_loaded(emb, on_progress)
 
     original_cb = emb._on_progress
 
-    if missing:
-        total = len(missing)
-        on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
-
-        inputs = [m for _, m in missing]
-        emb._on_progress = on_progress
-        try:
-            vectors = emb.embed_media_bulk(inputs)
-        except Exception:
-            logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
-            vectors = None
-        finally:
-            emb._on_progress = original_cb
-
-        if vectors is not None:
-            embedder_id = emb.name
-            for (mid, _), vec in zip(missing, vectors):
-                if vec is None:
-                    continue
-                media = medias.get(mid)
-                if media is None:
-                    continue
-                set_media_embedding(media, embedder_id, vec)
+    _run_embed_pass(emb, medias, media_type, missing, on_progress, original_cb)
 
     # Patch-region pass for embedders that support it (DINOv2/v3/EUPE).  Runs
     # over every patch-capable image still lacking a region tree, including
     # ones that arrived already-embedded - not just the items embedded above.
     if patch_capable:
-        patch_inputs = [m for m in medias.values() if _needs_patch(m)]
-        if patch_inputs:
-            emb._on_progress = on_progress
-            try:
-                outputs = emb.patch_forward_bulk(patch_inputs)
-            except Exception:
-                logging.getLogger(__name__).exception(
-                    "Bulk patch-forward failed for media_type=%s (%d items)", media_type, len(patch_inputs)
-                )
-                outputs = [None] * len(patch_inputs)
-            finally:
-                emb._on_progress = original_cb
-
-            for media, patch_out in zip(patch_inputs, outputs):
-                if patch_out is None:
-                    continue
-                _attach_patch_regions_to_media(media, patch_out)
+        _run_backfill_pass(
+            emb,
+            medias,
+            media_type,
+            on_progress,
+            original_cb,
+            needs=_needs_patch,
+            forward=emb.patch_forward_bulk,
+            attach=_attach_patch_regions_to_media,
+            fail_message="Bulk patch-forward failed for media_type=%s (%d items)",
+        )
 
     # Local-features pass for structural embedders (SIFT/VLAD).  Same back-fill
     # shape as the patch pass: detect+describe every structural image still
     # missing ``local_features`` and store the compact (fp16/uint8) form.
     if structural_capable:
-        structural_inputs = [m for m in medias.values() if _needs_local_features(m)]
-        if structural_inputs:
-            emb._on_progress = on_progress
-            try:
-                features = emb.local_features_forward_bulk(structural_inputs)
-            except Exception:
-                logging.getLogger(__name__).exception(
-                    "Bulk local-feature detection failed for media_type=%s (%d items)",
-                    media_type,
-                    len(structural_inputs),
-                )
-                features = [None] * len(structural_inputs)
-            finally:
-                emb._on_progress = original_cb
-
-            for media, feats in zip(structural_inputs, features):
-                if feats is None:
-                    continue
-                media["local_features"] = feats.compact()
+        _run_backfill_pass(
+            emb,
+            medias,
+            media_type,
+            on_progress,
+            original_cb,
+            needs=_needs_local_features,
+            forward=emb.local_features_forward_bulk,
+            attach=lambda media, feats: media.__setitem__("local_features", feats.compact()),
+            fail_message="Bulk local-feature detection failed for media_type=%s (%d items)",
+        )
 
     # Re-key any legacy single-vector media into the dict-keyed representation
     # and drop the singular media["embedding"] mirror (Phase 2c): afterward

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -361,7 +361,7 @@ def record_vote(
     mutate_user(lambda cache: _credit_vote(cache, ts, detector_id, media_type, date_str, hour))
 
 
-def _credit_vote(  # noqa: C901
+def _credit_vote(
     cache: dict[str, Any],
     ts: float,
     detector_id: str,

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -180,11 +180,52 @@ def save_detector_labels(name: str):
 # ---------------------------------------------------------------------------
 
 
+def _merge_entries_into_labelset(existing_ls, label_entries: list[dict]) -> tuple[int, int, list[dict]]:
+    """Merge imported label entries into ``existing_ls`` in place, deduping.
+
+    Iterates ``label_entries``, skipping entries whose label isn't ``good`` or
+    ``bad`` and entries whose ``(md5, label)`` pair already exists in the
+    labelset.  Each accepted entry is appended to ``existing_ls.elements`` and
+    recorded so the caller can resolve/apply it later.
+
+    Returns ``(applied, skipped, new_entries)`` matching the legacy counts and
+    list that the route built inline.
+    """
+    from vtscore.datasets.labelset import LabeledElement
+
+    # Build a set of existing (md5, label) pairs for dedup
+    existing_keys: set[tuple[str, str]] = set()
+    for el in existing_ls.elements:
+        if el.md5:
+            existing_keys.add((el.md5, el.label))
+
+    applied = 0
+    skipped = 0
+    new_entries: list[dict] = []
+    for entry in label_entries:
+        label = entry.get("label", "")
+        if label not in ("good", "bad"):
+            skipped += 1
+            continue
+        md5 = entry.get("md5", "")
+        if md5 and (md5, label) in existing_keys:
+            skipped += 1
+            continue
+        elem = LabeledElement.from_dict(entry)
+        existing_ls.elements.append(elem)
+        new_entries.append(entry)
+        if md5:
+            existing_keys.add((md5, label))
+        applied += 1
+
+    return applied, skipped, new_entries
+
+
 @detectors_labels_bp.route(
     "/api/detectors/<name>/import-labels/<importer_name>",
     methods=["POST"],
 )
-def import_labels_into_detector(name: str, importer_name: str):  # noqa: C901
+def import_labels_into_detector(name: str, importer_name: str):
     """Run a label importer and merge results into this detector's labelset.
 
     Unlike the regular ``/api/label-importers/import/`` route, this does
@@ -228,34 +269,11 @@ def import_labels_into_detector(name: str, importer_name: str):  # noqa: C901
     # ------------------------------------------------------------------
     # 1) Merge into the persisted labelset (always, whether loaded or not)
     # ------------------------------------------------------------------
-    from vtscore.datasets.labelset import LabeledElement, LabelSet
+    from vtscore.datasets.labelset import LabelSet
 
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 
-    # Build a set of existing (md5, label) pairs for dedup
-    existing_keys: set[tuple[str, str]] = set()
-    for el in existing_ls.elements:
-        if el.md5:
-            existing_keys.add((el.md5, el.label))
-
-    applied = 0
-    skipped = 0
-    new_entries: list[dict] = []
-    for entry in label_entries:
-        label = entry.get("label", "")
-        if label not in ("good", "bad"):
-            skipped += 1
-            continue
-        md5 = entry.get("md5", "")
-        if md5 and (md5, label) in existing_keys:
-            skipped += 1
-            continue
-        elem = LabeledElement.from_dict(entry)
-        existing_ls.elements.append(elem)
-        new_entries.append(entry)
-        if md5:
-            existing_keys.add((md5, label))
-        applied += 1
+    applied, skipped, new_entries = _merge_entries_into_labelset(existing_ls, label_entries)
 
     data["labelset"] = existing_ls.to_dict()
     _write_detector(path, data)

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -323,12 +323,170 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
 # ---------------------------------------------------------------------------
 
 
+_LOAD_STEPS = 3  # restore labels, seed examples, train MLP
+# MLP training dominates; label restore + example seeding are quick I/O.
+_LOAD_STEP_WEIGHTS = [0.15, 0.15, 0.70]
+
+
+def _run_detector_load_task(
+    *,
+    detector_id: str,
+    det_ctx,
+    thread_ds_ctx,
+    det_name: str,
+    tracker,
+    task_id: str,
+) -> None:
+    """Background worker for :func:`load_detector_route`.
+
+    Restores labels, seeds example votes, embeds + trains the MLP for the
+    detector, then marks it loaded. Cancellation and errors tear the
+    just-built context back down and surface on the task tracker. Lifted out
+    of the route's closure so the route itself stays simple; the captured
+    values are passed explicitly.
+    """
+    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
+    from vtscore.detectors.registry import add_loaded_detector_id, remove_loaded_detector_id
+    from vtscore.state.core import thread_dataset_context, thread_detector_context
+
+    try:
+        with thread_dataset_context(thread_ds_ctx), thread_detector_context(det_ctx):
+            try:
+                if det_name:
+                    tracker.check_cancelled()
+                    tracker.update(
+                        "loading",
+                        "Restoring labels…",
+                        0,
+                        0,
+                        step=1,
+                        total_steps=_LOAD_STEPS,
+                    )
+                    det_data = _read_detector(_detector_path(det_name))
+                    if det_data:
+                        # The detector's locked embedder type (immutable;
+                        # set at create time): load it so the label-embed /
+                        # score / invalidation paths resolve the concrete
+                        # embedder of that type the active dataset supplies.
+                        # Empty for a legacy detector with neither type nor
+                        # primary → routing falls back to the precedence.
+                        det_ctx.embedder_type = detector_embedder_type_from_data(det_data)
+                        _restore_labels_from_detector(det_data)
+
+                        tracker.check_cancelled()
+                        tracker.update(
+                            "loading",
+                            "Seeding examples…",
+                            0,
+                            0,
+                            step=2,
+                            total_steps=_LOAD_STEPS,
+                        )
+                        _seed_good_votes_from_examples(det_data.get("examples", []))
+
+                        tracker.check_cancelled()
+                        tracker.update(
+                            "loading",
+                            "Embedding labels…",
+                            0,
+                            0,
+                            step=3,
+                            total_steps=_LOAD_STEPS,
+                        )
+
+                        from vtscore.datasets.labelset import LabelSet
+                        from vtscore.detectors.labelset_ops import train_from_labelset
+                        from vtsearch.state import snapshot_medias as _snap_medias
+
+                        labelset = LabelSet.from_dict(det_data.get("labelset") or {})
+                        media_type = det_data.get("media_type", "") or ""
+                        snap = _snap_medias()
+
+                        det_ctx.labelset_good_count = sum(1 for el in labelset.elements if el.label == "good")
+                        det_ctx.labelset_bad_count = sum(1 for el in labelset.elements if el.label == "bad")
+                        # Cache the parsed labelset so before_request's rehydrate
+                        # hook and learned_sort don't re-read the JSON file.
+                        det_ctx.cached_labelset = labelset
+                        det_ctx.cached_labelset_media_type = media_type
+                        try:
+                            det_ctx.cached_labelset_mtime = _detector_path(det_name).stat().st_mtime
+                        except OSError:
+                            det_ctx.cached_labelset_mtime = 0.0
+
+                        def _embed_progress(name: str, done: int, total: int) -> None:
+                            tracker.check_cancelled()
+                            tracker.update(
+                                "loading",
+                                "Embedding labels…",
+                                done,
+                                total,
+                                step=3,
+                                total_steps=_LOAD_STEPS,
+                            )
+
+                        train_from_labelset(
+                            det_ctx,
+                            labelset,
+                            media_type=media_type,
+                            snap=snap,
+                            on_progress=_embed_progress,
+                        )
+
+                # Stamp the dataset whose medias the cid-keyed vote dicts were
+                # derived against, so before_request's rehydrate hook can detect
+                # subsequent dataset switches and re-derive against the new
+                # dataset's medias.
+                det_ctx.votes_dataset_id = thread_ds_ctx.dataset_id
+                add_loaded_detector_id(detector_id)
+                tracker.update("idle", "", 0, 0, step=None, total_steps=None)
+            except CancelledError:
+                from vtsearch.state import unregister_detector_context as _unreg
+
+                _unreg(detector_id)
+                remove_loaded_detector_id(detector_id)
+                tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+            except Exception as e:
+                import traceback as _tb
+
+                _tb.print_exc()
+                from vtsearch.state import unregister_detector_context as _unreg
+
+                _unreg(detector_id)
+                remove_loaded_detector_id(detector_id)
+                error_msg = str(e) or repr(e) or "Unknown error during detector loading"
+                tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
+    finally:
+        detector_loading_tasks.mark_finished(task_id)
+
+
+def _unload_active_detector() -> dict:
+    """Tear down the active detector context (the ``detector_id=None`` path).
+
+    Used by :func:`load_detector_route` when the caller passes a null/omitted
+    ``detector_id`` to unload without loading another detector. Returns the
+    route's success payload.
+    """
+    from vtscore.detectors.registry import remove_loaded_detector_id
+    from vtsearch.state import get_active_detector_context
+
+    det_ctx = get_active_detector_context()
+    prev_id = det_ctx.detector_id if det_ctx.detector_id else None
+    if prev_id:
+        from vtsearch.state import unregister_detector_context
+
+        # Find mode lived on this detector's context (per-detector), so
+        # tearing the context down clears it; no separate global to reset.
+        unregister_detector_context(prev_id)
+        remove_loaded_detector_id(prev_id)
+    return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
+
+
 @detectors_registry_bp.route("/api/detectors/registry/load", methods=["POST"])
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
 @detectors_registry_bp.alt_response(403, description="Access denied for the current user.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
-def load_detector_route(body: dict):  # noqa: C901
+def load_detector_route(body: dict):
     """Load a detector into memory and make it active.
 
     Pass ``detector_id=null`` (or omit the field) to unload the active
@@ -360,18 +518,7 @@ def load_detector_route(body: dict):  # noqa: C901
         sync_labels_to_loaded_detector()
 
     if detector_id is None:
-        from vtscore.detectors.registry import remove_loaded_detector_id
-
-        det_ctx = get_active_detector_context()
-        prev_id = det_ctx.detector_id if det_ctx.detector_id else None
-        if prev_id:
-            from vtsearch.state import unregister_detector_context
-
-            # Find mode lived on this detector's context (per-detector), so
-            # tearing the context down clears it; no separate global to reset.
-            unregister_detector_context(prev_id)
-            remove_loaded_detector_id(prev_id)
-        return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
+        return _unload_active_detector()
 
     if is_detector_loaded(detector_id):
         # Detector is already in memory, but its cached label embeddings may
@@ -397,7 +544,7 @@ def load_detector_route(body: dict):  # noqa: C901
                 }
         return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
 
-    from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
+    from vtscore.concurrency.progress import detector_loading_tasks
 
     det_ctx = DetectorContext(
         detector_id,
@@ -406,9 +553,6 @@ def load_detector_route(body: dict):  # noqa: C901
     )
     register_detector_context(det_ctx)
 
-    _LOAD_STEPS = 3  # restore labels, seed examples, train MLP
-    # MLP training dominates; label restore + example seeding are quick I/O.
-    _LOAD_STEP_WEIGHTS = [0.15, 0.15, 0.70]
     task_id = f"_detload_{detector_id[:8]}"
     tracker = detector_loading_tasks.create_task(
         task_id,
@@ -426,117 +570,14 @@ def load_detector_route(body: dict):  # noqa: C901
     _thread_ds_ctx = get_active_context()
 
     def load_task():
-        from vtscore.detectors.registry import add_loaded_detector_id, remove_loaded_detector_id
-        from vtscore.state.core import thread_dataset_context, thread_detector_context
-
-        try:
-            with thread_dataset_context(_thread_ds_ctx), thread_detector_context(det_ctx):
-                try:
-                    if det_name:
-                        tracker.check_cancelled()
-                        tracker.update(
-                            "loading",
-                            "Restoring labels…",
-                            0,
-                            0,
-                            step=1,
-                            total_steps=_LOAD_STEPS,
-                        )
-                        det_data = _read_detector(_detector_path(det_name))
-                        if det_data:
-                            # The detector's locked embedder type (immutable;
-                            # set at create time): load it so the label-embed /
-                            # score / invalidation paths resolve the concrete
-                            # embedder of that type the active dataset supplies.
-                            # Empty for a legacy detector with neither type nor
-                            # primary → routing falls back to the precedence.
-                            det_ctx.embedder_type = detector_embedder_type_from_data(det_data)
-                            _restore_labels_from_detector(det_data)
-
-                            tracker.check_cancelled()
-                            tracker.update(
-                                "loading",
-                                "Seeding examples…",
-                                0,
-                                0,
-                                step=2,
-                                total_steps=_LOAD_STEPS,
-                            )
-                            _seed_good_votes_from_examples(det_data.get("examples", []))
-
-                            tracker.check_cancelled()
-                            tracker.update(
-                                "loading",
-                                "Embedding labels…",
-                                0,
-                                0,
-                                step=3,
-                                total_steps=_LOAD_STEPS,
-                            )
-
-                            from vtscore.datasets.labelset import LabelSet
-                            from vtscore.detectors.labelset_ops import train_from_labelset
-                            from vtsearch.state import snapshot_medias as _snap_medias
-
-                            labelset = LabelSet.from_dict(det_data.get("labelset") or {})
-                            media_type = det_data.get("media_type", "") or ""
-                            snap = _snap_medias()
-
-                            det_ctx.labelset_good_count = sum(1 for el in labelset.elements if el.label == "good")
-                            det_ctx.labelset_bad_count = sum(1 for el in labelset.elements if el.label == "bad")
-                            # Cache the parsed labelset so before_request's rehydrate
-                            # hook and learned_sort don't re-read the JSON file.
-                            det_ctx.cached_labelset = labelset
-                            det_ctx.cached_labelset_media_type = media_type
-                            try:
-                                det_ctx.cached_labelset_mtime = _detector_path(det_name).stat().st_mtime
-                            except OSError:
-                                det_ctx.cached_labelset_mtime = 0.0
-
-                            def _embed_progress(name: str, done: int, total: int) -> None:
-                                tracker.check_cancelled()
-                                tracker.update(
-                                    "loading",
-                                    "Embedding labels…",
-                                    done,
-                                    total,
-                                    step=3,
-                                    total_steps=_LOAD_STEPS,
-                                )
-
-                            train_from_labelset(
-                                det_ctx,
-                                labelset,
-                                media_type=media_type,
-                                snap=snap,
-                                on_progress=_embed_progress,
-                            )
-
-                    # Stamp the dataset whose medias the cid-keyed vote dicts were
-                    # derived against, so before_request's rehydrate hook can detect
-                    # subsequent dataset switches and re-derive against the new
-                    # dataset's medias.
-                    det_ctx.votes_dataset_id = _thread_ds_ctx.dataset_id
-                    add_loaded_detector_id(detector_id)
-                    tracker.update("idle", "", 0, 0, step=None, total_steps=None)
-                except CancelledError:
-                    from vtsearch.state import unregister_detector_context as _unreg
-
-                    _unreg(detector_id)
-                    remove_loaded_detector_id(detector_id)
-                    tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
-                except Exception as e:
-                    import traceback as _tb
-
-                    _tb.print_exc()
-                    from vtsearch.state import unregister_detector_context as _unreg
-
-                    _unreg(detector_id)
-                    remove_loaded_detector_id(detector_id)
-                    error_msg = str(e) or repr(e) or "Unknown error during detector loading"
-                    tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
-        finally:
-            detector_loading_tasks.mark_finished(task_id)
+        _run_detector_load_task(
+            detector_id=detector_id,
+            det_ctx=det_ctx,
+            thread_ds_ctx=_thread_ds_ctx,
+            det_name=det_name,
+            tracker=tracker,
+            task_id=task_id,
+        )
 
     from vtsearch.threading import spawn
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -113,7 +113,7 @@ def _media_info_for_response(media: dict) -> dict:
 @detector_scoring_bp.alt_response(404, description="Detector not found.")
 @require_dataset_header
 @require_detector_header
-def find_label(body: dict):  # noqa: C901
+def find_label(body: dict):
     """Score all loaded medias with a detector and apply labels based on threshold.
 
     Resolves the detector from the registry, scores every loaded media, and

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -71,13 +71,68 @@ def _display_path(entry: Path, root: Path) -> str:
     return rel
 
 
+def _parse_allowed_exts(extensions_param: str) -> set[str] | None:
+    """Parse the comma-separated ``extensions`` query param.
+
+    Returns a normalized set of lowercase, dot-prefixed extensions, or
+    ``None`` when no extension filter was supplied (param empty).
+    """
+    if not extensions_param:
+        return None
+    allowed_exts: set[str] = set()
+    for ext in extensions_param.split(","):
+        ext = ext.strip().lower()
+        if ext and not ext.startswith("."):
+            ext = "." + ext
+        if ext:
+            allowed_exts.add(ext)
+    return allowed_exts
+
+
+def _entry_to_listing(entry: Path, root: Path, allowed_exts: set[str] | None) -> tuple[str, dict] | None:
+    """Classify *entry* under *root* and build its listing dict.
+
+    Returns ``("dir", dict)`` for a directory, ``("file", dict)`` for a
+    file, or ``None`` when the entry should be skipped (hidden name,
+    out-of-root symlink, or a file filtered out by *allowed_exts*).
+    """
+    if entry.name.startswith("."):
+        return None
+    # is_dir() / is_file() / stat() follow symlinks by default, so an
+    # in-root symlink pointing outside root would otherwise be listed
+    # like an ordinary entry and leak the target's name/size/mtime.
+    # Resolve symlinks up front and skip any that escape root.
+    if entry.is_symlink():
+        try:
+            entry.resolve(strict=True).relative_to(root)
+        except (OSError, ValueError):
+            return None
+    rel = _display_path(entry, root)
+    if entry.is_dir():
+        return "dir", {"name": entry.name, "path": rel, "modified_at": format_mtime(entry)}
+    if entry.is_file():
+        if allowed_exts is not None and entry.suffix.lower() not in allowed_exts:
+            return None
+        try:
+            size = entry.stat().st_size
+        except OSError:
+            size = 0
+        return "file", {
+            "name": entry.name,
+            "path": rel,
+            "size_bytes": size,
+            "modified_at": format_mtime(entry),
+        }
+    return None
+
+
 @file_browser_bp.route("/api/browse")
 @file_browser_bp.arguments(BrowseQuerySchema, location="query")
 @file_browser_bp.response(200, BrowseResponseSchema)
 @file_browser_bp.alt_response(400, description="Invalid path (traversal blocked).")
 @file_browser_bp.alt_response(403, description="Permission denied reading the requested directory.")
 @file_browser_bp.alt_response(404, description="Directory not found within the allowed root.")
-def browse(query: dict):  # noqa: C901
+def browse(query: dict):
     """List directories and files at a relative path.
 
     Returns a directories+files listing with names, relative paths,
@@ -89,15 +144,7 @@ def browse(query: dict):  # noqa: C901
 
     root = _get_browse_root().resolve()
 
-    allowed_exts: set[str] | None = None
-    if extensions_param:
-        allowed_exts = set()
-        for ext in extensions_param.split(","):
-            ext = ext.strip().lower()
-            if ext and not ext.startswith("."):
-                ext = "." + ext
-            if ext:
-                allowed_exts.add(ext)
+    allowed_exts = _parse_allowed_exts(extensions_param)
 
     if subpath:
         target = (root / subpath).resolve()
@@ -121,28 +168,14 @@ def browse(query: dict):  # noqa: C901
         abort(403, message="Permission denied")
 
     for entry in entries:
-        if entry.name.startswith("."):
+        listing = _entry_to_listing(entry, root, allowed_exts)
+        if listing is None:
             continue
-        # is_dir() / is_file() / stat() follow symlinks by default, so an
-        # in-root symlink pointing outside root would otherwise be listed
-        # like an ordinary entry and leak the target's name/size/mtime.
-        # Resolve symlinks up front and skip any that escape root.
-        if entry.is_symlink():
-            try:
-                entry.resolve(strict=True).relative_to(root)
-            except (OSError, ValueError):
-                continue
-        rel = _display_path(entry, root)
-        if entry.is_dir():
-            directories.append({"name": entry.name, "path": rel, "modified_at": format_mtime(entry)})
-        elif entry.is_file():
-            if allowed_exts is not None and entry.suffix.lower() not in allowed_exts:
-                continue
-            try:
-                size = entry.stat().st_size
-            except OSError:
-                size = 0
-            files.append({"name": entry.name, "path": rel, "size_bytes": size, "modified_at": format_mtime(entry)})
+        kind, item = listing
+        if kind == "dir":
+            directories.append(item)
+        else:
+            files.append(item)
 
     current_path = _display_path(target, root) if target != root else ""
 

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -742,30 +742,79 @@ def vote_media_bulk(body: dict):
     return {"ok": True, "changed": changed, "missing": missing}
 
 
-@medias_bp.route("/api/medias/add-to-pile", methods=["POST"])
-@medias_bp.response(200, MediaAddToPileResponseSchema)
-@medias_bp.alt_response(
-    201,
-    schema=MediaAddToPileResponseSchema,
-    description="A new media was embedded and inserted before being voted.",
-)
-@medias_bp.alt_response(
-    400,
-    description=(
-        "Missing or malformed multipart body (no file / empty file / "
-        "invalid label), no dataset loaded, or no embedder available."
-    ),
-)
-@require_dataset_header
-@require_detector_header
-def add_media_to_pile():  # noqa: C901
-    """Upload a media file and add it directly to the Good or Bad pile.
+def _resolve_embedder(dataset_embedder_name: str, dataset_media_type: str):
+    """Resolve the embedder to use for an add-to-pile upload.
 
-    If a media with the same MD5 already exists in the dataset, the existing
-    media is voted accordingly. Otherwise the file is embedded using the
-    dataset's embedder, inserted as a new media item, and then voted. The
-    request body is multipart/form-data with ``file`` (the upload) and
-    ``label`` (``"good"`` or ``"bad"``).
+    Prefers the dataset's recorded embedder by name; falls back to the first
+    embedder registered for the dataset's media type.  Returns ``None`` when no
+    embedder is available (the caller ``abort``-s 400 in that case).
+    """
+    from vtscore.media import embedders_for_type, get_embedder  # noqa: PLC0415
+
+    if dataset_embedder_name:
+        try:
+            return get_embedder(dataset_embedder_name)
+        except KeyError:
+            pass
+    avail = embedders_for_type(dataset_media_type)
+    return avail[0] if avail else None
+
+
+def _embed_upload(embedder, file_bytes: bytes, original_filename: str):
+    """Embed an add-to-pile upload via a temporary file.
+
+    Writes *file_bytes* to a temp file (preserving the upload's suffix so the
+    embedder can sniff the format), embeds it, and cleans the temp file up.
+    ``abort``-s 400 when the embedder returns ``None``.
+    """
+    import tempfile  # noqa: PLC0415
+
+    suffix = Path(original_filename).suffix or ".bin"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(file_bytes)
+        tmp_path = Path(tmp.name)
+
+    from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+
+    try:
+        embedding = embedder.embed_media(media_from_path(tmp_path))
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    if embedding is None:
+        abort(400, message="Failed to embed the uploaded file.")
+    return embedding
+
+
+def _make_pile_thumbnail(media_type: str, file_bytes: bytes) -> bytes | None:
+    """Precompute the grid/list thumbnail for an add-to-pile upload.
+
+    Dispatches per media type (audio waveform, video frame, image downscale) so
+    the request path never decodes the full-resolution upload on a cold tile
+    fetch.  Returns ``None`` for types without a thumbnail generator.
+    """
+    if media_type == "audio":
+        from vtscore.media.audio.media_type import generate_waveform_thumbnail  # noqa: PLC0415
+
+        return generate_waveform_thumbnail(file_bytes)
+    if media_type == "video":
+        from vtscore.media.video.media_type import generate_video_thumbnail  # noqa: PLC0415
+
+        return generate_video_thumbnail(file_bytes)
+    if media_type == "image":
+        from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
+
+        result = make_image_thumbnail(file_bytes)
+        return result[0] if result is not None else None
+    return None
+
+
+def _read_pile_upload():
+    """Parse and validate the add-to-pile multipart request.
+
+    Returns ``(file, file_bytes, label)`` where *file* is the Werkzeug
+    ``FileStorage``, *file_bytes* its non-empty contents, and *label* one of
+    ``"good"``/``"bad"``.  ``abort``-s 400 on any missing/empty/invalid field.
     """
     if "file" not in request.files:
         abort(400, message="No file provided")
@@ -782,6 +831,60 @@ def add_media_to_pile():  # noqa: C901
     if not file_bytes:
         abort(400, message="Empty file")
 
+    return file, file_bytes, label
+
+
+def _insert_or_collide(new_media: dict[str, Any], file_md5: str) -> tuple[list[int], int, bool]:
+    """Insert *new_media* under ``_state_lock``, deduping on a concurrent MD5.
+
+    Re-checks the MD5 lookup under the lock immediately before inserting.
+    Embedding ran without the lock (it can take seconds), so a concurrent
+    request uploading the same bytes may have inserted a media with this MD5 in
+    the meantime. Without this re-check, both requests would each insert a fresh
+    media, producing duplicates with identical md5/embedding/bytes.
+    (logical-bug-audit.md H32.)
+
+    Returns ``(target_cids, target_id, is_new)``: on a collision the existing
+    cids are returned with ``is_new=False``; otherwise the freshly-assigned id
+    is returned with ``is_new=True``.
+    """
+    with _state_lock:
+        _, md5_lookup_now, _ = build_media_lookup(medias)
+        collided_cids = md5_lookup_now.get(file_md5, [])
+        if collided_cids:
+            return list(collided_cids), collided_cids[0], False
+        target_id = next_media_id(medias)
+        new_media["id"] = target_id
+        medias[target_id] = new_media
+        return [target_id], target_id, True
+
+
+@medias_bp.route("/api/medias/add-to-pile", methods=["POST"])
+@medias_bp.response(200, MediaAddToPileResponseSchema)
+@medias_bp.alt_response(
+    201,
+    schema=MediaAddToPileResponseSchema,
+    description="A new media was embedded and inserted before being voted.",
+)
+@medias_bp.alt_response(
+    400,
+    description=(
+        "Missing or malformed multipart body (no file / empty file / "
+        "invalid label), no dataset loaded, or no embedder available."
+    ),
+)
+@require_dataset_header
+@require_detector_header
+def add_media_to_pile():
+    """Upload a media file and add it directly to the Good or Bad pile.
+
+    If a media with the same MD5 already exists in the dataset, the existing
+    media is voted accordingly. Otherwise the file is embedded using the
+    dataset's embedder, inserted as a new media item, and then voted. The
+    request body is multipart/form-data with ``file`` (the upload) and
+    ``label`` (``"good"`` or ``"bad"``).
+    """
+    file, file_bytes, label = _read_pile_upload()
     file_md5 = hashlib.md5(file_bytes).hexdigest()
 
     # First-pass MD5 lookup (outside _state_lock). When this hits we can
@@ -807,55 +910,16 @@ def add_media_to_pile():  # noqa: C901
     dataset_media_type = first_media.get("media_type", "audio")
     dataset_embedder_name = first_media.get("embedder", "")
 
-    from vtscore.media import embedders_for_type, get_embedder
-
-    embedder = None
-    if dataset_embedder_name:
-        try:
-            embedder = get_embedder(dataset_embedder_name)
-        except KeyError:
-            pass
-    if embedder is None:
-        avail = embedders_for_type(dataset_media_type)
-        embedder = avail[0] if avail else None
+    embedder = _resolve_embedder(dataset_embedder_name, dataset_media_type)
     if embedder is None:
         abort(400, message="No embedder available for the current dataset type.")
 
-    # Write to a temporary file for embedding
-    import tempfile
-
     original_filename = file.filename or "upload.bin"
-    suffix = Path(original_filename).suffix or ".bin"
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-        tmp.write(file_bytes)
-        tmp_path = Path(tmp.name)
-
-    from vtscore.media.embedder import media_from_path  # noqa: PLC0415
-
-    try:
-        embedding = embedder.embed_media(media_from_path(tmp_path))
-    finally:
-        tmp_path.unlink(missing_ok=True)
-
-    if embedding is None:
-        abort(400, message="Failed to embed the uploaded file.")
+    embedding = _embed_upload(embedder, file_bytes, original_filename)
 
     # Precompute the grid/list thumbnail so the request path never decodes the
     # full-resolution upload on a cold tile fetch (matches the ingest path).
-    thumb = None
-    if dataset_media_type == "audio":
-        from vtscore.media.audio.media_type import generate_waveform_thumbnail  # noqa: PLC0415
-
-        thumb = generate_waveform_thumbnail(file_bytes)
-    elif dataset_media_type == "video":
-        from vtscore.media.video.media_type import generate_video_thumbnail  # noqa: PLC0415
-
-        thumb = generate_video_thumbnail(file_bytes)
-    elif dataset_media_type == "image":
-        from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
-
-        result = make_image_thumbnail(file_bytes)
-        thumb = result[0] if result is not None else None
+    thumb = _make_pile_thumbnail(dataset_media_type, file_bytes)
 
     new_media: dict[str, Any] = {
         "media_type": dataset_media_type,
@@ -875,25 +939,7 @@ def add_media_to_pile():  # noqa: C901
     if thumb is not None:
         new_media["thumbnail_bytes"] = thumb
 
-    # Re-check the MD5 lookup under _state_lock immediately before inserting.
-    # Embedding above ran without the lock (it can take seconds), so a
-    # concurrent request uploading the same bytes may have inserted a media
-    # with this MD5 in the meantime. Without this re-check, both requests
-    # would each insert a fresh media, producing duplicates with identical
-    # md5/embedding/bytes. (logical-bug-audit.md H32.)
-    with _state_lock:
-        _, md5_lookup_now, _ = build_media_lookup(medias)
-        collided_cids = md5_lookup_now.get(file_md5, [])
-        if collided_cids:
-            target_cids: list[int] = list(collided_cids)
-            target_id = collided_cids[0]
-            is_new = False
-        else:
-            target_id = next_media_id(medias)
-            new_media["id"] = target_id
-            medias[target_id] = new_media
-            target_cids = [target_id]
-            is_new = True
+    target_cids, target_id, is_new = _insert_or_collide(new_media, file_md5)
 
     for cid in target_cids:
         apply_label(cid, label)


### PR DESCRIPTION
## What & why

Audited every `# noqa: C901` (McCabe complexity) suppression in the repo to answer: *does each function genuinely need the exception, or is the marker hiding avoidable complexity?* Method: `ruff check --select C901 --ignore-noqa` reports the true complexity past the suppression, then each was classified **stale** / **justified** / **refactorable**.

The audit found that **not all of them need the exception**: 5 markers were inert, and ~22 functions are cleanly refactorable. This PR removes the inert markers and refactors the highest-complexity tier (McCabe ≥16).

## Inert markers removed (5)
The marker was suppressing nothing:
- `achievements._credit_vote`, `routes/detectors/scoring.find_label`, `datasets/archive.extract_archive`, `clipper_chain._select_chain_output` — all already ≤10 (bodies simplified since the marker was added).
- `scripts/spike_structural_roxford.main` — `scripts/**` is already C901-exempt via `per-file-ignores`, so the inline `C901` token was redundant (kept `PLR0915`).

## Refactored below threshold (9)
Extracted cohesive sub-blocks into module-private helpers so each function drops under 10 and sheds its noqa. Behavior preserved exactly.

| Function | Was → now |
|---|---|
| `stages/embedding.embed_missing` | 33 → 10 |
| `media/list.add_media_to_pile` | 20 → ≤10 |
| `file_browser.browse` | 17 → 8 |
| `detectors/registry.load_detector_route` | 17 → ≤10 |
| `loader_demo.load_demo_dataset` | 17 → 8 |
| `downloader/core._download_and_extract` | 17 → ≤10 |
| `detectors/labels.import_labels_into_detector` | 16 → 10 |
| `datasets/ingest.ingest_missing_medias` | 16 → ≤10 |
| `downloader/text.download_bbc_news` | 16 → ≤10 |

## Left justified
~27 functions keep their noqa: intrinsic complexity (flat one-branch-per-case dispatch, coupled validation cascades, retry state machines, irreducible loop nests, and nested-closure factories whose McCabe is inflated by aggregated `def`s sharing captured state). Extracting them would scatter tightly-coupled logic and hurt readability.

## Follow-ups
The 13 refactorable-but-deferred candidates (each with a named extraction) are recorded in `docs/plans/c901-complexity-cleanup.md`, not here.

## Testing
`./run-tests.sh` — **all 5168 tests pass** (1 skipped, 2 xpassed). ruff / ruff-format / codespell / deptry / frontend build all gate the run and are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wiWVSWF3FSKMTUF9AtkjP)_