### PR TITLE
Fix right-panel snap-back regression in the Train view

### DIFF
--- a/frontend/src/app/components/label-view/panel-resize.directive.ts
+++ b/frontend/src/app/components/label-view/panel-resize.directive.ts
@@ -52,6 +52,11 @@ export class PanelResizeDirective implements OnDestroy {
   onMouseDown(event: MouseEvent): void {
     event.preventDefault();
     this.dragging = true;
+    // Seed `lastWidth` with the current width so a mousedown→mouseup with no
+    // intervening move emits the panel's existing width on `resizeEnd`, not the
+    // 0 it would otherwise carry — which the parent would clamp/snap straight to
+    // the minimum, jumping the panel on a stray click of the divider.
+    this.lastWidth = this.computeWidth(event);
     this.ngZone.runOutsideAngular(() => {
       document.addEventListener('mousemove', this.boundMove);
       document.addEventListener('mouseup', this.boundUp);
@@ -63,12 +68,17 @@ export class PanelResizeDirective implements OnDestroy {
     document.removeEventListener('mouseup', this.boundUp);
   }
 
-  private onMouseMove(event: MouseEvent): void {
-    if (!this.dragging) return;
+  /** Translate a pointer position into a clamped width for this side. */
+  private computeWidth(event: MouseEvent): number {
     const rect = this.layoutEl().getBoundingClientRect();
     const raw = this.side() === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
     const max = rect.width - this.dividerTotal() - this.centerMin() - this.opposingWidth();
-    const width = Math.max(this.minWidth(), Math.min(max, raw));
+    return Math.max(this.minWidth(), Math.min(max, raw));
+  }
+
+  private onMouseMove(event: MouseEvent): void {
+    if (!this.dragging) return;
+    const width = this.computeWidth(event);
     this.lastWidth = width;
     this.widthChange.emit(width);
   }

--- a/frontend/src/app/utils/grid-icon-size.spec.ts
+++ b/frontend/src/app/utils/grid-icon-size.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from './grid-icon-size';
+
+describe('iconSizeToGoalWidth', () => {
+  it('maps known sizes to their goal widths', () => {
+    expect(iconSizeToGoalWidth('XS')).toBe(25);
+    expect(iconSizeToGoalWidth('M')).toBe(80);
+    expect(iconSizeToGoalWidth('XL')).toBe(200);
+  });
+
+  it('falls back to M for unknown sizes', () => {
+    expect(iconSizeToGoalWidth('???')).toBe(80);
+    expect(iconSizeToGoalWidth('')).toBe(80);
+  });
+});
+
+describe('snapPanelWidthToGridColumns', () => {
+  // jsdom does no layout, so the grid container's geometry is stubbed to a known
+  // shape: a content box wide enough for exactly 3 columns of an 80px goal width
+  // (3 * 84 - 4 = 248 content + 16 padding = 264 client), plus a 15px scrollbar.
+  const GOAL = 80;
+  const COLS = 3;
+  const SCROLLBAR = 15;
+  const contentWidth = COLS * (GOAL + 4) - 4; // 248
+  const clientWidth = contentWidth + 16; // 264 (8px padding each side)
+  const boundingWidth = clientWidth + SCROLLBAR; // 279
+
+  let panel: HTMLElement;
+
+  function makeGrid(className: string): HTMLElement {
+    const grid = document.createElement('div');
+    grid.className = className;
+    grid.style.setProperty('--grid-goal-width', `${GOAL}px`);
+    // Inline padding is reflected by jsdom's getComputedStyle.
+    grid.style.paddingLeft = '8px';
+    grid.style.paddingRight = '8px';
+    // Stub the layout-derived geometry jsdom can't compute.
+    Object.defineProperty(grid, 'clientWidth', { value: clientWidth, configurable: true });
+    grid.getBoundingClientRect = () =>
+      ({ width: boundingWidth, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+    return grid;
+  }
+
+  beforeEach(() => {
+    panel = document.createElement('div');
+    document.body.appendChild(panel);
+  });
+
+  afterEach(() => {
+    panel.remove();
+  });
+
+  it('snaps a right-panel .vote-list (regression: no .grid-layout class)', () => {
+    panel.appendChild(makeGrid('vote-list'));
+    // currentPanelWidth carries a 20px structural offset over the grid bounding box.
+    const snapped = snapPanelWidthToGridColumns(panel, boundingWidth + 20);
+    expect(snapped).not.toBeNull();
+    // Tight bounding width (279, already exactly 3 cols) + offset (20) + 1px margin.
+    expect(snapped).toBe(300);
+  });
+
+  it('snaps a browse .bsp-list (regression: no .grid-layout class)', () => {
+    panel.appendChild(makeGrid('bsp-list'));
+    expect(snapPanelWidthToGridColumns(panel, boundingWidth)).not.toBeNull();
+  });
+
+  it('still snaps a left-panel .media-list.grid-layout', () => {
+    panel.appendChild(makeGrid('media-list grid-layout'));
+    expect(snapPanelWidthToGridColumns(panel, boundingWidth)).not.toBeNull();
+  });
+
+  it('returns null when the panel has no grid container', () => {
+    panel.appendChild(document.createElement('div'));
+    expect(snapPanelWidthToGridColumns(panel, 300)).toBeNull();
+  });
+});

--- a/frontend/src/app/utils/grid-icon-size.ts
+++ b/frontend/src/app/utils/grid-icon-size.ts
@@ -16,11 +16,17 @@ const GRID_GAP = 4;
  * When the user releases the panel resize divider, snap the panel width down to
  * the minimum width that still shows the same number of grid columns.
  *
- * Finds the active grid container (.media-list.grid-layout, .vote-list.grid-layout,
- * .bsp-list.grid-layout, or the virtualized .media-list.grid-virtual viewport) inside
- * panelEl, reads the current column count from the live DOM (so scrollbar width and all
- * structural offsets are automatically accounted for), and returns the snapped panel
- * width. Returns null if the panel is not in grid mode or the element is not found.
+ * Finds the active grid container (.media-list.grid-layout, the virtualized
+ * .media-list.grid-virtual viewport, .vote-list, or .bsp-list) inside panelEl, reads the
+ * current column count from the live DOM (so scrollbar width and all structural offsets
+ * are automatically accounted for), and returns the snapped panel width. Returns null if
+ * no grid container is found.
+ *
+ * The right panel's `.vote-list` and the browse panel's `.bsp-list` are always grids
+ * (the old list view mode was removed), so they carry no `.grid-layout` marker class;
+ * they are matched by their base class alone. The left `.media-list` still carries
+ * `.grid-layout` (and `.grid-virtual` when virtualized) because that selector also has
+ * to exclude its skeleton/non-grid states.
  *
  * The left panel switches to a CDK virtual-scroll viewport (.grid-virtual) once a view
  * grows past its grid-virtualization threshold; that viewport carries the same
@@ -31,8 +37,8 @@ export function snapPanelWidthToGridColumns(panelEl: HTMLElement, currentPanelWi
   const gridEl = (
     panelEl.querySelector('.media-list.grid-layout') ??
     panelEl.querySelector('.media-list.grid-virtual') ??
-    panelEl.querySelector('.vote-list.grid-layout') ??
-    panelEl.querySelector('.bsp-list.grid-layout')
+    panelEl.querySelector('.vote-list') ??
+    panelEl.querySelector('.bsp-list')
   ) as HTMLElement | null;
   if (!gridEl) return null;
 


### PR DESCRIPTION
## What was wrong

In the Train (label) view, the right panel stopped snapping back to fit its thumbnails on divider release, and dragging it felt like it was "jumping around" with hidden state.

Both symptoms trace to one regression. The earlier commit that **removed the List view modes** (`27854785`) dropped the now-unconditional `[class.grid-layout]` binding from the right panel's `.vote-list` and the browse panel's `.bsp-list` (grid is now the only mode). But `snapPanelWidthToGridColumns` still queried `.vote-list.grid-layout` / `.bsp-list.grid-layout`, which now match nothing — so the function returned `null` and the snap-to-column "pop tight" never ran.

The left panel was unaffected because its `.media-list` kept the `grid-layout` class. The right panel's grid is `justify-content: end`, so the un-snapped slack showed up as an empty gap on the **left**, with thumbnails re-flowing/shifting as the divider moved — the "jumping around like there's internal state not on screen" the report describes.

## Changes

- **`utils/grid-icon-size.ts`** — match `.vote-list` and `.bsp-list` by their base class (they're always grids now); keep `.media-list.grid-layout` / `.media-list.grid-virtual` for the left panel, whose selector still has to exclude skeleton/non-grid states. Docstring updated to explain why the two panels differ.
- **`label-view/panel-resize.directive.ts`** — seed `lastWidth` from the current width at `mousedown` (extracted a shared `computeWidth`). A mousedown→mouseup with no movement previously emitted `0` on `resizeEnd`, which the parent then clamped/snapped to the panel minimum — a visible jump on a stray click of the divider.
- **`utils/grid-icon-size.spec.ts`** — new regression coverage: snapping resolves for `.vote-list` and `.bsp-list` without a `grid-layout` class, still resolves for `.media-list.grid-layout`, and returns `null` when no grid container exists.

## Testing

`./run-tests.sh frontend` passes (lint, build, audit, 901 Vitest tests).

No screenshot reshoot needed: the doc shots capture resting state at default panel widths; this fix only affects snap behavior on drag-release / icon-size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9PLYJDKK6AnrUxPfM3Cbm)_