### PR TITLE
Stabilize progress-bar layout against variable stage/item text

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -14,12 +14,14 @@
           [value]="buildProgress()"
           [max]="buildTotal()"
         />
-        @if (buildTotal() > 0) {
-          <span class="browse-status-count">{{ buildProgress() }} / {{ buildTotal() }}</span>
-        }
-        @if (buildMessage()) {
-          <span class="browse-status-detail">{{ buildMessage() }}</span>
-        }
+        <!-- Reserved-height lines so the count/detail appearing or disappearing
+             doesn't re-center the column and shift the bar above it. -->
+        <span class="browse-status-count">
+          @if (buildTotal() > 0) {
+            {{ buildProgress() }} / {{ buildTotal() }}
+          }
+        </span>
+        <span class="browse-status-detail">{{ buildMessage() }}</span>
       </div>
     }
     @case ('error') {

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -30,15 +30,21 @@
   color: var(--color-good);
 }
 
+// Reserve the lines even when empty so toggling the count/detail never
+// re-centers the column and shifts the bar above.
 .browse-status-count {
   font-size: var(--font-sm);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  min-height: 1.4em;
 }
 
 .browse-status-detail {
   font-size: var(--font-sm);
   color: var(--text-muted);
+  line-height: 1.4;
+  min-height: 1.4em;
 }
 
 // Top-left overlay cluster, anchored to ``.browse-main`` like the other

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -112,23 +112,22 @@
                     <div class="loading-task-progress">
                       <div class="progress-context">
                         <div class="progress-header">{{ info.header }}</div>
-                        @if (info.subtitle) {
-                          <div class="progress-subtitle">{{ info.subtitle }}</div>
-                        }
+                        <div class="progress-subtitle">{{ info.subtitle }}</div>
+                      </div>
+                      <!-- Variable text lives on its own reserved-height line so
+                           the bar below keeps a fixed position as the detail/ETA
+                           change between stages. -->
+                      <div class="progress-meta">
+                        <span class="progress-msg">{{ info.detail }}</span>
+                        <span class="progress-eta">{{ info.eta }}</span>
                       </div>
                       <div class="progress-row">
-                        @if (info.detail) {
-                          <span class="progress-msg">{{ info.detail }}</span>
-                        }
                         <vt-progress-bar
                           [value]="taskBar(task).value"
                           [max]="taskBar(task).max"
                           [indeterminate]="taskBar(task).indeterminate"
                           [smooth]="true"
                         />
-                        @if (info.eta) {
-                          <span class="progress-eta">{{ info.eta }}</span>
-                        }
                         <button class="btn btn--cancel btn--sm" (click)="loadingTasksSvc.cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
                       </div>
                     </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -161,9 +161,23 @@
     font-weight: var(--weight-medium);
   }
 
+  // Reserve one line so a phase whose subtitle is empty doesn't shift the bar up.
   .progress-subtitle {
     font-size: var(--font-xs);
     color: var(--text-muted);
+    line-height: 1.4;
+    min-height: 1.4em;
+  }
+
+  // Detail (left) + ETA (right) share one reserved-height line above the bar so
+  // the bar never moves as the text changes length or appears/disappears.
+  .progress-meta {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    font-size: var(--font-xs);
+    line-height: 1.4;
+    min-height: 1.4em;
   }
 
   .progress-row {
@@ -173,17 +187,19 @@
   }
 
   .progress-msg {
-    font-size: var(--font-xs);
-    max-width: 240px;
+    color: var(--text-muted);
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
   }
 
   .progress-eta {
-    font-size: var(--font-xs);
     color: var(--text-muted);
     white-space: nowrap;
     flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
   }
 }
 
@@ -229,8 +245,6 @@
 
   .loading-task-progress .progress-msg {
     font-size: var(--font-xs);
-    flex-shrink: 0;
-    max-width: 300px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -41,23 +41,21 @@
     <div class="inline-loading-progress">
       <div class="progress-context">
         <div class="progress-header">{{ taskProgressInfo.header }}</div>
-        @if (taskProgressInfo.subtitle) {
-          <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
-        }
+        <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
+      </div>
+      <!-- Variable text lives on its own reserved-height line so the bar below
+           keeps a fixed position as the detail/ETA change between stages. -->
+      <div class="progress-meta">
+        <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
+        <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
       </div>
       <div class="progress-row">
-        @if (taskProgressInfo.detail) {
-          <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
-        }
         <vt-progress-bar
           [value]="taskBar.value"
           [max]="taskBar.max"
           [indeterminate]="taskBar.indeterminate"
           [smooth]="true"
         />
-        @if (taskProgressInfo.eta) {
-          <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
-        }
         <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" [title]="taskKind() === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'">Cancel</button>
       </div>
     </div>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -272,9 +272,39 @@ td.select-col {
     font-weight: var(--weight-medium);
   }
 
+  // Reserve one line so a phase whose subtitle is empty doesn't shift the bar up.
   .progress-subtitle {
     font-size: var(--font-xs);
     color: var(--text-muted);
+    line-height: 1.4;
+    min-height: 1.4em;
+  }
+
+  // Detail (left) + ETA (right) share one reserved-height line above the bar so
+  // the bar never moves as the text changes length or appears/disappears.
+  .progress-meta {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    font-size: var(--font-xs);
+    line-height: 1.4;
+    min-height: 1.4em;
+  }
+
+  .progress-msg {
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .progress-eta {
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
   }
 
   .progress-row {
@@ -283,25 +313,8 @@ td.select-col {
     gap: var(--space-md);
   }
 
-  .progress-msg {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    max-width: 240px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   vt-progress-bar {
     flex: 1;
-  }
-
-  .progress-eta {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
   }
 
   &.inline-loading-failed {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -35,23 +35,21 @@
     <div class="loading-task-progress">
       <div class="progress-context">
         <div class="progress-header">{{ taskProgressInfo.header }}</div>
-        @if (taskProgressInfo.subtitle) {
-          <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
-        }
+        <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
+      </div>
+      <!-- Variable text lives on its own reserved-height line so the bar below
+           keeps a fixed position as the detail/ETA change between stages. -->
+      <div class="progress-meta">
+        <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
+        <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
       </div>
       <div class="progress-row">
-        @if (taskProgressInfo.detail) {
-          <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
-        }
         <vt-progress-bar
           [value]="taskBar().value"
           [max]="taskBar().max"
           [indeterminate]="taskBar().indeterminate"
           [smooth]="true"
         />
-        @if (taskProgressInfo.eta) {
-          <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
-        }
         <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel loading">Cancel</button>
       </div>
     </div>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -195,9 +195,39 @@ td.actions-col {
     font-weight: var(--weight-medium);
   }
 
+  // Reserve one line so a phase whose subtitle is empty doesn't shift the bar up.
   .progress-subtitle {
     font-size: var(--font-xs);
     color: var(--text-muted);
+    line-height: 1.4;
+    min-height: 1.4em;
+  }
+
+  // Detail (left) + ETA (right) share one reserved-height line above the bar so
+  // the bar never moves as the text changes length or appears/disappears.
+  .progress-meta {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    font-size: var(--font-xs);
+    line-height: 1.4;
+    min-height: 1.4em;
+  }
+
+  .progress-msg {
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .progress-eta {
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
   }
 
   .progress-row {
@@ -206,25 +236,8 @@ td.actions-col {
     gap: var(--space-md);
   }
 
-  .progress-msg {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    max-width: 240px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   vt-progress-bar {
     flex: 1;
-  }
-
-  .progress-eta {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
   }
 
   &.loading-task-failed {

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -50,12 +50,16 @@
             [value]="sortBar.value"
             [max]="sortBar.max"
           />
-          @if (sortState.sortProgressTotal > 0) {
-            <span class="find-wait-count">{{ sortState.sortProgress | number }} / {{ sortState.sortProgressTotal | number }}</span>
-          }
-          @if (sortEta) {
-            <span class="find-wait-count">{{ sortEta }}</span>
-          }
+          <!-- Reserved-height line so the count/ETA appearing or disappearing
+               doesn't re-center the column and shift the bar above it. -->
+          <span class="find-wait-count">
+            @if (sortState.sortProgressTotal > 0) {
+              {{ sortState.sortProgress | number }} / {{ sortState.sortProgressTotal | number }}
+            }
+            @if (sortEta) {
+              <span class="find-wait-eta">{{ sortEta }}</span>
+            }
+          </span>
           <button class="btn btn--secondary btn--sm" (click)="onSortCancel()">Cancel</button>
         </div>
       </div>

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -110,4 +110,15 @@
   font-size: var(--font-sm);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+  // Reserve the line even when empty so toggling the count/ETA never re-centers
+  // the column and shifts the bar above.
+  line-height: 1.4;
+  min-height: 1.4em;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.find-wait-eta {
+  color: var(--text-muted);
 }

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -1,22 +1,24 @@
 <div class="progress-check-bar">
   @if (sortBusy) {
     <div class="sort-overlay" aria-live="polite">
-      @if (sortStatus) {
+      <!-- Status (left) + ETA (right) share one reserved-height line above the
+           bar so the bar keeps a fixed position as the text changes. -->
+      <div class="sort-overlay-meta">
         <span class="sort-overlay-status">{{ sortStatus }}</span>
-      }
-      <vt-progress-bar
-        [indeterminate]="sortBar.indeterminate"
-        [value]="sortBar.value"
-        [max]="sortBar.max"
-      />
-      @if (sortEta) {
-        <span class="sort-overlay-status">{{ sortEta }}</span>
-      }
-      <button
-        class="btn btn--cancel btn--sm"
-        (click)="onCancel()"
-        title="Cancel the running sort"
-      >Cancel</button>
+        <span class="sort-overlay-status sort-overlay-eta">{{ sortEta }}</span>
+      </div>
+      <div class="sort-overlay-bar">
+        <vt-progress-bar
+          [indeterminate]="sortBar.indeterminate"
+          [value]="sortBar.value"
+          [max]="sortBar.max"
+        />
+        <button
+          class="btn btn--cancel btn--sm"
+          (click)="onCancel()"
+          title="Cancel the running sort"
+        >Cancel</button>
+      </div>
     </div>
   } @else {
     <button

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -9,14 +9,30 @@
 .sort-overlay {
   flex: 1;
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
-  gap: var(--space-sm);
+  gap: var(--space-2xs);
   padding: var(--space-2xs) var(--space-sm);
   border: 1px solid var(--indicator-border);
   border-radius: var(--radius-md);
   background: var(--bg-panel);
+  min-width: 0;
+}
+
+// Status (left) + ETA (right) on one reserved-height line; the bar below never
+// shifts as the text changes length or appears/disappears.
+.sort-overlay-meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  min-height: 1.4em;
+}
+
+.sort-overlay-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-sm);
   min-width: 0;
 
   vt-progress-bar {
@@ -27,9 +43,22 @@
 
 .sort-overlay-status {
   font-size: var(--font-xs);
+  line-height: 1.4;
   color: var(--text-muted);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+// The status text takes the slack; the ETA hugs the right edge.
+.sort-overlay-status:not(.sort-overlay-eta) {
+  flex: 1;
+}
+
+.sort-overlay-eta {
   flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .labeling-indicator {

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal title="Running Auto-Detect" [open]="true" (closed)="close()">
   <div class="autodetect-progress">
-    <p aria-live="polite">{{ statusText }}</p>
+    <p class="progress-status" aria-live="polite">{{ statusText }}</p>
     <vt-progress-bar [value]="progress" [max]="100"></vt-progress-bar>
     <p class="progress-pct">{{ progress }}%</p>
     <button class="btn btn--secondary" (click)="onCancel()" title="Cancel the auto-detect process">Cancel</button>

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
@@ -6,10 +6,21 @@
     margin-bottom: var(--space-xl);
   }
 
+  // Reserve two lines for the status so a one- vs two-line message never shifts
+  // the bar below it as the auto-detect steps through detectors.
+  .progress-status {
+    line-height: 1.4;
+    min-height: 2.8em;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+  }
+
   .progress-pct {
     margin-top: var(--space-md);
     font-size: var(--font-md);
     color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
   }
 
   button {


### PR DESCRIPTION
## Problem

The progress **bar** itself (not the fill inside it) was getting knocked around as a job moved between stages. Each stage shows status text of a different length — or none at all — and that text was laid out *flanking* the bar (or in a vertically-centered column with it), so the bar's left/right edges and vertical position shifted from stage to stage and item to item. The result read as "stuff is happening" rather than legible progress.

## Fix

Standardize the surrounding text so the bar holds a fixed position everywhere. The rule applied across every multi-stage / multi-item bar:

- **The bar gets its own full-width row.** Nothing variable-width shares its inline row (only the fixed-width Cancel button).
- **All variable text lives on dedicated lines with reserved height**, so text appearing/disappearing or changing length never moves the bar.

### Touched surfaces

- **Dataset / detector / dashboard loading rows** — detail + ETA moved from flanking the bar into a single reserved-height meta line *above* it; the bar row now holds only the bar + Cancel. The subtitle line is reserved so phases with no subtitle don't shift the bar up.
- **Sort / scoring overlay (left panel)** — status + ETA moved to a reserved-height line above a bar + Cancel row.
- **Auto-detect modal** — the status paragraph reserves two lines, so a one- vs two-line message never shifts the bar below it.
- **Find + Browse wait overlays** — the count / ETA / detail lines reserve their height so toggling them no longer re-centers the column and shifts the bar above.

Counts and ETAs also get `tabular-nums` so digit changes don't jiggle their own line.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright/OpenAPI/Docker checks pass, frontend `build:prod` OK (no budget warnings), `npm audit` clean, 862 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019XS7PNuhnDREWz8us17ane)_