### PR TITLE
slurm runner: avoid srun 2000-char arg limit (regression from the "i" option)

### DIFF
--- a/scripts/slurm/vtsearch-slurm.sh
+++ b/scripts/slurm/vtsearch-slurm.sh
@@ -50,9 +50,20 @@ echo ">>> (this may queue; once it lands, VTSearch starts and prints its node + 
 # app.py reads VTSEARCH_PORT for the dev server's bind port.
 export VTS_DIR="$DIR" VTS_VENV="$VENV" VTS_MODULE="$MODULE" VTSEARCH_PORT="$PORT"
 
-exec srun --job-name=vtsearch --pty \
-    -p "$PART" --gres=gpu:${GPU}:1 -c "$CPUS" --mem "$MEM" -t "$TIME" \
-    bash -lc '
+# The per-node script below is too long to pass as an inline `bash -lc '...'`
+# argument: this cluster's srun caps that single argument at 2000 chars and
+# rejects anything longer ("script argument list exceeds 2000 characters").
+# So write the body to a temp file on a SHARED filesystem -- the compute node
+# has to read it, so node-local /tmp won't do -- and have srun run that file.
+# This keeps the srun argv tiny no matter how long the body grows.
+RUNNER_DIR="/exp/$USER"; [ -d "$RUNNER_DIR" ] || RUNNER_DIR="$HOME"
+RUNNER=$(mktemp "$RUNNER_DIR/.vtsearch-run.XXXXXX") \
+    || { echo "could not create runner temp file in $RUNNER_DIR"; exit 1; }
+# Clean up the temp file on exit (normal quit, Ctrl+C, or kill).
+trap 'rm -f "$RUNNER"' EXIT INT TERM
+# Quoted heredoc: $VTS_DIR etc. stay literal here and expand on the compute
+# node, exactly as they did inside the old single-quoted `bash -lc '...'`.
+cat > "$RUNNER" <<'REMOTE'
         # A no-op INT handler keeps THIS wrapper alive on Ctrl+C while still
         # letting child processes (python) take the default SIGINT and die.
         trap ":" INT
@@ -99,4 +110,8 @@ exec srun --job-name=vtsearch --pty \
             done
         done
         echo ">>> Releasing the allocation. Bye."
-    '
+REMOTE
+
+srun --job-name=vtsearch --pty \
+    -p "$PART" --gres=gpu:${GPU}:1 -c "$CPUS" --mem "$MEM" -t "$TIME" \
+    bash -l "$RUNNER"


### PR DESCRIPTION
## What

The SLURM launcher (`scripts/slurm/vtsearch-slurm.sh`) passed its **entire per-node body** as a single inline `srun ... bash -lc '<script>'` argument. This cluster caps that argument at 2000 chars and rejects anything longer:

```
srun: error: ERROR: The script argument list exceeds 2000 characters, length=2868
srun: error: Unable to allocate resources: Pathname ... too long
```

The recently-added **`i` (reinstall) prompt** (#2087) pushed the body from just-under-2000 to 2868 chars, so `vtsearch` began failing at allocation time. This is a regression fix for that.

## Fix

Write the per-node body to a temp file on a **shared** filesystem (`/exp/$USER`, falling back to `$HOME` — node-local `/tmp` isn't visible on the compute node) and run `srun ... bash -l "$RUNNER"`. The srun argv is now ~50 chars regardless of how long the body grows, so this class of failure can't recur as the script evolves.

- Temp file removed via an `EXIT`/`INT`/`TERM` trap.
- Exported `VTS_*` / `VTSEARCH_PORT` still reach the body through the environment; the **quoted** heredoc keeps them literal until they expand on the node — identical semantics to the old single-quoted `bash -lc '...'`.

## Verification

- `bash -n` clean; heredoc opens/closes exactly once.
- Extracted the body and ran it with stubs: `i` reinstalls and re-prompts, Enter restarts `app.py`, `q`/EOF release — all correct, env vars propagate.
- Deployed to the live GRID launcher (`~/.local/bin/vtsearch`) and confirmed syntax, the `i` option, the temp-file runner, and that `/exp/$USER` resolves to shared storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)