### PR TITLE
Scalability Phase 2.1: smarter diversity-tree defaults + deferred build

### DIFF
--- a/docs/plans/scalability-plan.md
+++ b/docs/plans/scalability-plan.md
@@ -4,10 +4,12 @@
 gallery now virtualizes both grid and list and no longer freezes the UI at a
 few hundred items (added §3.4/S17 as the deferred backend cancel/progress
 follow-up surfaced by that work).  **§1.2 (S9) GMM subsampling has shipped.**
-**§2.1 is partially shipped** — the diversity tree is now cached in the dataset
-pickle and restored on reload (skipping the rebuild), but the first build at
-dataset creation still pays full cost; the cap/defer/on-demand-endpoint scope
-remains open.
+**§2.1 has shipped** — reload caching plus Part A (smarter k-means
+defaults / auto-capped depth) and Part B (skip auto-build above 50k items + an
+on-demand `POST .../diversity-tree` endpoint); only the optional frontend
+"Build diversity index" button is deferred.  **§2.2 (S12) debounce label sync
+was already implemented** in `vtscore/labels/sync.py` (200ms per-detector
+timer).  Phase 2 is therefore effectively complete on the backend.
 Separately, the CLI-specific streaming work (lazy folder enumeration, per-chunk
 embed, and streaming export — partial fixes for S20/S15/S13 on the
 `--autodetect` target side) **has** shipped; see
@@ -267,7 +269,7 @@ medias) cannot happen because the epoch is only bumped on structural change.
 
 ## Phase 2: Medium effort, high leverage
 
-### 2.1  Cap and defer diversity tree construction (S2, S8) — ⏳ PARTIALLY SHIPPED
+### 2.1  Cap and defer diversity tree construction (S2, S8) — ✅ SHIPPED
 
 > **Reload caching shipped 2026-06-19** (commit 64cccd5e, PR #1987). The
 > diversity tree is now serialized into the dataset pickle at creation and
@@ -276,10 +278,26 @@ medias) cannot happen because the epoch is only bumped on structural change.
 > remap/dedup/drop falls back to a rebuild). `_build_diversity_tree_stage`
 > skips when a tree is already present; cache-less (pre-change) pickles keep
 > rebuilding eagerly and age off. This removes the rebuild cost on every
-> *reload*, but the **first** build at dataset creation still pays full cost.
-> **Still open below:** Part A (smarter k-means defaults / auto-capped depth)
-> and Part B (skip auto-build above a threshold + on-demand build endpoint),
-> which together address that first-build cost at scale.
+> *reload*, but the **first** build at dataset creation still paid full cost.
+>
+> **Part A + Part B shipped 2026-06-25** (backend only). Part A:
+> `_n_init_for(node_size)` scales k-means restarts down for large nodes (3 above
+> 10k, 5 above 1k, 10 otherwise) and `auto_max_depth(n, k, min_node_size)` caps
+> tree depth at the natural splitting depth bounded by `_MAX_LEAVES=4000`; both
+> live in `vtscore/state/diversity_tree.py` and are applied by the two build
+> helpers in `vtscore/state/diversity.py`. Because the small-node branch keeps
+> the full restart count and `auto_max_depth` never caps *below* the natural
+> depth (where `_build_node` already stops via `min_node_size`), trees over
+> normal/test-sized datasets are structurally unchanged. Part B:
+> `should_auto_build_diversity_tree(n)` (threshold
+> `DIVERSITY_TREE_AUTO_THRESHOLD=50_000`) gates the auto-build; the load
+> pipeline (`stages/finalize.py`) and the registry load path skip it above the
+> threshold, and `POST /api/datasets/registry/<id>/diversity-tree` builds it on
+> demand in a cancellable background job (resyncing the active detector's votes
+> when they belong to the dataset). **Deferred:** the frontend "Build diversity
+> index" button — the endpoint is reachable via API/CLI; tree absence already
+> degrades gracefully (autopilot falls back to score-only sampling). See Open
+> follow-ups.
 
 **Files:** `vtscore/state/diversity_tree.py`,
 `vtscore/datasets/load_pipeline.py:968–981`
@@ -346,7 +364,17 @@ acceptable and already handled by the `if tree is None` guard in
 
 ---
 
-### 2.2  Debounce label sync writes (S12)
+### 2.2  Debounce label sync writes (S12) — ✅ ALREADY SHIPPED
+
+> **Already implemented** in `vtscore/labels/sync.py`. `sync_to_labelset_source`
+> is debounced and asynchronous: each call schedules a per-detector
+> `threading.Timer` (`_DEBOUNCE_DELAY = 0.2s`, keyed by `detector_id`), so a
+> rapid voting burst collapses into a single background push that uses the
+> latest state. `flush_pending_label_syncs` drains synchronously for tests /
+> graceful shutdown, and an `atexit` hook flushes the last pending push on
+> normal exit. The shipped delay is 200ms rather than the 2s sketched below,
+> which keeps the on-disk labels within a UI tick while still coalescing
+> bursts. No further work needed.
 
 **File:** `vtscore/labels/sync.py` (`sync_to_labelset_source`)
 
@@ -683,6 +711,10 @@ Each phase needs targeted tests before merging:
 
 ## Open follow-ups
 
+- Frontend "Build diversity index" button (deferred from §2.1 Part B): surface a
+  trigger for `POST /api/datasets/registry/<id>/diversity-tree` when a loaded
+  dataset has no tree. No existing dataset/tree-status panel hosts it today, so
+  it needs a UI home; the endpoint is meanwhile reachable via API/CLI.
 - FAISS / HNSW replacement for diversity tree (long-term S2 fix)
 - Columnar `medias` storage (S4): deferred; requires redesign of every
   media-reading call site

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -9130,6 +9130,51 @@
         }
       ]
     },
+    "/api/datasets/registry/{dataset_id}/diversity-tree": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "dataset_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Datasets past ``should_auto_build_diversity_tree`` skip the automatic build\nat load time so they load fast; this endpoint lets the user trigger that\nbuild on demand.  The dataset must already be loaded in memory.  Progress\nis reported via ``/api/progress`` under the returned ``task_id``; the build\nis cancellable.  Calling it on a dataset that already has a tree rebuilds\nit from scratch.",
+        "operationId": "build_dataset_diversity_tree",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRegistryLoadResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Dataset is not currently loaded."
+          },
+          "403": {
+            "description": "Access denied for the current user."
+          },
+          "404": {
+            "description": "Dataset not found."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Build the diversity index for a loaded dataset in a background thread.",
+        "tags": [
+          "datasets_registry"
+        ]
+      }
+    },
     "/api/datasets/registry/{dataset_id}/load": {
       "parameters": [
         {

--- a/tests/datasets/test_diversity_tree_endpoint.py
+++ b/tests/datasets/test_diversity_tree_endpoint.py
@@ -1,0 +1,92 @@
+"""App-tier tests for the on-demand diversity-tree build endpoint.
+
+``POST /api/datasets/registry/<id>/diversity-tree`` lets the user build the
+diversity index for a loaded dataset that skipped the automatic build at load
+time (see Phase 2.1 Part B in ``docs/plans/scalability-plan.md``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+
+import numpy as np
+
+from vtscore.state.core import (
+    DatasetContext,
+    get_context,
+    register_context,
+    set_thread_dataset_context,
+)
+
+
+def _make_media(media_id: int) -> dict:
+    rng = np.random.default_rng(media_id)
+    return {
+        "id": media_id,
+        "media_type": "audio",
+        "embedder": "clap",
+        "duration": 1.0,
+        "file_size": 100,
+        "md5": hashlib.md5(f"divtree_{media_id}".encode()).hexdigest(),
+        "embedding": rng.standard_normal(64).astype(np.float32),
+        "media_bytes": b"fake",
+        "filename": f"divtree_{media_id}.wav",
+        "category": "test",
+        "origin": {"importer": "test", "params": {}},
+        "origin_name": f"divtree_{media_id}.wav",
+    }
+
+
+def _loaded_dataset(n: int = 30):
+    from vtscore.datasets.registry import add_loaded_id, register_dataset
+
+    entry = register_dataset(name="DivTree", media_type="audio", num_items=n, pkl_path="/tmp/divtree.pkl")
+    ctx = DatasetContext(entry["id"])
+    for i in range(n):
+        ctx.medias[i] = _make_media(i)
+    register_context(ctx)
+    add_loaded_id(entry["id"])
+    set_thread_dataset_context(ctx)
+    return entry, ctx
+
+
+def _wait_for_tree(dataset_id: str, timeout: float = 10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        ctx = get_context(dataset_id)
+        if ctx is not None and ctx.diversity_tree is not None:
+            return ctx.diversity_tree
+        time.sleep(0.05)
+    return None
+
+
+class TestDiversityTreeEndpoint:
+    def test_builds_tree_on_demand(self, client):
+        entry, ctx = _loaded_dataset()
+        # Simulate a large-dataset load that deferred the build.
+        ctx.diversity_tree = None
+
+        resp = client.post(f"/api/datasets/registry/{entry['id']}/diversity-tree")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["task_id"]
+
+        tree = _wait_for_tree(entry["id"])
+        assert tree is not None
+        # Every media with an embedding lands in a leaf.
+        assert set(tree.vector_to_leaf.keys()) == set(ctx.medias.keys())
+
+    def test_not_loaded_returns_400(self, client):
+        from vtscore.datasets.registry import register_dataset
+
+        entry = register_dataset(
+            name="NotLoaded", media_type="audio", num_items=1, pkl_path="/tmp/divtree_nl.pkl"
+        )
+        resp = client.post(f"/api/datasets/registry/{entry['id']}/diversity-tree")
+        assert resp.status_code == 400
+
+    def test_unknown_dataset_returns_404(self, client):
+        resp = client.post("/api/datasets/registry/does-not-exist/diversity-tree")
+        assert resp.status_code == 404

--- a/tests/datasets/test_diversity_tree_endpoint.py
+++ b/tests/datasets/test_diversity_tree_endpoint.py
@@ -29,7 +29,7 @@ def _make_media(media_id: int) -> dict:
         "duration": 1.0,
         "file_size": 100,
         "md5": hashlib.md5(f"divtree_{media_id}".encode()).hexdigest(),
-        "embedding": rng.standard_normal(64).astype(np.float32),
+        "embeddings": {"clap": rng.standard_normal(64).astype(np.float32)},
         "media_bytes": b"fake",
         "filename": f"divtree_{media_id}.wav",
         "category": "test",
@@ -81,9 +81,7 @@ class TestDiversityTreeEndpoint:
     def test_not_loaded_returns_400(self, client):
         from vtscore.datasets.registry import register_dataset
 
-        entry = register_dataset(
-            name="NotLoaded", media_type="audio", num_items=1, pkl_path="/tmp/divtree_nl.pkl"
-        )
+        entry = register_dataset(name="NotLoaded", media_type="audio", num_items=1, pkl_path="/tmp/divtree_nl.pkl")
         resp = client.post(f"/api/datasets/registry/{entry['id']}/diversity-tree")
         assert resp.status_code == 400
 

--- a/tests_lib/sorting/test_diversity_scaling.py
+++ b/tests_lib/sorting/test_diversity_scaling.py
@@ -68,19 +68,24 @@ class TestAutoMaxDepth:
         assert auto_max_depth(1, k=3) >= 1
 
     def test_leaf_count_bounded_for_huge_n(self):
-        # The cap term keeps k**depth from blowing past the soft leaf ceiling
-        # by more than one level.
+        # Once n/min_node_size exceeds the budget the depth is clamped so the
+        # full leaf count stays under the soft ceiling.
         depth = auto_max_depth(10_000_000, k=3)
-        assert 3 ** (depth - 1) <= _MAX_LEAVES
+        assert depth < DIVERSITY_TREE_MAX_DEPTH
+        assert 3**depth <= _MAX_LEAVES
+
+    def test_no_cap_until_leaf_budget_exceeded(self):
+        # n/min_node_size within budget -> full depth (behaviour-preserving).
+        assert auto_max_depth(4_000 * 20, k=3, min_node_size=20) == DIVERSITY_TREE_MAX_DEPTH
+        # Just past the budget -> clamped.
+        assert auto_max_depth(4_001 * 20, k=3, min_node_size=20) < DIVERSITY_TREE_MAX_DEPTH
 
     def test_does_not_cap_below_natural_depth(self):
         # For a small dataset the natural splitting depth (where _build_node
         # already stops via min_node_size) is below the global cap, so the
         # tree is structurally identical to one built with the default depth.
         vectors = _make_vectors(300)
-        capped = DiversityTree(
-            vectors, k=3, max_depth=auto_max_depth(len(vectors), k=3)
-        )
+        capped = DiversityTree(vectors, k=3, max_depth=auto_max_depth(len(vectors), k=3))
         full = DiversityTree(vectors, k=3, max_depth=DIVERSITY_TREE_MAX_DEPTH)
         assert capped.vector_to_leaf == full.vector_to_leaf
         assert set(capped.nodes) == set(full.nodes)

--- a/tests_lib/sorting/test_diversity_scaling.py
+++ b/tests_lib/sorting/test_diversity_scaling.py
@@ -1,0 +1,156 @@
+"""Library-tier tests for the Phase 2 diversity-tree scalability changes.
+
+Covers the two open Phase 2.1 pieces from ``docs/plans/scalability-plan.md``:
+
+- **Part A** (smarter k-means defaults): ``_n_init_for`` scales restarts down
+  for large nodes while leaving small (test-sized) nodes at the full
+  ``_N_INIT``, and ``auto_max_depth`` never caps *below* the natural splitting
+  depth - so trees over normal datasets are structurally unchanged.
+- **Part B** (defer large builds): ``should_auto_build_diversity_tree`` gates
+  the threshold and ``_build_diversity_tree_stage`` skips the build above it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.state.core import DatasetContext
+from vtscore.state.diversity import (
+    DIVERSITY_TREE_AUTO_THRESHOLD,
+    should_auto_build_diversity_tree,
+)
+from vtscore.state.diversity_tree import (
+    DIVERSITY_TREE_MAX_DEPTH,
+    DIVERSITY_TREE_MIN_NODE_SIZE,
+    DiversityTree,
+    _MAX_LEAVES,
+    _n_init_for,
+    auto_max_depth,
+)
+
+
+def _make_vectors(n: int, dim: int = 32, seed: int = 42) -> dict[int, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    return {i + 1: rng.standard_normal(dim).astype(np.float32) for i in range(n)}
+
+
+# ---------------------------------------------------------------------------
+# Part A: _n_init_for
+# ---------------------------------------------------------------------------
+
+
+class TestNInitFor:
+    def test_small_nodes_keep_full_restarts(self):
+        # <=1000 stays at the small-node default so test-sized trees are
+        # bit-for-bit unchanged.
+        assert _n_init_for(1) == 10
+        assert _n_init_for(1_000) == 10
+
+    def test_medium_nodes_get_fewer_restarts(self):
+        assert _n_init_for(1_001) == 5
+        assert _n_init_for(10_000) == 5
+
+    def test_large_nodes_get_fewest_restarts(self):
+        assert _n_init_for(10_001) == 3
+        assert _n_init_for(1_000_000) == 3
+
+
+# ---------------------------------------------------------------------------
+# Part A: auto_max_depth
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMaxDepth:
+    def test_never_exceeds_global_cap(self):
+        assert auto_max_depth(10_000_000, k=3) <= DIVERSITY_TREE_MAX_DEPTH
+
+    def test_always_at_least_one(self):
+        assert auto_max_depth(0) == DIVERSITY_TREE_MAX_DEPTH  # degenerate guard
+        assert auto_max_depth(1, k=3) >= 1
+
+    def test_leaf_count_bounded_for_huge_n(self):
+        # The cap term keeps k**depth from blowing past the soft leaf ceiling
+        # by more than one level.
+        depth = auto_max_depth(10_000_000, k=3)
+        assert 3 ** (depth - 1) <= _MAX_LEAVES
+
+    def test_does_not_cap_below_natural_depth(self):
+        # For a small dataset the natural splitting depth (where _build_node
+        # already stops via min_node_size) is below the global cap, so the
+        # tree is structurally identical to one built with the default depth.
+        vectors = _make_vectors(300)
+        capped = DiversityTree(
+            vectors, k=3, max_depth=auto_max_depth(len(vectors), k=3)
+        )
+        full = DiversityTree(vectors, k=3, max_depth=DIVERSITY_TREE_MAX_DEPTH)
+        assert capped.vector_to_leaf == full.vector_to_leaf
+        assert set(capped.nodes) == set(full.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Part B: should_auto_build_diversity_tree
+# ---------------------------------------------------------------------------
+
+
+class TestShouldAutoBuild:
+    def test_below_threshold_builds(self):
+        assert should_auto_build_diversity_tree(0)
+        assert should_auto_build_diversity_tree(DIVERSITY_TREE_AUTO_THRESHOLD)
+
+    def test_above_threshold_skips(self):
+        assert not should_auto_build_diversity_tree(DIVERSITY_TREE_AUTO_THRESHOLD + 1)
+
+
+# ---------------------------------------------------------------------------
+# Part B: finalize stage honours the threshold
+# ---------------------------------------------------------------------------
+
+
+class _NullTracker:
+    """Minimal tracker stand-in: never cancels, swallows updates."""
+
+    def check_cancelled(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def update(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _ctx_with_medias(n: int) -> DatasetContext:
+    ctx = DatasetContext("_scaling_test")
+    rng = np.random.default_rng(7)
+    for i in range(n):
+        ctx.medias[i] = {
+            "id": i,
+            "embeddings": {"siglip": rng.standard_normal(16).astype(np.float32)},
+            "embedder": "siglip",
+        }
+    return ctx
+
+
+class TestFinalizeStageThreshold:
+    def test_builds_below_threshold(self, monkeypatch):
+        from vtscore.datasets.stages import finalize
+
+        monkeypatch.setattr(finalize, "should_auto_build_diversity_tree", lambda n: n <= 30)
+        ctx = _ctx_with_medias(25)
+        finalize._build_diversity_tree_stage(ctx, _NullTracker())
+        assert ctx.diversity_tree is not None
+
+    def test_skips_above_threshold(self, monkeypatch):
+        from vtscore.datasets.stages import finalize
+
+        monkeypatch.setattr(finalize, "should_auto_build_diversity_tree", lambda n: n <= 30)
+        ctx = _ctx_with_medias(40)
+        finalize._build_diversity_tree_stage(ctx, _NullTracker())
+        assert ctx.diversity_tree is None
+
+    def test_skip_leaves_existing_tree_untouched(self, monkeypatch):
+        from vtscore.datasets.stages import finalize
+
+        monkeypatch.setattr(finalize, "should_auto_build_diversity_tree", lambda n: False)
+        ctx = _ctx_with_medias(10)
+        sentinel = object()
+        ctx.diversity_tree = sentinel  # type: ignore[assignment]
+        finalize._build_diversity_tree_stage(ctx, _NullTracker())
+        assert ctx.diversity_tree is sentinel

--- a/tests_lib/sorting/test_diversity_scaling.py
+++ b/tests_lib/sorting/test_diversity_scaling.py
@@ -21,7 +21,6 @@ from vtscore.state.diversity import (
 )
 from vtscore.state.diversity_tree import (
     DIVERSITY_TREE_MAX_DEPTH,
-    DIVERSITY_TREE_MIN_NODE_SIZE,
     DiversityTree,
     _MAX_LEAVES,
     _n_init_for,

--- a/vtscore/datasets/stages/finalize.py
+++ b/vtscore/datasets/stages/finalize.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING
 
 from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import media_embedding
-from vtscore.state import build_diversity_tree_for_context, collapse_duplicates
+from vtscore.state import (
+    build_diversity_tree_for_context,
+    collapse_duplicates,
+    should_auto_build_diversity_tree,
+)
 
 from vtscore.datasets.stages._common import _TOTAL_LOAD_STEPS
 
@@ -77,6 +81,19 @@ def _build_diversity_tree_stage(ctx: DatasetContext, tracker) -> None:
     # An upstream step (e.g. a pickle restore) may have already populated the
     # tree; skip the expensive hierarchical k-means rebuild when so.
     if ctx.diversity_tree is not None:
+        return
+
+    # Past the auto-build threshold the tree is deferred: the build would cost
+    # minutes/GBs and the autopilot degrades gracefully without it.  The user
+    # can trigger it later via POST /api/datasets/registry/<id>/diversity-tree.
+    if not should_auto_build_diversity_tree(len(ctx.medias)):
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).info(
+            "Skipping automatic diversity-tree build for %d items (> threshold); "
+            "build on demand via the diversity-tree endpoint.",
+            len(ctx.medias),
+        )
         return
 
     def _progress(current: int, total: int) -> None:

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -79,6 +79,7 @@ from vtscore.state.votes import (  # noqa: F401
 
 # Re-export diversity tree --------------------------------------------------
 from vtscore.state.diversity import (  # noqa: F401
+    DIVERSITY_TREE_AUTO_THRESHOLD,
     build_diversity_tree,
     build_diversity_tree_for_context,
     diversity_tree_label,
@@ -87,6 +88,7 @@ from vtscore.state.diversity import (  # noqa: F401
     get_diversity_tree,
     restore_diversity_tree_from_cache,
     resync_diversity_tree_to_detector,
+    should_auto_build_diversity_tree,
 )
 
 # Re-export media lookup ----------------------------------------------------

--- a/vtscore/state/diversity.py
+++ b/vtscore/state/diversity.py
@@ -20,6 +20,23 @@ from vtscore.state.core import (
     get_active_detector_context,
 )
 
+# Above this item count the diversity tree is *not* built automatically at
+# dataset load: hierarchical k-means over millions of vectors costs minutes and
+# gigabytes, and the tree only feeds the labeling autopilot (which degrades
+# gracefully to score-only sampling when the tree is absent - see the
+# ``tree is None`` guards in this module).  Large datasets can build it
+# on demand via ``POST /api/datasets/registry/<id>/diversity-tree``.
+DIVERSITY_TREE_AUTO_THRESHOLD = 50_000
+
+
+def should_auto_build_diversity_tree(n: int) -> bool:
+    """Whether a dataset of *n* items should build its diversity tree at load.
+
+    Returns ``False`` past :data:`DIVERSITY_TREE_AUTO_THRESHOLD` so large
+    datasets load fast; the tree can then be built on demand.
+    """
+    return n <= DIVERSITY_TREE_AUTO_THRESHOLD
+
 
 def resync_diversity_tree_to_detector(
     ds_ctx: DatasetContext,
@@ -65,7 +82,7 @@ def build_diversity_tree(
     """
     import numpy as np
 
-    from vtscore.state.diversity_tree import DiversityTree
+    from vtscore.state.diversity_tree import DiversityTree, auto_max_depth
 
     with _state_lock:
         ds_ctx = get_active_context()
@@ -80,7 +97,12 @@ def build_diversity_tree(
             ds_ctx.diversity_tree = None
             return
 
-        tree = DiversityTree(vectors, k=3, on_progress=on_progress)
+        tree = DiversityTree(
+            vectors,
+            k=3,
+            max_depth=auto_max_depth(len(vectors), k=3),
+            on_progress=on_progress,
+        )
         ds_ctx.diversity_tree = tree
 
         # Replay existing labels so the tree reflects the current vote state.
@@ -99,7 +121,7 @@ def build_diversity_tree_for_context(
     """
     import numpy as np
 
-    from vtscore.state.diversity_tree import DiversityTree
+    from vtscore.state.diversity_tree import DiversityTree, auto_max_depth
 
     vectors: dict[int, np.ndarray] = {}
     for cid, media in ctx.medias.items():
@@ -111,7 +133,12 @@ def build_diversity_tree_for_context(
         ctx.diversity_tree = None
         return
 
-    tree = DiversityTree(vectors, k=3, on_progress=on_progress)
+    tree = DiversityTree(
+        vectors,
+        k=3,
+        max_depth=auto_max_depth(len(vectors), k=3),
+        on_progress=on_progress,
+    )
     ctx.diversity_tree = tree
     # Fresh context has no votes - nothing to replay.
 

--- a/vtscore/state/diversity_tree.py
+++ b/vtscore/state/diversity_tree.py
@@ -28,7 +28,49 @@ from sklearn.cluster import KMeans
 DIVERSITY_TREE_DEFAULT_K = 2
 DIVERSITY_TREE_MAX_DEPTH = 10
 DIVERSITY_TREE_MIN_NODE_SIZE = 20
-_N_INIT = 10  # number of k-means initialisations per node
+_N_INIT = 10  # number of k-means initialisations per node (small nodes)
+
+# Soft ceiling on leaf count used by :func:`auto_max_depth` so a huge dataset
+# can't explode the tree into tens of thousands of nodes.
+_MAX_LEAVES = 4_000
+
+
+def _n_init_for(node_size: float) -> int:
+    """Number of k-means restarts to run for a node of *node_size* vectors.
+
+    Large nodes converge reliably from a single init, so spending 10 restarts
+    on them (the small-node default) is wasted compute that dominates build
+    time at scale.  Nodes of 1 000 or fewer keep the full ``_N_INIT`` restarts,
+    so trees over the test-sized datasets are bit-for-bit unchanged.
+    """
+    if node_size > 10_000:
+        return 3
+    if node_size > 1_000:
+        return 5
+    return _N_INIT
+
+
+def auto_max_depth(
+    n: int,
+    k: int = DIVERSITY_TREE_DEFAULT_K,
+    min_node_size: int = DIVERSITY_TREE_MIN_NODE_SIZE,
+) -> int:
+    """Depth cap that scales with *n* and bounds the leaf count at ``_MAX_LEAVES``.
+
+    The *natural* depth - ``ceil(log_k(n / min_node_size))`` - is where
+    :meth:`DiversityTree._build_node` already stops splitting (a node smaller
+    than ``min_node_size`` is never split), so capping at it is structurally a
+    no-op for any dataset whose natural depth is below
+    ``DIVERSITY_TREE_MAX_DEPTH``.  The separate ``_MAX_LEAVES`` cap only binds
+    for datasets large enough that the natural depth would otherwise blow the
+    node count up.  Always returns at least 1.
+    """
+    if n <= 0:
+        return DIVERSITY_TREE_MAX_DEPTH
+    base = max(k, 2)
+    natural = math.ceil(math.log(max(n / max(min_node_size, 1), 1.0), base))
+    cap = math.ceil(math.log(_MAX_LEAVES, base))
+    return max(1, min(DIVERSITY_TREE_MAX_DEPTH, natural, cap))
 
 
 class DiversityTree:
@@ -93,7 +135,16 @@ class DiversityTree:
                 num_levels = min(num_levels, max_depth)
             else:
                 num_levels = 0
-            self._estimated_total_work = max(num_levels * total * _N_INIT, 1)
+            # Per-level node size shrinks by ~k each level, so the k-means
+            # restart count (see ``_n_init_for``) drops as we descend.  Weight
+            # the estimate by the per-level restart count so the progress bar
+            # tracks wall-clock now that large nodes run fewer restarts.
+            estimated_work = 0.0
+            node_size = float(total)
+            for _ in range(num_levels):
+                estimated_work += total * _n_init_for(node_size)
+                node_size /= k
+            self._estimated_total_work = max(int(estimated_work), 1)
             self._work_done = 0
             if on_progress:
                 on_progress(0, self._estimated_total_work)
@@ -138,7 +189,8 @@ class DiversityTree:
         # at 0% until it finishes.
         best_labels = None
         best_inertia = float("inf")
-        for init_i in range(_N_INIT):
+        n_init = _n_init_for(len(ids))
+        for init_i in range(n_init):
             km = KMeans(
                 n_clusters=actual_k,
                 random_state=42 + init_i,

--- a/vtscore/state/diversity_tree.py
+++ b/vtscore/state/diversity_tree.py
@@ -55,22 +55,24 @@ def auto_max_depth(
     k: int = DIVERSITY_TREE_DEFAULT_K,
     min_node_size: int = DIVERSITY_TREE_MIN_NODE_SIZE,
 ) -> int:
-    """Depth cap that scales with *n* and bounds the leaf count at ``_MAX_LEAVES``.
+    """Depth cap that bounds the leaf count at ``_MAX_LEAVES`` for large *n*.
 
-    The *natural* depth - ``ceil(log_k(n / min_node_size))`` - is where
-    :meth:`DiversityTree._build_node` already stops splitting (a node smaller
-    than ``min_node_size`` is never split), so capping at it is structurally a
-    no-op for any dataset whose natural depth is below
-    ``DIVERSITY_TREE_MAX_DEPTH``.  The separate ``_MAX_LEAVES`` cap only binds
-    for datasets large enough that the natural depth would otherwise blow the
-    node count up.  Always returns at least 1.
+    ``min_node_size`` already bounds the leaf count at ``n / min_node_size``
+    (a node smaller than it is never split), so when that bound is within the
+    ``_MAX_LEAVES`` budget the cap is unnecessary and the full
+    ``DIVERSITY_TREE_MAX_DEPTH`` is returned - a structural no-op for normal
+    datasets, including the skewed k-means splits whose dense branches reach
+    deeper than a balanced tree would.  Only once ``n / min_node_size`` exceeds
+    the budget (very large datasets) is the depth clamped so ``k**depth`` stays
+    under ``_MAX_LEAVES``.  Always returns at least 1.
     """
     if n <= 0:
         return DIVERSITY_TREE_MAX_DEPTH
+    if n / max(min_node_size, 1) <= _MAX_LEAVES:
+        return DIVERSITY_TREE_MAX_DEPTH
     base = max(k, 2)
-    natural = math.ceil(math.log(max(n / max(min_node_size, 1), 1.0), base))
-    cap = math.ceil(math.log(_MAX_LEAVES, base))
-    return max(1, min(DIVERSITY_TREE_MAX_DEPTH, natural, cap))
+    cap = int(math.floor(math.log(_MAX_LEAVES, base)))
+    return max(1, min(DIVERSITY_TREE_MAX_DEPTH, cap))
 
 
 class DiversityTree:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -349,9 +349,7 @@ def build_dataset_diversity_tree(dataset_id: str):
 
                 def _progress(current: int, total: int) -> None:
                     tracker.check_cancelled()
-                    tracker.update(
-                        "loading", "Building diversity index…", current, total, step=1, total_steps=1
-                    )
+                    tracker.update("loading", "Building diversity index…", current, total, step=1, total_steps=1)
 
                 _progress(0, 0)
                 build_diversity_tree_for_context(ctx, on_progress=_progress)

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -16,6 +16,7 @@ Endpoints
 ---------
 GET    /api/datasets/registry                       List datasets visible to the user.
 POST   /api/datasets/registry/<id>/load             Load a registered dataset from its pkl.
+POST   /api/datasets/registry/<id>/diversity-tree   Build the diversity index on demand (large datasets).
 POST   /api/datasets/registry/<id>/unload           Unload a dataset from memory.
 DELETE /api/datasets/registry/<id>                  Remove a dataset from the registry.
 PUT    /api/datasets/registry/<id>/rename           Rename a registered dataset.
@@ -136,7 +137,11 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     """
     from vtsearch.auth import get_current_user
     from vtscore.concurrency.progress import clear_thread_progress, set_thread_progress
-    from vtsearch.state import build_diversity_tree_for_context, restore_diversity_tree_from_cache
+    from vtsearch.state import (
+        build_diversity_tree_for_context,
+        restore_diversity_tree_from_cache,
+        should_auto_build_diversity_tree,
+    )
 
     entry = _reg_get(dataset_id)
     if entry is None:
@@ -239,9 +244,13 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 # set still matches the (post-dedup) medias; only rebuild the
                 # hierarchical k-means from scratch when there is no usable
                 # cache (older pickles, or a media set that shifted on load).
+                # Past the auto-build threshold a missing cache is left absent -
+                # the build would cost minutes/GBs and the user can trigger it
+                # on demand via the diversity-tree endpoint.
                 if not restore_diversity_tree_from_cache(ctx, cached_diversity_tree):
-                    _diversity_progress(0, 0)
-                    build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
+                    if should_auto_build_diversity_tree(len(ctx.medias)):
+                        _diversity_progress(0, 0)
+                        build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
                 _reg_add_loaded(dataset_id)
                 # Update item count and dupe count in case they changed
                 num_dupes = sum(
@@ -282,6 +291,94 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
 
     spawn(load_task, name=f"ds-load-{dataset_id[:8]}")
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
+
+
+@datasets_registry_bp.route("/api/datasets/registry/<dataset_id>/diversity-tree", methods=["POST"])
+@datasets_registry_bp.response(200, DatasetRegistryLoadResponseSchema)
+@datasets_registry_bp.alt_response(400, description="Dataset is not currently loaded.")
+@datasets_registry_bp.alt_response(403, description="Access denied for the current user.")
+@datasets_registry_bp.alt_response(404, description="Dataset not found.")
+def build_dataset_diversity_tree(dataset_id: str):
+    """Build the diversity index for a loaded dataset in a background thread.
+
+    Datasets past ``should_auto_build_diversity_tree`` skip the automatic build
+    at load time so they load fast; this endpoint lets the user trigger that
+    build on demand.  The dataset must already be loaded in memory.  Progress
+    is reported via ``/api/progress`` under the returned ``task_id``; the build
+    is cancellable.  Calling it on a dataset that already has a tree rebuilds
+    it from scratch.
+    """
+    from vtsearch.auth import get_current_user
+    from vtsearch.state import (
+        build_diversity_tree_for_context,
+        get_active_detector_context,
+        get_context,
+        resync_diversity_tree_to_detector,
+    )
+    from vtscore.state.core import _state_lock
+
+    entry = _reg_get(dataset_id)
+    if entry is None:
+        abort(404, message="Dataset not found in registry")
+    if not _reg_can_access(dataset_id, get_current_user()):
+        abort(403, message="Access denied")
+    if not _reg_is_loaded(dataset_id):
+        abort(400, message="Load the dataset before building its diversity index")
+
+    ctx = get_context(dataset_id)
+    if ctx is None:
+        abort(400, message="This dataset is not currently loaded")
+
+    task_id = f"_divtree_{dataset_id[:8]}"
+    tracker = _loading_tasks.create_task(
+        task_id,
+        entry.get("name", dataset_id),
+        dataset_id=dataset_id,
+        media_type=entry.get("media_type", ""),
+        embedder=entry.get("embedder", ""),
+    )
+    tracker.update("loading", "Building diversity index…", 0, 0, step=1, total_steps=1)
+
+    _request_user = get_current_user()
+
+    def build_task():
+        from vtsearch.auth import thread_user
+
+        with thread_user(_request_user):
+            try:
+
+                def _progress(current: int, total: int) -> None:
+                    tracker.check_cancelled()
+                    tracker.update(
+                        "loading", "Building diversity index…", current, total, step=1, total_steps=1
+                    )
+
+                _progress(0, 0)
+                build_diversity_tree_for_context(ctx, on_progress=_progress)
+
+                # Replay the active detector's votes into the fresh tree when
+                # they belong to this dataset, so seen-state is correct right
+                # away (mirrors the resync the detector-sync path performs).
+                det_ctx = get_active_detector_context()
+                if det_ctx is not None and getattr(det_ctx, "votes_dataset_id", None) == dataset_id:
+                    with _state_lock:
+                        resync_diversity_tree_to_detector(ctx, det_ctx)
+            except CancelledError:
+                ctx.diversity_tree = None
+                tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+            except Exception as e:
+                import traceback as _tb
+
+                _tb.print_exc()
+                error_msg = str(e) or repr(e) or "Unknown error building diversity index"
+                tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
+            finally:
+                _loading_tasks.mark_finished(task_id)
+
+    from vtsearch.threading import spawn
+
+    spawn(build_task, name=f"divtree-{dataset_id[:8]}")
+    return {"ok": True, "message": "Diversity index build started", "task_id": str(task_id)}
 
 
 @datasets_registry_bp.route("/api/datasets/registry/<dataset_id>/unload", methods=["POST"])

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 # Re-export every public name from the library tier.
 from vtscore.state import (  # noqa: F401
+    DIVERSITY_TREE_AUTO_THRESHOLD,
     DatasetContext,
     DetectorContext,
     _core,
@@ -77,6 +78,7 @@ from vtscore.state import (  # noqa: F401
     set_thread_dataset_context,
     set_thread_detector_context,
     set_vote,
+    should_auto_build_diversity_tree,
     snapshot_medias,
     thread_dataset_context,
     thread_detector_context,


### PR DESCRIPTION
Implements the actionable backend pieces of **Phase 2** from `docs/plans/scalability-plan.md`. (2.2 — debounce label sync — was already shipped in `vtscore/labels/sync.py`, so no work was needed there; this PR notes that in the plan.)

## What landed

### 2.1 Part A — smarter k-means defaults (`vtscore/state/diversity_tree.py`)
- `_n_init_for(node_size)` scales k-means restarts down for large nodes (3 above 10k, 5 above 1k, **10 otherwise**). Small/test-sized nodes keep the full restart count, so existing trees are bit-for-bit unchanged.
- `auto_max_depth(n, k, min_node_size)` clamps tree depth **only once `n / min_node_size` exceeds a soft leaf budget** (`_MAX_LEAVES = 4000`). Below that — i.e. all normal datasets — the full depth is returned, so structure is preserved (this matters because k-means produces skewed clusters whose dense branches reach deeper than a balanced tree, which a naive natural-depth cap would wrongly truncate).
- The per-level work estimate that drives the progress bar is updated to weight by the new per-level restart counts.

### 2.1 Part B — defer large builds + on-demand endpoint
- `should_auto_build_diversity_tree(n)` gates a `DIVERSITY_TREE_AUTO_THRESHOLD = 50_000` threshold (`vtscore/state/diversity.py`).
- The load pipeline (`stages/finalize.py`) and the registry load path (`routes/datasets/registry.py`) skip the automatic build above the threshold.
- New `POST /api/datasets/registry/<id>/diversity-tree` builds the index on demand in a cancellable background job, resyncing the active detector's votes when they belong to the dataset.

## Behavior on normal-sized datasets
**No change.** `_n_init_for` only reduces restarts for nodes >1000 items; `auto_max_depth` only clamps once `n/min_node_size > 4000` (≈80k+ items); and the auto-build skip only triggers above 50k items. Tree absence already degrades gracefully (autopilot falls back to score-only sampling).

## Deferred
The optional frontend "Build diversity index" button (no existing dataset/tree-status panel hosts it today). The endpoint is reachable via API/CLI meanwhile. Recorded under Open follow-ups in the plan.

## Tests
- `tests_lib/sorting/test_diversity_scaling.py` — `_n_init_for` thresholds, `auto_max_depth` leaf-budget gating + structure preservation, threshold gate, finalize-stage skip.
- `tests/datasets/test_diversity_tree_endpoint.py` — on-demand endpoint builds the tree, 400 when not loaded, 404 when unknown.
- OpenAPI snapshot regenerated for the new route.
- Full `./run-tests.sh` green (5194 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgbfqZkbaJ55hruJTiJwvy)_