### PR TITLE
Capitalize media-type display across pulldown, metadata, auto-find, and combine modal

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -91,7 +91,7 @@
           </div>
           <div class="metadata-item">
             <span class="metadata-label">Media Type</span>
-            <span class="metadata-value">{{ mediaType }}</span>
+            <span class="metadata-value">{{ mediaType | titlecase }}</span>
           </div>
           @for (entry of customMetadata | keyvalue; track entry.key) {
             <div class="metadata-item">

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, effect, inject, Input, input, OnChanges, OnDestroy, output, signal, SimpleChanges, untracked, ViewChild } from '@angular/core';
-import { KeyValuePipe } from '@angular/common';
+import { KeyValuePipe, TitleCasePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
 import { MediasApiService } from '../../services/medias-api.service';
@@ -22,6 +22,7 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
   standalone: true,
   imports: [
     KeyValuePipe,
+    TitleCasePipe,
     AudioPlayerComponent,
     ImageViewerComponent,
     VideoPlayerComponent,

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.html
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.html
@@ -47,7 +47,7 @@
           >
             <span class="row-glyph" [title]="glyphTitle(row)">{{ glyphFor(row) }}</span>
             <span class="row-name">{{ row.name }}</span>
-            <span class="row-type">· {{ row.mediaType }}</span>
+            <span class="row-type">· {{ row.mediaType | titlecase }}</span>
             @if (row.busy) {
               <span class="row-spinner" [title]="busyTitle(row)" aria-hidden="true">⟳</span>
             }

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, inject, input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { TitleCasePipe } from '@angular/common';
 
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -45,7 +46,7 @@ interface PulldownRow {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-context-pulldown',
   standalone: true,
-  imports: [],
+  imports: [TitleCasePipe],
   templateUrl: './context-pulldown.component.html',
   styleUrl: './context-pulldown.component.scss',
 })

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -15,7 +15,7 @@
           </li>
         }
       </ul>
-      <p class="info-text">{{ rows.length }} detectors · {{ totalLabels }} total labels (will dedupe + drop conflicts) · media type: {{ mediaType }}</p>
+      <p class="info-text">{{ rows.length }} detectors · {{ totalLabels }} total labels (will dedupe + drop conflicts) · media type: {{ mediaType | titlecase }}</p>
     </div>
 
     <div class="form-group">

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, input, OnInit, output } from '@angular/core';
+import { TitleCasePipe } from '@angular/common';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -16,7 +17,7 @@ interface SourceRow {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-combine-detectors-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent],
+  imports: [FormsModule, ModalComponent, TitleCasePipe],
   templateUrl: './combine-detectors-modal.component.html',
   styleUrl: './combine-detectors-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -19,7 +19,7 @@
         <input type="checkbox" [ngModel]="d.autofind" (ngModelChange)="toggleDetector(d, $event)" />
         {{ d.name }}
         @if (d.media_type) {
-          <span class="detector-type">{{ d.media_type }}</span>
+          <span class="detector-type">{{ d.media_type | titlecase }}</span>
         }
       </label>
     }

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnDestroy, OnInit, output, SimpleChanges } from '@angular/core';
+import { TitleCasePipe } from '@angular/common';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -45,7 +46,7 @@ export interface AutoFindExporterChange {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-auto-find-settings',
   standalone: true,
-  imports: [FormsModule, IconComponent],
+  imports: [FormsModule, IconComponent, TitleCasePipe],
   templateUrl: './auto-find-settings.component.html',
   styleUrl: './auto-find-settings.component.scss',
 })


### PR DESCRIPTION
## What & why

Follow-up to the progress-header title-casing (#2057). That change capitalized the `·`-separated header segments; the same "lowercase where the rest of the app capitalizes" inconsistency existed for **media-type values rendered raw** (`audio`, `image`, …).

The app already has a convention — `capitalizeType()` on the dashboard cards and `| titlecase` in the stats modals all render `Audio`/`Image`. Four spots bypassed it; this PR brings them in line via the `titlecase` pipe:

| Location | Was | Now |
|---|---|---|
| Context pulldown rows (switch dataset/detector) | `name · audio` | `name · Audio` |
| Center-panel metadata ("Media Type" field) | `audio` | `Audio` |
| Auto-find detector chip (settings) | `name audio` | `name Audio` |
| Combine-detectors info line | `… · media type: audio` | `… · media type: Audio` |

## Out of scope (deliberately unchanged)

- **Left panel** (`Images (45)`) already capitalizes via `mediaTypeName()`.
- **`formatProgressMessage`** renders the backend message verbatim, which already arrives capitalized.
- **CSS-uppercased badges** (`text-transform: uppercase`) don't care about source casing.

## Tests

`./run-tests.sh frontend` green (build + audit + 875 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGFMwXCAdU1KqBw4afWTc7)_