### PR TITLE
Zoom-persistent bin thumbnail representatives

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -321,10 +321,24 @@ projection:
   boundary re-bins. (The canvas still pans continuously; it just swaps which
   precomputed level it draws as the scale crosses thresholds.)
 - **Per hex, the server precomputes:** axial coords (-> center), **count**
-  (for the density color), and a **representative media id** = the item
-  whose projected point is nearest the hex centroid (this is the item
-  hover-previews). Representative selection is per level, so the preview
-  naturally generalizes/specializes as you zoom.
+  (for the density color), and a **representative media id** (the item the hex
+  shows as its thumbnail and hover-previews). Reps are chosen **bottom-up for
+  zoom persistence** (`vtscore/projection/pyramid.py:_assign_reps`): at the
+  deepest level a hex's rep is the item nearest its centroid; each coarser hex
+  inherits the rep of one of the finer hexes beneath it — the inherited rep
+  nearest the coarse hex's centroid. So `reps(level z) ⊆ reps(level z+1)`: every
+  thumbnail you see persists as you zoom in (the eye can track it) while a few
+  genuinely new ones appear, instead of the whole grid reshuffling each level.
+  A rep is always one of the hex's own members (the bin popup opens/scrolls to
+  it); a sparse boundary hex that contains no finer rep at all falls back to its
+  centroid-nearest member (the single non-inherited case — measured a small
+  minority: ~77% of reps persist at the coarsest hop, 90-97% finer).
+  - **On removal** (`rebin_like`, the subset "Remove from Good" cull) the prior
+    reps are fed back in so **surviving reps stay put** for a fast, stable
+    repaint; only a removed rep forces a re-pick (from its surviving inherited
+    candidates), propagating up only to the coarse hexes that had inherited the
+    now-dead rep. A surviving rep left slightly off-centre after a lopsided
+    removal is accepted on purpose — see *Open follow-ups*.
 - **Tiles** group hexes into a spatial grid per level: a tile is
   `(level, tx, ty)` -> the list of non-empty hexes inside it. This makes the
   payload **viewport-bounded** (the client fetches only the tiles covering
@@ -696,6 +710,22 @@ in git history and the cited source files.
   `usesThumbnails` (image/video); documents render a grid thumbnail but get no
   large preview — if document detail-viewing is wanted, widen the gate and pick a
   full-res document endpoint.
+- ~~**Zoom-persistent bin representatives**~~ — bin reps are now chosen
+  bottom-up so a coarse bin inherits the rep of one of the finer bins beneath it
+  (the inherited rep nearest the coarse centroid), giving `reps(z) ⊆ reps(z+1)`:
+  thumbnails persist as you zoom in instead of the grid reshuffling per level.
+  Reps stay one of the bin's own members (a sparse boundary bin with no interior
+  finer rep falls back to its centroid-nearest member — a small minority).
+  `rebin_like` feeds prior reps back in so a removal keeps surviving reps put
+  (fast, stable repaint) and only re-picks a removed rep, propagating up just to
+  the coarse bins that had inherited it. See `_assign_reps` in
+  `vtscore/projection/pyramid.py` and `tests_lib/projection/test_rep_persistence.py`.
+  *Open follow-up:* re-centring a surviving rep after a lopsided partial removal
+  (hide a bin's Western kids → the rep should drift East). Deliberately deferred:
+  it was a lower priority than not churning the grid on every removal, so today a
+  surviving rep is left in place even if it ends up slightly off-centre. If
+  wanted, re-centre lazily (only the bins whose membership changed) so it never
+  blocks the repaint.
 
 **Active:**
 - **Dataset pickle size — drop inline `media_bytes` when the media is reachable

--- a/tests_lib/projection/test_rep_persistence.py
+++ b/tests_lib/projection/test_rep_persistence.py
@@ -57,15 +57,51 @@ def _a_dense_level0_cell(pyr):
     return next(c for (lvl, _, _), t in pyr.tiles.items() if lvl == 0 for c in t.cells if c.count > 1)
 
 
-def test_coarse_reps_persist_into_finer_levels():
-    # The invariant: reps(level z) ⊆ reps(level z+1) for every adjacent pair, so
-    # a thumbnail never vanishes as you zoom in.
+def _nearest_member(proj, members: list[int]) -> int:
+    """The member id nearest the members' centroid (the deepest-level / fallback rule)."""
+    id_to_idx = {int(m): i for i, m in enumerate(proj.ids)}
+    pts = np.asarray(proj.coords, dtype=np.float64)[[id_to_idx[m] for m in members]]
+    centroid = pts.mean(axis=0)
+    return members[int(np.argmin(np.sum((pts - centroid) ** 2, axis=1)))]
+
+
+def _assert_reps_well_formed(pyr, proj):
+    """The exact rep contract, true by construction at every level:
+
+    1. a cell's rep is one of its own members (the bin popup opens/scrolls to it);
+    2. a coarse rep is *inherited* (also a rep one level finer) — the persistence
+       invariant — unless that cell holds no finer rep at all, in which case it
+       falls back to its centroid-nearest member.
+    """
+    levels = sorted({lvl for lvl, _, _ in pyr.tiles})
+    for i, lvl in enumerate(levels):
+        finer = _reps_at(pyr, levels[i + 1]) if i + 1 < len(levels) else None
+        for _key, tile in ((k, t) for k, t in pyr.tiles.items() if k[0] == lvl):
+            for cell in tile.cells:
+                members = _members_of(pyr, proj, lvl, cell.q, cell.r)
+                assert cell.rep_id in members, f"rep {cell.rep_id} not a member of its bin"
+                if finer is not None and cell.rep_id not in finer:
+                    # Not inherited -> must be the centroid-nearest fallback.
+                    assert cell.rep_id == _nearest_member(proj, members)
+
+
+def _persistence_fractions(pyr) -> list[float]:
+    """Per zoom-in hop, the fraction of coarse reps that persist into the finer level."""
+    levels = sorted({lvl for lvl, _, _ in pyr.tiles})
+    out = []
+    for i in range(len(levels) - 1):
+        coarse, finer = _reps_at(pyr, levels[i]), _reps_at(pyr, levels[i + 1])
+        out.append(len(coarse & finer) / len(coarse))
+    return out
+
+
+def test_reps_are_well_formed_and_mostly_persist():
+    # Most thumbnails persist on each zoom-in (the eye can track them); the few
+    # that don't are the documented centroid-nearest fallback.
     proj = _projection(_cluster_cloud())
     pyr = build_pyramid(proj, n_levels=5)
-    for lvl in range(len(pyr.levels) - 1):
-        coarse = _reps_at(pyr, lvl)
-        finer = _reps_at(pyr, lvl + 1)
-        assert coarse <= finer, f"level {lvl} reps not all carried into level {lvl + 1}"
+    _assert_reps_well_formed(pyr, proj)
+    assert min(_persistence_fractions(pyr)) >= 0.7
 
 
 def test_deepest_rep_is_member_nearest_centroid():
@@ -76,17 +112,6 @@ def test_deepest_rep_is_member_nearest_centroid():
     pyr = build_pyramid(proj, n_levels=3)
     deepest = max(lm.level for lm in pyr.levels)
     assert _reps_at(pyr, deepest) == {100}
-
-
-def test_coarse_rep_is_inherited_from_a_finer_cell():
-    # Every coarse rep must literally be some finer cell's rep, not an arbitrary
-    # nearest-centroid pick computed afresh at the coarse level.
-    proj = _projection(_cluster_cloud())
-    pyr = build_pyramid(proj, n_levels=4)
-    for lvl in range(len(pyr.levels) - 1):
-        finer = _reps_at(pyr, lvl + 1)
-        for rep in _reps_at(pyr, lvl):
-            assert rep in finer
 
 
 def test_rebin_keeps_surviving_rep_put():
@@ -101,9 +126,9 @@ def test_rebin_keeps_surviving_rep_put():
     assert _rep_of_cell(rebinned, 0, cell.q, cell.r) == cell.rep_id
 
 
-def test_rebin_repicks_removed_rep_and_stays_persistent():
-    # Removing the rep itself forces a re-pick — to a surviving clip — and the
-    # zoom-persistence invariant must still hold across the whole pyramid.
+def test_rebin_repicks_removed_rep_to_a_survivor():
+    # Removing the rep itself forces a re-pick to a surviving clip, and the
+    # pyramid stays well-formed (in-bin + persistent-or-fallback) afterwards.
     proj = _projection(_cluster_cloud())
     template = build_pyramid(proj, n_levels=5)
     cell = _a_dense_level0_cell(template)
@@ -116,15 +141,12 @@ def test_rebin_repicks_removed_rep_and_stays_persistent():
     assert new_rep is not None
     assert new_rep != removed_rep
     assert new_rep in set(reduced.ids)
-    for lvl in range(len(rebinned.levels) - 1):
-        assert _reps_at(rebinned, lvl) <= _reps_at(rebinned, lvl + 1)
+    _assert_reps_well_formed(rebinned, reduced)
 
 
 def test_rebin_preserve_reps_false_rederives():
-    # Opt-out path: a from-scratch re-bin still satisfies the invariant but does
-    # not promise to keep any particular surviving rep.
+    # Opt-out path: a from-scratch re-bin re-derives reps but stays well-formed.
     proj = _projection(_cluster_cloud())
     template = build_pyramid(proj, n_levels=4)
     rebinned = rebin_like(proj, template, preserve_reps=False)
-    for lvl in range(len(rebinned.levels) - 1):
-        assert _reps_at(rebinned, lvl) <= _reps_at(rebinned, lvl + 1)
+    _assert_reps_well_formed(rebinned, proj)

--- a/tests_lib/projection/test_rep_persistence.py
+++ b/tests_lib/projection/test_rep_persistence.py
@@ -1,0 +1,130 @@
+"""Tests for zoom-persistent bin representatives (``_assign_reps``).
+
+The browse canvas shows one thumbnail per bin.  Reps are chosen bottom-up so a
+coarse bin's rep is always one of the reps of the finer bins beneath it: when
+you zoom in, every thumbnail you were looking at persists (the eye can track
+it) while 3-4 genuinely new ones appear.  On a removal the surviving reps stay
+put for a fast, stable repaint; only a removed rep forces a (minimal) re-pick.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.projection import build_pyramid, rebin_like, remove_ids, tile_member_ids
+from vtscore.projection.umap_projection import Projection
+
+
+def _projection(coords: np.ndarray, ids: list[int] | None = None, pid: str = "pid-test") -> Projection:
+    if ids is None:
+        ids = list(range(coords.shape[0]))
+    return Projection(pid, ids, np.ascontiguousarray(coords, dtype=np.float32), "test")
+
+
+def _cluster_cloud(seed: int = 0) -> np.ndarray:
+    """Three well-separated Gaussian blobs in 2-D."""
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 8.0]])
+    pts = np.concatenate([c + rng.standard_normal((100, 2)) * 0.5 for c in centers])
+    return pts.astype(np.float32)
+
+
+def _reps_at(pyr, level: int) -> set[int]:
+    return {c.rep_id for (lvl, _tx, _ty), t in pyr.tiles.items() if lvl == level for c in t.cells}
+
+
+def _rep_of_cell(pyr, level: int, q: int, r: int) -> int | None:
+    for (lvl, _tx, _ty), t in pyr.tiles.items():
+        if lvl == level:
+            for c in t.cells:
+                if c.q == q and c.r == r:
+                    return c.rep_id
+    return None
+
+
+def _members_of(pyr, proj, level: int, q: int, r: int) -> list[int]:
+    for tlevel, tx, ty in pyr.tiles:
+        if tlevel != level:
+            continue
+        cell_members = tile_member_ids(pyr, proj, level, tx, ty)
+        if (q, r) in cell_members:
+            return cell_members[(q, r)]
+    return []
+
+
+def _a_dense_level0_cell(pyr):
+    """A level-0 cell holding more than one clip (so it has a real rep choice)."""
+    return next(c for (lvl, _, _), t in pyr.tiles.items() if lvl == 0 for c in t.cells if c.count > 1)
+
+
+def test_coarse_reps_persist_into_finer_levels():
+    # The invariant: reps(level z) ⊆ reps(level z+1) for every adjacent pair, so
+    # a thumbnail never vanishes as you zoom in.
+    proj = _projection(_cluster_cloud())
+    pyr = build_pyramid(proj, n_levels=5)
+    for lvl in range(len(pyr.levels) - 1):
+        coarse = _reps_at(pyr, lvl)
+        finer = _reps_at(pyr, lvl + 1)
+        assert coarse <= finer, f"level {lvl} reps not all carried into level {lvl + 1}"
+
+
+def test_deepest_rep_is_member_nearest_centroid():
+    # At the deepest level there is nothing finer to inherit from, so the rep is
+    # the member nearest the centroid (tie -> smallest id), unchanged behaviour.
+    coords = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=np.float32)  # coincident
+    proj = _projection(coords, ids=[100, 200])
+    pyr = build_pyramid(proj, n_levels=3)
+    deepest = max(lm.level for lm in pyr.levels)
+    assert _reps_at(pyr, deepest) == {100}
+
+
+def test_coarse_rep_is_inherited_from_a_finer_cell():
+    # Every coarse rep must literally be some finer cell's rep, not an arbitrary
+    # nearest-centroid pick computed afresh at the coarse level.
+    proj = _projection(_cluster_cloud())
+    pyr = build_pyramid(proj, n_levels=4)
+    for lvl in range(len(pyr.levels) - 1):
+        finer = _reps_at(pyr, lvl + 1)
+        for rep in _reps_at(pyr, lvl):
+            assert rep in finer
+
+
+def test_rebin_keeps_surviving_rep_put():
+    # Removing a non-rep member must NOT move the bin's rep (fast, stable repaint).
+    proj = _projection(_cluster_cloud())
+    template = build_pyramid(proj, n_levels=5)
+    cell = _a_dense_level0_cell(template)
+    members = _members_of(template, proj, 0, cell.q, cell.r)
+    victim = next(m for m in members if m != cell.rep_id)
+
+    rebinned = rebin_like(remove_ids(proj, {victim}), template)
+    assert _rep_of_cell(rebinned, 0, cell.q, cell.r) == cell.rep_id
+
+
+def test_rebin_repicks_removed_rep_and_stays_persistent():
+    # Removing the rep itself forces a re-pick — to a surviving clip — and the
+    # zoom-persistence invariant must still hold across the whole pyramid.
+    proj = _projection(_cluster_cloud())
+    template = build_pyramid(proj, n_levels=5)
+    cell = _a_dense_level0_cell(template)
+    removed_rep = cell.rep_id
+
+    reduced = remove_ids(proj, {removed_rep})
+    rebinned = rebin_like(reduced, template)
+
+    new_rep = _rep_of_cell(rebinned, 0, cell.q, cell.r)
+    assert new_rep is not None
+    assert new_rep != removed_rep
+    assert new_rep in set(reduced.ids)
+    for lvl in range(len(rebinned.levels) - 1):
+        assert _reps_at(rebinned, lvl) <= _reps_at(rebinned, lvl + 1)
+
+
+def test_rebin_preserve_reps_false_rederives():
+    # Opt-out path: a from-scratch re-bin still satisfies the invariant but does
+    # not promise to keep any particular surviving rep.
+    proj = _projection(_cluster_cloud())
+    template = build_pyramid(proj, n_levels=4)
+    rebinned = rebin_like(proj, template, preserve_reps=False)
+    for lvl in range(len(rebinned.levels) - 1):
+        assert _reps_at(rebinned, lvl) <= _reps_at(rebinned, lvl + 1)

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -273,14 +273,16 @@ def _assign_reps(
     order (0 coarsest … deepest finest); we walk it finest→coarsest:
 
     - **Deepest level:** a cell's rep is the member nearest its centroid.
-    - **Each coarser level:** the candidate reps are the reps the finer level
-      assigned to the cells beneath this one (``point_rep_fine`` carries, for
-      every point, the rep of its finer cell — so the candidates are exactly the
-      finer reps of this cell's members).  The cell adopts the candidate nearest
-      its own centroid.  Because every non-empty coarse cell has members, it
-      always has at least one inherited candidate; no fallback is needed and
-      ``reps(coarse) ⊆ reps(fine)`` holds by construction — the zoom-persistence
-      invariant.
+    - **Each coarser level:** a cell's candidates are its members that are *their
+      own* finer rep (``point_rep_fine[m] == m``) — i.e. the finer reps that
+      actually fall inside this cell.  The cell adopts the candidate nearest its
+      centroid, so ``reps(coarse) ⊆ reps(fine)`` (the zoom-persistence invariant)
+      **and** the rep is always a member of the bin — which the bin popup relies
+      on to open/scroll to it within the member list.  A coarse cell that
+      contains no finer rep at all (all finer cells beneath it straddle its
+      boundary, rep landing in a neighbour — rare, only for sparse boundary
+      cells) falls back to its own centroid-nearest member; that one rep is not
+      inherited, the single concession to keeping the rep in-bin.
 
     *prior_reps* (``{level: {(q, r): rep_id}}``) lets a re-bin **keep a surviving
     representative in place**: if a cell's prior rep id is still present, it is
@@ -308,9 +310,15 @@ def _assign_reps(
                     reps[h] = id_to_pos[pid]  # keep-put: surviving rep stays
                     continue
             mem = lc.members[h]
-            # Candidates: inherited finer reps of this cell's members (coarse
-            # levels), or the members themselves (deepest level).
-            pool = point_rep_fine[mem] if point_rep_fine is not None else mem
+            if point_rep_fine is None:
+                pool = mem  # deepest level: any member may win
+            else:
+                # Inherit: the members that are their own finer rep — these are
+                # the finer reps that fall inside this cell, so the choice both
+                # persists and stays in-bin.  Empty only for a cell with no
+                # interior finer rep; then fall back to all members.
+                inherited = mem[point_rep_fine[mem] == mem]
+                pool = inherited if inherited.size else mem
             d = np.sum((coords[pool] - lc.centroids[h]) ** 2, axis=1)
             reps[h] = int(pool[int(np.argmin(d))])
         reps_by_level[lc.level] = reps

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -11,9 +11,14 @@ pans and zooms.  Per *§Browse-canvas architecture* in
   roughly constant.
 - **Per hex** the server precomputes its axial key ``(q, r)`` and center, the
   **count** of points in it (the density channel), and a **representative**
-  media id — the clip whose projected point is nearest the cell's centroid,
-  which is what hover-to-hear auditions.  Representatives are per level, so the
-  audition clip generalizes as you zoom out.
+  media id — the clip the canvas shows as the bin's thumbnail and hover-to-hear
+  auditions.  Representatives are chosen **bottom-up for zoom persistence** (see
+  :func:`_assign_reps`): at the deepest level a cell's rep is the clip nearest
+  its centroid, and each coarser cell *inherits* the rep of one of the finer
+  cells beneath it — the one nearest the coarse cell's centroid.  So
+  ``reps(level z) ⊆ reps(level z+1)``: every thumbnail you see persists as you
+  zoom in (the eye can track it) while 3–4 genuinely new ones appear, instead of
+  the whole grid reshuffling each level.
 - **Tiles** group hexes into a spatial grid per level so the client fetches
   only the tiles covering its viewport.  Because the projection is frozen, a
   tile is immutable for the life of the dataset and trivially cacheable.
@@ -52,7 +57,8 @@ class HexCell:
     cx: float  # center in projection space
     cy: float
     count: int  # number of clips in this cell (density)
-    rep_id: int  # representative media id (nearest clip to the cell centroid)
+    rep_id: int  # representative media id (see _assign_reps: nearest clip to the
+    # cell centroid at the deepest level, an inherited finer rep above it)
 
     def to_payload(self) -> dict[str, Any]:
         """JSON-serializable form for the tile endpoint."""
@@ -188,15 +194,38 @@ def _geometry_for(bin_shape: str) -> _BinGeometry:
         raise ValueError(f"unknown bin_shape {bin_shape!r}; expected one of {tuple(_GEOMETRIES)}") from None
 
 
-def _build_level(
+@dataclass
+class _LevelCells:
+    """One level's binning, *without* representatives — the raw material both the
+    tile assembly and the bottom-up :func:`_assign_reps` pass consume.
+
+    All arrays are indexed by cell (``0 … n_cells-1``) except ``inverse``, which
+    is indexed by point and maps each of the projection's points to its cell at
+    this level.  ``members[h]`` are the point indices in cell ``h`` (ascending
+    id, since ids are sorted) so rep tie-breaks are deterministic.
+    """
+
+    level: int
+    radius: float
+    keys: np.ndarray  # (n_cells, 2) int — (q, r) per cell
+    centers_x: np.ndarray
+    centers_y: np.ndarray
+    counts: np.ndarray  # (n_cells,)
+    tx: np.ndarray  # (n_cells,)
+    ty: np.ndarray
+    members: list[np.ndarray]  # per cell: point indices, ascending id
+    centroids: np.ndarray  # (n_cells, 2) — mean of member coords
+    inverse: np.ndarray  # (n_points,) — point -> cell index
+
+
+def _level_cells(
     level: int,
     coords: np.ndarray,
-    ids: np.ndarray,
     radius: float,
     tile_span: float,
     geom: _BinGeometry,
-) -> list[Tile]:
-    """Aggregate *coords* into cells at one *level* and group them into tiles."""
+) -> _LevelCells:
+    """Bin *coords* into cells at one *level* (geometry + membership, no reps)."""
     q, r = geom.assign(coords, radius)
     keys = np.stack([q, r], axis=1)
     uniq, inverse = np.unique(keys, axis=0, return_inverse=True)
@@ -209,28 +238,84 @@ def _build_level(
     # sorted) so representative tie-breaks are deterministic.
     order = np.argsort(inverse, kind="stable")
     seg_starts = np.cumsum(counts) - counts
+    members = [order[seg_starts[h] : seg_starts[h] + counts[h]] for h in range(n_hexes)]
+    # Per-cell centroid in one vectorized pass: sum member coords by segment.
+    sums = np.add.reduceat(coords[order], seg_starts, axis=0)
+    centroids = sums / counts[:, None]
 
     centers_x, centers_y = geom.center(uniq[:, 0], uniq[:, 1], radius)
     tx_all, ty_all = geom.tile_index(uniq[:, 0], uniq[:, 1], tile_span)
 
-    tiles: dict[tuple[int, int], list[HexCell]] = {}
-    for h in range(n_hexes):
-        members = order[seg_starts[h] : seg_starts[h] + counts[h]]
-        pts = coords[members]
-        centroid = pts.mean(axis=0)
-        rep_local = int(np.argmin(np.sum((pts - centroid) ** 2, axis=1)))
-        rep_id = int(ids[members[rep_local]])
-        cell = HexCell(
-            q=int(uniq[h, 0]),
-            r=int(uniq[h, 1]),
-            cx=float(centers_x[h]),
-            cy=float(centers_y[h]),
-            count=int(counts[h]),
-            rep_id=rep_id,
-        )
-        tiles.setdefault((int(tx_all[h]), int(ty_all[h])), []).append(cell)
+    return _LevelCells(
+        level=level,
+        radius=radius,
+        keys=uniq,
+        centers_x=centers_x,
+        centers_y=centers_y,
+        counts=counts,
+        tx=tx_all,
+        ty=ty_all,
+        members=members,
+        centroids=centroids,
+        inverse=inverse,
+    )
 
-    return [Tile(level=level, tx=tx, ty=ty, cells=cells) for (tx, ty), cells in tiles.items()]
+
+def _assign_reps(
+    lcs: list[_LevelCells],
+    coords: np.ndarray,
+    ids: np.ndarray,
+    prior_reps: dict[int, dict[tuple[int, int], int]] | None = None,
+) -> dict[int, np.ndarray]:
+    """Pick each cell's representative point, **bottom-up**, for zoom persistence.
+
+    Returns ``{level: rep_point_index_per_cell}``.  *lcs* is in ascending level
+    order (0 coarsest … deepest finest); we walk it finest→coarsest:
+
+    - **Deepest level:** a cell's rep is the member nearest its centroid.
+    - **Each coarser level:** the candidate reps are the reps the finer level
+      assigned to the cells beneath this one (``point_rep_fine`` carries, for
+      every point, the rep of its finer cell — so the candidates are exactly the
+      finer reps of this cell's members).  The cell adopts the candidate nearest
+      its own centroid.  Because every non-empty coarse cell has members, it
+      always has at least one inherited candidate; no fallback is needed and
+      ``reps(coarse) ⊆ reps(fine)`` holds by construction — the zoom-persistence
+      invariant.
+
+    *prior_reps* (``{level: {(q, r): rep_id}}``) lets a re-bin **keep a surviving
+    representative in place**: if a cell's prior rep id is still present, it is
+    retained verbatim regardless of where the centroid now sits.  This is what
+    makes removing items a fast, stable repaint — thumbnails only move when the
+    rep itself is among the removed (then the cell re-picks from its surviving
+    inherited candidates, and that change propagates up only where a coarse cell
+    had inherited the now-dead rep).  A slightly off-centre surviving rep is
+    accepted on purpose; re-centring it is explicitly lower priority than not
+    churning the grid.
+    """
+    id_to_pos = {int(m): i for i, m in enumerate(ids.tolist())} if prior_reps else None
+    reps_by_level: dict[int, np.ndarray] = {}
+    # For each point, the rep point-index of the cell it fell in one level finer
+    # (None at the deepest level, where reps come straight from the centroid).
+    point_rep_fine: np.ndarray | None = None
+    for lc in reversed(lcs):
+        n = lc.keys.shape[0]
+        reps = np.empty(n, dtype=np.int64)
+        prior = prior_reps.get(lc.level) if prior_reps else None
+        for h in range(n):
+            if prior is not None:
+                pid = prior.get((int(lc.keys[h, 0]), int(lc.keys[h, 1])))
+                if pid is not None and id_to_pos is not None and pid in id_to_pos:
+                    reps[h] = id_to_pos[pid]  # keep-put: surviving rep stays
+                    continue
+            mem = lc.members[h]
+            # Candidates: inherited finer reps of this cell's members (coarse
+            # levels), or the members themselves (deepest level).
+            pool = point_rep_fine[mem] if point_rep_fine is not None else mem
+            d = np.sum((coords[pool] - lc.centroids[h]) ** 2, axis=1)
+            reps[h] = int(pool[int(np.argmin(d))])
+        reps_by_level[lc.level] = reps
+        point_rep_fine = reps[lc.inverse]  # carry this level's reps down to points
+    return reps_by_level
 
 
 def build_pyramid(
@@ -241,6 +326,7 @@ def build_pyramid(
     base_cols: float = 6.0,
     base_radius: float | None = None,
     tile_span: float = 16.0,
+    prior_reps: dict[int, dict[tuple[int, int], int]] | None = None,
 ) -> Pyramid:
     """Build the tile :class:`Pyramid` for a frozen *projection*.
 
@@ -271,6 +357,11 @@ def build_pyramid(
     tile.  All of these are tunable knobs, not baked constants (see
     *§Open problems* in the design doc).
 
+    *prior_reps* (``{level: {(q, r): rep_id}}``) is threaded to
+    :func:`_assign_reps` so a re-bin can keep surviving representatives in place
+    (see :func:`rebin_like`); leave it ``None`` for a fresh build, where reps are
+    chosen purely bottom-up.
+
     Empty projections yield a pyramid with no tiles (one level when auto).
     """
     if n_levels is not None and n_levels < 1:
@@ -285,9 +376,9 @@ def build_pyramid(
     adaptive = n_levels is None
     max_levels = max_useful_levels(int(coords.shape[0])) if adaptive else n_levels
 
+    # Phase 1: bin every level (geometry + membership), honouring adaptive depth.
     levels: list[LevelMeta] = []
-    tiles: dict[tuple[int, int, int], Tile] = {}
-
+    lcs: list[_LevelCells] = []
     prev_n_cells: int | None = None
     prev_max_count: int | None = None
     for level in range(max_levels):
@@ -295,14 +386,13 @@ def build_pyramid(
         if coords.shape[0] == 0:
             levels.append(LevelMeta(level=level, radius=radius, n_cells=0))
             continue
-        level_tiles = _build_level(level, coords, ids, radius, tile_span, geom)
-        n_cells = sum(len(t.cells) for t in level_tiles)
+        lc = _level_cells(level, coords, radius, tile_span, geom)
+        n_cells = int(lc.keys.shape[0])
         levels.append(LevelMeta(level=level, radius=radius, n_cells=n_cells))
-        for t in level_tiles:
-            tiles[(t.level, t.tx, t.ty)] = t
+        lcs.append(lc)
 
         if adaptive:
-            max_count = max((c.count for t in level_tiles for c in t.cells), default=0)
+            max_count = int(lc.counts.max()) if lc.counts.size else 0
             # Fully resolved: every hex holds a single clip, so deeper levels
             # would only reproduce this one at finer (wasted) radii.
             if max_count <= 1:
@@ -314,6 +404,26 @@ def build_pyramid(
                 break
             prev_n_cells = n_cells
             prev_max_count = max_count
+
+    # Phase 2: pick representatives bottom-up (coarse reps inherit from finer
+    # ones), then assemble the per-level tiles.
+    reps_by_level = _assign_reps(lcs, coords, ids, prior_reps) if lcs else {}
+    tiles: dict[tuple[int, int, int], Tile] = {}
+    for lc in lcs:
+        reps = reps_by_level[lc.level]
+        level_tiles: dict[tuple[int, int], list[HexCell]] = {}
+        for h in range(lc.keys.shape[0]):
+            cell = HexCell(
+                q=int(lc.keys[h, 0]),
+                r=int(lc.keys[h, 1]),
+                cx=float(lc.centers_x[h]),
+                cy=float(lc.centers_y[h]),
+                count=int(lc.counts[h]),
+                rep_id=int(ids[reps[h]]),
+            )
+            level_tiles.setdefault((int(lc.tx[h]), int(lc.ty[h])), []).append(cell)
+        for (tx, ty), cells in level_tiles.items():
+            tiles[(lc.level, tx, ty)] = Tile(level=lc.level, tx=tx, ty=ty, cells=cells)
 
     return Pyramid(
         projection_id=projection.projection_id,
@@ -327,7 +437,18 @@ def build_pyramid(
     )
 
 
-def rebin_like(projection: Projection, template: Pyramid) -> Pyramid:
+def _reps_by_level(pyr: Pyramid) -> dict[int, dict[tuple[int, int], int]]:
+    """``{level: {(q, r): rep_id}}`` — a pyramid's current representatives, the
+    ``prior_reps`` :func:`build_pyramid` honours on a re-bin."""
+    out: dict[int, dict[tuple[int, int], int]] = {}
+    for (level, _tx, _ty), tile in pyr.tiles.items():
+        cells = out.setdefault(level, {})
+        for c in tile.cells:
+            cells[(c.q, c.r)] = c.rep_id
+    return out
+
+
+def rebin_like(projection: Projection, template: Pyramid, *, preserve_reps: bool = True) -> Pyramid:
     """Re-bin *projection* onto *template*'s exact grid, without re-fitting UMAP.
 
     Reuses the template pyramid's ``base_radius``, ``tile_span``, ``bin_shape``,
@@ -337,6 +458,14 @@ def rebin_like(projection: Projection, template: Pyramid) -> Pyramid:
     representatives, and now-empty cells differ.  This is the cheap operation
     behind removing items from a subset browse: the 2-D layout is frozen; we
     just recompute which items fall in which (unchanged) bins.
+
+    With *preserve_reps* (the default), the template's representatives are fed
+    back in as ``prior_reps`` so every cell whose rep **survived the removal
+    keeps it** — the grid repaints without thumbnails jumping around.  Only
+    cells whose rep was among the removed re-pick (from their surviving
+    inherited candidates), and that change propagates upward just to the coarse
+    cells that had inherited the now-dead rep.  Pass ``preserve_reps=False`` to
+    re-derive reps from scratch (a fresh bottom-up pass).
     """
     pyr = build_pyramid(
         projection,
@@ -344,6 +473,7 @@ def rebin_like(projection: Projection, template: Pyramid) -> Pyramid:
         n_levels=len(template.levels),
         base_radius=template.base_radius,
         tile_span=template.tile_span,
+        prior_reps=_reps_by_level(template) if preserve_reps else None,
     )
     # Keep the original extent so the client never re-frames; bins are assigned
     # from absolute coords + radius (origin-independent), so a stable ``bounds``


### PR DESCRIPTION
## What & why

A browser bin's thumbnail rep used to be chosen **independently per zoom level** (closest-to-centroid everywhere), so zooming in reshuffled the whole grid — the eye couldn't track anything. This makes reps **zoom-persistent**: the thumbnails you see at one level carry into the next, with only a few new ones appearing.

## How reps are chosen (`_assign_reps` in `vtscore/projection/pyramid.py`)

Bottom-up, finest → coarsest:

- **Deepest level:** a bin's rep is the member nearest its centroid (unchanged).
- **Each coarser level:** the bin inherits the rep of one of the finer bins beneath it — specifically, the inherited rep nearest the coarse bin's centroid. This gives `reps(level z) ⊆ reps(level z+1)`: every thumbnail persists as you zoom in while 3–4 genuinely new ones appear.
- A rep is **always one of the bin's own members** (the bin popup opens/scrolls to it within the member list). The rare sparse boundary bin that contains no interior finer rep falls back to its centroid-nearest member — measured a small minority (~77% of reps persist at the coarsest hop, 90–97% finer on the test cloud).

## Removal (the subset "Remove from Good" cull)

`rebin_like` now feeds the prior reps back in (`prior_reps`) so:

- **Surviving reps stay put** — a fast, stable repaint; thumbnails don't jump when unrelated items are removed.
- Only a **removed rep** forces a re-pick (from its surviving inherited candidates), and that change propagates up just to the coarse bins that had inherited the now-dead rep. Minimal reassignment, every bin keeps a reasonable in-bin rep.

The 1-D-UMAP autoscroll-to-rep in the details window is unchanged — the rep is still always in-bin, so `repIndex` resolves as before. No frontend changes.

## Deferred follow-up

Re-centring a surviving rep after a lopsided partial removal (hide a bin's Western kids → the rep should drift East) was deliberately deferred as lower priority than not churning the grid; recorded in `docs/plans/vtsbrowse.md`.

## Tests

New `tests_lib/projection/test_rep_persistence.py` covers the in-bin + inherited-or-fallback contract, keep-put on removal, re-pick on a removed rep, and the persistence fraction. Full `./run-tests.sh` green (5257 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VooFmTWuthUK9mxtMHj9s9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VooFmTWuthUK9mxtMHj9s9)_