### PR TITLE
Fix "Step 4 of 4" load progress: label the finalize phase and stop the bar/ETA from lying

### DIFF
--- a/frontend/src/app/utils/format-progress.spec.ts
+++ b/frontend/src/app/utils/format-progress.spec.ts
@@ -97,3 +97,28 @@ describe('formatProgressHeader detail line', () => {
     expect(detail).toBe('3/9 cats/img.png');
   });
 });
+
+describe('formatProgressHeader step-4 finalize phases', () => {
+  // The serialize → zip → write window of step 4 used to match no phase, so
+  // the header collapsed to a bare "Step 4 of 4" with no descriptor.
+  it.each([
+    ['Saving to registry…', 'saving dataset'],
+    ['Serializing dataset…', 'saving dataset'],
+    ['Packaging dataset…', 'saving dataset'],
+    ['Building diversity index…', 'building diversity index'],
+    ['Building 2-D projection…', 'building projection'],
+    ['Building tile pyramid…', 'building projection'],
+    ['Dropped 3 item(s) with failed embedding…', 'cleaning up'],
+  ])('labels %j as "%s"', (message, expectedPhase) => {
+    const { header, subtitle } = formatProgressHeader(
+      { status: 'loading', message, step: 4, total_steps: 4 },
+      'dataset',
+    );
+    expect(header).toBe(`Loading dataset · Step 4 of 4 · ${capitalizeFirst(expectedPhase)}`);
+    expect(subtitle).not.toBe('');
+  });
+});
+
+function capitalizeFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -303,15 +303,24 @@ export function formatProgressHeader(
   } else if (status === 'loading' && /text encoder|warming/i.test(message)) {
     phase = 'warming text encoder';
     subtitle = 'One-time warm-up so the first text search returns instantly.';
+  } else if (/failed embedding|dropped /i.test(message)) {
+    phase = 'cleaning up';
+    subtitle = 'Discarding items that could not be embedded.';
   } else if (/duplicates/i.test(message)) {
     phase = 'removing duplicates';
     subtitle = 'Collapsing media that share the same content fingerprint.';
   } else if (/diversity/i.test(message)) {
     phase = 'building diversity index';
     subtitle = 'Indexing for fast diverse browsing and autopilot guidance.';
-  } else if (/saving to registry/i.test(message)) {
-    phase = 'saving to registry';
-    subtitle = 'Persisting the dataset so it survives a restart.';
+  } else if (/projection|tile pyramid/i.test(message)) {
+    phase = 'building projection';
+    subtitle = 'Precomputing the 2-D Browse map so the canvas opens instantly.';
+  } else if (/saving to registry|serial|packaging|registering/i.test(message)) {
+    // The whole serialize → zip → write → register window of step 4. These
+    // messages used to match nothing, leaving a bare "Step 4 of 4" with no
+    // descriptor — the longest part of the load with the least to show for it.
+    phase = 'saving dataset';
+    subtitle = 'Writing the dataset to disk so it survives a restart.';
   } else if (/clipping/i.test(message)) {
     phase = 'slicing clips';
     subtitle = 'Cutting media into clips for finer-grained search.';

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -197,3 +197,65 @@ class TestOverallEta:
         clock["now"] = 7.0
         t.update("embedding", "x", current=10, total=100, step=2, total_steps=2)
         assert t.get()["eta_seconds"] is not None
+
+
+class TestFinalizeProgress:
+    """The FinalizeProgress proxy maps each finalize sub-stage into its own
+    ordered slice of step 4, so no single sub-stage can pin the unified bar at
+    100% while later sub-stages are still running (the old "frozen at 100%
+    while saving to disk" bug)."""
+
+    def _finalize_tracker(self):
+        from vtscore.datasets.stages._common import _LOAD_STEP_WEIGHTS, _TOTAL_LOAD_STEPS
+
+        t = _tracker()
+        t.set_step_weights(_LOAD_STEP_WEIGHTS)
+        # Pretend steps 1-3 finished so the bar is parked at the start of the
+        # finalize slice, exactly where a cache-backed demo load lands.
+        t.update("embedding", "emb", current=1, total=1, step=3, total_steps=_TOTAL_LOAD_STEPS)
+        return t
+
+    def test_substages_advance_monotonically_within_step_four(self):
+        from vtscore.datasets.stages._common import FinalizeProgress
+
+        t = self._finalize_tracker()
+        start = t.get()["overall"]
+        fin = FinalizeProgress(t)
+        overalls = []
+
+        def rec():
+            overalls.append(t.get()["overall"])
+
+        fin.begin("dedup")
+        fin.update("loading", "Removing duplicates…", current=0, total=10)
+        rec()
+        fin.update("loading", "Removing duplicates…", current=10, total=10)
+        rec()
+        after_dedup = t.get()["overall"]
+        fin.begin("diversity")
+        fin.update("loading", "Building diversity index…", current=5, total=10)
+        rec()
+        fin.begin("registry")
+        fin.update("loading", "Saving to registry…", current=3, total=3)
+        rec()
+        fin.begin("projection")
+        fin.update("loading", "Projection ready", current=1, total=1)
+        rec()
+
+        # Never rewinds, starts no earlier than the finalize floor, ends full.
+        assert overalls == sorted(overalls)
+        assert start <= overalls[0]
+        assert overalls[-1] == pytest.approx(1.0)
+        # The key fix: finishing the first sub-stage (dedup) must NOT slam the
+        # whole bar to 100% — later sub-stages still have room to advance.
+        assert after_dedup < 1.0
+
+    def test_check_cancelled_forwards_to_real_tracker(self):
+        from vtscore.concurrency.progress import CancelledError
+        from vtscore.datasets.stages._common import FinalizeProgress
+
+        t = self._finalize_tracker()
+        fin = FinalizeProgress(t)
+        t.cancel()
+        with pytest.raises(CancelledError):
+            fin.check_cancelled()

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -37,6 +37,7 @@ from vtscore.datasets.registry import unregister_dataset as _reg_unregister
 from vtscore.state import DatasetContext, clear_all, register_context
 
 from vtscore.datasets.stages._common import (
+    FinalizeProgress,
     _LOAD_STEP_WEIGHTS,
     _STATUS_TO_STEP,
     _TOTAL_LOAD_STEPS,
@@ -486,17 +487,28 @@ def _run_origin_load_in_background(
                     _tag_origins(ctx.medias, origin)
                     _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
                     _embed_missing_stage(ctx, tracker, embedders if embedders else [embedder])
-                    _drop_none_embeddings_stage(ctx, tracker)
+                    # Step 4 (finalize) bundles several sub-stages. Route them
+                    # through a FinalizeProgress proxy so each maps into its own
+                    # ordered slice of the step-4 bar instead of independently
+                    # filling (and pinning at 100%) the whole slice — keeps the
+                    # bar advancing and the ETA self-correcting through the
+                    # serialize/disk-write window. See FinalizeProgress.
+                    fin = FinalizeProgress(tracker)
+                    fin.begin("cleanup")
+                    _drop_none_embeddings_stage(ctx, fin)
                     # Re-lazify clips from reference (thin) parents now that
                     # embedding is done: strip their materialized bytes so the
                     # dataset stores recipes, not duplicated clip payloads.
-                    _relazify_reference_clips_stage(ctx, tracker)
-                    _collapse_duplicates_stage(ctx, tracker)
-                    _collapse_near_duplicates_stage(ctx, tracker)
-                    _build_diversity_tree_stage(ctx, tracker)
+                    _relazify_reference_clips_stage(ctx, fin)
+                    fin.begin("dedup")
+                    _collapse_duplicates_stage(ctx, fin)
+                    _collapse_near_duplicates_stage(ctx, fin)
+                    fin.begin("diversity")
+                    _build_diversity_tree_stage(ctx, fin)
                     tracker.check_cancelled()
+                    fin.begin("registry")
                     context_id, registry_entry_id = _register_and_migrate(
-                        ctx, tracker, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
+                        ctx, fin, task_id, origin, name, clipper, embedder, created_by, ingest_started_at
                     )
                     # Opt-in: compute + persist the 2-D Browse projection now,
                     # so the Browse canvas opens instantly instead of building
@@ -505,8 +517,9 @@ def _run_origin_load_in_background(
                     # a failure (or a cancel during the fit) leaves it intact
                     # and just defers the projection to the lazy Browse path.
                     if build_projection:
+                        fin.begin("projection")
                         try:
-                            _build_projection_stage(ctx, tracker, context_id)
+                            _build_projection_stage(ctx, fin, context_id)
                         except Exception:
                             traceback.print_exc()
                     # Embedder warm-up is fire-and-forget so the dashboard row goes

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -44,6 +44,89 @@ _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
 _LOAD_STEP_WEIGHTS = [0.25, 0.10, 0.55, 0.10]
 
 
+class FinalizeProgress:
+    """Tracker proxy that maps each finalize sub-stage into an ordered slice
+    of step 4 (the finalize phase).
+
+    Step 4 bundles several sub-stages — drop-failed-embeds, dedup, the
+    diversity-tree build, the registry save, and the optional Browse
+    projection. Each of them used to report its *own* ``current``/``total``
+    against the single step-4 slice, so whichever finished first (usually
+    dedup) drove the within-step fraction to ``1.0`` and pinned the unified
+    bar at 100% while the slower sub-stages (serialize + zip + disk write,
+    diversity k-means) were still grinding — the bar looked done, the ETA
+    froze at its last embed-phase estimate, and the user sat there.
+
+    This proxy fixes that by assigning each sub-stage an ordered, non-
+    overlapping sub-range of the finalize phase. The sub-stage code is
+    unchanged: it still calls ``tracker.update(..., step=_TOTAL_LOAD_STEPS)``
+    and ``tracker.check_cancelled()``. The load pipeline wraps the real
+    tracker in one of these for the finalize block and calls :meth:`begin`
+    before each sub-stage; the proxy rewrites that stage's within-step
+    fraction into the active slot before forwarding, so the bar advances once,
+    monotonically, across the whole phase and the overall ETA self-corrects.
+
+    A skipped sub-stage (opt-in near-dup merge, deferred diversity tree above
+    the size threshold, opt-out projection) simply leaves its slice unfilled;
+    the next :meth:`begin` jumps the bar forward, which is monotonic and fine.
+    """
+
+    #: Resolution of the synthetic within-step counter forwarded to the real
+    #: tracker. The finalize fraction (0..1) is reported as ``current`` out of
+    #: this ``total`` so the tracker's overall math sees a normal sub-step.
+    _SCALE = 1000
+
+    #: Ordered finalize sub-stages with a rough wall-clock share each. The
+    #: registry save (serialize + zip + write) dominates, with the diversity
+    #: tree second; the rest are quick. Shares need only be in the right
+    #: ballpark — they shape pacing within the finalize slice, and the overall
+    #: ETA self-corrects from the real rate (see ProgressTracker._compute_overall).
+    _SLOTS: tuple[tuple[str, float], ...] = (
+        ("cleanup", 0.05),
+        ("dedup", 0.15),
+        ("diversity", 0.30),
+        ("registry", 0.45),
+        ("projection", 0.05),
+    )
+
+    def __init__(self, tracker) -> None:
+        self._tracker = tracker
+        total = sum(weight for _, weight in self._SLOTS) or 1.0
+        self._ranges: dict[str, tuple[float, float]] = {}
+        acc = 0.0
+        for name, weight in self._SLOTS:
+            self._ranges[name] = (acc / total, weight / total)
+            acc += weight
+        # Default to the first slot so an update before any begin() still maps
+        # somewhere sane rather than raising.
+        self._base, self._span = self._ranges[self._SLOTS[0][0]]
+
+    def begin(self, slot: str) -> None:
+        """Activate *slot*; subsequent :meth:`update` calls map into its range."""
+        self._base, self._span = self._ranges[slot]
+
+    def check_cancelled(self) -> None:
+        self._tracker.check_cancelled()
+
+    def update(self, status: str, message: str = "", current: int = 0, total: int = 0, **kwargs) -> None:
+        within = current / total if total and total > 0 else 0.0
+        within = min(max(within, 0.0), 1.0)
+        frac = self._base + self._span * within
+        # The active slot already encodes the finalize step; the sub-stage's own
+        # step/total_steps are redundant, so drop them and stamp step 4 here.
+        kwargs.pop("step", None)
+        kwargs.pop("total_steps", None)
+        self._tracker.update(
+            status,
+            message,
+            current=int(frac * self._SCALE),
+            total=self._SCALE,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+            **kwargs,
+        )
+
+
 def _origin_to_str(origin: dict | None) -> str:
     """Convert an origin dict to a human-readable string."""
     if not origin:

--- a/vtscore/datasets/stages/registry.py
+++ b/vtscore/datasets/stages/registry.py
@@ -176,10 +176,27 @@ def _register_and_migrate(
     exception propagates so we never leave an orphan on disk.
     """
 
+    # The registry save fires _on_stage roughly three times ("Saving to
+    # registry…", "Serializing dataset…", "Packaging dataset…"). Report an
+    # incrementing count so the finalize bar advances across that window
+    # instead of sitting frozen at the slot's floor through the long pickle +
+    # zip write. ``_STAGE_TOTAL`` is a rough denominator; the count is clamped
+    # so an extra message can't push past it.
+    _STAGE_TOTAL = 3
+    _stage_n = [0]
+
     def _on_stage(message: str) -> None:
         # Keep the dashboard row alive through the otherwise-silent
         # serialize → write → register window (the old "frozen bar" gap).
-        tracker.update("loading", message, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
+        _stage_n[0] += 1
+        tracker.update(
+            "loading",
+            message,
+            current=min(_stage_n[0], _STAGE_TOTAL),
+            total=_STAGE_TOTAL,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
 
     # Cache the freshly-built diversity tree into the pickle so reloads skip
     # the expensive hierarchical k-means rebuild (it is re-derived only when


### PR DESCRIPTION
## What this fixes

When loading a dataset (most noticeably a **Demo Dataset**, where the embed phase is near-instant), the load modal's final phase showed a bare **"Loading dataset · Step 4 of 4"** with no descriptor, and the weighted progress bar/ETA were wrong — the bar hit ~100% and the ETA sat at "< 5 sec" for a long time while work was still happening.

"Step 4 of 4" is the **finalize** phase (`load_pipeline.py`): drop failed embeds → dedup → diversity index → save to registry (serialize → zip → write to disk) → optional Browse projection.

Two root causes:

1. **No label for the long part.** The header's phase label is derived by string-matching the progress message (`frontend/src/app/utils/format-progress.ts`). The registry save emits `"Serializing dataset…"` / `"Packaging dataset…"` (and drop-failed emits `"Dropped N…"`, projection emits `"Building 2-D projection…"`), none of which matched any pattern — so `phase` was empty and the header collapsed to a bare "Step 4 of 4".

2. **Each finalize sub-stage independently filled the single step-4 slice.** Dedup, diversity, registry, and projection each reported their own `current`/`total` against step 4, so whichever finished first (dedup) drove the within-step fraction to 1.0 and pinned the unified bar at 100% while the slower sub-stages kept running. With nothing advancing, the overall ETA held its last (instant) embed-phase estimate → "< 5 sec".

## Changes

**Backend**
- Add `FinalizeProgress` (`vtscore/datasets/stages/_common.py`): a tracker proxy that maps each finalize sub-stage into an ordered, non-overlapping sub-range of step 4, so the bar advances once monotonically across the whole phase and the overall ETA self-corrects. `load_pipeline.py` wraps the tracker for the finalize block and calls `begin(slot)` before each sub-stage; the sub-stage code is unchanged.
- `registry.py`: `_on_stage` now reports an incrementing count so the registry slot advances across the long serialize/zip/write window instead of sitting frozen at the slot floor.

**Frontend**
- Label the previously-unmatched step-4 messages in `formatProgressHeader`: serialize/package → **"saving dataset"**, projection → **"building projection"**, drop-failed-embeds → **"cleaning up"**, each with a subtitle.

## Tests
- `tests_lib/core/test_progress_overall.py`: `TestFinalizeProgress` — sub-stages advance monotonically within step 4, finishing the first sub-stage no longer slams the bar to 100%, and `check_cancelled` forwards.
- `frontend/src/app/utils/format-progress.spec.ts`: the step-4 finalize messages now resolve to a labeled header + non-empty subtitle.

Full suite green: `./run-tests.sh core datasets`, `./run-tests.sh frontend`, `./run-tests.sh vtscore-clean`.

## Note
The static `_LOAD_STEP_WEIGHTS` still allot finalize only ~10% of the bar; on a cache-backed demo load (instant embed) finalize is most of the wall-clock, so the bar still jumps toward ~90% before the finalize slice. The ETA now self-corrects and the phase is labeled, so this is cosmetic, but rebalancing weights per load path is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeiXxVE8Bnha5TvAJrz62F

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeiXxVE8Bnha5TvAJrz62F)_