### PR TITLE
Open bin popup on the pile's centroid thumbnail

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -84,6 +84,7 @@
             <div
               class="bin-popup-entry"
               [class.selected]="isSelected(id)"
+              [class.representative]="isRepresentative(id)"
               role="button"
               tabindex="0"
               [attr.aria-pressed]="isSelected(id)"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -210,6 +210,13 @@
     box-shadow: 0 0 0 2px var(--accent);
   }
 
+  // The bin's representative — the pile thumbnail the user right-clicked, shown
+  // large in the preview and scrolled into view here. A softer ring marks it in
+  // the 1-D list; the solid ``.selected`` ring takes over once it's selected.
+  &.representative:not(.selected) {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
+  }
+
   &:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: -2px;

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -116,6 +116,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
 
   /** Member media ids of the bin the popup was summoned over. */
   readonly memberIds = input<number[]>([]);
+  /** The bin's representative (centroid) id — the clip whose thumbnail is drawn
+   *  for the pile on the canvas. The popup opens its preview on this item and
+   *  scrolls the member grid to it, so the detail view starts on the same image
+   *  the user right-clicked rather than the 1-D list's first item. Null falls
+   *  back to the first member. */
+  readonly repId = input<number | null>(null);
   /** Active dataset media type, used for the view prefs, hover-to-hear, and placeholders. */
   readonly mediaType = input('');
   /** Viewport anchor (clientX/clientY) the popup opens at, then clamps inward. */
@@ -217,19 +223,24 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['memberIds']) {
+    if (changes['memberIds'] || changes['repId']) {
       this.ids = this.memberIds() ?? [];
       this.stopAudio();
-      // Open on the bin's representative so the pane is never blank (a singleton
-      // therefore lands straight on a large high-res view).
-      this.previewId = this.ids.length > 0 ? this.ids[0] : null;
+      // Open on the bin's representative (the centroid whose thumbnail the user
+      // right-clicked) so the pane is never blank and the detail view starts on
+      // the same image — not the 1-D list's first item, which differs.
+      this.previewId = this.representativeId();
       // A fresh bin is a fresh popup: forget any drag from the previous one so
       // it re-anchors to the new summon point.
       this.dragged = false;
       this.rebuildRows();
-      // A fresh bin: jump the list back to the top and prefetch its first window.
-      this.viewport?.scrollToIndex(0);
-      this.prefetchVisible();
+      // A fresh bin: scroll the list to the representative (centred) and prefetch
+      // the window around it. Deferred so the virtual viewport has the new rows
+      // (and, on first open, exists at all — it's created after ngOnChanges).
+      setTimeout(() => {
+        this.scrollToRep();
+        this.prefetchVisible();
+      });
     }
     if (changes['mediaType']) {
       // A new media type may carry a different remembered thumbnail size.
@@ -302,6 +313,43 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       });
     }
     this.cdr.markForCheck();
+  }
+
+  /** The id the preview opens on and the grid scrolls to: the bin's
+   *  representative (centroid) when it's a member, else the first member so the
+   *  pane is never blank. */
+  private representativeId(): number | null {
+    const rep = this.repId();
+    if (rep != null && this.ids.includes(rep)) return rep;
+    return this.ids.length > 0 ? this.ids[0] : null;
+  }
+
+  /** Index of the representative within {@link ids} (the bin's 1-D order), or 0
+   *  when it isn't resolvable so we fall back to the top of the list. */
+  private repIndex(): number {
+    const rep = this.representativeId();
+    const idx = rep == null ? -1 : this.ids.indexOf(rep);
+    return idx >= 0 ? idx : 0;
+  }
+
+  /** True for the representative entry, so the grid can ring the item whose
+   *  thumbnail the user right-clicked (the one shown large in the preview). */
+  isRepresentative(id: number): boolean {
+    return id === this.representativeId();
+  }
+
+  /** Scroll the member grid so the representative's row sits roughly centred, so
+   *  the popup opens looking at the same item whose pile thumbnail was clicked
+   *  rather than the 1-D list's first item. No-op for a singleton bin (no grid)
+   *  or before the viewport exists. */
+  private scrollToRep(): void {
+    const vp = this.viewport;
+    if (!vp) return;
+    const row = Math.floor(this.repIndex() / Math.max(1, this.columns));
+    const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
+    // Centre the row in the visible window, clamped so we never scroll past 0.
+    const offset = row * this.rowSize - Math.max(0, viewportH - this.rowSize) / 2;
+    vp.scrollToOffset(Math.max(0, offset));
   }
 
   /** Recompute the column count + row chunking for the current thumbnail size. */
@@ -513,7 +561,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  bin's representative so the pane stays populated. */
   onGridLeave(): void {
     this.stopAudio();
-    if (this.showPreview) this.previewId = this.ids.length > 0 ? this.ids[0] : null;
+    if (this.showPreview) this.previewId = this.representativeId();
   }
 
   private stopAudio(): void {

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -35,6 +35,11 @@ export interface BrowseContextMenuEvent {
   clientY: number;
   /** Member media ids of the bin under the cursor; empty over blank space. */
   members: number[];
+  /** The bin's representative id — the centroid clip whose thumbnail is drawn
+   *  on the canvas (see ``rep_id``). The popup opens on this item and scrolls
+   *  its 1-D member list to it, so the detail view starts on the same image the
+   *  user right-clicked. Null over blank space. */
+  repId: number | null;
   /** The canvas's bounding rect (viewport coords); the popup clamps inside it
    *  so it never spills onto the side panel or past the canvas edges. */
   bounds: DOMRect;
@@ -1639,6 +1644,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       clientX: event.clientX,
       clientY: event.clientY,
       members,
+      repId: cell ? cell.rep_id : null,
       bounds: rect,
     });
   }

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -90,6 +90,7 @@
               [y]="contextMenuY"
               [bounds]="contextBounds"
               [memberIds]="contextMembers"
+              [repId]="contextRepId"
               [mediaType]="mediaType()"
               [hoverThumbRadius]="thumbnailRadius"
               (dismissed)="dismissContextMenu()"

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -192,6 +192,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   contextMenuX = 0;
   contextMenuY = 0;
   contextMembers: number[] = [];
+  /** Representative (centroid) id of the right-clicked bin — the popup opens on
+   *  it and scrolls its 1-D member list to it, so the detail view starts on the
+   *  same image whose thumbnail the user clicked. */
+  contextRepId: number | null = null;
   /** Canvas bounds the popup clamps inside, so it stays on the canvas rather
    *  than spilling onto the side panel or past the canvas edges. */
   contextBounds: DOMRect | null = null;
@@ -547,6 +551,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       return;
     }
     this.contextMembers = event.members;
+    this.contextRepId = event.repId;
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
     this.contextBounds = event.bounds;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,8 +247,9 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # Domain terms (clap/siglip/xclip = embedder names; wrest/caller/recaller =
 # extension scaffold names), legitimate code identifiers (numer/denom in
 # slope formulas, medias as the global state proxy, goup as a TS method,
-# ans as a shell read-loop variable in scripts/slurm),
+# ans as a shell read-loop variable in scripts/slurm, repid as the
+# camelCase TS mirror of the projection's rep_id field),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable). usera = the "userA" persona in
 # design docs; teh = Yee Whye Teh in references.
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,ans,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh"
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,ans,repid,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh"


### PR DESCRIPTION
## Problem

Right-clicking a pile on the VTSBrowse canvas shows the pile's **centroid** clip (`rep_id`) as the thumbnail — and on right-click that small thumbnail visually grows into the popup's preview pane. But the popup's 1-D member list (Hilbert order) opened at its *first* item, which is generally **not** the centroid. So the image you watched get big wasn't the one highlighted/scrolled-to in the detail list — a jarring mismatch.

## Fix

Thread the bin's representative id through to the popup and make the detail view start on it:

- **`BrowseContextMenuEvent`** now carries `repId` (`browse-canvas`), populated from `cell.rep_id` — the same id the canvas draws as the pile thumbnail.
- **`browse-view`** stores `contextRepId` and passes it to the popup as `[repId]`.
- **`browse-bin-popup`**:
  - Opens the preview pane on the representative (`representativeId()`), falling back to the first member when `rep_id` isn't a member (degenerate case). The hover-out fallback resets to the representative too.
  - **Autoscrolls** the virtualized 1-D member grid so the representative's row is centred (`scrollToRep()`), instead of jumping to index 0.
  - **Rings** the representative entry in the grid (`.representative` class) with a softer accent ring so the item shown large in the preview is identifiable in the list; the solid selection ring takes over once it's selected.

Net effect: you see the small centroid thumbnail grow into the preview, and the smart 1-D list opens scrolled to and marking that same image.

## Testing

`./run-tests.sh frontend` — TypeScript build OK, Vitest 875 passed, ruff/codespell/deptry/pyright/audit all clean. (Added `repId` to the codespell ignore list as the camelCase mirror of the existing `rep_id` field.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbcFqusugVR5PP2S2iRrtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbcFqusugVR5PP2S2iRrtS)_