### PR TITLE
Tighten structured progress detail and title-case the header

### DIFF
--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -53,8 +53,14 @@ job had, and there was no honest "% of the total job done".
 - **One bar + step count (frontend).**
   `progressBarState()` in `utils/format-progress.ts` is the shared resolver:
   prefer `overall` (one bar across the whole job) → else `current/total` → else
-  indeterminate. `formatProgressHeader` now surfaces `step S of T` in the
-  header. Wired into the dashboard loading rows (dataset-card, detector-card,
+  indeterminate. `formatProgressHeader` now surfaces a capitalized `Step S of T`
+  in the header (each `·`-separated segment is title-cased so the line reads as a
+  row of labels, e.g. `Loading dataset · Step 3 of 4 · Embedding files`), and the
+  per-item `detail` line drops the parentheses around the count and strips the
+  redundant leading verb (`012/345 cats/img.png`, not `(012/345) Embedding
+  cats/img.png`) so the narrow, ellipsized detail slot spends its characters on
+  the filename rather than repeating the phase the header already names. Wired
+  into the dashboard loading rows (dataset-card, detector-card,
   orphan-task rows), the Find/learned-sort overlay (find-view) and the
   left-panel sort indicator (via `SortStateService.sortOverall` /
   `sortEtaSeconds`).

--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -23,12 +23,12 @@ describe('JobProgressComponent', () => {
   });
 
   it('renders the header, detail and eta', async () => {
-    fixture.componentRef.setInput('header', 'Loading dataset · step 2 of 4 · downloading source');
-    fixture.componentRef.setInput('detail', '(012/345) FileABC.img');
+    fixture.componentRef.setInput('header', 'Loading dataset · Step 2 of 4 · Downloading source');
+    fixture.componentRef.setInput('detail', '012/345 FileABC.img');
     fixture.componentRef.setInput('eta', '~5.5 min left');
     await settleZoneless(fixture);
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(text).toContain('downloading source');
+    expect(text).toContain('Downloading source');
     expect(text).toContain('FileABC.img');
     expect(text).toContain('~5.5 min left');
   });

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -30,11 +30,11 @@ import { ProgressBarState } from '../../utils/format-progress';
   host: { '[class.jp-host--cell]': 'cell' },
 })
 export class JobProgressComponent {
-  /** One-line title, e.g. "Loading dataset · step 2 of 4 · downloading source". */
+  /** One-line title, e.g. "Loading dataset · Step 2 of 4 · Downloading source". */
   @Input() header = '';
   /** Longer explanation surfaced behind the `(?)` chip; empty hides the chip. */
   @Input() description = '';
-  /** Per-item detail (left of the bar), e.g. "(012/345) FileABC.img". */
+  /** Per-item detail (left of the bar), e.g. "012/345 FileABC.img". */
   @Input() detail = '';
   /** Right-justified status, e.g. "~5.5 min left" or "45%". */
   @Input() eta = '';

--- a/frontend/src/app/utils/format-progress.spec.ts
+++ b/frontend/src/app/utils/format-progress.spec.ts
@@ -51,14 +51,12 @@ describe('isProgressIndeterminate', () => {
 });
 
 describe('formatProgressHeader step count', () => {
-  it('surfaces "step S of T" in the header for multi-step jobs', () => {
+  it('surfaces a capitalized "Step S of T" in the header for multi-step jobs', () => {
     const { header } = formatProgressHeader(
       { status: 'embedding', message: 'Embedding files', step: 3, total_steps: 4 },
       'dataset',
     );
-    expect(header).toContain('step 3 of 4');
-    expect(header).toContain('Loading dataset');
-    expect(header).toContain('embedding files');
+    expect(header).toBe('Loading dataset · Step 3 of 4 · Embedding files');
   });
 
   it('omits the step count for single-step jobs', () => {
@@ -66,6 +64,36 @@ describe('formatProgressHeader step count', () => {
       { status: 'downloading', message: 'Fetching', step: 1, total_steps: 1 },
       'dataset',
     );
-    expect(header).not.toContain('step 1 of 1');
+    expect(header).not.toContain('Step 1 of 1');
+  });
+});
+
+describe('formatProgressHeader detail line', () => {
+  it('drops the parentheses around the count and strips the redundant verb', () => {
+    // Header already says "· Embedding files", so the per-item detail keeps only
+    // the count and the filename — no "(…)" and no repeated "Embedding".
+    const { header, detail } = formatProgressHeader(
+      { status: 'embedding', message: 'Embedding cats/img.png', current: 12, total: 345 },
+      'dataset',
+    );
+    expect(header).toContain('Embedding files');
+    expect(detail).toBe('12/345 cats/img.png');
+  });
+
+  it('shows the bare count when there is no per-item identifier', () => {
+    const { detail } = formatProgressHeader(
+      { status: 'embedding', message: 'Embedding files', current: 12, total: 345 },
+      'dataset',
+    );
+    // "Embedding files" → verb stripped → "files"; the count carries the signal.
+    expect(detail).toBe('12/345 files');
+  });
+
+  it('keeps a message that has no leading action verb intact', () => {
+    const { detail } = formatProgressHeader(
+      { status: 'loading', message: 'cats/img.png', current: 3, total: 9 },
+      'dataset',
+    );
+    expect(detail).toBe('3/9 cats/img.png');
   });
 });

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -179,13 +179,19 @@ export function isProgressIndeterminate(
  * ``[Step 3/4] Loading embedding model…`` is uninformative to users who have
  * no mental model of the load steps. ``formatProgressHeader`` instead returns:
  *
- *   - ``header``: ``"<what> · <phase>"``, e.g. ``"Loading dataset · embedding model"``.
+ *   - ``header``: ``"<What> · <Phase>"``, e.g. ``"Loading dataset · Embedding model"``.
+ *     Each ``·``-separated segment is capitalized so the line reads like a row
+ *     of labels ("Loading dataset · Step 3 of 4 · Embedding files") rather than
+ *     a run-on sentence.
  *   - ``subtitle``: a plain-English one-liner explaining what the phase actually does.
- *   - ``detail``: the original message + ``(current/total)`` counts, with the
- *     redundant ``[Step S/T]`` prefix stripped (the header conveys the phase).
- *     The ETA tail is omitted here; it is returned separately as ``eta`` so the
- *     UI can pin it to the right of the progress bar where it stays visible
- *     even when a long file path ellipsizes the detail.
+ *   - ``detail``: the per-item line — ``current/total`` counts (no parentheses)
+ *     followed by the item identifier, e.g. ``"012/345 cats/img.png"``. The
+ *     leading action verb is stripped because the header already names the phase
+ *     ("· Embedding files"); repeating "Embedding" in the narrow, ellipsized
+ *     detail slot would just eat the characters the filename needs. The ETA tail
+ *     is omitted here; it is returned separately as ``eta`` so the UI can pin it
+ *     to the right of the progress bar where it stays visible even when a long
+ *     file path ellipsizes the detail.
  *   - ``eta``: the bare ``~5.5 min left`` chip, or empty when no estimate is available.
  */
 export interface ProgressHeader {
@@ -227,8 +233,21 @@ function prettifyEmbedder(name: string | undefined): string {
   return EMBEDDER_PRETTY[key] ?? name;
 }
 
-function stripStepPrefix(msg: string): string {
-  return msg.replace(/^\[Step \d+\/\d+\]\s*/, '');
+/**
+ * Strip a leading action verb (a gerund like "Embedding"/"Converting"/"Loading",
+ * optionally "Re-…") from a per-item progress message. The structured header
+ * already names the phase ("· Embedding files"), so the verb is redundant in the
+ * narrow detail slot — dropping it leaves the whole width for the filename, which
+ * is the only part that actually varies per item. ``"Embedding cats/img.png"`` →
+ * ``"cats/img.png"``. A message with no leading gerund is returned unchanged.
+ */
+function stripActionVerb(msg: string): string {
+  return msg.replace(/^(?:re-?)?[a-z]+ing\s+/i, '');
+}
+
+/** Capitalize the first character of a string (leaving the rest untouched). */
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
 /**
@@ -324,16 +343,25 @@ export function formatProgressHeader(
       : 'Setting up the load pipeline.';
   }
 
-  // Surface the step count in the header ("step 3 of 4") so the user always
+  // Surface the step count in the header ("Step 3 of 4") so the user always
   // knows how many phases the whole job has — per the consolidation brief, the
-  // job count matters more than any single phase's fine detail. The redundant
-  // "[Step S/T]" text is stripped from the detail line below.
+  // job count matters more than any single phase's fine detail. Each segment is
+  // capitalized so the line reads as a row of labels, not a sentence.
   const step = prog.step;
   const totalSteps = prog.total_steps;
   const stepPart =
-    step != null && totalSteps != null && totalSteps > 1 ? `step ${step} of ${totalSteps}` : '';
-  const header = [what, stepPart, phase].filter(Boolean).join(' · ');
-  const detail = stripStepPrefix(formatProgressMessage(progress, '', { includeEta: false }));
+    step != null && totalSteps != null && totalSteps > 1 ? `Step ${step} of ${totalSteps}` : '';
+  const header = [what, stepPart, capitalize(phase)].filter(Boolean).join(' · ');
+
+  // Detail = bare "current/total" (no parentheses — characters are precious in
+  // the narrow, ellipsized slot) + the item identifier with its redundant
+  // leading verb stripped (the header already names the phase).
+  const current = prog.current;
+  const total = prog.total;
+  const counts =
+    current != null && total != null && total > 0 ? formatProgressFraction(current, total) : '';
+  const item = stripActionVerb(message);
+  const detail = [counts, item].filter(Boolean).join(' ');
   const eta = formatEta(prog.eta_seconds);
   return { header, subtitle, detail, eta };
 }


### PR DESCRIPTION
## What & why

The new structured progress bar's per-item **detail** slot is narrow and ellipsized (`flex: 0 0 16ch` in table cells), so it was wasting its limited width repeating the phase the header already names. A detail like `(012/345) Embedding asdf.img` truncated down to `(012/345) Embed…` — the filename, the only part that actually varies per item, never made it onto the screen.

Two fixes in `formatProgressHeader` (`frontend/src/app/utils/format-progress.ts`):

- **Detail line** now drops the parentheses around the count and strips the redundant leading action verb (the header already says `· Embedding files`). `(012/345) Embedding cats/img.png` → **`012/345 cats/img.png`**, so the slot spends its characters on the filename.
- **Header** title-cases each `·`-separated segment so the line reads as a row of labels rather than a run-on sentence: `Loading dataset · step 3 of 4 · embedding files` → **`Loading dataset · Step 3 of 4 · Embedding files`**.

## Notes

- The verb strip removes a leading gerund (`Embedding`/`Converting`/`Loading`/`Re-embedding`…); a message with no leading verb is left intact.
- `formatProgressMessage` (the single-line consumer used by the sort overlay / orphan task line) is unchanged — it keeps the canonical `(C/T) message` form.

## Tests

- New `formatProgressHeader detail line` specs cover the paren drop, verb strip, the bare-count fallback, and the no-verb passthrough; the step-count spec now asserts the capitalized header.
- `./run-tests.sh frontend` green (build + audit + 875 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGFMwXCAdU1KqBw4afWTc7)_