### PR TITLE
Make detail preview image selectable in browse bin popup

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -50,7 +50,16 @@
 
   <div class="bin-popup-body" [style.height.px]="bodyHeight">
     @if (showPreview) {
-      <div class="bin-popup-preview" [style.width.px]="previewPaneSize">
+      <div
+        class="bin-popup-preview"
+        [class.selected]="isPreviewSelected()"
+        [style.width.px]="previewPaneSize"
+        role="button"
+        tabindex="0"
+        [attr.aria-pressed]="isPreviewSelected()"
+        [attr.aria-label]="(previewId != null ? name(previewId) : 'item') + (isPreviewSelected() ? ' (selected; click to deselect)' : ' (click to select)')"
+        (click)="onPreviewClick()"
+        (keydown)="onPreviewKeydown($event)">
         @if (previewUrl()) {
           <img
             class="bin-popup-preview-img"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -129,6 +129,24 @@
   border-radius: var(--radius-sm);
   background: var(--bg-body);
   overflow: hidden;
+  // Clicking the detail image toggles selection of the item it shows — the only
+  // way to select in a singleton popup (no grid), and a convenience in any popup.
+  cursor: pointer;
+
+  // A faint ring hints the image is clickable; the solid ``.selected`` ring
+  // (mirroring a grid entry's) takes over once the shown item is selected.
+  &:hover:not(.selected) {
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
+  }
+
+  &.selected {
+    box-shadow: inset 0 0 0 2px var(--accent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
 }
 
 .bin-popup-preview-img {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -540,6 +540,29 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     }
   }
 
+  /** True when the item currently shown in the preview pane is selected, so the
+   *  large detail image can render the same highlight ring as a grid entry. */
+  isPreviewSelected(): boolean {
+    return this.previewId != null && this.selection.has(this.previewId);
+  }
+
+  /** Toggle selection of the item shown in the preview pane (the hovered grid
+   *  item, or the lone member of a singleton bin). This is the only way to select
+   *  in a one-member popup, where the grid — and so every other select target —
+   *  is dropped; it also lets the user select by clicking the big detail image in
+   *  a multi-member popup. */
+  onPreviewClick(): void {
+    const id = this.previewId;
+    if (id != null) this.onEntryClick(id);
+  }
+
+  onPreviewKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onPreviewClick();
+    }
+  }
+
   // --- Hover: preview the full-res original (image/video) + hear (audio) ----
 
   onEntryEnter(id: number): void {


### PR DESCRIPTION
## Problem

In the bin popup, the only way to select items (and thus mark them good/bad from the popup) was the side thumbnail grid. But a single-member bin **drops the grid** — the large preview pane already shows the lone item, so the grid would just repeat it (`previewOnly`). That left no select target at all for a one-item popup, so you couldn't select/deselect it.

## Fix

Make the large preview pane itself a select target:

- Clicking the detail image — or pressing Enter/Space when it's focused — toggles selection of the item it currently shows (`previewId`): the hovered grid member, or the lone member of a singleton bin.
- The pane mirrors a grid entry's affordances: a solid `.selected` ring, a faint hover ring hinting it's clickable, `role="button"`, `tabindex`, and `aria-pressed`.
- It shares the same `BrowseSelectionService` as the grid and canvas, so selection stays in sync everywhere and the existing good/bad flow in the selection panel works unchanged.
- Works in any popup, not just singletons — clicking the big image is a natural way to select in a multi-member popup too.

## Testing

`./run-tests.sh frontend` — Angular `build:prod`, `npm audit`, and the Vitest suite (877 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1q4Vwcwmqj5GgFfHEigBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1q4Vwcwmqj5GgFfHEigBW)_