### PR TITLE
Bin popup: detail-canvas size buttons, relocated item count, on-screen clamp

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -336,6 +336,12 @@
             },
             "type": "object"
           },
+          "popup_preview_size": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object"
+          },
           "safe_thresholds": {
             "type": "boolean"
           },
@@ -4583,6 +4589,7 @@
           "last_embedder_per_media_type": {},
           "panel_pct_left": {},
           "panel_pct_right": {},
+          "popup_preview_size": {},
           "safe_thresholds": {
             "type": "boolean"
           },

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -11,11 +11,28 @@
     class="bin-popup-header"
     [class.dragging]="dragging"
     (pointerdown)="onHeaderPointerDown($event)">
-    <span
-      class="bin-popup-title"
-      [title]="'Items in this bin (' + ids.length + ') — drag to move'">
-      {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
-    </span>
+    @if (showPreview) {
+      <div class="bin-popup-size-group" role="group" aria-label="Detail image size">
+        <button
+          type="button"
+          class="bin-popup-size-btn"
+          [disabled]="atMinPreview"
+          (click)="bumpPreview(-1)"
+          title="Smaller detail image"
+          aria-label="Smaller detail image">
+          <vt-icon type="image" [size]="11" />
+        </button>
+        <button
+          type="button"
+          class="bin-popup-size-btn"
+          [disabled]="atMaxPreview"
+          (click)="bumpPreview(1)"
+          title="Bigger detail image"
+          aria-label="Bigger detail image">
+          <vt-icon type="image" [size]="18" />
+        </button>
+      </div>
+    }
     <vt-view-controls
       side="popup"
       [currentMediaType]="mediaType()"
@@ -47,10 +64,16 @@
     }
 
     @if (!previewOnly) {
-      <cdk-virtual-scroll-viewport
-        [itemSize]="rowSize"
-        class="bin-popup-scroll"
-        (mouseleave)="onGridLeave()">
+      <div class="bin-popup-grid-col">
+        <span
+          class="bin-popup-count"
+          [title]="'Items in this bin (' + ids.length + ')'">
+          {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
+        </span>
+        <cdk-virtual-scroll-viewport
+          [itemSize]="rowSize"
+          class="bin-popup-scroll"
+          (mouseleave)="onGridLeave()">
         <div
           *cdkVirtualFor="let row of rows; trackBy: trackByRow"
           class="bin-popup-row"
@@ -85,7 +108,8 @@
             </div>
           }
         </div>
-      </cdk-virtual-scroll-viewport>
+        </cdk-virtual-scroll-viewport>
+      </div>
     }
   </div>
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -35,14 +35,55 @@
   }
 }
 
-.bin-popup-title {
-  font-size: var(--font-xs);
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+// Top-left detail-canvas (large preview) size buttons. A segmented pair that
+// mirrors the top-right grid-thumbnail size buttons (``vc-btn--size``), but
+// resizes the single large preview — and so the whole popup — instead of the
+// member thumbnails.
+.bin-popup-size-group {
+  display: inline-flex;
   flex-shrink: 0;
+}
+
+.bin-popup-size-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 22px;
+  padding: 0 var(--space-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base),
+    border-color var(--transition-base);
+
+  &:not(:first-child) {
+    margin-left: -1px;
+  }
+
+  &:first-child {
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  &:last-child {
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+    z-index: 1;
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+
+  vt-icon {
+    line-height: 0;
+  }
 }
 
 .bin-popup-view-controls {
@@ -100,12 +141,36 @@
   display: block;
 }
 
-// The scrolling thumbnail grid. Fixed-width column so the popup hugs it plus
-// the preview pane; height fills the bound body height so the viewport scrolls.
-.bin-popup-scroll {
+// The grid column: a fixed-width stack of the member-count label above the
+// scrolling thumbnail grid, so the popup hugs it plus the preview pane. The
+// count sits at the column's top-left; the grid fills the remaining height.
+.bin-popup-grid-col {
   width: 280px;
   height: 100%;
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+// Member-count label, top-left of the grid column.
+.bin-popup-count {
+  flex-shrink: 0;
+  font-size: var(--font-xs);
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+  padding: 0 var(--space-2xs) var(--space-2xs);
+}
+
+// The scrolling thumbnail grid fills the column below the count label.
+.bin-popup-scroll {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-x: hidden;
 }
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -7,8 +7,10 @@ import { MediaMetadataCacheService } from '../../services/media-metadata-cache.s
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { IconComponent } from '../icon/icon.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { usesThumbnails } from '../browse-canvas/hex-render.util';
+import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 
 /** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
 const GRID_LABEL_HEIGHT = 18;
@@ -51,6 +53,15 @@ const PREVIEW_OVERSIZE = 2.0;
  * {@link PREVIEW_OVERSIZE}.
  */
 const HOVER_EXTENT_PER_RADIUS = 3;
+/** Vertical room (px) the member-count label takes above the scrolling grid. */
+const COUNT_LABEL_HEIGHT = 22;
+/**
+ * Discrete ladder (px) of detail-canvas sizes the top-left size buttons step
+ * through. Each click moves to the next rung past the current size in the click
+ * direction, so the popup grows/shrinks in clean increments. Bounded by
+ * {@link MIN_PREVIEW_PX}..{@link MAX_PREVIEW_PX}.
+ */
+const PREVIEW_SIZE_STEPS = [120, 160, 208, 272, 352, 448, 560, 640, 720] as const;
 
 /**
  * The bin popup: a floating panel showing the media items in the bin the user
@@ -69,9 +80,16 @@ const HOVER_EXTENT_PER_RADIUS = 3;
  * The thumbnail size of the grid is remembered per media type under the
  * ``grid_icon_size_popup`` setting (independent of the left/right panels), so
  * tuning the popup while browsing one bin becomes the default for every future
- * popup of that media type. The in-header {@link ViewControlsComponent} writes
+ * popup of that media type. The top-right {@link ViewControlsComponent} writes
  * that setting (its Grid/List toggle is hidden here) and this component re-reads
  * it from {@link SettingsStateService}, keyed by the active dataset's media type.
+ *
+ * A second, top-left pair of size buttons controls the *detail canvas* (the
+ * large preview pane) rather than the grid thumbnails. Because the popup's
+ * height is the preview pane's height, growing/shrinking the detail canvas
+ * resizes the whole window. That size is likewise remembered per media type,
+ * under ``popup_preview_size`` (px); unset, the pane falls back to a size scaled
+ * from the main-canvas thumbnail radius ({@link hoverThumbRadius}).
  *
  * It shares the {@link BrowseSelectionService} instance provided by the browse
  * view, so toggling an item here is the same selection the canvas rings and the
@@ -84,7 +102,7 @@ const HOVER_EXTENT_PER_RADIUS = 3;
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-bin-popup',
   standalone: true,
-  imports: [CommonModule, ScrollingModule, ViewControlsComponent],
+  imports: [CommonModule, ScrollingModule, ViewControlsComponent, IconComponent],
   templateUrl: './browse-bin-popup.component.html',
   styleUrl: './browse-bin-popup.component.scss',
 })
@@ -179,7 +197,15 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
       this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
+      this.previewSizeDict = (settings.popup_preview_size as Record<string, number>) ?? {};
       this.applyViewPrefs();
+      // A detail-canvas size change (the top-left buttons) resizes the preview
+      // pane, hence the whole popup, so re-clamp it back fully on-screen.
+      const override = this.previewOverride;
+      if (override !== this.lastPreviewOverride) {
+        this.lastPreviewOverride = override;
+        setTimeout(() => this.place());
+      }
     });
     // A selection change anywhere (here, the canvas, the panel) re-highlights.
     // An effect on the signal (rather than a `changed$` subscription) schedules
@@ -246,6 +272,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   }
 
   private gridSizeDict: Record<string, string> = {};
+  /** Per-media-type detail-canvas size (px) the user has chosen via the popup's
+   *  top-left buttons; absent entries fall back to the radius-derived default. */
+  private previewSizeDict: Record<string, number> = {};
+  /** Last applied preview override, so the settings effect only re-clamps the
+   *  popup when the detail-canvas size actually changed. */
+  private lastPreviewOverride: number | null = null;
 
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
@@ -297,17 +329,65 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return Math.min(Math.max(this.rows.length, 1) * this.rowSize, this.bodyCapPx);
   }
 
-  /** Target/minimum side (px) of the square preview pane: scaled up from the
-   *  item's on-canvas mouse-over break-out at the current main-canvas thumbnail
-   *  size, clamped to the room the visible region leaves. The rendered pane grows
-   *  to {@link previewPaneSize} (the full body height) when the member grid is
+  /** The user's chosen detail-canvas size (px) for the active media type, or
+   *  ``null`` when they haven't set one (and the radius-derived default is used). */
+  get previewOverride(): number | null {
+    const mediaType = this.mediaType();
+    const value = mediaType ? this.previewSizeDict[mediaType] : undefined;
+    return typeof value === 'number' ? value : null;
+  }
+
+  /** Detail-canvas side (px) the popup opens at before any user override:
+   *  scaled up from the item's on-canvas mouse-over break-out at the current
+   *  main-canvas thumbnail size. */
+  private previewDefault(): number {
+    return this.hoverThumbRadius() * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
+  }
+
+  /** Target/minimum side (px) of the square preview pane: the user's chosen size
+   *  (the top-left buttons) or, unset, a size scaled up from the item's
+   *  on-canvas mouse-over break-out at the current main-canvas thumbnail size.
+   *  Clamped to the room the visible region leaves. The rendered pane grows to
+   *  {@link previewPaneSize} (the full body height) when the member grid is
    *  taller. Zero when there is no preview. */
   get previewSize(): number {
     if (!this.showPreview) return 0;
-    const desired = this.hoverThumbRadius() * HOVER_EXTENT_PER_RADIUS * PREVIEW_OVERSIZE;
+    const desired = this.previewOverride ?? this.previewDefault();
     // Keep it within the vertical room the region leaves (which already folds in
     // the absolute MAX_PREVIEW_PX cap via ``previewCapPx``).
     return Math.round(Math.max(MIN_PREVIEW_PX, Math.min(desired, this.previewCapPx)));
+  }
+
+  /** Step the detail-canvas size to the next ladder rung past the current size in
+   *  the given direction and persist it (per media type, under
+   *  ``popup_preview_size``), so it becomes the default for future popups of this
+   *  type — mirroring how the grid thumbnail-size buttons persist. The settings
+   *  effect re-clamps the popup so growing the canvas can't push it off-screen. */
+  bumpPreview(delta: 1 | -1): void {
+    const mediaType = this.mediaType();
+    if (!this.showPreview || !mediaType) return;
+    const current = this.previewOverride ?? Math.round(this.previewDefault());
+    const next =
+      delta > 0
+        ? (PREVIEW_SIZE_STEPS.find((s) => s > current) ?? PREVIEW_SIZE_STEPS[PREVIEW_SIZE_STEPS.length - 1])
+        : ([...PREVIEW_SIZE_STEPS].reverse().find((s) => s < current) ?? PREVIEW_SIZE_STEPS[0]);
+    if (next === this.previewOverride) return;
+    const dict = { ...this.previewSizeDict, [mediaType]: next };
+    this.settingsState.update({ popup_preview_size: dict } as SettingsUpdate).subscribe();
+  }
+
+  /** True when the detail canvas is already at the smallest ladder rung. */
+  get atMinPreview(): boolean {
+    if (!this.showPreview) return true;
+    const current = this.previewOverride ?? Math.round(this.previewDefault());
+    return current <= PREVIEW_SIZE_STEPS[0];
+  }
+
+  /** True when the detail canvas is already at the largest ladder rung. */
+  get atMaxPreview(): boolean {
+    if (!this.showPreview) return true;
+    const current = this.previewOverride ?? Math.round(this.previewDefault());
+    return current >= PREVIEW_SIZE_STEPS[PREVIEW_SIZE_STEPS.length - 1];
   }
 
   /** True for a one-member bin that has a preview pane: the grid would just
@@ -317,11 +397,19 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return this.showPreview && this.ids.length === 1;
   }
 
-  /** Height (px) of the body row: tall enough for the grid (capped to the
-   *  region), but at least the preview pane's height so the pane is shown in
-   *  full. The preview may exceed the grid's cap; both are region-bounded. */
+  /** Height (px) of the grid column: the scrolling grid (capped to the region)
+   *  plus the member-count label stacked above it. Zero for a singleton bin
+   *  (no grid column — only the preview). */
+  get gridColHeight(): number {
+    return this.previewOnly ? 0 : this.gridHeight + COUNT_LABEL_HEIGHT;
+  }
+
+  /** Height (px) of the body row: tall enough for the grid column (grid capped to
+   *  the region, plus its count label), but at least the preview pane's height so
+   *  the pane is shown in full. The preview may exceed the grid's cap; both are
+   *  region-bounded. */
   get bodyHeight(): number {
-    return Math.max(this.gridHeight, this.previewSize);
+    return Math.max(this.gridColHeight, this.previewSize);
   }
 
   /** Side (px) of the *rendered* square preview pane. {@link previewSize} is the
@@ -502,9 +590,42 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   // --- Positioning ---------------------------------------------------------
 
   /** Re-clamp the popup, anchoring at the summon point unless the user has
-   *  dragged it (then keep their spot, just nudged back on-screen if needed). */
+   *  dragged it (then keep their spot, just nudged back on-screen if needed).
+   *  The computed clamp derives the popup size from known widths/heights; once
+   *  it has laid out we additionally measure the real panel and correct any
+   *  residual overflow, so the window ends up entirely on-screen even if the
+   *  computed height drifts from what actually rendered. */
   private place(): void {
     this.clampInto(this.dragged ? this.left : this.x(), this.dragged ? this.top : this.y());
+    requestAnimationFrame(() => this.nudgeOnScreen());
+  }
+
+  /** Measure the rendered panel and slide it so its real rect sits inside the
+   *  visible region (canvas ∩ viewport), keeping the bottom (and the detail
+   *  image's bottom with it) on-screen. Purely corrective: a no-op when the
+   *  computed clamp already fits. */
+  private nudgeOnScreen(): void {
+    const panel = this.panelRef?.nativeElement;
+    if (!panel) return;
+    const rect = panel.getBoundingClientRect();
+    const b = this.bounds();
+    const regionLeft = Math.max(b ? b.left : 0, 0);
+    const regionTop = Math.max(b ? b.top : 0, 0);
+    const regionRight = Math.min(b ? b.right : window.innerWidth, window.innerWidth);
+    const regionBottom = Math.min(b ? b.bottom : window.innerHeight, window.innerHeight);
+    let l = this.left;
+    let t = this.top;
+    // Pull in from the far edges first, then guarantee the near edges, so a popup
+    // larger than the region pins to top-left (losing the far edge, not the near).
+    if (rect.right > regionRight - EDGE_MARGIN) l -= rect.right - (regionRight - EDGE_MARGIN);
+    if (rect.bottom > regionBottom - EDGE_MARGIN) t -= rect.bottom - (regionBottom - EDGE_MARGIN);
+    l = Math.max(regionLeft + EDGE_MARGIN, l);
+    t = Math.max(regionTop + EDGE_MARGIN, t);
+    if (l !== this.left || t !== this.top) {
+      this.left = l;
+      this.top = t;
+      this.cdr.markForCheck();
+    }
   }
 
   /** Clamp ``(desiredLeft, desiredTop)`` so the *whole* popup sits inside the
@@ -532,7 +653,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     // Squeeze the scrolling body to whatever vertical room the region leaves, so
     // a short canvas can't make the popup taller than what's visible.
     const regionRoom = regionBottom - regionTop - 2 * EDGE_MARGIN - headerH;
-    this.bodyCapPx = Math.max(MIN_BODY_PX, Math.min(MAX_BODY_PX, regionRoom));
+    // The grid column also carries the member-count label above the scroll, so
+    // its cap leaves that label room; the scroll then fills what's left.
+    const gridRoom = regionRoom - COUNT_LABEL_HEIGHT;
+    this.bodyCapPx = Math.max(MIN_BODY_PX, Math.min(MAX_BODY_PX, gridRoom));
     // The preview gets its own, larger cap: it may grow past the grid's body cap,
     // bounded only by the visible region and the absolute MAX_PREVIEW_PX.
     this.previewCapPx = Math.max(MIN_PREVIEW_PX, Math.min(MAX_PREVIEW_PX, regionRoom));

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -422,6 +422,24 @@ class TestSettingsAPI:
         res = client.put("/api/settings", json={"grid_icon_size_popup": {"audio": "TINY"}})
         assert res.status_code == 400
 
+    def test_update_popup_preview_size_per_type(self, client):
+        res = client.put("/api/settings", json={"popup_preview_size": {"image": 320, "video": 480}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["popup_preview_size"]["image"] == 320
+        assert data["popup_preview_size"]["video"] == 480
+
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["popup_preview_size"]["image"] == 320
+
+    def test_update_popup_preview_size_clamps_out_of_range(self, client):
+        # Values outside POPUP_PREVIEW_SIZE_PX (96..720) clamp rather than reject.
+        res = client.put("/api/settings", json={"popup_preview_size": {"image": 5000, "video": 1}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["popup_preview_size"]["image"] == 720
+        assert data["popup_preview_size"]["video"] == 96
+
     def test_update_focus_mode_left_per_type(self, client):
         res = client.put("/api/settings", json={"focus_mode_left": {"audio": "hover", "image": "click"}})
         assert res.status_code == 200

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -100,6 +100,9 @@ class AppSettingsSchema(Schema):
     # VTSBrowse bin-popup thumbnail size, per media type. Driven by the popup's
     # own size buttons and the Settings → Browser tab. (The popup is grid-only.)
     grid_icon_size_popup = _PerMediaTypeStringDict()
+    # VTSBrowse bin-popup detail-canvas (large single-item preview) size in CSS
+    # px, per media type. Driven by the popup's own top-left size buttons.
+    popup_preview_size = _PerMediaTypeIntDict()
 
     # Server-tier. These are fixed at server start (config file /
     # environment / CLI flags) and shared across all users; the frontend
@@ -204,6 +207,7 @@ class SettingsUpdateSchema(Schema):
     panel_pct_left = fields.Raw()
     panel_pct_right = fields.Raw()
     grid_icon_size_popup = fields.Raw()
+    popup_preview_size = fields.Raw()
 
     autopilot_enabled = fields.Boolean()
     hide_autopilot = fields.Boolean()

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -30,6 +30,7 @@ from vtscore.config import DATA_DIR, DEFAULT_CALIBRATE_COUNT
 
 __all__ = [
     "BROWSE_THUMBNAIL_BORDER_PX",
+    "POPUP_PREVIEW_SIZE_PX",
     "BinShape",
     "BrowseColormap",
     "BrowseIconSize",
@@ -82,6 +83,11 @@ VALID_PANEL_PX: tuple[int, int] = (150, 10000)
 # Allowed range (CSS px) for the VTSBrowse pile-thumbnail border width. ``0``
 # disables the border; values are clamped into this range on read/write.
 BROWSE_THUMBNAIL_BORDER_PX: tuple[int, int] = (0, 8)
+# Allowed range (CSS px) for the VTSBrowse bin-popup detail-canvas (the large
+# single-item preview) side. The popup's own size buttons drive it; values are
+# clamped into this range on read/write. The floor keeps a usable preview; the
+# ceiling matches the frontend's absolute preview cap.
+POPUP_PREVIEW_SIZE_PX: tuple[int, int] = (96, 720)
 
 
 def _clamp(lo: float, hi: float):
@@ -286,6 +292,14 @@ class UserSettings(BaseModel):
     # per-side machinery): the popup is a single, third context, so it uses the
     # generic Pydantic-driven accessors.
     grid_icon_size_popup: dict[str, Annotated[GridIconSize, BeforeValidator(_upper)]] = Field(default_factory=dict)
+    # VTSBrowse bin-popup detail-canvas size, per media type (CSS px). The popup
+    # opens its hovered/representative item in a large square preview pane beside
+    # the member grid; this is the user's chosen side for that pane, driven by the
+    # popup's own top-left size buttons (independent of the grid thumbnail size in
+    # ``grid_icon_size_popup``). Empty entries fall back on the frontend to a size
+    # derived from the main-canvas thumbnail radius. Clamped to
+    # ``POPUP_PREVIEW_SIZE_PX``.
+    popup_preview_size: dict[str, Annotated[int, _clamp(*POPUP_PREVIEW_SIZE_PX)]] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)
 


### PR DESCRIPTION
Right-clicking a thumbnailable pile on the VTSBrowse canvas opens the bin detail popup. This addresses three layout issues with it.

## 1. Keep the whole popup on-screen
The popup was routinely positioned too low, so the bottom of the detail image fell below the window. The existing clamp derived the popup size from known widths/heights; it now additionally **measures the rendered panel** after layout (`nudgeOnScreen`, via `requestAnimationFrame`) and slides it back inside the visible region (canvas ∩ viewport). It pulls in from the far edges first, then guarantees the near edges, so an oversized popup pins to the top-left (losing the far edge, never the near). This is purely corrective — a no-op when the computed clamp already fits.

## 2. Top-left detail-canvas size buttons
A new pair of smaller/bigger image buttons sits at the **top-left** of the header, mirroring the top-right grid-thumbnail buttons — but these resize the **large detail canvas** (the single-item preview pane). Because the popup's height *is* the preview height, this resizes the whole window. Clicks step through a discrete size ladder.

The chosen size **persists per media type** under a new `popup_preview_size` setting (px), just like the grid thumbnail size persists under `grid_icon_size_popup`. Unset, the pane falls back to the existing radius-derived default. The buttons only appear for thumbnail media (image/video), which is where a detail canvas exists.

## 3. Item count moved to the thumbnail scroll
The "N items" label moved out of the window header to the **top-left of the thumbnail scroll column**. Body-height math now reserves room for the label so the grid still fills (and scrolls within) the column.

## Implementation notes
- New per-user setting `popup_preview_size: dict[str, int]` (clamped to `POPUP_PREVIEW_SIZE_PX` = 96..720) in `settings_models.py` + marshmallow dump/update schemas; OpenAPI snapshot regenerated.
- A detail-canvas size change re-clamps the popup so growing it can't push it off-screen.
- Backend tests added for the new setting (per-type round-trip + out-of-range clamp).

## Testing
`./run-tests.sh` — full suite green (5224 passed, 1 skipped); frontend gate (build + typecheck + OpenAPI drift + Vitest) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016XVL7fskUcjZPw8RUosbpv)_