### PR TITLE
Fix demo clipper default being silently skipped (TUT S produced only 4 clips)

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1048,15 +1048,16 @@ export class DatasetImporterModalComponent implements OnInit {
     });
   }
 
-  /** The demo clipper the user actually chose, or ``''`` when it is the
-   *  pre-selected no-op default.  Mirrors the backend's
-   *  ``_effective_clipper`` and the form path's ``isDefaultClipper`` rule so
-   *  status checks and the load request agree on when clipping happens. */
+  /** The demo clipper the user actually chose, or ``''`` when it is a
+   *  no-op (the explicit "None"/``*_default`` choice).  Mirrors the
+   *  backend's ``_effective_clipper`` so status checks and the load request
+   *  agree on when clipping happens.  The pre-selected default a media type
+   *  offers (``clippers[0]``) can be a *real* clipper - audio defaults to
+   *  ``sound_tiling``, video to ``video_auto`` - so it is deliberately NOT
+   *  treated as a no-op; selecting it splits the media as intended. */
   private effectiveDemoClipper(): string {
     const name = this.selectedDemoClipper();
-    const clippers = this.demoClippers();
-    const isDefault =
-      !name || name.endsWith('_default') || (clippers.length > 0 && clippers[0].name === name);
+    const isDefault = !name || name.endsWith('_default');
     return isDefault ? '' : name;
   }
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1039,7 +1039,7 @@ class TestDemoCacheEmbedderMismatch:
 
 
 class TestEffectiveClipper:
-    """`_effective_clipper` normalises the pre-selected default clipper to ''."""
+    """`_effective_clipper` normalises only the no-op (``*_default``) clipper to ''."""
 
     def test_empty_and_default_normalise_to_blank(self):
         from vtscore.datasets.loader_demo import _effective_clipper
@@ -1048,18 +1048,22 @@ class TestEffectiveClipper:
         # sound_default ends with _default → the explicit "import as-is" no-op.
         assert _effective_clipper("sound_default", "audio") == ""
 
-    def test_first_clipper_in_list_is_treated_as_default(self):
+    def test_first_clipper_in_list_is_a_real_clipper_and_passes_through(self):
         from vtscore.datasets.loader_demo import _effective_clipper
         from vtscore.media import clippers_for_type
 
+        # The pre-selected default for audio is a *real* clipper
+        # (``sound_tiling``); selecting it must still split the media, so it
+        # is NOT normalised away. Only ``*_default`` clippers are no-ops.
         first = clippers_for_type("audio")[0].name
-        assert _effective_clipper(first, "audio") == ""
+        assert first == "sound_tiling"
+        assert _effective_clipper(first, "audio") == first
 
     def test_real_clipper_passes_through(self):
         from vtscore.datasets.loader_demo import _effective_clipper
 
-        # sound_silence is a real, non-default clipper (not first in the list),
-        # so it is never normalised away.
+        # sound_silence is a real, non-default clipper, so it is never
+        # normalised away.
         assert _effective_clipper("sound_silence", "audio") == "sound_silence"
 
 
@@ -1109,8 +1113,7 @@ class TestDemoClipperApplied:
         return mock_clip, fake_embedder
 
     def test_real_clipper_is_applied_with_params_and_embedder(self, tmp_path):
-        # sound_silence is a real, non-default clipper (sound_tiling is now the
-        # pre-selected first entry and so is treated as a no-op for demos).
+        # sound_silence is a real, non-default clipper.
         mock_clip, fake_embedder = self._run(tmp_path, "sound_silence", clipper_params={"top_db": 30.0})
         mock_clip.assert_called_once()
         args, kwargs = mock_clip.call_args
@@ -1119,11 +1122,22 @@ class TestDemoClipperApplied:
         assert args[2] == {"top_db": 30.0}
         assert kwargs["embedder"] is fake_embedder
 
-    def test_default_clipper_is_a_noop(self, tmp_path):
+    def test_pre_selected_default_clipper_is_applied(self, tmp_path):
+        # The pre-selected default for audio (``sound_tiling``) is a real
+        # clipper, so loading a demo with it must split the media - it is
+        # NOT a no-op.
         from vtscore.media import clippers_for_type
 
         first = clippers_for_type("audio")[0].name
+        assert first == "sound_tiling"
         mock_clip, _ = self._run(tmp_path, first)
+        mock_clip.assert_called_once()
+        args, _kwargs = mock_clip.call_args
+        assert args[1] == first
+
+    def test_explicit_none_clipper_is_a_noop(self, tmp_path):
+        # The explicit "None" choice (``sound_default``) imports as-is.
+        mock_clip, _ = self._run(tmp_path, "sound_default")
         mock_clip.assert_not_called()
 
 

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -27,23 +27,22 @@ from vtscore.datasets.loader import (
 def _effective_clipper(clipper_name: str, media_type_id: str) -> str:
     """Return *clipper_name* if it is a real (non-default) clipper, else ``""``.
 
-    The demo UI always sends *a* clipper name (the first one in the
-    media-type's list is pre-selected), but the conventional "default"
-    choice is a no-op that should not split the media.  Mirrors the
-    frontend's ``isDefaultClipper`` rule so that the two sides agree on
-    when clipping actually happens: a clipper is a no-op when it is empty,
-    ends with ``_default``, or is the first clipper registered for the
-    media type (the pre-selected default).  Normalising to ``""`` here also
-    means legacy pickles that recorded the pre-selected default name (e.g.
-    ``"sound_tiling"``) compare equal to "no clipper" and don't trigger a
-    needless re-embed.
+    A clipper is a no-op (so the media is imported as-is, never split) only
+    when it is empty or its name ends with ``_default`` (the canonical
+    no-op convention: ``sound_default``, ``image_default``, etc., whose
+    ``display_name`` is "None"). This mirrors ``normalise_chain`` and the
+    frontend's ``effectiveDemoClipper`` rule so the two sides agree on when
+    clipping actually happens.
+
+    The pre-selected *default* clipper a media type offers is whatever it
+    registers first (``clippers_for_type(media_type_id)[0]``), and that can
+    be a **real** clipper - e.g. audio defaults to ``sound_tiling`` and
+    video to ``video_auto`` so demo recordings are split uniformly. Such a
+    pre-selected default must still clip, so we deliberately do *not* treat
+    "first registered" as a no-op here. The ``media_type_id`` argument is
+    retained for call-site symmetry but is no longer consulted.
     """
     if not clipper_name or clipper_name.endswith("_default"):
-        return ""
-    from vtscore.media import clippers_for_type  # noqa: PLC0415
-
-    clippers = clippers_for_type(media_type_id)
-    if clippers and clippers[0].name == clipper_name:
         return ""
     return clipper_name
 


### PR DESCRIPTION
## Problem

Loading the **TUT Sound Events 2017 (S)** demo with the default (pre-selected) clipper produced only 4 medias — one per source recording — instead of tiling the 4 long (~4 min) recordings into many clips.

## Root cause

It is **not** an md5/dedup collapse. Clip MD5s are recomputed from each tile's bytes in `_fixup_clip_md5_and_embeddings`, so distinct clips survive dedup *once clipping runs*. The problem is that **clipping never ran**.

The demo loader's `_effective_clipper` (and the frontend's `effectiveDemoClipper`) treated the **first-registered** clipper for a media type as a no-op "default" that should not split media. That heuristic was only correct while the first clipper was always the `*_default` pass-through.

Commit `a595dd0b` ("Remove confusing audio Auto clipper; default to Tiling 10s/1s overlap") made `SoundTilingClipper(10s/1s)` the first/default audio clipper *"so every audio file is split uniformly"*, and video already registered `VideoAutoClipper` first. So selecting the pre-selected default clipper for a demo normalised to `""` and skipped clipping entirely.

## Fix

A clipper is now a no-op **only** when it is empty or its name ends with `_default` (the canonical convention already used by `normalise_chain`, the legacy `_apply_clipper` path, and the "cancel → default" UI logic). The pre-selected real defaults (audio `sound_tiling`, video `video_auto`) now actually split the media as intended.

- `vtscore/datasets/loader_demo.py` — drop the "first registered clipper is a no-op" branch from `_effective_clipper`.
- `dataset-importer-modal.component.ts` — same in `effectiveDemoClipper`.

The regular folder/server import path was already correct (it sends the selected clipper unconditionally and the backend applies it via `normalise_chain`), so no change there.

## Scope

This fixes audio **and** video demos (both had a real clipper registered first). Document / image / text register their `*_default` clipper first, so they were unaffected and stay unchanged.

## Tests

Updated `tests/datasets/test_datasets.py` to assert the pre-selected default real clipper is applied and only `*_default`/empty is a no-op. Full `./run-tests.sh` green (5169 passed), including the frontend build + Vitest gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsJoeGuEMYFmTtofUpMfu3)_