### PR TITLE
Make votes land in the Good/Bad pile immediately in train mode

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -23,6 +23,7 @@ import { DatasetsRegistryApiService } from '../../services/datasets-registry-api
 import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
+import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SortStateService, SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
@@ -67,6 +68,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private labelSession = inject(LabelSessionService);
   mediaState = inject(MediaStateService);
   voteState = inject(VoteStateService);
+  private labelsetState = inject(LabelsetStateService);
   sortState = inject(SortStateService);
   private settingsState = inject(SettingsStateService);
   private autopilotStateService = inject(AutopilotStateService);
@@ -828,6 +830,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Local vote state is already reconciled from the POST response inside
     // submitToggleVote; loadVotes() only refreshes derived counters.
     this.voteState.loadVotes();
+    // In train mode the right pane's Good/Bad piles are sourced from the
+    // labelset (not the cid-based vote signals), and the labelset only repaints
+    // on its 1500ms poll — so a just-cast vote takes up to that long to land in
+    // a pile. Kick an immediate labelset refresh so the new label appears as
+    // soon as the server has it, instead of waiting for the next poll tick.
+    // No-op when no detector is being trained (refresh() bails on a null model).
+    this.labelsetState.refresh();
     this.autoSelectNext(event.id);
     if (this.sortState.sortMode === 'learned' && this.voteState.learnedSortAvailable) {
       this.scheduleLearnedSort(false);


### PR DESCRIPTION
## Problem

There's a noticeable pause between clicking a vote and seeing it appear in the Good/Bad pile when training a detector. The pile lagged by up to a full poll interval, which read as sluggish.

## Root cause

In train-a-detector mode (`useLabelset`), the right pane's Good/Bad piles are sourced from the **labelset** (`DetectorLabelView` elements via `LabelsetStateService`), not the cid-based vote signals. The labelset only repaints on its **1500ms poll** (`LabelsetStateService.startPolling`).

A vote cast from the center panel went through `VoteStateService`, which updates the cid-based vote signals optimistically — but in labelset mode those signals aren't what the piles render. `LabelViewComponent.onMediaVoted` refreshed the vote counters but never refreshed the labelset, so the just-voted item only showed up on the next poll tick (up to ~1.5s later).

The Find-mode pile and the non-train Label pile already update instantly (they render the optimistic `voteState` signals); only the labelset-backed train pile had the lag.

## Fix

Trigger an immediate `LabelsetStateService.refresh()` from `onMediaVoted` (the single convergence point for big-button, hover, and right-pane votes). The new label now lands in the pile as soon as the server has it, instead of waiting for the next poll.

It's a no-op when no detector is being trained — `refresh()` bails on a null model — so the non-train paths are unaffected. A fully faked optimistic insert was rejected because the labelset thumbnail is keyed by a server-derived element id, which would render broken until reconciliation; an immediate real refresh is the crisp, correct improvement.

## Testing

- `./run-tests.sh frontend` — build OK, 860 Vitest tests pass, lint/format/typecheck/audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtHPMyEfXiuh3a7jgocoGk)_