### PR TITLE
Drive import progress bars from live module count instead of showing 100% while running

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -1020,3 +1020,61 @@ class TestTimedProgress:
         captured = capsys.readouterr()
         # Should see the initial message and at least one elapsed update
         assert "Importing torch…" in captured.out
+
+    def test_est_modules_drives_bar_from_module_count(self):
+        """With est_modules the bar starts at 0 and is driven by the live
+        module-count delta, clamped one below the estimate so a running import
+        can never report 100% (the snap to done is signalled externally)."""
+        import sys
+        import time
+        import types
+
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append((current, total))
+
+        fake = [f"_vt_est_fake_mod_{i}" for i in range(5)]
+        try:
+            with timed_progress(cb, "loading", "Importing thing…", est_modules=3):
+                for name in fake:
+                    sys.modules[name] = types.ModuleType(name)
+                time.sleep(1.5)
+        finally:
+            for name in fake:
+                sys.modules.pop(name, None)
+
+        # The bar starts empty (0 of the estimate), not at the estimate.
+        assert calls[0] == (0, 3)
+        # Every emit reports the estimate as the denominator…
+        assert all(total == 3 for _, total in calls)
+        # …and never reaches it while running, even though 5 (> est) modules
+        # were registered — clamped to est - 1 = 2.
+        assert all(current <= 2 for current, _ in calls)
+        # The ticker did move the bar off zero once modules loaded.
+        assert any(current > 0 for current, _ in calls)
+
+    def test_est_modules_console_bar_never_full_while_running(self, capsys):
+        """A running est_modules import renders a climbing console bar that
+        never shows 100% (that only happens on completion, via the next phase
+        message or cb.flush())."""
+        import sys
+        import time
+        import types
+
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        fake = [f"_vt_est_con_mod_{i}" for i in range(8)]
+        try:
+            with timed_progress(cb, "loading", "Importing thing…", est_modules=4):
+                for name in fake:
+                    sys.modules[name] = types.ModuleType(name)
+                time.sleep(1.5)
+        finally:
+            for name in fake:
+                sys.modules.pop(name, None)
+
+        out = capsys.readouterr().out
+        assert "Importing thing…" in out
+        # Bar climbs (8 modules clamped to 3/4 = 75%) but never completes here.
+        assert "100%" not in out

--- a/vtscore/docs/extending/embedders.md
+++ b/vtscore/docs/extending/embedders.md
@@ -101,6 +101,11 @@ keep heavy loads non-blocking from the UI's point of view:
 - `timed_progress(on_progress, status, message, ...)` - context
   manager that appends an elapsed-time suffix to a long-running
   import or load step every second, so the UI doesn't look frozen.
+  Pass `est_modules=IMPORT_MODULE_ESTIMATES["<lib>"]` to *drive* the
+  bar from the live `sys.modules` delta: it starts at 0 %, climbs as
+  submodules load, and is clamped below 100 % until the import returns
+  (so a still-importing step never reads as done). Without it the
+  passed `current`/`total` are forwarded unchanged.
 - `load_pretrained_local_first(load_fn, *args, **kw)` - tries
   `local_files_only=True` first so a slow Hub round-trip doesn't
   stall a cached model load, then falls back to a network load with
@@ -178,6 +183,7 @@ from typing import Any, Optional
 import numpy as np
 
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     intercept_tqdm_progress,
@@ -216,7 +222,12 @@ class TextMiniLMEmbedder(MediaEmbedder):
     def _load_models_impl(self) -> None:
         if self._model is not None:
             return
-        with timed_progress(self._on_progress, "loading", "Importing sentence-transformers…", 1, 2):
+        with timed_progress(
+            self._on_progress,
+            "loading",
+            "Importing sentence-transformers…",
+            est_modules=IMPORT_MODULE_ESTIMATES["sentence_transformers"],
+        ):
             from sentence_transformers import SentenceTransformer  # noqa: PLC0415
         cache_dir = embedder_load_setup(self._on_progress, "Loading MiniLM weights…")
         with intercept_tqdm_progress(self._on_progress):

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -263,12 +263,22 @@ def initialize_models(on_progress: ProgressCallback | None = None) -> None:
         _warm()
         _bridge()
     else:
-        from vtscore.media.embedder import timed_progress  # noqa: PLC0415
+        from vtscore.media.embedder import IMPORT_MODULE_ESTIMATES, timed_progress  # noqa: PLC0415
 
         console_cb = _make_console_progress(on_progress)
-        with timed_progress(console_cb, "loading", "Importing scikit-learn…", 1, 2):
+        with timed_progress(
+            console_cb, "loading", "Importing scikit-learn…", est_modules=IMPORT_MODULE_ESTIMATES["sklearn"]
+        ):
             _warm()
-        with timed_progress(console_cb, "loading", "Importing transformers…", 2, 2):
+        # The transformers import here is only the lightweight logging bridge,
+        # not the full model classes, so it pulls in far fewer modules than an
+        # embedder's ``from transformers import …``.
+        with timed_progress(
+            console_cb,
+            "loading",
+            "Importing transformers…",
+            est_modules=IMPORT_MODULE_ESTIMATES["transformers_logging"],
+        ):
             _bridge()
         console_cb.flush()  # type: ignore[attr-defined]
 

--- a/vtscore/media/audio/_clap_shared.py
+++ b/vtscore/media/audio/_clap_shared.py
@@ -35,6 +35,7 @@ from vtscore.config import CLAP_SAMPLE_RATE
 # extractor then takes its equal-length branch and never crops.
 CLAP_MAX_SAMPLES = 480000
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -87,16 +88,24 @@ class _ClapBase(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing librosa…", est_modules=IMPORT_MODULE_ESTIMATES["librosa"]
+        ):
             import librosa  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing soundfile…", 4, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing soundfile…", est_modules=IMPORT_MODULE_ESTIMATES["soundfile"]
+        ):
             import soundfile  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, f"Loading {self.label} model weights…")

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from vtscore.config import AST_MODEL_ID, AST_SAMPLE_RATE
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -66,13 +67,19 @@ class AudioASTEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import ASTFeatureExtractor, ASTModel  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing librosa…", est_modules=IMPORT_MODULE_ESTIMATES["librosa"]
+        ):
             import librosa  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading AST model weights…")

--- a/vtscore/media/audio/embedder_paraspeechclap.py
+++ b/vtscore/media/audio/embedder_paraspeechclap.py
@@ -41,6 +41,7 @@ from vtscore.config import (
     PARASPEECHCLAP_TEXT_MODEL_ID,
 )
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     intercept_tqdm_progress,
@@ -89,16 +90,24 @@ class AudioParaSpeechClapEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import AutoTokenizer, Wav2Vec2FeatureExtractor  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing librosa…", est_modules=IMPORT_MODULE_ESTIMATES["librosa"]
+        ):
             import librosa  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing soundfile…", 4, 4):
+        with timed_progress(
+            self._on_progress, "loading", "Importing soundfile…", est_modules=IMPORT_MODULE_ESTIMATES["soundfile"]
+        ):
             import soundfile  # noqa: F401, PLC0415
 
         from huggingface_hub import hf_hub_download  # noqa: PLC0415

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from vtscore.config import WHISPER_MODEL_ID, WHISPER_SAMPLE_RATE
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -73,13 +74,19 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import WhisperFeatureExtractor, WhisperModel  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing librosa…", est_modules=IMPORT_MODULE_ESTIMATES["librosa"]
+        ):
             import librosa  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading Whisper encoder weights…")

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DEFAULT_EMBED_BATCH_SIZE",
+    "IMPORT_MODULE_ESTIMATES",
     "MediaEmbedder",
     "embedder_load_setup",
     "extract_tensor",
@@ -35,6 +36,29 @@ __all__ = [
 
 
 DEFAULT_EMBED_BATCH_SIZE = 32
+
+#: Rough module-count estimates used only to *pace* the "Importing …" progress
+#: bars: :func:`timed_progress` divides the live ``sys.modules`` delta by the
+#: matching value to fill the bar.  Python reports no advance count of how many
+#: submodules an ``import`` will pull in, and the delta is heavily
+#: context-dependent — a bare ``import torch`` is ~1000 modules, but
+#: ``from transformers import CLIPModel`` *after* torch is ~2600, while the
+#: startup logging-bridge import of transformers is only ~170.  So these are
+#: deliberately per-call-site approximations, not exact totals: the bar is
+#: clamped just below 100 % and only snapped to 100 % once the import actually
+#: returns (by the next phase message or ``cb.flush()``), so an off estimate
+#: merely paces the bar and can never report a still-running import as finished.
+IMPORT_MODULE_ESTIMATES: dict[str, int] = {
+    "torch": 1100,
+    "torch_hub": 50,
+    "torchvision": 1100,
+    "transformers": 2700,
+    "transformers_logging": 190,
+    "sentence_transformers": 3300,
+    "sklearn": 1700,
+    "librosa": 30,
+    "soundfile": 160,
+}
 
 
 def resolve_embed_batch_size(default: int = DEFAULT_EMBED_BATCH_SIZE) -> int:
@@ -133,6 +157,7 @@ def timed_progress(
     message: str,
     current: int = 0,
     total: int = 0,
+    est_modules: int | None = None,
 ) -> Any:
     """Show elapsed time in the progress message while a block executes.
 
@@ -149,11 +174,35 @@ def timed_progress(
     The initial progress update is sent immediately (without a time suffix).
     After the first second the background ticker appends the elapsed-time
     and module-count suffix until the ``with`` block exits.
+
+    When *est_modules* is given (a rough count of how many modules the wrapped
+    import pulls in, see :data:`IMPORT_MODULE_ESTIMATES`), the bar is *driven*
+    by that live module delta: it starts at 0 %, climbs as submodules load, and
+    is clamped to one below *est_modules* so it can never read 100 % while the
+    import is still running.  Completion is signalled by the surrounding layers
+    (the next phase message or ``cb.flush()`` on the console, the next job step
+    on the web), so a too-small or too-large estimate only paces the bar — it
+    never claims a still-running import has finished.  Without *est_modules* the
+    passed *current*/*total* are forwarded unchanged (e.g. a fixed step counter
+    or an indeterminate ``0/0`` phase message).
     """
     import sys  # noqa: PLC0415
 
     stop = threading.Event()
     baseline_modules = len(sys.modules)
+    est_total = est_modules if (est_modules is not None and est_modules > 0) else 0
+    use_est = est_total > 0
+    if use_est:
+        # The module-count delta is the progress signal; start the bar empty.
+        current, total = 0, est_total
+
+    def _bar_current(loaded: int) -> int:
+        if not use_est:
+            return current
+        # Clamp one below the estimate so a running import never fills the bar;
+        # the snap to 100 % happens when the block exits and the next message
+        # (or flush) completes the bar.
+        return max(0, min(loaded, est_total - 1))
 
     def _ticker() -> None:
         start = time.monotonic()
@@ -161,7 +210,7 @@ def timed_progress(
             elapsed = int(time.monotonic() - start)
             loaded = len(sys.modules) - baseline_modules
             suffix = f"({elapsed}s, {loaded} modules)" if loaded > 0 else f"({elapsed}s)"
-            on_progress(status, f"{message} {suffix}", current, total)
+            on_progress(status, f"{message} {suffix}", _bar_current(loaded), total)
 
     on_progress(status, message, current, total)
     t = threading.Thread(target=_ticker, daemon=True)

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from vtscore.config import DINOV2_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -64,10 +65,14 @@ class _Dinov2Base(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import AutoImageProcessor, AutoModel  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading DINOv2 model weights…")

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from vtscore.config import DINOV3_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -75,10 +76,14 @@ class _Dinov3Base(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import AutoImageProcessor, AutoModel  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading DINOv3 model weights…")

--- a/vtscore/media/image/_eupe_shared.py
+++ b/vtscore/media/image/_eupe_shared.py
@@ -36,6 +36,7 @@ import numpy as np
 
 from vtscore.config import EUPE_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     intercept_tqdm_progress,
@@ -94,13 +95,19 @@ class _EupeBase(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing torchvision…", 2, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torchvision…", est_modules=IMPORT_MODULE_ESTIMATES["torchvision"]
+        ):
             from torchvision import transforms  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing torch.hub…", 3, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch.hub…", est_modules=IMPORT_MODULE_ESTIMATES["torch_hub"]
+        ):
             import torch.hub  # noqa: F401, PLC0415
 
         # Point torch.hub at our shared model cache so that pre-baked

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from vtscore.config import CLIP_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
@@ -55,10 +56,14 @@ class ImageClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLIP model weights…")

--- a/vtscore/media/image/embedder_face.py
+++ b/vtscore/media/image/embedder_face.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
-from vtscore.media.embedder import MediaEmbedder, timed_progress, to_compute_device
+from vtscore.media.embedder import IMPORT_MODULE_ESTIMATES, MediaEmbedder, timed_progress, to_compute_device
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
@@ -73,7 +73,9 @@ class ImageFaceEmbedder(MediaEmbedder):
     def _load_models_impl(self) -> None:
         if self._model is not None:
             return
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
         with timed_progress(self._on_progress, "loading", "Loading FaceNet weights…", 2, 2):

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from vtscore.config import SIGLIP_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
@@ -69,10 +70,14 @@ class ImageSiglipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP model weights…")

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from vtscore.config import SIGLIP2_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
@@ -61,10 +62,14 @@ class ImageSiglip2Embedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import AutoModel, AutoProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP 2 model weights…")

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from vtscore.config import BGE_MODEL_ID, resolve_device
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -80,13 +81,22 @@ class TextBGEEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import BertModel  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing sentence_transformers…", 3, 3):
+        with timed_progress(
+            self._on_progress,
+            "loading",
+            "Importing sentence_transformers…",
+            est_modules=IMPORT_MODULE_ESTIMATES["sentence_transformers"],
+        ):
             from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading BGE model…")

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from vtscore.config import E5_MODEL_ID, resolve_device
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -84,13 +85,22 @@ class TextE5Embedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import BertModel  # noqa: PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing sentence_transformers…", 3, 3):
+        with timed_progress(
+            self._on_progress,
+            "loading",
+            "Importing sentence_transformers…",
+            est_modules=IMPORT_MODULE_ESTIMATES["sentence_transformers"],
+        ):
             from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading E5 model…")

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from vtscore.config import LANGUAGEBIND_VIDEO_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -100,10 +101,17 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch...", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch...", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers...", 2, 2):
+        with timed_progress(
+            self._on_progress,
+            "loading",
+            "Importing transformers...",
+            est_modules=IMPORT_MODULE_ESTIMATES["transformers"],
+        ):
             from transformers import AutoModel, AutoTokenizer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading LanguageBind model weights...")

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from vtscore.config import VIDEOMAE_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     hf_token,
@@ -139,10 +140,17 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch...", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch...", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers...", 2, 2):
+        with timed_progress(
+            self._on_progress,
+            "loading",
+            "Importing transformers...",
+            est_modules=IMPORT_MODULE_ESTIMATES["transformers"],
+        ):
             from transformers import AutoModel  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading VideoMAE v2 model weights...")

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from vtscore.config import XCLIP_MODEL_ID
 from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
     MediaEmbedder,
     embedder_load_setup,
     extract_tensor as _extract_tensor,
@@ -66,10 +67,14 @@ class VideoXClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
             from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading X-CLIP model weights…")


### PR DESCRIPTION
## Problem

The CLI startup bars (and every per-embedder model-load bar) abused the
`timed_progress` `(current, total)` arguments as a **"step N of M" phase
counter**, which the renderer turned straight into the fill percentage. So
the *last* import step sat pinned at **100% the entire time it was still
running**:

```
    Importing transformers…          [##############################] 100% (6s, 167 modules)
```

That reads as "done" when it's actually an indeterminate, in-progress import —
"we've loaded 167 modules; we don't know how many there'll be."

## Fix

Add an opt-in `est_modules` parameter to `timed_progress`. When given, the bar
is **driven by the live `sys.modules` delta** instead of a static step
counter: it starts at **0%**, climbs as submodules load, and is clamped one
below the estimate so a running import can never read 100%. Completion is
snapped to 100% by the existing layers (the next phase message / `cb.flush()`
on the console; the next job step on the web). Now:

```
    Importing transformers…          [..............................]   0%
    Importing transformers…          [#########.....................]  32% (2s, 61 modules)
    Importing transformers…          [##################............]  63% (3s, 121 modules)
    Importing transformers…          [############################..]  95% (4s, 181 modules)
    Importing transformers…          [##############################] 100%
```

### Can we guess the denominator?

Yes, approximately. Python gives no advance count of how many submodules an
`import` will pull in, and the delta is **heavily context-dependent** — I
measured the same `from transformers import …` at ~167 modules during startup
(the lightweight logging bridge, with torch already loaded) versus ~2600 when
an embedder pulls full model classes. So the estimates live in a per-call-site
table (`IMPORT_MODULE_ESTIMATES`) rather than a single global guess. Because
the bar is clamped below 100% and only snapped on actual completion, an off
estimate merely paces the bar — it can never report a still-running import as
finished.

## Scope

- `timed_progress(..., est_modules=…)` — the engine change.
- `IMPORT_MODULE_ESTIMATES` table (torch, transformers, the lightweight
  transformers logging bridge, sentence_transformers, torchvision, torch.hub,
  sklearn, librosa, soundfile).
- Startup `initialize_models` scikit-learn / transformers bars.
- Every embedder `_load_models_impl` "Importing X…" step (16 files).

The frontend already rendered genuinely-indeterminate progress correctly
(`progressBarState` returns `indeterminate: true` with value 0 when
`total <= 0`), so no frontend change was needed. The non-import
`"Loading FaceNet weights…"` step is left as-is — it's a weight download with
no module-count signal to drive a bar from.

## Tests

- New unit tests for the `est_modules` path: starts at 0, reports the estimate
  as the denominator, clamps to `est - 1` while running (never 100%), and
  moves off zero once modules load — plus a console-render test asserting the
  bar never shows 100% mid-import.
- Existing `timed_progress` / console tests (the no-`est` passthrough path) are
  unchanged and still pass.
- Full `./run-tests.sh` green (5253 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyrndPCf7tcQc45zeaQe5D)_