### PR TITLE
Fix view-controls toggle requiring two clicks and stuck-disabled size buttons

### DIFF
--- a/frontend/src/app/components/view-controls/view-controls.component.html
+++ b/frontend/src/app/components/view-controls/view-controls.component.html
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMinSize || !currentMediaType() || (viewMode === 'list' && !allowSizeInList())"
+      [disabled]="atMinSize() || !currentMediaType() || (viewMode() === 'list' && !allowSizeInList())"
       (click)="bumpSize(-1)"
       title="Smaller thumbnails"
       aria-label="Smaller thumbnails">
@@ -12,7 +12,7 @@
     <button
       type="button"
       class="vc-btn vc-btn--size"
-      [disabled]="atMaxSize || !currentMediaType() || (viewMode === 'list' && !allowSizeInList())"
+      [disabled]="atMaxSize() || !currentMediaType() || (viewMode() === 'list' && !allowSizeInList())"
       (click)="bumpSize(1)"
       title="Bigger thumbnails"
       aria-label="Bigger thumbnails">
@@ -25,21 +25,21 @@
     <button
       type="button"
       class="vc-btn"
-      [class.vc-btn--active]="viewMode === 'list'"
+      [class.vc-btn--active]="viewMode() === 'list'"
       (click)="setViewMode('list')"
       title="Show items as a list"
       aria-label="List view"
-      [attr.aria-pressed]="viewMode === 'list'">
+      [attr.aria-pressed]="viewMode() === 'list'">
       <vt-icon type="list" [size]="13"></vt-icon>
     </button>
     <button
       type="button"
       class="vc-btn"
-      [class.vc-btn--active]="viewMode === 'grid'"
+      [class.vc-btn--active]="viewMode() === 'grid'"
       (click)="setViewMode('grid')"
       title="Show items as a grid"
       aria-label="Grid view"
-      [attr.aria-pressed]="viewMode === 'grid'">
+      [attr.aria-pressed]="viewMode() === 'grid'">
       <vt-icon type="grid" [size]="13"></vt-icon>
     </button>
   </div>
@@ -50,21 +50,21 @@
     <button
       type="button"
       class="vc-btn"
-      [class.vc-btn--active]="focusMode === 'click'"
+      [class.vc-btn--active]="focusMode() === 'click'"
       (click)="setFocusMode('click')"
       title="Click to preview"
       aria-label="Click focus mode"
-      [attr.aria-pressed]="focusMode === 'click'">
+      [attr.aria-pressed]="focusMode() === 'click'">
       <vt-icon type="cursor-click" [size]="13"></vt-icon>
     </button>
     <button
       type="button"
       class="vc-btn"
-      [class.vc-btn--active]="focusMode === 'hover'"
+      [class.vc-btn--active]="focusMode() === 'hover'"
       (click)="setFocusMode('hover')"
       title="Hover to preview"
       aria-label="Hover focus mode"
-      [attr.aria-pressed]="focusMode === 'hover'">
+      [attr.aria-pressed]="focusMode() === 'hover'">
       <vt-icon type="cursor-hover" [size]="13"></vt-icon>
     </button>
   </div>

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, OnChanges, OnInit, signal, SimpleChanges } from '@angular/core';
 
 import { SettingsStateService } from '../../services/settings-state.service';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
@@ -42,9 +42,14 @@ export class ViewControlsComponent implements OnInit, OnChanges {
    */
   readonly showViewMode = input(true);
 
-  viewMode: 'grid' | 'list' = 'list';
-  focusMode: 'click' | 'hover' = 'click';
-  gridIconSize: IconSize = 'M';
+  // These are signals (not plain fields) so the OnPush template re-renders when
+  // the constructor effect's `refresh()` updates them after a settings change.
+  // With plain fields the controls would not repaint until the next unrelated
+  // change-detection pass, which is what made the Grid/List toggle take two
+  // clicks and left the thumbnail-size buttons looking stuck-disabled.
+  readonly viewMode = signal<'grid' | 'list'>('list');
+  readonly focusMode = signal<'click' | 'hover'>('click');
+  readonly gridIconSize = signal<IconSize>('M');
 
   private settings: AppSettings = { volume: 50 };
 
@@ -69,10 +74,10 @@ export class ViewControlsComponent implements OnInit, OnChanges {
 
   private refresh(): void {
     const type = this.currentMediaType();
-    this.viewMode = (this.getDict('view_mode')[type] as 'grid' | 'list') ?? this.defaultViewMode();
-    this.focusMode = (this.getDict('focus_mode')[type] as 'click' | 'hover') ?? 'click';
+    this.viewMode.set((this.getDict('view_mode')[type] as 'grid' | 'list') ?? this.defaultViewMode());
+    this.focusMode.set((this.getDict('focus_mode')[type] as 'click' | 'hover') ?? 'click');
     const size = this.getDict('grid_icon_size')[type] as IconSize | undefined;
-    this.gridIconSize = (size && ICON_SIZES.includes(size)) ? size : 'M';
+    this.gridIconSize.set((size && ICON_SIZES.includes(size)) ? size : 'M');
   }
 
   private defaultViewMode(): 'grid' | 'list' {
@@ -91,30 +96,32 @@ export class ViewControlsComponent implements OnInit, OnChanges {
   }
 
   setViewMode(mode: 'grid' | 'list'): void {
-    if (!this.currentMediaType() || this.viewMode === mode) return;
+    if (!this.currentMediaType() || this.viewMode() === mode) return;
+    // Reflect the change immediately so the toggle (and the thumbnail-size
+    // buttons it gates) update on the first click; `refresh()` reconciles with
+    // the persisted settings once the round-trip lands.
+    this.viewMode.set(mode);
     this.save('view_mode', mode);
   }
 
   setFocusMode(mode: 'click' | 'hover'): void {
-    if (!this.currentMediaType() || this.focusMode === mode) return;
+    if (!this.currentMediaType() || this.focusMode() === mode) return;
+    this.focusMode.set(mode);
     this.save('focus_mode', mode);
   }
 
   bumpSize(delta: 1 | -1): void {
-    if (!this.currentMediaType() || (this.viewMode === 'list' && !this.allowSizeInList())) return;
-    const idx = ICON_SIZES.indexOf(this.gridIconSize);
+    if (!this.currentMediaType() || (this.viewMode() === 'list' && !this.allowSizeInList())) return;
+    const idx = ICON_SIZES.indexOf(this.gridIconSize());
     const next = ICON_SIZES[Math.max(0, Math.min(ICON_SIZES.length - 1, idx + delta))];
-    if (next === this.gridIconSize) return;
+    if (next === this.gridIconSize()) return;
+    this.gridIconSize.set(next);
     this.save('grid_icon_size', next);
   }
 
-  get atMaxSize(): boolean {
-    return this.gridIconSize === ICON_SIZES[ICON_SIZES.length - 1];
-  }
+  readonly atMaxSize = computed(() => this.gridIconSize() === ICON_SIZES[ICON_SIZES.length - 1]);
 
-  get atMinSize(): boolean {
-    return this.gridIconSize === ICON_SIZES[0];
-  }
+  readonly atMinSize = computed(() => this.gridIconSize() === ICON_SIZES[0]);
 
   private save(prefix: 'view_mode' | 'focus_mode' | 'grid_icon_size', value: string): void {
     const key = this.key(prefix);


### PR DESCRIPTION
## Problem

When running Find on an image dataset, the left-panel **Smaller/Bigger thumbnails** buttons stayed disabled and switching between **Grid** and **List** took two clicks — the panel would switch on the first click but the toggle buttons wouldn't update until a second click, giving a "half grid, half list" feeling.

## Root cause

`vt-view-controls` uses `ChangeDetectionStrategy.OnPush` but stored `viewMode` / `focusMode` / `gridIconSize` as **plain fields**, reassigned inside a constructor `effect()` after each settings change. Reassigning a plain field from an effect does **not** schedule change-detection for an OnPush component whose template reads plain fields. So:

- **Two-click toggle:** click 1 persisted the setting and the actual panels (signal-driven) switched, but the control buttons didn't repaint — they only caught up on the next unrelated CD pass (click 2). The second click's `setViewMode` early-returned because the internal value had already advanced; it merely forced a render.
- **Stuck-disabled size buttons:** the left panel defaults to list mode (where size buttons are intentionally disabled), and because switching to grid silently failed to reflect on the first click, the size buttons appeared permanently disabled.

## Fix

- Convert `viewMode`, `focusMode`, `gridIconSize` to **signals**, and `atMinSize`/`atMaxSize` to **computed**, so the OnPush template tracks them and repaints when `refresh()` updates them.
- Apply **optimistic local updates** in `setViewMode` / `setFocusMode` / `bumpSize` so the controls flip on the first click without waiting for the settings persist round-trip; `refresh()` still reconciles with the saved value afterward.
- Update the template bindings to call the signals/computeds as functions.

## Testing

`./run-tests.sh frontend` — TypeScript build OK, 875 Vitest tests pass, ruff/pyright/audit gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFwnopwuAdvPJy6RRiFTNs)_