### PR TITLE
docs: refresh user-docs-screenshots shot list to the current 20 shots

### DIFF
--- a/docs/plans/docs-audit-2026-06-28.md
+++ b/docs/plans/docs-audit-2026-06-28.md
@@ -261,8 +261,9 @@ These will time out or click dead/disabled targets if run as-is:
 2. ~~Retake the 7 stale shots (Part A) + capture the new shots (Part B).~~
    **Done 2026-06-28** — all 7 retaken, all 4 Part B added/captured/embedded.
 3. ~~Apply the prose fixes (Part D).~~ **Already landed** in `3b172f0c`.
-4. Update `docs/plans/user-docs-screenshots.md` "Shot list" to the current
-   20 shots and record the 4 new manifest entries there. *(Still owed.)*
+4. ~~Update `docs/plans/user-docs-screenshots.md` "Shot list" to the current
+   20 shots and record the 4 new manifest entries there.~~ **Done 2026-06-28** —
+   added a "Shot list (v2 — 2026-06-28)" addendum there.
 5. **Optional `browse-bin-popup`** (Part B item 5) was **not** added — it has
    no USER_GUIDE anchor/placeholder, so it stayed out of scope this pass.
 6. **Masking is now gauge-robust.** `maskVolatile` masks both the RAM *and*

--- a/docs/plans/user-docs-screenshots.md
+++ b/docs/plans/user-docs-screenshots.md
@@ -178,6 +178,43 @@ annotations. README reuses guide shots rather than adding new ones. The
 `dashboard-loaded` (and optionally `results-grid`); demos.md embeds
 `importer-picker`.
 
+## Shot list (v2 — 2026-06-28)
+
+The list above is the original v1 (shipped 2026-06-10). After ~170 frontend
+commits the [2026-06-28 documentation audit](docs-audit-2026-06-28.md) retook 7
+drifted shots and added 4 new ones, taking the manifest to **20 logical shots ×
+2 themes = 40 PNGs**. The v1 rows still name every original shot; the deltas:
+
+**New shots (Part B) — 4 added to `screenshots.manifest.ts`:**
+
+| id | Doc · section | What it shows | Annotated |
+|----|---------------|---------------|-----------|
+| `new-detector` | Creating a detector | The **New Detector** modal on the Blank tab: Media Type, a seeded Text Example, the media-example drop zone, and the embedder-type picker | |
+| `find-view` | Find · scoring and verifying | The Find **three-pane verification view**: work queue (left), viewer with Good/Bad (centre), Verified Good / Verified Bad piles + actions (right) | |
+| `find-stats` | Find · scoring and verifying | The Find view's **Detector Stats** modal (clipped): counts, confusion matrix, false-pos/neg vs. inclusion curve | |
+| `achievements` | Achievements | The **Achievements** panel: total score + tiered milestones (Bronze/Silver/Gold/Platinum) with next-tier progress | |
+
+**Retake description corrections (v1 rows whose UI moved):**
+
+- `view-options` — *not* a modal; it's the inline `vt-view-controls` toolbar
+  (thumbnail size + focus mode). The list/grid toggle was removed; the shot is a
+  `clip` of that toolbar.
+- `settings-appearance` — the Appearance pane no longer hosts **Solo media
+  type** (it moved to the Import Defaults tab); the shot shows theme + the
+  animation/metadata/achievements toggles + per-type Scroll Style.
+- `importer-picker` — now drills into the **Downloaded Media catalogue** (media-
+  type selector + readiness-badge table), not the bare Demo landing.
+- `browse-view` — captured with **hex bins + two zoom-outs** (no hover popup;
+  `Zoom to fit` over-zooms 60 points to blank), plus legend + minimap.
+- `dashboard-manage` — annotation is a `box` (not `highlight`) so the open `⋯`
+  overflow menu, where Browse/Stats/Rename now live, stays visible.
+- `autopilot-progress` — caption now names the real phases (Find Initial Goods,
+  Find Initial Bads, Refine Boundary, Explore Diversity).
+
+Captured against a live GRID-hosted app over an SSH tunnel (browser local,
+embedders remote). The optional `browse-bin-popup` was not added — it has no
+USER_GUIDE anchor.
+
 **Determinism-risk shots (candidates for hand-capture fallback).** Two
 shots resist clean scripting:
 


### PR DESCRIPTION
Follow-up to #2102 (the screenshot retake/add pass, already merged). Records the
shot-list change the audit's follow-up #4 asked for.

Adds a **"Shot list (v2 — 2026-06-28)"** addendum to `docs/plans/user-docs-screenshots.md`:
- the 4 new Part B manifest entries (`new-detector`, `find-view`, `find-stats`, `achievements`), and
- the retake description corrections for the v1 rows whose UI moved (`view-options` toolbar, `settings-appearance`, `importer-picker` catalogue, `browse-view` hex, `dashboard-manage` box, `autopilot-progress` phases).

Takes the manifest count to 20 logical shots × 2 themes = 40 PNGs. Also marks
the matching follow-up done in `docs/plans/docs-audit-2026-06-28.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)