### PR TITLE
Browse: stop flashing the default hex grid before the saved bin shape loads

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -206,22 +206,55 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private pollErrors = 0;
   private static readonly MAX_POLL_ERRORS = 5;
 
+  /**
+   * Gate for the *first* projection load. Held until we know which bin shape to
+   * request, which needs two async facts: the saved settings and the dataset's
+   * media type (the ``browse_bin_shape`` pref is keyed per-media). Loading
+   * sooner would fetch+render the default hex lattice for ~a second and then
+   * re-bin to the user's saved square — a confusing wrong grid. We'd rather
+   * hold on the loading spinner until the right shape is known. Once true,
+   * later reloads (pair change, shape toggle) go through the normal paths.
+   */
+  private initialLoadStarted = false;
+  /** Set once the dataset-status fetch — which yields the media type the
+   *  per-media bin-shape pref is keyed on — has resolved or failed. */
+  private statusResolved = false;
+
   constructor() {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
-      if (!settings) return;
-      this.lastSettings = settings;
-      if (settings.browse_panel_width != null) {
-        this.panelWidth.set(
-          this.clamp(
-            settings.browse_panel_width,
-            BrowseViewComponent.PANEL_MIN,
-            BrowseViewComponent.PANEL_MAX,
-          ),
-        );
+      // Also track the settings load error so this effect re-runs (and the
+      // gated initial load can proceed with defaults) if settings never load,
+      // rather than stranding the view on the loading spinner forever.
+      const settingsErrored = this.settingsState.error() != null;
+      if (settings) {
+        this.lastSettings = settings;
+        if (settings.browse_panel_width != null) {
+          this.panelWidth.set(
+            this.clamp(
+              settings.browse_panel_width,
+              BrowseViewComponent.PANEL_MIN,
+              BrowseViewComponent.PANEL_MAX,
+            ),
+          );
+        }
+        this.applyBrowsePrefsForMediaType();
       }
-      this.applyBrowsePrefsForMediaType();
+      if (settings || settingsErrored) this.maybeStartInitialLoad();
     });
+  }
+
+  /**
+   * Start the first projection load once — but only when the bin shape is
+   * known: the saved settings must be in (or their load have failed) AND the
+   * dataset's media type resolved. See {@link initialLoadStarted}.
+   */
+  private maybeStartInitialLoad(): void {
+    if (this.initialLoadStarted) return;
+    const settingsIn = this.lastSettings != null || this.settingsState.error() != null;
+    if (!settingsIn || !this.statusResolved) return;
+    this.initialLoadStarted = true;
+    this.loadProjection();
   }
 
   ngOnInit(): void {
@@ -256,19 +289,31 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
           if (!this.subset) this.datasetName.set(status.display_name || '');
           this.mediaType.set(status.media_type || '');
           this.applyBrowsePrefsForMediaType();
+          this.statusResolved = true;
+          this.maybeStartInitialLoad();
+        },
+        error: () => {
+          // Couldn't read the dataset status (media type unknown). Proceed with
+          // the default lattice rather than hang on the loading spinner.
+          this.statusResolved = true;
+          this.maybeStartInitialLoad();
         },
       });
 
-    this.loadProjection();
-
     // The full-dataset projection re-resolves when the active pair changes via
     // the top bar. A subset projection is tied to the ids that produced it, so
-    // ignore pair changes in subset mode.
+    // ignore pair changes in subset mode. The first (replayed) emission lands
+    // before settings/status are in, so it routes through the gated initial
+    // load; genuine later changes reload directly.
     if (!this.subset) {
       this.activeContext.pair$
         .pipe(takeUntil(this.destroy$))
         .subscribe(() => {
-          this.loadProjection();
+          if (this.initialLoadStarted) {
+            this.loadProjection();
+          } else {
+            this.maybeStartInitialLoad();
+          }
         });
     }
   }
@@ -381,7 +426,17 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.canvas?.setThumbnailRadius(this.thumbnailRadius, false);
 
     const shape: BinShape = this.perMediaValue(s.browse_bin_shape, mt) === 'square' ? 'square' : 'hex';
-    if (shape !== this.binShape()) this.switchBinShape(shape, false);
+    if (!this.initialLoadStarted) {
+      // Before the first projection load there's nothing on screen to re-bin —
+      // just record the resolved shape so the initial fetch uses the right
+      // lattice. Routing through switchBinShape() here would either no-op (when
+      // the saved shape equals the default) and strand the gated load, or kick
+      // a premature load off a half-resolved media type.
+      this.binShape.set(shape);
+      this.tileCache.setBinShape(shape);
+    } else if (shape !== this.binShape()) {
+      this.switchBinShape(shape, false);
+    }
 
     const borderMap = s.browse_thumbnail_border as { [key: string]: number } | undefined;
     const rawBorder = mt && borderMap ? borderMap[mt] : undefined;

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -64,7 +64,11 @@ describe('BrowseViewComponent (zoneless canary)', () => {
         >,
     };
     const settingsStub: Partial<SettingsStateService> = {
-      settingsSignal: signal(null) as SettingsStateService['settingsSignal'],
+      // Settings resolve (as they do in production): the browse view holds its
+      // first projection load until settings + media type are in, so it fetches
+      // the saved bin shape rather than flashing the default hex lattice.
+      settingsSignal: signal({}) as unknown as SettingsStateService['settingsSignal'],
+      error: signal(null) as unknown as SettingsStateService['error'],
       load: noop,
       update: () => of({}) as ReturnType<SettingsStateService['update']>,
     };


### PR DESCRIPTION
## Problem

Opening the browser always rendered the **hex** lattice for ~a second before switching to the user's preselected **square** setting — a confusing wrong grid, and a wasted re-bin round-trip.

The cause was an initialization race: `ngOnInit` called `loadProjection()` immediately with the hardcoded default `binShape = 'hex'`, rendering hexes as soon as the meta came back. Settings load asynchronously, so only *afterward* did `applyBrowsePrefsForMediaType()` resolve the saved `square` preference and call `switchBinShape()`, triggering a server re-bin (the visible ~1s).

The correct shape can't be resolved synchronously: it depends on **two** async facts — the saved `browse_bin_shape` setting **and** the dataset's media type (the pref is keyed per-media, and the media type comes from `getStatus()`).

## Fix

Hold the *first* projection load until both facts are in, staying on the existing "Loading projection…" spinner instead of rendering the wrong grid. Then fetch the user's saved lattice directly — no flash, no wasted re-bin.

- Added a gated `maybeStartInitialLoad()` that fires the first `loadProjection()` exactly once, only after settings have resolved (or their load errored) **and** the dataset status (media type) has resolved.
- Before the initial load, `applyBrowsePrefsForMediaType()` just records the resolved shape (`binShape.set(...)`) rather than routing through `switchBinShape()`, which would either no-op (when the saved shape equals the default) and strand the load, or kick a premature load off a half-resolved media type. After the initial load, the existing re-bin-in-place path is unchanged.
- Robustness: if settings or the status fetch fail, the view proceeds with the default lattice rather than hanging on the spinner forever.

This matches the request: a moment on the loading state beats a confusing wrong grid, and the saved shape now loads in a single pass.

## Testing

- `npm run test:ci` — 875 frontend tests pass, clean production build (no budget warnings). Updated the browse-view zoneless canary stub so settings resolve (as in production) and provide the `error` signal the new effect reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013836bQSbNUBSg66a9Mh7tw

---
_Generated by [Claude Code](https://claude.ai/code/session_013836bQSbNUBSg66a9Mh7tw)_