### PR TITLE
Fix dashboard ⋯ menu not dismissing when clicking another card's ⋯ button

### DIFF
--- a/frontend/src/app/components/context-menu/context-menu.component.spec.ts
+++ b/frontend/src/app/components/context-menu/context-menu.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContextMenuComponent } from './context-menu.component';
+import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('ContextMenuComponent', () => {
+  let fixture: ComponentFixture<ContextMenuComponent>;
+  let component: ContextMenuComponent;
+  let dismissCount: number;
+  const outsideEls: HTMLElement[] = [];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContextMenuComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContextMenuComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('x', 10);
+    fixture.componentRef.setInput('y', 20);
+    fixture.componentRef.setInput('items', [{ id: 'a', label: 'Action A' }]);
+    // The capture-phase listeners are on `document`, so the menu host must be
+    // connected for dispatched clicks to propagate through the document.
+    document.body.appendChild(fixture.nativeElement);
+    await settleZoneless(fixture);
+
+    dismissCount = 0;
+    component.dismissed.subscribe(() => (dismissCount += 1));
+  });
+
+  afterEach(() => {
+    outsideEls.forEach((el) => el.remove());
+    outsideEls.length = 0;
+    fixture.destroy();
+  });
+
+  /** Append a detached button to the body and return it. */
+  function makeOutsideButton(stopProp: boolean): HTMLElement {
+    const btn = document.createElement('button');
+    if (stopProp) {
+      // Mirrors a dashboard card's ⋯ overflow button, which stops the click
+      // from bubbling so the row isn't selected.
+      btn.addEventListener('click', (e) => e.stopPropagation());
+    }
+    document.body.appendChild(btn);
+    outsideEls.push(btn);
+    return btn;
+  }
+
+  it('should dismiss on an outside click', () => {
+    makeOutsideButton(false).click();
+    expect(dismissCount).toBe(1);
+  });
+
+  it('should dismiss on an outside click even when the target stops propagation', () => {
+    // Regression: clicking another card's ⋯ button (which calls
+    // stopPropagation) used to leave this menu open because the bubble-phase
+    // document listener never fired.
+    makeOutsideButton(true).click();
+    expect(dismissCount).toBe(1);
+  });
+
+  it('should dismiss on an outside right-click', () => {
+    const btn = makeOutsideButton(false);
+    btn.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(dismissCount).toBe(1);
+  });
+
+  it('should not dismiss when clicking inside the menu', () => {
+    const item = fixture.nativeElement.querySelector('.menu-item') as HTMLElement;
+    item.click();
+    expect(dismissCount).toBe(0);
+  });
+
+  it('should dismiss on Escape', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(dismissCount).toBe(1);
+  });
+
+  it('should stop listening once destroyed', () => {
+    fixture.destroy();
+    makeOutsideButton(true).click();
+    expect(dismissCount).toBe(0);
+  });
+});

--- a/frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/frontend/src/app/components/context-menu/context-menu.component.ts
@@ -1,5 +1,5 @@
 
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, OnDestroy, OnInit, inject, input, output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 export interface ContextMenuItem {
@@ -27,7 +27,7 @@ export interface ContextMenuItem {
   templateUrl: './context-menu.component.html',
   styleUrl: './context-menu.component.scss',
 })
-export class ContextMenuComponent {
+export class ContextMenuComponent implements OnInit, OnDestroy {
   private host = inject<ElementRef<HTMLElement>>(ElementRef);
   private sanitizer = inject(DomSanitizer);
 
@@ -49,18 +49,35 @@ export class ContextMenuComponent {
     return safe;
   }
 
-  @HostListener('document:click', ['$event'])
-  onDocumentClick(event: MouseEvent): void {
+  /**
+   * Dismiss on any click / right-click outside the menu. These run in the
+   * *capture* phase (note the `true` flag) rather than via a bubble-phase
+   * `@HostListener('document:click')`, because the element being clicked may
+   * `stopPropagation()` before the event bubbles to `document` — e.g. a
+   * dashboard card's ⋯ overflow button stops the click so it doesn't select
+   * the row. A bubble-phase listener never fires in that case, so an
+   * already-open menu would linger when the user clicked a *different* card's
+   * ⋯ button. Capture sees every event before any descendant can swallow it.
+   *
+   * The listeners are plain DOM listeners (not Angular `@HostListener`s) so
+   * they can opt into capture. They fire outside Angular, but the consumer's
+   * `(dismissed)` template binding still schedules change detection on emit
+   * under zoneless (the same mechanism `panel-resize.directive` relies on).
+   */
+  private readonly onDocumentPointer = (event: Event): void => {
     if (!this.host.nativeElement.contains(event.target as Node)) {
       this.dismissed.emit();
     }
+  };
+
+  ngOnInit(): void {
+    document.addEventListener('click', this.onDocumentPointer, true);
+    document.addEventListener('contextmenu', this.onDocumentPointer, true);
   }
 
-  @HostListener('document:contextmenu', ['$event'])
-  onDocumentContextMenu(event: MouseEvent): void {
-    if (!this.host.nativeElement.contains(event.target as Node)) {
-      this.dismissed.emit();
-    }
+  ngOnDestroy(): void {
+    document.removeEventListener('click', this.onDocumentPointer, true);
+    document.removeEventListener('contextmenu', this.onDocumentPointer, true);
   }
 
   @HostListener('document:keydown.escape')


### PR DESCRIPTION
## Problem

The new ⋯ ("more actions") buttons on the Dashboard cards open a shared `vt-context-menu`. Clicking a **different** card's ⋯ button left the first menu open, so two menus could be on screen at once.

## Root cause

A card's `onOverflow` calls `event.stopPropagation()` so the click doesn't bubble up to the row and select it. But the shared context menu dismissed outside-clicks via a **bubble-phase** `@HostListener('document:click')`. Since the ⋯ button stops the click before it reaches `document`, the already-open menu never heard it and stayed open. The same applied to a card's other action buttons (load/browse/checkbox/pencil), which also `stopPropagation`.

## Fix

Move the outside-click / outside-right-click dismissal in `vt-context-menu` to **capture-phase** `document` listeners. Capture runs before the event reaches the target, so no descendant's `stopPropagation()` can swallow it. These are plain DOM listeners (capture isn't available via `@HostListener`); they fire outside Angular, but the consumers' `(dismissed)` template binding still schedules change detection under zoneless — the same mechanism `panel-resize.directive` documents.

Escape (`@HostListener('document:keydown.escape')`) is unaffected by the click-stopPropagation issue and is left as-is.

### Dismissal paths reviewed

| Path | Status |
|------|--------|
| Click another card's ⋯ button | **Fixed** (was broken) |
| Click empty space / elsewhere | ✓ |
| Right-click outside | ✓ |
| Escape | ✓ |
| Select a menu item | ✓ (no double-fire) |
| Same card's other action buttons | **Fixed** (same root cause) |

## Tests

Added `context-menu.component.spec.ts` covering each dismissal path, including the regression case where the outside target calls `stopPropagation`. `./run-tests.sh frontend` passes (build clean, 885 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011i32yyQdSGCzsbpExtpknj)_