### PR TITLE
Make VTSBrowser minimap viewport marker visible on grayscale map

### DIFF
--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -340,9 +340,15 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     const rw = Math.abs(x1 - x0);
     const rh = Math.abs(y1 - y0);
     ctx.save();
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.15)';
+    // The default white marker is invisible on the grayscale map, whose ramp
+    // runs all the way through near-white — so against that achromatic field
+    // use the chromatic accent (and its pre-baked translucent fill), which the
+    // theme already adapts. Heat/Ocean never approach white, so white stays the
+    // cleanest neutral marker for them.
+    const gray = this.colormap() === 'gray';
+    ctx.fillStyle = gray ? this.themeColor('--accent-highlight-bg') : 'rgba(255, 255, 255, 0.15)';
     ctx.fillRect(rx, ry, rw, rh);
-    ctx.strokeStyle = '#ffffff';
+    ctx.strokeStyle = gray ? this.themeColor('--accent') : '#ffffff';
     ctx.lineWidth = 1.5;
     ctx.strokeRect(rx, ry, rw, rh);
     ctx.restore();


### PR DESCRIPTION
## Problem

When the VTSBrowser minimap uses the **grayscale** colormap, the "current view" marker is very hard to see. The marker is drawn pure white (`#ffffff` stroke, `rgba(255,255,255,0.15)` fill), but the grayscale density ramp runs all the way through near-white — in dark/highviz themes high-density cells reach `[240,240,240]`, and in light theme single/low-density cells sit at medium gray — so a white marker blends into the field.

## Fix

In `drawViewportRect` (`browse-minimap.component.ts`), when the active colormap is `gray`, draw the marker with the **theme accent** instead of white:

- stroke → `--accent` (chromatic in every theme: indigo in dark/light, yellow in highviz)
- fill → `--accent-highlight-bg` (the pre-baked translucent accent, already defined per-theme)

Because the grayscale map is achromatic by construction, any saturated color pops against it, and the accent already adapts per theme. Heat and Ocean never approach white, so they keep the existing clean white marker — no regression there.

## Testing

`./run-tests.sh frontend` passes: TypeScript build OK, audit OK (0 vulns), Vitest 877 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014hs3XJfNShUvYADpKo821J)_