### PR TITLE
Compress all job-progress UIs to two lines via shared vt-job-progress

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -103,34 +103,23 @@
                 </td>
                 <td [attr.colspan]="visibleDatasetColumns.length + 1">
                   @if (task.error) {
-                    <div class="loading-task-progress loading-task-failed">
+                    <div class="loading-task-failed">
                       <span class="error-msg">Failed: {{ task.error }}</span>
                       <button class="btn btn--cancel btn--sm" (click)="loadingTasksSvc.dismissLoadingTask(task.task_id)" title="Dismiss this error">Dismiss</button>
                     </div>
                   } @else {
                     @let info = taskProgressInfo(task);
-                    <div class="loading-task-progress">
-                      <div class="progress-context">
-                        <div class="progress-header">{{ info.header }}</div>
-                        <div class="progress-subtitle">{{ info.subtitle }}</div>
-                      </div>
-                      <!-- Variable text lives on its own reserved-height line so
-                           the bar below keeps a fixed position as the detail/ETA
-                           change between stages. -->
-                      <div class="progress-meta">
-                        <span class="progress-msg">{{ info.detail }}</span>
-                        <span class="progress-eta">{{ info.eta }}</span>
-                      </div>
-                      <div class="progress-row">
-                        <vt-progress-bar
-                          [value]="taskBar(task).value"
-                          [max]="taskBar(task).max"
-                          [indeterminate]="taskBar(task).indeterminate"
-                          [smooth]="true"
-                        />
-                        <button class="btn btn--cancel btn--sm" (click)="loadingTasksSvc.cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
-                      </div>
-                    </div>
+                    <vt-job-progress
+                      [cell]="true"
+                      [header]="info.header"
+                      [description]="info.subtitle"
+                      [detail]="info.detail"
+                      [eta]="info.eta"
+                      [bar]="taskBar(task)"
+                      [smooth]="true"
+                      cancelTitle="Cancel this dataset load"
+                      (cancel)="loadingTasksSvc.cancelLoadingTask(task.task_id)"
+                    />
                   }
                 </td>
               </tr>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -243,12 +243,6 @@
     text-overflow: ellipsis;
   }
 
-  .loading-task-progress .progress-msg {
-    font-size: var(--font-xs);
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   &.loading-task-error {
     background: var(--error-bg);
   }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -36,7 +36,7 @@ import {
   DatasetColumn,
   DetectorColumn,
 } from '../../services/dashboard-columns.service';
-import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../job-progress/job-progress.component';
 import { SkeletonComponent } from '../skeleton/skeleton.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
@@ -55,7 +55,7 @@ import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
   selector: 'vt-dashboard',
   standalone: true,
   imports: [
-    ProgressBarComponent,
+    JobProgressComponent,
     AutoDetectResultsModalComponent,
     DatasetCardComponent,
     DetectorCardComponent,

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -38,27 +38,17 @@
        waggle while their job runs; a plain dataset load replaces the actions
        column too. -->
   <td [attr.colspan]="taskKind() === 'projection' ? columnOrder.length : columnOrder.length + 1">
-    <div class="inline-loading-progress">
-      <div class="progress-context">
-        <div class="progress-header">{{ taskProgressInfo.header }}</div>
-        <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
-      </div>
-      <!-- Variable text lives on its own reserved-height line so the bar below
-           keeps a fixed position as the detail/ETA change between stages. -->
-      <div class="progress-meta">
-        <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
-        <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
-      </div>
-      <div class="progress-row">
-        <vt-progress-bar
-          [value]="taskBar.value"
-          [max]="taskBar.max"
-          [indeterminate]="taskBar.indeterminate"
-          [smooth]="true"
-        />
-        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" [title]="taskKind() === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'">Cancel</button>
-      </div>
-    </div>
+    <vt-job-progress
+      [cell]="true"
+      [header]="taskProgressInfo.header"
+      [description]="taskProgressInfo.subtitle"
+      [detail]="taskProgressInfo.detail"
+      [eta]="taskProgressInfo.eta"
+      [bar]="taskBar"
+      [smooth]="true"
+      [cancelTitle]="taskKind() === 'projection' ? 'Cancel building the projection' : 'Cancel this dataset load'"
+      (cancel)="onCancelTask()"
+    />
   </td>
   @if (taskKind() === 'projection') {
     <td class="actions-col">
@@ -75,7 +65,7 @@
 } @else if (loadingTask && loadingTask.error) {
   <!-- Inline error: replace remaining columns (middle + actions) with error message -->
   <td [attr.colspan]="columnOrder.length + 1">
-    <div class="inline-loading-progress inline-loading-failed">
+    <div class="inline-loading-failed">
       <span class="error-msg">Failed: {{ loadingTask.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss this error">Dismiss</button>
     </div>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -253,78 +253,17 @@ td.select-col {
   }
 }
 
-// Inline loading progress (replaces data columns while loading)
-.inline-loading-progress {
+// Inline loading progress now renders via the shared `vt-job-progress`
+// component; only the failed-row variant keeps bespoke styling here.
+.inline-loading-failed {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--space-xs);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-md);
 
-  .progress-context {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2xs);
-  }
-
-  .progress-header {
+  .error-msg {
+    flex: 1;
     font-size: var(--font-sm);
-    color: var(--text-primary);
-    font-weight: var(--weight-medium);
-  }
-
-  // Reserve one line so a phase whose subtitle is empty doesn't shift the bar up.
-  .progress-subtitle {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    line-height: 1.4;
-    min-height: 1.4em;
-  }
-
-  // Detail (left) + ETA (right) share one reserved-height line above the bar so
-  // the bar never moves as the text changes length or appears/disappears.
-  .progress-meta {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-md);
-    font-size: var(--font-xs);
-    line-height: 1.4;
-    min-height: 1.4em;
-  }
-
-  .progress-msg {
-    color: var(--text-muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .progress-eta {
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .progress-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-  }
-
-  vt-progress-bar {
-    flex: 1;
-  }
-
-  &.inline-loading-failed {
-    flex-direction: row;
-    align-items: center;
-
-    .error-msg {
-      flex: 1;
-      font-size: var(--font-sm);
-      color: var(--error-text);
-    }
+    color: var(--error-text);
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListen
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../../job-progress/job-progress.component';
 import {
   ProgressBarState,
   ProgressHeader,
@@ -18,7 +18,7 @@ import { buildDatasetCardMenuItems } from '../card-context-menu-items';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dataset-card',
   standalone: true,
-  imports: [CommonModule, FormsModule, ProgressBarComponent, ContextMenuComponent],
+  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
   templateUrl: './dataset-card.component.html',
   styleUrl: './dataset-card.component.scss',
 })
@@ -230,8 +230,8 @@ export class DatasetCardComponent implements OnChanges {
     return progressBarState(task);
   }
 
-  onCancelTask(event: MouseEvent): void {
-    event.stopPropagation();
+  // `vt-job-progress` stops the click before it reaches the row, so no event.
+  onCancelTask(): void {
     if (this.loadingTask) {
       this.cancelTask.emit(this.loadingTask.task_id);
     }

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -32,31 +32,21 @@
 </td>
 @if (loadingTask && !loadingTask.error) {
   <td [attr.colspan]="columnOrder.length + 1">
-    <div class="loading-task-progress">
-      <div class="progress-context">
-        <div class="progress-header">{{ taskProgressInfo.header }}</div>
-        <div class="progress-subtitle">{{ taskProgressInfo.subtitle }}</div>
-      </div>
-      <!-- Variable text lives on its own reserved-height line so the bar below
-           keeps a fixed position as the detail/ETA change between stages. -->
-      <div class="progress-meta">
-        <span class="progress-msg">{{ taskProgressInfo.detail }}</span>
-        <span class="progress-eta">{{ taskProgressInfo.eta }}</span>
-      </div>
-      <div class="progress-row">
-        <vt-progress-bar
-          [value]="taskBar().value"
-          [max]="taskBar().max"
-          [indeterminate]="taskBar().indeterminate"
-          [smooth]="true"
-        />
-        <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel loading">Cancel</button>
-      </div>
-    </div>
+    <vt-job-progress
+      [cell]="true"
+      [header]="taskProgressInfo.header"
+      [description]="taskProgressInfo.subtitle"
+      [detail]="taskProgressInfo.detail"
+      [eta]="taskProgressInfo.eta"
+      [bar]="taskBar()"
+      [smooth]="true"
+      cancelTitle="Cancel loading"
+      (cancel)="onCancelTask()"
+    />
   </td>
 } @else if (loadingTask?.error) {
   <td [attr.colspan]="columnOrder.length + 1">
-    <div class="loading-task-progress loading-task-failed">
+    <div class="loading-task-failed">
       <span class="error-msg">Failed: {{ loadingTask?.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss error">Dismiss</button>
     </div>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -174,81 +174,18 @@ td.actions-col {
   }
 }
 
-// Inline loading progress (replaces data columns while loading). Mirrors the
-// stack layout used by the dataset card's `.inline-loading-progress` so the
-// dashboard's loading rows have a consistent shape.
-.loading-task-progress {
+// Inline loading progress now renders via the shared `vt-job-progress`
+// component; only the failed-row variant keeps bespoke styling here.
+.loading-task-failed {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--space-xs);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-md);
 
-  .progress-context {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2xs);
-  }
-
-  .progress-header {
+  .error-msg {
+    flex: 1;
     font-size: var(--font-md);
-    color: var(--text-primary);
-    font-weight: var(--weight-medium);
-  }
-
-  // Reserve one line so a phase whose subtitle is empty doesn't shift the bar up.
-  .progress-subtitle {
-    font-size: var(--font-xs);
-    color: var(--text-muted);
-    line-height: 1.4;
-    min-height: 1.4em;
-  }
-
-  // Detail (left) + ETA (right) share one reserved-height line above the bar so
-  // the bar never moves as the text changes length or appears/disappears.
-  .progress-meta {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-md);
-    font-size: var(--font-xs);
-    line-height: 1.4;
-    min-height: 1.4em;
-  }
-
-  .progress-msg {
-    color: var(--text-muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .progress-eta {
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .progress-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-  }
-
-  vt-progress-bar {
-    flex: 1;
-  }
-
-  &.loading-task-failed {
-    flex-direction: row;
-    align-items: center;
-
-    .error-msg {
-      flex: 1;
-      font-size: var(--font-md);
-      color: var(--error-text);
-    }
+    color: var(--error-text);
   }
 }
 

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListen
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../../job-progress/job-progress.component';
 import {
   ProgressBarState,
   ProgressHeader,
@@ -17,7 +17,7 @@ import { buildDetectorCardMenuItems } from '../card-context-menu-items';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-detector-card',
   standalone: true,
-  imports: [CommonModule, FormsModule, ProgressBarComponent, ContextMenuComponent],
+  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
   templateUrl: './detector-card.component.html',
   styleUrl: './detector-card.component.scss',
 })
@@ -263,8 +263,8 @@ export class DetectorCardComponent implements OnChanges {
     this.unload.emit();
   }
 
-  onCancelTask(event: MouseEvent): void {
-    event.stopPropagation();
+  // `vt-job-progress` stops the click before it reaches the row, so no event.
+  onCancelTask(): void {
     if (this.loadingTask) {
       this.cancelTask.emit(this.loadingTask.task_id);
     }

--- a/frontend/src/app/components/job-progress/job-progress.component.html
+++ b/frontend/src/app/components/job-progress/job-progress.component.html
@@ -1,0 +1,39 @@
+<div class="jp">
+  <div class="jp__top">
+    <span class="jp__title">
+      <span class="jp__header" [title]="header">{{ header }}</span>
+      @if (description) {
+        <span
+          class="jp__info"
+          tabindex="0"
+          role="img"
+          [attr.aria-label]="description"
+          [title]="description"
+          >?</span
+        >
+      }
+    </span>
+    @if (cancelTitle !== null) {
+      <button
+        type="button"
+        class="btn btn--cancel btn--sm jp__cancel"
+        (click)="onCancelClick($event)"
+        [title]="cancelTitle"
+      >
+        {{ cancelLabel }}
+      </button>
+    }
+  </div>
+  <!-- Detail is a fixed-width, ellipsized column and the ETA hugs the right
+       edge, so the bar between them keeps both edges still as the text changes. -->
+  <div class="jp__bottom">
+    <span class="jp__detail" [title]="detail">{{ detail }}</span>
+    <vt-progress-bar
+      [value]="bar.value"
+      [max]="bar.max"
+      [indeterminate]="bar.indeterminate"
+      [smooth]="smooth"
+    />
+    <span class="jp__eta">{{ eta }}</span>
+  </div>
+</div>

--- a/frontend/src/app/components/job-progress/job-progress.component.scss
+++ b/frontend/src/app/components/job-progress/job-progress.component.scss
@@ -1,0 +1,128 @@
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
+// Table-cell mode: the host is the direct child of a `<td colspan>` in an
+// auto-layout grid. `width: 0` tells the column-sizing algorithm this cell
+// prefers no width (so the loading row's text can't widen the grid's columns),
+// while `min-width: 100%` stretches the widget back out to fill the cell.
+// `overflow: hidden` clips any content that would otherwise spill.
+:host(.jp-host--cell) {
+  width: 0;
+  min-width: 100%;
+  overflow: hidden;
+}
+
+.jp {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  width: 100%;
+  min-width: 0;
+}
+
+.jp__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  min-height: 1.5em;
+}
+
+// Header + info chip share the left; both stay clamped so a long header
+// truncates instead of wrapping (which would shift the bar down).
+.jp__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+.jp__header {
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+// Small `(?)` chip; its tooltip carries the longer phase description.
+.jp__info {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  border-radius: 50%;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  line-height: 1;
+  cursor: help;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+  }
+}
+
+.jp__cancel {
+  flex: none;
+}
+
+.jp__bottom {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  min-height: 1.5em;
+  min-width: 0;
+}
+
+// Per-item detail. In a table cell it is a fixed-width column so the bar's
+// left edge never moves as the filename/counts change length; outside a table
+// it simply takes the available slack and ellipsizes.
+.jp__detail {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+:host(.jp-host--cell) .jp__detail {
+  flex: 0 0 16ch;
+}
+
+// An empty detail slot must not reserve width (modals have no per-item detail),
+// so the bar can centre. The fixed-width cell rule above always wins in tables.
+.jp__detail:empty {
+  flex-basis: 0;
+}
+
+vt-progress-bar {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+// ETA hugs the right edge; tabular figures + reserved width keep the bar's
+// right edge still as the estimate ticks down.
+.jp__eta {
+  flex: none;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.jp__eta:not(:empty) {
+  min-width: 5.5rem;
+}

--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { JobProgressComponent } from './job-progress.component';
+import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('JobProgressComponent', () => {
+  let component: JobProgressComponent;
+  let fixture: ComponentFixture<JobProgressComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JobProgressComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(JobProgressComponent);
+    component = fixture.componentInstance;
+    await settleZoneless(fixture);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the header, detail and eta', async () => {
+    fixture.componentRef.setInput('header', 'Loading dataset · step 2 of 4 · downloading source');
+    fixture.componentRef.setInput('detail', '(012/345) FileABC.img');
+    fixture.componentRef.setInput('eta', '~5.5 min left');
+    await settleZoneless(fixture);
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('downloading source');
+    expect(text).toContain('FileABC.img');
+    expect(text).toContain('~5.5 min left');
+  });
+
+  it('shows the info chip only when a description is provided', async () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.jp__info')).toBeNull();
+    fixture.componentRef.setInput('description', 'Fetching the dataset archive.');
+    await settleZoneless(fixture);
+    const chip = el.querySelector('.jp__info');
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute('title')).toContain('Fetching the dataset archive');
+  });
+
+  it('renders Cancel by default and hides it when cancelTitle is null', async () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.jp__cancel')).toBeTruthy();
+    fixture.componentRef.setInput('cancelTitle', null);
+    await settleZoneless(fixture);
+    expect(el.querySelector('.jp__cancel')).toBeNull();
+  });
+
+  it('emits cancel and stops the click from bubbling', async () => {
+    const emit = vi.spyOn(component.cancel, 'emit');
+    const btn = (fixture.nativeElement as HTMLElement).querySelector(
+      '.jp__cancel',
+    ) as HTMLButtonElement;
+    const event = new MouseEvent('click', { bubbles: true });
+    const stop = vi.spyOn(event, 'stopPropagation');
+    btn.dispatchEvent(event);
+    expect(emit).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('adds the cell host class in table-cell mode', async () => {
+    expect((fixture.nativeElement as HTMLElement).classList.contains('jp-host--cell')).toBe(false);
+    fixture.componentRef.setInput('cell', true);
+    await settleZoneless(fixture);
+    expect((fixture.nativeElement as HTMLElement).classList.contains('jp-host--cell')).toBe(true);
+  });
+});

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -1,0 +1,64 @@
+import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
+import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { ProgressBarState } from '../../utils/format-progress';
+
+/**
+ * Canonical two-line progress widget shared by every long-running job UI
+ * (dataset / detector loads, the orphan loading-task row, the sort overlay,
+ * and the auto-detect / training modals).
+ *
+ * Line 1 — `header` (truncated to one line) + an optional `(?)` info chip whose
+ * tooltip carries the longer `description`, with a right-justified Cancel.
+ * Line 2 — a fixed-width, ellipsized `detail` slot, the bar (which takes the
+ * slack), and a right-justified `eta`.
+ *
+ * Why a dedicated component: the bar used to be shoved around — horizontally
+ * and vertically — by the variable-length status text around it. Pinning the
+ * detail to a fixed-width column and the ETA to the right edge keeps both of
+ * the bar's edges still as the text changes between phases and items. In a
+ * table cell (`cell` = true) the host also uses the `width: 0; min-width: 100%`
+ * idiom so the loading row's text can't widen the grid's columns under
+ * `table-layout: auto` (see job-progress.component.scss).
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-job-progress',
+  standalone: true,
+  imports: [ProgressBarComponent],
+  templateUrl: './job-progress.component.html',
+  styleUrl: './job-progress.component.scss',
+  host: { '[class.jp-host--cell]': 'cell' },
+})
+export class JobProgressComponent {
+  /** One-line title, e.g. "Loading dataset · step 2 of 4 · downloading source". */
+  @Input() header = '';
+  /** Longer explanation surfaced behind the `(?)` chip; empty hides the chip. */
+  @Input() description = '';
+  /** Per-item detail (left of the bar), e.g. "(012/345) FileABC.img". */
+  @Input() detail = '';
+  /** Right-justified status, e.g. "~5.5 min left" or "45%". */
+  @Input() eta = '';
+  /** Bar fill state; defaults to an indeterminate spinner. */
+  @Input() bar: ProgressBarState = { value: 0, max: 1, indeterminate: true };
+  /** Ease the fill for multi-phase jobs (see `vt-progress-bar`'s `smooth`). */
+  @Input() smooth = false;
+  /** Cancel-button tooltip; `null` hides the button entirely. */
+  @Input() cancelTitle: string | null = 'Cancel';
+  /** Cancel-button label. */
+  @Input() cancelLabel = 'Cancel';
+  /**
+   * Table-cell mode: pin the host to the cell width (`width: 0; min-width:
+   * 100%`) and give the detail slot a fixed width, so the loading row's text
+   * never feeds the auto column-sizing algorithm.
+   */
+  @Input() cell = false;
+
+  readonly cancel = output<void>();
+
+  // Cancel lives inside clickable hosts (a selectable dashboard row); stop the
+  // click here so cancelling never also toggles row selection.
+  onCancelClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.cancel.emit();
+  }
+}

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -1,24 +1,13 @@
 <div class="progress-check-bar">
   @if (sortBusy) {
     <div class="sort-overlay" aria-live="polite">
-      <!-- Status (left) + ETA (right) share one reserved-height line above the
-           bar so the bar keeps a fixed position as the text changes. -->
-      <div class="sort-overlay-meta">
-        <span class="sort-overlay-status">{{ sortStatus }}</span>
-        <span class="sort-overlay-status sort-overlay-eta">{{ sortEta }}</span>
-      </div>
-      <div class="sort-overlay-bar">
-        <vt-progress-bar
-          [indeterminate]="sortBar.indeterminate"
-          [value]="sortBar.value"
-          [max]="sortBar.max"
-        />
-        <button
-          class="btn btn--cancel btn--sm"
-          (click)="onCancel()"
-          title="Cancel the running sort"
-        >Cancel</button>
-      </div>
+      <vt-job-progress
+        [header]="sortStatus"
+        [eta]="sortEta"
+        [bar]="sortBar"
+        cancelTitle="Cancel the running sort"
+        (cancel)="onCancel()"
+      />
     </div>
   } @else {
     <button

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -19,48 +19,6 @@
   min-width: 0;
 }
 
-// Status (left) + ETA (right) on one reserved-height line; the bar below never
-// shifts as the text changes length or appears/disappears.
-.sort-overlay-meta {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-sm);
-  min-height: 1.4em;
-}
-
-.sort-overlay-bar {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--space-sm);
-  min-width: 0;
-
-  vt-progress-bar {
-    flex: 1;
-    min-width: 0;
-  }
-}
-
-.sort-overlay-status {
-  font-size: var(--font-xs);
-  line-height: 1.4;
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-
-// The status text takes the slack; the ETA hugs the right edge.
-.sort-overlay-status:not(.sort-overlay-eta) {
-  flex: 1;
-}
-
-.sort-overlay-eta {
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-}
-
 .labeling-indicator {
   flex: 1;
   display: flex;

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
 
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../../job-progress/job-progress.component';
 import {
   ProgressBarState,
   formatEta,
@@ -12,7 +12,7 @@ import type { LabelingStatusResponse } from '../../../generated/api-client/model
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-progress-indicators',
   standalone: true,
-  imports: [ProgressBarComponent],
+  imports: [JobProgressComponent],
   templateUrl: './progress-indicators.component.html',
   styleUrl: './progress-indicators.component.scss',
 })

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
@@ -1,8 +1,11 @@
 <vt-modal title="Running Auto-Detect" [open]="true" (closed)="close()">
-  <div class="autodetect-progress">
-    <p class="progress-status" aria-live="polite">{{ statusText }}</p>
-    <vt-progress-bar [value]="progress" [max]="100"></vt-progress-bar>
-    <p class="progress-pct">{{ progress }}%</p>
-    <button class="btn btn--secondary" (click)="onCancel()" title="Cancel the auto-detect process">Cancel</button>
+  <div class="autodetect-progress" aria-live="polite">
+    <vt-job-progress
+      [header]="statusText"
+      [eta]="progress + '%'"
+      [bar]="{ value: progress, max: 100, indeterminate: false }"
+      cancelTitle="Cancel the auto-detect process"
+      (cancel)="onCancel()"
+    />
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.scss
@@ -1,29 +1,3 @@
 .autodetect-progress {
-  text-align: center;
   padding: var(--space-2xl);
-
-  p {
-    margin-bottom: var(--space-xl);
-  }
-
-  // Reserve two lines for the status so a one- vs two-line message never shifts
-  // the bar below it as the auto-detect steps through detectors.
-  .progress-status {
-    line-height: 1.4;
-    min-height: 2.8em;
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
-  }
-
-  .progress-pct {
-    margin-top: var(--space-md);
-    font-size: var(--font-md);
-    color: var(--text-secondary);
-    font-variant-numeric: tabular-nums;
-  }
-
-  button {
-    margin-top: var(--space-xl);
-  }
 }

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../../job-progress/job-progress.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autodetect-progress-modal',
   standalone: true,
-  imports: [ModalComponent, ProgressBarComponent],
+  imports: [ModalComponent, JobProgressComponent],
   templateUrl: './autodetect-progress-modal.component.html',
   styleUrl: './autodetect-progress-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -4,16 +4,14 @@
       @if (useCachedHistory()) {
         <p aria-live="polite">Loading indicator history...</p>
       } @else {
-        <p aria-live="polite">Training detectors over label history...</p>
-        <div class="progress-row">
-          <vt-progress-bar [value]="analysisProgress" [max]="100"></vt-progress-bar>
-          <button
-            class="btn btn--cancel btn--sm"
-            (click)="onCancel()"
-            title="Cancel the running analysis"
-          >Cancel</button>
-        </div>
-        <p class="progress-text">{{ analysisProgress }}%</p>
+        <vt-job-progress
+          aria-live="polite"
+          header="Training detectors over label history"
+          [eta]="analysisProgress + '%'"
+          [bar]="{ value: analysisProgress, max: 100, indeterminate: false }"
+          cancelTitle="Cancel the running analysis"
+          (cancel)="onCancel()"
+        />
       }
     </div>
   } @else if (emptyHistory) {

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
@@ -7,22 +7,6 @@
   }
 }
 
-.progress-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-
-  vt-progress-bar {
-    flex: 1;
-  }
-}
-
-.progress-text {
-  margin-top: var(--space-md);
-  font-size: var(--font-md);
-  color: var(--text-secondary);
-}
-
 .chart-container {
   display: flex;
   justify-content: center;

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, O
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { JobProgressComponent } from '../../job-progress/job-progress.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { ChartsService } from '../../../services/charts.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
@@ -20,7 +20,7 @@ export type ProgressMetric = 'smart' | 'stable' | 'diverse';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-progress-modal',
   standalone: true,
-  imports: [ModalComponent, ProgressBarComponent],
+  imports: [ModalComponent, JobProgressComponent],
   templateUrl: './progress-modal.component.html',
   styleUrl: './progress-modal.component.scss',
 })


### PR DESCRIPTION
## Why

The DemoDataset/dataset (and detector) loading bars still jumped **horizontally** as their status text changed. The cause wasn't the reserved-height work from #2052 (that only fixed vertical shift) — it's that these bars live in a `<td colspan>` of the dashboard grid, which is **`table-layout: auto`** until a column is manually resized. Under auto layout the variable-length header/detail text feeds the column-sizing algorithm, so as the text changed length between phases and items it shoved the bar — and the sibling grid columns — around.

They were also tall: **4 rows** (header, description subtitle, detail+ETA, bar+Cancel).

## What changed

A shared **`vt-job-progress`** component renders the canonical **two-line** layout everywhere:

1. **Line 1** — one-line `header` (truncated) + optional `(?)` chip whose tooltip carries the phase description + right-justified **Cancel**.
2. **Line 2** — fixed-width, ellipsized **detail** slot · **bar** (takes the slack) · right-justified **ETA**.

Pinning the detail to a fixed-width column and the ETA to the right edge keeps **both** of the bar's edges still. In table cells the host also uses the `width: 0; min-width: 100%; overflow: hidden` idiom so the loading row's text contributes **zero** intrinsic width and can no longer move the grid's columns under auto layout.

The former description/subtitle line collapses into the `(?)` tooltip.

## Surfaces adopted (all five; six markup sites)

- `dataset-card` (the DemoDataset import) and `detector-card` inline loaders
- the dashboard **orphan loading-task row** (was duplicate inline markup)
- the left-panel **sort/scoring overlay**
- the **auto-detect** and **training/analysis** modals — their standalone Cancel button and percent text fold into the widget (percent now shown in the ETA slot)

## Tests

`./run-tests.sh frontend` green: `build:prod` OK, `npm audit` clean, **868** Vitest tests pass (incl. a new `job-progress.component.spec.ts`); ruff/codespell/deptry/pip-audit/pyright/OpenAPI all clean.

> Note: I diagnosed the horizontal jump from the code (auto-layout grid + variable text) and am confident in the fix, but couldn't watch it render in this environment. If it still moves at all, point me at a watchable env and I'll confirm pixel-by-pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1bCkqf7xkEHvGCvqv1mrN)_