### PR TITLE
Make prepping Browse button read as disabled

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -148,8 +148,16 @@ td.actions-col {
   justify-content: center;
   transition: color var(--transition-base), background var(--transition-base);
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--btn-icon-hover-bg);
+  }
+
+  // While its projection pre-builds, the Browse eye keeps waggling but is
+  // `disabled` (the user is just waiting to enter the browse view). Dim it and
+  // drop the pointer/hover affordance so it reads as disabled, not clickable.
+  &:disabled {
+    cursor: default;
+    opacity: var(--opacity-disabled);
   }
 }
 


### PR DESCRIPTION
## Problem

Clicking **Browse** on a dashboard dataset row kicks off a UMAP/projection pre-build before navigating to the browse view. While that runs, the dataset-card Browse eye waggles to signal work in progress. The button is already functionally `disabled` (it carries the HTML `disabled` attribute during the projection phase), but `.browse-btn` had **no disabled visual treatment** — it kept `cursor: pointer`, full opacity, and a live `:hover` background — so it *read* as enabled/clickable even though it isn't.

## Fix

Add a disabled appearance to `.browse-btn`:
- Gate the hover highlight behind `:not(:disabled)`.
- When disabled: dim via `--opacity-disabled` and drop the pointer cursor (`cursor: default`).

The waggle animation stays as the "working" cue. The button remains genuinely non-clickable (the `disabled` attribute already blocks clicks, and `BrowsePrepService.prepareAndBrowse` no-ops while a prep is in flight); this just makes the visual state match.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, 870 Vitest tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVfsD9kH8BvFP4bbUQFBLt)_