### PR TITLE
Region voting in the eval harness

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -47,6 +47,8 @@ python -m vtscore.eval [OPTIONS]
 | `--safe-thresholds` | Blend cross-calibration threshold with GMM for robustness | off |
 | `--calibrate-count K` | Number of random Train/Calibrate splits for threshold calibration | `2` |
 | `--calibration-fraction F` | Fraction of training data reserved for calibration | `0.5` |
+| `--embedder NAME` | Build each demo dataset with this embedder (empty = media-type default) | `` |
+| `--region-voting` | Region-pool learned-sort Good votes from each media's ground-truth box (needs `--embedder <patch>` + a dataset with stored regions, e.g. Visual Genome) | off |
 | `--list` | List available eval datasets and exit | - |
 
 ### Examples
@@ -60,6 +62,12 @@ python -m vtscore.eval --mode learned --train-fraction 0.7 --seed 123 --plot-dir
 
 # Learned sort with safe thresholds and calibration tuning
 python -m vtscore.eval --mode learned --safe-thresholds --calibrate-count 4 --plot-dir eval_output
+
+# Region voting on Visual Genome: re-embed with a patch embedder, then have
+# each Good vote use the object's ground-truth box instead of the whole image.
+# Run once without and once with --region-voting and diff the F1s.
+python -m vtscore.eval --mode learned --datasets visual_genome_s --embedder dinov3_patch
+python -m vtscore.eval --mode learned --datasets visual_genome_s --embedder dinov3_patch --region-voting
 
 # List available eval datasets
 python -m vtscore.eval --list
@@ -258,6 +266,27 @@ paths = plot_voting_iterations(df, output_dir="eval_output")
 for p in paths:
     print(f"Saved: {p}")
 ```
+
+#### Region voting
+
+On a **patch-embedder** dataset that carries ground-truth boxes (Visual Genome,
+loaded with `embedder_name="dinov3_patch"`), pass `region_voting=True` to make
+each simulated Good vote train on the object's box instead of the whole image:
+
+```python
+medias = {}
+load_demo_dataset("visual_genome_s", medias, embedder_name="dinov3_patch")
+
+# Same dataset, two runs — the only difference is the Good-vote training vector.
+baseline = run_voting_iterations_eval({"vg": medias}, seeds=[1, 2, 3], region_voting=False)
+region   = run_voting_iterations_eval({"vg": medias}, seeds=[1, 2, 3], region_voting=True)
+```
+
+A Good vote uses the **minimal box covering every annotated instance** of the
+target category (two apples → one box around both); images with no annotated box
+fall back to the whole-image vector. Scoring is region-aware (max-pool over
+regions) in both runs, so the comparison isolates region voting's effect. Region
+voting is a no-op on single-vector datasets (no `patch_grid` to pool).
 
 ### Example: voting iterations from pickle files
 

--- a/docs/plans/visual-genome-dataset.md
+++ b/docs/plans/visual-genome-dataset.md
@@ -126,11 +126,37 @@ Phase 1:
   download/collect/load + region normalization) and multi-label eval tests in
   `tests_lib/detectors/test_eval.py`.
 
+## Phase 2 — Region voting in evals (shipped)
+
+The stored ground-truth boxes now feed the eval harness as simulated region
+votes. `vtscore/eval/labels.py::region_box_for_category(media, category)`
+returns the **minimal box covering every annotated instance** of the category
+(multiple apples → one box around all of them; `None` when the image has no
+annotated box, so callers fall back to the whole-image vector — exactly an
+image-level Good vote). Both simulated-voting evaluators take a `region_voting`
+flag:
+
+- **Voting-iterations** (`vtscore/eval/voting_iterations.py`): each Good vote
+  region-pools its box from the media's `patch_grid` via
+  `pool_box_from_media` / `box_to_vote_vector`. Bad votes always stay
+  whole-image (matching the live detector, where only Yes-votes carry a
+  region). Scoring is **independent** of the flag — any patch dataset (media
+  with `patch_regions`) is scored region-aware (max-pool over regions) the same
+  way the live detector scores it, so the only variable `region_voting` toggles
+  is the Good-vote training vector, isolating its effect.
+- **Learned-sort** (`vtscore/eval/runner.py::eval_learned_sort`): passes the
+  per-Good `vote_region_boxes` map straight to `train_and_score`, which already
+  region-pools and region-max-pool-scores.
+- **CLI**: `python -m vtscore.eval --embedder dinov3_patch --region-voting`.
+  Region voting needs a **patch embedder** (DINOv2/v3/EUPE) — SigLIP, the
+  default VG embedder, produces no `patch_grid`, so `--embedder` re-embeds VG
+  in a patch space. No embedder is hardcoded; any patch embedder works.
+
 ## Open follow-ups
 
-- **Region consumers.** Region-level eval and seeding region votes from
-  ground-truth boxes are deferred. The boxes are stored now; wiring them into
-  the patch-embedder region-voting flow is the natural Phase 2.
+- **Region-vote eval reporting.** The boxes are consumed now; a dedicated
+  side-by-side image-vs-region report/plot (baseline vs `region_voting`) is not
+  yet built — callers run the eval twice (flag off/on) and diff the frames.
 - **Vocab matching quality.** Object→category matching is a case/plural-folding
   heuristic. VG synonyms/synsets (`names` has multiple aliases; `synsets` exists)
   are only partially exploited; a richer synonym map would recover more positives.

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -599,3 +599,92 @@ class TestEvalMultiLabel:
         results = eval_learned_sort(medias, [EvalQuery("an apple", "apple")], seed=42)
         assert len(results) == 1
         assert results[0].f1 > 0.7  # generous threshold for small synthetic data
+
+
+class TestRegionBoxForCategory:
+    """Ground-truth box lookup that feeds region voting in the eval harness."""
+
+    def test_single_box(self):
+        from vtscore.eval.labels import region_box_for_category
+
+        media = {"regions": [{"box": [0.1, 0.2, 0.3, 0.4], "label": "apple"}]}
+        assert region_box_for_category(media, "apple") == (0.1, 0.2, 0.3, 0.4)
+
+    def test_multiple_boxes_returns_minimal_cover(self):
+        from vtscore.eval.labels import region_box_for_category
+
+        # Two apples in one image -> the smallest box covering both, not an
+        # arbitrary pick of one.
+        media = {
+            "regions": [
+                {"box": [0.10, 0.20, 0.30, 0.40], "label": "apple"},
+                {"box": [0.50, 0.10, 0.90, 0.60], "label": "apple"},
+                {"box": [0.00, 0.00, 1.00, 1.00], "label": "man"},  # different label, ignored
+            ]
+        }
+        assert region_box_for_category(media, "apple") == (0.10, 0.10, 0.90, 0.60)
+
+    def test_no_regions_returns_none(self):
+        from vtscore.eval.labels import region_box_for_category
+
+        assert region_box_for_category({"category": "apple"}, "apple") is None
+        assert region_box_for_category({"regions": []}, "apple") is None
+
+    def test_no_matching_label_returns_none(self):
+        from vtscore.eval.labels import region_box_for_category
+
+        media = {"regions": [{"box": [0.1, 0.2, 0.3, 0.4], "label": "man"}]}
+        assert region_box_for_category(media, "apple") is None
+
+
+class TestRegionVotingLearnedSort:
+    """eval_learned_sort wires ground-truth boxes into train_and_score."""
+
+    def _make_region_clips(self, n_per_cat=10):
+        """Positive (apple) images carry a ground-truth box; negatives don't."""
+        rng = np.random.RandomState(7)
+        medias = {}
+        media_id = 1
+        for _ in range(n_per_cat):
+            emb = rng.normal(1.0, 0.3, 16).astype(np.float32)
+            medias[media_id] = {
+                "id": media_id,
+                "embeddings": {"dinov3_patch": emb},
+                "category": "apple",
+                "media_type": "image",
+                "regions": [{"box": [0.2, 0.2, 0.6, 0.6], "label": "apple"}],
+            }
+            media_id += 1
+        for _ in range(n_per_cat):
+            emb = rng.normal(-1.0, 0.3, 16).astype(np.float32)
+            medias[media_id] = {
+                "id": media_id,
+                "embeddings": {"dinov3_patch": emb},
+                "category": "other",
+                "media_type": "image",
+            }
+            media_id += 1
+        return medias
+
+    def test_passes_groundtruth_boxes_only_when_region_voting(self):
+        captured: list[dict | None] = []
+
+        def _fake_train_and_score(medias, good, bad, **kwargs):
+            captured.append(kwargs.get("vote_region_boxes"))
+            # Score every media as its embedding's first component (separable).
+            scored = [{"id": cid, "score": 1.0 if medias[cid]["category"] == "apple" else 0.0} for cid in medias]
+            return scored, 0.5, None
+
+        medias = self._make_region_clips()
+        query = [EvalQuery("an apple", "apple")]
+
+        with patch("vtscore.detectors.training.train_and_score", _fake_train_and_score):
+            eval_learned_sort(medias, query, train_fraction=0.5, seed=1, region_voting=True)
+            eval_learned_sort(medias, query, train_fraction=0.5, seed=1, region_voting=False)
+
+        boxes_on, boxes_off = captured
+        # Region voting: every trained Good (apple) media contributes its box.
+        assert boxes_on
+        assert all(b == (0.2, 0.2, 0.6, 0.6) for b in boxes_on.values())
+        # Baseline: no boxes passed at all.
+        assert boxes_off is None

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from vtscore.eval.voting_iterations import (
+    _good_training_vec,
     _inclusion_weights,
     _make_vote_sequence,
     _split_media_ids,
@@ -367,3 +368,135 @@ class TestRunVotingIterationsEval:
         )
         combos = df.groupby(["seed", "dataset", "category"]).ngroups
         assert combos == 4  # 2 seeds x 1 dataset x 2 categories
+
+
+# ------------------------------------------------------------------
+# Region voting (patch datasets)
+# ------------------------------------------------------------------
+
+_PATCH_DIM = 8
+_GRID = 3  # 3x3 patch grid
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=np.float32)
+    n = float(np.linalg.norm(v))
+    return v / n if n else v
+
+
+def _patch_media(media_id, positive, *, category, with_box=True):
+    """A synthetic patch-embedder media (``patch_grid`` + ``patch_regions``).
+
+    Positive media have grid cells pointing along ``+e0`` and a ground-truth
+    box; negatives point along ``-e0`` and carry no box.  Separable so the MLP
+    trains cleanly without flakiness.
+    """
+    from vtscore.media.patch_embed import RegionVector
+
+    rng = np.random.default_rng(media_id)
+    sign = 1.0 if positive else -1.0
+    grid = np.zeros((_GRID, _GRID, _PATCH_DIM), dtype=np.float32)
+    for r in range(_GRID):
+        for c in range(_GRID):
+            base = np.zeros(_PATCH_DIM, dtype=np.float32)
+            base[0] = sign
+            grid[r, c] = _unit(base + rng.standard_normal(_PATCH_DIM).astype(np.float32) * 0.05)
+    img_vec = _unit(grid.reshape(-1, _PATCH_DIM).mean(axis=0))
+
+    regions = [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=img_vec)]
+    for r in range(_GRID):
+        for c in range(_GRID):
+            box = (c / _GRID, r / _GRID, (c + 1) / _GRID, (r + 1) / _GRID)
+            regions.append(RegionVector(box=box, vec=grid[r, c]))
+
+    media = {
+        "id": media_id,
+        "media_type": "image",
+        "embedder": "dinov3_patch",
+        "embeddings": {"dinov3_patch": img_vec},
+        "patch_grid": grid,
+        "patch_regions": regions,
+        "category": category,
+    }
+    if positive and with_box:
+        media["regions"] = [{"box": [0.0, 0.0, 2 / 3, 1.0], "label": category}]
+    return media
+
+
+def _make_patch_clips(n_per_cat=10):
+    medias = {}
+    media_id = 1
+    for _ in range(n_per_cat):
+        medias[media_id] = _patch_media(media_id, positive=True, category="apple")
+        media_id += 1
+    for _ in range(n_per_cat):
+        medias[media_id] = _patch_media(media_id, positive=False, category="other")
+        media_id += 1
+    return medias
+
+
+class TestGoodTrainingVec:
+    """The per-Good-vote training vector, region-pooled or whole-image."""
+
+    def test_image_level_when_region_voting_off(self):
+        from vtscore.embedding.media_vectors import media_embedding
+
+        media = _patch_media(1, positive=True, category="apple")
+        vec = _good_training_vec(media, "apple", region_voting=False)
+        np.testing.assert_allclose(vec, media_embedding(media))
+
+    def test_pools_box_when_region_voting_on(self):
+        from vtscore.media.patch_embed import box_to_vote_vector
+
+        media = _patch_media(1, positive=True, category="apple")
+        vec = _good_training_vec(media, "apple", region_voting=True)
+        expected = box_to_vote_vector(np.asarray(media["patch_grid"]), (0.0, 0.0, 2 / 3, 1.0))
+        np.testing.assert_allclose(vec, expected)
+
+    def test_falls_back_without_patch_grid(self):
+        from vtscore.embedding.media_vectors import media_embedding
+
+        media = _patch_media(1, positive=True, category="apple")
+        del media["patch_grid"]
+        vec = _good_training_vec(media, "apple", region_voting=True)
+        np.testing.assert_allclose(vec, media_embedding(media))
+
+    def test_falls_back_without_matching_box(self):
+        from vtscore.embedding.media_vectors import media_embedding
+
+        # Positive image but no annotated box for this category.
+        media = _patch_media(1, positive=True, category="apple", with_box=False)
+        vec = _good_training_vec(media, "apple", region_voting=True)
+        np.testing.assert_allclose(vec, media_embedding(media))
+
+
+class TestRegionVotingSimulate:
+    """End-to-end region voting on a synthetic patch dataset."""
+
+    def test_region_voting_produces_finite_rows(self):
+        medias = _make_patch_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(medias, target_category="apple", seed=0, region_voting=True)
+        assert rows  # region-aware scoring path runs end-to-end
+        for row in rows:
+            assert np.isfinite(row["cost"])
+            assert np.isfinite(row["fpr"])
+            assert np.isfinite(row["fnr"])
+
+    def test_baseline_on_patch_data_also_scores_region_aware(self):
+        # region_voting=False still works on a patch dataset: Good votes train
+        # whole-image, but scoring max-pools over regions (the live inference).
+        medias = _make_patch_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(medias, target_category="apple", seed=0, region_voting=False)
+        assert rows
+        assert all(np.isfinite(r["cost"]) for r in rows)
+
+    def test_run_eval_threads_region_voting_flag(self):
+        medias = _make_patch_clips(n_per_cat=8)
+        df = run_voting_iterations_eval(
+            dataset_clips={"vg": medias},
+            seeds=[0],
+            categories={"vg": ["apple"]},
+            region_voting=True,
+        )
+        assert not df.empty
+        assert (df["category"] == "apple").all()

--- a/vtscore/eval/__main__.py
+++ b/vtscore/eval/__main__.py
@@ -121,6 +121,27 @@ def main() -> None:
         default=0.5,
         help="Fraction of training data used for calibration (default: 0.5).",
     )
+    parser.add_argument(
+        "--embedder",
+        type=str,
+        default="",
+        metavar="NAME",
+        help=(
+            "Embedder to build each demo dataset with (default: media type's "
+            "default). Pass a patch embedder (e.g. dinov3_patch) to enable "
+            "--region-voting."
+        ),
+    )
+    parser.add_argument(
+        "--region-voting",
+        action="store_true",
+        help=(
+            "Learned-sort Good votes are region-pooled from each media's "
+            "ground-truth box instead of the whole image. Needs a patch "
+            "embedder (--embedder) and a dataset with stored regions (Visual "
+            "Genome)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -146,6 +167,8 @@ def main() -> None:
         safe_thresholds=args.safe_thresholds,
         calibrate_count=args.calibrate_count,
         calibration_fraction=args.calibration_fraction,
+        embedder_name=args.embedder,
+        region_voting=args.region_voting,
     )
 
     # Print summary

--- a/vtscore/eval/labels.py
+++ b/vtscore/eval/labels.py
@@ -37,9 +37,7 @@ def media_is_positive(media: dict[str, Any], category: str) -> bool:
     return media.get("category") == category
 
 
-def region_box_for_category(
-    media: dict[str, Any], category: str
-) -> Optional[tuple[float, float, float, float]]:
+def region_box_for_category(media: dict[str, Any], category: str) -> Optional[tuple[float, float, float, float]]:
     """Return the ground-truth region box for *category* on *media*, or ``None``.
 
     Datasets like Visual Genome stamp store-only ground-truth boxes on each

--- a/vtscore/eval/labels.py
+++ b/vtscore/eval/labels.py
@@ -19,7 +19,7 @@ their behavior is unchanged.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 
 def media_is_positive(media: dict[str, Any], category: str) -> bool:
@@ -35,3 +35,39 @@ def media_is_positive(media: dict[str, Any], category: str) -> bool:
     if cats is not None:
         return category in cats
     return media.get("category") == category
+
+
+def region_box_for_category(
+    media: dict[str, Any], category: str
+) -> Optional[tuple[float, float, float, float]]:
+    """Return the ground-truth region box for *category* on *media*, or ``None``.
+
+    Datasets like Visual Genome stamp store-only ground-truth boxes on each
+    media as ``media["regions"] = [{"box": [x0, y0, x1, y1], "label": cat}, ...]``
+    (normalised ``[0, 1]`` coordinates - see
+    ``docs/plans/visual-genome-dataset.md``).  The eval harness uses these to
+    simulate a user who, when voting Good, also drags a region around the
+    object instead of voting on the whole image.
+
+    When more than one annotated region carries *category* (e.g. an image with
+    two apples), we return the **minimal axis-aligned box that covers them
+    all** (``min`` of the corners, ``max`` of the far corners).  Covering all
+    of them keeps every annotated instance inside the voted region; picking one
+    box arbitrarily would discard real signal and depend on annotation order.
+
+    Returns ``None`` when *media* has no ``regions`` (single-label datasets, or
+    a positive image with no box annotation for this category), so callers fall
+    back to the whole-image embedding - exactly the behaviour of an image-level
+    Good vote.
+    """
+    regions = media.get("regions")
+    if not regions:
+        return None
+    boxes = [r["box"] for r in regions if r.get("label") == category]
+    if not boxes:
+        return None
+    x0 = min(float(b[0]) for b in boxes)
+    y0 = min(float(b[1]) for b in boxes)
+    x1 = max(float(b[2]) for b in boxes)
+    y1 = max(float(b[3]) for b in boxes)
+    return (x0, y0, x1, y1)

--- a/vtscore/eval/runner.py
+++ b/vtscore/eval/runner.py
@@ -114,6 +114,7 @@ def eval_learned_sort(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     start_time: float | None = None,
+    region_voting: bool = False,
 ) -> list[LearnedSortMetrics]:
     """Run learned-sort evaluation via simulated voting.
 
@@ -139,11 +140,19 @@ def eval_learned_sort(
             calibration in each split (default 0.5).
         start_time: Monotonic timestamp from the start of the eval run.
             When provided, each result records ``elapsed_seconds``.
+        region_voting: When ``True``, each Good vote passes the media's
+            ground-truth region box for the target category to
+            ``train_and_score`` (the minimal box covering every annotated
+            instance), so the positive is region-pooled instead of trained on
+            the whole image.  Requires a patch dataset with stored ``regions``
+            and ``patch_grid``; on any other dataset the boxes are absent and
+            this is a no-op.
 
     Returns:
         List of :class:`LearnedSortMetrics`, one per query.
     """
     from vtscore.detectors.training import train_and_score
+    from vtscore.eval.labels import region_box_for_category
 
     rng = np.random.RandomState(seed)
     results: list[LearnedSortMetrics] = []
@@ -175,6 +184,18 @@ def eval_learned_sort(
         good_votes: dict[int, None] = {cid: None for cid in train_good}
         bad_votes: dict[int, None] = {cid: None for cid in train_bad}
 
+        # When region voting, a Good vote carries the ground-truth box for the
+        # target category (minimal box over all annotated instances); media
+        # without an annotated box are simply omitted and train_and_score falls
+        # back to their whole-image vector.
+        vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None
+        if region_voting:
+            vote_region_boxes = {
+                cid: box
+                for cid in train_good
+                if (box := region_box_for_category(medias[cid], query.target_category)) is not None
+            }
+
         # Run train_and_score
         scored, threshold, _model = train_and_score(
             medias,
@@ -183,6 +204,7 @@ def eval_learned_sort(
             safe_thresholds=safe_thresholds,
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
+            vote_region_boxes=vote_region_boxes,
         )
 
         # Evaluate on test set
@@ -220,6 +242,8 @@ def run_eval(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    embedder_name: str = "",
+    region_voting: bool = False,
 ) -> list[DatasetResult]:
     """Run evaluation on one or more eval datasets.
 
@@ -242,6 +266,14 @@ def run_eval(
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
             calibration in each split (default 0.5).
+        embedder_name: Optional embedder to build each demo dataset with
+            (empty = the media type's default).  Pass a patch embedder
+            (e.g. ``"dinov3_patch"``) to make ``region_voting`` meaningful -
+            only patch embedders produce the ``patch_grid`` region pooling
+            needs.
+        region_voting: When ``True``, learned-sort Good votes are region-pooled
+            from each media's ground-truth box (see :func:`eval_learned_sort`).
+            Only affects patch datasets with stored ``regions`` (Visual Genome).
 
     Returns:
         List of :class:`DatasetResult`, one per evaluated dataset.
@@ -277,7 +309,7 @@ def run_eval(
         # Load the demo dataset into a fresh medias dict
         medias: dict[int, dict] = {}
         try:
-            load_demo_dataset(demo_id, medias)
+            load_demo_dataset(demo_id, medias, embedder_name=embedder_name)
         except Exception as e:
             print(f"ERROR loading dataset {demo_id}: {e}", file=sys.stderr)
             continue
@@ -318,6 +350,7 @@ def run_eval(
                 calibrate_count=calibrate_count,
                 calibration_fraction=calibration_fraction,
                 start_time=start_time,
+                region_voting=region_voting,
             )
             ds_result.learned_sort = learned_results
 

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -104,6 +104,34 @@ def _good_training_vec(
     return media_embedding(media)
 
 
+def _blend_safe_threshold(
+    threshold: float,
+    model: torch.nn.Sequential,
+    region_aware: bool,
+    sim_clips: dict[int, dict[str, Any]] | None,
+    X_all_clips: Any,
+    n_labels: int,
+) -> float:
+    """Blend *threshold* with a GMM threshold over the simulation set's scores.
+
+    Region-aware datasets score the sim set via region max-pool (matching the
+    test-set scoring); single-vector datasets use the pre-computed whole-image
+    matrix *X_all_clips*.  Kept separate so the per-step loop stays flat.
+    """
+    import torch  # noqa: PLC0415
+
+    if region_aware:
+        from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
+
+        assert sim_clips is not None
+        all_scores = [r["score"] for r in score_media_with_model(model, sim_clips)]
+    else:
+        with torch.no_grad():
+            X_eval = X_all_clips.to(next(model.parameters()).device)
+            all_scores = torch.sigmoid(model(X_eval)).squeeze(1).cpu().tolist()
+    return calculate_safe_threshold(threshold, all_scores, n_labels)
+
+
 def _evaluate_on_test(
     model: torch.nn.Sequential,
     threshold: float,
@@ -239,15 +267,17 @@ def simulate_voting_iterations(
     # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
     # simulation set so the held-out ``test_ids`` never feed into the GMM that
     # picks the threshold - otherwise the test scores leak into calibration
-    # and the reported metrics are biased upward.  Region-aware datasets score
-    # the sim set via region max-pool (built per-step inside the loop) to match
-    # how the test set is scored.
-    if safe_thresholds and not region_aware:
-        gmm_media_ids = sorted(sim_ids)
-        gmm_clip_embs = np.array([media_embedding(clips_dict[cid]) for cid in gmm_media_ids])
-        X_all_clips = torch.tensor(gmm_clip_embs, dtype=torch.float32)
-    elif safe_thresholds:
+    # and the reported metrics are biased upward.  Region-aware datasets keep a
+    # sim-set snapshot and score it per-step via region max-pool (to match how
+    # the test set is scored); single-vector datasets pre-stack whole-image
+    # embeddings once.
+    sim_clips: dict[int, dict[str, Any]] | None = None
+    X_all_clips: Any = None
+    if safe_thresholds and region_aware:
         sim_clips = {cid: clips_dict[cid] for cid in sim_ids}
+    elif safe_thresholds:
+        gmm_clip_embs = np.array([media_embedding(clips_dict[cid]) for cid in sorted(sim_ids)])
+        X_all_clips = torch.tensor(gmm_clip_embs, dtype=torch.float32)
 
     good_votes: dict[int, None] = {}
     bad_votes: dict[int, None] = {}
@@ -294,16 +324,9 @@ def simulate_voting_iterations(
 
         # Apply safe threshold blending if enabled
         if safe_thresholds:
-            if region_aware:
-                from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
-
-                all_scores = [r["score"] for r in score_media_with_model(model, sim_clips)]
-            else:
-                with torch.no_grad():
-                    X_eval = X_all_clips.to(next(model.parameters()).device)
-                    all_scores = torch.sigmoid(model(X_eval)).squeeze(1).cpu().tolist()
-            n_labels = len(good_votes) + len(bad_votes)
-            threshold = calculate_safe_threshold(threshold, all_scores, n_labels)
+            threshold = _blend_safe_threshold(
+                threshold, model, region_aware, sim_clips, X_all_clips, len(good_votes) + len(bad_votes)
+            )
 
         # Evaluate on held-out test set
         metrics = _evaluate_on_test(

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     import torch
 
 from vtscore.embedding.media_vectors import media_embedding
-from vtscore.eval.labels import media_is_positive
+from vtscore.eval.labels import media_is_positive, region_box_for_category
 from vtscore.training.mlp import train_model
 from vtscore.training.thresholds import (
     calculate_cross_calibration_threshold,
@@ -79,6 +79,31 @@ def _make_vote_sequence(
     return [votes[i] for i in order]
 
 
+def _good_training_vec(
+    media: dict[str, Any],
+    target_category: str,
+    region_voting: bool,
+) -> np.ndarray:
+    """Return the training vector for one Good vote on *media*.
+
+    With *region_voting* the simulated user drags the ground-truth box around
+    the object: when *media* carries a stored ``patch_grid`` and an annotated
+    region for *target_category*, the box is pooled on-the-fly via
+    :func:`vtscore.detectors.training.pool_box_from_media` (the same path the
+    live region-vote flow uses).  Falls back to the whole-image embedding when
+    region voting is off, the media has no patch grid (single-vector
+    embedders), or no box is annotated for this category - exactly an
+    image-level Good vote.
+    """
+    if region_voting:
+        from vtscore.detectors.training import pool_box_from_media  # noqa: PLC0415
+
+        pooled = pool_box_from_media(media, region_box_for_category(media, target_category))
+        if pooled is not None:
+            return pooled
+    return media_embedding(media)
+
+
 def _evaluate_on_test(
     model: torch.nn.Sequential,
     threshold: float,
@@ -86,20 +111,35 @@ def _evaluate_on_test(
     test_ids: list[int],
     target_category: str,
     inclusion: int,
+    region_aware: bool = False,
 ) -> dict[str, float]:
-    """Score *test_ids* with *model* and return inclusion-weighted cost, FPR, FNR."""
+    """Score *test_ids* with *model* and return inclusion-weighted cost, FPR, FNR.
+
+    When *region_aware* the test media carry ``patch_regions`` (a patch
+    embedder), so scoring max-pools the MLP over every region of each image -
+    exactly the live detector's inference for patch datasets (an image scores
+    by its best-matching region).  Otherwise each media is scored by its single
+    whole-image vector, the fast path used for every single-vector dataset.
+    """
     import numpy as np  # noqa: PLC0415
     import torch  # noqa: PLC0415
 
     if not test_ids:
         return {"cost": float("nan"), "fpr": float("nan"), "fnr": float("nan")}
 
-    embs = np.array([media_embedding(clips_dict[cid]) for cid in test_ids])
-    X = torch.tensor(embs, dtype=torch.float32)
+    if region_aware:
+        from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
 
-    with torch.no_grad():
-        X = X.to(next(model.parameters()).device)
-        scores = torch.sigmoid(model(X)).squeeze(1).cpu().tolist()
+        test_clips = {cid: clips_dict[cid] for cid in test_ids}
+        score_map = {r["id"]: r["score"] for r in score_media_with_model(model, test_clips)}
+        scores = [score_map[cid] for cid in test_ids]
+    else:
+        embs = np.array([media_embedding(clips_dict[cid]) for cid in test_ids])
+        X = torch.tensor(embs, dtype=torch.float32)
+
+        with torch.no_grad():
+            X = X.to(next(model.parameters()).device)
+            scores = torch.sigmoid(model(X)).squeeze(1).cpu().tolist()
 
     true_labels = [1.0 if media_is_positive(clips_dict[cid], target_category) else 0.0 for cid in test_ids]
 
@@ -138,6 +178,7 @@ def simulate_voting_iterations(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    region_voting: bool = False,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -154,6 +195,15 @@ def simulate_voting_iterations(
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
             calibration in each split (default 0.5).
+        region_voting: When ``True``, each Good vote trains on the region-pooled
+            vector of the media's ground-truth box for *target_category* (the
+            minimal box covering every annotated instance), instead of the
+            whole-image vector - simulating a user who drags a region around the
+            object.  Requires a patch embedder: media without a ``patch_grid``
+            or without an annotated box fall back to the whole-image vector.
+            Scoring is unaffected by this flag - a patch dataset always scores
+            region-aware (max-pool over regions), so the only thing this toggles
+            is the Good-vote training vector, isolating region voting's effect.
 
     Returns:
         List of row dicts with keys ``seed, dataset, category, t, n_good,
@@ -171,22 +221,33 @@ def simulate_voting_iterations(
 
     sim_ids, test_ids = _split_media_ids(clips_dict, sim_fraction, rng)
 
-    # Ensure the test set has both positive and negative medias
-    test_pos = [cid for cid in test_ids if clips_dict[cid]["category"] == target_category]
-    test_neg = [cid for cid in test_ids if clips_dict[cid]["category"] != target_category]
+    # Ensure the test set has both positive and negative medias.  Routes through
+    # ``media_is_positive`` so multi-label (Visual Genome) images - where the
+    # target may be a non-primary category - are counted correctly.
+    test_pos = [cid for cid in test_ids if media_is_positive(clips_dict[cid], target_category)]
+    test_neg = [cid for cid in test_ids if not media_is_positive(clips_dict[cid], target_category)]
     if not test_pos or not test_neg:
         return []
+
+    # A patch dataset exposes ``patch_regions`` per media; such datasets are
+    # scored region-aware (max-pool over regions) the same way the live
+    # detector scores them, regardless of how the Good votes were assembled.
+    region_aware = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
 
     vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
 
     # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
     # simulation set so the held-out ``test_ids`` never feed into the GMM that
     # picks the threshold - otherwise the test scores leak into calibration
-    # and the reported metrics are biased upward.
-    if safe_thresholds:
+    # and the reported metrics are biased upward.  Region-aware datasets score
+    # the sim set via region max-pool (built per-step inside the loop) to match
+    # how the test set is scored.
+    if safe_thresholds and not region_aware:
         gmm_media_ids = sorted(sim_ids)
         gmm_clip_embs = np.array([media_embedding(clips_dict[cid]) for cid in gmm_media_ids])
         X_all_clips = torch.tensor(gmm_clip_embs, dtype=torch.float32)
+    elif safe_thresholds:
+        sim_clips = {cid: clips_dict[cid] for cid in sim_ids}
 
     good_votes: dict[int, None] = {}
     bad_votes: dict[int, None] = {}
@@ -202,11 +263,14 @@ def simulate_voting_iterations(
         if not good_votes or not bad_votes:
             continue
 
-        # Build training data
+        # Build training data.  Good votes region-pool their ground-truth box
+        # when ``region_voting`` is on (and the media supports it); bad votes
+        # always train on the whole-image vector - matching the live detector,
+        # where only Yes-votes carry a region.
         X_list: list[np.ndarray] = []
         y_list: list[float] = []
         for vid in good_votes:
-            X_list.append(media_embedding(clips_dict[vid]))
+            X_list.append(_good_training_vec(clips_dict[vid], target_category, region_voting))
             y_list.append(1.0)
         for vid in bad_votes:
             X_list.append(media_embedding(clips_dict[vid]))
@@ -230,14 +294,21 @@ def simulate_voting_iterations(
 
         # Apply safe threshold blending if enabled
         if safe_thresholds:
-            with torch.no_grad():
-                X_eval = X_all_clips.to(next(model.parameters()).device)
-                all_scores = torch.sigmoid(model(X_eval)).squeeze(1).cpu().tolist()
+            if region_aware:
+                from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
+
+                all_scores = [r["score"] for r in score_media_with_model(model, sim_clips)]
+            else:
+                with torch.no_grad():
+                    X_eval = X_all_clips.to(next(model.parameters()).device)
+                    all_scores = torch.sigmoid(model(X_eval)).squeeze(1).cpu().tolist()
             n_labels = len(good_votes) + len(bad_votes)
             threshold = calculate_safe_threshold(threshold, all_scores, n_labels)
 
         # Evaluate on held-out test set
-        metrics = _evaluate_on_test(model, threshold, clips_dict, test_ids, target_category, inclusion)
+        metrics = _evaluate_on_test(
+            model, threshold, clips_dict, test_ids, target_category, inclusion, region_aware=region_aware
+        )
 
         rows.append(
             {
@@ -269,6 +340,7 @@ def run_voting_iterations_eval(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    region_voting: bool = False,
 ) -> pd.DataFrame:
     """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
 
@@ -288,6 +360,9 @@ def run_voting_iterations_eval(
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
             calibration in each split (default 0.5).
+        region_voting: When ``True``, Good votes train on the ground-truth
+            region-pooled vector for patch datasets (see
+            :func:`simulate_voting_iterations`).
 
     Returns:
         A :class:`~pandas.DataFrame` with columns ``seed, dataset, category,
@@ -298,11 +373,17 @@ def run_voting_iterations_eval(
     all_rows: list[dict[str, Any]] = []
 
     for ds_name, clips_dict in dataset_clips.items():
-        # Determine target categories
+        # Determine target categories.  For multi-label datasets each image's
+        # ``category`` is only its primary, so fall back to the union of every
+        # image's ``categories`` list when present.
         if categories and ds_name in categories:
             target_cats = categories[ds_name]
         else:
-            target_cats = sorted({clips_dict[cid]["category"] for cid in clips_dict})
+            cat_set: set[str] = set()
+            for cid in clips_dict:
+                media = clips_dict[cid]
+                cat_set.update(media.get("categories") or [media["category"]])
+            target_cats = sorted(cat_set)
 
         for seed in seeds:
             for cat in target_cats:
@@ -316,6 +397,7 @@ def run_voting_iterations_eval(
                     safe_thresholds=safe_thresholds,
                     calibrate_count=calibrate_count,
                     calibration_fraction=calibration_fraction,
+                    region_voting=region_voting,
                 )
                 all_rows.extend(rows)
 
@@ -336,6 +418,7 @@ def run_voting_iterations_eval_from_pickles(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    region_voting: bool = False,
 ) -> pd.DataFrame:
     """Convenience wrapper that loads datasets from pickle files.
 
@@ -350,6 +433,9 @@ def run_voting_iterations_eval_from_pickles(
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
             calibration in each split (default 0.5).
+        region_voting: When ``True``, Good votes train on the ground-truth
+            region-pooled vector for patch datasets (see
+            :func:`simulate_voting_iterations`).
 
     Returns:
         A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
@@ -373,4 +459,5 @@ def run_voting_iterations_eval_from_pickles(
         safe_thresholds=safe_thresholds,
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
+        region_voting=region_voting,
     )


### PR DESCRIPTION
## What

Lets the simulated user in the eval harness vote Good **on a region** instead of the whole image, consuming the ground-truth bounding boxes Visual Genome already stores (`media["regions"]`) but the eval previously ignored.

Region voting is a **general capability**, not VG-specific and not tied to one embedder: it engages whenever the loaded dataset's media carry per-patch vectors (`patch_grid` / `patch_regions`), which is the case for any patch embedder (`dinov3_patch`, `dinov2_patch`, `eupe_patch`). The embedder is chosen at dataset-build time via the existing `embedder_name` argument; nothing is hardcoded. Single-vector datasets (e.g. SigLIP) have nothing to pool and fall back to whole-image, a no-op.

## How

- **`vtscore/eval/labels.py`** — new `region_box_for_category(media, category)` returns the **minimal box covering every annotated instance** of the category (two apples → one box around both), or `None` so callers fall back to the whole-image vector (exactly an image-level Good vote).
- **`vtscore/eval/voting_iterations.py`** (incremental simulated voting) — `region_voting` flag pools each Good vote's box from the media's `patch_grid` via the live region-vote path (`pool_box_from_media` / `box_to_vote_vector`). Bad votes stay whole-image, matching the detector (only Yes-votes carry a region). A patch dataset scores **region-aware** (max-pool over regions) regardless of the flag, so the only thing `region_voting` toggles is the Good-vote training vector — isolating its effect. The multi-label category enumeration and the test-set pos/neg guard now route through `media_is_positive`.
- **`vtscore/eval/runner.py`** (batch learned-sort) — `region_voting` builds the per-Good `vote_region_boxes` map and passes it to `train_and_score`, which already region-pools and region-max-pool-scores.
- **`vtscore/eval/__main__.py`** — `--embedder NAME` and `--region-voting` CLI flags; both threaded through `run_eval`.

## Multiple boxes

When an image is a positive for a category via several annotated instances, the Good vote uses the **minimal axis-aligned box covering all of them** rather than picking one arbitrarily — every instance stays inside the voted region and the result is order-independent.

## Tests

`tests_lib/detectors/test_eval.py` (box lookup incl. multi-box min-cover; learned-sort box wiring) and `tests_lib/detectors/test_eval_voting_iterations.py` (`_good_training_vec` pooling/fallbacks; end-to-end region voting on synthetic patch data). `./run-tests.sh detectors` → **1312 passed**, lint/format green.

## Docs

`docs/EVAL.md` (CLI flags + examples) and `docs/plans/visual-genome-dataset.md` (Phase 2 marked shipped; remaining follow-up = a side-by-side baseline-vs-region report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsakxoDqN7HXpy6vfSYdLH)_