### PR TITLE
Fix CUDA tag selection when the driver is too old for every covering wheel

### DIFF
--- a/scripts/detect_cuda_tag.py
+++ b/scripts/detect_cuda_tag.py
@@ -69,20 +69,25 @@ def select_cuda_tag(
     if not compute_caps:
         return None
     lo, hi = min(compute_caps), max(compute_caps)
-    valid = [c for c in _CANDIDATES if c[2] <= lo and c[3] >= hi]
-    if driver_cuda is not None:
-        gated = [c for c in valid if c[1] <= driver_cuda]
-        # Only apply the driver ceiling if it leaves something runnable; if even
-        # the oldest covering wheel out-runs the driver, the driver is simply
-        # too old and the caller surfaces that rather than picking nothing.
-        if gated:
-            valid = gated
-    if not valid:
+    covering = [c for c in _CANDIDATES if c[2] <= lo and c[3] >= hi]
+    if not covering:
         return None
-    for tag, *_ in valid:
+
+    if driver_cuda is not None:
+        gated = [c for c in covering if c[1] <= driver_cuda]
+        if not gated:
+            # The driver is older than every covering wheel; best effort is the
+            # oldest covering wheel (lowest toolkit requirement, most likely to
+            # run). The caller surfaces the driver mismatch separately.
+            return min(covering, key=lambda c: c[1])[0]
+        covering = gated
+
+    # Prefer the safe anchor when it qualifies; otherwise the newest wheel that
+    # does (the only covering wheel for Blackwell, or the best the driver allows).
+    for tag, *_ in covering:
         if tag == DEFAULT_TAG:
             return DEFAULT_TAG
-    return max(valid, key=lambda c: c[1])[0]
+    return max(covering, key=lambda c: c[1])[0]
 
 
 def parse_compute_caps(query_output: str) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Context

PR #2060 merged the GPU CUDA-tag auto-detection (`scripts/detect_cuda_tag.py`) into `dev`, **including** a test — `test_driver_too_old_for_any_covering_wheel_still_returns_best` — that asserts the new fallback behavior. The one-commit code fix that makes that test pass was authored after the merge and never landed, so **`dev`'s suite is currently red on that test**. This PR carries just that fix.

## The bug

`select_cuda_tag()` applies the driver-version ceiling, but when the driver is older than *every* wheel that covers the GPU (e.g. a V100 on a CUDA 11.0 driver), the gated set is empty. The old code then fell through to "prefer `cu124`", returning `cu124` — a wheel that needs CUDA 12.4 and definitely won't run on an 11.0 driver.

## The fix

When the driver out-ranks every covering wheel, return the **oldest** covering wheel (lowest toolkit requirement, most likely to actually run) as a best effort, and let the caller surface the driver mismatch separately. The common paths (prefer `cu124`; bump to `cu128` only for Blackwell; step down to `cu121`/`cu118` on moderately old drivers) are unchanged.

16-line change to `select_cuda_tag()`; no other files touched.

## Testing

`python -m pytest tests_lib/core/test_detect_cuda_tag.py` → all 24 pass (red on `dev` before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnqAYZiLuDmAZQJZ87dshH)_