### PR TITLE
Degrade cuML to CPU on fit-time nvrtc failures + cap cuml-cu12 below RAPIDS 26

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -77,10 +77,16 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # fail-loud on purpose: a build-once-ship image should break here if cuML can't
 # resolve against the pinned torch build, rather than silently shipping a 12 GB
 # GPU image that still runs UMAP on the CPU. Adds ~3-4 GB to the image.
+#
+# Capped below RAPIDS 26 to match scripts/install.sh: 26.x requires
+# nvidia-nvjitlink-cu12>=12.9, which the cu121 torch pinned above (CUDA 12.1)
+# can't satisfy, so an unpinned cuml-cu12 would fail this fail-loud layer. 25.x
+# declares cuda-toolkit==12.* and resolves cleanly. See docs/DEPLOYMENT.md
+# "cuML crashes compiling a kernel".
 RUN pip install --no-cache-dir \
         --extra-index-url https://pypi.nvidia.com \
         --prefer-binary \
-        cuml-cu12
+        "cuml-cu12<26"
 
 # ---------- application layer ----------
 COPY . .

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -589,31 +589,43 @@ storage class or type specifier  __NV_SILENCE_DEPRECATION_BEGIN
 ... N errors detected in the compilation of ".../<hash>.cubin.cu".
 ```
 
-**Cause**: a **mixed CUDA toolchain** in the venv. cuML compiles its
-cuVS/raft kernels with nvrtc lazily, on the first UMAP/k-means `fit`. When
-CUDA-13 NVIDIA wheels (`nvidia-*-cu13`, which install headers under
-`site-packages/nvidia/cu13/include/`) are present alongside a CUDA-12
-cuML/cupy stack, cupy's nvrtc ends up compiling the CUDA-13 fp8/fp6/fp4
-headers, which reference a `__NV_SILENCE_DEPRECATION_BEGIN` macro the
-CUDA-12 nvrtc doesn't define — so the parse fails. A clean
-`scripts/install.sh` does **not** produce this mix (it pins torch, `cuml-cu12`
-and `cupy-cuda12x` all to CUDA 12); it usually comes from an out-of-band
-`pip install` that pulled in a `cupy-cuda13x` or CUDA-13 `nvidia-*-cu13`
-wheel.
+**Cause**: a **RAPIDS release newer than your torch's CUDA**. cuML compiles
+its cuVS/raft kernels with nvrtc lazily, on the first UMAP/k-means `fit`.
+RAPIDS **26.x** (`cuml-cu12 >= 26`) raised its CUDA floor to require
+`nvidia-nvjitlink-cu12 >= 12.9`, but the torch CUDA wheels VTSearch pins
+(`cu124` = CUDA 12.4 ... `cu128` = CUDA 12.8) cap the CUDA libraries at 12.8 —
+and no torch wheel ships CUDA 12.9 yet. An **unpinned** `cuml-cu12` therefore
+floats up to 26.x, which fails the pip resolver:
 
-VTSearch now **degrades to the CPU UMAP/k-means path** when this happens
-(logging a one-time warning) instead of crashing, so the run still
-completes — just slower, without GPU acceleration. To restore the GPU path,
-repair the toolchain mix:
+```
+cuml-cu12 26.6.0 requires nvidia-nvjitlink-cu12<13,>=12.9, but you have
+nvidia-nvjitlink-cu12 12.4.127 which is incompatible.
+```
+
+...and, if mismatched libraries land anyway, makes cupy's nvrtc compile the
+wrong-version fp8/fp6/fp4 headers (the `__NV_SILENCE_DEPRECATION_BEGIN` macro
+the resident nvrtc doesn't define), producing the `cuda_fp8.hpp` crash above.
+
+`scripts/install.sh` and `docker/Dockerfile.gpu` now **cap the wheel at
+`cuml-cu12<26`** (RAPIDS 25.x declares `cuda-toolkit==12.*` and resolves
+cleanly against the pinned torch), so fresh installs are unaffected. A venv
+that already pulled 26.x just needs the matching downgrade.
+
+VTSearch also now **degrades to the CPU UMAP/k-means path** whenever a cuML
+fit fails for any reason (logging a one-time warning) instead of crashing, so
+the run still completes — just slower, without GPU acceleration. To restore
+the GPU path:
 
 ```bash
-# 1. See which CUDA majors are installed; a healthy GPU venv shows ONLY cu12.
-pip list | grep -iE 'cu13|cupy|cuml|cuvs|pylibraft|nvidia'
+# 1. Inspect the installed CUDA stack (look for cuml-cu12 / libcuml-cu12 26.x,
+#    and any stray *-cu13 wheels from an out-of-band install).
+pip list | grep -iE 'cu13|cupy|cuml|cuvs|libraft|pylibraft|nvidia-nvjitlink'
 
-# 2. Remove the stray CUDA-13 / mismatched wheels (adjust to what step 1 shows).
+# 2. Reinstall the RAPIDS stack capped below 26 so it matches the pinned torch.
+pip install --extra-index-url https://pypi.nvidia.com --prefer-binary "cuml-cu12<26"
+
+# 3. If step 1 showed stray CUDA-13 wheels, remove them and reinstall cleanly:
 pip uninstall -y $(pip list --format=freeze | grep -iE '(-cu13|cupy-cuda13x)' | cut -d= -f1)
-
-# 3. Reinstall a consistent CUDA-12 GPU stack.
 bash scripts/install.sh            # or: bash scripts/install.sh cu124
 ```
 

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -26,7 +26,9 @@
 # (air-gapped re-install, or after VTSEARCH_SKIP_CUML=1), install the wheel
 # matching your CUDA major version from the NVIDIA index, e.g. for CUDA 12:
 #
-#   pip install --extra-index-url https://pypi.nvidia.com cuml-cu12
+#   pip install --extra-index-url https://pypi.nvidia.com "cuml-cu12<26"
 #
-# (use cuml-cu11 on CUDA 11 hosts). Output differs numerically from the CPU
+# (the <26 cap matches scripts/install.sh: RAPIDS 26.x needs CUDA 12.9, newer
+# than the torch CUDA wheels we pin -- see docs/DEPLOYMENT.md "cuML crashes
+# compiling a kernel". Use cuml-cu11 on CUDA 11 hosts). Output differs from CPU
 # path; this is safe because both consumers freeze/persist their result once.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,6 +115,16 @@ vts_install_cpu() {
 #     separate index (pypi.nvidia.com), so a slow/unreachable index or a
 #     resolver hiccup must NOT abort an otherwise-good GPU install.
 #   - The wheel is CUDA-major-pinned: cu11* tags -> cuml-cu11, cu12* -> cuml-cu12.
+#   - The cu12 wheel is ALSO capped below RAPIDS 26 (see VTS_CUML_CU12_SPEC).
+#     RAPIDS 26.x raised its CUDA floor to require nvidia-nvjitlink-cu12>=12.9,
+#     but the torch CUDA wheels we pin (cu124 = CUDA 12.4 .. cu128 = CUDA 12.8)
+#     top out at 12.8 and no torch wheel ships 12.9 yet, so an UNpinned
+#     cuml-cu12 floats to 26.x and pip dies with an nvjitlink conflict (and
+#     cupy then JIT-compiles cuVS/raft kernels against mismatched CUDA-13 fp8
+#     headers -> "cuda_fp8.hpp: this declaration has no storage class" at fit
+#     time). 25.x declares cuda-toolkit==12.* and resolves cleanly against the
+#     pinned torch. Bump the cap once a torch wheel ships the CUDA minor 26.x
+#     needs. See docs/DEPLOYMENT.md "cuML crashes compiling a kernel".
 #   - RAPIDS ships linux-only wheels for a fixed Python range; on an unsupported
 #     platform/Python this step just warns and the app uses the CPU fallback.
 #
@@ -128,10 +138,14 @@ vts_install_cuml() {
         return 0
     fi
 
+    # The cu12 spec is capped below RAPIDS 26 (whose CUDA-12.9 floor outruns the
+    # torch CUDA wheels we pin); see the header comment above. Override the cap
+    # via VTS_CUML_CU12_SPEC, e.g. once a matching torch wheel exists:
+    #   VTS_CUML_CU12_SPEC='cuml-cu12' bash scripts/install.sh cu128
     local cuml_pkg
     case "$cuda_tag" in
         cu11*) cuml_pkg="cuml-cu11" ;;
-        *) cuml_pkg="cuml-cu12" ;;  # cu12x and anything else: cuML's CUDA-12 wheel
+        *) cuml_pkg="${VTS_CUML_CU12_SPEC:-cuml-cu12<26}" ;;  # cu12x + anything else
     esac
 
     # Isolated pass against the NVIDIA index. Guarded so `set -e` can't abort the


### PR DESCRIPTION
## What & why

A ROxford5k eval crashed inside cuML's runtime kernel compilation:

```
.../nvidia/cu13/include/cuda_fp8.hpp(1460): error: this declaration has no
storage class or type specifier  __NV_SILENCE_DEPRECATION_BEGIN
... 12 errors detected in the compilation of ".../<hash>.cubin.cu".
```

cuML compiles its cuVS/raft kernels (the `segment_idx` kernel here is the UMAP nearest-neighbor graph build) with nvrtc **lazily, on the first `fit`**.

**Confirmed root cause (a `pip` resolver conflict pinned it down):** RAPIDS **26.x** (`cuml-cu12 26.6.0`) raised its CUDA floor to require `nvidia-nvjitlink-cu12>=12.9`, but the torch CUDA wheels VTSearch pins (`cu124` = CUDA 12.4 … `cu128` = CUDA 12.8) cap the CUDA libs at 12.8 — and no torch wheel ships CUDA 12.9 yet:

```
cuml-cu12 26.6.0 requires nvidia-nvjitlink-cu12<13,>=12.9, but you have
nvidia-nvjitlink-cu12 12.4.127 which is incompatible.
```

The `cuml-cu12` install in `vts_install_cuml` / `Dockerfile.gpu` was **unpinned**, so it floated up to 26.x; when mismatched libraries land anyway, cupy's nvrtc compiles the wrong-version fp8/fp6/fp4 headers (whose `__NV_SILENCE_DEPRECATION_BEGIN` macro the resident nvrtc doesn't define) → the `cuda_fp8.hpp` crash.

**Why it crashed instead of degrading:** VTSearch already had a cuML→CPU fallback in `vtscore/gpu_backends.py`, but it only wrapped estimator **construction**. The nvrtc failure happens later, at **fit time** (`reducer.fit_transform`, `km.fit_predict`), so it escaped the `try/except`.

## Changes

**Runtime resilience (so any cuML fit failure degrades, never crashes):**
- **`vtscore/gpu_backends.py`** — replace `make_umap` / `make_kmeans` (construct-only) with `umap_fit_transform` / `kmeans_fit_predict`, which wrap the **whole construct-and-fit** in one `try` and fall back to `umap-learn` / `sklearn` on any cuML failure, including a fit-time nvrtc blowup. The first failure flips a process-global kill switch (`cuml_enabled()` returns `False` thereafter) so the rest of the run skips cuML rather than re-paying the multi-second compile failure on every call (the diversity tree alone fits k-means dozens of times). One clear warning is logged so a GPU box silently on the slow path stays visible.
- **`vtscore/projection/umap_projection.py`**, **`vtscore/state/diversity_tree.py`** — call the new fit-level helpers; threading/heartbeat and the per-init loop otherwise unchanged.

**Packaging root-cause fix (so the conflict can't recur):**
- **`scripts/install.sh`**, **`docker/Dockerfile.gpu`** — cap the wheel at `cuml-cu12<26` (RAPIDS 25.x declares `cuda-toolkit==12.*` and resolves cleanly against the pinned torch). Overridable via `VTS_CUML_CU12_SPEC` for when a torch wheel eventually ships the CUDA minor 26.x needs.
- **`requirements/gpu.txt`** — manual-install example updated to the capped spec.

**Docs & tests:**
- **`docs/DEPLOYMENT.md`** — troubleshooting entry rewritten around the real cause, the new automatic CPU degradation, and the downgrade recipe.
- **`docs/plans/gpu-acceleration.md`** — describes the fit-time fallback + kill switch.
- **`tests_lib/projection/test_gpu_backends.py`** (new) — injects a fake `cuml` whose estimators construct cleanly but raise inside `fit` (faithfully reproducing the nvrtc scenario on a CPU box) and asserts the fallback returns a correct result, flips the kill switch, and warns exactly once. `tests_lib/gpu/test_gpu.py` updated for the new API.

## Behavior change

A cuML failure now **degrades to the CPU UMAP/k-means path** with a one-time warning instead of crashing — the run completes, just without GPU acceleration. Fresh `scripts/install.sh` / Docker builds no longer pull the conflicting RAPIDS 26.x; an already-polluted venv is repaired with `pip install "cuml-cu12<26"` (see DEPLOYMENT.md).

## Testing

`./run-tests.sh` — **5251 passed, 1 skipped, 2 xpassed** (ruff / format / codespell / deptry / frontend build all green). Installer/Docker/docs changes are non-code; `bash -n` + codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017GreyfHVHo5SNTL5oRmekC)_