### PR TITLE
Fix bin popup lurching on first resize after open

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -246,16 +246,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       // A new media type may carry a different remembered thumbnail size.
       this.applyViewPrefs();
     }
-    if (
-      changes['x'] ||
-      changes['y'] ||
-      changes['bounds'] ||
-      changes['memberIds'] ||
-      changes['hoverThumbRadius']
-    ) {
-      // Re-anchor to the summon point, unless the user has dragged the popup —
-      // then keep their spot (``place`` re-clamps it back on-screen if needed).
-      if (!this.dragged) {
+    // A genuine (re)summon — a fresh bin or a new anchor/region — re-seeds the
+    // position at the summon point (unless the user has dragged the popup). A
+    // pure size change (the main-canvas thumbnail radius) must NOT snap back to
+    // the cursor: it keeps the popup where it sits and only re-clamps it
+    // on-screen. Without this, the first resize after opening lurches the window
+    // from the cursor across to the clamped edge, because ``place`` was
+    // re-deriving the position from the raw summon point every time rather than
+    // from where the window had settled.
+    const resummoned = changes['x'] || changes['y'] || changes['bounds'] || changes['memberIds'];
+    if (resummoned || changes['hoverThumbRadius']) {
+      if (resummoned && !this.dragged) {
         this.left = this.x();
         this.top = this.y();
       }
@@ -637,14 +638,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
 
   // --- Positioning ---------------------------------------------------------
 
-  /** Re-clamp the popup, anchoring at the summon point unless the user has
-   *  dragged it (then keep their spot, just nudged back on-screen if needed).
-   *  The computed clamp derives the popup size from known widths/heights; once
-   *  it has laid out we additionally measure the real panel and correct any
-   *  residual overflow, so the window ends up entirely on-screen even if the
-   *  computed height drifts from what actually rendered. */
+  /** Re-clamp the popup to stay fully on-screen, anchored at its *current*
+   *  position. The summon point seeds {@link left}/{@link top} once, when the
+   *  popup opens (and on a genuine re-summon — see {@link ngOnChanges}); from
+   *  then on every re-clamp (size changes, the settings-driven detail-image
+   *  resize, region changes) keeps the popup where it sits rather than snapping
+   *  back to the cursor. The computed clamp derives the popup size from known
+   *  widths/heights; once it has laid out we additionally measure the real panel
+   *  and correct any residual overflow, so the window ends up entirely on-screen
+   *  even if the computed height drifts from what actually rendered. */
   private place(): void {
-    this.clampInto(this.dragged ? this.left : this.x(), this.dragged ? this.top : this.y());
+    this.clampInto(this.left, this.top);
     requestAnimationFrame(() => this.nudgeOnScreen());
   }
 


### PR DESCRIPTION
## Problem

When you right-click for the details popup, it opens in a good spot at the cursor — but the first time you change the thumbnail size (or the detail-image size), the window **lurches** across the screen to a new spot. After that, further size changes are smooth and keep the window largely in place.

## Root cause

The popup re-anchored to the **raw right-click summon point** `(x, y)` on *every* re-clamp, not just the initial placement:

- `place()` clamped from `this.x()/this.y()` (the cursor), and
- `ngOnChanges` reset `left = x()/top = y()` on a `hoverThumbRadius` (size) change.

So the sequence was:

1. **Open:** the small popup fits at the cursor → `top = y` (cursor).
2. **First size change:** the bigger popup no longer fits, so `clampInto` edge-clamps it → `top` jumps discontinuously from the cursor to `regionBottom − height`. That jump is the "lurch."
3. **Subsequent changes:** the popup is now in the edge-clamped regime, so the position tracks the size smoothly → "largely the same spot."

The underlying anchor state was stale relative to where the window had visibly settled — exactly the "underlying state hasn't caught up to the move" symptom.

## Fix

The summon point now seeds `left/top` **once**, on a genuine (re)summon (a fresh bin or new anchor/region), unless the user has dragged the popup. Pure size changes — the main-canvas thumbnail radius, the settings-driven detail-image resize, region changes — keep the popup where it sits and only re-clamp it on-screen. `place()` now anchors at the current `left/top` instead of re-deriving from the cursor.

This makes the very first resize behave like every subsequent one: the window stays put and just nudges to remain fully visible.

## Testing

`./run-tests.sh frontend` passes clean — Angular `build:prod`, `npm audit` (0 vulns), and all 875 Vitest unit tests, plus the ruff/codespell/deptry/pyright/pip-audit stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYdSgL84s7r75UDcSQRrpi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYdSgL84s7r75UDcSQRrpi)_