### PR TITLE
Add startup progress bars for the "Loading ML libraries" step

### DIFF
--- a/app.py
+++ b/app.py
@@ -604,9 +604,8 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
                     flush=True,
                 )
 
-    print("  Loading ML libraries...", end="", flush=True)
-    initialize_models()
-    print(" done", flush=True)
+    print("  Loading ML libraries...", flush=True)
+    initialize_models(on_progress=lambda *a, **k: None)
     # ``--solo-media-type`` (process-level CLI fallback) tells us which
     # mediaType's default embedder to warm even if no datasets or detectors
     # are registered yet. Per-user explicit values are not consulted here

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -446,8 +446,12 @@ def clear_text_query_cache() -> None: ...
 def get_torch_device() -> torch.device:
     """Resolve config.DEVICE to a concrete torch.device."""
 
-def initialize_models() -> None:
-    """Set up the torch runtime: cache dir, thread limits, optional CUDA visibility."""
+def initialize_models(on_progress: ProgressCallback | None = None) -> None:
+    """Set up the torch runtime: cache dir, thread limits, optional CUDA visibility.
+
+    Pass on_progress to render console progress bars for the heavy sklearn /
+    transformers imports; omit it (default) to run silently.
+    """
 
 def predict_embedders_to_preload(
     datasets: Iterable[DatasetRegistryEntry],

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -24,7 +24,12 @@ from vtscore.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
-from vtscore.embedding.loader import _make_console_progress, predict_embedders_to_preload, preload_predicted_embedders
+from vtscore.embedding.loader import (
+    _make_console_progress,
+    initialize_models,
+    predict_embedders_to_preload,
+    preload_predicted_embedders,
+)
 
 
 class TestMakeConsoleProgress:
@@ -240,6 +245,51 @@ class TestPreloadConsoleOutput:
         assert result == []
         captured = capsys.readouterr()
         assert captured.out == ""
+
+
+class TestInitializeModelsProgress:
+    """``initialize_models`` renders progress bars for its heavy library imports."""
+
+    def test_no_callback_is_silent(self, capsys):
+        """Without an ``on_progress`` callback (tests/eval CLI), nothing prints."""
+        with (
+            patch("vtscore.embedding.loader._warm_threadpool_controller"),
+            patch("vtsearch.logging_config.install_transformers_logging_bridge"),
+        ):
+            initialize_models()
+
+        assert capsys.readouterr().out == ""
+
+    def test_callback_receives_import_steps(self):
+        """The callback is driven with one step per heavy import (sklearn, transformers)."""
+        calls = []
+
+        def cb(status, message="", current=0, total=0):
+            calls.append((status, message, current, total))
+
+        with (
+            patch("vtscore.embedding.loader._warm_threadpool_controller"),
+            patch("vtsearch.logging_config.install_transformers_logging_bridge"),
+        ):
+            initialize_models(on_progress=cb)
+
+        messages = [m for _, m, _, _ in calls]
+        assert any("scikit-learn" in m for m in messages)
+        assert any("transformers" in m for m in messages)
+
+    def test_callback_renders_console_bars(self, capsys):
+        """With a callback, both import steps render completed console bars."""
+        with (
+            patch("vtscore.embedding.loader._warm_threadpool_controller"),
+            patch("vtsearch.logging_config.install_transformers_logging_bridge"),
+        ):
+            initialize_models(on_progress=lambda *a, **kw: None)
+
+        out = capsys.readouterr().out
+        assert "Importing scikit-learn" in out
+        assert "Importing transformers" in out
+        # Both bars complete at 100% (the second via flush at the end).
+        assert out.count("100%") >= 2
 
 
 class TestPredictEmbeddersToPreload:

--- a/vtscore/docs/packages/embedding.md
+++ b/vtscore/docs/packages/embedding.md
@@ -149,10 +149,13 @@ model.to(dev)
 ## Runtime initialisation
 
 ```python
-def initialize_models() -> None: ...
+def initialize_models(on_progress: ProgressCallback | None = None) -> None: ...
 ```
 
-(`vtscore/embedding/loader.py:76`.) Sets up the runtime environment:
+(`vtscore/embedding/loader.py:76`.) Pass `on_progress` to render console
+progress bars for the two heavy first-time imports it triggers (scikit-learn
+and transformers, ~10s combined on a cold start); omit it (the default, used
+by tests and the eval CLI) to run silently. Sets up the runtime environment:
 
 1. Creates `vtscore.config.MODELS_CACHE_DIR` on disk.
 2. Calls `ensure_torch_configured()` which applies

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -32,6 +32,7 @@ def _strip_time_suffix(msg: str) -> str:
 
 
 from vtscore.config import MODELS_CACHE_DIR, resolve_device
+from vtscore.media.base import ProgressCallback
 from vtscore.media.torch_setup import ensure_torch_configured
 
 logger = logging.getLogger(__name__)
@@ -223,7 +224,7 @@ def _warm_threadpool_controller() -> None:
             pass
 
 
-def initialize_models() -> None:
+def initialize_models(on_progress: ProgressCallback | None = None) -> None:
     """Prepare the runtime environment for embedding models.
 
     Creates the model cache directory, configures PyTorch thread count
@@ -235,16 +236,42 @@ def initialize_models() -> None:
     path that actually imports torch.
 
     Models themselves are **not** loaded here.
+
+    The two heavy first-time imports this triggers - scikit-learn (pulled in
+    by the threadpool warm-up) and transformers (pulled in by the logging
+    bridge) - dominate the wall-clock cost and can take ~10s combined on a
+    cold start, during which the process looks frozen.  Pass *on_progress* to
+    render a live elapsed-time progress bar for each, matching the embedder
+    preload bars printed later in startup.  When ``None`` (the default, used
+    by tests and the eval CLI) the imports run silently as before.
     """
     MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     ensure_torch_configured()
-    _warm_threadpool_controller()
-    try:
-        from vtsearch.logging_config import install_transformers_logging_bridge  # noqa: PLC0415
 
-        install_transformers_logging_bridge()
-    except Exception:
-        pass
+    def _warm() -> None:
+        _warm_threadpool_controller()
+
+    def _bridge() -> None:
+        try:
+            from vtsearch.logging_config import install_transformers_logging_bridge  # noqa: PLC0415
+
+            install_transformers_logging_bridge()
+        except Exception:
+            pass
+
+    if on_progress is None:
+        _warm()
+        _bridge()
+    else:
+        from vtscore.media.embedder import timed_progress  # noqa: PLC0415
+
+        console_cb = _make_console_progress(on_progress)
+        with timed_progress(console_cb, "loading", "Importing scikit-learn…", 1, 2):
+            _warm()
+        with timed_progress(console_cb, "loading", "Importing transformers…", 2, 2):
+            _bridge()
+        console_cb.flush()  # type: ignore[attr-defined]
+
     gc.collect()
 
 


### PR DESCRIPTION
## Problem

On startup, the `Loading ML libraries... done` line had no progress indicator, yet it's the slowest step (~10s on a cold start). It looked frozen while every step below it — torch/transformers import, weight loading — already animated a progress bar.

## Cause

That step is `initialize_models()`, which triggers two heavy first-time imports with no incremental feedback:
- **scikit-learn**, pulled in by `_warm_threadpool_controller()`
- **transformers**, pulled in by `install_transformers_logging_bridge()`

These dominate the wall-clock cost and ran silently.

## Change

`initialize_models()` now accepts an optional `on_progress` callback. When provided, each heavy import is wrapped in the existing `timed_progress` helper and rendered through `_make_console_progress`, so the user sees a live elapsed-time bar per step — identical in style/alignment to the embedder preload bars printed later in startup:

```
  Loading ML libraries...
    Importing scikit-learn…          [#############.................]  50% (3s, 247 modules)
    Importing scikit-learn…          [##############################] 100%
    Importing transformers…          [##############################] 100%
```

`app.py` passes a callback so startup renders the bars. When `on_progress` is omitted (the default, used by tests and the eval CLI) the imports run silently exactly as before.

## Tests

- New `TestInitializeModelsProgress` in `tests_lib/cli/test_preload_progress.py`: silent without a callback, callback driven with one step per import, and both bars rendered to the console at 100%.
- `./run-tests.sh` full suite green (5247 passed); `vtscore-clean` import-cleanliness gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZmQJq3cseyCVkgNLGZDJU)_