### PR TITLE
New Detector: Text/media example tabs instead of two columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,14 @@ Breaking backwards compatibility is acceptable; do not add shims, feature flags,
 
 VTSearch is a desktop web app. **Do not design, implement, or test for mobile or narrow viewports.** No responsive breakpoints, no touch-targeted controls, no mobile-only layouts, no concerns about portrait orientation. If a design discussion raises "what about mobile?", the answer is "we don't care." When evaluating a layout, assume a standard desktop viewport and skip mobile considerations entirely.
 
+## Screenshot reshoots (when you change the GUI)
+
+User-facing docs embed screenshots captured by a Playwright harness that **needs a real browser**, which the standard cloud container doesn't have (see "Environment Notes" below). So when your change alters a GUI surface that a doc screenshot frames, you usually can't reshoot it in the same session. **Do not let that drift go silently unrecorded.**
+
+Instead, add the affected shot id(s) to the **reshoot queue**: `docs/user/screenshots-reshoot-queue.md`. Each id must match an entry in `docs/user/screenshots.manifest.ts`; the wiring check (`scripts/screenshots/wiring-check.py`, gated in `run-tests.sh`) fails if a queued id has no matching shot, so the queue can't rot. To know whether a change touches a shot, scan the manifest's `embeddedIn` / `caption` fields for the surface you modified (e.g. a modal, a panel, a toolbar).
+
+If you *do* have a browser this session, drain the queue instead of growing it: run `scripts/screenshots/refresh.sh`, review `git diff docs/user/assets/`, commit the regenerated PNGs, and delete the drained rows. The full system (manifest, harness, determinism knobs, embedding convention) lives in `docs/plans/user-docs-screenshots.md`.
+
 ## No Persisted Vectors or MLPs (CRITICAL)
 
 **Embeddings and trained MLP weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → MLP` on demand.

--- a/docs/plans/user-docs-screenshots.md
+++ b/docs/plans/user-docs-screenshots.md
@@ -148,6 +148,20 @@ Reads the manifest and, for each shot × theme:
 `check.sh` is the optional tripwire run before a release to catch shots
 that *should* have been refreshed but weren't.
 
+### The reshoot queue (for no-browser sessions)
+
+The everyday refresh above assumes a browser. The standard cloud container
+has none (CLAUDE.md → "No Chrome/Chromium available"), so a session that
+changes the GUI usually *can't* run `refresh.sh` itself. To keep that drift
+from going silently unrecorded, such a session records the affected shot
+id(s) in **`docs/user/screenshots-reshoot-queue.md`** — a tracked list of
+known-stale shots. `wiring-check.py` validates that every queued id is a real
+manifest id (invariant (c)), so the queue can't reference a renamed or
+deleted shot. A later browser-capable session **drains** the queue: run
+`refresh.sh`, commit the regenerated PNGs, and delete the drained rows
+(empty queue = no known-stale shots). CLAUDE.md → "Screenshot reshoots"
+points contributors here.
+
 ## Shot list (v1)
 
 All in **light + dark** (so ~2× the files). `*` = carries declarative

--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -1,0 +1,39 @@
+# Screenshot reshoot queue
+
+A running list of doc screenshots that are **known stale** — the GUI they
+capture has changed, but the PNGs under `docs/user/assets/` haven't been
+re-rendered yet.
+
+**Why this file exists.** Screenshots are captured by a Playwright harness
+(`scripts/screenshots/refresh.sh`) that needs a real browser. The standard
+cloud container has **no chromium** (see `CLAUDE.md` → "No Chrome/Chromium
+available"), so a session that changes the GUI usually *can't* reshoot the
+affected shots itself. Instead of letting that drift go silently unrecorded,
+the changing session adds the affected shot id(s) here. A later
+browser-capable session drains the queue.
+
+See `docs/plans/user-docs-screenshots.md` for the full screenshot system
+(manifest, harness, determinism knobs, embedding convention).
+
+## How to use it
+
+**When you change the GUI and can't reshoot (no browser):** for every shot
+whose framed UI your change alters, add a row to the table below. The shot
+`id` must match an entry in `docs/user/screenshots.manifest.ts` — the wiring
+check (`scripts/screenshots/wiring-check.py`, gated in `run-tests.sh`)
+enforces this, so a typo'd or renamed id fails the suite.
+
+**When you have a browser and want to drain the queue:**
+
+1. Run `scripts/screenshots/refresh.sh` to re-render the stale shots (or all).
+2. Review `git diff --stat docs/user/assets/` like any diff.
+3. Commit the regenerated PNGs and **delete the drained rows** from the table
+   below (leave the queue empty, not stale).
+
+An empty table means "no known-stale shots" — the desired resting state.
+
+## Queue
+
+| Shot id | Embedded in | Why it's stale | Flagged |
+|---------|-------------|----------------|---------|
+| `new-detector` | USER_GUIDE → "Creating a detector" | The New Detector modal's blank-detector example input changed from a side-by-side Text / media two-column layout to a Text / `<MediaType>` tabbed layout. | 2026-06-28 · PR #2107 |

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -67,23 +67,23 @@
       }
 
       @if (tab === 'blank') {
-        @if (hasMediaExample) {
-          <div class="example-display">
-            <label class="col-label">Example</label>
-            <div class="example-row">
-              @if (exampleThumbnailUrl) {
-                <img class="example-thumbnail" [src]="exampleThumbnailUrl" [alt]="exampleDisplay()" (error)="onExampleThumbError()" />
-              } @else {
-                <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
-              }
-              <span class="example-label" [title]="exampleDisplay()">{{ exampleDisplay() }}</span>
-              <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()" title="Remove this example and choose a different one">Change</button>
-            </div>
+        <div class="form-group example-group">
+          <label class="col-label">Example</label>
+          <div class="tab-bar example-tab-bar" role="tablist">
+            <button type="button" class="tab-btn" role="tab"
+              [class.active]="exampleTab() === 'text'"
+              [attr.aria-selected]="exampleTab() === 'text'"
+              (click)="setExampleTab('text')"
+              title="Describe what this detector should find in words.">Text</button>
+            <button type="button" class="tab-btn" role="tab"
+              [class.active]="exampleTab() === 'media'"
+              [attr.aria-selected]="exampleTab() === 'media'"
+              (click)="setExampleTab('media')"
+              [title]="'Pick a ' + exampleMediaTabLabel.toLowerCase() + ' example to find more like it.'">{{ exampleMediaTabLabel }}</button>
           </div>
-        } @else {
-          <div class="example-columns">
-            <div class="example-col">
-              <label class="col-label">Text Example</label>
+
+          @if (exampleTab() === 'text') {
+            <div class="example-panel">
               <div class="text-input-row">
                 <input
                   class="form-input"
@@ -103,18 +103,29 @@
                 </p>
               }
             </div>
-            <div class="example-col">
-              <label class="col-label">{{ exampleColumnLabel }}</label>
-              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">{{ browseMediaLabel }}</button>
-              <vt-drop-zone
-                [label]="dropMediaLabel"
-                sublabel="or click to upload from this computer"
-                [disabled]="hasPendingText"
-                (filesSelected)="onLocalFileDropped($event)"
-              ></vt-drop-zone>
+          } @else {
+            <div class="example-panel">
+              @if (hasMediaExample) {
+                <div class="example-row">
+                  @if (exampleThumbnailUrl) {
+                    <img class="example-thumbnail" [src]="exampleThumbnailUrl" [alt]="exampleDisplay()" (error)="onExampleThumbError()" />
+                  } @else {
+                    <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+                  }
+                  <span class="example-label" [title]="exampleDisplay()">{{ exampleDisplay() }}</span>
+                  <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()" title="Remove this example and choose a different one">Change</button>
+                </div>
+              } @else {
+                <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" title="Browse demos, server folders, or upload a file to pick an example">{{ browseMediaLabel }}</button>
+                <vt-drop-zone
+                  [label]="dropMediaLabel"
+                  sublabel="or click to upload from this computer"
+                  (filesSelected)="onLocalFileDropped($event)"
+                ></vt-drop-zone>
+              }
             </div>
-          </div>
-        }
+          }
+        </div>
       }
 
       @if (tab === 'trained') {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -76,15 +76,24 @@
   color: var(--text-warning);
 }
 
-// Two-column layout for text vs media example input
-.example-columns {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-xl);
-  margin-top: var(--space-xs);
+// Text vs media example input, behind a nested tab. The two are mutually
+// exclusive, so only one panel shows at a time.
+.example-group {
+  gap: var(--space-sm);
 }
 
-.example-col {
+// Nested tab bar (Text / Image) under the "Example" label. Tighter than the
+// top-level Blank/Trained tabs since it sits inside a form group.
+.example-tab-bar {
+  margin-bottom: var(--space-sm);
+
+  .tab-btn {
+    padding: var(--space-sm) var(--space-lg);
+    font-size: var(--font-md);
+  }
+}
+
+.example-panel {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
@@ -112,19 +121,16 @@
   text-align: center;
 }
 
-// In the example column the drop zone sits below the "Browse Media…" button,
+// In the example panel the drop zone sits below the "Browse Media…" button,
 // so use a more compact padding than the standalone version inside the media
-// picker; the column is short and we don't want it to dwarf the text input.
-.example-col vt-drop-zone ::ng-deep .drop-zone {
+// picker; the panel is short and we don't want it to dwarf the text input.
+.example-panel vt-drop-zone ::ng-deep .drop-zone {
   padding: var(--space-lg) var(--space-lg);
 }
-.example-col vt-drop-zone ::ng-deep .drop-zone-icon {
+.example-panel vt-drop-zone ::ng-deep .drop-zone-icon {
   width: 22px;
   height: 22px;
 }
-
-// Single example display
-.example-display { margin-top: var(--space-xs); }
 
 .example-row {
   display: flex;

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -97,12 +97,36 @@ describe('NewDetectorModalComponent', () => {
     expect(component.canSubmitBlank).toBe(true);
   });
 
-  it('should disable media buttons when text is entered', () => {
-    component.pendingText.set('');
-    expect(component.hasPendingText).toBe(false);
+  it('should default the example tab to text', () => {
+    expect(component.exampleTab()).toBe('text');
+  });
 
-    component.pendingText.set('some text');
-    expect(component.hasPendingText).toBe(true);
+  it('should switch between text and media example tabs', () => {
+    component.setExampleTab('media');
+    expect(component.exampleTab()).toBe('media');
+    component.setExampleTab('text');
+    expect(component.exampleTab()).toBe('text');
+  });
+
+  it('should label the media tab from the detector media type', () => {
+    component.mediaType.set('image');
+    expect(component.exampleMediaTabLabel).toBe('Image');
+    component.mediaType.set('audio');
+    expect(component.exampleMediaTabLabel).toBe('Audio');
+  });
+
+  it('should drop a selected media example when the user types text', () => {
+    component.exampleType.set('media');
+    component.exampleValue.set('file.wav');
+    component.exampleDisplay.set('file.wav');
+    component.exampleTab.set('media');
+    expect(component.hasMediaExample).toBe(true);
+
+    // Typing a text example is mutually exclusive with the media example.
+    component.onPendingTextInput('dog barking');
+
+    expect(component.hasMediaExample).toBe(false);
+    expect(component.pendingText()).toBe('dog barking');
   });
 
   it('should clear pending text when media example is set', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -89,6 +89,10 @@ export class NewDetectorModalComponent implements OnInit {
   nameTouched = false;
   readonly mediaType = signal('audio');
   readonly pendingText = signal('');
+  /** Which example kind the user is filling in. Text and media examples are
+   *  mutually exclusive, so the blank-detector form shows one at a time behind
+   *  a tab; this tracks the active tab. Defaults to text (the quick path). */
+  readonly exampleTab = signal<'text' | 'media'>('text');
   readonly mediaTypes = signal<string[]>([]);
   readonly mediaTypeInfos = signal<MediaTypeInfo[]>([]);
   readonly submitting = signal(false);
@@ -283,6 +287,7 @@ export class NewDetectorModalComponent implements OnInit {
           this.exampleMediaType = this.mediaType();
           this.exampleThumbFailed.set(false);
           this.pendingText.set('');
+          this.exampleTab.set('media');
           this.autoFillNameFromExample();
           this.submitting.set(false);
         },
@@ -325,6 +330,11 @@ export class NewDetectorModalComponent implements OnInit {
 
   onPendingTextInput(value: string): void {
     this.pendingText.set(value);
+    // Text and media examples are mutually exclusive — typing a text example
+    // drops any previously selected media example so the two never coexist.
+    if (this.hasMediaExample) {
+      this.clearMediaExample();
+    }
     if (!this.nameTouched) {
       this.name.set(this.sanitizeName(value));
     }
@@ -441,6 +451,20 @@ export class NewDetectorModalComponent implements OnInit {
     if (this.submitting()) return;
     this.tab = tab;
     this.error.set('');
+  }
+
+  /** Switch between the Text and media example tabs in the blank-detector form. */
+  setExampleTab(tab: 'text' | 'media'): void {
+    if (this.submitting()) return;
+    this.exampleTab.set(tab);
+    this.error.set('');
+  }
+
+  /** Label for the media example tab: "Image", "Audio", "Video", etc. (the
+   *  detector's media type), falling back to "Media". */
+  get exampleMediaTabLabel(): string {
+    const mediaType = this.mediaType();
+    return (mediaType ? this.getMediaTypeLabel(mediaType) : '') || 'Media';
   }
 
   // --- Media picker (shared structure with Add Dataset) ---
@@ -670,6 +694,7 @@ export class NewDetectorModalComponent implements OnInit {
         this.exampleMediaType = this.activeDemoTab || this.mediaType();
         this.exampleThumbFailed.set(false);
         this.pendingText.set('');
+        this.exampleTab.set('media');
         this.autoFillNameFromExample();
         this.demoFileLoading.set(false);
         this.view.set('main');
@@ -717,6 +742,7 @@ export class NewDetectorModalComponent implements OnInit {
         this.exampleMediaType = this.mediaType() || this.mediaTypeFromFilename(raw);
         this.exampleThumbFailed.set(false);
         this.pendingText.set('');
+        this.exampleTab.set('media');
         this.autoFillNameFromExample();
         this.sfFileSelecting.set(false);
         this.view.set('main');
@@ -763,6 +789,7 @@ export class NewDetectorModalComponent implements OnInit {
           this.exampleMediaType = mediaType || this.mediaType();
           this.exampleThumbFailed.set(false);
           this.pendingText.set('');
+          this.exampleTab.set('media');
           this.autoFillNameFromExample();
           // Close the picker if it was open so the user lands back on the form.
           if (this.view() === 'media-picker') this.view.set('main');
@@ -813,12 +840,19 @@ export class NewDetectorModalComponent implements OnInit {
   // --- Clear example ---
 
   clearExample(): void {
+    this.clearMediaExample();
+    this.pendingText.set('');
+  }
+
+  /** Reset only the media-example fields, leaving any pending text untouched.
+   *  Used both by the "Change" button and when the user starts typing a text
+   *  example (the two kinds are mutually exclusive). */
+  private clearMediaExample(): void {
     this.exampleType.set(null);
     this.exampleValue.set('');
     this.exampleDisplay.set('');
     this.exampleMediaType = '';
     this.exampleThumbFailed.set(false);
-    this.pendingText.set('');
   }
 
   // --- Trained tab: label importers ---
@@ -1005,13 +1039,6 @@ export class NewDetectorModalComponent implements OnInit {
       return mt.name.trim();
     }
     return typeId;
-  }
-
-  /** "Image Example", "Audio Example", "Media Example" as a fallback. */
-  get exampleColumnLabel(): string {
-    const mediaType = this.mediaType();
-    const name = mediaType ? this.getMediaTypeLabel(mediaType) : '';
-    return `${name || 'Media'} Example`;
   }
 
   /** "Browse Images...", "Browse Audio...", "Browse Media..." as a fallback. */

--- a/scripts/screenshots/wiring-check.py
+++ b/scripts/screenshots/wiring-check.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Docs ⇄ screenshot-manifest wiring check (no browser needed).
 
-Asserts two invariants from docs/plans/user-docs-screenshots.md:
+Asserts three invariants from docs/plans/user-docs-screenshots.md:
 
   (a) every shot id in docs/user/screenshots.manifest.ts has BOTH theme files
       (`<id>.light.png` and `<id>.dark.png`) on disk under docs/user/assets/;
   (b) every screenshot the user-facing docs embed (USER_GUIDE.md, README.md,
       demos.md) — i.e. each `assets/<id>.<theme>.png` reference — resolves to a
-      real manifest id.
+      real manifest id;
+  (c) every shot id listed in the reshoot queue
+      (docs/user/screenshots-reshoot-queue.md) resolves to a real manifest id,
+      so the queue can't reference a renamed or deleted shot.
 
 This catches docs/manifest drift without rendering anything, so it is cheap
 enough to gate in run-tests.sh. It does NOT render or diff pixels (that is
@@ -23,6 +26,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 MANIFEST = ROOT / "docs" / "user" / "screenshots.manifest.ts"
 ASSETS = ROOT / "docs" / "user" / "assets"
+RESHOOT_QUEUE = ROOT / "docs" / "user" / "screenshots-reshoot-queue.md"
 THEMES = ("light", "dark")
 DOCS = [
     ROOT / "docs" / "user" / "USER_GUIDE.md",
@@ -35,6 +39,10 @@ DOCS = [
 ID_RE = re.compile(r"^\s*id:\s*'([a-z0-9-]+)'", re.MULTILINE)
 # Any embedded asset reference, e.g. assets/dashboard-loaded.dark.png
 REF_RE = re.compile(r"assets/([a-z0-9-]+)\.(light|dark)\.png")
+# A reshoot-queue table row: the shot id is the first backticked token in a
+# Markdown table row (a line starting with `|`). The header and `|----|`
+# separator rows carry no backticks, so they don't match.
+QUEUE_ROW_RE = re.compile(r"^\|[^`|]*`([a-z0-9-]+)`", re.MULTILINE)
 
 
 def manifest_ids() -> list[str]:
@@ -66,13 +74,24 @@ def main() -> int:
             if ref_id not in id_set:
                 errors.append(f"{doc.relative_to(ROOT)} embeds 'assets/{ref_id}.*.png' with no matching manifest id")
 
+    # (c) every shot id queued for reshoot maps to a manifest id.
+    queued = 0
+    if RESHOOT_QUEUE.exists():
+        for match in QUEUE_ROW_RE.finditer(RESHOOT_QUEUE.read_text(encoding="utf-8")):
+            queued += 1
+            queue_id = match.group(1)
+            if queue_id not in id_set:
+                errors.append(
+                    f"{RESHOOT_QUEUE.relative_to(ROOT)} queues reshoot for '{queue_id}' with no matching manifest id"
+                )
+
     if errors:
         print("wiring-check FAILED:")
         for e in errors:
             print(f"  - {e}")
         return 1
 
-    print(f"wiring-check OK: {len(ids)} shots, both themes present, docs consistent.")
+    print(f"wiring-check OK: {len(ids)} shots, both themes present, docs consistent, {queued} reshoot(s) queued.")
     return 0
 
 


### PR DESCRIPTION
## What & why

The blank-detector form in the **New Detector** modal rendered a **Text Example** column and a media example (Image/Audio/…) column side by side. They were always mutually exclusive — each side disabled the other via `[disabled]="hasPendingText"` — but the two-column layout visually implied you could fill in both.

This replaces the columns with an **"Example"** header and a nested **Text / `<MediaType>`** tab row, so the GUI reflects the one-or-the-other reality. Shared **Detector Name** and the **Cancel / Create** footer stay below, unchanged.

## Behavior

- Tabs default to **Text** (the quick path); the media tab is labeled from the detector's media type (`Image`, `Audio`, `Video`, …).
- Picking a media example (upload, demo, server folder, or seed) auto-selects the media tab and shows the existing thumbnail + **Change** card.
- Text and media examples stay mutually exclusive in state: picking media clears any pending text (as before), and typing text now drops any selected media example (previously enforced by the greyed-out columns).
- No-text-embedder case is unchanged: the Text tab stays selectable and shows the existing inline warning.

## Implementation

- `new-detector-modal.component.ts`: added `exampleTab` signal + `setExampleTab`, `exampleMediaTabLabel` getter, a `clearMediaExample` helper, and the type-clears-media rule in `onPendingTextInput`. Removed the now-unused `exampleColumnLabel` getter.
- `.html`: replaced the two-column block with the tabbed `Example` group.
- `.scss`: dropped the `.example-columns` / `.example-col` grid styles, added tighter nested `.example-tab-bar` + `.example-panel` rules.
- `.spec.ts`: added tab default / switch / label / mutual-exclusion tests.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, 890 Vitest tests pass (lint/pyright/etc. all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017zYUf1sLedDNwVHQz3eac3)_