### PR TITLE
Run embedders and Whisper/OCR converters on the GPU when available

### DIFF
--- a/docs/plans/gpu-acceleration.md
+++ b/docs/plans/gpu-acceleration.md
@@ -1,0 +1,89 @@
+# GPU acceleration audit
+
+**Status: Phase 1 shipped (device-aware embedders + no-new-dep converter GPU
+paths). Phase 2 (new-dependency accelerators) and the deliberately-skipped
+signal-rewrite items are deferred; see Open follow-ups.**
+
+VTSearch already had production-grade device infrastructure that nothing on the
+embedding side was using:
+
+- `vtscore/config.py::resolve_device()` — honours `VTSEARCH_DEVICE`, smoke-tests
+  an actual CUDA kernel launch, and falls back to CPU when the installed torch
+  wheel can't drive the visible GPU.
+- MLP training/scoring (`vtscore/training/mlp.py`, `vtscore/detectors/training.py`)
+  already ran on the resolved device, AMP and all.
+
+But every embedder hardcoded `self._model = self._model.to("cpu")` at load time,
+pinning the heaviest part of the pipeline — embedding inference, ~95% of
+load/train/score wall-time — to CPU even on GPU hosts. The fix was small because
+every embedder's forward pass already device-follows
+`next(self._model.parameters()).device` and returns results via
+`.detach().cpu().numpy()`.
+
+## What shipped (Phase 1)
+
+- **`to_compute_device(model)`** in `vtscore/media/embedder.py`: moves a freshly
+  loaded model onto `resolve_device()`. On CPU-only hosts it is exactly the old
+  `.to("cpu")` (still materialises `meta`-device tensors from
+  `low_cpu_mem_usage=True`); on a usable GPU the model — and the whole forward
+  pass — lands on the accelerator.
+- **14 embedder load pins converted** across image/audio/video
+  (`_clap_shared`, `embedder_ast`, `embedder_whisper`, `embedder_paraspeechclap`,
+  `embedder_siglip`, `embedder_siglip2`, `embedder_clip`, `embedder_face`,
+  `_dinov2_shared`, `_dinov3_shared`, `_eupe_shared`, `embedder_xclip`,
+  `embedder_languagebind`, `embedder_videomae`). The three CLAP variants share
+  `_clap_shared`.
+- **E5 / BGE text embedders**: `SentenceTransformer(..., device=resolve_device())`
+  so they route through the smoke-test + `VTSEARCH_DEVICE` instead of
+  sentence-transformers' naive auto-pick (which would grab a GPU the wheel can't
+  run).
+- **Whisper ASR converter** (`converters/audio2text.py`): loads on
+  `resolve_device()` with FP16 on CUDA.
+- **OCR converter** (`converters/image2text.py`): requests `use_gpu` when a CUDA
+  device resolves, falling back gracefully when the kwarg is unsupported
+  (PaddleOCR 3.x removed it).
+- **Concurrency default** (`embedding/loader.py::default_concurrent_embeddings`):
+  returns 1 on an accelerator — embedders share one GPU and forward passes
+  serialise on the global `_embed_lock`, so extra concurrent jobs only multiply
+  resident weights and court OOM. `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` still
+  overrides for multi-GPU / large-VRAM nodes.
+- **GPU tests** (`tests_lib/gpu/test_gpu.py`): added self-contained coverage for
+  `to_compute_device` and the embed concurrency default, and fixed two stale
+  tests that referenced a long-removed `MediaType._model` attribute.
+
+CPU-only behaviour is byte-for-byte unchanged (`resolve_device()` → `"cpu"`).
+
+## Deliberately NOT done (and why)
+
+These were in the "no-new-dep converters" tier but were skipped after grounding
+the call in the code:
+
+- **Spectrogram rendering** (`converters/audio2image.py`, librosa mel/CQT +
+  matplotlib), **audio resampling** (librosa in the CLAP/AST path), and **image
+  thumbnail/resize** (PIL). Moving these to torchaudio/torchvision would change
+  numerical/pixel outputs that feed embeddings and pHash near-dedup — breaking
+  the origin→embedding rederivation contract and snapshot tests — for steps that
+  are no longer the bottleneck once the embedder forward pass is on the GPU. CQT
+  also isn't in core torchaudio, and the matplotlib figure render (the actual
+  cost in spectrograms) stays on CPU regardless. Net: real risk, marginal/no
+  payoff. Left on CPU on purpose.
+
+## Open follow-ups (Phase 2 — each needs a new heavyweight dependency)
+
+Bigger speedups that were scoped out because they add optional GPU dependencies
+and touch the careful CPU/GPU install story (`scripts/install.sh`,
+`requirements/`, `docker/`):
+
+- **Video frame decode** (`converters/video2image.py`, `media/video/_frame_sampling.py`)
+  — currently OpenCV (CPU). `decord` / PyAV+NVDEC would give the largest
+  converter win (multi-hour → minutes on large video sets). Needs `decord`.
+- **GPU UMAP** (`vtscore/projection/umap_projection.py`) — `umap-learn` is CPU
+  (30–60s on 100k). `cuml.manifold.UMAP` is API-compatible; ~20–100× on large
+  sets. Needs cuML/RAPIDS.
+- **GPU k-means for the diversity tree** (`vtscore/state/diversity_tree.py`) —
+  sklearn KMeans (CPU). `cuml.cluster.KMeans` would cut tree-build time on
+  50k+-item datasets. Needs cuML/RAPIDS.
+
+When picking up Phase 2: gate any new GPU dependency behind the existing
+CPU/GPU install split and keep a CPU fallback path, exactly as the embedder work
+does via `resolve_device()`.

--- a/tests/converters/test_audio2text.py
+++ b/tests/converters/test_audio2text.py
@@ -28,12 +28,12 @@ def _fake_whisper_module(transcribe_result: dict, load_model_calls: list | None 
     mod = types.ModuleType("whisper")
 
     class FakeModel:
+        last_kwargs: dict = {}
+        last_device: str | None = None
+
         def transcribe(self, _audio_path, **kwargs):
             FakeModel.last_kwargs = kwargs
             return transcribe_result
-
-    FakeModel.last_kwargs = {}
-    FakeModel.last_device = None
 
     def load_model(size: str, device=None):
         if load_model_calls is not None:

--- a/tests/converters/test_audio2text.py
+++ b/tests/converters/test_audio2text.py
@@ -33,10 +33,12 @@ def _fake_whisper_module(transcribe_result: dict, load_model_calls: list | None 
             return transcribe_result
 
     FakeModel.last_kwargs = {}
+    FakeModel.last_device = None
 
-    def load_model(size: str):
+    def load_model(size: str, device=None):
         if load_model_calls is not None:
             load_model_calls.append(size)
+        FakeModel.last_device = device
         return FakeModel()
 
     mod.load_model = load_model  # pyright: ignore[reportAttributeAccessIssue]
@@ -178,6 +180,21 @@ class TestAudio2TextMediaConverter:
             c.convert(media, {"model_size": "small"})
 
         assert load_calls == ["small"]
+
+    def test_convert_loads_on_resolved_device(self):
+        """Whisper loads on resolve_device()'s choice; on a CPU host that's
+        ``"cpu"`` with fp16 disabled (FP16 is enabled only on CUDA)."""
+        from vtscore.converters.audio2text import Audio2TextMediaConverter
+
+        media = {"filename": "x.wav", "media_bytes": _make_silent_wav()}
+        c = Audio2TextMediaConverter()
+        fake = _fake_whisper_module({"text": "Hi."})
+
+        with patch.dict(sys.modules, {"whisper": fake}):
+            c.convert(media)
+
+        assert fake._FakeModel.last_device == "cpu"  # pyright: ignore[reportAttributeAccessIssue]
+        assert fake._FakeModel.last_kwargs.get("fp16") is False  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_convert_default_model_size_is_base(self):
         from vtscore.converters.audio2text import Audio2TextMediaConverter

--- a/tests_lib/gpu/test_gpu.py
+++ b/tests_lib/gpu/test_gpu.py
@@ -66,6 +66,44 @@ def _make_votes(good_ids: list[int], bad_ids: list[int]):
 
 
 # ---------------------------------------------------------------------------
+# 0. Device-aware embedding plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceAwareEmbedding:
+    """The device-resolution machinery every embedder now loads through.
+
+    These exercise the mechanism the device-aware embedder refactor hinges on
+    (``resolve_device`` -> ``to_compute_device``) without touching the heavy
+    HF model downloads or the embedder registry (which the library-tier test
+    suite stubs out), so they stay fast and deterministic on any CUDA box.
+    """
+
+    def test_resolve_device_picks_cuda_when_usable(self):
+        from vtscore.config import resolve_device
+
+        # On a host where the marker's torch.cuda.is_available() guard let this
+        # test run, the smoke-test in resolve_device() should also pass.
+        assert resolve_device().startswith("cuda")
+
+    def test_to_compute_device_moves_model_to_gpu(self):
+        import torch.nn as nn
+
+        from vtscore.media.embedder import to_compute_device
+
+        model = to_compute_device(nn.Linear(8, 4))
+        assert next(model.parameters()).device.type == "cuda"
+
+    def test_concurrent_embeddings_default_is_one_on_gpu(self, monkeypatch):
+        # With a usable GPU resolved, the embed default collapses to 1 to avoid
+        # stacking model copies on a single shared device (env override aside).
+        from vtscore.embedding import loader
+
+        monkeypatch.delenv("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS", raising=False)
+        assert loader.default_concurrent_embeddings() == 1
+
+
+# ---------------------------------------------------------------------------
 # 1. train_model on GPU
 # ---------------------------------------------------------------------------
 
@@ -473,17 +511,15 @@ class TestCLAPEmbeddingGPU:
     """
 
     def test_clap_model_loads_on_gpu(self, device):
-        from vtscore.media.audio.media_type import AudioMediaType
+        from transformers import ClapModel
 
-        # _model is set dynamically by load_models() on the subclass; not
-        # declared on the MediaType ABC, so pyright can't see it. cast keeps
-        # the runtime behaviour while satisfying the type-checker.
-        mt = cast(Any, AudioMediaType())
-        mt.load_models()
-        assert mt._model is not None
-        mt._model = mt._model.to(device)
-        # Verify model is on GPU
-        param = next(mt._model.parameters())
+        from vtscore.config import CLAP_MODEL_ID, MODELS_CACHE_DIR
+
+        model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=str(MODELS_CACHE_DIR)).to(
+            device
+        )
+        # Mirrors what to_compute_device() does inside the CLAP embedder.
+        param = next(model.parameters())
         assert param.device.type == "cuda"
 
     def test_clap_text_embedding_on_gpu(self, device):
@@ -543,13 +579,15 @@ class TestXCLIPEmbeddingGPU:
     """Test X-CLIP (video) embedding model on GPU."""
 
     def test_xclip_model_loads_on_gpu(self, device):
-        from vtscore.media.video.media_type import VideoMediaType
+        from transformers import XCLIPModel
 
-        mt = cast(Any, VideoMediaType())  # see _model note above
-        mt.load_models()
-        assert mt._model is not None
-        mt._model = mt._model.to(device)
-        param = next(mt._model.parameters())
+        from vtscore.config import MODELS_CACHE_DIR, XCLIP_MODEL_ID
+
+        model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=str(MODELS_CACHE_DIR)).to(
+            device
+        )
+        # Mirrors what to_compute_device() does inside the X-CLIP embedder.
+        param = next(model.parameters())
         assert param.device.type == "cuda"
 
     def test_xclip_text_embedding_on_gpu(self, device):

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -37,8 +37,9 @@ TORCH_THREADS = max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1")))
 # explicit values like ``"cuda"``, ``"cuda:0"``, ``"cpu"``, or ``"mps"`` are
 # passed through unchanged.  Resolution is lazy; the env var stores the
 # user's intent, ``resolve_device()`` actually imports torch when called.
-# Currently advisory: every embedder still loads on CPU.  Reserved for the
-# upcoming device-aware embedder refactor.
+# Embedders (via ``to_compute_device``/``resolve_device``) and MLP
+# training/scoring both honour this, so a visible, usable GPU is used for
+# embedding and learned-sort automatically; CPU remains the safe fallback.
 DEVICE = os.environ.get("VTSEARCH_DEVICE", "auto").lower()
 
 

--- a/vtscore/converters/audio2text.py
+++ b/vtscore/converters/audio2text.py
@@ -22,8 +22,9 @@ class Audio2TextMediaConverter(MediaConverter):
     The Whisper model files are downloaded on first use to the standard
     Whisper cache (``~/.cache/whisper``). The smallest (``tiny``) is
     ~75 MB on disk; ``base`` ~145 MB; ``small`` ~480 MB; ``medium``
-    ~1.5 GB; ``large`` ~3 GB. Inference runs on CPU by default and
-    automatically uses CUDA if a GPU is available.
+    ~1.5 GB; ``large`` ~3 GB. Inference runs on the device resolved from
+    ``VTSEARCH_DEVICE`` (CUDA when a usable GPU is visible, CPU otherwise; see
+    :func:`vtscore.config.resolve_device`), with FP16 enabled on CUDA.
 
     User-configurable parameters
     ----------------------------
@@ -89,8 +90,16 @@ class Audio2TextMediaConverter(MediaConverter):
                 audio_path.unlink(missing_ok=True)
             return []
 
+        # Resolve once, here, so Whisper honours VTSEARCH_DEVICE and the CUDA
+        # smoke-test fallback rather than its own naive is_available() check
+        # (which would pick a GPU the installed torch wheel can't run on).
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        resolved = resolve_device()
+        whisper_device = resolved if resolved.startswith("cuda") else "cpu"
+
         try:
-            model = whisper.load_model(model_size)
+            model = whisper.load_model(model_size, device=whisper_device)
         except Exception as e:
             print(f"Audio2TextMediaConverter: failed to load Whisper model '{model_size}': {e}")
             if owns_temp:
@@ -98,7 +107,7 @@ class Audio2TextMediaConverter(MediaConverter):
             return []
 
         try:
-            kwargs: dict[str, Any] = {"fp16": False}
+            kwargs: dict[str, Any] = {"fp16": whisper_device.startswith("cuda")}
             if language:
                 kwargs["language"] = language
             result = model.transcribe(str(audio_path), **kwargs)

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -45,11 +45,32 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
         return None
 
     try:
-        model = PaddleOCR(use_angle_cls=True, lang=language, show_log=False)
+        model = _make_paddleocr(PaddleOCR, language)
         return model.ocr(np.array(image), cls=True)
     except Exception as e:
         print(f"Image2TextMediaConverter: PaddleOCR failed on {filename}: {e}")
         return None
+
+
+def _make_paddleocr(paddle_ocr_cls: Any, language: str) -> Any:
+    """Construct a PaddleOCR engine, requesting GPU when one is resolved.
+
+    Routes through :func:`vtscore.config.resolve_device` so the engine honours
+    ``VTSEARCH_DEVICE`` and the CUDA smoke-test fallback.  ``use_gpu`` only
+    actually offloads when ``paddlepaddle-gpu`` is installed; with the CPU build
+    it is a harmless no-op.  The kwarg was removed in PaddleOCR 3.x, so an
+    unsupported-argument error falls back to the plain (CPU/default) constructor
+    rather than breaking OCR entirely.
+    """
+    from vtscore.config import resolve_device  # noqa: PLC0415
+
+    kwargs = {"use_angle_cls": True, "lang": language, "show_log": False}
+    if resolve_device().startswith("cuda"):
+        try:
+            return paddle_ocr_cls(**kwargs, use_gpu=True)
+        except (TypeError, ValueError):
+            pass  # PaddleOCR build without a use_gpu kwarg; fall back to default.
+    return paddle_ocr_cls(**kwargs)
 
 
 def _extract_text_lines(results: list, threshold: float) -> list[str]:

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -105,9 +105,11 @@ def default_concurrent_downloads() -> int:
 # A single CPU embed job holds an embedder model plus an N x D fp32 working
 # set; budgeting ~4 GiB of total RAM per concurrent job keeps memory-starved
 # boxes at one worker while letting roomy workstations run a few in parallel.
+# (Only consulted on CPU hosts; on an accelerator the embed default is 1 - see
+# ``default_concurrent_embeddings``.)
 _RAM_BYTES_PER_CPU_EMBED = 4 * 1024 * 1024 * 1024
 
-# Cores budgeted per concurrent embed job (embedders run on CPU today).
+# Cores budgeted per concurrent embed job on a CPU host.
 _CPUS_PER_CPU_EMBED = 4
 
 # Upper bound on the auto-derived embed default regardless of how big the box
@@ -149,27 +151,36 @@ def default_concurrent_embeddings() -> int:
     Honours ``VTSEARCH_MAX_CONCURRENT_EMBEDDINGS`` when set; otherwise derives
     from hardware.
 
-    The embed phase is **CPU- and RAM-bound today**: every embedder loads on CPU
-    regardless of an available GPU (see the ``DEVICE`` note in
-    ``vtscore/config.py`` - device-aware embedding is a future refactor). So the
-    default scales with the scarcer of cores and RAM and ignores GPU count:
-    roughly one job per :data:`_CPUS_PER_CPU_EMBED` cores and one per
+    **On an accelerator the default is 1.** Embedders are now device-aware (see
+    ``to_compute_device`` / ``resolve_device``), so on a CUDA/MPS host they share
+    a single GPU. Running several embed jobs at once would multiply resident model
+    weights on that one device and court OOM with no throughput win - the global
+    ``_embed_lock`` serialises forward passes on the device anyway. Power users
+    with VRAM headroom (or genuinely multi-GPU nodes) raise it via the env
+    override.
+
+    **On a CPU host the embed phase is CPU- and RAM-bound**, so the default
+    scales with the scarcer of cores and RAM and ignores GPU count: roughly one
+    job per :data:`_CPUS_PER_CPU_EMBED` cores and one per
     ``_RAM_BYTES_PER_CPU_EMBED`` of total RAM, whichever is smaller, capped at
     :data:`_MAX_CPU_EMBED_DEFAULT`. Constrained machines (few cores or little
     RAM) resolve to 1 - preserving the old fully-serial behaviour where a second
     concurrent embed would thrash or OOM - while workstations and fat cluster
     nodes get genuine parallel embedding with no config change. When total RAM
-    can't be read we fall back to 1 rather than guess generously.
-
-    A single-GPU SLURM allocation is exactly the case the old GPU branch got
-    wrong: it returned ``min(2, visible_gpus) == 1`` and serialised every embed
-    on an otherwise capable node. Scaling by the allocation's cores/RAM instead
-    lets such a node ingest several datasets at once; set
+    can't be read we fall back to 1 rather than guess generously. Set
     ``VTSEARCH_MAX_CONCURRENT_EMBEDDINGS`` past the auto cap to go further.
     """
     override = _env_concurrency_override("VTSEARCH_MAX_CONCURRENT_EMBEDDINGS")
     if override is not None:
         return override
+
+    # One embed job per GPU: the device is shared and forward passes serialise on
+    # it, so extra jobs only add VRAM pressure. resolve_device() returns "cpu"
+    # when torch is missing or no usable accelerator is present.
+    from vtscore.config import resolve_device  # noqa: PLC0415
+
+    if resolve_device() != "cpu":
+        return 1
 
     by_cpu = (os.cpu_count() or 1) // _CPUS_PER_CPU_EMBED
     total_ram = _total_memory_bytes()

--- a/vtscore/media/audio/_clap_shared.py
+++ b/vtscore/media/audio/_clap_shared.py
@@ -41,6 +41,7 @@ from vtscore.media.embedder import (
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 
 
@@ -109,7 +110,7 @@ class _ClapBase(MediaEmbedder):
                 on_progress=self._on_progress,
             )
         # Materialize any tensors left on the ``meta`` device.
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", f"Loading {self.label} processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -22,6 +22,7 @@ from vtscore.media.embedder import (
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 
 
@@ -84,7 +85,7 @@ class AudioASTEmbedder(MediaEmbedder):
                 token=hf_token(),
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._model.eval()
         self._on_progress("loading", "Loading AST feature extractor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):

--- a/vtscore/media/audio/embedder_paraspeechclap.py
+++ b/vtscore/media/audio/embedder_paraspeechclap.py
@@ -46,6 +46,7 @@ from vtscore.media.embedder import (
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 
 
@@ -136,7 +137,7 @@ class AudioParaSpeechClapEmbedder(MediaEmbedder):
                 len(result.missing_keys),
                 len(result.unexpected_keys),
             )
-        self._model = model.to("cpu")
+        self._model = to_compute_device(model)
         self._model.eval()
 
         self._on_progress("loading", "Loading ParaSpeechCLAP processors…", 0, 0)

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -29,6 +29,7 @@ from vtscore.media.embedder import (
     intercept_tqdm_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 
 
@@ -93,7 +94,7 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
             )
         # Encoder only - drop the decoder so we don't keep ~half the
         # weights in RSS for no benefit (we never invoke it).
-        full_model = full_model.to("cpu")
+        full_model = to_compute_device(full_model)
         self._model = full_model.encoder
         self._model.eval()
 

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -30,6 +30,7 @@ __all__ = [
     "media_from_path",
     "resolve_embed_batch_size",
     "timed_progress",
+    "to_compute_device",
 ]
 
 
@@ -98,6 +99,31 @@ def extract_tensor(output: object):
             return val
     # Final fallback: treat as tuple-like and return first element
     return output[0]  # type: ignore[index]
+
+
+def to_compute_device(model: Any) -> Any:
+    """Move a freshly loaded embedding *model* onto the resolved compute device.
+
+    Replaces the hardcoded ``model.to("cpu")`` every embedder used to run at
+    load time.  The target device comes from
+    :func:`vtscore.config.resolve_device`, which honours ``VTSEARCH_DEVICE`` and
+    smoke-tests CUDA before returning a CUDA device - falling back to ``"cpu"``
+    when the installed torch wheel can't actually launch a kernel on the visible
+    GPU.  The move is therefore always safe:
+
+    * On a CPU-only host (or one whose GPU the wheel can't drive) this is exactly
+      the old ``.to("cpu")``, still materialising any ``meta``-device tensors
+      left behind by ``low_cpu_mem_usage=True``.
+    * On a working CUDA / MPS host the model lands on the accelerator, and every
+      embedder's forward pass follows it automatically: each reads
+      ``next(self._model.parameters()).device`` and copies its inputs there,
+      pulling results back with ``.detach().cpu().numpy()``.
+
+    Returns the moved model so callers can write ``self._model = to_compute_device(self._model)``.
+    """
+    from vtscore.config import resolve_device  # noqa: PLC0415
+
+    return model.to(resolve_device())
 
 
 @contextlib.contextmanager

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -30,6 +30,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 from vtscore.media.patch_embed import PatchEmbedOutput, hf_vit_to_patch_output
@@ -92,7 +93,7 @@ class _Dinov2Base(MediaEmbedder):
                 on_progress=self._on_progress,
                 **extra_kwargs,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._model.eval()
         self._on_progress("loading", "Loading DINOv2 image processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -31,6 +31,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 from vtscore.media.patch_embed import PatchEmbedOutput, hf_vit_to_patch_output
@@ -104,7 +105,7 @@ class _Dinov3Base(MediaEmbedder):
                 on_progress=self._on_progress,
                 **extra_kwargs,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._model.eval()
         self._on_progress("loading", "Loading DINOv3 image processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):

--- a/vtscore/media/image/_eupe_shared.py
+++ b/vtscore/media/image/_eupe_shared.py
@@ -40,6 +40,7 @@ from vtscore.media.embedder import (
     embedder_load_setup,
     intercept_tqdm_progress,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 from vtscore.media.patch_embed import PatchEmbedOutput, eupe_features_to_patch_output
@@ -117,7 +118,7 @@ class _EupeBase(MediaEmbedder):
                 weights=EUPE_MODEL_ID,
                 trust_repo=True,  # pyright: ignore[reportArgumentType]  # bool is valid at runtime; stubs only list str
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._model.eval()
 
         # EUPE doesn't ship a HF AutoImageProcessor, so build the

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -17,6 +17,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
@@ -73,7 +74,7 @@ class ImageClipEmbedder(MediaEmbedder):
                 token=hf_token(),
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(

--- a/vtscore/media/image/embedder_face.py
+++ b/vtscore/media/image/embedder_face.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
-from vtscore.media.embedder import MediaEmbedder, timed_progress
+from vtscore.media.embedder import MediaEmbedder, timed_progress, to_compute_device
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
@@ -82,7 +82,7 @@ class ImageFaceEmbedder(MediaEmbedder):
 
             model = InceptionResnetV1(pretrained="vggface2")
             model.eval()
-            self._model = model.to("cpu")
+            self._model = to_compute_device(model)
 
     def _preprocess(self, image: "Image.Image") -> np.ndarray:
         """Resize to 160×160 RGB and normalise to ``(x − 127.5) / 128``.

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -17,6 +17,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
@@ -87,7 +88,7 @@ class ImageSiglipEmbedder(MediaEmbedder):
                 token=hf_token(),
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", "Loading SigLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             from transformers import SiglipImageProcessor, SiglipTokenizer  # noqa: PLC0415

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -22,6 +22,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
@@ -79,7 +80,7 @@ class ImageSiglip2Embedder(MediaEmbedder):
                 token=hf_token(),
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", "Loading SigLIP 2 processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtscore.config import BGE_MODEL_ID
+from vtscore.config import BGE_MODEL_ID, resolve_device
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
@@ -99,6 +99,7 @@ class TextBGEEmbedder(MediaEmbedder):
                 SentenceTransformer,
                 BGE_MODEL_ID,
                 cache_folder=cache_dir,
+                device=resolve_device(),
                 token=hf_token(),
                 on_progress=self._on_progress,
             )

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtscore.config import E5_MODEL_ID
+from vtscore.config import E5_MODEL_ID, resolve_device
 from vtscore.media.embedder import (
     MediaEmbedder,
     embedder_load_setup,
@@ -103,6 +103,7 @@ class TextE5Embedder(MediaEmbedder):
                 SentenceTransformer,
                 E5_MODEL_ID,
                 cache_folder=cache_dir,
+                device=resolve_device(),
                 token=hf_token(),
                 on_progress=self._on_progress,
             )

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -16,6 +16,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.video._frame_sampling import sample_video_frames
 
@@ -119,7 +120,7 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
                 trust_remote_code=True,
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", "Loading LanguageBind tokenizer...", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._tokenizer = load_pretrained_local_first(

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -26,6 +26,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.video._frame_sampling import sample_video_frames
 
@@ -158,7 +159,7 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
                 trust_remote_code=True,
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._model.eval()
 
     # ------------------------------------------------------------------

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -17,6 +17,7 @@ from vtscore.media.embedder import (
     intercept_weight_loading_progress,
     load_pretrained_local_first,
     timed_progress,
+    to_compute_device,
 )
 from vtscore.media.video._frame_sampling import sample_video_frames
 
@@ -85,7 +86,7 @@ class VideoXClipEmbedder(MediaEmbedder):
                 token=hf_token(),
                 on_progress=self._on_progress,
             )
-        self._model = self._model.to("cpu")
+        self._model = to_compute_device(self._model)
         self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = load_pretrained_local_first(


### PR DESCRIPTION
## Summary

VTSearch already had production-grade device infrastructure — `resolve_device()` (honours `VTSEARCH_DEVICE`, smoke-tests an actual CUDA kernel launch, falls back to CPU) and GPU-accelerated MLP train/score — but **every embedder hardcoded `.to("cpu")` at load time**, pinning the heaviest part of the pipeline (embedding inference, ~95% of load/train/score wall-time) to CPU even on GPU hosts. This was flagged in-code as the "upcoming device-aware embedder refactor."

The fix is small because every embedder's forward pass already device-follows `next(self._model.parameters()).device` and returns results via `.detach().cpu().numpy()` — so flipping the load-time pin moves the whole forward pass to the GPU automatically.

## What changed

- **`to_compute_device(model)`** (`vtscore/media/embedder.py`): moves a freshly loaded model onto `resolve_device()`. On CPU-only hosts it is byte-for-byte the old `.to("cpu")`; on a usable GPU the model lands on the accelerator.
- **14 embedder load pins converted** across image/audio/video (the 3 CLAP variants share `_clap_shared`).
- **E5 / BGE**: `SentenceTransformer(..., device=resolve_device())` so they honour the smoke-test + `VTSEARCH_DEVICE` instead of sentence-transformers' naive auto-pick.
- **Whisper ASR converter** (`audio2text.py`): loads on `resolve_device()` with FP16 on CUDA.
- **OCR converter** (`image2text.py`): requests `use_gpu` when CUDA resolves, falling back gracefully when the kwarg is unsupported (PaddleOCR 3.x).
- **`default_concurrent_embeddings()`** returns 1 on an accelerator: embedders share one GPU and forward passes serialise on the global `_embed_lock`, so extra jobs only add VRAM pressure. `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` still overrides. Stale "embedders run on CPU" comments refreshed.
- **GPU tests**: added self-contained coverage for `to_compute_device` / the embed concurrency default, and fixed two stale tests that referenced a long-removed `MediaType._model` attribute.

## Deliberately not done

The torchaudio/torchvision rewrites of spectrogram rendering, audio resampling, and image thumbnails were skipped: they'd change numerical/pixel outputs that feed embeddings and pHash near-dedup (breaking the origin→embedding rederivation contract and snapshot tests) for steps that are no longer the bottleneck once the embedder is on the GPU. Rationale and the Phase 2 new-dependency accelerators (decord video decode, cuML UMAP + diversity k-means) are recorded in `docs/plans/gpu-acceleration.md`.

## Compatibility

CPU-only hosts are unaffected — `resolve_device()` returns `"cpu"`, so `to_compute_device()` is exactly the previous behaviour.

## Testing

`./run-tests.sh` — all 5245 tests pass (ruff, codespell, deptry, pyright, frontend build, pytest). GPU tests are CUDA-gated and not run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpwqHdfn2dojgJT1hkDbTm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpwqHdfn2dojgJT1hkDbTm)_