### PR TITLE
Backend debt sweep: H1 labelset vote, M18 pickle hardening, C901 refactors

### DIFF
--- a/docs/plans/c901-complexity-cleanup.md
+++ b/docs/plans/c901-complexity-cleanup.md
@@ -1,6 +1,6 @@
 # C901 complexity-marker cleanup
 
-**Status:** First pass shipped (stale-marker removal + the McCabe ≥16 tier refactored). Remaining refactor candidates deferred; see Open follow-ups.
+**Status:** Complete (2026-06-25). First pass (stale-marker removal + the McCabe ≥16 tier) and the deferred refactor tier are both shipped. Every audited *refactorable* function now passes McCabe ≤10 with its `# noqa: C901` removed; the only markers left are the **justified-intrinsic** set below. No open follow-ups.
 
 ## Background
 
@@ -60,23 +60,28 @@ aggregated `def`s sharing captured state (`_make_per_side_setting`,
 `intercept_tqdm_progress`, `stream_progress_events`, `_resolve_context`,
 `_transcode_to_mp4`, `media_type.load_demo_source`).
 
-## Open follow-ups
+## Second pass — shipped (2026-06-25)
 
-Refactorable but deferred (the audit found a clean extraction for each; not done in
-this pass). Each drops under 10 with the named helper:
+The deferred tier below is now refactored. Each function dropped under McCabe 10
+behaviour-preservingly and lost its `# noqa: C901`. Most took the single
+extraction the audit predicted; three needed a second cohesive block (noted),
+and one lived at a different path than the original table guessed (corrected).
 
-| Function | McCabe | Suggested extraction |
+| Function | McCabe → | Helper(s) extracted |
 |---|---|---|
-| `media/list._resolve_display_image` | 11 | `_MIMETYPE_BY_EXT` dict lookup |
-| `converters/video2image.convert` | 14 | `_compute_n_frames(...)` |
-| `concurrency/progress.list_tasks` | 14 | `_build_snapshot(task_id, entry)` (de-dup branches) |
-| `detectors/labeling_progress._ensure_cache` | 11 | `_resolve_step_model(...)` |
-| `detectors/labeling_progress._eval_cached_models` | 14 | `_score_step(...)` |
-| `detectors/label_restoration.restore_labels_from_detector` | 15 | `_resolve_unmatched(...)` |
-| `detectors/media_seeding.seed_good_votes_from_examples` | 14 | `_ensure_embedder(...)` |
-| `routes/labels/vote.fill_labels_from_sort` | 15 | `_partition_candidates(...)` |
-| `labels/importers/server_csv_file._parse_csv_bytes` | 13 | `_row_to_entry(...)` |
-| `datasets/stages/clipper._apply_clipper` | 12 | `_stamp_default_clipper(...)` |
-| `datasets/stages/clipper._regenerate_clip_thumbnails` | 14 | `_thumb_for(clip, media_type)` over one loop |
-| `downloader/images.download_caltech101` | 14 | `_extract_members(...)` |
-| `media/image/clipper.clip` | 14 | `_box_from_detection(det, w, h)` |
+| `routes/media/list._resolve_display_image` (was listed under `media/list`) | 11 → ≤10 | module-level `_MIMETYPE_BY_EXT` dict + `.get(suffix, "image/jpeg")` lookup |
+| `converters/video2image.convert` | 14 → ≤10 | `_compute_n_frames(...)` **+** `_resolve_frame_params(...)` (second block) |
+| `concurrency/progress.list_tasks` | 14 → ≤10 | `_build_snapshot(task_id, entry)` |
+| `detectors/labeling_progress._ensure_cache` | 11 → ≤10 | `_resolve_step_model(...)` |
+| `detectors/labeling_progress._eval_cached_models` | 14 → ≤10 | `_score_step(...)` **+** `_build_eval_set(...)` (second block) |
+| `detectors/label_restoration.restore_labels_from_detector` | 15 → ≤10 | `_resolve_unmatched(...)` |
+| `detectors/media_seeding.seed_good_votes_from_examples` | 14 → ≤10 | `_ensure_embedder(...)` |
+| `routes/labels/vote.fill_labels_from_sort` | 15 → 7 | `_partition_candidates(...)` |
+| `labels/importers/server_csv_file._parse_csv_bytes` | 13 → 6 | `_row_to_entry(...)` + module-level `_OPTIONAL_COLS` |
+| `datasets/stages/clipper._apply_clipper` | 12 → 7 | `_stamp_default_clipper(...)` |
+| `datasets/stages/clipper._regenerate_clip_thumbnails` | 14 → 4 | `_thumb_for(clip, media_type)` (two media-type loops collapse to one) |
+| `downloader/images.download_caltech101` | 14 → 10 | `_extract_members(..., start=...)` (preserves both passes' progress cadence) |
+| `media/image/clipper.clip` (`ImageFaceClipper`) | 14 → ≤10 | `_box_from_detection(det, w, h)` |
+
+The remaining `# noqa: C901` markers (e.g. `clipper._fixup_clip_md5_and_embeddings`,
+`media_type._transcode_to_mp4`) are in the **Justified** set above and stay flagged.

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1163,37 +1163,29 @@ Cross-cutting open items that don't fit any single finding above:
   transparently) would neutralise the whole category and let the
   matrix accessor compare a single int instead of two id lists.
 
-- **M18 follow-ups: pickle peek hardening.** Two adjacent leaks
-  surfaced while closing M18 but were left out of scope:
-  (1) `_codecs.encode` is not on the `_PICKLE_SAFE_CLASSES` allowlist,
+- ~~**M18 follow-ups: pickle peek hardening.**~~ **Shipped 2026-06-25.**
+  Both adjacent leaks closed:
+  (1) `_codecs.encode` is now on the `_PICKLE_SAFE_CLASSES` allowlist,
   so protocol-0/1/2 pickles containing inline `bytes` (which pickle
-  serialises as `_codecs.encode(s, 'latin-1')`) fail outright in both
-  `_PeekUnpickler` and `RestrictedUnpickler` / `safe_pickle_load`.
-  The staging route now surfaces this as an `error` field (no longer
-  silent), but a user trying to load an externally-produced legacy
-  pickle still gets a hard reject. Add `_codecs.encode` to the
-  allowlist (low risk; it's a codec dispatcher, not RCE) if we want
-  to support those uploads.
-  (2) `BINUNICODE` / `BINUNICODE8` are not overridden, so a pickle
-  with a multi-MB inline `media_string` (a long document) is still
-  fully materialised during peek. A blanket override doesn't work
-  because the peek needs short unicode strings (dict keys, `"media_type"`
-  value); a size-bounded handler (e.g. truncate over N bytes) would
-  cap the worst case.
+  serialises as `_codecs.encode(s, 'latin-1')`) load through
+  `RestrictedUnpickler` / `safe_pickle_load` instead of being rejected
+  (it's a codec dispatcher, not an RCE vector).
+  (2) `_PeekUnpickler` overrides `BINUNICODE` / `BINUNICODE8` with a
+  size-bounded handler (`_PEEK_MAX_INLINE_STR = 4096`): short strings
+  (dict keys, `"media_type"`) decode normally, while an over-cap inline
+  `media_string` (a long document) is consumed in bounded chunks and
+  replaced by `""`, so the peek never materialises the whole body.
 
-- **H1 follow-up: labelset element vote endpoint still toggles.**
-  `POST /api/detectors/<name>/labels/<element_id>/vote` (and the
-  underlying `apply_element_vote_in_data` in
-  `vtscore/detectors/labelset_elements.py`) still takes
-  `vote: "good" | "bad"` with toggle-on-same-direction semantics; a
-  stale-view tab voting against an already-good labelset element
-  removes the element from the on-disk labelset, same kind of
-  inflation race the media-vote H1 fix eliminated.  Migrating that
-  endpoint to absolute-target (`target: "good" | "bad" | "remove"`)
-  would let the in-memory `set_vote()` mirror run idempotently too,
-  closing the same class of race on the labelset side.  Deferred
-  because the labelset element CRUD is a separate user surface
-  (`vt-labels-list` modal, not the centre-pane click flow that H1
-  was scoped to).  The on-disk labelset write is idempotent already
-  via `_write_detector`; the race is on the in-memory mirror and
-  the `num_training` registry counter.
+- ~~**H1 follow-up: labelset element vote endpoint still toggles.**~~
+  **Shipped 2026-06-25.** `POST /api/detectors/<name>/labels/<element_id>/vote`
+  and the underlying `apply_element_vote_in_data` in
+  `vtscore/detectors/labelset_elements.py` now take an absolute
+  `target: "good" | "bad" | "remove"` instead of a toggle `vote`.
+  Re-asserting an element's current label is an idempotent `"unchanged"`
+  no-op, so a stale-view tab can no longer flip an element off the
+  labelset by re-sending its current polarity — the same inflation race
+  the media-vote H1 fix eliminated. The in-memory mirror moved from
+  `toggle_vote()` to `set_vote()` with the same absolute target
+  (`"remove"` → `"none"`), so it stays idempotent too; the frontend
+  (`vt-labels-list` via `LabelsetStateService`) translates the clicked
+  direction into a target in one place, mirroring the centre-pane vote.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1875,16 +1875,17 @@
       "DetectorLabelVoteRequest": {
         "additionalProperties": false,
         "properties": {
-          "vote": {
+          "target": {
             "enum": [
               "good",
-              "bad"
+              "bad",
+              "remove"
             ],
             "type": "string"
           }
         },
         "required": [
-          "vote"
+          "target"
         ],
         "type": "object"
       },
@@ -10760,7 +10761,7 @@
         }
       ],
       "post": {
-        "description": "Body: ``{\"vote\": \"good\"}`` or ``{\"vote\": \"bad\"}``.\n\nToggle semantics mirror :func:`~vtsearch.state.toggle_vote`: the same\nvote on an element with that label removes the element; the opposite\nvote flips it.  When the element resolves into the active dataset, the\ndetector's in-memory ``good_votes`` / ``bad_votes`` are kept in sync so\nMLP retraining and learned-sort see the change.",
+        "description": "Body: ``{\"target\": \"good\"}``, ``{\"target\": \"bad\"}``, or\n``{\"target\": \"remove\"}``.\n\nAbsolute-target semantics mirror :func:`~vtsearch.state.set_vote`:\n``\"good\"`` / ``\"bad\"`` set the element's label (a re-assert of the\ncurrent label is an idempotent no-op), ``\"remove\"`` drops the element.\nWhen the element resolves into the active dataset, the detector's\nin-memory ``good_votes`` / ``bad_votes`` are kept in sync so MLP\nretraining and learned-sort see the change.",
         "operationId": "vote_detector_label",
         "requestBody": {
           "content": {
@@ -10793,7 +10794,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Toggle the label on a saved labelset element.",
+        "summary": "Set a saved labelset element's label to an absolute target.",
         "tags": [
           "detectors_labels"
         ]

--- a/frontend/src/app/services/detectors-crud-api.service.ts
+++ b/frontend/src/app/services/detectors-crud-api.service.ts
@@ -88,12 +88,12 @@ export class DetectorsCrudApiService {
   voteLabelElement(
     name: string,
     elementId: string,
-    vote: 'good' | 'bad',
+    target: 'good' | 'bad' | 'remove',
   ): Observable<DetectorLabelVoteResponse> {
     return voteDetectorLabel(this.http, this.config.rootUrl, {
       name,
       element_id: elementId,
-      body: { vote },
+      body: { target },
     }).pipe(map((r) => r.body));
   }
 

--- a/frontend/src/app/services/labelset-state.service.ts
+++ b/frontend/src/app/services/labelset-state.service.ts
@@ -65,34 +65,50 @@ export class LabelsetStateService implements OnDestroy {
     this.fetch$().subscribe();
   }
 
-  vote(elementId: string, vote: 'good' | 'bad'): void {
+  /**
+   * Apply a clicked Good/Bad direction to a labelset element.
+   *
+   * The click direction is translated into an absolute ``target`` (the
+   * desired end state) before it leaves the client, mirroring the
+   * center-pane media vote: re-clicking an element's current label removes
+   * it, the opposite label flips it. Sending an absolute target keeps
+   * repeated requests from stale tabs idempotent on the server
+   * (logical-bug-audit H1).
+   */
+  vote(elementId: string, clickedDirection: 'good' | 'bad'): void {
     if (!this.modelName) return;
     const name = this.modelName;
-    this.applyOptimisticVote(elementId, vote);
-    this.api.voteLabelElement(name, elementId, vote).subscribe({
+    const target = this.targetFor(elementId, clickedDirection);
+    this.applyOptimisticState(elementId, target);
+    this.api.voteLabelElement(name, elementId, target).subscribe({
       next: () => this.refresh(),
       error: () => this.refresh(),
     });
   }
 
-  /** Optimistic: flip the element's label or remove it on same-vote toggle. */
-  private applyOptimisticVote(elementId: string, vote: 'good' | 'bad'): void {
+  /** Translate a clicked direction into an absolute target by the element's
+   *  current label: same label → ``'remove'``, otherwise the clicked label. */
+  private targetFor(elementId: string, clickedDirection: 'good' | 'bad'): 'good' | 'bad' | 'remove' {
+    const elem = [...this.goodSubject.value, ...this.badSubject.value].find((e) => e.id === elementId);
+    return elem?.label === clickedDirection ? 'remove' : clickedDirection;
+  }
+
+  /** Optimistically move the element to its absolute target state. */
+  private applyOptimisticState(elementId: string, target: 'good' | 'bad' | 'remove'): void {
     const allCurrent = [...this.goodSubject.value, ...this.badSubject.value];
     const elem = allCurrent.find((e) => e.id === elementId);
     if (!elem) return;
 
     const nextGood = this.goodSubject.value.filter((e) => e.id !== elementId);
     const nextBad = this.badSubject.value.filter((e) => e.id !== elementId);
-    if (elem.label === vote) {
-      // Same vote → remove
+    if (target === 'remove') {
       this.goodSubject.next(nextGood);
       this.badSubject.next(nextBad);
       return;
     }
-    // Flip
-    const flipped: DetectorLabelView = { ...elem, label: vote };
-    if (vote === 'good') nextGood.push(flipped);
-    else nextBad.push(flipped);
+    const updated: DetectorLabelView = { ...elem, label: target };
+    if (target === 'good') nextGood.push(updated);
+    else nextBad.push(updated);
     this.goodSubject.next(nextGood);
     this.badSubject.next(nextBad);
   }

--- a/tests/datasets/test_pickle_safety.py
+++ b/tests/datasets/test_pickle_safety.py
@@ -144,6 +144,18 @@ class TestRestrictedUnpicklerAllows:
         assert result["raw"] == b"\x00\x01\x02"
         assert result["ba"] == bytearray(b"\x03\x04")
 
+    @pytest.mark.parametrize("protocol", [0, 1, 2])
+    def test_legacy_protocol_inline_bytes(self, protocol):
+        """Protocols 0/1/2 predate the BINBYTES opcode and serialise inline
+        ``bytes`` as ``_codecs.encode(latin1_str, 'latin1')``.  Without that
+        callable on the allowlist, an externally-produced legacy pickle
+        carrying media blobs is rejected outright; M18 follow-up adds it."""
+        blob = b"\x00\x01\x02hello\xff\xfe"
+        raw = pickle.dumps({"media_type": "image", "image": blob}, protocol=protocol)
+        result = _safe_loads(raw)
+        assert result["image"] == blob
+        assert result["media_type"] == "image"
+
     def test_numpy_array(self):
         arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
         result = _safe_loads(_dumps(arr))
@@ -421,6 +433,35 @@ class TestPeekUnpicklerStripsAcrossProtocols:
         assert first["filename"] == "m_0.wav"
         # The array is replaced by an empty placeholder, never materialised.
         assert len(first["embedding"]) == 0
+
+    @pytest.mark.parametrize("protocol", [1, 2, 3, 4, 5])
+    def test_long_inline_string_truncated(self, protocol):
+        """A multi-MB inline ``media_string`` (a long document) is consumed but
+        not retained during peek; short keys and ``media_type`` survive.
+
+        At protocol >= 1 a long ``str`` serialises via the BINUNICODE opcode;
+        without the size-bounded override the peek materialised the whole
+        document as a live dict value (M18 follow-up)."""
+        from vtscore.security.pickle import peek_pickle_dataset_summary
+
+        long_doc = "lorem ipsum dolor " * 100_000  # ~1.8 MB, far over the cap
+        data = {
+            "medias": {
+                0: {
+                    "media_type": "text",
+                    "media_string": long_doc,
+                    "filename": "doc_0.txt",
+                }
+            }
+        }
+        raw = pickle.dumps(data, protocol=protocol)
+        peeked = peek_pickle_dataset_summary(io.BytesIO(raw))
+        first = peeked["medias"][0]
+        # Short strings (dict keys, media_type, filename) decode normally...
+        assert first["media_type"] == "text"
+        assert first["filename"] == "doc_0.txt"
+        # ...while the over-cap document body is dropped, not materialised.
+        assert first["media_string"] == ""
 
     def test_protocol_0_floats_stripped_quickly(self):
         """Protocol 0 ASCII floats fall through to the default handler if

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -3,9 +3,9 @@
 These cover three concerns introduced together so that a detector loaded
 against a different dataset still shows its training labels on the right:
 
-* ``POST /api/detectors/<name>/labels/<id>/vote``; toggle on a
-* ``POST /api/detectors/<name>/labels/<id>/vote`` - toggle on a
-  saved labelset element (origin-keyed, dataset-agnostic).
+* ``POST /api/detectors/<name>/labels/<id>/vote`` - set an absolute
+  ``target`` (``good`` / ``bad`` / ``remove``) on a saved labelset element
+  (origin-keyed, dataset-agnostic), idempotent under stale-tab repeats.
 * ``sync_labels_to_loaded_detector`` is now non-destructive across datasets:
   a vote in dataset B no longer wipes labels saved from dataset A.
 """
@@ -188,11 +188,11 @@ class TestLabelElementVote:
     def test_flip_label(self, client):
         _seed_cross_dataset_model()
         detail = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
-        target = detail["good"][0]
+        elem = detail["good"][0]
 
         res = client.post(
-            f"/api/detectors/cross-ds-model/labels/{target['id']}/vote",
-            json={"vote": "bad"},
+            f"/api/detectors/cross-ds-model/labels/{elem['id']}/vote",
+            json={"target": "bad"},
         )
         assert res.status_code == 200
         assert res.get_json()["action"] == "flipped"
@@ -200,16 +200,16 @@ class TestLabelElementVote:
         after = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
         assert len(after["good"]) == 1
         assert len(after["bad"]) == 2
-        assert any(e["id"] == target["id"] for e in after["bad"])
+        assert any(e["id"] == elem["id"] for e in after["bad"])
 
-    def test_same_vote_removes_element(self, client):
+    def test_remove_target_removes_element(self, client):
         _seed_cross_dataset_model()
         detail = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
-        target = detail["good"][0]
+        elem = detail["good"][0]
 
         res = client.post(
-            f"/api/detectors/cross-ds-model/labels/{target['id']}/vote",
-            json={"vote": "good"},
+            f"/api/detectors/cross-ds-model/labels/{elem['id']}/vote",
+            json={"target": "remove"},
         )
         assert res.status_code == 200
         assert res.get_json()["action"] == "removed"
@@ -217,27 +217,48 @@ class TestLabelElementVote:
         after = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
         assert len(after["good"]) == 1
         assert len(after["bad"]) == 1
-        assert not any(e["id"] == target["id"] for e in after["good"] + after["bad"])
+        assert not any(e["id"] == elem["id"] for e in after["good"] + after["bad"])
+
+    def test_reassert_current_label_is_idempotent_noop(self, client):
+        """H1: target == current label leaves the element in place.
+
+        A stale tab re-asserting an element's existing label must not flip it
+        off the labelset (the toggle bug the absolute-target migration closed).
+        """
+        _seed_cross_dataset_model()
+        detail = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
+        elem = detail["good"][0]
+
+        res = client.post(
+            f"/api/detectors/cross-ds-model/labels/{elem['id']}/vote",
+            json={"target": "good"},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["action"] == "unchanged"
+
+        after = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
+        assert len(after["good"]) == 2
+        assert any(e["id"] == elem["id"] for e in after["good"])
 
     def test_unknown_id_404(self, client):
         _seed_cross_dataset_model()
         res = client.post(
             "/api/detectors/cross-ds-model/labels/deadbeef/vote",
-            json={"vote": "good"},
+            json={"target": "good"},
         )
         assert res.status_code == 404
 
-    def test_invalid_vote_value_422(self, client):
+    def test_invalid_target_value_422(self, client):
         _seed_cross_dataset_model()
         detail = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
-        target = detail["good"][0]
+        elem = detail["good"][0]
         res = client.post(
-            f"/api/detectors/cross-ds-model/labels/{target['id']}/vote",
-            json={"vote": "maybe"},
+            f"/api/detectors/cross-ds-model/labels/{elem['id']}/vote",
+            json={"target": "maybe"},
         )
         # Schema-level OneOf validation → 422 with the standard errors envelope.
         assert res.status_code == 422
-        assert "vote" in res.get_json()["errors"]["json"]
+        assert "target" in res.get_json()["errors"]["json"]
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -500,7 +500,25 @@ class LoadingTasksTracker:
             self._tasks.pop(task_id, None)
         self._notify()
 
-    def list_tasks(self) -> list[dict[str, Any]]:  # noqa: C901
+    @staticmethod
+    def _build_snapshot(task_id: str, entry: dict[str, Any]) -> dict[str, Any]:
+        """Build the public snapshot dict for one task entry.
+
+        Reads the task's :class:`ProgressTracker` and stamps on the
+        ``task_id``, ``name``, ``created_at`` identity plus any optional
+        association fields (``dataset_id``, ``detector_id``, ``media_type``,
+        ``embedder``) that are set.
+        """
+        snapshot = entry["tracker"].get()
+        snapshot["task_id"] = task_id
+        snapshot["name"] = entry["name"]
+        snapshot["created_at"] = entry["created_at"]
+        for key in ("dataset_id", "detector_id", "media_type", "embedder"):
+            if entry.get(key):
+                snapshot[key] = entry[key]
+        return snapshot
+
+    def list_tasks(self) -> list[dict[str, Any]]:
         """Return a snapshot of all active loading tasks.
 
         Each entry includes: ``task_id``, ``name``, ``created_at``, and
@@ -518,38 +536,12 @@ class LoadingTasksTracker:
         for task_id, entry in entries:
             finished = entry.get("finished_at")
             if finished is not None:
-                snapshot = entry["tracker"].get()
-                has_error = bool(snapshot.get("error"))
+                has_error = bool(entry["tracker"].get().get("error"))
                 max_age = 30 if has_error else 5
                 if (now - finished) > max_age:
                     stale.append(task_id)
                     continue
-                snapshot["task_id"] = task_id
-                snapshot["name"] = entry["name"]
-                snapshot["created_at"] = entry["created_at"]
-                if entry.get("dataset_id"):
-                    snapshot["dataset_id"] = entry["dataset_id"]
-                if entry.get("detector_id"):
-                    snapshot["detector_id"] = entry["detector_id"]
-                if entry.get("media_type"):
-                    snapshot["media_type"] = entry["media_type"]
-                if entry.get("embedder"):
-                    snapshot["embedder"] = entry["embedder"]
-                result.append(snapshot)
-            else:
-                snapshot = entry["tracker"].get()
-                snapshot["task_id"] = task_id
-                snapshot["name"] = entry["name"]
-                snapshot["created_at"] = entry["created_at"]
-                if entry.get("dataset_id"):
-                    snapshot["dataset_id"] = entry["dataset_id"]
-                if entry.get("detector_id"):
-                    snapshot["detector_id"] = entry["detector_id"]
-                if entry.get("media_type"):
-                    snapshot["media_type"] = entry["media_type"]
-                if entry.get("embedder"):
-                    snapshot["embedder"] = entry["embedder"]
-                result.append(snapshot)
+            result.append(self._build_snapshot(task_id, entry))
         if stale:
             with self._lock:
                 for tid in stale:

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -10,6 +10,22 @@ from vtscore.converters.base import MediaConverter
 from vtscore.plugins import PluginField
 
 
+def _compute_n_frames(frame_count: int, fps: float, n_clips: int, seconds_per_frame: float) -> int:
+    """Choose how many frames to extract from a video.
+
+    When ``seconds_per_frame`` is positive and a real ``fps`` is known, the
+    count is derived from the video's duration so longer videos yield more
+    frames; otherwise it falls back to the fixed ``n_clips``. The result is
+    capped at ``frame_count`` so we never ask for more frames than exist.
+    """
+    if seconds_per_frame > 0 and fps > 0:
+        duration = frame_count / fps
+        n = max(1, round(duration / seconds_per_frame))
+    else:
+        n = n_clips
+    return min(n, frame_count)
+
+
 class Video2ImageMediaConverter(MediaConverter):
     """Cut a video into evenly-spaced segments and extract the middle frame
     from each segment as a PNG image.
@@ -74,9 +90,13 @@ class Video2ImageMediaConverter(MediaConverter):
     def target_type(self) -> str:
         return "image"
 
-    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:  # noqa: C901
-        import tempfile  # noqa: PLC0415
+    def _resolve_frame_params(self, params: dict[str, Any] | None) -> tuple[int, float]:
+        """Parse the two frame-count knobs into ``(n_clips, seconds_per_frame)``.
 
+        ``n_clips`` is coerced to an integer of at least 1 (defaulting to 10 on
+        a missing/invalid value); ``seconds_per_frame`` is coerced to a float,
+        defaulting to ``0.0`` (meaning "use ``n_clips``") when blank or invalid.
+        """
         try:
             n_clips = int(self.get_param(params, "n_clips") or 10)
         except (TypeError, ValueError):
@@ -89,6 +109,13 @@ class Video2ImageMediaConverter(MediaConverter):
             seconds_per_frame = float(seconds_raw) if seconds_raw not in (None, "") else 0.0
         except (TypeError, ValueError):
             seconds_per_frame = 0.0
+
+        return n_clips, seconds_per_frame
+
+    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        import tempfile  # noqa: PLC0415
+
+        n_clips, seconds_per_frame = self._resolve_frame_params(params)
 
         media_bytes = media.get("media_bytes")
         media_path = media.get("media_path")
@@ -128,16 +155,8 @@ class Video2ImageMediaConverter(MediaConverter):
                 # "Seconds per frame" wins when supplied: derive the frame
                 # count from the video's duration so longer videos yield more
                 # frames.  Otherwise fall back to the fixed "frames per video".
-                if seconds_per_frame > 0:
-                    fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
-                    if fps > 0:
-                        duration = frame_count / fps
-                        n = max(1, round(duration / seconds_per_frame))
-                    else:
-                        n = n_clips
-                else:
-                    n = n_clips
-                n = min(n, frame_count)
+                fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0) if seconds_per_frame > 0 else 0.0
+                n = _compute_n_frames(frame_count, fps, n_clips, seconds_per_frame)
                 # Divide video into n equal segments, pick middle frame of each
                 segment_size = frame_count / n
                 mid_indices = [int((i + 0.5) * segment_size) for i in range(n)]

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -44,7 +44,24 @@ def download_cifar10(on_progress: Optional[ProgressCallback] = None) -> Path:
     return extract_dir
 
 
-def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:  # noqa: C901
+def _extract_members(members, extract_one, on_progress, message: str, *, start: int) -> None:
+    """Extract *members* one at a time, reporting progress every 100 items.
+
+    *extract_one* is called as ``extract_one(member)`` for each member (it
+    closes over the archive's own ``extract`` call and destination).  Indices
+    run from *start* (1 for the outer zip pass, 0 for the nested tar pass to
+    match the cadence each used inline); progress is pushed on every 100th
+    member and on the final one.
+    """
+    total = len(members)
+    for offset, member in enumerate(members):
+        i = offset + start
+        if i % 100 == 0 or i == total - (1 - start):
+            on_progress("downloading", message, offset + 1, total)
+        extract_one(member)
+
+
+def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
     """Download and extract the Caltech-101 image classification dataset.
 
     Downloads ``caltech-101.zip`` from the configured ``CALTECH101_URL``
@@ -93,17 +110,13 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
         on_progress("downloading", "Extracting Caltech-101 zip...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(temp_archive, "r") as zip_ref:
-            members = zip_ref.namelist()
-            total = len(members)
-            for i, member in enumerate(members, 1):
-                if i % 100 == 0 or i == total:
-                    on_progress(
-                        "downloading",
-                        "Extracting Caltech-101 zip...",
-                        i,
-                        total,
-                    )
-                zip_ref.extract(member, temp_extract)
+            _extract_members(
+                zip_ref.namelist(),
+                lambda member, zip_ref=zip_ref: zip_ref.extract(member, temp_extract),
+                on_progress,
+                "Extracting Caltech-101 zip...",
+                start=1,
+            )
 
         # The zip contains 101_ObjectCategories.tar.gz (a nested archive).
         # Extract it to produce the actual category directories.
@@ -112,17 +125,13 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
             on_progress("downloading", "Extracting 101_ObjectCategories...", 0, 0)
             inner_dest = temp_extract / "caltech-101"
             with tarfile.open(inner_tar, "r:gz") as tar_ref:
-                members = tar_ref.getmembers()
-                total = len(members)
-                for i, member in enumerate(members):
-                    if i % 100 == 0 or i == total - 1:
-                        on_progress(
-                            "downloading",
-                            "Extracting 101_ObjectCategories...",
-                            i + 1,
-                            total,
-                        )
-                    tar_ref.extract(member, inner_dest, filter="data")
+                _extract_members(
+                    tar_ref.getmembers(),
+                    lambda member, tar_ref=tar_ref: tar_ref.extract(member, inner_dest, filter="data"),
+                    on_progress,
+                    "Extracting 101_ObjectCategories...",
+                    start=0,
+                )
             inner_tar.unlink(missing_ok=True)
 
         if categories_dir.exists():

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -20,7 +20,37 @@ if TYPE_CHECKING:
     from vtscore.state import DatasetContext
 
 
-def _apply_clipper(  # noqa: C901
+def _stamp_default_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | None) -> None:
+    """Stamp legacy ``clipper`` / ``clipper_<param>`` keys for a ``*_default`` clipper.
+
+    A single ``*_default`` clipper is a no-op on the data but records the
+    clipper name and its resolved parameters in every media's
+    ``origin.params``.  We copy the ``origin`` (and its ``params``) before
+    mutating so we never write through to a shared dict.  Unknown clipper
+    names are a no-op (legacy semantics).
+    """
+    from vtscore.media import get_clipper  # noqa: PLC0415
+
+    try:
+        clipper = get_clipper(clipper_name)
+    except KeyError:
+        return
+    if clipper_params:
+        clipper = clipper.with_params(clipper_params)
+    resolved_dict = clipper.to_dict()
+    base_keys = {"name", "display_name", "media_type", "parameters", "description", "creation_questions"}
+    effective_params = {k: v for k, v in resolved_dict.items() if k not in base_keys}
+    for media in clips_dict.values():
+        orig = media.get("origin")
+        if isinstance(orig, dict):
+            media["origin"] = dict(orig)
+            media["origin"]["params"] = dict(orig.get("params", {}))
+            media["origin"]["params"]["clipper"] = clipper.name
+            for pk, pv in effective_params.items():
+                media["origin"]["params"][f"clipper_{pk}"] = str(pv)
+
+
+def _apply_clipper(
     clips_dict: dict,
     clipper_name: str,
     clipper_params: dict | None = None,
@@ -73,25 +103,7 @@ def _apply_clipper(  # noqa: C901
         # origin. We don't put it in the chain (so ``clipper_chain``
         # isn't written for default-only loads) but we do preserve the
         # legacy stamp so existing readers continue to see it.
-        from vtscore.media import get_clipper  # noqa: PLC0415
-
-        try:
-            clipper = get_clipper(clipper_name)
-        except KeyError:
-            return
-        if clipper_params:
-            clipper = clipper.with_params(clipper_params)
-        resolved_dict = clipper.to_dict()
-        base_keys = {"name", "display_name", "media_type", "parameters", "description", "creation_questions"}
-        effective_params = {k: v for k, v in resolved_dict.items() if k not in base_keys}
-        for media in clips_dict.values():
-            orig = media.get("origin")
-            if isinstance(orig, dict):
-                media["origin"] = dict(orig)
-                media["origin"]["params"] = dict(orig.get("params", {}))
-                media["origin"]["params"]["clipper"] = clipper.name
-                for pk, pv in effective_params.items():
-                    media["origin"]["params"][f"clipper_{pk}"] = str(pv)
+        _stamp_default_clipper(clips_dict, clipper_name, clipper_params)
         return
 
     if not steps and clipper_name:
@@ -219,7 +231,52 @@ def _relazify_reference_clips_stage(ctx: DatasetContext, tracker=None) -> None:
         clip["media_string"] = None
 
 
-def _regenerate_clip_thumbnails(  # noqa: C901
+def _thumb_for(clip: dict, media_type: str) -> bytes | None:
+    """Compute a refreshed thumbnail for one clip, or ``None`` to leave it.
+
+    For ``audio`` clips, render a waveform thumbnail from the clip's
+    ``media_bytes`` (or its ``media_path`` when bytes aren't held).  For
+    ``video`` clips, render a frame at the midpoint of
+    ``clip_start``/``clip_end``; a clip missing either boundary yields
+    ``None``.  Other media types yield ``None``.
+    """
+    if media_type == "audio":
+        from vtscore.media.audio.media_type import (
+            generate_waveform_thumbnail,
+            generate_waveform_thumbnail_from_file,
+        )
+
+        wav = clip.get("media_bytes")
+        if wav is not None:
+            return generate_waveform_thumbnail(wav)
+        path = clip.get("media_path")
+        if path:
+            return generate_waveform_thumbnail_from_file(Path(path))
+        return None
+
+    if media_type == "video":
+        from vtscore.media.video.media_type import (
+            generate_video_thumbnail_at,
+            generate_video_thumbnail_from_file_at,
+        )
+
+        t0 = clip.get("clip_start")
+        t1 = clip.get("clip_end")
+        if t0 is None or t1 is None:
+            return None
+        mid = (float(t0) + float(t1)) / 2.0
+        video_bytes = clip.get("media_bytes")
+        if video_bytes is not None:
+            return generate_video_thumbnail_at(video_bytes, mid)
+        path = clip.get("media_path")
+        if path:
+            return generate_video_thumbnail_from_file_at(Path(path), mid)
+        return None
+
+    return None
+
+
+def _regenerate_clip_thumbnails(
     clips: list[dict],
     needs_recompute: list[bool],
     media_type: str,
@@ -233,51 +290,12 @@ def _regenerate_clip_thumbnails(  # noqa: C901
     Image clips don't go through this path; their thumbnail is the cropped
     ``media_bytes`` itself, served directly by the media-image route.
     """
-    if media_type == "audio":
-        from vtscore.media.audio.media_type import (
-            generate_waveform_thumbnail,
-            generate_waveform_thumbnail_from_file,
-        )
-
-        for clip, recompute in zip(clips, needs_recompute):
-            if not recompute:
-                continue
-            wav = clip.get("media_bytes")
-            thumb: bytes | None = None
-            if wav is not None:
-                thumb = generate_waveform_thumbnail(wav)
-            else:
-                path = clip.get("media_path")
-                if path:
-                    thumb = generate_waveform_thumbnail_from_file(Path(path))
-            if thumb is not None:
-                clip["thumbnail_bytes"] = thumb
-        return
-
-    if media_type == "video":
-        from vtscore.media.video.media_type import (
-            generate_video_thumbnail_at,
-            generate_video_thumbnail_from_file_at,
-        )
-
-        for clip, recompute in zip(clips, needs_recompute):
-            if not recompute:
-                continue
-            t0 = clip.get("clip_start")
-            t1 = clip.get("clip_end")
-            if t0 is None or t1 is None:
-                continue
-            mid = (float(t0) + float(t1)) / 2.0
-            video_bytes = clip.get("media_bytes")
-            thumb: bytes | None = None
-            if video_bytes is not None:
-                thumb = generate_video_thumbnail_at(video_bytes, mid)
-            else:
-                path = clip.get("media_path")
-                if path:
-                    thumb = generate_video_thumbnail_from_file_at(Path(path), mid)
-            if thumb is not None:
-                clip["thumbnail_bytes"] = thumb
+    for clip, recompute in zip(clips, needs_recompute):
+        if not recompute:
+            continue
+        thumb = _thumb_for(clip, media_type)
+        if thumb is not None:
+            clip["thumbnail_bytes"] = thumb
 
 
 def _fixup_clip_md5_and_embeddings(  # noqa: C901

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -8,7 +8,62 @@ resolving origin files for cross-dataset scenarios.
 from __future__ import annotations
 
 
-def restore_labels_from_detector(det_data: dict) -> int:  # noqa: C901
+def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> int:
+    """Resolve unmatched labelset entries from their origin files.
+
+    When a detector was trained on Dataset A and we're now on Dataset B,
+    the origin+name keys won't match.  But if the same underlying file
+    exists in both datasets, resolving the origin file and computing its
+    MD5 lets us match by content hash.  Matched entries are labeled
+    silently.
+
+    Returns the number of labels restored via this fallback path.
+    """
+    import hashlib
+    import logging
+
+    from vtscore.detectors.resolver import resolve_file_context
+    from vtscore.state import apply_label
+
+    _log = logging.getLogger(__name__)
+
+    restored = 0
+    for elem in unresolved:
+        entry = elem.to_dict()
+        origin = entry.get("origin")
+        origin_name = entry.get("origin_name", "")
+        filename = entry.get("filename", "")
+        with resolve_file_context(origin, origin_name, filename) as resolved_path:
+            if resolved_path is None:
+                continue
+
+            # Compute MD5 of the resolved file and check against loaded medias
+            try:
+                h = hashlib.md5()
+                with open(resolved_path, "rb") as f:
+                    for chunk in iter(lambda: f.read(8192), b""):
+                        h.update(chunk)
+                resolved_md5 = h.hexdigest()
+            except OSError:
+                _log.debug("restore-labels: could not read resolved file %s", resolved_path)
+                continue
+
+            cids = md5_lookup.get(resolved_md5, [])
+            if cids:
+                for cid in cids:
+                    apply_label(cid, elem.label, silent=True)
+                restored += 1
+            else:
+                _log.debug(
+                    "restore-labels: resolved %s but MD5 %s not in loaded dataset",
+                    resolved_path,
+                    resolved_md5,
+                )
+
+    return restored
+
+
+def restore_labels_from_detector(det_data: dict) -> int:
     """Restore saved labels from a detector's labelset into votes.
 
     Matches labelset entries to loaded medias by origin+origin_name, MD5, and
@@ -60,48 +115,7 @@ def restore_labels_from_detector(det_data: dict) -> int:  # noqa: C901
             unresolved.append(elem)
 
     # Second pass: resolve unmatched labels from their origin files.
-    # When a detector was trained on Dataset A and we're now on Dataset B,
-    # the origin+name keys won't match.  But if the same underlying file
-    # exists in both datasets, resolving the origin file and computing its
-    # MD5 lets us match by content hash.
     if unresolved:
-        import hashlib
-        import logging
-
-        from vtscore.detectors.resolver import resolve_file_context
-
-        _log = logging.getLogger(__name__)
-
-        for elem in unresolved:
-            entry = elem.to_dict()
-            origin = entry.get("origin")
-            origin_name = entry.get("origin_name", "")
-            filename = entry.get("filename", "")
-            with resolve_file_context(origin, origin_name, filename) as resolved_path:
-                if resolved_path is None:
-                    continue
-
-                # Compute MD5 of the resolved file and check against loaded medias
-                try:
-                    h = hashlib.md5()
-                    with open(resolved_path, "rb") as f:
-                        for chunk in iter(lambda: f.read(8192), b""):
-                            h.update(chunk)
-                    resolved_md5 = h.hexdigest()
-                except OSError:
-                    _log.debug("restore-labels: could not read resolved file %s", resolved_path)
-                    continue
-
-                cids = md5_lookup.get(resolved_md5, [])
-                if cids:
-                    for cid in cids:
-                        apply_label(cid, elem.label, silent=True)
-                    restored += 1
-                else:
-                    _log.debug(
-                        "restore-labels: resolved %s but MD5 %s not in loaded dataset",
-                        resolved_path,
-                        resolved_md5,
-                    )
+        restored += _resolve_unmatched(unresolved, md5_lookup)
 
     return restored

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -310,7 +310,51 @@ def _train_step(
     return model, threshold, stability
 
 
-def _ensure_cache(  # noqa: C901
+def _resolve_step_model(
+    clips_dict: dict[int, dict[str, Any]],
+    all_media_ids: list[int],
+    t: int,
+    num_labels: int,
+    inclusion_value: int,
+    good_ids: list[int],
+    bad_ids: list[int],
+    prev: Optional[dict[str, Any]],
+) -> tuple[Optional[nn.Sequential], Optional[float], Optional[dict[str, Any]]]:
+    """Resolve the model, threshold, and stability for one cache step.
+
+    Reuses the previous step's model when the training data is unchanged,
+    otherwise reuses a live model injected by ``train_and_score`` for this
+    exact label set, or trains a fresh one.  Returns ``(model, threshold,
+    stability)``.
+    """
+    # Check whether the training data actually changed compared to the
+    # previous step.  If the good/bad ID sets are identical, the model
+    # would be the same - skip training and stability recording so the
+    # line graph and Stable indicator only reflect genuine model updates.
+    training_data_changed = (
+        prev is None or set(good_ids) != set(prev["good_ids"]) or set(bad_ids) != set(prev["bad_ids"])
+    )
+
+    if not training_data_changed:
+        # Reuse previous model - no new training or stability entry.
+        model = prev["model"] if prev else None
+        threshold = prev["threshold"] if prev else None
+        return model, threshold, None
+
+    # Check whether train_and_score already produced a model for
+    # this exact label set during live sorting.  If so, reuse it
+    # (correct cross-calibrated threshold, zero compute cost).
+    live_key = (frozenset(_cache_good_ids), frozenset(_cache_bad_ids))
+    live = _live_models.get(live_key)
+    if live is not None:
+        model, threshold = live
+        stability = _compute_step_stability(model, threshold, clips_dict, all_media_ids, t, num_labels)
+        return model, threshold, stability
+
+    return _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
+
+
+def _ensure_cache(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
     inclusion_value: int,
@@ -356,31 +400,10 @@ def _ensure_cache(  # noqa: C901
         bad_ids = list(_cache_bad_ids)
         num_labels = len(good_ids) + len(bad_ids)
 
-        # Check whether the training data actually changed compared to the
-        # previous step.  If the good/bad ID sets are identical, the model
-        # would be the same - skip training and stability recording so the
-        # line graph and Stable indicator only reflect genuine model updates.
         prev = _cached_steps[-1] if _cached_steps else None
-        training_data_changed = (
-            prev is None or set(good_ids) != set(prev["good_ids"]) or set(bad_ids) != set(prev["bad_ids"])
+        model, threshold, stability = _resolve_step_model(
+            clips_dict, all_media_ids, t, num_labels, inclusion_value, good_ids, bad_ids, prev
         )
-
-        if training_data_changed:
-            # Check whether train_and_score already produced a model for
-            # this exact label set during live sorting.  If so, reuse it
-            # (correct cross-calibrated threshold, zero compute cost).
-            live_key = (frozenset(_cache_good_ids), frozenset(_cache_bad_ids))
-            live = _live_models.get(live_key)
-            if live is not None:
-                model, threshold = live
-                stability = _compute_step_stability(model, threshold, clips_dict, all_media_ids, t, num_labels)
-            else:
-                model, threshold, stability = _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
-        else:
-            # Reuse previous model - no new training or stability entry.
-            model = prev["model"] if prev else None
-            threshold = prev["threshold"] if prev else None
-            stability = None
 
         _cached_steps.append(
             {
@@ -399,7 +422,87 @@ def _ensure_cache(  # noqa: C901
 # ---------------------------------------------------------------------------
 
 
-def _eval_cached_models(  # noqa: C901
+def _score_step(
+    step: dict[str, Any],
+    X_eval: Any,
+    eval_labels: list[float],
+    total_positives: int,
+    total_negatives: int,
+    fpr_weight: float,
+    fnr_weight: float,
+    t: int,
+) -> dict[str, Any]:
+    """Score one cached step against the evaluation set (forward pass only).
+
+    Returns an error-cost dict for the step.  The caller guarantees
+    ``step["model"]`` is not ``None``.
+    """
+    import torch  # noqa: PLC0415
+
+    with torch.no_grad():
+        X_in = X_eval.to(next(step["model"].parameters()).device)
+        scores = torch.sigmoid(step["model"](X_in)).squeeze(1).cpu().tolist()
+
+    fp = fn = 0
+    for score, true_label in zip(scores, eval_labels, strict=True):
+        predicted = 1 if score >= step["threshold"] else 0
+        if predicted == 1 and true_label == 0:
+            fp += 1
+        elif predicted == 0 and true_label == 1:
+            fn += 1
+
+    fpr = fp / total_negatives if total_negatives > 0 else 0.0
+    fnr = fn / total_positives if total_positives > 0 else 0.0
+    error_cost = fpr_weight * fpr + fnr_weight * fnr
+
+    return {
+        "time_index": t,
+        "num_labels": len(step["good_ids"]) + len(step["bad_ids"]),
+        "error_cost": round(error_cost, 4),
+        "fpr": round(fpr, 4),
+        "fnr": round(fnr, 4),
+    }
+
+
+def _build_eval_set(
+    clips_dict: dict[int, dict[str, Any]],
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+) -> Optional[tuple[Any, list[float], int, int]]:
+    """Build the evaluation tensor and label set from the current votes.
+
+    Returns ``(X_eval, eval_labels, total_positives, total_negatives)`` or
+    ``None`` when there are no usable labeled medias to evaluate against.
+    """
+    # Build evaluation set from current votes
+    current_labels: dict[int, float] = {}
+    for cid in current_good_votes:
+        current_labels[cid] = 1.0
+    for cid in current_bad_votes:
+        current_labels[cid] = 0.0
+
+    if not current_labels:
+        return None
+
+    eval_embs: list[np.ndarray] = []
+    eval_labels: list[float] = []
+    for cid, lbl in current_labels.items():
+        if cid in clips_dict and media_embedding(clips_dict[cid]) is not None:
+            eval_embs.append(media_embedding(clips_dict[cid]))
+            eval_labels.append(lbl)
+
+    if not eval_embs:
+        return None
+
+    import torch  # noqa: PLC0415
+
+    X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
+    total_positives = sum(1 for lbl in eval_labels if lbl == 1)
+    total_negatives = len(eval_labels) - total_positives
+    return X_eval, eval_labels, total_positives, total_negatives
+
+
+def _eval_cached_models(
     clips_dict: dict[int, dict[str, Any]],
     current_good_votes: dict[int, None],
     current_bad_votes: dict[int, None],
@@ -419,31 +522,10 @@ def _eval_cached_models(  # noqa: C901
         fpr_weight = 2.0 ** (-inclusion_value)
         fnr_weight = 1.0
 
-    # Build evaluation set from current votes
-    current_labels: dict[int, float] = {}
-    for cid in current_good_votes:
-        current_labels[cid] = 1.0
-    for cid in current_bad_votes:
-        current_labels[cid] = 0.0
-
-    if not current_labels:
+    eval_set = _build_eval_set(clips_dict, current_good_votes, current_bad_votes)
+    if eval_set is None:
         return []
-
-    eval_embs: list[np.ndarray] = []
-    eval_labels: list[float] = []
-    for cid, lbl in current_labels.items():
-        if cid in clips_dict and media_embedding(clips_dict[cid]) is not None:
-            eval_embs.append(media_embedding(clips_dict[cid]))
-            eval_labels.append(lbl)
-
-    if not eval_embs:
-        return []
-
-    import torch  # noqa: PLC0415
-
-    X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
-    total_positives = sum(1 for lbl in eval_labels if lbl == 1)
-    total_negatives = len(eval_labels) - total_positives
+    X_eval, eval_labels, total_positives, total_negatives = eval_set
 
     if end is None:
         end = len(_cached_steps)
@@ -454,30 +536,8 @@ def _eval_cached_models(  # noqa: C901
         if step["model"] is None:
             continue
 
-        with torch.no_grad():
-            X_in = X_eval.to(next(step["model"].parameters()).device)
-            scores = torch.sigmoid(step["model"](X_in)).squeeze(1).cpu().tolist()
-
-        fp = fn = 0
-        for score, true_label in zip(scores, eval_labels, strict=True):
-            predicted = 1 if score >= step["threshold"] else 0
-            if predicted == 1 and true_label == 0:
-                fp += 1
-            elif predicted == 0 and true_label == 1:
-                fn += 1
-
-        fpr = fp / total_negatives if total_negatives > 0 else 0.0
-        fnr = fn / total_positives if total_positives > 0 else 0.0
-        error_cost = fpr_weight * fpr + fnr_weight * fnr
-
         results.append(
-            {
-                "time_index": t,
-                "num_labels": len(step["good_ids"]) + len(step["bad_ids"]),
-                "error_cost": round(error_cost, 4),
-                "fpr": round(fpr, 4),
-                "fnr": round(fnr, 4),
-            }
+            _score_step(step, X_eval, eval_labels, total_positives, total_negatives, fpr_weight, fnr_weight, t)
         )
 
     return results

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -166,25 +166,29 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
 def apply_element_vote_in_data(
     detector_data: dict[str, Any],
     target_id: str,
-    vote: str,
+    target: str,
 ) -> tuple[bool, LabeledElement | None, str]:
-    """Toggle the label on the element with stable id *target_id*.
+    """Set the label on the element with stable id *target_id* to *target*.
+
+    *target* is an **absolute** end state, one of ``"good"`` / ``"bad"``
+    (set the element's label) or ``"remove"`` (drop the element from the
+    labelset).
 
     Returns ``(changed, updated_element, action)`` where:
 
     * ``changed`` is ``True`` if the on-disk labelset must be re-written.
     * ``updated_element`` is the element after the operation, or ``None``
-      when the element was removed.
+      when the element was removed or the target is invalid / not found.
     * ``action`` is one of ``"removed"``, ``"flipped"``, ``"unchanged"``,
       or ``"not_found"``.
 
-    Toggle semantics mirror :func:`~vtsearch.state.toggle_vote`:
-
-    * Same vote on the same element → remove the element from the labelset.
-    * Opposite vote → flip the element's label.
-    * Vote that's neither ``"good"`` nor ``"bad"`` → unchanged.
+    Absolute-target semantics mirror :func:`~vtsearch.state.set_vote`:
+    behaviour is **idempotent**, so re-sending ``"good"`` on an
+    already-good element is an ``"unchanged"`` no-op rather than a removal.
+    A stale-view tab can no longer flip an element off the labelset by
+    re-asserting its current label (logical-bug-audit H1).
     """
-    if vote not in ("good", "bad"):
+    if target not in ("good", "bad", "remove"):
         return False, None, "unchanged"
 
     labelset = LabelSet.from_dict(detector_data.get("labelset") or {})
@@ -193,11 +197,14 @@ def apply_element_vote_in_data(
         return False, None, "not_found"
 
     idx, el = found
-    if el.label == vote:
+    if target == "remove":
         labelset.elements.pop(idx)
         detector_data["labelset"] = labelset.to_dict()
         return True, None, "removed"
 
-    el.label = vote
+    if el.label == target:
+        return False, el, "unchanged"
+
+    el.label = target
     detector_data["labelset"] = labelset.to_dict()
     return True, el, "flipped"

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -7,7 +7,31 @@ files, matches them to loaded dataset medias by MD5, and votes them good.
 from __future__ import annotations
 
 
-def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
+def _ensure_embedder(embedder, dataset_embedder_name: str, dataset_media_type: str):
+    """Resolve an embedder for example media, loading it lazily.
+
+    Returns the already-loaded *embedder* if non-``None``; otherwise tries
+    the dataset's named embedder, then falls back to the first embedder
+    available for *dataset_media_type*.  Returns ``None`` when no embedder
+    is available.
+    """
+    if embedder is not None:
+        return embedder
+
+    from vtscore.media import embedders_for_type, get_embedder
+
+    if dataset_embedder_name:
+        try:
+            embedder = get_embedder(dataset_embedder_name)
+        except KeyError:
+            pass
+    if embedder is None:
+        avail = embedders_for_type(dataset_media_type)
+        embedder = avail[0] if avail else None
+    return embedder
+
+
+def seed_good_votes_from_examples(examples: list[dict]) -> int:
     """Seed good votes from a model's media examples.
 
     For each ``type: "media"`` example, reads the file from
@@ -80,20 +104,10 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
             seeded += 1
         else:
             # Example is NOT in the dataset - embed and insert as new media.
+            embedder = _ensure_embedder(embedder, dataset_embedder_name, dataset_media_type)
             if embedder is None:
-                from vtscore.media import embedders_for_type, get_embedder
-
-                if dataset_embedder_name:
-                    try:
-                        embedder = get_embedder(dataset_embedder_name)
-                    except KeyError:
-                        pass
-                if embedder is None:
-                    avail = embedders_for_type(dataset_media_type)
-                    embedder = avail[0] if avail else None
-                if embedder is None:
-                    # No embedder available; skip remaining examples.
-                    continue
+                # No embedder available; skip remaining examples.
+                continue
 
             from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 

--- a/vtscore/labels/importers/server_csv_file/__init__.py
+++ b/vtscore/labels/importers/server_csv_file/__init__.py
@@ -75,7 +75,43 @@ class ServerCsvLabelImporter(LabelImporter):
         )
 
 
-def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:  # noqa: C901
+# Optional columns that enrich resolution (origin_name, filename, category, origin)
+_OPTIONAL_COLS = ("origin_name", "filename", "category")
+
+
+def _row_to_entry(row: dict[str, Any], normalised: dict[str, str]) -> dict[str, Any] | None:
+    """Build a label entry from one CSV *row*, or ``None`` to skip it.
+
+    *normalised* maps lower-cased/stripped header names to the original
+    field names.  A row is skipped (returns ``None``) when its ``md5`` or
+    ``label`` cell is empty.  Present optional columns are copied through,
+    and an ``origin`` cell is parsed as JSON (a non-object or invalid value
+    is ignored).
+    """
+    md5 = row.get(normalised["md5"], "").strip()
+    label = row.get(normalised["label"], "").strip().lower()
+    if not (md5 and label):
+        return None
+    entry: dict[str, Any] = {"md5": md5, "label": label}
+    for col in _OPTIONAL_COLS:
+        if col in normalised:
+            val = row.get(normalised[col], "").strip()
+            if val:
+                entry[col] = val
+    # Parse origin dict from JSON if present
+    if "origin" in normalised:
+        origin_raw = row.get(normalised["origin"], "").strip()
+        if origin_raw:
+            try:
+                origin = json.loads(origin_raw)
+                if isinstance(origin, dict):
+                    entry["origin"] = origin
+            except (json.JSONDecodeError, ValueError):
+                pass
+    return entry
+
+
+def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:
     """Decode *raw* bytes as CSV and extract ``md5``/``label`` pairs."""
     try:
         text = raw.decode("utf-8-sig")  # strip BOM if present
@@ -96,30 +132,10 @@ def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:  # noqa: C901
     if "md5" not in normalised or "label" not in normalised:
         raise ValueError("CSV must have 'md5' and 'label' column headers.")
 
-    # Optional columns that enrich resolution (origin_name, filename, category, origin)
-    optional_cols = ("origin_name", "filename", "category")
-
     results = []
     for row in reader:
-        md5 = row.get(normalised["md5"], "").strip()
-        label = row.get(normalised["label"], "").strip().lower()
-        if md5 and label:
-            entry: dict[str, Any] = {"md5": md5, "label": label}
-            for col in optional_cols:
-                if col in normalised:
-                    val = row.get(normalised[col], "").strip()
-                    if val:
-                        entry[col] = val
-            # Parse origin dict from JSON if present
-            if "origin" in normalised:
-                origin_raw = row.get(normalised["origin"], "").strip()
-                if origin_raw:
-                    try:
-                        origin = json.loads(origin_raw)
-                        if isinstance(origin, dict):
-                            entry["origin"] = origin
-                    except (json.JSONDecodeError, ValueError):
-                        pass
+        entry = _row_to_entry(row, normalised)
+        if entry is not None:
             results.append(entry)
     return results
 

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -566,7 +566,36 @@ class ImageFaceClipper(MediaClipper):
             model_selection=self._model_selection,
         )
 
-    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: C901
+    def _box_from_detection(self, det: Any, w: int, h: int) -> tuple[int, int, int, int, float] | None:
+        """Turn one MediaPipe detection into a padded, clamped pixel box.
+
+        Returns ``(x1, y1, x2, y2, conf)`` in pixel coordinates of a ``w`` x
+        ``h`` image, or ``None`` when the detection has no usable score, falls
+        below :attr:`_threshold`, or is smaller than :attr:`_min_size` on
+        either axis after padding.
+        """
+        try:
+            conf = float(det.score[0])
+        except (AttributeError, IndexError, TypeError):
+            return None
+        if conf < self._threshold:
+            return None
+        rel = det.location_data.relative_bounding_box
+        fx1 = rel.xmin * w
+        fy1 = rel.ymin * h
+        fx2 = (rel.xmin + rel.width) * w
+        fy2 = (rel.ymin + rel.height) * h
+        pad_x = (fx2 - fx1) * self._padding
+        pad_y = (fy2 - fy1) * self._padding
+        x1 = max(0, int(round(fx1 - pad_x)))
+        y1 = max(0, int(round(fy1 - pad_y)))
+        x2 = min(w, int(round(fx2 + pad_x)))
+        y2 = min(h, int(round(fy2 + pad_y)))
+        if x2 - x1 < self._min_size or y2 - y1 < self._min_size:
+            return None
+        return (x1, y1, x2, y2, conf)
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         from PIL import Image  # noqa: PLC0415
         import numpy as np  # noqa: PLC0415
 
@@ -589,26 +618,9 @@ class ImageFaceClipper(MediaClipper):
 
         boxes: list[tuple[int, int, int, int, float]] = []
         for det in detections:
-            try:
-                conf = float(det.score[0])
-            except (AttributeError, IndexError, TypeError):
-                continue
-            if conf < self._threshold:
-                continue
-            rel = det.location_data.relative_bounding_box
-            fx1 = rel.xmin * img_w
-            fy1 = rel.ymin * img_h
-            fx2 = (rel.xmin + rel.width) * img_w
-            fy2 = (rel.ymin + rel.height) * img_h
-            pad_x = (fx2 - fx1) * self._padding
-            pad_y = (fy2 - fy1) * self._padding
-            x1 = max(0, int(round(fx1 - pad_x)))
-            y1 = max(0, int(round(fy1 - pad_y)))
-            x2 = min(img_w, int(round(fx2 + pad_x)))
-            y2 = min(img_h, int(round(fy2 + pad_y)))
-            if x2 - x1 < self._min_size or y2 - y1 < self._min_size:
-                continue
-            boxes.append((x1, y1, x2, y2, conf))
+            box = self._box_from_detection(det, img_w, img_h)
+            if box is not None:
+                boxes.append(box)
 
         # Highest-confidence face first so clip_index=0 is the "primary" face.
         boxes.sort(key=lambda b: b[4], reverse=True)

--- a/vtscore/security/pickle.py
+++ b/vtscore/security/pickle.py
@@ -21,6 +21,12 @@ _PICKLE_SAFE_CLASSES: set[tuple[str, str]] = {
     ("builtins", "bytes"),
     ("builtins", "bytearray"),
     ("builtins", "complex"),
+    # Protocol 0/1/2 serialise inline ``bytes`` as ``_codecs.encode(s, 'latin1')``;
+    # without this, externally-produced legacy pickles carrying inline bytes
+    # (e.g. media blobs) are rejected outright.  ``codecs.encode`` only dispatches
+    # to registered text codecs - none execute arbitrary code, so it is not an
+    # RCE vector (logical-bug-audit M18 follow-up).
+    ("_codecs", "encode"),
     # collections
     ("collections", "OrderedDict"),
     # numpy – reconstruction helpers used by numpy's __reduce__
@@ -68,6 +74,14 @@ class _PeekStubArray(list):
 def _peek_stub_numpy(*args: Any, **kwargs: Any) -> _PeekStubArray:
     """Stand-in for numpy's array/scalar reconstruction during a peek."""
     return _PeekStubArray()
+
+
+# Inline unicode strings longer than this are consumed but not decoded/retained
+# during a peek. The summary only needs short keys and the first entry's
+# ``"media_type"`` value, so a multi-MB ``media_string`` (a long document) never
+# has to be materialised. Comfortably above any dict key / media-type / origin
+# string, well below a document body (M18 follow-up).
+_PEEK_MAX_INLINE_STR = 4096
 
 
 class RestrictedUnpickler(pickle.Unpickler):
@@ -136,6 +150,37 @@ class _PeekUnpickler(pickle._Unpickler):
         raise pickle.UnpicklingError(
             f"Forbidden pickle class: {module}.{name}. Only plain Python types and numpy arrays are allowed."
         )
+
+    def _bounded_unicode(self, size: int) -> str:
+        """Consume *size* string bytes; decode only when small enough to matter.
+
+        Strings at or under :data:`_PEEK_MAX_INLINE_STR` are decoded as usual
+        (dict keys, the ``"media_type"`` value).  Larger ones - a multi-MB
+        inline ``media_string`` - are skipped in bounded chunks (keeping the
+        pickle stream aligned) and replaced by ``""`` so the peek never holds
+        the whole document in memory.
+        """
+        if size <= _PEEK_MAX_INLINE_STR:
+            return str(self.read(size), "utf-8", "surrogatepass")
+        remaining = size
+        while remaining > 0:
+            chunk = self.read(min(remaining, 1 << 20))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+        return ""
+
+    def load_binunicode(self) -> None:
+        (size,) = struct.unpack("<I", self.read(4))
+        self.append(self._bounded_unicode(size))
+
+    dispatch[pickle.BINUNICODE[0]] = load_binunicode
+
+    def load_binunicode8(self) -> None:
+        (size,) = struct.unpack("<Q", self.read(8))
+        self.append(self._bounded_unicode(size))
+
+    dispatch[pickle.BINUNICODE8[0]] = load_binunicode8
 
     def load_binfloat(self) -> None:
         self.read(8)

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -23,7 +23,7 @@ GET  /api/detectors/<name>/labels/<element_id>/thumbnail
     Stream a small thumbnail image for a saved labelset element.
 
 POST /api/detectors/<name>/labels/<element_id>/vote
-    Toggle the label on a saved labelset element.
+    Set a saved labelset element's label to an absolute target.
 
 Migrated to ``flask_smorest`` for the JSON-shaped routes (save, labels-detail,
 vote). ``import-labels`` keeps its plain-Flask route on the same smorest
@@ -578,22 +578,24 @@ def thumbnail_detector_label(name: str, element_id: str):
 @detectors_labels_bp.response(200, DetectorLabelVoteResponseSchema)
 @detectors_labels_bp.alt_response(404, description="Detector or label element not found.")
 def vote_detector_label(body: dict, name: str, element_id: str):
-    """Toggle the label on a saved labelset element.
+    """Set a saved labelset element's label to an absolute target.
 
-    Body: ``{"vote": "good"}`` or ``{"vote": "bad"}``.
+    Body: ``{"target": "good"}``, ``{"target": "bad"}``, or
+    ``{"target": "remove"}``.
 
-    Toggle semantics mirror :func:`~vtsearch.state.toggle_vote`: the same
-    vote on an element with that label removes the element; the opposite
-    vote flips it.  When the element resolves into the active dataset, the
-    detector's in-memory ``good_votes`` / ``bad_votes`` are kept in sync so
-    MLP retraining and learned-sort see the change.
+    Absolute-target semantics mirror :func:`~vtsearch.state.set_vote`:
+    ``"good"`` / ``"bad"`` set the element's label (a re-assert of the
+    current label is an idempotent no-op), ``"remove"`` drops the element.
+    When the element resolves into the active dataset, the detector's
+    in-memory ``good_votes`` / ``bad_votes`` are kept in sync so MLP
+    retraining and learned-sort see the change.
     """
     from vtscore.detectors.labelset_elements import (
         apply_element_vote_in_data,
         resolve_current_dataset_cid,
     )
 
-    vote = body["vote"]
+    target = body["target"]
 
     path = _detector_path(name)
     data = _read_detector(path)
@@ -611,7 +613,7 @@ def vote_detector_label(body: dict, name: str, element_id: str):
 
     cid_before = resolve_current_dataset_cid(pre_elem)
 
-    changed, _updated, action = apply_element_vote_in_data(data, element_id, vote)
+    changed, _updated, action = apply_element_vote_in_data(data, element_id, target)
     if not changed:
         return {"ok": True, "action": action}
 
@@ -619,10 +621,12 @@ def vote_detector_label(body: dict, name: str, element_id: str):
 
     # Mirror into in-memory votes when the element resolves into the active
     # dataset, so the MLP and learned-sort stay aligned with the labelset.
+    # ``set_vote`` takes the same absolute target ("remove" → "none"), so the
+    # mirror stays idempotent under stale-tab duplicates.
     if cid_before is not None:
-        from vtsearch.state import toggle_vote
+        from vtsearch.state import set_vote
 
-        toggle_vote(cid_before, vote)
+        set_vote(cid_before, "none" if target == "remove" else target)
 
     from vtscore.detectors.registry import find_by_name, update_detector
 

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -245,35 +245,23 @@ def import_labels(body: dict):
     return {"applied": applied, "skipped": skipped}
 
 
-@labels_bp.route("/api/labels/fill-from-sort", methods=["POST"])
-@labels_bp.arguments(FillFromSortRequestSchema)
-@labels_bp.response(200, FillFromSortResponseSchema)
-@require_dataset_header
-@require_detector_header
-def fill_labels_from_sort(body: dict):  # noqa: C901
-    """Fill labels from the current sort results.
+def _partition_candidates(
+    sort_results: list[dict],
+    thresh: float,
+    sides: str,
+    snap_good: dict[int, None],
+    snap_bad: dict[int, None],
+    snap_medias: dict,
+) -> tuple[list[dict], list[dict]]:
+    """Split sort results into (good, bad) candidate lists by threshold.
 
-    Assigns Good/Bad labels to currently-unlabeled medias based on their
-    position relative to the sort threshold. With ``confirm=false`` (the
-    default), returns counts only; with ``confirm=true``, applies the
-    labels and returns the resulting data as a results dict suitable for
-    any exporter.
+    Skips entries that are missing an id/score, carry a non-numeric score,
+    are already voted (in *snap_good* / *snap_bad*), or are absent from
+    *snap_medias*.  An entry scoring at or above *thresh* becomes a good
+    candidate; below it, a bad candidate.  The *sides* selector then clears
+    whichever list isn't wanted (``"good"`` drops bads, ``"bad"`` drops
+    goods, ``"both"`` keeps both).
     """
-    sort_results = body["sort_results"]
-    thresh = body["threshold"]
-    sides = body["sides"]
-    confirm = body["confirm"]
-
-    # Atomic snapshot so the membership checks below use the same dataset's
-    # cid space as the medias dict; a concurrent rehydrate on the detector
-    # against a different dataset can't make us think an A-cid is "already
-    # voted" when in fact we're scoring against B's medias.
-    vote_snap = validated_vote_snapshot()
-    snap_good = vote_snap.good_votes
-    snap_bad = vote_snap.bad_votes
-    snap_medias = vote_snap.medias
-
-    # Find unlabeled medias above/below threshold
     good_candidates = []
     bad_candidates = []
     for entry in sort_results:
@@ -297,6 +285,41 @@ def fill_labels_from_sort(body: dict):  # noqa: C901
     elif sides == "bad":
         good_candidates = []
     # "both" keeps both lists
+    return good_candidates, bad_candidates
+
+
+@labels_bp.route("/api/labels/fill-from-sort", methods=["POST"])
+@labels_bp.arguments(FillFromSortRequestSchema)
+@labels_bp.response(200, FillFromSortResponseSchema)
+@require_dataset_header
+@require_detector_header
+def fill_labels_from_sort(body: dict):
+    """Fill labels from the current sort results.
+
+    Assigns Good/Bad labels to currently-unlabeled medias based on their
+    position relative to the sort threshold. With ``confirm=false`` (the
+    default), returns counts only; with ``confirm=true``, applies the
+    labels and returns the resulting data as a results dict suitable for
+    any exporter.
+    """
+    sort_results = body["sort_results"]
+    thresh = body["threshold"]
+    sides = body["sides"]
+    confirm = body["confirm"]
+
+    # Atomic snapshot so the membership checks below use the same dataset's
+    # cid space as the medias dict; a concurrent rehydrate on the detector
+    # against a different dataset can't make us think an A-cid is "already
+    # voted" when in fact we're scoring against B's medias.
+    vote_snap = validated_vote_snapshot()
+    snap_good = vote_snap.good_votes
+    snap_bad = vote_snap.bad_votes
+    snap_medias = vote_snap.medias
+
+    # Find unlabeled medias above/below threshold
+    good_candidates, bad_candidates = _partition_candidates(
+        sort_results, thresh, sides, snap_good, snap_bad, snap_medias
+    )
 
     if not confirm:
         return {

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -64,6 +64,15 @@ medias_bp = Blueprint(
 # Extensions the browser's <video> element can play natively.
 _BROWSER_VIDEO_EXTS = {".mp4", ".m4v", ".webm", ".ogg", ".ogv"}
 
+# Image filename extension -> served mimetype. Unlisted extensions fall back to
+# ``image/jpeg`` (see :func:`_resolve_display_image`).
+_MIMETYPE_BY_EXT = {
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
 
 def _parse_region_box(raw: Any) -> tuple[float, float, float, float] | None:
     """Validate a ``region_box`` field from a vote request body.
@@ -445,7 +454,7 @@ def media_video(media_id: int):
     return _send_video_bytes(media_bytes, mimetype, f"media_{media_id}{ext}")
 
 
-def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:  # noqa: C901
+def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
     """Resolve the displayable image for a media item.
 
     Returns ``(image_bytes, mimetype, download_name)`` for the bytes the
@@ -482,18 +491,10 @@ def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:  # noqa: C9
 
     # Determine mimetype based on filename extension
     filename = c.get("filename", "")
-    if filename.endswith(".png"):
-        mimetype = "image/png"
-    elif filename.endswith(".gif"):
-        mimetype = "image/gif"
-    elif filename.endswith(".webp"):
-        mimetype = "image/webp"
-    elif filename.endswith(".bmp"):
-        mimetype = "image/bmp"
-    else:
-        mimetype = "image/jpeg"
+    suffix = Path(filename).suffix if filename and Path(filename).suffix else ""
+    mimetype = _MIMETYPE_BY_EXT.get(suffix, "image/jpeg")
 
-    suffix = Path(filename).suffix if filename and Path(filename).suffix else ".jpg"
+    suffix = suffix or ".jpg"
     return media_bytes, mimetype, f"media_{media_id}{suffix}"
 
 

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -771,9 +771,15 @@ class DetectorLabelsDetailResponseSchema(Schema):
 
 
 class DetectorLabelVoteRequestSchema(Schema):
-    """Body for ``POST /api/detectors/<name>/labels/<element_id>/vote``."""
+    """Body for ``POST /api/detectors/<name>/labels/<element_id>/vote``.
 
-    vote = fields.String(required=True, validate=validate.OneOf(["good", "bad"]))
+    ``target`` is the absolute end state for the element, not a clicked
+    direction: ``"good"`` / ``"bad"`` set the element's label, ``"remove"``
+    drops it from the labelset. Sending an absolute target makes repeated
+    requests from stale tabs idempotent (logical-bug-audit H1).
+    """
+
+    target = fields.String(required=True, validate=validate.OneOf(["good", "bad", "remove"]))
 
 
 class DetectorLabelVoteResponseSchema(Schema):


### PR DESCRIPTION
Clears three concrete backend follow-ups from the plan backlog (`logical-bug-audit.md` + `c901-complexity-cleanup.md`). No new features, behavior-preserving except the deliberate H1 semantics change.

## H1 follow-up — labelset-element vote → absolute target
`POST /api/detectors/<name>/labels/<element_id>/vote` now takes an absolute `target` (`"good" | "bad" | "remove"`) instead of a toggle `vote`. Re-asserting an element's current label is an idempotent `"unchanged"` no-op, so a stale-view tab can no longer flip an element off the on-disk labelset by re-sending its current polarity — the same inflation race the center-pane media-vote H1 fix already eliminated.
- `apply_element_vote_in_data` rewritten to absolute semantics; the in-memory mirror moves from `toggle_vote()` to `set_vote()` (`"remove"` → `"none"`) so it stays idempotent too.
- Request schema + OpenAPI snapshot regenerated; `LabelsetStateService` translates the clicked direction into a target in one place, mirroring the center-pane vote.
- New regression test: re-asserting an element's label leaves it in place.

## M18 follow-ups — pickle peek hardening
- Added `_codecs.encode` to the pickle allowlist so legacy protocol-0/1/2 pickles with inline `bytes` load instead of being rejected (it's a codec dispatcher, not an RCE vector).
- `_PeekUnpickler` now overrides `BINUNICODE` / `BINUNICODE8` with a size-bounded handler (`_PEEK_MAX_INLINE_STR = 4096`): short strings (keys, `media_type`) decode normally, while an over-cap inline `media_string` is consumed in bounded chunks and dropped — the peek never materialises a multi-MB document body.

## C901 — 13 deferred refactors
Extracted the named helper for each of the deferred functions in `c901-complexity-cleanup.md`; every one drops under McCabe 10 and loses its `# noqa: C901`. A few needed a second cohesive extraction (noted in the plan), and `_resolve_display_image` was corrected to its real path. The only markers left are the justified-intrinsic set.

## Deferred
The `media_revision` counter (Pattern #4) is intentionally left open — it rewrites a hot-path cache invariant for zero current bug; tracked in `logical-bug-audit.md`.

## Testing
- `./run-tests.sh` — **5177 passed, 1 skipped, 2 xpassed**
- `./run-tests.sh frontend` — build OK, Vitest **860 passed**, pyright 0 errors, OpenAPI snapshot drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaakfEACvzGKcwmSZvXxH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaakfEACvzGKcwmSZvXxH3)_