### PR TITLE
Flatten the Select Media Example picker

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -331,7 +331,6 @@
         [noImporterHintTemplate]="'Select a {label} source to browse.'"
         [tabTitleTemplate]="'Show {label} media sources'"
         [emptyCategoryText]="'No sources in this category.'"
-        [alwaysShowSubtabBar]="true"
         [demos]="demos()"
         [filteredDemos]="filteredDemos"
         [demoLoading]="demoLoading()"

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -218,6 +218,31 @@ describe('NewDetectorModalComponent', () => {
     expect(component.pendingText()).toBe('cat meowing');
     expect(component.name()).toBe('Dog Barks');
   });
+
+  it('auto-selects the lone importer when a single-source category is opened', () => {
+    // "Files" has exactly one importer (server_folder), so opening it should
+    // skip the redundant one-button sub-tab bar and land on the path input.
+    component.mediaImporters.set([
+      { name: 'server_folder', picker_view: 'server_folder', category: 'server' },
+      { name: 'demo', picker_view: 'demo', category: 'demo' },
+    ]);
+
+    component.selectImporterTab('server');
+
+    expect(component.selectedImporter?.name).toBe('server_folder');
+    expect(component.activePickerView).toBe('server_folder');
+  });
+
+  it('does not auto-select when a category holds more than one importer', () => {
+    component.mediaImporters.set([
+      { name: 'server_folder', picker_view: 'server_folder', category: 'server' },
+      { name: 'server_other', picker_view: 'server_folder', category: 'server' },
+    ]);
+
+    component.selectImporterTab('server');
+
+    expect(component.selectedImporter).toBeNull();
+  });
 });
 
 describe('NewDetectorModalComponent with defaultMediaType', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -533,6 +533,13 @@ export class NewDetectorModalComponent implements OnInit {
     this.selectedImporter = null;
     this.resetDemoPickerState();
     this.resetServerFolderState();
+    // A category with a single source has no meaningful sub-tab choice, so
+    // skip straight to that source's input (e.g. opening "Files" lands the
+    // user on the server-path entry instead of a one-button sub-tab bar).
+    const importers = this.importersForActiveTab;
+    if (importers.length === 1) {
+      this.selectImporter(importers[0]);
+    }
   }
 
   selectImporter(importer: ImporterInfo): void {


### PR DESCRIPTION
## What & why

The "Select Media Example" window (the `media-picker` view of `new-detector-modal`, via the shared `<vt-source-picker>`) buried its one real interaction behind redundant chrome:

1. **Pointless single sub-tab.** The "Files" category contains exactly one importer (`server_folder`), yet the modal passed `[alwaysShowSubtabBar]="true"`, forcing a one-button sub-tab bar that the source-picker would otherwise hide.
2. **Path entry two levels deep.** Reaching the lone "Path to a media file on the server" input meant: pick the *Files* tab → click the only sub-tab → finally see the text box.

## Changes

- Remove the forced `[alwaysShowSubtabBar]="true"` from the media-picker so a single-importer category no longer renders a redundant sub-tab bar (default is `false`).
- Auto-select the sole importer in `selectImporterTab()` when a category holds exactly one source. Opening **Files** now lands directly on the server-path entry; opening **Demo** opens its table immediately. Multi-source categories are unaffected and still require an explicit sub-tab choice.

## Tests

- Added two unit tests to `new-detector-modal.component.spec.ts` covering auto-select for a single-source category and no auto-select for a multi-source category.
- `./run-tests.sh frontend` passes (892 Vitest tests, build, audit, lint).

## Notes

This is the scoped "flatten it" fix. Out of scope (and untouched): the empty **Services** tab (the `recaller` importer stays `hidden_from_picker` until its API clients land) and the dead `local_files`/`local_folder` upload bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BASKJXShmdFssou7EUa13U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BASKJXShmdFssou7EUa13U)_