### PR TITLE
Speed up browse wheel zoom to 1.4x per notch

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -191,8 +191,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private pendingToggleX = 0;
   private pendingToggleY = 0;
   private static readonly DBLCLICK_MS = 250;
+  // Per-notch wheel zoom factor. A pyramid level spans a full 2x of zoom, so
+  // this sets how many notches cross a bin layer: log_1.4(2) ≈ 2 notches.
+  private static readonly WHEEL_ZOOM_FACTOR = 1.4;
   // How hard a double-click zooms in about the cursor. Larger than the wheel's
-  // 1.15/tick so the gesture lands a decisive jump, matching the map idiom.
+  // per-notch factor so the gesture lands a decisive jump, matching the map idiom.
   private static readonly DOUBLE_CLICK_ZOOM = 2.0;
 
   // Shift+drag draws a marquee rectangle (canvas-relative screen coords) that
@@ -1799,7 +1802,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
-    const factor = event.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const wheelFactor = BrowseCanvasComponent.WHEEL_ZOOM_FACTOR;
+    const factor = event.deltaY < 0 ? wheelFactor : 1 / wheelFactor;
     this.zoomBy(factor, mx, my);
   }
 

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -178,8 +178,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private boundPanelUp = this.onPanelMouseUp.bind(this);
 
   /**
-   * Per-click zoom step for the on-screen +/- buttons. Larger than the wheel's
-   * 1.15 per-tick factor so a single click makes a visible difference; button
+   * Per-click zoom step for the on-screen +/- buttons. Matches the wheel's
+   * per-notch factor so a single click makes a visible difference; button
    * zoom anchors at the viewport centre (no cursor to zoom toward).
    */
   private readonly ZOOM_BUTTON_FACTOR = 1.4;


### PR DESCRIPTION
## What & why

In the browse view, changing which hex-bin layer is shown took **~5 scroll-wheel notches**, which felt like too many zooms to cross a layer.

The cause is structural: the pyramid spaces levels by halving the hex radius (`radius = r0 / 2**level`), and the canvas picks a level with `round(log2(base_radius * zoom / targetRadius))`. With `round()` over factor-of-2 level spacing, **a bin layer only changes when zoom moves by a full 2x**. The wheel's old `1.15x` per-notch factor meant `log_1.15(2) ≈ 5` notches per layer change.

## Change

Bump the per-notch wheel zoom factor `1.15 → 1.4`, so crossing a layer now takes `log_1.4(2) ≈ 2` notches — matching the existing `+/-` zoom-button step. Extracted the factor into a named `WHEEL_ZOOM_FACTOR` constant and refreshed the two comments that referenced the old `1.15`.

This is the cheap, frontend-only lever (zoom step size). The other lever — finer pyramid layer spacing (÷√2 radius → 2:1 area splits) — was discussed but not taken here; it's a backend pyramid rebuild.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, 875 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017riD1t7QVNXzauzjVZJKXm

---
_Generated by [Claude Code](https://claude.ai/code/session_017riD1t7QVNXzauzjVZJKXm)_