### PR TITLE
VTSBrowse zoom: step by exactly √2 so one level = two notches (fixes "three at the top")

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -192,8 +192,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private pendingToggleY = 0;
   private static readonly DBLCLICK_MS = 250;
   // Per-notch wheel zoom factor. A pyramid level spans a full 2x of zoom, so
-  // this sets how many notches cross a bin layer: log_1.4(2) ≈ 2 notches.
-  private static readonly WHEEL_ZOOM_FACTOR = 1.4;
+  // this sets how many notches cross a bin layer. It is exactly √2, so two
+  // notches = exactly one level (and exactly one DOUBLE_CLICK_ZOOM). The earlier
+  // 1.4 was a hair under √2, making a level cost log_1.4(2) ≈ 2.06 notches; the
+  // 0.06 surplus accumulates, so when the whole-projection fit happens to land
+  // near the bottom edge of a level band the *first* flip from that overview
+  // rounds up to a 3rd notch (then ~2 thereafter) — felt as an inconsistent
+  // "three at the top, two after". Exact √2 makes every flip cost two notches.
+  private static readonly WHEEL_ZOOM_FACTOR = Math.SQRT2;
   // How hard a double-click zooms in about the cursor. Larger than the wheel's
   // per-notch factor so the gesture lands a decisive jump, matching the map idiom.
   private static readonly DOUBLE_CLICK_ZOOM = 2.0;

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -179,10 +179,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /**
    * Per-click zoom step for the on-screen +/- buttons. Matches the wheel's
-   * per-notch factor so a single click makes a visible difference; button
-   * zoom anchors at the viewport centre (no cursor to zoom toward).
+   * per-notch factor (√2, so two clicks = exactly one pyramid level) and makes
+   * a single click a visible difference; button zoom anchors at the viewport
+   * centre (no cursor to zoom toward).
    */
-  private readonly ZOOM_BUTTON_FACTOR = 1.4;
+  private readonly ZOOM_BUTTON_FACTOR = Math.SQRT2;
 
   /** Bin-popup state: open flag, the viewport anchor it opens at, and the
    *  member ids of the bin the user right-clicked. Right-clicking a bin pops a


### PR DESCRIPTION
## Symptom

When the browser first opens (on the whole-projection overview), it takes **three** scroll notches to change zoom level, then **two** ever after.

## Cause — not the quadtree floor; the wheel factor

This is unrelated to the square-quadtree change (level selection still uses `round()`, as chosen). The cause is the per-notch zoom factor:

- The wheel and the +/− buttons stepped zoom by **`1.4`**, which is a hair under **√2 ≈ 1.41421**.
- A pyramid level spans a 2× zoom range, so a level costs `log₁.₄(2) ≈ 2.06` notches — a **0.06-notch surplus per level** that accumulates.
- Level flips happen at `round()` boundaries. When `computeFitZoom` (the overview the browser opens on) lands near the **bottom edge of a level band**, the first flip from that overview has to climb a full level (≈2.06 notches), which rounds up to a **3rd discrete notch**. After that you land mid-band, so subsequent flips are the expected ~2.

That's the "three at the top, two after."

## Fix

Set both zoom steps to **exactly `Math.SQRT2`**:
- `WHEEL_ZOOM_FACTOR` (`browse-canvas.component.ts`)
- `ZOOM_BUTTON_FACTOR` (the +/− buttons, `browse-view.component.ts`)

Now two notches = **exactly** one pyramid level, so every flip costs two notches — including the first one from the overview. As a bonus, two notches now equal exactly one double-click (`DOUBLE_CLICK_ZOOM = 2`), matching the intended model (one double-click = one level = two wheel notches).

## Note

For datasets whose overview fit lands with bins slightly *larger* than the target size, the very first flip from the overview can be a single notch (a quick first step) rather than two — that's the opposite of the reported problem and reads as responsive. The reported "three" case (fit at a band's bottom edge) now resolves to exactly two. No more 3-notch step anywhere.

## Tests

Frontend gate green: build OK, audit OK, 870 Vitest passed. No test pinned the old `1.4` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014fYfxuq2w53BNeznY4ttyD)_