### PR TITLE
Smooth the unified load progress bar across stages

### DIFF
--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -67,8 +67,55 @@ job had, and there was no honest "% of the total job done".
   `frontend/src/app/utils/format-progress.spec.ts` (`progressBarState`,
   step-count header).
 
+## Smoothness pass (shipped)
+
+Follow-up to the consolidation: the unified bar was monotonic *in principle* but
+still got "knocked around" between stages. Fixed the concrete jump sources:
+
+- **Clipper backslide (the worst offender).** The clipper stage
+  (`vtscore/datasets/stages/clipper.py`) reported the *finalize* step while
+  running *before* the embed step. It ran the bar to ~100 %, then the following
+  embed step (a lower number) tripped `_compute_overall`'s "step went backwards
+  = new job" reset and slammed the bar from ~100 % back to mid-job. Clipping is
+  really the embed phase for clipped datasets (it cuts + embeds clips; the later
+  `_embed_missing_stage` is then a no-op), so it now reports the **embedding**
+  step. The whole-job fraction stays monotonic across a clipped load.
+- **`converting` status nulled the bar.** `converters/runner.py` emits a
+  `"converting"` status (document→image, video→frames) that was missing from
+  `_STATUS_TO_STEP`, so it resolved to `step=None`, nulled `overall`, and bounced
+  the bar onto the raw `current/total` scale mid-job. It now maps to the loading
+  step (it's pre-embed work). The map's docstring states the invariant: every
+  load-path status must be present.
+- **Smaller model-load jump.** `_LOAD_STEP_WEIGHTS` shifted `0.25/0.15/0.50/0.10`
+  → `0.25/0.10/0.55/0.10`: the un-measurable model-load slice (the one that
+  fills in a single step the moment embedding starts) is trimmed and the freed
+  weight handed to embedding, the phase that reports per-item progress — so more
+  of the bar advances smoothly and the between-stage jump is smaller.
+- **Gentle fill ease (frontend).** `ProgressBarComponent` gained an opt-in
+  `smooth` input (a longer `0.6s ease-out` fill transition, class
+  `progress-fill--smooth`) wired into the dataset-load bars (dashboard orphan
+  rows, dataset-card, detector-card). Unavoidable between-phase jumps glide
+  instead of snapping. Honest by construction: the fill only ever eases *toward*
+  the real reported value, never ahead of it (no fake/timer-driven motion — that
+  approach was explicitly rejected).
+
 ## Open follow-ups
 
+- **Finalize lumps ~6 sub-stages into one step.** The finalize step (drop-none,
+  relazify, collapse-dup, diversity-tree, registry, projection) is a single
+  weighted slice; each sub-stage reports its own `current/total` from 0→1, so the
+  monotonic clamp pins the bar at 100 % as soon as the first counted sub-stage
+  finishes, then holds while the rest (notably the expensive diversity-tree
+  build) run. Honest-smoothing this needs the finalize slice spread across its
+  real sub-stages (a nested weight model, since the sub-stages vary in presence
+  and cost). Deferred: it's the last ~10 % and brief, but a large dataset can sit
+  at 100 % for a few seconds during the diversity-tree build.
+- **Multi-embedder (v3 trio) holds mid-embed.** `_embed_missing_stage` loops
+  over each bound embedder; each `embed_missing` call restarts its `current` at
+  0, so after the first embedder fills the embed slice the clamp holds the bar
+  steady through the 2nd/3rd embedders. No backslide, but a long static stretch.
+  Rare for demo imports (single embedder); fix by reporting cumulative progress
+  across the embedder loop.
 - **Text sort (`sort` channel) is not unified.** `vtsearch/routes/sorting.py`
   encodes its 3 phases as `current/total` (current = step index) rather than
   the `step`/`total_steps` fields, so it gets no `overall` and stays a coarse

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -124,6 +124,7 @@
                           [value]="taskBar(task).value"
                           [max]="taskBar(task).max"
                           [indeterminate]="taskBar(task).indeterminate"
+                          [smooth]="true"
                         />
                         @if (info.eta) {
                           <span class="progress-eta">{{ info.eta }}</span>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -53,6 +53,7 @@
           [value]="taskBar.value"
           [max]="taskBar.max"
           [indeterminate]="taskBar.indeterminate"
+          [smooth]="true"
         />
         @if (taskProgressInfo.eta) {
           <span class="progress-eta">{{ taskProgressInfo.eta }}</span>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -47,6 +47,7 @@
           [value]="taskBar().value"
           [max]="taskBar().max"
           [indeterminate]="taskBar().indeterminate"
+          [smooth]="true"
         />
         @if (taskProgressInfo.eta) {
           <span class="progress-eta">{{ taskProgressInfo.eta }}</span>

--- a/frontend/src/app/components/progress-bar/progress-bar.component.html
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.html
@@ -8,6 +8,7 @@
   <div
     class="progress-fill"
     [class.indeterminate]="indeterminate"
+    [class.progress-fill--smooth]="smooth"
     [style.width.%]="indeterminate ? 100 : percentage"
   ></div>
 </div>

--- a/frontend/src/app/components/progress-bar/progress-bar.component.scss
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.scss
@@ -12,6 +12,14 @@
   border-radius: var(--radius-sm);
   transition: width var(--transition-slow) ease;
 
+  // Multi-stage load bar: a longer, decelerating ease so the jumps between
+  // phases (e.g. an un-measurable model-load slice filling in one step) glide
+  // gently into place instead of snapping, holding the illusion of one
+  // continuous process. Opt-in via the `smooth` input.
+  &.progress-fill--smooth {
+    transition: width 0.6s ease-out;
+  }
+
   &.indeterminate {
     width: 30% !important;
     animation: indeterminate 1.5s infinite ease-in-out;

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -67,4 +67,17 @@ describe('ProgressBarComponent', () => {
     const track = fixture.nativeElement.querySelector('.progress-track');
     expect(track.getAttribute('aria-valuenow')).toBeNull();
   });
+
+  it('should not apply the smooth modifier by default', async () => {
+    await settleZoneless(fixture);
+    const fill = fixture.nativeElement.querySelector('.progress-fill');
+    expect(fill.classList).not.toContain('progress-fill--smooth');
+  });
+
+  it('should apply the smooth modifier when [smooth] is set', async () => {
+    fixture.componentRef.setInput('smooth', true);
+    await settleZoneless(fixture);
+    const fill = fixture.nativeElement.querySelector('.progress-fill');
+    expect(fill.classList).toContain('progress-fill--smooth');
+  });
 });

--- a/frontend/src/app/components/progress-bar/progress-bar.component.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.ts
@@ -11,6 +11,16 @@ export class ProgressBarComponent {
   @Input() value = 0;
   @Input() max = 100;
   @Input() indeterminate = false;
+  /**
+   * Opt-in for multi-stage jobs whose `value` is a single whole-job fraction
+   * stitched from several phases (the dataset-load bar). It swaps the snappy
+   * default fill transition for a longer ease so the unavoidable between-phase
+   * jumps (an un-measurable phase filling its slice in one step) glide instead
+   * of snapping, keeping the illusion of one continuous process. The fill still
+   * only ever eases *toward* the real reported value, so it never overstates
+   * progress.
+   */
+  @Input() smooth = false;
 
   get percentage(): number {
     if (this.max <= 0) return 0;

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -82,6 +82,48 @@ class TestOverallFraction:
         assert t.get()["overall"] is None
 
 
+class TestLoadStepMapping:
+    """The status→step map and clipper step keep the unified bar monotonic."""
+
+    def test_converting_shares_the_loading_step(self):
+        # Source→media conversion (document→image, video→frames) is pre-embed
+        # work; it must map to a real step so it does not null `overall` and
+        # bounce the bar onto the raw current/total scale.
+        from vtscore.datasets.stages._common import _STATUS_TO_STEP
+
+        assert _STATUS_TO_STEP["converting"] == _STATUS_TO_STEP["loading"]
+
+    def test_clipper_reports_embed_step_not_finalize(self):
+        # Clipping cuts + embeds clips and runs *before* the embed step. If it
+        # reported the finalize step the bar would run to ~100% and then the
+        # following embed step (a lower number) would trip the "new job" reset
+        # and slam the bar backwards. Pinning clipping to the embed step keeps
+        # the whole-job fraction monotonic across a clipped load.
+        from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
+
+        clip_step = _STATUS_TO_STEP["embedding"]
+        t = _tracker()
+        t.set_step_weights([0.25, 0.10, 0.55, 0.10])
+        overalls = []
+
+        def record(status, cur, total, step):
+            t.update(status, "x", current=cur, total=total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+            overalls.append(t.get()["overall"])
+
+        # download → load → clip(+embed clips) → embed-missing(no-op) → finalize.
+        record("downloading", 100, 100, 1)
+        record("loading", 0, 0, 2)
+        for cur in (0, 5, 10):  # clipping/embedding clips, reported on the embed step
+            record("loading", cur, 10, clip_step)
+        record("loading", 0, 0, clip_step)  # embed-missing finds nothing to do
+        record("loading", 1, 1, _TOTAL_LOAD_STEPS)  # finalize
+
+        assert overalls == sorted(overalls)  # never rewinds
+        assert overalls[-1] == pytest.approx(1.0)
+        # The clip+embed slice really advanced the bar (not pinned at a floor).
+        assert max(overalls[2:5]) > overalls[1]
+
+
 class TestWeightedOverall:
     def test_weights_shape_the_fraction(self):
         t = _tracker()

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -9,11 +9,21 @@ from __future__ import annotations
 
 # Maps the status strings emitted by inner functions to step numbers.
 # "downloading" covers both download and extraction.
-# "loading" covers model loading and pickle loading.
-# "embedding" covers per-file embedding.
+# "loading"/"converting" cover model loading, pickle loading, and source→media
+# conversion (document→image, video→frames): all pre-embed work that produces
+# the medias to embed, so they share the loading slice.
+# "embedding" covers per-file embedding (and clip+embed for clipped datasets;
+# see clipper.py — clipping IS the embed phase there, so it reports this step).
+#
+# Every status that can fire during a load MUST appear here. A status missing
+# from this map resolves to ``step=None``, which nulls the whole-job ``overall``
+# fraction for that update and makes the bar fall back to the raw within-phase
+# ``current``/``total`` — a different scale that visibly knocks the unified bar
+# off its track. Keep the map exhaustive instead.
 _STATUS_TO_STEP = {
     "downloading": 1,
     "loading": 2,
+    "converting": 2,
     "embedding": 3,
 }
 _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
@@ -22,10 +32,16 @@ _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
 # unified whole-job progress bar (see ProgressTracker.set_step_weights).
 # Embedding dominates almost any real dataset; the model load is a roughly
 # fixed one-time cost; finalize (dedup + diversity tree + registry) is short.
-# These only shape the bar's pacing — the overall ETA self-corrects from the
-# real rate — so they need only be in the right ballpark.
+#
+# The model-load slice is kept deliberately small: it is the one phase that
+# cannot report fine-grained progress, so the bar sits at its floor for the
+# whole load and then fills the slice in one step the moment embedding starts.
+# A smaller weight there means a smaller between-stage jump; the freed weight
+# goes to embedding, the phase that *does* report per-item progress and so
+# advances the bar smoothly. These weights only shape pacing — the overall ETA
+# self-corrects from the real rate — so they need only be in the right ballpark.
 #               download  model  embed  finalize
-_LOAD_STEP_WEIGHTS = [0.25, 0.15, 0.50, 0.10]
+_LOAD_STEP_WEIGHTS = [0.25, 0.10, 0.55, 0.10]
 
 
 def _origin_to_str(origin: dict | None) -> str:

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Callable
 from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import media_embedding
 
-from vtscore.datasets.stages._common import _TOTAL_LOAD_STEPS
+from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
 
 if TYPE_CHECKING:
     from vtscore.state import DatasetContext
@@ -524,8 +524,21 @@ def _apply_clipper_stage(
             # (e.g. "Loading CLAP model weights…", "Warming up audio
             # pipeline…") while the model loads on the first embed call.
             msg = phase
+        # Clipping is the embed phase for clipped datasets: it cuts segments
+        # and embeds the resulting clips (the standard `_embed_missing_stage`
+        # is a no-op afterwards). So it reports the *embedding* step, not the
+        # finalize step. Reporting finalize here ran the bar up to ~100% before
+        # embedding even began and then — because clipping runs *before* the
+        # embed step — tripped the "step went backwards = new job" reset, which
+        # visibly slammed the unified bar from ~100% back to mid-job. Keeping it
+        # on the embed step makes the whole-job fraction monotonic.
         tracker.update(
-            "loading", msg, current=current, total=total, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
+            "loading",
+            msg,
+            current=current,
+            total=total,
+            step=_STATUS_TO_STEP["embedding"],
+            total_steps=_TOTAL_LOAD_STEPS,
         )
 
     _clipper_progress(0, 0, "clipping")


### PR DESCRIPTION
## Problem

The consolidated dataset-load bar (download → load → embed → finalize) is one whole-job 0→100 % fraction, but it still **jitters and jumps between stages** — the bar gets "knocked around" as each phase reports a different scale of information.

## Root causes fixed

- **Clipper backslide (worst offender).** The clipper stage reported the *finalize* step while running *before* the embed step. It ran the bar to ~100 %, then the following embed step (a lower number) tripped `_compute_overall`'s "step went backwards = new job" reset and slammed the bar from ~100 % back to mid-job. Clipping *is* the embed phase for clipped datasets (it cuts + embeds clips; the later `_embed_missing_stage` is then a no-op), so it now reports the **embedding** step → the whole-job fraction stays monotonic.
- **`converting` status nulled the bar.** `converters/runner.py` emits a `"converting"` status (document→image, video→frames) that was missing from `_STATUS_TO_STEP`, so it resolved to `step=None`, nulled `overall`, and bounced the bar onto the raw `current/total` scale mid-job. Now mapped to the loading step, with the map's docstring stating the invariant: every load-path status must be mapped.
- **Smaller model-load jump.** `_LOAD_STEP_WEIGHTS` shifted `0.25/0.15/0.50/0.10` → `0.25/0.10/0.55/0.10`: the un-measurable model-load slice (which fills in one step the moment embedding begins) is trimmed and the freed weight handed to embedding, the phase that reports per-item progress — more of the bar advances smoothly and the between-stage jump shrinks.
- **Gentle fill ease (frontend).** New opt-in `smooth` input on `ProgressBarComponent` (a longer `0.6s ease-out` fill) wired into the dataset-load bars (dashboard orphan rows, dataset-card, detector-card). Unavoidable between-phase jumps glide instead of snapping.

Per the design decision on this task, the smoothing is **honest**: the fill only ever eases *toward* the real reported value, never ahead of it — no fake/timer-driven motion.

## Tests

- `tests_lib/core/test_progress_overall.py`: new `TestLoadStepMapping` — `converting` shares the loading step, and a simulated clipped-load sequence stays monotonic and reaches 100 %.
- `progress-bar.component.spec.ts`: the `smooth` modifier class toggles with the input.
- Full suite green: `./run-tests.sh` (5180 passed) + frontend gate (build, audit, 862 Vitest), pyright/ruff/codespell/deptry clean.

Follow-ups (finalize sub-stage lumping; multi-embedder hold) recorded in `docs/plans/progress-bar-consolidation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7Z1wpznxYpaoHcbp7nnW4)_