### PR TITLE
Make dataset-load progress weights GPU-aware

### DIFF
--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -105,17 +105,38 @@ still got "knocked around" between stages. Fixed the concrete jump sources:
   the real reported value, never ahead of it (no fake/timer-driven motion — that
   approach was explicitly rejected).
 
+## GPU pacing profile (shipped)
+
+The static load weights `[0.25, 0.10, 0.55, 0.10]` assumed embedding dominates
+wall-clock — true on a CPU host, false on a GPU one. On a GPU the embed phase is
+several times faster, but the finalize phase is **not** GPU-accelerated: the
+registry save (serialize → zip → disk write) is always CPU, and the
+diversity-tree k-means only moves to the GPU when cuML is installed (a
+best-effort RAPIDS dep that is frequently absent). So on a GPU host finalize
+dominated wall-clock while still getting only 10 % of the bar — the bar raced to
+~90 % during embed, then crawled through the last 10 % for 20+ seconds while the
+rate-based ETA (computed mostly from the fast embed phase) reported "< 5 sec
+left".
+
+Fixed by making the weights device-aware (`load_step_weights()` in
+`stages/_common.py`, resolved once at task creation): the CPU profile is
+unchanged, and a GPU profile `[0.20, 0.10, 0.30, 0.40]` shrinks embed and grows
+finalize so the bar paces by real time and the overall ETA has room to
+self-correct through the diversity-tree build + registry save. Detector-load
+weights are unaffected. Tests: `tests_lib/datasets/test_load_step_weights.py`.
+
 ## Open follow-ups
 
 - **Finalize lumps ~6 sub-stages into one step.** The finalize step (drop-none,
   relazify, collapse-dup, diversity-tree, registry, projection) is a single
-  weighted slice; each sub-stage reports its own `current/total` from 0→1, so the
-  monotonic clamp pins the bar at 100 % as soon as the first counted sub-stage
-  finishes, then holds while the rest (notably the expensive diversity-tree
-  build) run. Honest-smoothing this needs the finalize slice spread across its
-  real sub-stages (a nested weight model, since the sub-stages vary in presence
-  and cost). Deferred: it's the last ~10 % and brief, but a large dataset can sit
-  at 100 % for a few seconds during the diversity-tree build.
+  weighted slice. The `FinalizeProgress` proxy (`stages/_common.py`) now spreads
+  it across ordered sub-ranges (cleanup 0.05, dedup 0.15, diversity 0.30,
+  registry 0.45, projection 0.05) so finishing one sub-stage no longer pins the
+  bar at 100 % while the rest run — the bar advances once, monotonically, across
+  the phase. The remaining roughness is that those sub-slot shares are static
+  ballparks (e.g. on a non-cuML GPU host the diversity k-means can outweigh the
+  registry save), not measured; a future pass could record real per-sub-stage
+  durations and feed them back in, mirroring the device-aware top-level weights.
 - **Multi-embedder (v3 trio) holds mid-embed.** `_embed_missing_stage` loops
   over each bound embedder; each `embed_missing` call restarts its `current` at
   0, so after the first embedder fills the embed slice the clamp holds the bar

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -1,0 +1,56 @@
+"""GPU/CPU pacing profiles for the dataset-load progress bar.
+
+``load_step_weights`` picks a heavier finalize slice on a GPU host, where the
+fast embed phase no longer dominates wall-clock and the un-accelerated finalize
+(registry serialize/write + CPU k-means) does. See
+``vtscore/datasets/stages/_common.py``.
+"""
+
+from __future__ import annotations
+
+from vtscore.datasets.stages._common import (
+    _LOAD_STEP_WEIGHTS_CPU,
+    _LOAD_STEP_WEIGHTS_GPU,
+    _TOTAL_LOAD_STEPS,
+    load_step_weights,
+)
+
+
+def test_profiles_are_well_formed():
+    for weights in (_LOAD_STEP_WEIGHTS_CPU, _LOAD_STEP_WEIGHTS_GPU):
+        assert len(weights) == _TOTAL_LOAD_STEPS
+        assert all(w >= 0 for w in weights)
+        assert sum(weights) == 1.0
+
+
+def test_gpu_profile_weights_finalize_more_than_cpu():
+    # The whole point of the GPU profile: finalize (index 3) gets a bigger slice
+    # and embed (index 2) a smaller one, because embedding is GPU-accelerated
+    # but the finalize work is not.
+    assert _LOAD_STEP_WEIGHTS_GPU[3] > _LOAD_STEP_WEIGHTS_CPU[3]
+    assert _LOAD_STEP_WEIGHTS_GPU[2] < _LOAD_STEP_WEIGHTS_CPU[2]
+
+
+def test_selects_cpu_profile_on_cpu_host(monkeypatch):
+    # ``load_step_weights`` imports ``resolve_device`` lazily from
+    # ``vtscore.config``, so patch it there.
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cpu")
+    assert load_step_weights() == _LOAD_STEP_WEIGHTS_CPU
+
+
+def test_selects_gpu_profile_on_cuda_host(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    assert load_step_weights() == _LOAD_STEP_WEIGHTS_GPU
+
+
+def test_selects_gpu_profile_on_indexed_cuda_device(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda:1")
+    assert load_step_weights() == _LOAD_STEP_WEIGHTS_GPU
+
+
+def test_falls_back_to_cpu_when_device_resolution_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError("no torch")
+
+    monkeypatch.setattr("vtscore.config.resolve_device", _boom)
+    assert load_step_weights() == _LOAD_STEP_WEIGHTS_CPU

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -38,10 +38,10 @@ from vtscore.state import DatasetContext, clear_all, register_context
 
 from vtscore.datasets.stages._common import (
     FinalizeProgress,
-    _LOAD_STEP_WEIGHTS,
     _STATUS_TO_STEP,
     _TOTAL_LOAD_STEPS,
     _origin_to_str,
+    load_step_weights,
 )
 from vtscore.datasets.stages.clipper import _apply_clipper_stage, _relazify_reference_clips_stage
 from vtscore.datasets.stages.embedding import embed_missing, _embed_missing_stage
@@ -416,7 +416,7 @@ def _run_origin_load_in_background(
         name or _origin_to_str(origin),
         media_type=media_type,
         embedder=embedder,
-        step_weights=_LOAD_STEP_WEIGHTS,
+        step_weights=load_step_weights(),
     )
     tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
 

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -30,8 +30,9 @@ _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
 
 # Rough typical wall-clock split across the four load phases, used to pace the
 # unified whole-job progress bar (see ProgressTracker.set_step_weights).
-# Embedding dominates almost any real dataset; the model load is a roughly
-# fixed one-time cost; finalize (dedup + diversity tree + registry) is short.
+# Embedding dominates almost any real dataset on a CPU host; the model load is a
+# roughly fixed one-time cost; finalize (dedup + diversity tree + registry) is
+# short *relative to a slow CPU embed*.
 #
 # The model-load slice is kept deliberately small: it is the one phase that
 # cannot report fine-grained progress, so the bar sits at its floor for the
@@ -40,8 +41,46 @@ _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
 # goes to embedding, the phase that *does* report per-item progress and so
 # advances the bar smoothly. These weights only shape pacing — the overall ETA
 # self-corrects from the real rate — so they need only be in the right ballpark.
-#               download  model  embed  finalize
-_LOAD_STEP_WEIGHTS = [0.25, 0.10, 0.55, 0.10]
+#                   download  model  embed  finalize
+_LOAD_STEP_WEIGHTS_CPU = [0.25, 0.10, 0.55, 0.10]
+
+# GPU profile. When embedding runs on a CUDA device it is several times faster,
+# so the embed phase shrinks while the *finalize* phase does not: the registry
+# save (serialize → zip → disk write) is never GPU-accelerated, and the
+# diversity-tree k-means only moves to the GPU when cuML is installed (a
+# best-effort RAPIDS dependency that is frequently absent — see
+# ``vtscore/gpu_backends.py``), so it usually still runs on CPU ``sklearn``.
+# The net effect on a GPU host is that finalize dominates wall-clock instead of
+# embedding, so it gets a much larger slice of the bar. Without this the bar
+# raced to ~90% during the fast embed phase and then crawled through the last
+# 10% for many seconds while reporting "< 5 sec left" (the rate-based ETA was
+# dominated by the fast embed phase). See ``load_step_weights``.
+#                   download  model  embed  finalize
+_LOAD_STEP_WEIGHTS_GPU = [0.20, 0.10, 0.30, 0.40]
+
+# Back-compat / CPU default alias. The detector-load weights and the progress
+# tests reference this; the dataset loader picks the right profile at task
+# creation via :func:`load_step_weights`.
+_LOAD_STEP_WEIGHTS = _LOAD_STEP_WEIGHTS_CPU
+
+
+def load_step_weights() -> list[float]:
+    """Return the dataset-load step weights for the active embedding device.
+
+    GPU hosts embed several times faster, so the un-accelerated finalize phase
+    (registry serialize/write, and CPU k-means when cuML is absent) becomes the
+    dominant cost and earns a larger slice of the unified bar. Falls back to the
+    CPU profile whenever the device can't be resolved (e.g. torch missing), so a
+    library-only caller never crashes here.
+    """
+    try:
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        if resolve_device().startswith("cuda"):
+            return list(_LOAD_STEP_WEIGHTS_GPU)
+    except Exception:
+        pass
+    return list(_LOAD_STEP_WEIGHTS_CPU)
 
 
 class FinalizeProgress:


### PR DESCRIPTION
## Problem

On a GPU host, the dataset-load progress bar raced to ~90% during embedding and then crawled through the final "Step 4 of 4" (Building diversity index → Saving dataset) for 20+ seconds while the ETA chip sat at "< 5 sec left".

The cause is the static step weights `[0.25, 0.10, 0.55, 0.10]` (download, model, embed, **finalize**). They assume embedding dominates wall-clock — true on **CPU**, false on **GPU**:

- Embedding is several times faster on a CUDA device.
- The finalize phase is **not** GPU-accelerated: the registry save (serialize → zip → disk write) is always CPU, and the diversity-tree k-means only moves to the GPU when cuML is installed (a best-effort RAPIDS dependency that is frequently absent, so it usually runs on CPU `sklearn`).

So on a GPU host finalize actually dominates wall-clock, yet it only got 10% of the bar. Because the overall ETA is rate-based and that rate was dominated by the fast embed phase, it reported "< 5 sec left" while finalize ground on.

## Change

`vtscore/datasets/stages/_common.py` now resolves the active embedding device once at task creation (`load_step_weights()`) and picks a profile:

- **CPU** (unchanged): `[0.25, 0.10, 0.55, 0.10]`
- **GPU**: `[0.20, 0.10, 0.30, 0.40]` — embed shrinks, finalize grows

This leaves the bar room to pace by real time on a GPU host and gives the overall ETA room to self-correct through the diversity-tree build and registry save. The weights only shape pacing; the ETA still self-corrects from the real rate, so they need only be in the right ballpark. Device resolution is cached and falls back to the CPU profile if it can't be determined (e.g. torch missing), so library-only callers never crash.

Detector-load weights and the within-finalize `FinalizeProgress` sub-slot shares are unaffected.

## Tests

- `tests_lib/datasets/test_load_step_weights.py` — profile well-formedness, GPU vs CPU selection (incl. indexed `cuda:1`), and the raise → CPU fallback.
- Existing `tests_lib/core/test_progress_overall.py` still references the `_LOAD_STEP_WEIGHTS` CPU alias and passes.

Ran `./run-tests.sh datasets`, `./run-tests.sh core` (incl. the ruff/format/codespell/deptry/pyright gate + frontend build), and `./run-tests.sh vtscore-clean` — all green.

## Docs

`docs/plans/progress-bar-consolidation.md` records this under a new "GPU pacing profile (shipped)" section and refreshes the finalize follow-up note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZsrPsXDi2LN8phpfBqPVu)_