### PR TITLE
Add select-all button to VTSBrowser bin-popup details view

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -63,11 +63,43 @@
 
     @if (!previewOnly) {
       <div class="bin-popup-grid-col">
-        <span
-          class="bin-popup-count"
-          [title]="'Items in this bin (' + ids.length + ')'">
-          {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
-        </span>
+        <div class="bin-popup-grid-header">
+          @if (ids.length > 1) {
+            <button
+              type="button"
+              class="bin-popup-select-all"
+              role="checkbox"
+              (click)="toggleAll()"
+              [title]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+              [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+              [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
+              @switch (selectionState) {
+                @case ('all') {
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="3" width="18" height="18" rx="2"/>
+                    <polyline points="8 12 11 15 16 9"/>
+                  </svg>
+                }
+                @case ('some') {
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="3" width="18" height="18" rx="2"/>
+                    <line x1="8" y1="12" x2="16" y2="12"/>
+                  </svg>
+                }
+                @default {
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="3" width="18" height="18" rx="2"/>
+                  </svg>
+                }
+              }
+            </button>
+          }
+          <span
+            class="bin-popup-count"
+            [title]="'Items in this bin (' + ids.length + ')'">
+            {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
+          </span>
+        </div>
         <cdk-virtual-scroll-viewport
           [itemSize]="rowSize"
           class="bin-popup-scroll"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -153,7 +153,40 @@
   min-height: 0;
 }
 
-// Member-count label, top-left of the grid column.
+// Top row of the grid column: the select-all control on the left and the
+// member-count label pushed to the right. With a single member there is no
+// button, so `space-between` leaves the count alone at the left as before.
+.bin-popup-grid-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2xs);
+  padding: 0 var(--space-2xs) var(--space-2xs);
+}
+
+// Tri-state master checkbox, mirroring the dashboard's select-all button but
+// tuned to this window: smaller icon and tighter padding for the compact header.
+.bin-popup-select-all {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-2xs);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+    color: var(--text-primary);
+  }
+}
+
+// Member-count label, right end of the header row.
 .bin-popup-count {
   flex-shrink: 0;
   font-size: var(--font-xs);
@@ -163,7 +196,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.4;
-  padding: 0 var(--space-2xs) var(--space-2xs);
 }
 
 // The scrolling thumbnail grid fills the column below the count label.

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -525,6 +525,27 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return this.selection.has(id);
   }
 
+  /** Tri-state of the select-all control: how many members are selected, as
+   *  none / some / all — mirroring the dashboard's master-checkbox states. */
+  get selectionState(): 'none' | 'some' | 'all' {
+    const total = this.ids.length;
+    if (total === 0) return 'none';
+    const sel = this.selection.selectedCountIn(this.ids);
+    if (sel === 0) return 'none';
+    if (sel >= total) return 'all';
+    return 'some';
+  }
+
+  /** Select every member, or — when all are already selected — clear them.
+   *  Matches the dashboard's toggle-all semantics. */
+  toggleAll(): void {
+    if (this.selectionState === 'all') {
+      this.selection.removeAll(this.ids);
+    } else {
+      this.selection.addAll(this.ids);
+    }
+  }
+
   onEntryClick(id: number): void {
     if (this.selection.has(id)) {
       this.selection.remove(id);


### PR DESCRIPTION
## What

Adds a **select-all** control to the VTSBrowser Details (bin) popup, shown only when the bin has more than one member. It sits where the "# items" tag used to be (top-left of the grid column), and the count tag is pushed to the right end of that row.

## Why

There was no way to select all members of a bin from the details popup short of clicking each thumbnail. The dashboard already has a select-all affordance; this brings the same convenience to the bin popup.

## How

- **Template** (`browse-bin-popup.component.html`): wraps the count in a new `.bin-popup-grid-header` flex row. When `ids.length > 1`, a tri-state checkbox button renders on the left using the same SVG icon set as the dashboard's master checkbox (empty / indeterminate / checked); the count tag is pushed right via `space-between`. With a single member there's no button and the count stays left as before.
- **Component** (`browse-bin-popup.component.ts`): adds a `selectionState` getter (`none` / `some` / `all`, derived from `BrowseSelectionService.selectedCountIn` over the bin's members) and a `toggleAll()` method mirroring the dashboard's toggle-all semantics (select all, or clear when already all-selected). Reuses the existing `addAll` / `removeAll` service methods, so no new selection state is introduced.
- **Styles** (`browse-bin-popup.component.scss`): adds `.bin-popup-grid-header` and a `.bin-popup-select-all` button styled like the dashboard's `.select-checkbox` but tuned to this window (smaller 15px icon, tighter padding). The count's old padding moved onto the header row.

## Testing

`./run-tests.sh frontend` — frontend build OK, audit OK, 877 Vitest unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvFggH5x9nZiJML4dkbGTN)_