### PR TITLE
Align console preload progress bars

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -121,6 +121,38 @@ class TestMakeConsoleProgress:
         captured = capsys.readouterr()
         assert "100%" in captured.out
 
+    def test_bars_align_across_different_labels(self, capsys):
+        """Bars for labels of different lengths should start at the same column."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Importing torch…", 1, 2)
+        cb("loading", "Importing transformers…", 2, 2)
+        cb("loading", "Loading weights", 5, 10)
+        cb.flush()
+
+        captured = capsys.readouterr()
+        # Each \r-overwrite is a separate render; the bar's open-bracket column
+        # must be identical for every label so the bars line up vertically.
+        renders = [seg for seg in captured.out.replace("\033[K", "").split("\r") if "[" in seg]
+        cols = {seg.index("[") for seg in renders}
+        assert len(cols) == 1, f"bars not aligned: columns were {cols}"
+
+    def test_elapsed_suffix_does_not_shift_bar(self, capsys):
+        """A growing elapsed-time suffix ('1s' -> '10s') must not move the bar."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Importing torch… (1s)", 1, 2)
+        cb("loading", "Importing torch… (10s)", 1, 2)
+        cb("loading", "Importing torch… (100s)", 1, 2)
+
+        captured = capsys.readouterr()
+        renders = [seg for seg in captured.out.replace("\033[K", "").split("\r") if "[" in seg]
+        cols = {seg.index("[") for seg in renders}
+        assert len(cols) == 1, f"bar shifted while suffix grew: columns were {cols}"
+        # The suffix is rendered after the percentage, not before the bar.
+        for seg in renders:
+            assert seg.index("s)") > seg.index("%")
+
     def test_phase_after_progress_starts_new_line(self, capsys):
         """A phase message arriving mid-progress-bar should start a new line."""
         cb = _make_console_progress(lambda *a, **kw: None)

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -19,6 +19,13 @@ from typing import Any, cast
 
 _TIME_SUFFIX_RE = re.compile(r"\s*\(\d+s(?:,\s*\d+\s+modules)?\)$")
 
+#: Fixed column width for the label printed before a console progress bar.
+#: Padding every label to this width makes the ``[####…]`` bars line up
+#: vertically.  Sized to fit the longest common preload label
+#: ("Importing sentence_transformers…", 32 chars); longer labels simply
+#: push their own bar right rather than being truncated.
+_LABEL_WIDTH = 32
+
 
 def _strip_time_suffix(msg: str) -> str:
     return _TIME_SUFFIX_RE.sub("", msg) if msg else msg
@@ -243,6 +250,11 @@ def _make_console_progress(original_callback):
     instead of stacking new lines.  The progress line is terminated with a
     newline only when a different base message arrives, a phase message
     arrives, or the caller invokes ``cb.flush()``.
+
+    Every bar's label is left-padded to a fixed width (:data:`_LABEL_WIDTH`)
+    so successive bars line up vertically, and the elapsed-time/status suffix
+    is rendered after the percentage so its changing length (``1s`` → ``10s``)
+    never shifts the bar mid-progress.
     """
     _last_msg: list[str | None] = [None]
     _last_base: list[str | None] = [None]
@@ -253,7 +265,8 @@ def _make_console_progress(original_callback):
     def _complete_bar() -> None:
         """Overwrite the current progress line with a 100% bar."""
         if _last_base[0]:
-            sys.stdout.write(f"\r    {_last_base[0]} [{_FULL_BAR}] 100%\033[K")
+            label = f"{_last_base[0]:<{_LABEL_WIDTH}}"
+            sys.stdout.write(f"\r    {label} [{_FULL_BAR}] 100%\033[K")
 
     def _flush() -> None:
         if _on_progress_line[0]:
@@ -277,9 +290,15 @@ def _make_console_progress(original_callback):
             pct = min(100, current * 100 // total)
             filled = pct * 30 // 100
             bar = "#" * filled + "." * (30 - filled)
+            # Pad the base label to a fixed width so every bar starts at the
+            # same column and the bars line up vertically.  The elapsed-time /
+            # status suffix (e.g. "(3s, 247 modules)") goes *after* the
+            # percentage, where its changing length can't shift the bar.
+            suffix = message[len(base) :].strip()
+            tail = f" {suffix}" if suffix else ""
             # \033[K clears from cursor to end of line so a shorter message
             # doesn't leave trailing chars from a longer prior render.
-            line = f"\r    {message} [{bar}] {pct:>3}%\033[K"
+            line = f"\r    {base:<{_LABEL_WIDTH}} [{bar}] {pct:>3}%{tail}\033[K"
             sys.stdout.write(line)
             sys.stdout.flush()
             _on_progress_line[0] = True


### PR DESCRIPTION
## Problem

During startup preloading, the console progress bars didn't line up: each `[####…]` bar started right after a variable-length label, so the bars sat at different columns. Worse, the elapsed-time/status suffix (`(1s)`, `(10s)`, `(247 modules)`) was rendered *before* the bar, so the bar visibly jittered to the right as the suffix grew while a single operation progressed.

```
Importing torch… [##############################] 100%
    Importing transformers… [##############################] 100%
    Loading weights [##############################] 100%
```

## Fix

In `_make_console_progress` (`vtscore/embedding/loader.py`):

- **Fixed-width labels** — every label is left-padded to `_LABEL_WIDTH` (32, sized to the longest common preload label, `Importing sentence_transformers…`) so all bars start at the same column.
- **Suffix after the percentage** — the elapsed-time/status suffix now renders *after* `NN%`, where its changing length can no longer shift the bar mid-progress.

Result — bars align and stay put:

```
    Importing torch…                 [##############################] 100%
    Importing transformers…          [##############################] 100% (10s)
    Loading weights                  [###############...............]  50%
```

## Tests

- New `test_bars_align_across_different_labels` and `test_elapsed_suffix_does_not_shift_bar` in `tests_lib/cli/test_preload_progress.py`.
- Full suite green (5252 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8869iMrw979wKxWDmEMh9)_