### PR TITLE
docs: systemic accuracy pass + screenshot-retake audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A trainable media search tool. VTSearch searches collections of audio clips, ima
   <img src="docs/user/assets/dashboard-loaded.light.png" alt="The VTSearch dashboard with a synthetic dataset loaded and a trained detector listed in the sidebar" width="720" />
 </picture>
 
+> **New to VTSearch?** Read **[docs/user/USER_GUIDE.md](docs/user/USER_GUIDE.md)** for a walkthrough of loading a dataset, training a detector with Autopilot (or applying an existing one), and exporting the matches. Most users never need anything else.
+
 ## Setup and running tests
 
 See [docs/SETUP.md](docs/SETUP.md) for prerequisites, getting the code, virtual environment setup, installing dependencies, and running the test suite.
@@ -17,6 +19,12 @@ For development, start the Flask dev server:
 
 ```bash
 python app.py
+```
+
+Use `--local` to run in local development mode:
+
+```bash
+python app.py --local
 ```
 
 You should see output like:
@@ -37,77 +45,43 @@ VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 
 See [docs/SETUP.md](docs/SETUP.md#running-the-app) and [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for details.
 
-> **New to VTSearch?** Read **[docs/user/USER_GUIDE.md](docs/user/USER_GUIDE.md)** for a walkthrough of loading a dataset, training a detector with Autopilot (or applying an existing one), and exporting the matches. Most users never need anything else.
+## Loading a demo dataset
+
+When the app is running, click the **+** button on the **Datasets** card to open the **Add Dataset** dialog, then pick the **Demo** tab. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.
+
+See [docs/demos.md](docs/demos.md) for the full list of available demo datasets.
+
+You can also load your own data from pickle files or folders via the same dialog.
+
+---
 
 ## Command-line interface
 
 VTSearch provides several CLI workflows for applying detectors to datasets, importing labels, and importing processors, all without starting the web server. See [docs/CLI.md](docs/CLI.md) for the full CLI reference.
 
-## Loading a demo dataset
-
-When the app is running, click the hamburger menu in the top-left corner to open the dataset panel. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.
-
-See [docs/demos.md](docs/demos.md) for the full list of available demo datasets.
-
-You can also load your own data from pickle files or folders via the same menu.
-
 ## Project structure
 
+VTSearch is split into two Python packages along an **app tier / library tier** line:
+
+- **`vtsearch/`** — the app tier: Flask routes, authentication, settings, the achievements state machine, and the CLI entry point (`vtsearch/cli_main.py`). Anything that depends on Flask/Werkzeug lives here.
+- **`vtscore/`** — the library tier: the ML (training, MLP, thresholds), embedding runtime, media-type plugins (audio, image, text, video, document), converters, datasets/importers, exporters, labels, evaluation, projection (VTSBrowse), concurrency, security, and the plugin/sync machinery. It is import-clean of Flask so it can be reused as a standalone library. The CLI orchestration (`vtscore/cli.py`, `cli_pipeline.py`, `cli_progress.py`) lives here too.
+
+The remaining top level:
+
 ```
-├── app.py                          # Flask entry point, registers blueprints, CLI arg parsing
-├── gunicorn.conf.py                # Gunicorn WSGI config (single worker + threads)
-├── vtsearch/                       # Main application package
-│   ├── config.py                   # Constants (paths, model IDs, sample rates)
-│   ├── cli.py                      # CLI utilities: autodetect workflow
-│   ├── cli_pipeline.py             # CLI orchestration shared by autodetect
-│   ├── cli_progress.py             # CLI progress bars
-│   ├── settings.py                 # Persistent settings (server tier + per-user tier)
-│   ├── settings_factory.py         # Accessor factories for the settings table
-│   ├── settings_models.py          # Settings dataclass schemas
-│   ├── achievements.py             # User-achievement state machine
-│   ├── logging_config.py           # Logging setup
-│   ├── auth/                       # Authentication (LoginProvider ABC, DefaultLoginProvider)
-│   ├── routes/                     # Flask blueprints (datasets, detectors, processors, media, settings, labels, …)
-│   ├── detectors/                  # Detector lifecycle: registry, store, training, label sync, restoration
-│   ├── training/                   # Generic learned-sort training primitives (MLP, thresholds, SVM, region-sim)
-│   ├── embedding/                  # Embedder façades, torch runtime, smart preload, cached embedding matrix
-│   ├── media/                      # Media type plugins (audio, image, text, video, document) + embedders, clippers
-│   ├── converters/                 # Media converters (document→image/text, video→audio/image, audio→image, image→text)
-│   ├── datasets/                   # Dataset loading, importers, origin tracking, labelsets, media sources
-│   ├── eval/                       # Evaluation framework (metrics, runner, visualisation, voting iterations)
-│   ├── exporters/                  # Results exporter plugins
-│   ├── labels/                     # Label importers and labelset sync sources
-│   ├── settings_io/                # Settings importers, exporters and sync sources
-│   ├── state/                      # Per-dataset / per-detector context registries; medias/votes proxies
-│   ├── plugins/                    # Plugin registry, PluginBase, sentinel-based discovery
-│   ├── sync/                       # Generic SyncSource base for settings + labelset sources
-│   ├── concurrency/                # Async job manager, memory-aware worker capping, progress trackers
-│   ├── security/                   # Path/URL/pickle safety validation
-│   ├── schemas/                    # JSON / OpenAPI schemas
-│   └── utils/                      # build_media_hit helper + offline synthetic-media generators
-├── static/                         # Angular build output (HTML, JS, CSS, assets)
-├── frontend/                       # Angular SPA source (TypeScript, SCSS); builds into static/
-├── tests/                          # Test suite (pytest); grouped by folder (core, api, sorting, datasets, io, …)
-├── docs/                           # Extended documentation
-│   ├── HANDOFF.md                  # Project handoff & orientation guide
-│   ├── DEPLOYMENT.md               # Deployment, offline mode, operations
-│   ├── ARCHITECTURE.md             # Architecture deep-dive
-│   ├── API.md                      # HTTP API reference (all REST endpoints)
-│   ├── EXTENDING.md                # Plugin authoring index (auth, deps, checklists)
-│   ├── EXTENDING-plugins.md        # Data/results/label/processor/settings importers & sources
-│   ├── EXTENDING-media.md          # Media types, embedders, clippers, converters, sources
-│   ├── EXTENDING-processors.md     # Detectors, localizers, extractors
-│   ├── EVAL.md                     # Evaluation framework guide
-│   ├── CLI.md                      # CLI reference
-│   ├── ML.md                       # ML model details
-│   ├── SETUP.md                    # Setup instructions
-│   ├── demos.md                    # Demo dataset listing
-│   ├── user/                       # End-user docs (rendered in-app via the Help window)
-│   │   └── USER_GUIDE.md           # End-user walkthrough (training detectors, applying detectors, exporting)
-│   ├── plans/                      # Open design plans (see plans/README.md)
-│   └── design/                     # Architecture design documents
-└── pyproject.toml                  # Project metadata and dependencies
+├── app.py            # Flask entry point: builds the app, registers blueprints, parses CLI args
+├── gunicorn.conf.py  # Gunicorn WSGI config (single worker + threads)
+├── vtsearch/         # App tier (Flask routes, auth, settings, CLI entry point)
+├── vtscore/          # Library tier (ML, embedding, media, datasets, plugins, projection)
+├── frontend/         # Angular SPA source (TypeScript, SCSS); builds into static/
+├── static/           # Angular build output (HTML, JS, CSS, assets)
+├── tests/            # App-tier test suite (pytest); grouped by folder (core, api, sorting, …)
+├── tests_lib/        # Library-tier test suite (mirrors tests/, import-clean of Flask)
+├── docs/             # Extended documentation (see docs/ARCHITECTURE.md for the full map)
+└── pyproject.toml    # Project metadata and dependencies
 ```
+
+For the complete directory map, dependency graph, and the app-tier/library-tier rules, see **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 
 ## HTTP API
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,10 +12,25 @@ unless otherwise noted. File uploads use `multipart/form-data`.
 | [Labeling & Diversity](api/labeling.md) | Inclusion, thresholds, labeling progress, diversity tree |
 | [Detectors](api/detectors.md) | Detector CRUD, detector registry, Auto-Find toggle, loading SSE |
 | [Datasets](api/datasets.md) | Loading, importers, demos, staging, registry, media types, embedders, clippers, converters, file browsing |
-| [Import & Export](api/io.md) | Result exporters, label importers, processor importers |
+| [Import & Export](api/io.md) | Result exporters, label importers, pregen processors, autorun extractors/localizers |
 | [Settings](api/settings.md) | App settings, autorun processors, settings sources, labelset sources |
-| [Dashboard & Lookup](api/dashboard.md) | Dashboard info, multi-dataset find, find progress |
+| [Dashboard & Lookup](api/dashboard.md) | Dashboard info (incl. disk/RAM usage), multi-dataset find (incl. cancel/stats/corrections), find progress |
 | [File Browser](api/file-browser.md) | Server filesystem browsing |
+
+### Not yet documented in depth
+
+The OpenAPI snapshot (`frontend/openapi.json`) is the ground truth and covers
+several endpoint families that the hand-written pages above don't yet describe
+in full. Use Swagger (`GET /api/docs`) for these:
+
+- **Achievements** — gamification unlock/state endpoints (see `vtsearch/achievements.py`).
+- **Projection / VTSBrowse** — `GET/POST /api/projection/*` (UMAP projection + hex-tile pyramid).
+- **Sessions** — session lifecycle endpoints.
+- **Jobs** — async job listing/status (backed by `vtscore.concurrency.async_jobs`).
+- **Find** — `cancel`, `stats`, and `corrections` companions to multi-dataset find.
+- **Dashboard usage** — disk-usage / RAM-usage probes.
+- **Health probes** — `GET /healthz`, `GET /readyz` (liveness / readiness).
+- **Version** — `GET /api/version` (returns the running build's version string).
 
 ## Conventions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,12 +102,20 @@ VTSearch/
 │   │   ├── registry.py             In-memory detector registry
 │   │   ├── store.py                On-disk labelset/query store
 │   │   ├── training.py             Vote-aware training, origin-based training
+│   │   ├── learned_sort.py         Learned-sort scoring/ranking over a trained detector
+│   │   ├── model_loading.py        Build/restore in-memory MLP from labels (no persisted weights)
 │   │   ├── workflow.py             apply-labels-and-retrain orchestration (uses flask.g)
 │   │   ├── resolver.py             Origin → file + embedding resolution
+│   │   ├── embedder_sync.py        Reconcile detector labels against the active embedder
+│   │   ├── embedder_type.py        Embedder-type compatibility (semantic / patch / structural)
+│   │   ├── input_spec.py           Detector input spec (media type + embedder type)
 │   │   ├── label_sync.py           Sync labels to loaded detector
 │   │   ├── label_restoration.py    Label restoration
 │   │   ├── labelset_elements.py    Labelset element materialisation
+│   │   ├── labelset_ops.py         Labelset add/remove/merge operations
+│   │   ├── labelset_rename.py      Labelset / category rename
 │   │   ├── labelset_training.py    Cross-dataset MLP training
+│   │   ├── positives_browse.py     Browse the detector's positive examples
 │   │   ├── dataset_sync.py         Sync detectors when a dataset loads
 │   │   ├── media_seeding.py        Media seeding utilities
 │   │   └── labeling_progress.py    Per-step MLP cache + stability analysis
@@ -126,7 +134,7 @@ VTSearch/
 │   │   ├── downloader/             Demo dataset downloaders (audio, image, video, text, docs)
 │   │   ├── archive.py              Local zip/tar/rar extraction + cached loading (local_archive origin)
 │   │   ├── sources/                MediaSource abstraction (local_folder, local_archive, http_archive,
-│   │   │                           pullwrest); all fetch/resolve ops return FetchedItem (path +
+│   │   │                           server_files, pullwrest); all fetch/resolve ops return FetchedItem (path +
 │   │   │                           optional embedding, embedder_name, extra metadata)
 │   │   └── importers/              Plugin importers (server_folder, server_files, local_folder,
 │   │                               local_files, pickle, http_archive, combine_datasets,
@@ -147,10 +155,19 @@ VTSearch/
 │   │   ├── visualize.py            Matplotlib chart generation
 │   │   └── voting_iterations.py    Voting-iteration simulation
 │   │
+│   ├── projection/                 VTSBrowse browse canvas backend (Flask-free)
+│   │   ├── umap_projection.py      Stage 1: UMAP layout of the (N, d) embedding matrix
+│   │   ├── compaction.py           Stage 1.5: close empty regions in the layout
+│   │   ├── hexbin.py               Vectorized hex-grid binning of the 2-D points
+│   │   ├── squarebin.py            Vectorized square-grid binning of the 2-D points
+│   │   ├── pyramid.py              Stage 2: hex/square-tile zoom pyramid
+│   │   └── persistence.py          Projection (de)serialization (npz <-> meta)
+│   │
 │   ├── concurrency/                Async jobs, memory budgeting, progress tracking
 │   │   ├── async_jobs.py           AsyncJob, JobManager, eval_jobs, learned_sort_jobs
 │   │   ├── gate.py                 ConcurrencyGate (dynamic-limit semaphore for load phases)
 │   │   ├── memory_budget.py        cap_workers_by_memory
+│   │   ├── events.py               SSE channel registry feeding /api/events (push, replaces polling)
 │   │   └── progress.py             ProgressTracker, update_progress, cancel_dataset_progress
 │   │
 │   ├── state/                      Multi-dataset / multi-detector global state (library tier)
@@ -158,6 +175,8 @@ VTSearch/
 │   │   ├── votes.py                toggle_vote / apply_label / clear_votes
 │   │   ├── clicks.py               Vote click-time tracking
 │   │   ├── diversity.py            Diversity tree construction and sampling
+│   │   ├── diversity_tree.py       DiversityTree data structure (hierarchical k-means)
+│   │   ├── near_dupes.py           Near-duplicate detection / grouping
 │   │   └── media_lookup.py         Origin-keyed lookup, collapse_duplicates
 │   │
 │   ├── plugins/                    PluginBase, PluginField, PluginRegistry (shared plugin infra)
@@ -209,6 +228,7 @@ VTSearch/
 │       ├── jobs.py                 Job management (/api/jobs/*)
 │       ├── sessions.py             Session management (/api/sessions/*)
 │       ├── achievements.py         Achievement routes (/api/achievements/*)
+│       ├── projection.py           VTSBrowse projection routes (/api/projection/*)
 │       ├── datasets/               Dataset routes; listings, load, staging, registry, status, ui
 │       ├── detectors/              Detector routes; crud, labels, registry, scoring, find
 │       ├── processors/             Processor routes; crud, scoring (extractors/localizers)
@@ -366,7 +386,7 @@ thresholds.
 from vtscore.training.mlp import train_model
 from vtscore.training.thresholds import find_optimal_threshold
 
-model = train_model(X_train, y_train, input_dim=512, inclusion_value=0)
+model = train_model(X_train, y_train, input_dim=512, seed=42, hidden_dim=None)
 threshold = find_optimal_threshold(scores, labels, inclusion_value=0)
 ```
 
@@ -411,7 +431,7 @@ embedder.load_models()
 
 ### The plugin systems
 
-**Pattern:** Each of the ten plugin systems uses the same architecture:
+**Pattern:** Each of the nine plugin systems uses the same architecture:
 1. An abstract base class with `fields` (form descriptors) and a
    `run()`/`export()`/`load()`/`save()` method.
 2. Auto-discovery via `PluginRegistry` using direct filesystem scanning

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -169,6 +169,20 @@ multi-minute embedding pass. `--import-labels-into ... --label-importer-file ...
 is announced as part of the plan but skipped (no detector JSON is
 modified).
 
+### Progress output format
+
+By default, `--autodetect` prints human-readable progress to the console. For
+scripted or CI callers, add `--progress-format json` to emit
+**newline-delimited JSON (NDJSON)** on stdout instead — one progress event per
+line, which is easy to parse from a wrapping script:
+
+```bash
+python app.py --autodetect --dataset data.pkl --settings settings.json --progress-format json
+```
+
+The two choices are `text` (default, prose) and `json` (NDJSON events). The
+event schema is defined in `vtscore.cli_progress`.
+
 ## Pipeline file
 
 For repeatable runs (cron, CI), put the whole autodetect invocation in a YAML
@@ -246,6 +260,16 @@ banner text (`LOCAL` vs. `PRODUCTION`); the bind address is the same either
 way. This entry point uses Flask's built-in dev server and is not
 recommended for production.
 
+**Port** (`--port`): bind the dev server to a port other than the default
+`5000`. Precedence is `--port` > `VTSEARCH_PORT` env var > `5000`. This lets
+several instances share a host (e.g. co-located single-GPU SLURM jobs on a
+multi-GPU node). Gunicorn ignores this flag; under WSGI use `VTSEARCH_BIND`
+instead.
+
+```bash
+python app.py --port 8080
+```
+
 **Verbose logging** (`-v` / `--verbose`): logging defaults to `WARNING`, which
 keeps the console quiet — including the per-request access log. Pass `-v` to
 raise the level to `INFO`, which turns on the dev-server access log (one
@@ -277,11 +301,21 @@ bundled Docker images already run gunicorn this way. See
 [DEPLOYMENT.md](DEPLOYMENT.md#tuning) for tuning.
 
 **Authentication mode** (`--login`): select the login provider (dev
-server only; set up the provider in code when running under gunicorn):
+server only; set up the provider in code when running under gunicorn).
+Two providers are accepted:
 
 ```bash
-python app.py --login trivial    # multi-user mode with simple username auth
+python app.py --login trivial    # multi-user mode with simple username auth (cookie-based, no password)
+python app.py --login api_key    # Bearer-key auth against data/api_keys.json
 ```
+
+- **`trivial`** shows a username prompt (no password) and tracks the user via a
+  cookie; useful for low-stakes multi-user setups.
+- **`api_key`** authenticates each request via an `Authorization: Bearer <key>`
+  header, checking the key against `data/api_keys.json`. This is the same key
+  store the CLI's `--user` + `--api-key` flags use (see [Which user's Auto-Find
+  list runs](#which-users-auto-find-list-runs) above), so a key minted for the
+  server also works for a per-user `--autodetect` run.
 
 Without `--login`, the app uses `DefaultLoginProvider` (single-user, always authenticated).
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -127,13 +127,49 @@ to handle TLS, gzip, and static-asset caching. Flask serves the Angular
 build from `static/` directly, but a dedicated reverse proxy is much
 more efficient for that traffic.
 
+A few VTSearch-specific points matter when configuring the proxy:
+
+- **TLS termination.** Terminate HTTPS at the proxy and forward plain HTTP to
+  gunicorn on the loopback / private network. Gunicorn itself is not configured
+  for TLS.
+- **Long-running requests vs. proxy read-timeouts.** Imports, embedding,
+  detector training, and evaluation routinely run for minutes. The bundled
+  `gunicorn.conf.py` sets `timeout = 0` (no worker timeout) precisely so these
+  don't get SIGKILLed — but the **proxy** has its own read timeout that will sever
+  the connection independently. nginx's default `proxy_read_timeout` is **60s**,
+  which will cut off any import or training run that takes longer. Raise it to
+  cover your longest operation (e.g. `proxy_read_timeout 1800s;`), matching the
+  same reasoning behind `VTSEARCH_TIMEOUT=0`.
+- **Server-Sent Events (`/api/events`).** VTSearch streams live progress over an
+  SSE endpoint. Proxy response buffering breaks SSE (events arrive only when the
+  buffer flushes), so disable it for the stream — `proxy_buffering off;` in nginx
+  (and the equivalent elsewhere) — and ensure the same long read-timeout applies,
+  since the connection stays open for the life of the page.
+- **Forwarded headers.** Pass `X-Forwarded-For`, `X-Forwarded-Proto`, and
+  `X-Forwarded-Host` (and `Host`) so the app sees the real client and external
+  scheme. For SSE/WebSocket-style streams also forward `Connection`/`Upgrade` if
+  your proxy requires it.
+
+Minimal nginx `location` for the API (illustrative):
+
+```nginx
+location /api/ {
+    proxy_pass http://127.0.0.1:5000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 1800s;   # cover long imports / training (gunicorn timeout is 0)
+    proxy_buffering off;        # required for /api/events SSE streaming
+}
+```
+
 ---
 
 ## Network dependencies
 
 ### Embedding models (HuggingFace Hub)
 
-VTSearch downloads four embedding models on first use. Each model is
+VTSearch downloads five embedding models on first use. Each model is
 lazy-loaded when a dataset of the corresponding media type is opened for
 the first time. At startup, VTSearch also runs a smart-preload pass that
 warms every embedder referenced by the dataset and detector registries
@@ -145,10 +181,13 @@ cost. On an empty registry, nothing is preloaded.
 |-------|-----------|----------------|-------------|
 | CLAP | Audio (default) | `laion/clap-htsat-unfused` | ~1.1 GB |
 | SigLIP | Image (default) | `google/siglip-base-patch16-224` | ~400 MB |
+| CLIP | Image (alternative) | `openai/clip-vit-base-patch32` | ~600 MB |
 | X-CLIP | Video (default) | `microsoft/xclip-base-patch32` | ~1.2 GB |
 | E5 | Text (default) | `intfloat/e5-base-v2` | ~440 MB |
 
-**Total: ~3.2 GB** for the four default models.
+**Total: ~3.8 GB** for the five models `download_models.sh` fetches (four
+defaults plus CLIP, the image alternative). At runtime, only the embedders a
+dataset or detector actually uses are loaded.
 
 #### Alternative embedders
 
@@ -217,7 +256,7 @@ Run the provided script on a machine with internet access:
 ./scripts/download_models.sh [CACHE_DIR]
 ```
 
-This downloads all four embedding models to `CACHE_DIR` (defaults to
+This downloads all five embedding models (CLAP, SigLIP, CLIP, X-CLIP, E5) to `CACHE_DIR` (defaults to
 `data/models`). The script prints instructions for offline use when
 finished.
 
@@ -371,8 +410,14 @@ Notable fields:
   clipping, dedup, and diversity-tree construction. Changes take
   effect on queued and future loads (running tasks are never
   preempted). Defaults derive from hardware on first read (and are
-  **not** persisted to disk): downloads = `min(4, cpu_count)`,
-  embeddings = `1` on CPU-only hosts else `min(2, gpu_count)`. An
+  **not** persisted to disk): downloads = `max(1, min(4, cpu_count))`;
+  embeddings = `1` on an accelerator (CUDA/MPS — embed jobs share the
+  one device and serialise on it, so extra workers only add VRAM
+  pressure), and on a CPU host the scarcer of `cores/4` and
+  `RAM/4 GiB` (cap 4, floor 1). See `default_concurrent_downloads` /
+  `default_concurrent_embeddings` in `vtscore/embedding/loader.py`.
+  These match the autodetect described under
+  [Dataset-ingest concurrency](#dataset-ingest-concurrency) above. An
   explicit value in `settings.json` always wins.
 - `settings_source` (not shown above; excluded from defaults): opt-in
   bidirectional sync. Set to a plugin name + field values to auto-export
@@ -475,6 +520,21 @@ docker compose \
 ```
 
 Add `--no-cache` after dependency changes to force a full rebuild.
+
+> **Note on the baked version string.** `vtsearch.__version__` is normally
+> derived from git at import time, but the Docker build context excludes `.git`,
+> so the Dockerfile reads the version from a build arg instead. None of the
+> `docker/compose/*.yml` files pass it, so a plain `docker compose build` bakes
+> the fallback `0.0.0-unknown` into the image. To stamp the real version, pass it
+> explicitly, e.g.:
+>
+> ```bash
+> docker compose -f docker/compose/docker-compose.yml build \
+>   --build-arg VTSEARCH_VERSION="$(TZ=UTC git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ HEAD)"
+> ```
+>
+> The Dockerfile writes this into `vtsearch/_version.txt`; `__init__.py` reads it
+> when git is unavailable.
 
 ---
 

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -55,7 +55,7 @@ python -m vtscore.eval [OPTIONS]
 
 ```bash
 # Text sort only, on image datasets, save JSON
-python -m vtscore.eval --mode text --datasets caltech101_s caltech256_l --output results.json --plot-dir eval_output
+python -m vtscore.eval --mode text --datasets caltech101_s caltech256_a --output results.json --plot-dir eval_output
 
 # Learned sort with a different train/test split
 python -m vtscore.eval --mode learned --train-fraction 0.7 --seed 123 --plot-dir eval_output
@@ -75,7 +75,7 @@ python -m vtscore.eval --list
 
 ## Available eval datasets
 
-Each eval dataset wraps a demo dataset and defines text queries targeting specific categories. The `_s`, `_m`, `_l` suffixes denote **small**, **medium**, and **large** size variants of the same dataset (more clips = slower evaluation but more statistically robust results).
+Each eval dataset wraps a demo dataset and defines text queries targeting specific categories. The `_s`, `_m`, `_l` suffixes denote **small**, **medium**, and **large** size variants of the same dataset (more clips = slower evaluation but more statistically robust results); `_a` denotes the **all** (full) variant.
 
 | Eval dataset ID | Media type | Demo dataset | Categories |
 |----------------|-----------|--------------|------------|
@@ -84,7 +84,9 @@ Each eval dataset wraps a demo dataset and defines text queries targeting specif
 | `esc50_l` | Audio | esc50_l | All 50 ESC-50 categories |
 | `caltech101_s` | Image | caltech101_s | 25 Caltech-101 categories (airplanes, bonsai, dolphin, helicopter, watch, etc.) |
 | `caltech101_m` | Image | caltech101_m | 25 Caltech-101 categories |
-| `caltech256_l` | Image | caltech256_l | 25 Caltech-256 categories |
+| `caltech256_a` | Image | caltech256_a | 25 Caltech-256 categories (backpack, butterfly, camel, giraffe, lighthouse, etc.) |
+| `visual_genome_s` | Image (multi-label) | visual_genome_s | ~40 Visual Genome object categories (person, car, dog, tree, building, etc.); an image can be a positive for several at once |
+| `visual_genome_m` | Image (multi-label) | visual_genome_m | ~40 Visual Genome object categories |
 | `20newsgroups_s` | Text | 20newsgroups_s | 15 topics (sports, science, cars, religion, politics, medicine, etc.) |
 | `20newsgroups_m` | Text | 20newsgroups_m | 15 topics |
 | `20newsgroups_l` | Text | 20newsgroups_l | 15 topics |

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -259,8 +259,15 @@ embedder per media type should override the `is_default` property to return
 |------|----------|-----------|---------|
 | `audio/embedder_clap.py` | `AudioClapEmbedder` | audio | ✅ |
 | `audio/embedder_clap_music.py` | `AudioClapMusicEmbedder` | audio | |
+| `audio/embedder_clap_general.py` | `AudioClapGeneralEmbedder` | audio | |
 | `audio/embedder_paraspeechclap.py` | `AudioParaSpeechClapEmbedder` | audio | |
+| `audio/embedder_ast.py` | `AudioASTEmbedder` | audio | |
+| `audio/embedder_whisper.py` | `AudioWhisperEncoderEmbedder` | audio | |
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image | ✅ |
+| `image/embedder_siglip2.py` | `ImageSiglip2Embedder` | image | |
+| `image/embedder_clip.py` | `ImageClipEmbedder` | image | |
+| `image/embedder_sift_vlad.py` | `ImageSiftVladEmbedder` | image | |
+| `image/embedder_face.py` | `ImageFaceEmbedder` | image | |
 | `text/embedder_e5.py` | `TextE5Embedder` | text | ✅ |
 | `text/embedder_bge.py` | `TextBGEEmbedder` | text | |
 | `video/embedder_xclip.py` | `VideoXClipEmbedder` | video | ✅ |
@@ -478,11 +485,18 @@ loaded via `spec_from_file_location` so discovery still works.
 |----------|------|------------|-------|------------|
 | `AudioClapEmbedder` | `clap` | `audio` | LAION CLAP (laion/clap-htsat-unfused) | 512 |
 | `AudioClapMusicEmbedder` | `clap_music` | `audio` | CLAP Music & Speech (laion/larger_clap_music_and_speech) | 512 |
+| `AudioClapGeneralEmbedder` | `clap_general` | `audio` | CLAP General 2024 (laion/larger_clap_general) | 512 |
 | `AudioParaSpeechClapEmbedder` | `paraspeechclap` | `audio` | ParaSpeechCLAP speech-style (WavLM-Large + Granite, ajd12342/paraspeechclap-combined) | 768 |
+| `AudioASTEmbedder` | `ast` | `audio` | AST audio spectrogram (MIT/ast-finetuned-audioset-10-10-0.4593), audio-only | 768 |
+| `AudioWhisperEncoderEmbedder` | `whisper_encoder` | `audio` | Whisper-base encoder (openai/whisper-base), audio-only | 512 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |
+| `ImageSiglip2Embedder` | `siglip2` | `image` | SigLIP 2 (google/siglip2-base-patch16-224) | 768 |
+| `ImageClipEmbedder` | `clip` | `image` | CLIP (openai/clip-vit-base-patch32) | 512 |
 | `ImageDinov2SingleEmbedder` / `ImageDinov2PatchEmbedder` | `dinov2_single` / `dinov2_patch` | `image` | DINOv2 ViT-B/14 (facebook/dinov2-base), ungated | 768 |
 | `ImageDinov3SingleEmbedder` / `ImageDinov3PatchEmbedder` | `dinov3_single` / `dinov3_patch` | `image` | DINOv3 ViT-B/16 (facebook/dinov3-vitb16-pretrain-lvd1689m), HF-gated | 768 |
 | `ImageEupeSingleEmbedder` / `ImageEupePatchEmbedder` | `eupe_single` / `eupe_patch` | `image` | EUPE ViT-B/16 (facebookresearch/EUPE), FAIR Noncommercial Research Licence | 768 |
+| `ImageSiftVladEmbedder` | `sift_vlad` | `image` | SIFT/VLAD instance matching (classical, no text encoder) | 8192 (64 × 128) |
+| `ImageFaceEmbedder` | `face` | `image` | FaceNet identity (InceptionResnetV1, face crops, no text encoder) | 512 |
 | `TextE5Embedder` | `e5` | `text` | E5-base-v2 (intfloat/e5-base-v2) | 768 |
 | `TextBGEEmbedder` | `bge` | `text` | BGE-base-en-v1.5 (BAAI/bge-base-en-v1.5) | 768 |
 | `VideoXClipEmbedder` | `xclip` | `video` | X-CLIP (microsoft/xclip-base-patch32) | 768 |

--- a/docs/EXTENDING-processors.md
+++ b/docs/EXTENDING-processors.md
@@ -2,7 +2,7 @@
 
 How to add new detectors, localizers, and extractors (the three kinds
 of **Processor** in VTSearch). All three subclass `Processor` from
-`vtscore/media/base.py`.
+`vtscore/media/processors.py`.
 
 **Related docs:** [EXTENDING.md](EXTENDING.md) (index, checklists, auth,
 dependencies) · [EXTENDING-plugins.md](EXTENDING-plugins.md) (importers,
@@ -23,7 +23,7 @@ types, embedders, clippers, converters).
 
 Processors analyze media items. The hierarchy has a common base
 (`Processor`) with three concrete subtypes. All are defined in
-`vtscore/media/base.py`.
+`vtscore/media/processors.py`.
 
 ```
 Processor (ABC)
@@ -135,7 +135,12 @@ class ObjectExtractor(Extractor):
 |--------|------|-------------|
 | `name` | `str` (property) | Unique identifier |
 | `media_type` | `str` (property) | Which media type it operates on |
-| `process(media)` | `(dict) -> Any` | Run the processor (delegates to subclass) |
+
+`process(media)` is declared on the base, but each subtype
+(`Detector`/`Localizer`/`Extractor`) already provides a **concrete**
+`process()` that delegates to `detect()` / `localize()` / `extract()`.
+When you subclass one of those subtypes you implement only the
+subtype-specific method below — you do **not** override `process()`.
 
 **Processor (base class) - optional members:**
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -126,7 +126,8 @@ Five media types are supported:
 | Text | E5 | `intfloat/e5-base-v2` | BGE (`BAAI/bge-base-en-v1.5`) |
 | Document | None (convert first) | N/A; use converters to transform to image/text | None |
 
-Models are loaded lazily on first use. Default models total ~3.1 GB.
+Models are loaded lazily on first use. The four default models total ~3.2 GB
+(`download_models.sh` also fetches the CLIP image alternative, ~3.8 GB all told).
 
 ### Converters
 
@@ -254,10 +255,12 @@ vulture vtsearch/ .vulture-whitelist.py --min-confidence 80   # dead code audit
 ```
 
 Configuration is in `pyproject.toml`. `pre-commit install` wires up
-ruff, codespell, and deptry as git hooks; the same checks plus
-`pip-audit` run on every push via the `Lint` and `Audit dependencies`
-workflows. See `docs/plans/python-quality-tools.md` for the rationale
-behind which security rules are enabled and which are ignored.
+ruff, codespell, and deptry as git hooks. There is **no CI**: VTSearch has
+no GitHub Actions workflows, so `./run-tests.sh` is the only gate — it runs
+ruff, `ruff format --check`, codespell, deptry, `pip-audit`, pyright, and the
+frontend build before pytest. Run it before pushing. See
+`docs/plans/python-quality-tools.md` for the rationale behind which security
+rules are enabled and which are ignored.
 
 ---
 

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -32,11 +32,11 @@ The model outputs raw logits (not probabilities) during training. This allows th
 
 ### Class Weighting
 
-Training uses inverse-frequency weighting to balance classes, with an additional `inclusion_value` parameter (range [-10, +10]) that lets users bias the model toward recall or precision:
+Training uses **inverse-frequency weighting only** to balance classes (`mlp.py:193-197`). Inclusion does **not** enter training — the trained model, and therefore every item's score, is independent of inclusion. Inclusion is applied later as a pure threshold knob in `find_optimal_threshold` (see [Threshold Calibration](#threshold-calibration) below).
 
-- **Base weights**: `weight_true = num_false / num_true`, `weight_false = 1.0`
-- **Inclusion >= 0**: `weight_true *= 2^inclusion_value` (include more items)
-- **Inclusion < 0**: `weight_false *= 2^(-inclusion_value)` (exclude more items)
+- **Weights**: `weight_true = num_false / num_true`, `weight_false = 1.0`
+
+Keeping the model inclusion-independent is what lets the calibration cache reuse fold scores across cutoff slides: when the user changes inclusion, the labels are unchanged, the fold models are unchanged, and only the cheap min-cost threshold search re-runs.
 
 ### Threshold Calibration
 
@@ -48,13 +48,19 @@ A decision threshold separating "good" from "bad" predictions is computed via **
 4. Repeat for `calibrate_count` independent random splits.
 5. Return the mean of all thresholds.
 
-The `calibrate_count` setting defaults to `2` but can be lowered (`VTSEARCH_CALIBRATE_COUNT`) to trade calibration quality for latency. When `safe_thresholds` is enabled and fewer than 6 labels exist, the cross-calibration step is skipped entirely; the `calculate_safe_threshold` blender weights the calibrated value at 0 in that regime, so paying for the fold trainings would be pure waste.
+The `calibrate_count` setting defaults to `1` (`DEFAULT_CALIBRATE_COUNT` in `vtscore/config.py`) and can be raised or lowered (`VTSEARCH_CALIBRATE_COUNT`) to trade calibration quality for latency. (The eval runner uses its own default of `2` for a separate, non-interactive path — see [`docs/EVAL.md`](EVAL.md).) When `safe_thresholds` is enabled and fewer than 6 labels exist, the cross-calibration step is skipped entirely; the `calculate_safe_threshold` blender weights the calibrated value at 0 in that regime, so paying for the fold trainings would be pure waste.
 
 **Why fold models use the full-data hidden_dim:** The hidden-layer width is normally auto-sized from the training-set size (`n_train // 3`, clamped to 4–32). Without intervention, each fold model would train on fewer examples and therefore get a smaller hidden layer than the final model. A smaller architecture produces a different score distribution, so thresholds found on fold models would not transfer faithfully to the final model. By forcing fold models to use the same `hidden_dim` as the final model, the architectures match: same capacity, same score distribution shape. The only difference is the fold models see less data, which is the whole point (you want held-out calibration data). Existing regularization (dropout 0.5, weight decay 1e-4) and the small max width (32) prevent the slightly "oversized" fold models from overfitting meaningfully.
 
 The **Calibration Fraction** setting (0–1, default 0.5) controls how much data is reserved for threshold calibration vs. model training in each split. For example, a value of 0.2 means 80% Train / 20% Calibrate. If the fraction is so extreme that a valid Train/Calibrate split cannot be formed (fewer than 2 training examples or fewer than 1 calibration example), the system returns a maximum threshold so that nothing is predicted as Good.
 
-The optimal threshold at each split minimizes a weighted combination of false-positive rate and false-negative rate, governed by the same `inclusion_value`.
+The optimal threshold at each split minimizes a weighted combination of false-positive rate (FPR) and false-negative rate (FNR), governed by the `inclusion_value` parameter (integer in range [-10, +10]). This is where inclusion biases the result toward recall or precision — at calibration/threshold time, **not** at training time:
+
+- **Inclusion = 0**: minimize `fpr + fnr` (equal weight).
+- **Inclusion > 0**: minimize `fpr + 2^inclusion_value * fnr` (prefer recall — include more items).
+- **Inclusion < 0**: minimize `2^(-inclusion_value) * fpr + fnr` (prefer precision — exclude more items).
+
+Because the fold models are inclusion-independent, the per-fold held-out scores can be cached once and re-thresholded at any inclusion (this powers the Find Stats sweep across all inclusion values).
 
 For semantic (text/example) sorts, a **GMM-based threshold** is used instead: a 2-component Gaussian Mixture Model is fitted to the score distribution and the midpoint between component means serves as the threshold.
 
@@ -78,11 +84,18 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 |------------------------|----------|-------|--------------|
 | Audio (`audio`) | `clap` (default) | LAION CLAP (`laion/clap-htsat-unfused`) | 512 |
 | Audio (`audio`) | `clap_music` | CLAP Music & Speech (`laion/larger_clap_music_and_speech`) | 512 |
+| Audio (`audio`) | `clap_general` | CLAP General 2024 (`laion/larger_clap_general`) | 512 |
 | Audio (`audio`) | `paraspeechclap` | ParaSpeechCLAP speech-style (WavLM + Granite, `ajd12342/paraspeechclap-combined`) | 768 |
+| Audio (`audio`) | `ast` | AST audio spectrogram (`MIT/ast-finetuned-audioset-10-10-0.4593`, audio-only) | 768 |
+| Audio (`audio`) | `whisper_encoder` | Whisper-base encoder (`openai/whisper-base`, audio-only) | 512 |
 | Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |
+| Image (`image`) | `siglip2` | SigLIP 2 (`google/siglip2-base-patch16-224`) | 768 |
+| Image (`image`) | `clip` | CLIP (`openai/clip-vit-base-patch32`) | 512 |
 | Image (`image`) | `dinov2_single` / `dinov2_patch` | DINOv2 ViT-B/14 (`facebook/dinov2-base`) | 768 |
 | Image (`image`) | `dinov3_single` / `dinov3_patch` | DINOv3 ViT-B/16 (`facebook/dinov3-vitb16-pretrain-lvd1689m`, gated) | 768 |
 | Image (`image`) | `eupe_single` / `eupe_patch` | EUPE ViT-B/16 (`facebookresearch/EUPE`, FAIR Noncommercial) | 768 |
+| Image (`image`) | `sift_vlad` | SIFT/VLAD instance matching (classical, no text encoder) | 8192 (64 centroids × 128-dim SIFT) |
+| Image (`image`) | `face` | FaceNet identity (`InceptionResnetV1`, face crops, no text encoder) | 512 |
 | Video (`video`) | `xclip` (default) | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
 | Text (`text`) | `e5` (default) | E5 (`intfloat/e5-base-v2`) | 768 |
 | Text (`text`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -55,6 +55,23 @@ GET /api/label-importers
 
 → JSON array of label importer objects.
 
+### Dynamic field options
+
+```
+POST /api/label-importers/field-options/{importer_name}
+```
+
+**Body:** `{"field_key": "...", "field_values": {...}}`
+
+Returns the dropdown options for a dynamic-options field on a label importer
+(used to populate dependent selects in the importer form).
+
+→ `{"options": [...]}`
+
+Errors: 400 (unknown/non-dynamic field key), 404 (unknown importer),
+501 (importer does not implement `get_field_options`),
+502 (remote service backing dynamic options failed).
+
 ### Run label import
 
 ```
@@ -91,27 +108,118 @@ Re-ingests medias from their recorded origins and applies labels.
 
 ---
 
-## Processor Importers
+## Pregen Processors
 
-### List processor importers
+Pregen processors are the built-in autorun processors VTSearch ships with: an
+OCR extractor (PaddleOCR), a Speech extractor (Whisper Tiny), and a Face
+localizer (MediaPipe). Adding them registers each into the autorun
+extractors / localizers stores so they run automatically after a dataset
+loads. They do **not** create detectors.
 
-```
-GET /api/processor-importers
-```
-
-→ JSON array of processor importer objects.
-
-### Run processor import
+### List pregen processors
 
 ```
-POST /api/processor-importers/import/{importer_name}
+GET /api/pregen-processors
 ```
 
-**Form or Body:** importer-specific fields. `name` is required.
+→ `{"processors": [{"name": "OCR (PaddleOCR)", "kind": "extractor", "processor_type": "ocr", "media_type": "image", "config": {...}}, ...]}`
 
-Runs the importer and saves the result as a registered detector.
+### Add all pregen processors
 
-→ `{"success": true, "name": "...", "media_type": "audio"}`
+```
+POST /api/pregen-processors/add
+```
+
+Registers every bundled pregen processor (OCR extractor, Speech extractor,
+Face localizer) into the autorun extractor / localizer stores.
+
+→ `{"success": true, "added": ["OCR (PaddleOCR)", "Speech (Whisper Tiny)", "Face (MediaPipe)"]}`
+
+---
+
+## Autorun Extractors
+
+Autorun extractors run after a dataset loads and attach free-form metadata
+records to each media (e.g. OCR text, speech transcripts, image classes).
+
+### List autorun extractors
+
+```
+GET /api/autorun-extractors
+```
+
+→ `{"extractors": [...]}`
+
+### Add an autorun extractor
+
+```
+POST /api/autorun-extractors
+```
+
+**Body:** `{"name": "...", "extractor_type": "ocr"|"speech"|"image_class", "media_type": "image", "config": {...}}`
+
+→ `{"success": true, "name": "..."}` (400 if the config can't be built).
+
+### Delete an autorun extractor
+
+```
+DELETE /api/autorun-extractors/{name}
+```
+
+→ `{"success": true}` (404 if not found).
+
+### Rename an autorun extractor
+
+```
+PUT /api/autorun-extractors/{name}/rename
+```
+
+**Body:** `{"new_name": "..."}`
+
+→ `{"success": true, "new_name": "..."}` (400 if not found or name taken).
+
+---
+
+## Autorun Localizers
+
+Autorun localizers run after a dataset loads and attach a list of
+`(box, confidence)` regions to each media (e.g. face detection).
+
+### List autorun localizers
+
+```
+GET /api/autorun-localizers
+```
+
+→ `{"localizers": [...]}`
+
+### Add an autorun localizer
+
+```
+POST /api/autorun-localizers
+```
+
+**Body:** `{"name": "...", "localizer_type": "face", "media_type": "image", "config": {...}}`
+
+→ `{"success": true, "name": "..."}` (400 if the config can't be built).
+
+### Delete an autorun localizer
+
+```
+DELETE /api/autorun-localizers/{name}
+```
+
+→ `{"success": true}` (404 if not found).
+
+### Rename an autorun localizer
+
+```
+PUT /api/autorun-localizers/{name}/rename
+```
+
+**Body:** `{"new_name": "..."}`
+
+→ `{"success": true, "new_name": "..."}` (400 if not found or name taken).
 
 ---
 

--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -71,6 +71,14 @@ GET /api/labeling-status
 
 Each metric has a `status` of `"red"`, `"yellow"`, or `"green"`.
 
+> **Metric-id naming note.** The third indicator is keyed **`span`** in this
+> `labeling-status` response, but the `metric` query/body parameter on
+> `indicator-score-history` and `eval/train-and-score` (below) uses
+> **`diverse`** for the same concept. Both spellings are intentional in the
+> current code: use `span` when reading a status object, and `diverse` when
+> requesting the diversity metric. (`smart` and `stable` are spelled the same
+> in both places.)
+
 ### Indicator score history
 
 ```
@@ -90,10 +98,44 @@ polling).
 POST /api/eval/train-and-score
 ```
 
-**Body:** `{"metric": "smart"}` (or `"stable"` / `"diverse"`)
+**Body:** `{"metric": "smart"}` (or `"stable"` / `"diverse"`; optional `"wait": true`)
 
-→ `{"error_cost": [...]}` (smart), `{"stability": [...]}` (stable), or
-`{"diversity": [...]}` (diverse).
+The work retrains a small MLP at every step of the label history, so it runs
+on a background daemon thread. The route returns immediately with a `job_id`;
+poll `GET /api/eval/train-and-score/result` for the metric data and subscribe
+to the `eval` SSE channel for live progress. A signature cache short-circuits
+identical re-runs. Tests can pass `{"wait": true}` to block until done and get
+the data inline.
+
+→ `{"job_id": "...", "status": "running", "current": 0, "total": 10}`, or
+(cached / `wait=true`) `{"job_id": "...", "status": "done", "metric": "smart",
+"error_cost": [...]}`. The metric-specific key is `error_cost` (smart),
+`stability` (stable), or `diversity` (diverse).
+
+### Poll train-and-score result
+
+```
+GET /api/eval/train-and-score/result
+```
+
+**Query params:** `job_id`: the id returned by `train-and-score`.
+
+→ `running`: `{"job_id": "...", "status": "running", "current": 5, "total": 10}`;
+`done`: same shape as the cached/`wait` response above; `cancelled`:
+`{"job_id": "...", "status": "cancelled"}`. 404 if the job is unknown; 500 if
+the background job failed.
+
+### Cancel train-and-score
+
+```
+POST /api/eval/train-and-score/cancel/{job_id}
+```
+
+Sets the cancel flag on the background job; the per-step retrain loop polls it
+cooperatively. Returns 200 even when the job has already finished. 404 if the
+job is unknown.
+
+→ `{"ok": true}`
 
 ### Evaluation progress (SSE)
 

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -21,8 +21,10 @@ GET /api/medias/ids
 ]
 ```
 
-Every stub carries `id` and `type`; `embedder` is included when the media
-has one.  Display-worthy metadata (`filename`, `md5`, `custom_metadata`,
+Every stub carries `id` and `media_type`; `embedder` (and the plural
+`embedders` array, when a media was embedded by more than one embedder, e.g.
+a semantic + region-patch pair) is included when present.  Display-worthy
+metadata (`filename`, `md5`, `custom_metadata`,
 `origin_name`, `description`, `clip_*`) is fetched on demand for the IDs
 the client actually needs via [Batch fetch](#batch-fetch-metadata); this
 keeps the listing payload bounded even for datasets with tens of
@@ -59,11 +61,12 @@ are silently omitted):
 ]
 ```
 
-Every returned item contains `id`, `type`, `filename`, `md5`, and
+Every returned item contains `id`, `media_type`, `filename`, `md5`, and
 `custom_metadata`.  The `custom_metadata` dict holds media-type-specific
 display fields (e.g.  `duration`/`frequency` for audio, `width`/`height`
 for images, `word_count` for text).  `origin_name`, `description`,
-`embedder`, and `clip_*` keys are included when present.
+`embedder`, `embedders` (plural array, when present), and `clip_*` keys are
+included when present.
 
 ### Stream audio
 
@@ -146,6 +149,42 @@ or switched good → bad.
 | `400` | Invalid `vote` value; `region_box` on a `bad` vote; `region_box` outside `[0, 1]` or not a 4-tuple. |
 | `404` | Media not found. |
 
+### Bulk vote
+
+```
+POST /api/medias/vote-bulk
+```
+
+**Body:** `{"ids": [1, 2, 3], "target": "good"}`
+
+Applies one absolute vote `target` (`"good"` / `"bad"`) to many medias in a
+single request, with the same idempotent semantics as the per-media vote
+(including Find-mode verification: a good/bad target marks the item verified).
+The detector labelset is persisted once rather than per id. Bulk votes are
+image-level (no region boxes). Powers the Browser's "Verified Good" /
+"Verified Bad" actions.
+
+→ `{"changed": 2, "missing": [3]}` — `changed` counts only ids whose state
+actually moved; ids not in the loaded dataset are reported in `missing`.
+400 if no ids supplied.
+
+### Thumbnail
+
+```
+GET /api/medias/{media_id}/thumbnail
+```
+
+**Query (optional):** `region=x0,y0,x1,y1` (normalised fractions in `[0, 1]`)
+crops the thumbnail to a sub-region (used so the Good pile shows a
+region-voted item's crop rather than the whole frame).
+
+Streams a downscaled thumbnail bounded to a fixed longest-side length, the
+same regardless of zoom level (an `ETag` lets the browser reuse it across
+scrolls/zoom). Grid and list tiles use this instead of `/image` so a gallery
+of high-resolution items doesn't decode every full-size bitmap at once.
+400 if the media is not an image and has no `image_response` delegate. 404 if
+not found or bytes unavailable.
+
 ---
 
 ## Sorting
@@ -218,6 +257,25 @@ Embeds the uploaded file and sorts by cosine similarity.
 
 `best_region` is included per-result on patch-region-aware datasets,
 same shape as text sort.
+
+### Example sort (by loaded media id)
+
+```
+POST /api/example-sort-by-id
+```
+
+**Body:** `{"media_id": 42}` (optionally `{"media_id": 42, "crop_params": {...}}`)
+
+Sorts all medias by similarity to an already-loaded media item. When
+`crop_params` is absent the media's existing embedding vector is reused (no
+fetch, no re-embed); when set, the media's bytes are materialised, cropped,
+and re-embedded before sorting. Powers the right-click "sort by similarity" /
+"crop then sort" context-menu actions.
+
+→ `{"results": [...], "threshold": 0.5123}`
+
+400 if no medias loaded or `media_id` not in the loaded snapshot. 404 if the
+media's bytes are unavailable when cropping is requested.
 
 ### Example sort (server file)
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,23 +1,13 @@
 # Demo Datasets
 
-When the app is running, click the **+** button on the **Datasets** card to open the **Add Dataset** dialog, then pick the **Demo** tab. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.
+This is the reference catalogue of every demo dataset VTSearch can download and embed on demand. For the step-by-step loading walkthrough (opening the **Add Dataset** dialog, the **Demo** tab, and the **🏭 Synthetic Media** offline generator), see **[user/USER_GUIDE.md](user/USER_GUIDE.md)**.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="user/assets/importer-picker.dark.png" />
   <img src="user/assets/importer-picker.light.png" alt="The Demo importer with the Synthetic Media generator and the Downloaded Media catalogue" width="720" />
 </picture>
 
-## Synthetic (offline)
-
-If you don't have an internet connection (or just want a quick test fixture), pick **🏭 Synthetic Media** on the **Demo** tab of the dataset importer. Choose `image`, `audio`, or `video` and a size (e.g. 100, 1000, 10000) and the app will generate fake media on the fly:
-
-| Media type | Ideas it cycles through |
-|------------|-------------------------|
-| Image      | smiley faces (4 emotions, varied colors / sizes / backgrounds), 1–5 colored shapes (circle / square / triangle) |
-| Audio      | sine tones, chords (major / minor / dim / sus4), drums (kick / snare / hihat at varying BPMs), rain, wind, FM-swept bird chirps |
-| Video      | bouncing ball, walking smiley, rotating polygon, scrolling marquee |
-
-Files are deterministic for a given size and cached under `data/synthetic/<media_type>_<size>/`, so reloads skip regeneration. The clusters are coarse on purpose; they give CLAP / CLIP / X-CLIP something to actually distinguish when you're testing a sort.
+Datasets are grouped by media type below. Each demo comes in size variants — **S** / **M** / **L** (progressively larger samples) and **A** (all items in the underlying dataset). Sizes are downloaded once and cached, so reloads are instant.
 
 ## Audio
 
@@ -26,6 +16,7 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 | **esc50_s** | ~350 clips across all 50 ESC-50 sound categories: animals, nature, urban, domestic, and human sounds |
 | **esc50_m** | ~650 clips across all 50 ESC-50 sound categories |
 | **esc50_l** | ~1000 clips across all 50 ESC-50 sound categories |
+| **esc50_a** | All clips across the 50 ESC-50 sound categories: animals, nature, urban, domestic, and human sounds (all) |
 | **gtzan_a** | 30-second music excerpts across 10 GTZAN genres: blues, classical, country, disco, hiphop, jazz, metal, pop, reggae, and rock |
 | **speech_commands_v2_s** | One-second keyword utterances across 35 Google Speech Commands v2 categories (small) |
 | **speech_commands_v2_m** | One-second keyword utterances across 35 Speech Commands v2 categories (medium) |
@@ -44,9 +35,14 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 
 | Demo | Description |
 |------|-------------|
-| **caltech101_s** | ~500 photographs across 25 Caltech-101 categories: animals, vehicles, household objects, and nature |
-| **caltech101_m** | ~1,000 photographs across 25 Caltech-101 categories |
-| **caltech256_l** | ~2,000 photographs across 25 Caltech-256 categories: animals, landmarks, vehicles, and everyday objects |
+| **caltech101_s** | Centered single-object photographs across 25 Caltech-101 categories: animals, vehicles, household objects, and nature (small) |
+| **caltech101_m** | Centered single-object photographs across 25 Caltech-101 categories (medium) |
+| **caltech101_l** | Centered single-object photographs across 25 Caltech-101 categories (large) |
+| **caltech101_a** | Centered single-object photographs across 25 Caltech-101 categories (all) |
+| **caltech256_s** | Cluttered, off-center object photographs across 25 Caltech-256 categories: animals, landmarks, vehicles, and everyday objects (small) |
+| **caltech256_m** | Cluttered object photographs across 25 Caltech-256 categories (medium) |
+| **caltech256_l** | Cluttered object photographs across 25 Caltech-256 categories (large) |
+| **caltech256_a** | Cluttered object photographs across 25 Caltech-256 categories (all) |
 | **oxford_flowers_102_a** | Close-up flower photography across 102 Oxford Flowers species |
 | **food101_s** | Crowd-sourced food photos across Food-101 categories (small) |
 | **food101_m** | Crowd-sourced food photos across Food-101 categories (medium) |
@@ -79,6 +75,7 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 | **20newsgroups_s** | ~375 articles across 15 topics from 20 Newsgroups: sports, science, politics, religion, and more |
 | **20newsgroups_m** | ~750 articles across 15 topics from 20 Newsgroups |
 | **20newsgroups_l** | ~1875 articles across 15 topics from 20 Newsgroups |
+| **20newsgroups_a** | All articles across 15 topics from 20 Newsgroups: sports, science, politics, religion, and more (all) |
 | **ag_news_s** | Short news summaries across AG News categories (small) |
 | **ag_news_m** | Short news summaries across AG News categories (medium) |
 | **ag_news_l** | Short news summaries across AG News categories (large) |
@@ -88,6 +85,18 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 | **imdb_m** | Long-form movie reviews with positive/negative sentiment labels (medium) |
 | **imdb_l** | Long-form movie reviews with positive/negative sentiment labels (large) |
 | **imdb_a** | Long-form user-written movie reviews with binary positive/negative sentiment labels (all) |
+| **wikipedia_topics_s** | Wikipedia article abstracts across 14 DBpedia ontology classes: companies, artists, athletes, buildings, animals, plants, films, and more (small) |
+| **wikipedia_topics_m** | Wikipedia article abstracts across 14 DBpedia ontology classes (medium) |
+| **wikipedia_topics_l** | Wikipedia article abstracts across 14 DBpedia ontology classes (large) |
+| **wikipedia_topics_a** | Wikipedia article abstracts across 14 DBpedia ontology classes (all) |
+| **arxiv_abstracts_s** | arXiv paper titles and abstracts across 12 subject categories spanning CS, math, physics, biology, and statistics (small) |
+| **arxiv_abstracts_m** | arXiv titles and abstracts across 12 subject categories (medium) |
+| **arxiv_abstracts_l** | arXiv titles and abstracts across 12 subject categories (large) |
+| **arxiv_abstracts_a** | arXiv titles and abstracts across 12 subject categories (all) |
+| **reuters21578_s** | Financial newswire stories across 10 Reuters-21578 topics: earnings, acquisitions, money/fx, grain, crude, trade, and more (small) |
+| **reuters21578_m** | Financial newswire stories across 10 Reuters-21578 topics (medium) |
+| **reuters21578_l** | Financial newswire stories across 10 Reuters-21578 topics (large) |
+| **reuters21578_a** | Financial newswire stories across 10 Reuters-21578 topics (all) |
 
 ## Video
 
@@ -96,7 +105,20 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 | **ucf101_s** | ~150 clips across 10 UCF-101 action categories: personal activities and sports |
 | **ucf101_m** | ~250 clips across 10 UCF-101 action categories |
 | **ucf101_l** | ~600 clips across 10 UCF-101 action categories |
+| **ucf101_a** | All clips across the same 10-category UCF-101 subset (all) |
+| **ucf101_full_s** | YouTube action videos across all 101 UCF-101 categories (small) |
+| **ucf101_full_m** | YouTube action videos across all 101 UCF-101 categories (medium) |
+| **ucf101_full_l** | YouTube action videos across all 101 UCF-101 categories (large) |
+| **ucf101_full_a** | YouTube action videos across all 101 UCF-101 categories (all) |
+| **hmdb51_s** | Human-motion clips across 51 HMDB51 categories: facial actions, body movements, and human interactions (small) |
+| **hmdb51_m** | Human-motion clips across 51 HMDB51 categories (medium) |
+| **hmdb51_l** | Human-motion clips across 51 HMDB51 categories (large) |
+| **hmdb51_a** | Human-motion clips across 51 HMDB51 categories (all) |
+| **kth_s** | Simple human-action recordings across 6 KTH categories: boxing, handclapping, handwaving, jogging, running, and walking (small) |
+| **kth_m** | Simple human-action recordings across 6 KTH categories (medium) |
+| **kth_l** | Simple human-action recordings across 6 KTH categories (large) |
+| **kth_a** | Simple human-action recordings across 6 KTH categories (all) |
 
-> **Note:** UCF-101 demos are downloaded from HuggingFace Datasets. On some networks or air-gapped systems this may require manual setup; see [DEPLOYMENT.md](DEPLOYMENT.md) for offline deployment instructions.
+> **Note:** Video demos are downloaded from HuggingFace Datasets. On some networks or air-gapped systems this may require manual setup; see [DEPLOYMENT.md](DEPLOYMENT.md) for offline deployment instructions.
 
-You can also load your own data from pickle files or folders via the same menu.
+You can also load your own data from pickle files or folders via the same dialog.

--- a/docs/plans/docs-audit-2026-06-28.md
+++ b/docs/plans/docs-audit-2026-06-28.md
@@ -1,0 +1,293 @@
+# Documentation Audit — 2026-06-28
+
+**Status:** Audit complete; no fixes applied yet. This is the systemic
+review requested before re-shooting screenshots "in a better environment."
+
+**Scope.** Every doc under `docs/` plus the root `README.md`, checked against
+the *current* frontend (`frontend/src/app`), backend routes (`vtsearch/`),
+library (`vtscore/`), the OpenAPI snapshot (`frontend/openapi.json`), the
+install/deploy scripts, and the Dockerfiles.
+
+**Why now.** The user-doc screenshots and the user guide were last refreshed
+at `b0bddcd3` (~2026-06-10/06-18). **~170 frontend commits** have landed
+since, and the drift is large enough that the user guide actively misleads
+in several places and 6 of 16 screenshots are stale (2 with broken capture
+recipes). The screenshot harness itself is intact (the
+`frontend/docs-assets → ../docs/user` symlink + angular.json glob still feed
+both GitHub `<picture>` embeds and the in-app Help panel), so a refresh is a
+re-run once the recipes below are fixed.
+
+---
+
+## Part A — Screenshots to RETAKE (existing shots)
+
+16 logical shots × 2 themes live in `docs/user/screenshots.manifest.ts` /
+`docs/user/assets/`. Verdicts (full table in the per-shot notes):
+
+| Shot | Why retake | Priority |
+|------|-----------|----------|
+| `view-options` | List/grid toggle **removed** (`27854785`); the shot also captures the *Settings* pane, not the real in-panel view toolbar — recipe must be re-targeted (see Part C). Caption factually wrong. | **P0** |
+| `results-grid` | media-item/list markup rewritten in the list-removal pass (`27854785`); `gridView()` step is now dead. | **P0** |
+| `dashboard-loaded` | Dashboard rows restructured: actions collapsed into a `⋯` overflow menu, Actions column content-pinned, inline Delete (`5b8826d9`, `e164e9b7`, `d5a22a28`). This is also the **README hero**. | **P0** |
+| `dashboard-manage` | Same dashboard-row restructuring. Retake with the `⋯` menu open. | **P0** |
+| `settings-appearance` | Settings tabs reorganized/renamed/re-sorted; Solo media type moved to a different tab (`9d670ef7`). | **P1** |
+| `browse-view` | VTSBrowser visuals changed (zoom borders/minimap/bin-popup); **and** the entry point moved — Browse is now a `⋯`-menu item, so `openBrowse()` is broken (see Part C). | **P1** |
+| `importer-picker` (also in demos.md) | Demo importer gained a **per-media-type tab bar** the shot predates; shot shows a flat Downloaded/Synthetic row. | **P1** |
+
+**Keep (still accurate):** `dataset-panel`, `importer-form`, `three-panel`,
+`autopilot-vote`, `manual-controls`, `region-voting`, `export-picker`,
+`import-detector`. (`autopilot-progress` keeps its image but needs a caption
+fix — Part F.)
+
+**Net: 7 logical shots to retake** (`view-options`, `results-grid`,
+`dashboard-loaded`, `dashboard-manage`, `settings-appearance`, `browse-view`,
+`importer-picker`) = 14 PNGs.
+
+---
+
+## Part B — NEW screenshots needed (undocumented/under-documented features)
+
+Ranked by value. Each implies a new manifest entry + USER_GUIDE section/paragraph.
+
+1. **Find three-pane verification view** — the entire Find workflow is invisible
+   today. Find is not "a ranked results modal"; it opens a full left/center/right
+   verification view (work queue → verify Good/Bad → Verified piles, plus
+   To-Dataset / Add-Corrections / Stats / inclusion). `find-view.component`.
+2. **Find Stats modal** — confusion matrix + "false pos/neg vs. inclusion" curve.
+   Doubles as the visual the guide currently lacks for the inclusion tradeoff.
+   `find-stats-modal.component`.
+3. **New-detector modal (Blank tab)** — how a detector first comes into being
+   (text seed / media example; Blank vs Trained; embedder-type picker). The guide
+   never documents detector *creation*. `new-detector-modal.component`.
+4. **Achievements panel** — a whole gamification system (trophy button, unlock
+   toasts, 10 achievements w/ tiers, the "code phrase" mechanic the guide's own
+   footer participates in) is completely undocumented. `achievements-tab`,
+   `vtsearch/achievements.py`.
+5. *(optional)* **Browse bin-popup** — select-all + representative-item preview,
+   to flesh out the Browse section.
+
+---
+
+## Part C — Capture recipes/helpers to fix BEFORE a refresh run
+
+These will time out or click dead/disabled targets if run as-is:
+
+- **`openBrowse()` helper** (`scripts/screenshots/capture.ts`): the inline
+  `.browse-btn` eye is gone from resting dataset rows (it now only renders as a
+  *disabled* projection-building button, `dataset-card.component.html:63`). Open
+  Browse via the row's `.overflow-btn` (`⋯`) → "Browse" context-menu item
+  (`card-context-menu-items.ts:110`).
+- **`gridView()` helper / `results-grid` recipe**
+  (`capture.ts`; `screenshots.manifest.ts:262-270`): the list/grid toggle was
+  removed (`27854785`); its selectors no longer match and `.vc-btn` nth(1) now
+  hits "Bigger thumbnails." Drop the grid-toggle step — the list is always a grid.
+- **`view-options` recipe** (`screenshots.manifest.ts:251-254`): currently calls
+  `openSettings()`, so it captures the Settings pane (duplicating
+  `settings-appearance`). Re-target to the in-panel `vt-view-controls` toolbar.
+- **`dashboard-manage` recipe**: add a step to open the `⋯` overflow menu so the
+  retaken shot shows where Browse/Stats/Export/Rename now live.
+
+---
+
+## Part D — Prose / instruction fixes by document
+
+### USER_GUIDE.md — heavily drifted; §7 is the worst
+
+- **§7 View options — rewrite wholesale.** There is no "View button" and no
+  view-settings *modal*; controls are an inline `vt-view-controls` toolbar
+  (thumbnail size + focus mode only). "List vs. grid" is gone. There is no
+  separate right-panel view modal. **Solo media type** moved to the **Import
+  Defaults** tab. The entire **"Locking the embedder / Solo media embedder / Ask
+  each time"** subsection describes UI that is not rendered (dead TS, no template
+  binding). Replace with the real Settings tabs: Appearance, Auto-Find, Autopilot,
+  Browser, Import Defaults, Server, Sorting.
+- **§4 Autopilot — labels wrong.** Phases render **"Find Initial Goods. / Find
+  Initial Bads. / Refine Boundary. / Explore Diversity. / Done!"** Config fields
+  are **"# Good to start / # Bad to start / # Start to re-sort / Goal Diversity"**
+  under a Settings tab now named **Autopilot**. Re-verify the cited defaults
+  (3/4/10/40%) against `vtscore` settings — they're backend-sourced.
+- **§5 Manual mode.** Sort order is **Text → Load → Learned** (not Text/Learned/
+  Load). The "inclusion slider" is a **numeric stepper**, and it **triggers
+  retraining** — the guide's "re-ranks instantly; you don't need to re-train" is
+  the opposite of the tooltip. "Load" picks a **saved registry detector**, not a
+  "detector file."
+- **§8 Dashboard.** Real dataset columns: Type / # Items / Created / Age-Off /
+  Creator / Readers — **not** duplicate-count/origin/clipper/embedder. No "Loaded"
+  column or ×/checkmark toggle (load is an inline "Load" button that vanishes once
+  loaded). Browse/Stats/Export/Add-Labels are in the `⋯` menu; Delete is inline.
+  No Auto-Find row indicator. Detector "Add Labels" menu item is labeled "Import
+  Labels."
+- **§9 Browse.** Browse is reached via the `⋯` menu, not an eye button on the row.
+  The prune buttons are **"Verified Good" / "Verified Bad"**, not "Remove from
+  Good."
+- **§10 Exporting.** Use real `display_name`s ("Server JSON File", "Server CSV
+  File", "Webhook (HTTP POST)", "Send by Email"; plus undocumented "Display
+  Results", "Holder Package"). **Clipboard** copies a column-selected delimited
+  table (default Label/MD5/Filename/Category), **not** a JSON `{id,label,score}` list.
+- **§2 Loading.** "Paths File" → "Paths file." The Advanced embedder control is a
+  collapsible section with a primary **Embedder** plus optional **Region embedder**
+  and **Instance embedder** selects (three-role picker). Mention the demo
+  **per-media-type tab bar**, "Merge near-duplicates," and "Reference files in
+  place" import options.
+- **§3 / §6.** Region/overlay capability now also covers **structural (SIFT/VLAD)**
+  embedders, not only `_patch`. Note the new **Highlight** toggle in the image
+  controls.
+- **§11 Importing.** Soften "import detector" (Load-sort lists registry detectors;
+  no detector-*file* upload surfaces) and the fixed `{md5,label}` claim (label
+  import is a server-driven importer picker).
+- **Reusability claim (§1).** Detectors reuse on the same media type **and
+  compatible embedder type** (semantic / patch / structural) — not "any future
+  dataset of the same media type" (`5c98732c`).
+- **New content to add:** Creating a detector; Find/verification; Achievements;
+  Settings-tabs overview; Combine datasets/detectors + bulk delete/select-all;
+  keyboard shortcuts + `?`/in-app guide; right-click media context menu
+  (sort-by-similarity, crop-then-sort, use-as-seed) + crop modal; top-bar
+  dataset/detector pulldowns; resort prompt; drag-and-drop upload; login/offline/
+  toast states (one-liners).
+
+### README.md
+
+- **Project-structure tree is badly stale** (biggest issue): ~18 paths listed
+  under `vtsearch/` now live in **`vtscore/`** (the app-tier vs library-tier
+  split); `vtscore/` isn't mentioned at all; CLI files mislabeled; `cli_main.py`
+  and `tests_lib/` missing. Fix the tree or replace it with a 2-line pointer to
+  `docs/ARCHITECTURE.md` (the canonical map).
+- **Hero `dashboard-loaded`** — retake (Part A).
+- **Audience:** lead with the visitor path (pitch → screenshot → install/run/try a
+  demo); push contributor material below a divider. Surface `--local`.
+
+### demos.md
+
+- **Catalogue is incomplete** (README calls it "the full list"): missing video
+  `hmdb51_*`, `ucf101_full_*`, `kth_*`, `ucf101_a`; text `wikipedia_topics_*`,
+  `arxiv_abstracts_*`, `reuters21578_*`; plus `_a`/`_l` size variants for audio
+  (`esc50_a`) and image (`caltech*`). Consider auto-generating tables from
+  `all_demo_datasets()` so they can't drift again.
+- **`importer-picker`** — retake (Part A).
+- **De-duplicate with USER_GUIDE** — reduce to a reference catalogue + a link to
+  the loading walkthrough.
+
+### Operator docs (CLI / SETUP / DEPLOYMENT / HANDOFF)
+
+- **DEPLOYMENT** "four embedding models" → **five** (`download_models.sh` runs
+  1/5–5/5 incl. CLIP); add CLIP to the model table. Concurrency-defaults prose
+  (lines ~372-376) contradicts the same doc's lines 30-37 and the current loader
+  (default 1 on accelerator, CPU-scaled by cores/RAM). Note `docker compose build`
+  bakes `0.0.0-unknown` unless `VTSEARCH_VERSION` build-arg is passed. Beef up the
+  thin reverse-proxy section (TLS/SSE/long-request timeouts vs `VTSEARCH_TIMEOUT=0`).
+- **HANDOFF** "Lint / Audit dependencies workflows run on every push" is **false**
+  — there is no CI (`./run-tests.sh` is the gate). Model-size figure 3.1 vs 3.2 GB
+  inconsistent with DEPLOYMENT.
+- **CLI** document `--login api_key` (second provider), `--progress-format`
+  (text/json NDJSON), and `--port`.
+- **SETUP** Node 22+ vs Dockerfiles' `node:20-slim` — repo-wide inconsistency
+  (CLAUDE.md also says 22+); needs a maintainer decision.
+- **Suggested visuals:** architecture SVG in HANDOFF (highest value), first-screen
+  screenshot in SETUP, an annotated `--autodetect`/`--dry-run` terminal capture in
+  CLI.
+
+### Developer docs (ARCHITECTURE / ML / EVAL / EXTENDING*)
+
+- **P0 correctness:**
+  - **ML.md class-weighting** describes inclusion entering *training*; it no longer
+    does (`mlp.py:193-197` uses inverse-frequency weights only; inclusion is a pure
+    threshold knob in `find_optimal_threshold`). Rewrite.
+  - **ARCHITECTURE.md** `train_model(...)` example (line ~369) passes a nonexistent
+    `inclusion_value` arg — won't run. Real signature
+    `train_model(X, y, input_dim, seed=42, hidden_dim=None)`.
+  - **EVAL.md** dataset table: `caltech256_l`→`caltech256_a`, remove `caltech101_l`,
+    add `visual_genome_s/m` (its own region-voting examples depend on them).
+  - **EXTENDING-processors.md** "defined in `vtscore/media/base.py`" →
+    `vtscore/media/processors.py` (two places); clarify `process()` is concrete.
+- **Stale/missing:** ML.md `calibrate_count` app default is **1**, not 2.
+  ARCHITECTURE "ten plugin systems" → nine. **Add the VTSBrowse projection
+  subsystem** (`vtscore/projection/` + `/api/projection/*` routes) to the map.
+  Add missing detector modules (`embedder_type`, `model_loading`, `learned_sort`,
+  `positives_browse`), state (`near_dupes`, `diversity_tree`), concurrency
+  (`events.py`), sources (`server_files.py`). Embedder tables in ML.md /
+  EXTENDING-media.md omit `ast`, `clap_general`, `whisper_encoder`, `clip`,
+  `siglip2`, `sift_vlad`, `face`.
+- **EXTENDING* plugin guides are otherwise accurate.**
+- **Suggested visuals:** request→context state-resolution diagram (ARCHITECTURE,
+  highest value); training/threshold dataflow diagram (ML, drawing inclusion as a
+  *threshold* input — would have prevented the current error); EVAL sample output.
+
+### API docs (API.md, api/*.md, vtscore-api.md)
+
+- All hand-written; OpenAPI snapshot (`frontend/openapi.json`, 213 endpoints) is
+  ground truth. Prose covers ~126; ~87 undocumented (many are acceptable
+  family-expansions, but whole features are missing).
+- **P0:** **io.md** documents `processor-importers` routes that **don't exist** —
+  real routes are `GET /api/pregen-processors` + `POST /api/pregen-processors/add`,
+  and they register OCR/Speech/Face autorun processors, not detectors.
+- **vtscore-api.md** import paths are largely wrong (claims package-root re-exports
+  that don't exist; `vtscore.concurrency`/`vtscore.security` have no `__init__.py`,
+  so `from vtscore.security import safe_pickle_load` fails — it's
+  `vtscore.security.pickle`). `set_thread_progress_callback` /
+  `get_thread_progress_callback` are documented but unimplemented.
+- **medias.md** prose `type` → `media_type` (×2); add `embedders` field;
+  add `vote-bulk`, `thumbnail`, `example-sort-by-id`.
+- **labeling.md** add eval `train-and-score` `cancel/{job_id}` + `result`;
+  reconcile `span` vs `diverse` indicator metric naming.
+- **Missing feature families to document:** achievements, projection/VTSBrowse,
+  sessions, jobs, autorun-extractors/localizers CRUD, dashboard disk/ram-usage,
+  find cancel/stats/corrections, health probes (`/healthz`, `/readyz`),
+  `GET /api/version`.
+
+---
+
+## Part E — Manifest changes (caption + new entries)
+
+- **Caption fix `autopilot-progress`** (`manifest:175`): phases →
+  "Find Initial Goods, Find Initial Bads, Refine Boundary, Explore Diversity."
+- **Caption fix `view-options`** (`manifest:249`): drop "List vs. grid" → grid
+  icon size + focus mode only.
+- **New entries** for the Part B shots (find-view, find-stats, new-detector,
+  achievements [, browse bin-popup]).
+
+---
+
+## Open follow-ups (what's owed)
+
+1. Fix the capture recipes/helpers in Part C, then run
+   `scripts/screenshots/refresh.sh` in a browser-capable env.
+2. Retake the 7 stale shots (Part A) + capture the new shots (Part B).
+3. Apply the prose fixes (Part D) — these are independent of the browser and can
+   land now.
+4. Update `docs/plans/user-docs-screenshots.md` "Shot list" to 20-ish shots and
+   record the new manifest entries there.
+
+---
+
+## Appendix — ready-to-paste recipes for the NEW shots (Part B)
+
+These are NOT yet in `screenshots.manifest.ts` because the wiring-check gate
+requires both PNGs on disk for every manifest id; add each entry only when you
+capture it in a browser-capable session. Selectors below were confirmed against
+the current components.
+
+- **`find-view`** — `embeddedIn: docs/user/USER_GUIDE.md#find--scoring-and-verifying`.
+  Route `find/:datasetId/:detectorId`; reached from the dashboard by selecting a
+  dataset row + detector row and clicking **Find** (`.dashboard-actions`, the
+  search-icon "Find" button). The view reuses `.panel-left/.panel-center/.panel-right`;
+  the right panel is in find mode (`right-panel.component.html`: headings
+  **"Verified Good" / "Verified Bad"**, "N Unverified Good/Bad" notes, and the
+  Browse / To Dataset / Export `.goods-action-btn`s). Recipe: a Find-mode twin of
+  `enterLabelView()` — select fixture dataset+detector, click Find, wait for
+  `.panel-right` to show the "Verified Good" heading. Annotate the Verified piles +
+  action row.
+- **`find-stats`** — `embeddedIn: ...#find--scoring-and-verifying`. The
+  `vt-find-stats-modal` (`.stats-table`, confusion-style Good/Bad/Verified rows +
+  the false-pos/neg-vs-inclusion SVG) is rendered inside find-view and opened by the
+  Stats control (`showStats`). Recipe: reach find-view (above) → open Stats → wait
+  for `.stats-table`. `clip` the modal.
+- **`new-detector`** — `embeddedIn: ...#creating-a-detector`. Open via the **+** on
+  the Detectors card; modal has a `.tab-bar` with `.tab-btn` **Blank** / **Trained**.
+  Capture the Blank tab (text-seed / media-example fields + embedder-type picker).
+  Recipe: dashboard → click the Detectors-card add button → wait for `.tab-bar`.
+- **`achievements`** — `embeddedIn: ...#achievements`. Open via the header
+  `.achievements-btn` (trophy). Capture the achievements panel/modal. Recipe:
+  dashboard → click `.achievements-btn` → wait for the panel. (Requires the
+  "Enable achievements" setting on, which is the default.)
+- **`browse-bin-popup`** *(optional)* — within `openBrowse()`, hover/click a tile so
+  the `vt-browse-bin-popup` appears; `clip` the popup.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -8,11 +8,16 @@
 4. [Autopilot - the guided workflow](#autopilot--the-guided-workflow) *(start here)*
 5. [Manual mode - for power users](#manual-mode--for-power-users)
 6. [Region voting on images](#region-voting-on-images)
-7. [View options](#view-options)
-8. [Dashboard - managing datasets and detectors](#dashboard--managing-datasets-and-detectors)
-9. [Browse - exploring a dataset spatially](#browse--exploring-a-dataset-spatially)
-10. [Exporting your work](#exporting-your-work)
-11. [Importing pre-trained detectors](#importing-pre-trained-detectors)
+7. [Creating a detector](#creating-a-detector)
+8. [Find - scoring and verifying](#find--scoring-and-verifying)
+9. [View options](#view-options)
+10. [Settings tabs](#settings-tabs)
+11. [Dashboard - managing datasets and detectors](#dashboard--managing-datasets-and-detectors)
+12. [Browse - exploring a dataset spatially](#browse--exploring-a-dataset-spatially)
+13. [Exporting your work](#exporting-your-work)
+14. [Importing pre-trained detectors](#importing-pre-trained-detectors)
+15. [Achievements](#achievements)
+16. [Tips and shortcuts](#tips-and-shortcuts)
 
 ---
 
@@ -27,8 +32,12 @@ you're looking for. There are two ways to search:
 1. **Train a new detector.** Vote a handful of items **good** or
    **bad** and a small neural net learns from your votes to rank the
    rest of the dataset. Detectors are reusable - once trained, you can
-   save one and re-apply it to any future dataset of the same media
-   type, or share it with another VTSearch user.
+   save one and re-apply it to any other dataset that shares its **media
+   type** *and* a **compatible embedder type** (semantic, patch, or
+   structural), or share it with another VTSearch user. A detector
+   trained in one embedding space can't score a dataset embedded in a
+   different one, so reuse is scoped to that pairing rather than to "any
+   future dataset of the same media type."
 2. **Use an existing detector.** Load one you (or someone else)
    trained earlier and score a fresh dataset with it. No new labeling
    required. Loaded detectors can also be re-trained against the new
@@ -71,9 +80,10 @@ dialog. It has three tabs, which boil down to two choices:
 
 - **Demo datasets** (the **Demo** tab) - VTSearch ships with a catalogue of open
   datasets across all five media types (audio, image, text, video,
-  document). Each demo downloads on first use (~15 MB to ~1.2 GB
-  depending on dataset) and is cached, so subsequent loads are
-  instant.
+  document). The demo importer groups them under a **per-media-type tab
+  bar**, so you can narrow the catalogue to just audio, just images, and
+  so on. Each demo downloads on first use (~15 MB to ~1.2 GB depending on
+  dataset) and is cached, so subsequent loads are instant.
 - **Import your own** (the **Files** and **Services** tabs) - Load a
   folder of files from the server, a VTSearch pickle file, a zipped HTTP
   archive, or combine several existing datasets. Each importer asks for
@@ -90,7 +100,7 @@ video on the fly:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/importer-picker.dark.png" />
-  <img src="assets/importer-picker.light.png" alt="The Demo importer with the Synthetic Media generator and the Downloaded Media catalogue" width="720" />
+  <img src="assets/importer-picker.light.png" alt="The Demo importer with its per-media-type tab bar, the Synthetic Media generator, and the Downloaded Media catalogue" width="720" />
 </picture>
 
 Each importer shows a small form for the fields it needs - here, the
@@ -100,6 +110,29 @@ Synthetic Media generator's media type and dataset size:
   <source media="(prefers-color-scheme: dark)" srcset="assets/importer-form.dark.png" />
   <img src="assets/importer-form.light.png" alt="A filled Synthetic Media importer form - media type and dataset size" width="720" />
 </picture>
+
+### Advanced import options
+
+The file importers expose a collapsible **Advanced** section. The most
+important control there is the embedder picker, which is actually a
+three-role picker:
+
+- **Embedder** - the primary embedding model used to score the dataset
+  (SigLIP for images, LAION-CLAP for audio, etc.).
+- **Region embedder (optional)** - a patch-region-aware model that
+  enables [region voting on images](#region-voting-on-images).
+- **Instance embedder (optional)** - a structural (SIFT/VLAD) model for
+  matching specific instances/patterns.
+
+Two more import toggles live nearby:
+
+- **Merge near-duplicates** - in addition to exact duplicates, fold in
+  visually/textually near-identical copies (resizes, recompressions,
+  trivial edits). VTSearch keeps the largest copy of each group, and
+  exporting one member exports the whole group.
+- **Reference files in place (don't copy)** - store a path reference to
+  each original file on the server instead of copying its bytes in. Saves
+  storage, but the dataset then depends on the source files staying put.
 
 Loading a dataset does three things: downloads or reads the media,
 generates an embedding for every item using the appropriate model
@@ -118,7 +151,7 @@ your own script using the same model VTSearch uses - you can skip the
 server-side re-embedding step by handing VTSearch a NumPy `.npz`
 archive of pre-computed vectors. The **Files → Manifest** importer
 accepts this: instead of a `.txt`/`.list` paths file, point the
-*Paths File* field at a `.npz`. The archive holds both the media-file
+*Paths file* field at a `.npz`. The archive holds both the media-file
 paths AND their vectors; VTSearch reads the paths from disk and reuses
 the supplied vectors.
 
@@ -153,14 +186,15 @@ Once a dataset is loaded, VTSearch shows three panels left to right:
 </picture>
 
 - **Left panel** - the sort bar, your selection-strategy controls,
-  the inclusion slider, and the **media list** (ranked by the current
+  the inclusion stepper, and the **media list** (ranked by the current
   sort). This is where you pick what to look at next.
 - **Centre panel** - the **media viewer**. The selected item plays
   (audio), displays (image, video, text, document page), and offers
   two big vote buttons: **Good** (green) and **Bad** (red).  On
-  image datasets that use a patch-region embedder
-  (DINOv2/DINOv3/EUPE `_patch`), the centre panel also supports
-  **region voting** - see "Region voting on images" below.
+  image datasets whose embedder supports regions - a patch-region
+  embedder (DINOv2/DINOv3/EUPE `_patch`) or a structural (SIFT/VLAD)
+  embedder - the centre panel also supports **region voting** - see
+  "Region voting on images" below.
 - **Right panel** - your **vote piles**. Everything you've voted good
   or bad is stacked here, most-recent first, so you can scan your
   work, un-vote, or re-vote.
@@ -187,27 +221,27 @@ just picks *which* items to show you and *when* each phase ends.
 
 ### The four phases
 
-1. **Good examples** - Vote some **good** items (default: 3). The
-   detector needs positive examples before it can learn anything.
+The phase panel labels them, in order:
+
+1. **Find Initial Goods.** - Vote some **good** items (default: 3).
+   The detector needs positive examples before it can learn anything.
    Autopilot offers strong candidates first via the same semantic
    ranking the Text sort uses. If you don't see anything good, type
    a text query into the sort bar to jump-start the ranking.
-2. **Bad examples** - Vote some **bad** items (default: 4). Now
+2. **Find Initial Bads.** - Vote some **bad** items (default: 4). Now
    the detector has both sides of the boundary. Autopilot flips to
    items ranked low, so finding clear bad examples is usually quick.
-3. **Boundary refinement (hard)** - Autopilot serves items the
-   detector is **uncertain about** - the hardest cases near the
-   decision boundary. Voting these teaches the detector fastest.
-   This phase continues until the detector's confidence stabilises
-   (the "smart" and "stable" indicators in the status bar both
-   turn green).
-4. **Diversity exploration (new)** - Autopilot serves items from
-   parts of the dataset the detector hasn't seen yet, using the
-   diversity tree. This catches edge cases the boundary phase
-   missed. Phase ends when the diversity coverage hits your goal
-   (default: 40%).
+3. **Refine Boundary.** - Autopilot serves items the detector is
+   **uncertain about** - the hardest cases near the decision boundary.
+   Voting these teaches the detector fastest. This phase continues
+   until the detector's confidence stabilises (the "smart" and
+   "stable" indicators in the status bar both turn green).
+4. **Explore Diversity.** - Autopilot serves items from parts of the
+   dataset the detector hasn't seen yet, using the diversity tree.
+   This catches edge cases the boundary phase missed. The phase ends
+   when the diversity coverage hits your goal (default: 40).
 
-When all four phases are done, Autopilot says **done**. You can
+When all four phases are done, Autopilot shows **Done!**. You can
 keep labeling if you want - the detector continues to improve - or
 move on to exporting results.
 
@@ -222,23 +256,25 @@ media list.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/autopilot-progress.dark.png" />
-  <img src="assets/autopilot-progress.light.png" alt="The Autopilot phase panel: the four phases (Good examples, Bad examples, Boundary refinement, Diversity) tracked in order" width="320" />
+  <img src="assets/autopilot-progress.light.png" alt="The Autopilot phase panel: the four phases (Find Initial Goods, Find Initial Bads, Refine Boundary, Explore Diversity) tracked in order" width="320" />
 </picture>
 
 ### Configuring Autopilot
 
-Most people never touch these, but the Settings modal (gear icon)
-exposes:
+Most people never touch these, but the **Autopilot** tab in the Settings
+modal (gear icon) exposes:
 
-- **Top greens** - how many good votes phase 1 requires (default 3).
-- **Hard reds** - how many bad votes phase 2 requires (default 4).
-- **Resort interval** - how often the learned detector is retrained
-  during phases 3 and 4 (default every 10 votes).
-- **Goal diversity** - the fraction of the dataset's diversity
-  tree that phase 4 must cover before finishing (default 40%).
+- **# Good to start** - how many good votes phase 1 requires (default 3).
+- **# Bad to start** - how many bad votes phase 2 requires (default 4).
+- **# Start to re-sort** - how many new votes to collect before the
+  learned detector is retrained and re-ranked during phases 3 and 4
+  (default 10).
+- **Goal Diversity** - the diversity coverage that phase 4 must reach
+  before finishing (default 40).
 
 Raising these numbers trains a more thorough detector at the cost of
-more labelling effort.
+more labelling effort. The same tab also has a **Hide autopilot panel**
+toggle.
 
 ---
 
@@ -254,23 +290,25 @@ The Manual tab shows three control rows above the media list.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/manual-controls.dark.png" />
-  <img src="assets/manual-controls.light.png" alt="The three Manual-mode control rows: Sort mode, Selection strategy, and the Inclusion slider" width="720" />
+  <img src="assets/manual-controls.light.png" alt="The three Manual-mode control rows: Sort mode, Selection strategy, and the Inclusion stepper" width="720" />
 </picture>
 
 ### 1. Sort mode
 
-Picks how the left-panel list is ordered.
+Picks how the left-panel list is ordered. The sort bar offers three
+modes, in order: **Text**, **Load**, **Learned**.
 
 - **Text** - Type a natural-language query (e.g. "dog barking",
   "aerial photo of farmland"). Items are ranked by semantic
   similarity to your query using the embedding model for this
   media type.
+- **Load** - Apply a previously saved detector. Opens a modal where
+  you can **Sort by Detector** (pick a saved detector from the
+  registry) or **Sort by Examples** (sort by similarity to one or
+  more example media items).
 - **Learned** - Trains a small neural net on your current good/bad
   votes and ranks items by its predictions. Needs at least one
   good vote and one bad vote before it works.
-- **Load** - Apply a previously saved detector (or one exported
-  from another VTSearch instance). Opens a modal to pick a
-  detector file or an example media item to sort by.
 
 You can freely switch modes - votes and the detector persist across
 switches.
@@ -289,101 +327,31 @@ Picks *which unlabeled item* the app highlights next.
 Autopilot cycles through these automatically in its four phases,
 but in Manual mode you choose directly.
 
-### 3. Inclusion slider
+### 3. Inclusion stepper
 
-A slider from **-10** (strict) to **+10** (lenient), default 0.
+A numeric stepper from **-10** (strict) to **+10** (lenient),
+default 0.
 
-Nudges the classification threshold after the learned detector runs.
+Nudges the classification threshold for the learned detector.
 Negative values mean "only call it good if you're very sure" -
 fewer positives, higher precision. Positive values mean "include
-borderline items" - more positives, higher recall. The slider
-re-ranks instantly; you don't need to re-train.
+borderline items" - more positives, higher recall. Changing it
+**triggers a retrain** of the learned sort so the new threshold is
+applied to the ranking.
 
 Leave at 0 unless you have a specific precision/recall trade-off
 in mind.
 
 ---
 
-## View options
-
-The **View** button above the media list opens the view-settings
-modal. All preferences are remembered per media type.
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/view-options.dark.png" />
-  <img src="assets/view-options.light.png" alt="The view settings: List vs. grid, grid icon size, and focus mode (Settings, Appearance, Scroll Style)" width="720" />
-</picture>
-
-- **List vs. grid** - List shows one item per row with rank, score,
-  and a preview. Grid shows a wall of thumbnails. Grid is faster
-  for images; list is usually better for audio and text. After training,
-  grid view ranks the thumbnails by the detector's score, with a
-  threshold line marking the good/bad cut:
-
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/results-grid.dark.png" />
-    <img src="assets/results-grid.light.png" alt="The left-panel media list in grid view after training - ranked thumbnails" width="320" />
-  </picture>
-- **Grid icon size** - XS, S, M, L, XL. Larger icons = fewer per
-  screen but more readable.
-- **Focus mode** - Click-focus means you select an item by
-  clicking it. Hover-focus means just moving your cursor over
-  an item selects it (faster for scanning, more mis-clicks).
-
-There's a separate view modal for the right panel (vote piles),
-with the same controls.
-
-### Solo media type - streamline for one media type
-
-If you only ever work with one kind of media (e.g. you exclusively
-search images, optionally pulled in from videos and documents via
-the built-in converters), pick that type under **Appearance → Solo
-media type** in the Settings modal. Once set:
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/settings-appearance.dark.png" />
-  <img src="assets/settings-appearance.light.png" alt="The Settings, Appearance pane: theme picker, Solo media type, and the per-type Scroll Style controls" width="720" />
-</picture>
-
-- The dataset importer and new-detector dialogs stop asking which
-  media type you want - they lock to your chosen type.
-- Converter offerings filter to those that produce your type
-  (so picking "image" still lets you import videos-as-frames and
-  documents-as-pages, just not raw audio).
-- Your chosen type's default embedder is warmed at startup so the
-  first detector run is fast.
-
-Pick **Show everything** to opt back out. Operators can also pass
-`--solo-media-type image` (or any type id) on the command line as a
-fallback for new users - anyone who explicitly changes the setting
-overrides the CLI value for themselves.
-
-### Locking the embedder for a media type
-
-The dataset importer normally shows an **Advanced** dropdown so you
-can pick which embedding model is used (SigLIP for images, LAION-CLAP
-for audio, etc.). If you always pick the same one for a given type,
-lock it under **Appearance → Solo media embedder** in the Settings
-modal: pick one row per media type and the importer hides the
-dropdown for that type the next time you open it. Other media types
-keep the normal dropdown.
-
-Pick **Ask each time** for any type to opt back out. Operators can
-also pass `--solo-embedder image=siglip --solo-embedder audio=clap`
-on the command line as a fallback - anyone who picks their own value
-(or "Ask each time") in Settings overrides the CLI value for
-themselves, per media type.
-
----
-
 ## Region voting on images
 
-When the dataset's embedder is patch-region-aware (DINOv2, DINOv3,
-or EUPE with a `_patch` slug - set when the dataset was created),
-you can vote **good** on a *region* of the image instead of the
-whole image.  This tells the detector "this specific part is what I
-like", and the learned sort uses that hint to find similar regions
-elsewhere in the dataset.
+When the dataset's embedder supports regions - a patch-region-aware
+model (DINOv2, DINOv3, or EUPE with a `_patch` slug) or a structural
+(SIFT/VLAD) model, set when the dataset was created - you can vote
+**good** on a *region* of the image instead of the whole image. This
+tells the detector "this specific part is what I like", and the learned
+sort uses that hint to find similar regions elsewhere in the dataset.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/region-voting.dark.png" />
@@ -421,6 +389,13 @@ pan, or rotate before voting.  A click without dragging (a
 zero-area "click") restores the previously drawn rectangle rather
 than discarding it.  `Esc` clears the rectangle without voting.
 
+### The Highlight toggle
+
+The image controls also include a **Highlight** toggle ("Highlight:
+outline the region the detector matched best"). When on, VTSearch
+draws the region the current detector keyed off of for the displayed
+item, so you can see *why* it scored the way it did.
+
 ### Voting bad while a region is drawn
 
 A `←` press while a region is drawn would normally throw the
@@ -449,31 +424,179 @@ in this image is good" regardless of whether you drew a rectangle.
 Region voting is image-only.  Audio, text, video, and document
 media types have no region affordance.
 
+---
+
+## Creating a detector
+
+Every search starts from a detector. Click the **+** button on the
+**Detectors** card on the Dashboard to open the **New Detector** modal.
+It has two tabs:
+
+<!-- SCREENSHOT TODO (new-detector): The New Detector modal on the Blank tab, with the Text Example field and the media-example picker -->
+
+- **Blank** - start a fresh detector that learns from your votes as you
+  label. Give it a name, and seed it one of two ways: type a short
+  **Text Example** ("e.g. dog barking sounds"), or pick a **media
+  example** by browsing demos / server folders / uploading a file. When
+  the active dataset offers more than one kind of embedder, a **Detector
+  Embedder Type** picker appears so you can choose the scoring space:
+  **Semantic**, **Patch Semantic**, or **Structural**. That choice fixes
+  what the detector is compatible with later. If the dataset's embedder
+  can't search by text, you'll see a note that you can still create the
+  detector but must label a few examples to train it.
+- **Trained** - create a detector pre-trained on labels imported from an
+  external source. It opens a label-importer picker (file, URL, or
+  service); pick a source, fill its form, and VTSearch trains the
+  detector on the imported labels (the button reads **Create & Import**).
+
+You can also reach the Blank flow with an item pre-selected as the
+example via the right-click media context menu's **Use as detector
+seed** option (see [Tips and shortcuts](#tips-and-shortcuts)).
+
+---
+
+## Find - scoring and verifying
+
+**Find** scores an entire dataset with a detector and drops you into a
+dedicated **three-pane verification view** so you can confirm or correct
+the detector's calls before exporting. Start it from the Dashboard:
+select a dataset row and a detector row, then click **Find** in the
+action bar (VTSearch scores every item, showing progress while it runs).
+
+<!-- SCREENSHOT TODO (find-view): The Find verification view with the work queue (left), the viewer (centre), and the Verified Good / Verified Bad piles (right) -->
+
+- **Left pane** - the **work queue** of items the detector hasn't been
+  confirmed on yet, ranked by score, with the same inclusion stepper
+  you use while labeling.
+- **Centre pane** - the **viewer** with Good / Bad buttons, so you
+  verify the current item just like you vote during training.
+- **Right pane** - the **Verified Good** and **Verified Bad** piles,
+  where confirmed items accumulate.
+
+The verification view's action buttons let you act on the result:
+
+- **To Dataset** - promote the full good set (verified + unverified)
+  into its own new dataset.
+- **Add Corrections to Detector** - fold the items you changed from the
+  detector's call back into the detector's labelset and retrain it, so
+  the detector gets better at the cases it got wrong.
+- **Stats** - open the evaluation modal: a confusion matrix plus a
+  false-positive / false-negative curve across inclusion, which is the
+  clearest way to see the precision/recall trade-off the inclusion
+  stepper controls.
+- **Export** - send the good set to clipboard, a file, email, or a
+  webhook (see [Exporting your work](#exporting-your-work)).
+- **Browse** - open the positive items in the spatial
+  [Browse](#browse--exploring-a-dataset-spatially) view.
+
+<!-- SCREENSHOT TODO (find-stats): The Find Stats modal with the confusion matrix and the false-positive / false-negative vs. inclusion curve -->
+
+---
+
+## View options
+
+The controls above the media list are an inline toolbar (no "View"
+button and no separate view-settings modal). It carries just two
+controls, remembered per media type:
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/view-options.dark.png" />
+  <img src="assets/view-options.light.png" alt="The inline view-controls toolbar: thumbnail size and focus mode" width="720" />
+</picture>
+
+- **Thumbnail size** - the two image icons shrink or grow the
+  thumbnails. Larger thumbnails = fewer per screen but more readable.
+  After training, the list ranks the thumbnails by the detector's score,
+  with a threshold line marking the good/bad cut:
+
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/results-grid.dark.png" />
+    <img src="assets/results-grid.light.png" alt="The left-panel media list after training - ranked thumbnails with a threshold line" width="320" />
+  </picture>
+- **Focus mode** - Click-focus means you select an item by
+  clicking it. Hover-focus means just moving your cursor over
+  an item selects it (faster for scanning, more mis-clicks).
+
+### Solo media type - streamline for one media type
+
+If you only ever work with one kind of media (e.g. you exclusively
+search images, optionally pulled in from videos and documents via
+the built-in converters), pick that type under the **Import Defaults**
+tab in the Settings modal (**Solo media type**). Once set:
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/settings-appearance.dark.png" />
+  <img src="assets/settings-appearance.light.png" alt="The Settings, Appearance pane: theme picker, toggles, and the per-type Scroll Style controls" width="720" />
+</picture>
+
+- The dataset importer and new-detector dialogs stop asking which
+  media type you want - they lock to your chosen type.
+- Converter offerings filter to those that produce your type
+  (so picking "image" still lets you import videos-as-frames and
+  documents-as-pages, just not raw audio).
+- Your chosen type's default embedder is warmed at startup so the
+  first detector run is fast.
+
+Pick **Show everything** to opt back out. Operators can also pass
+`--solo-media-type image` (or any type id) on the command line as a
+fallback for new users - anyone who explicitly changes the setting
+overrides the CLI value for themselves.
+
+---
+
+## Settings tabs
+
+The Settings modal (gear icon) is organised into seven tabs:
+
+- **Appearance** - theme, animations, the metadata panel, the
+  **Enable achievements** toggle, and per-media-type Scroll Style
+  (focus mode and thumbnail size).
+- **Auto-Find** - detectors that auto-run on import, and what exporter
+  to send their results to.
+- **Autopilot** - the guided-workflow knobs described under
+  [Configuring Autopilot](#configuring-autopilot).
+- **Browser** - per-media-type look of the spatial Browse view (bin
+  shape, density colormap, cell size).
+- **Import Defaults** - default embedder, clipper, and converters per
+  media type, plus the **Solo media type** picker.
+- **Server** - read-only settings fixed when the server started and
+  shared by everyone.
+- **Sorting** - options that control how learned sorting and
+  calibration behave.
 
 ---
 
 ## Dashboard - managing datasets and detectors
 
 The Dashboard is your inventory view. Two tables stacked vertically
-and a pair of action buttons underneath.
+with bulk-action and per-card controls.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/dashboard-manage.dark.png" />
-  <img src="assets/dashboard-manage.light.png" alt="A dataset row and a detector row selected, with the Train / Find action bar below the tables" width="720" />
+  <img src="assets/dashboard-manage.light.png" alt="A dataset row and a detector row selected, with the per-row overflow (⋯) menu open" width="720" />
 </picture>
 
 - **Datasets** - every dataset on the server. Each row shows
-  media type, item count, duplicate count, creation date, origin,
-  clipper, and embedder. The **Loaded** column is a toggle:
-  click the **×** to load into memory (a checkmark appears when
-  it's in). Per-row icon buttons: **Browse** (eye - opens the spatial
-  map, see below), **Rename** (pencil), **Stats** (pie chart), and
-  **Delete** (trash).
-- **Detectors** - every saved detector. Each row shows media type,
-  training count, whether it's an **Auto-Find** detector (scored automatically
-  during CLI autodetect), last-trained / created dates, and loaded
-  state. Per-row icon buttons: **Rename**, **Add Labels** (import
-  labels into this detector), **Export**, and **Delete**.
+  **Type**, **# Items**, **Created**, **Age-Off**, **Creator**, and
+  **Readers**. A row that isn't in memory shows an inline **Load**
+  button, which disappears once the dataset is loaded. The name has a
+  pencil for **Rename**, **Delete** is an inline button, and the
+  remaining actions (**Browse**, **Stats**, and - on multi-user
+  deployments - access controls) live behind a **⋯** overflow menu.
+- **Detectors** - every saved detector. Like datasets, the name carries
+  a **Rename** pencil and **Delete** is inline; the **⋯** overflow menu
+  holds the rest, including **Import Labels** (import labels into this
+  detector) and **Export**.
+
+The **+** button on each card creates a new dataset (the Add Dataset
+dialog) or a new detector (the [New Detector](#creating-a-detector)
+modal).
+
+**Bulk actions.** Each table has a header **select-all** checkbox and,
+once you've selected rows, **Combine selected datasets** / **Combine
+selected detectors** and **Delete selected** buttons - so you can merge
+or clean up several at once. See
+[Combining datasets and detectors](#combining-datasets-and-detectors).
 
 **Starting a labeling session:** click a dataset row and a detector
 row to select them, then click the **Train** button in the action
@@ -481,21 +604,28 @@ bar below the two tables. That opens the three-panel labeling view
 against your selection.
 
 **Scoring a dataset:** select a dataset and a detector, then click
-**Find** in the action bar. VTSearch scores every item in the
-dataset with the detector and opens a ranked results modal.
+**Find** in the action bar to open the verification view (see
+[Find - scoring and verifying](#find--scoring-and-verifying)).
 
 You can keep multiple datasets and multiple detectors loaded at once.
 Loading just pulls them into memory; the Train / Find buttons work
 on whichever rows you currently have selected.
 
+### Combining datasets and detectors
+
+Selecting two or more rows and clicking **Combine selected datasets**
+merges them into a single new dataset; **Combine selected detectors**
+likewise merges detectors (pooling their labelsets). This is handy for
+stitching together work that started out split across several imports.
+
 ---
 
 ## Browse - exploring a dataset spatially
 
-Click the **Browse** (eye) button on any dataset row in the Dashboard to
-open a bird's-eye map of the whole collection. VTSearch projects every
-item's embedding down to two dimensions (a UMAP projection) and renders
-the result as a pannable, zoomable density map.
+Open Browse from a dataset row's **⋯** overflow menu (**Browse
+dataset**) to get a bird's-eye map of the whole collection. VTSearch
+projects every item's embedding down to two dimensions (a UMAP
+projection) and renders the result as a pannable, zoomable density map.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/browse-view.dark.png" />
@@ -545,37 +675,43 @@ returns you to the inventory.
 
 Click a tile (or drag a region) to add its items to the **Selection**
 panel on the right. The panel lists what you've picked - sortable by
-recency, name, or ID, in list or grid view - and clicking any entry drops
-it from the selection. **Clear** empties the whole selection. This is how
-you carve a region of interest out of a large collection by eye.
+recency, name, or ID - and clicking any entry drops it from the
+selection. **Clear** empties the whole selection. This is how you carve
+a region of interest out of a large collection by eye.
 
 Browse can also open **scoped to a Find result**: after scoring a dataset
-you can project just the matched items and use **Remove from Good** to
-lasso and prune false positives before exporting. (See
-[Dashboard](#dashboard--managing-datasets-and-detectors) for Find.)
+you can project just the matched items and use **Verified Good** /
+**Verified Bad** to lasso and prune false positives before exporting.
+(See [Find](#find--scoring-and-verifying).)
 
 ---
 
 ## Exporting your work
 
-From the Labeling view, the right panel's **Export** button saves
-your current labels. Formats:
+From the Labeling or Find view, the right panel's **Export** button
+saves your current labels. Formats (by their display names):
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/export-picker.dark.png" />
   <img src="assets/export-picker.light.png" alt="The exporter with a chosen format and its configuration form" width="720" />
 </picture>
 
-- **Clipboard** - copies a JSON list of `{id, label, score}` to
-  your clipboard.
-- **JSON file (server)** - saves to a file on the server via the
-  JSON exporter.
-- **CSV file (server)** - same but in CSV.
-- **Webhook** - POSTs the result to a URL you configure.
-- **Email (SMTP)** - emails the result if SMTP is configured.
+- **Server JSON File** - saves a JSON file on the server.
+- **Server CSV File** - same, but CSV.
+- **Webhook (HTTP POST)** - POSTs the result to a URL you configure.
+- **Send by Email** - emails the result if SMTP is configured.
+- **Display Results** and **Holder Package** are also available for
+  on-screen review and for bundling the matched media into a package.
 
-You can also export **detector weights** from the Detectors dashboard -
-useful for sharing a trained detector with another VTSearch instance.
+The exporter also offers a **Clipboard** copy. It copies a
+column-selected, delimited table (a header row plus one line per item),
+not a raw JSON list - the default columns are **Label**, **MD5**,
+**Filename**, and **Category**, and you can pick which columns and which
+delimiter to use.
+
+You can also export **detector weights** from the Detectors dashboard
+(the **Export** overflow item) - useful for sharing a trained detector
+with another VTSearch instance.
 
 ---
 
@@ -588,15 +724,66 @@ Two ways to bring in existing work:
   <img src="assets/import-detector.light.png" alt="The Load-sort detector picker: choose a saved detector to score a fresh dataset" width="720" />
 </picture>
 
-- **Labels** - the right panel's **Import Labels** button reads
-  a JSON or CSV of `{md5, label}` pairs and populates your vote
-  piles from it. Useful for continuing labelling across sessions
-  or merging work from multiple labellers.
-- **Detectors** - the **Load** sort mode and the Detectors
-  dashboard both have "import detector" options. A detector file
-  contains the trained detector weights plus the threshold and
-  metadata needed to score a new dataset. Once imported, you can
-  use it for Load-sort or for Auto-Find scoring.
+- **Labels** - the right panel's **Import Labels** button (also the
+  detector card's **Import Labels** overflow item) opens a label-importer
+  picker - a server-driven list of import sources, each with its own
+  small form - that populates your vote piles from the chosen source.
+  Useful for continuing labelling across sessions or merging work from
+  multiple labellers.
+- **Detectors** - the **Load** sort mode's **Sort by Detector** option
+  lists the saved detectors already in the registry, so you can score a
+  fresh dataset with one without retraining. (There is no separate
+  detector-file upload step in the labeling UI; detectors come in via the
+  registry and via [Find](#find--scoring-and-verifying).)
+
+---
+
+## Achievements
+
+VTSearch has an optional light gamification layer. When **Enable
+achievements** is on (Settings → Appearance), a **trophy button**
+appears; click it to open the **Achievements** panel, which lists the
+achievements and your tier progress on each. As you use the app, hitting
+a milestone fires a small **unlock toast**.
+
+<!-- SCREENSHOT TODO (achievements): The Achievements panel with tiered achievements and the code-phrase entry box -->
+
+A few achievements unlock via a **code phrase** rather than usage: docs
+(like this guide) hide a phrase, and pasting it into the panel's code box
+("Paste a code phrase") and clicking **Submit** unlocks the matching
+achievement. The footer line of this guide is one such phrase.
+
+Turning **Enable achievements** off zeros all counters and tier progress
+and hides the trophy button and unlock pop-ups until you turn it back on.
+
+---
+
+## Tips and shortcuts
+
+- **Top-bar dataset/detector pulldowns.** The pulldowns in the top bar
+  let you switch the active dataset or detector without going back to the
+  Dashboard, and offer an "Add New" shortcut to create one.
+- **Keyboard shortcuts and the in-app guide.** Press **`?`** any time to
+  open the help sheet. It has two tabs: a **Keyboard shortcuts**
+  reference and a **User guide** that renders this document inside the
+  app (matching your theme).
+- **Right-click a media item** for a context menu: **Sort by similarity
+  to this**, **Crop, then sort by similarity…** (audio/image), **Use as
+  detector seed**, and **Crop, then use as detector seed…**. The crop
+  options open the **crop modal**, where you trim an image region or
+  audio span before using the item as a sort example or detector seed.
+- **The Autopilot resort prompt.** When you sort by an example and then
+  move on, VTSearch may ask whether to update the sort to your new
+  example (**Update Sort Example?**) or **Keep Current**.
+- **Drag-and-drop upload.** Importer file fields are drop zones - drag
+  files (or a folder) onto them instead of clicking to browse.
+- **Login-gated deployments.** Some servers ask for your name on first
+  load before you can start.
+- **Offline banner.** If the app can't reach the server, a banner reads
+  "Can't reach the server. Background updates are paused." with a
+  **Retry** button.
+- **Toasts.** Transient confirmations and errors appear as toast
+  notifications in the corner.
 
 ---
 

--- a/docs/user/screenshots.manifest.ts
+++ b/docs/user/screenshots.manifest.ts
@@ -59,8 +59,6 @@ export interface Helpers {
   leftTab(name: 'Autopilot' | 'Manual'): Promise<void>;
   /** Select the first media item so the centre viewer + vote buttons render. */
   serveItem(): Promise<void>;
-  /** Switch the left-panel media list to grid (thumbnail) layout. */
-  gridView(): Promise<void>;
   /** Open Browse for the fixture dataset and wait for the map to render. */
   openBrowse(): Promise<void>;
 }
@@ -172,7 +170,7 @@ export const SHOTS: Shot[] = [
   {
     id: 'autopilot-progress',
     embeddedIn: 'docs/user/USER_GUIDE.md#the-collapsed-bar',
-    caption: 'The Autopilot phase panel: the four phases (Good examples, Bad examples, Boundary refinement, Diversity) tracked in order',
+    caption: 'The Autopilot phase panel: the four phases (Find Initial Goods, Find Initial Bads, Refine Boundary, Explore Diversity) tracked in order',
     themes: BOTH,
     clip: { selector: '.autopilot-panel' },
     async recipe(_page, h) {
@@ -246,27 +244,30 @@ export const SHOTS: Shot[] = [
   {
     id: 'view-options',
     embeddedIn: 'docs/user/USER_GUIDE.md#view-options',
-    caption: 'The view settings: List vs. grid, grid icon size, and focus mode (Settings → Appearance → Scroll Style)',
+    caption: 'The in-panel view controls in the left-panel header: thumbnail size (smaller/bigger) and focus mode (click vs. hover preview)',
     themes: BOTH,
+    // The view controls are an inline `vt-view-controls` toolbar in the left
+    // panel header during the label view, not a Settings pane. Frame just that
+    // toolbar via clip.
+    clip: { selector: 'vt-view-controls' },
     async recipe(_page, h) {
-      await h.dashboard();
-      await h.openSettings();
+      await h.enterLabelView();
+      await h.leftTab('Manual');
     },
   },
   {
     id: 'results-grid',
     embeddedIn: 'docs/user/USER_GUIDE.md#view-options',
-    caption: 'The left-panel media list in grid view after training — ranked thumbnails',
+    caption: 'The left-panel media list after training — ranked thumbnails',
     themes: BOTH,
     clip: { selector: '.panel-left' },
     async recipe(page, h) {
       await h.enterLabelView();
       await h.leftTab('Manual');
-      // Rank by the trained detector and show the list as a thumbnail grid.
+      // The media list is always a thumbnail grid; just rank by the trained
+      // detector (the list/grid toggle was removed in 27854785).
       await page.locator('.sort-radio', { hasText: 'Learned' }).first().click();
       await h.wait(2500);
-      await h.gridView();
-      await h.wait(800);
     },
   },
   {
@@ -287,10 +288,16 @@ export const SHOTS: Shot[] = [
     annotations: [
       { target: '.dashboard-actions', kind: 'highlight', label: 'Train opens labeling; Find scores the dataset' },
     ],
-    async recipe(_page, h) {
+    async recipe(page, h) {
       await h.dashboard();
       await h.selectDatasetRow('syn-imgs');
       await h.selectDetectorRow('doc-demo');
+      // Open the dataset row's ⋯ overflow menu so the shot shows where Browse,
+      // Stats, Rename, and (for detectors) Export now live.
+      await page.locator('vt-dataset-card', { hasText: 'syn-imgs' }).first()
+        .locator('.overflow-btn').first().click();
+      await page.waitForSelector('.context-menu', { timeout: 10000 });
+      await h.wait(400);
     },
   },
   {

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -13,31 +13,41 @@
 ## Methodology
 
 The inventory was assembled by walking the library tree under `vtscore/` and
-identifying public symbols (no leading underscore) in each library subpackage,
-cross-referenced against each package's `__init__.py` re-exports. Every package below
-lives at its final library path. `vtsearch.state` is an app-tier shim that re-exports
-`vtscore.state` plus the proxy view (`medias`, `good_votes`, …); library callers
-should use `vtscore.state`, app callers may continue using either.
+identifying public symbols (no leading underscore) in each library subpackage.
+`vtsearch.state` is an app-tier shim that re-exports `vtscore.state` plus the
+proxy view (`medias`, `good_votes`, …); library callers should use
+`vtscore.state`, app callers may continue using either.
 
-| Library import path         | Notes                                                       |
-|------------------------------|-------------------------------------------------------------|
-| `vtscore.datasets.X`         |                                                             |
-| `vtscore.media.X`            |                                                             |
-| `vtscore.converters.X`       |                                                             |
-| `vtscore.labels.X`           |                                                             |
-| `vtscore.embedding.X`        |                                                             |
-| `vtscore.training.X`         |                                                             |
-| `vtscore.detectors.X`        |                                                             |
-| `vtscore.eval.X`             |                                                             |
-| `vtscore.state.X`            | Contexts + helpers; the `medias` / `good_votes` proxies are app-side in `vtsearch.state_proxies` |
-| `vtscore.plugins.X`          |                                                             |
-| `vtscore.sync.X`             |                                                             |
-| `vtscore.concurrency.X`      |                                                             |
-| `vtscore.security.X`         |                                                             |
-| `vtscore.utils.X`            |                                                             |
-| `vtscore.exporters.X`        |                                                             |
-| `vtscore.cli` etc.           |                                                             |
-| `vtscore.config`             |                                                             |
+### Import-path reality (read before copy-pasting)
+
+This sketch is a **logical inventory**, not a re-export contract. Most package
+`__init__.py` files do **not** re-export the full surface, and two subpackages
+have **no `__init__.py` at all** (PEP 420 namespace packages). Import from the
+**defining module**, using the real dotted path:
+
+| Logical group          | Import from (real path)                                         |
+|------------------------|----------------------------------------------------------------|
+| `vtscore.datasets`     | `vtscore.datasets` re-exports the loader/registry/`get_importer` surface; demo helpers live in their submodules. |
+| `vtscore.media`        | `vtscore.media` re-exports the registry helpers (`get`, `get_embedder`, `set_progress_callback`, …). |
+| `vtscore.converters`   | `vtscore.converters` (`get_converter`, `list_converters`).     |
+| `vtscore.labels`       | **No package-root re-exports.** Importers: `vtscore.labels.importers.get_label_importer` / `list_label_importers`. Sources: `vtscore.labels.sources.get_labelset_source` / `list_labelset_sources`. Sync: `vtscore.labels.sync`. |
+| `vtscore.embedding`    | `vtscore.embedding` re-exports the embed/loader helpers.        |
+| `vtscore.training`     | `vtscore.training` re-exports `build_model`/`train_model`/threshold helpers; `SVMClassifier` is at `vtscore.training.svm`, region helpers at `vtscore.training.region_similarity`. |
+| `vtscore.detectors`    | **`__init__` is a docstring only — no re-exports.** Use the submodule: `vtscore.detectors.registry.list_detectors`, `vtscore.detectors.workflow.apply_and_retrain`, etc. |
+| `vtscore.eval`         | `vtscore.eval` re-exports some runners/metrics; the dataclasses live at `vtscore.eval.metrics` (e.g. `vtscore.eval.metrics.QueryMetrics`). |
+| `vtscore.state`        | `vtscore.state` — contexts + helpers. The `medias` / `good_votes` proxies are app-side in `vtsearch.state_proxies`. |
+| `vtscore.plugins`      | `vtscore.plugins` (`PluginBase`, `PluginField`, `make_plugin_registry`). |
+| `vtscore.sync`         | `vtscore.sync` (`SyncSource`).                                  |
+| `vtscore.concurrency`  | **Namespace package (no `__init__.py`).** Always use the submodule: `vtscore.concurrency.progress.ProgressTracker`, `vtscore.concurrency.async_jobs.JobManager` / `eval_jobs` / `learned_sort_jobs`, `vtscore.concurrency.memory_budget.cap_workers_by_memory`. |
+| `vtscore.security`     | **Namespace package (no `__init__.py`).** Always use the submodule: `vtscore.security.pickle.safe_pickle_load` / `RestrictedUnpickler`, `vtscore.security.path_validation.validate_server_filepath`, `vtscore.security.url_validation.validate_url`. |
+| `vtscore.utils`        | `vtscore.utils` plus `vtscore.utils.synthetic`.                |
+| `vtscore.exporters`    | `vtscore.exporters` (`get_exporter`, `list_exporters`).        |
+| `vtscore.cli` etc.     | `vtscore.cli`, `vtscore.cli_pipeline`, `vtscore.cli_progress`. |
+| `vtscore.config`       | `vtscore.config`.                                               |
+
+The per-package sections below group symbols **by intent**; consult this table
+(or the `__init__.py` / source file) for the concrete import path of any given
+symbol.
 
 Symbols flagged **[SEAM]** import `flask` or `vtsearch.settings` today and must be
 detangled before they can ship in `vtscore`. They are listed here because they belong
@@ -173,7 +183,7 @@ def load_dataset_from_folder(
 
 def load_dataset_from_pickle(path: Path | str) -> tuple[list[Media], list[Embedding]]:
     """Restore a (media, embedding) snapshot previously written by export_dataset_to_file.
-    Uses vtscore.security.safe_pickle_load; no arbitrary code execution risk."""
+    Uses vtscore.security.pickle.safe_pickle_load; no arbitrary code execution risk."""
 
 def load_demo_dataset(dataset_id: str, *, progress=None) -> tuple[list[Media], list[Embedding]]:
     """Download (if needed) and load one of the built-in demo datasets keyed by
@@ -319,15 +329,17 @@ def all_demo_datasets() -> dict[str, DemoDataset]: ...
 def normalize_type_id(type_id: str) -> str: ...
 def set_progress_callback(cb: ProgressCallback) -> None:
     """Global default progress callback for media-registry operations.
-    A per-thread override via set_thread_progress_callback takes priority when set."""
+    This is the ONLY progress hook the media registry exposes today."""
 
-def set_thread_progress_callback(cb: ProgressCallback | None) -> None:
-    """Set a progress callback for the current thread only. Multi-threaded library
-    consumers (e.g. parallel evaluation harnesses) should use this to avoid one
-    thread clobbering another's callback. None clears the thread override and
-    falls back to the global. Mirrors vtscore.concurrency.progress.set_thread_progress."""
-
-def get_thread_progress_callback() -> ProgressCallback | None: ...
+# --- NOT IMPLEMENTED (Phase 1 decision #4, not yet shipped) ---
+# The plan calls for a per-thread override mirroring
+# vtscore.concurrency.progress.set_thread_progress, but
+# vtscore.media currently exposes ONLY set_progress_callback above.
+# These two names do not exist yet; do not import them:
+#   set_thread_progress_callback(cb: ProgressCallback | None) -> None
+#   get_thread_progress_callback() -> ProgressCallback | None
+# (For per-thread progress today, use
+#  vtscore.concurrency.progress.set_thread_progress / get_thread_progress.)
 ```
 
 ### Embedder registry

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -204,23 +204,14 @@ function makeHelpers(page: Page): Helpers {
       await page.waitForSelector('.btn-good', { timeout: 15000 }).catch(() => {});
       await wait(900);
     },
-    async gridView() {
-      const left = page.locator('.panel-left');
-      const candidates = [
-        left.locator('[title*="grid" i]'),
-        left.locator('[aria-label*="grid" i]'),
-        left.locator('.vc-btn').nth(1),
-      ];
-      for (const c of candidates) {
-        if (await c.count()) { await c.first().click().catch(() => {}); break; }
-      }
-      await wait(600);
-    },
     async openBrowse() {
       await h.dashboard();
-      // Browse (eye) button on the dataset card.
-      await page.locator('vt-dataset-card', { hasText: 'syn-imgs' }).first()
-        .locator('.browse-btn').first().click();
+      // Browse moved into the dataset row's ⋯ overflow menu (the inline eye is
+      // gone; it now only renders as a *disabled* projection-building button).
+      // Open the overflow menu, then click its "Browse dataset" item.
+      const card = page.locator('vt-dataset-card', { hasText: 'syn-imgs' }).first();
+      await card.locator('.overflow-btn').first().click();
+      await page.locator('.context-menu .menu-item', { hasText: 'Browse dataset' }).first().click();
       await page.waitForURL(/browse/i, { timeout: 15000 }).catch(() => {});
       // First visit builds the UMAP projection (progress bar); wait it out.
       await page.waitForSelector('.browse-content, canvas', { timeout: 180000 });


### PR DESCRIPTION
## What this is

A systemic documentation audit after ~170 frontend commits of drift, plus every browser-independent fix applied. Seven parallel agents verified each doc against the live frontend (`frontend/src/app`), backend routes (`vtsearch/`), library (`vtscore/`), the OpenAPI snapshot, the install/deploy scripts, and the Dockerfiles.

The screenshots themselves still need recapturing in a browser-capable environment — this PR fixes everything that **doesn't** need a browser and leaves a turnkey plan for the capture pass.

## The audit

`docs/plans/docs-audit-2026-06-28.md` is the deliverable: which screenshots to retake and why, which features need new screenshots, all prose fixes, and ready-to-paste recipes for the deferred new shots.

**Screenshots to retake (7 of 16):** `view-options`, `results-grid`, `dashboard-loaded` (README hero), `dashboard-manage`, `settings-appearance`, `browse-view`, `importer-picker` — driven by the removed List/grid toggle, the dashboard `⋯` overflow menu, the Settings-tab reorg, and the new demo-importer tab bar.

**New screenshots needed:** Find verification view, Find Stats modal, new-detector modal, achievements panel — all features with no visual today.

## Fixes applied (no browser needed)

- **USER_GUIDE**: rewrote View options (no more List/grid or "View modal"); corrected Autopilot phase/config labels, dashboard columns, sort order, the inclusion *stepper* (it retrains — the guide said the opposite), export/clipboard formats, Browse/Find labels. Added new sections: Creating a detector, Find — scoring & verifying, Achievements, Settings-tabs overview, Combining datasets/detectors, Tips & shortcuts. New screenshots are marked with comment placeholders (no live embeds, so the wiring-check gate stays green).
- **README**: replaced the stale `vtsearch/`-only project tree with the app-tier/library-tier (`vtscore/`) split + pointer to ARCHITECTURE; led with the visitor path.
- **demos.md**: completed the demo catalogue (added the missing video/text/audio/image families); de-duplicated the loading walkthrough with USER_GUIDE.
- **Dev docs**: ML.md inclusion is threshold-only (not training); fixed ARCHITECTURE's non-running `train_model` example; added the VTSBrowse projection subsystem to the map; fixed the EVAL dataset table; EXTENDING-processors path + EXTENDING-media embedder tables.
- **Operator docs**: five embedding models (not four); corrected concurrency defaults; reverse-proxy + `VTSEARCH_VERSION` build-arg notes; removed HANDOFF's false CI claim; documented `--login api_key` / `--port` / `--progress-format`.
- **API docs**: replaced io.md's nonexistent `processor-importers` with the real `pregen-processors` + autorun CRUD; fixed vtscore-api.md import paths (namespace packages); `media_type` field fixes; eval train-and-score async companions.
- **Screenshot harness**: `openBrowse()` now goes through the `⋯` menu, `gridView()` removed, `view-options` re-targeted to the real in-panel toolbar, `dashboard-manage` opens the overflow menu, captions fixed. No new manifest entries (they need the PNGs first).

## Open follow-ups

Recorded in `docs/plans/docs-audit-2026-06-28.md`: run `scripts/screenshots/refresh.sh` in a browser env, retake the 7 stale shots + capture the 4 new ones, then add their manifest entries.

## One thing for a maintainer

Node version is inconsistent repo-wide (docs + CLAUDE.md say 22+, every Dockerfile uses `node:20-slim`). Left untouched — it needs a decision, not a guess.

## Testing

`./run-tests.sh` — **ALL 5251 tests passed** (1 skipped). wiring-check, codespell, ruff format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBjEVvWaTRjPEXSehidKeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBjEVvWaTRjPEXSehidKeJ)_