### PR TITLE
Square VTSBrowse: corner-anchored quadtree bins for exact zoom persistence

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -332,7 +332,13 @@ projection:
   A rep is always one of the hex's own members (the bin popup opens/scrolls to
   it); a sparse boundary hex that contains no finer rep at all falls back to its
   centroid-nearest member (the single non-inherited case — measured a small
-  minority: ~77% of reps persist at the coarsest hop, 90-97% finer).
+  minority: ~77% of reps persist at the coarsest hop, 90-97% finer).  **This
+  fallback is hex-only.**  Because the hex lattice rounds to nearest center, a
+  fine hex can straddle a coarse boundary and land its rep in a neighbour,
+  leaving the coarse hex with no inherited candidate.  The **square** lattice is
+  a corner-anchored quadtree (see *§Bin shape*) where every fine cell nests
+  wholly inside one coarse cell, so the inherited pool is never empty and square
+  reps persist exactly (100% at every hop) — the fallback never fires.
   - **On removal** (`rebin_like`, the subset "Remove from Good" cull) the prior
     reps are fed back in so **surviving reps stay put** for a fast, stable
     repaint; only a removed rep forces a re-pick (from its surviving inherited
@@ -412,6 +418,18 @@ factoring binning out of the rest of the pipeline:
   share the renderer's level-of-detail picker and have a comparable on-screen
   footprint.  Every other knob (`base_radius`, `tile_span`, auto-depth) is
   shared.
+- **The square lattice is a quadtree; the hex lattice is not.**  Square cells
+  are **corner-anchored on a fixed data-space origin** (`q = floor(x/side)`),
+  and since the pyramid halves the side per level, a coarse cell of side `2s`
+  is *exactly* the union of the four fine cells of side `s` beneath it.  Every
+  fine cell nests wholly inside one coarse cell, so a child bin's rep is
+  provably a member of its parent and zoom persistence is **geometric, not
+  best-effort** (`reps(coarse) ⊆ reps(fine)` with no fallback — see the rep
+  section).  The hex lattice can't do this: hexagons don't tile 4-into-1
+  self-similarly, so it stays on round-to-nearest-center binning (which does
+  *not* nest — fine hexes straddle coarse boundaries) and accepts the small
+  non-persistent minority.  This is the one place the two shapes' binning math
+  genuinely differs, beyond cell geometry.
 - **The pyramid records its `bin_shape`** (in the dataclass, in `meta()`, and in
   the persisted JSON), so a loaded projection always knows which lattice it was
   binned with.  Containers written before the toggle have no `bin_shape` and are

--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -110,7 +110,10 @@ const SQUARE_SINGLE_CORNER_RATIO = 0.35;
 
 // Square cell of side `radius·√3` (matching the hex column spacing so the two
 // lattices have a comparable on-screen footprint and share the level picker).
-// Centered on lattice points, so columns and rows are spaced one side apart.
+// The backend corner-anchors the lattice on a fixed origin (a quadtree, so reps
+// persist across zoom — see vtscore/projection/squarebin.py) and reports each
+// cell's true midpoint as `(cx, cy)`; here we just draw a side-`radius·√3`
+// square around that centre, so columns and rows are spaced one side apart.
 const SQUARE_GEOMETRY: BinGeometry = {
   shape: 'square',
   dx: (radius) => radius * SQRT3,

--- a/tests_lib/projection/test_rep_persistence.py
+++ b/tests_lib/projection/test_rep_persistence.py
@@ -104,6 +104,17 @@ def test_reps_are_well_formed_and_mostly_persist():
     assert min(_persistence_fractions(pyr)) >= 0.7
 
 
+def test_square_reps_persist_perfectly():
+    # The square lattice is a corner-anchored quadtree: every fine cell nests
+    # wholly inside one coarse cell, so the inherited-candidate pool is never
+    # empty and the centroid-nearest fallback never fires.  Persistence is
+    # therefore exact — every coarse rep is also a rep one level finer.
+    proj = _projection(_cluster_cloud())
+    pyr = build_pyramid(proj, n_levels=5, bin_shape="square")
+    _assert_reps_well_formed(pyr, proj)
+    assert min(_persistence_fractions(pyr)) == 1.0
+
+
 def test_deepest_rep_is_member_nearest_centroid():
     # At the deepest level there is nothing finer to inherit from, so the rep is
     # the member nearest the centroid (tie -> smallest id), unchanged behaviour.

--- a/tests_lib/projection/test_squarebin.py
+++ b/tests_lib/projection/test_squarebin.py
@@ -31,11 +31,17 @@ def test_center_round_trips_to_same_cell():
     assert np.array_equal(r, r2)
 
 
-def test_origin_maps_to_a_cell_at_origin_center():
-    q, r = squarebin_assign(np.array([[0.0, 0.0]]), radius=1.0)
-    cx, cy = square_center(q, r, radius=1.0)
-    assert float(cx[0]) == pytest.approx(0.0, abs=1e-9)
-    assert float(cy[0]) == pytest.approx(0.0, abs=1e-9)
+def test_origin_lands_in_corner_anchored_cell_zero():
+    # Cells are corner-anchored on the fixed origin: the point (0, 0) is the
+    # lower-left corner of cell (0, 0), whose center is half a side in on each
+    # axis (NOT the origin itself — that is what lets the levels nest).
+    radius = 1.0
+    side = radius * SQUARE_SIDE_PER_RADIUS
+    q, r = squarebin_assign(np.array([[0.0, 0.0]]), radius)
+    assert (int(q[0]), int(r[0])) == (0, 0)
+    cx, cy = square_center(q, r, radius)
+    assert float(cx[0]) == pytest.approx(0.5 * side, abs=1e-9)
+    assert float(cy[0]) == pytest.approx(0.5 * side, abs=1e-9)
 
 
 def test_keys_are_plain_column_row_indices():
@@ -50,16 +56,34 @@ def test_keys_are_plain_column_row_indices():
 
 
 def test_cell_partitions_into_a_square():
-    # Points within half a side of a center in both axes share its cell; a point
-    # just past the half-side boundary falls into the neighbor.
+    # Cell (0, 0) covers [0, side) x [0, side); a point inside that half-open
+    # box bins to (0, 0), and a point just past the side boundary on x falls
+    # into the neighbor column.
     radius = 2.0
     side = radius * SQUARE_SIDE_PER_RADIUS
-    inside = np.array([[0.49 * side, -0.49 * side]])
-    outside = np.array([[0.51 * side, 0.0]])
+    inside = np.array([[0.01 * side, 0.99 * side]])
+    outside = np.array([[1.01 * side, 0.5 * side]])
     qi, ri = squarebin_assign(inside, radius)
     qo, ro = squarebin_assign(outside, radius)
     assert (int(qi[0]), int(ri[0])) == (0, 0)
     assert int(qo[0]) == 1 and int(ro[0]) == 0
+
+
+def test_levels_nest_four_into_one_quadtree():
+    # The defining quadtree property: corner-anchored cells at side `s` are the
+    # exact 4-way partition of cells at side `2s`. A point's coarse key must be
+    # its fine key floor-divided by two, on both axes, for every point. This is
+    # what guarantees a child bin nests wholly inside its parent (no straddling).
+    rng = np.random.default_rng(11)
+    pts = rng.standard_normal((2000, 2)) * 6.0
+    fine_radius = 0.5
+    coarse_radius = 2.0 * fine_radius  # one pyramid level up: side doubles
+    fq, fr = squarebin_assign(pts, fine_radius)
+    cq, cr = squarebin_assign(pts, coarse_radius)
+    # floor-division by 2 maps a fine cell to the coarse cell that contains it,
+    # for negatives too (Python/np floor-div rounds toward -inf, matching floor).
+    assert np.array_equal(cq, fq // 2)
+    assert np.array_equal(cr, fr // 2)
 
 
 def test_smaller_radius_yields_more_distinct_cells():

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -279,10 +279,15 @@ def _assign_reps(
       centroid, so ``reps(coarse) ⊆ reps(fine)`` (the zoom-persistence invariant)
       **and** the rep is always a member of the bin — which the bin popup relies
       on to open/scroll to it within the member list.  A coarse cell that
-      contains no finer rep at all (all finer cells beneath it straddle its
-      boundary, rep landing in a neighbour — rare, only for sparse boundary
-      cells) falls back to its own centroid-nearest member; that one rep is not
-      inherited, the single concession to keeping the rep in-bin.
+      contains no finer rep at all (every finer cell beneath it straddles its
+      boundary, the rep landing in a neighbour) falls back to its own
+      centroid-nearest member; that one rep is not inherited, the single
+      concession to keeping the rep in-bin.  This fallback only fires for the
+      **hex** lattice, whose round-to-nearest-center cells do not nest under a
+      radius halving.  The **square** lattice is a corner-anchored quadtree
+      (see :mod:`vtscore.projection.squarebin`): every fine cell nests wholly
+      inside one coarse cell, so the inherited pool is never empty and square
+      reps persist by construction.
 
     *prior_reps* (``{level: {(q, r): rep_id}}``) lets a re-bin **keep a surviving
     representative in place**: if a cell's prior rep id is still present, it is

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -331,6 +331,38 @@ def _assign_reps(
     return reps_by_level
 
 
+def _descent_resolved(
+    lc: _LevelCells,
+    coords: np.ndarray,
+    n_cells: int,
+    max_count: int,
+    prev_n_cells: int | None,
+    prev_max_count: int | None,
+) -> bool:
+    """Whether adaptive depth should stop descending after binning level *lc*.
+
+    Two terminal conditions:
+
+    - **Fully resolved:** every cell holds a single clip (``max_count <= 1``), so
+      deeper levels would only reproduce this one at finer (wasted) radii.
+    - **Co-located:** no progress across a radius halving — neither the cell count
+      nor the densest cell improved — *and* the densest cell's members are
+      genuinely coincident (zero spatial extent), so a finer radius can never
+      separate them.  The coincidence check matters because "no cell split" alone
+      does **not** imply co-location: a corner-anchored square cell wider than the
+      whole cloud holds every point for several levels before its boundaries fall
+      between them.  Only the spread test distinguishes "can't separate" from
+      "haven't separated yet"; without it the descent would stop short on tight
+      clouds under the square (quadtree) lattice.
+    """
+    if max_count <= 1:
+        return True
+    if n_cells == prev_n_cells and max_count == prev_max_count:
+        pile = coords[lc.members[int(np.argmax(lc.counts))]]
+        return float(np.max(pile.max(axis=0) - pile.min(axis=0))) == 0.0
+    return False
+
+
 def build_pyramid(
     projection: Projection,
     *,
@@ -406,24 +438,8 @@ def build_pyramid(
 
         if adaptive:
             max_count = int(lc.counts.max()) if lc.counts.size else 0
-            # Fully resolved: every hex holds a single clip, so deeper levels
-            # would only reproduce this one at finer (wasted) radii.
-            if max_count <= 1:
+            if _descent_resolved(lc, coords, n_cells, max_count, prev_n_cells, prev_max_count):
                 break
-            # No progress across a radius halving — neither the cell count nor
-            # the densest cell improved — *can* mean the remaining clips are
-            # co-located and will never separate (stop rather than grind to the
-            # cap), but it can also just mean the lattice is still too coarse to
-            # have reached the cloud: a corner-anchored square cell wider than
-            # the whole cloud holds every point for several levels before its
-            # boundaries finally fall between them.  Only stop if the densest
-            # cell's members are genuinely coincident (zero spatial extent);
-            # otherwise keep descending — a finer radius will split them.
-            if n_cells == prev_n_cells and max_count == prev_max_count:
-                densest = int(np.argmax(lc.counts))
-                pile = coords[lc.members[densest]]
-                if float(np.max(pile.max(axis=0) - pile.min(axis=0))) == 0.0:
-                    break
             prev_n_cells = n_cells
             prev_max_count = max_count
 

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -410,11 +410,20 @@ def build_pyramid(
             # would only reproduce this one at finer (wasted) radii.
             if max_count <= 1:
                 break
-            # No progress across a radius halving — neither the hex count nor
-            # the densest cell improved — means the remaining co-located clips
-            # can never be separated; stop rather than grind to the cap.
+            # No progress across a radius halving — neither the cell count nor
+            # the densest cell improved — *can* mean the remaining clips are
+            # co-located and will never separate (stop rather than grind to the
+            # cap), but it can also just mean the lattice is still too coarse to
+            # have reached the cloud: a corner-anchored square cell wider than
+            # the whole cloud holds every point for several levels before its
+            # boundaries finally fall between them.  Only stop if the densest
+            # cell's members are genuinely coincident (zero spatial extent);
+            # otherwise keep descending — a finer radius will split them.
             if n_cells == prev_n_cells and max_count == prev_max_count:
-                break
+                densest = int(np.argmax(lc.counts))
+                pile = coords[lc.members[densest]]
+                if float(np.max(pile.max(axis=0) - pile.min(axis=0))) == 0.0:
+                    break
             prev_n_cells = n_cells
             prev_max_count = max_count
 

--- a/vtscore/projection/squarebin.py
+++ b/vtscore/projection/squarebin.py
@@ -11,16 +11,33 @@ The lattice is anchored in *projection (data) space*, parameterized by the
 same per-level ``radius`` scale the hex lattice uses.  A square cell has side
 ``s = radius·√3`` — chosen to equal the hex lattice's column spacing so a
 square and a hexagon at the same pyramid level occupy a comparable on-screen
-footprint and the level-of-detail picker stays shared.  Cells are centered on
-the lattice points ``(q·s, r·s)``; a point ``(x, y)`` lands in the nearest
-center, i.e. ``q = round(x/s)`` and ``r = round(y/s)``.  Anchoring in data
-space is what keeps pure panning free in the renderer (membership only changes
-across a zoom level, where the radius halves), exactly as for the hex lattice.
+footprint and the level-of-detail picker stays shared.
+
+**The square lattice is a quadtree.**  Unlike the hex lattice, square cells are
+*corner-anchored* on a fixed origin ``(0, 0)`` in data space: cell ``(q, r)``
+covers ``[q·s, (q+1)·s) × [r·s, (r+1)·s)``, so a point ``(x, y)`` lands in
+``q = floor(x/s)``, ``r = floor(y/s)``.  Because the origin is the *same* at
+every level and the pyramid halves ``s`` from one level to the next, a coarse
+cell of side ``2s`` is exactly the union of the four fine cells of side ``s``
+beneath it (``[2q, 2q+2) × [2r, 2r+2)`` in fine-cell keys).  Every fine cell
+nests wholly inside one coarse cell — none straddle a coarse boundary — which
+is what makes a child bin's representative provably a member of its parent and
+gives :mod:`vtscore.projection.pyramid` *geometric* (not best-effort) zoom
+persistence.  This is the reason the square path uses ``floor`` (corner
+anchor) where the hex path uses round-to-nearest-center: a centered lattice
+does not nest under doubling (fine cells would straddle coarse boundaries),
+but hexagons cannot tile 4-into-1 self-similarly at all, so only the square
+shape can be a true quadtree.
+
+Anchoring in data space (a *fixed* origin, independent of ``radius``) is also
+what keeps pure panning free in the renderer: membership only changes across a
+zoom level, where the side halves, exactly as for the hex lattice.
 
 A cell is identified by an integer pair ``(q, r)`` (column, row).  Unlike the
 hex key, ``q`` is the plain column index (no doubling is needed because a
 square lattice has no half-integer columns).  :func:`square_center` inverts the
-key back to the cell's center in projection space.
+key back to the cell's center in projection space (the cell midpoint,
+``((q+0.5)·s, (r+0.5)·s)``).
 """
 
 from __future__ import annotations
@@ -47,8 +64,11 @@ def squarebin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.
     ``(column, row)`` cell key for each point.  Feed the same ``(q, r)`` to
     :func:`square_center` to recover the cell center.
 
-    The cell side is ``radius·√3`` (see module docstring); a point lands in the
-    cell whose center is nearest, i.e. ``round(coord / side)`` per axis.
+    The cell side is ``radius·√3`` (see module docstring); cells are
+    corner-anchored on the fixed origin ``(0, 0)``, so a point lands in the
+    cell whose lower-left corner is at or below it, i.e. ``floor(coord / side)``
+    per axis.  This corner anchor (rather than round-to-nearest-center) is what
+    makes the levels nest 4-into-1 as a quadtree.
     """
     if radius <= 0:
         raise ValueError(f"square radius must be positive, got {radius!r}")
@@ -57,17 +77,19 @@ def squarebin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.
         raise ValueError(f"points must be (M, 2), got shape {pts.shape}")
 
     side = _square_side(radius)
-    q = np.round(pts[:, 0] / side).astype(np.int64)
-    r = np.round(pts[:, 1] / side).astype(np.int64)
+    q = np.floor(pts[:, 0] / side).astype(np.int64)
+    r = np.floor(pts[:, 1] / side).astype(np.int64)
     return q, r
 
 
 def square_center(q: np.ndarray | int, r: np.ndarray | int, radius: float) -> tuple[np.ndarray, np.ndarray]:
     """Inverse of :func:`squarebin_assign`: the projection-space center of cell ``(q, r)``.
 
-    Accepts scalars or arrays.  Returns ``(cx, cy)`` as float64.
+    Cells are corner-anchored at ``(q·side, r·side)``, so the center is the
+    cell midpoint ``((q+0.5)·side, (r+0.5)·side)``.  Accepts scalars or arrays.
+    Returns ``(cx, cy)`` as float64.
     """
     side = _square_side(radius)
     q_arr = np.asarray(q, dtype=np.float64)
     r_arr = np.asarray(r, dtype=np.float64)
-    return q_arr * side, r_arr * side
+    return (q_arr + 0.5) * side, (r_arr + 0.5) * side


### PR DESCRIPTION
## Why

While reviewing the square VTSBrowser, the "persistent" thumbnail representatives turned out not to be very persistent (~77–97% per zoom hop), and the cause was in the **bins**, not the rep logic.

The square lattice was binned with **round-to-nearest-center** (`q = round(x/side)`), anchored on lattice points. That lattice **does not nest under a radius halving**: when the side doubles for a coarser level, the coarse cell boundaries fall on the *fine cell centers*, so fine cells straddle coarse boundaries and a single fine cell's points get split across two coarse cells. There was therefore no geometric guarantee that a child bin's representative is a member of its parent — persistence was a best-effort heuristic (`_assign_reps` centroid-nearest fallback) that breaks at every straddling boundary cell.

The mental model we wanted was a true **quadtree**: a parent square is exactly 4 child squares, child ⊂ parent, so the child's rep is *provably* in the parent.

## What changed

- **`vtscore/projection/squarebin.py`** — corner-anchor the square lattice on a **fixed data-space origin** (`q = floor(x/side)`, center at the cell midpoint `(q+0.5)·side`). With the pyramid halving the side per level, a coarse cell of side `2s` is exactly the union of the four fine cells of side `s` beneath it. Every fine cell now nests wholly inside one coarse cell → rep persistence is **geometric (100% at every hop)**, and the `_assign_reps` fallback can no longer fire for squares.
- **Hex is unchanged.** Hexagons can't tile 4-into-1 self-similarly, so the hex lattice keeps round binning and the documented (small-minority) fallback. This is now the one place the two shapes' binning math genuinely differs.
- **`vtscore/projection/pyramid.py`** — hardened the adaptive-depth "no progress → stop" guard. A corner-anchored square cell wider than the whole cloud holds every point for several levels before its boundaries fall between them, so "no cell split across a halving" no longer implies the clips are co-located. The descent now stops on no-progress **only** when the densest cell's members are genuinely coincident (zero spatial extent); otherwise it keeps descending so a finer radius can separate them. Extracted into `_descent_resolved` to stay under the complexity limit.
- **`frontend/.../bin-geometry.ts`** — comment-only: the renderer already draws squares from the backend's reported `cx/cy`, so it's unaffected; updated the stale "centered on lattice points" note.
- **Docs** — recorded the quadtree property and the hex-only fallback in `docs/plans/vtsbrowse.md`.

## Not changed (by request)

The zoom "give" stays **centered** (`round(log2(...))`): the configured thumbnail size remains the geometric center of a level's size range (~0.71×–1.41×), not a floor. That was a deliberate call to keep the current behavior.

## Tests

- New: `test_levels_nest_four_into_one_quadtree` (square keys floor-divide 4-into-1), `test_square_reps_persist_perfectly` (100% persistence, no fallback), and updated the two square-center tests for the corner anchor.
- `./run-tests.sh` full suite green (5239 passed), plus the frontend gate (build + audit + 870 Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014fYfxuq2w53BNeznY4ttyD)_