### PR TITLE
Scope dashboard gating so background work doesn't freeze the UI

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -5,14 +5,14 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</span>
       <div class="dashboard-section-actions">
-        <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isLoading || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
+        <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isContextSwitching || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
             <path d="M3 17 C 10 17, 10 12, 17 12"/>
             <polyline points="18 9 21 12 18 15"/>
           </svg>
         </button>
-        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
+        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isContextSwitching || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
           <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm() && wasDeletingSelectedDatasetsConfirm()" (animationend)="onDeleteSelectedDatasetsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 6 5 6 21 6"></polyline>
             <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
@@ -23,11 +23,10 @@
         </button>
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
-          [disabled]="isLoading"
+          [disabled]="isContextSwitching"
           (click)="openImporterModal()" title="Import a new dataset"><span class="plus-icon"
             [class.plus-open]="importerModalOpen"
             [class.plus-close]="importerClosing()"
-            [class.icon-waggle]="addDatasetBusy"
             (animationend)="onImporterAnimationEnd()">+</span></button>
       </div>
     </div>
@@ -51,7 +50,7 @@
           <thead>
             <tr>
               <th class="select-col" data-col="select" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['select'] : null">
-                <button class="select-checkbox header-checkbox" (click)="toggleAllDatasets()" [disabled]="isLoading || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
+                <button class="select-checkbox header-checkbox" (click)="toggleAllDatasets()" [disabled]="isContextSwitching || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (datasetSelectionState) {
                     @case ('all') {
                       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -142,13 +141,13 @@
                 [isDefaultLogin]="isDefaultLogin()"
                 [columnOrder]="visibleDatasetColumns"
                 [selected]="isDatasetSelected(dataset.id)"
-                [dimmed]="isLoading && !isDatasetSelected(dataset.id)"
+                [dimmed]="isContextSwitching && !isDatasetSelected(dataset.id)"
                 [loadingTask]="browsePrep.displayTask(dataset.id) ?? loadingTasksSvc.getInlineTask(dataset.id)"
                 [taskKind]="browsePrep.taskKind(dataset.id)"
                 [statsOpen]="modals.stats.open && modals.stats.datasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId() === dataset.id"
-                (rowClick)="!isLoading && toggleDatasetSelection(dataset.id, $event)"
-                (checkboxToggle)="!isLoading && toggleDatasetCheckbox(dataset.id)"
+                (rowClick)="!isContextSwitching && toggleDatasetSelection(dataset.id, $event)"
+                (checkboxToggle)="!isContextSwitching && toggleDatasetCheckbox(dataset.id)"
                 (rename)="renameDataset(dataset, $event)"
                 (stats)="showDatasetStats(dataset)"
                 (delete)="deleteDataset(dataset)"
@@ -172,14 +171,14 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Trained detectors for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Detectors</span>
       <div class="dashboard-section-actions">
-        <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isLoading || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
+        <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isContextSwitching || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
             <path d="M3 17 C 10 17, 10 12, 17 12"/>
             <polyline points="18 9 21 12 18 15"/>
           </svg>
         </button>
-        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDetectors()" [disabled]="isLoading || selectedDetectorIds.size === 0" [title]="selectedDetectorIds.size === 0 ? 'No detectors selected' : 'Delete selected detectors'" aria-label="Delete selected">
+        <button class="side-action-btn side-action-delete" (click)="deleteSelectedDetectors()" [disabled]="isContextSwitching || selectedDetectorIds.size === 0" [title]="selectedDetectorIds.size === 0 ? 'No detectors selected' : 'Delete selected detectors'" aria-label="Delete selected">
           <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDetectorsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDetectorsConfirm() && wasDeletingSelectedDetectorsConfirm()" (animationend)="onDeleteSelectedDetectorsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 6 5 6 21 6"></polyline>
             <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
@@ -190,7 +189,7 @@
         </button>
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
-          [disabled]="isLoading"
+          [disabled]="isContextSwitching"
           (click)="openNewDetectorModal()" title="Create a new detector"><span class="plus-icon"
             [class.plus-open]="newDetectorModalOpen"
             [class.plus-close]="newDetectorClosing()"
@@ -217,7 +216,7 @@
           <thead>
             <tr>
               <th class="select-col" data-col="select" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['select'] : null">
-                <button class="select-checkbox header-checkbox" (click)="toggleAllDetectors()" [disabled]="isLoading || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
+                <button class="select-checkbox header-checkbox" (click)="toggleAllDetectors()" [disabled]="isContextSwitching || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (detectorSelectionState) {
                     @case ('all') {
                       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -268,14 +267,14 @@
                 [isDefaultLogin]="isDefaultLogin()"
                 [columnOrder]="visibleDetectorColumns"
                 [selected]="isDetectorSelected(detector.id)"
-                [dimmed]="isLoading && !isDetectorSelected(detector.id)"
+                [dimmed]="isContextSwitching && !isDetectorSelected(detector.id)"
                 [loadingTask]="loadingTasksSvc.getInlineDetectorTask(detector.id)"
                 [deleteConfirmOpen]="deletingDetectorId() === detector.id"
                 [addLabelsOpen]="modals.addLabels.open && modals.addLabels.detectorId === detector.id"
                 [exportOpen]="modals.export.open && modals.export.detectorName === detector.name"
                 [statsOpen]="modals.detectorStats.open && modals.detectorStats.detectorId === detector.id"
-                (rowClick)="!isLoading && toggleDetectorSelection(detector.id, $event)"
-                (checkboxToggle)="!isLoading && toggleDetectorCheckbox(detector.id)"
+                (rowClick)="!isContextSwitching && toggleDetectorSelection(detector.id, $event)"
+                (checkboxToggle)="!isContextSwitching && toggleDetectorCheckbox(detector.id)"
                 (rename)="renameDetector(detector, $event)"
                 (delete)="deleteDetector(detector)"
                 (load)="loadDetector(detector)"
@@ -313,7 +312,7 @@
       <button
         class="btn btn--primary"
         [class.loading-active]="trainLoading()"
-        [disabled]="!labelEnabled || isLoading"
+        [disabled]="!labelEnabled || isNavBusy"
         [title]="labelHint || 'Open the labeling view to vote on items and train the selected detector on the selected dataset'"
         (click)="onLabel()"
       >
@@ -326,7 +325,7 @@
       <button
         class="btn btn--primary"
         [class.loading-active]="findLoading()"
-        [disabled]="!findEnabled || isLoading"
+        [disabled]="!findEnabled || isNavBusy"
         [title]="findHint || 'Score every item in the selected dataset using the selected detector and show ranked results'"
         (click)="onFind()"
       >

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -98,12 +98,13 @@
   to { transform: rotate(90deg); }
 }
 
-// The `+` Add-dataset glyph opts into the shared `.icon-waggle` while datasets
-// are downloading/installing (the button is disabled the whole time via
-// `isLoading`). `inline-block` is required for the waggle's transform to apply
-// to the otherwise-inline span. The `+`'s 90° rotational symmetry means its
-// start/end frames look identical, but `.icon-waggle`'s `ease-in-out` sweep
-// passes smoothly through `×` so the motion still reads.
+// The `+` Add-dataset / Add-detector glyph animates between `+` and `×` via the
+// `.plus-open` / `.plus-close` classes as its modal opens and closes.
+// `inline-block` is required for those rotation transforms to apply to the
+// otherwise-inline span. (The button no longer waggles during background
+// imports: it stays enabled now so a second import can start mid-load, and an
+// animating-but-clickable button would read as a pending action, not progress.
+// In-flight imports surface as their own progress rows in the table instead.)
 .plus-icon {
   display: inline-block;
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -310,6 +310,49 @@ describe('DashboardComponent', () => {
     });
   });
 
+  describe('parallel-task gating (isContextSwitching / isNavBusy)', () => {
+    // Regression guard for the GRID parallelism fix. Background work
+    // (dataset imports, card-initiated loads, browse-prep of another row)
+    // sets `datasetState.loading`, but that must NOT freeze independent
+    // dashboard actions — on a big machine you can saturate the import
+    // slots and still start another import, create/delete a detector, or
+    // change the selection. Only an in-flight *active-pair switch* gates
+    // them, via `isContextSwitching`. Train/Find additionally wait out a
+    // browse-prep (whose completion fires a competing /browse navigation),
+    // via `isNavBusy`.
+
+    it('keeps independent actions live while only a background load runs', () => {
+      flushInitialRequests();
+      vi.spyOn(component.datasetState, 'loading', 'get').mockReturnValue(true);
+      // A background import/load is the ONLY thing in flight.
+      expect(component.isContextSwitching).toBe(false);
+      expect(component.isNavBusy).toBe(false);
+    });
+
+    it('gates the whole dashboard during an active-pair context switch', () => {
+      flushInitialRequests();
+      vi.spyOn(component['contextSwitch'], 'switching', 'get').mockReturnValue(true);
+      expect(component.isContextSwitching).toBe(true);
+      expect(component.isNavBusy).toBe(true);
+    });
+
+    it('gates on a Train or Find click intent', () => {
+      flushInitialRequests();
+      component.trainLoading.set(true);
+      expect(component.isContextSwitching).toBe(true);
+      component.trainLoading.set(false);
+      component.findLoading.set(true);
+      expect(component.isContextSwitching).toBe(true);
+    });
+
+    it('gates Train/Find during browse-prep but leaves independent actions live', () => {
+      flushInitialRequests();
+      vi.spyOn(component.browsePrep, 'preparing', 'get').mockReturnValue(true);
+      expect(component.isContextSwitching).toBe(false);
+      expect(component.isNavBusy).toBe(true);
+    });
+  });
+
   describe('label hints', () => {
     it('should hint about missing dataset', () => {
       flushInitialRequests();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1119,30 +1119,35 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Button state ---
 
-  get isLoading(): boolean {
-    // Phase 2: the `activeContextGuard` owns the dataset/detector load
-    // path the Train/Find buttons used to drive locally. We mirror its
-    // signals (plus the per-button click-intent flags) here so
-    // dashboard controls stay disabled while the guard waits between
-    // click and route activation.
-    return (
-      this.trainLoading() ||
-      this.findLoading() ||
-      this.browsePrep.preparing ||
-      this.contextSwitch.switching ||
-      this.datasetState.loading
-    );
+  /** True only while the **active (dataset, detector) pair** is mid-switch:
+   *  a top-bar pulldown change, or a Train/Find click, that the
+   *  `activeContextGuard` is still promoting. That promotion is the
+   *  H25-critical window — the moment the HTTP interceptor's request
+   *  tagging is in transition — so the dashboard freezes its controls
+   *  while it lasts (a brief beat between click and route activation).
+   *
+   *  It deliberately EXCLUDES `datasetState.loading`. That flag is also
+   *  set, separately, for *background* work — dataset imports, registry
+   *  loads kicked off from a card, browse-prep of another row — which has
+   *  nothing to do with the active pair and must not freeze the rest of
+   *  the dashboard. (The same background load sets BOTH `datasetState.
+   *  loading` and `contextSwitch.switching` only when it's part of an
+   *  active-pair switch, so dropping the former loses no coverage of the
+   *  real switch window.) The upshot: on the GRID you can saturate the
+   *  concurrent-import slots and still start another import, create or
+   *  delete a detector, or change the selection — none of it is gated on
+   *  background work, only on the in-flight context switch. */
+  get isContextSwitching(): boolean {
+    return this.trainLoading() || this.findLoading() || this.contextSwitch.switching;
   }
 
-  /** True while one or more datasets are actively downloading/installing
-   *  (`datasetState.loading` is set from the count of active dataset
-   *  loading tasks). This is the slice of `isLoading` that disables the
-   *  `+` Add-dataset button while loads are in flight — saturate the
-   *  concurrent-download limit and several stay active, holding the
-   *  button disabled the whole time. Drives the `+` icon's waggle so the
-   *  disabled button reads as "busy, slots are full" rather than dead. */
-  get addDatasetBusy(): boolean {
-    return this.datasetState.loading;
+  /** Train/Find gate on this rather than `isContextSwitching` because they
+   *  must also wait out an in-flight browse-prep: when its projection build
+   *  finishes it fires a navigation to `/browse/:id`, and starting a Train/
+   *  Find navigation underneath it would race that redirect. Independent
+   *  actions don't care — to them browse-prep is just more background work. */
+  get isNavBusy(): boolean {
+    return this.isContextSwitching || this.browsePrep.preparing;
   }
 
   get labelEnabled(): boolean {


### PR DESCRIPTION
## Problem

On the Dashboard, nearly every control was disabled behind a single `isLoading` flag. That flag conflated two unrelated things:

1. An **in-flight active-pair context switch** — the H25-critical window where the HTTP interceptor's request tagging is mid-transition (`contextSwitch.switching`, plus the Train/Find click-intent flags).
2. Any **background loading task** — dataset imports, card-initiated registry loads, browse-prep of another row. These set `datasetState.loading` purely as progress state.

Because `isLoading` included `datasetState.loading`, background work froze **everything**: you could not start a second import, create a detector, delete an idle detector, combine, or even change the table selection while one import was downloading — despite the backend running all of these concurrently (imports are gated only by the configurable `max_concurrent_dataset_*` limits; detector deletion is an instant `path.unlink()` with no busy check).

## Fix

Split the one flag into two scoped getters in `DashboardComponent`:

- **`isContextSwitching`** = `trainLoading() || findLoading() || contextSwitch.switching`. Gates the independent actions (add/combine/delete dataset & detector, select-all, row click/checkbox) and row dimming. It deliberately **excludes** `datasetState.loading`, so background work no longer freezes them. No coverage of the real switch window is lost: an active-pair switch sets `contextSwitch.switching` too.
- **`isNavBusy`** = `isContextSwitching || browsePrep.preparing`. Gates only **Train/Find**, which must additionally wait out an in-flight browse-prep (its completion fires a competing navigation to `/browse/:id`).

The Add-dataset `+` glyph no longer waggles during imports — the button stays enabled now (so a second import can start mid-load), and an animating-but-clickable button reads as a pending action rather than progress. In-flight imports already surface as their own progress rows in the table.

## Result

During a background import/load, the dashboard stays fully interactive: start another import, create/delete/combine a detector, change the selection, even Find a different dataset. The brief active-pair switch still freezes the relevant controls exactly as before.

## Tests

- Added 4 regression tests covering both getters (background-load stays live; context-switch gates all; Train/Find click intent gates; browse-prep gates Train/Find but not independent actions).
- `./run-tests.sh frontend` green: ruff / pyright / codespell / deptry / pip-audit / OpenAPI / Dockerfiles / docs-wiring all pass; frontend TS build OK; Vitest **866 passed**. Frontend-only change — Python pytest groups are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnxEPN17wvabkmeCRrFjoK)_