### PR TITLE
Stop list autoscroll on hover-mode selection

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -116,6 +116,24 @@ describe('MediaListComponent', () => {
     expect(fixture.nativeElement.querySelector('.media-threshold-line')).toBeTruthy();
   });
 
+  it('queues an autoscroll when the selection changes in click mode', () => {
+    fixture.componentRef.setInput('focusMode', 'click');
+    TestBed.tick();
+    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
+    expect(component['pendingScrollToSelected']).toBe(true);
+  });
+
+  // Regression: in hover mode the selection follows the cursor. Scrolling the
+  // hovered item to the top shifts what's under the mouse, which re-selects and
+  // scrolls again — an infinite autoscroll loop. Hover selection must not queue
+  // an autoscroll.
+  it('does not queue an autoscroll on hover selection', () => {
+    fixture.componentRef.setInput('focusMode', 'hover');
+    TestBed.tick();
+    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
+    expect(component['pendingScrollToSelected']).toBe(false);
+  });
+
   // Regression: small datasets used to never prefetch metadata, so the list
   // displayed ``#284`` placeholders forever; names only filled in when the
   // user clicked an item. Without virtual scroll active, every row is in the

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -159,7 +159,15 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['selectedId'] && !changes['selectedId'].firstChange) {
+    // Only autoscroll the newly-selected item into view in click mode. In hover
+    // mode the selection follows the cursor, so scrolling the item to the top
+    // would shift what's under the mouse, re-trigger selection, and scroll
+    // again — an infinite autoscroll loop. Let the hovered item stay put.
+    if (
+      changes['selectedId'] &&
+      !changes['selectedId'].firstChange &&
+      this.focusMode() === 'click'
+    ) {
       this.pendingScrollToSelected = true;
     }
 


### PR DESCRIPTION
## Problem

In **hover mode** (e.g. the Train interface), the selection follows the cursor. The media list also autoscrolls the newly-selected item toward the top whenever `selectedId` changes. Together these fed back on each other: scrolling the hovered item up shifted what was under the mouse → that re-selected a different item → which scrolled again → an infinite autoscroll loop.

In **click mode** the autoscroll is the desired behavior (click an item and it jogs near the top), so that should stay.

## Fix

Only queue the scroll-to-selected when `focusMode` is `'click'`. In hover mode the hovered item stays put, breaking the loop. The change is a single guard in `MediaListComponent.ngOnChanges` on the `selectedId` change.

Explicit scrolls (minimap stripe clicks → `scrollToIndex`, keyboard navigation) are unaffected; they don't go through the `selectedId`-change path.

## Tests

Added two regression tests in `media-list.component.spec.ts`:
- click mode queues an autoscroll on selection change
- hover mode does **not** queue an autoscroll on selection change

`./run-tests.sh frontend` passes (877 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0177bJnuJd7ad7aFjL2eTKE5)_