### PR TITLE
Fix 422 on load-demo merge_near_duplicates field

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1133,6 +1133,11 @@
             "nullable": true,
             "type": "array"
           },
+          "merge_near_duplicates": {
+            "default": "false",
+            "description": "When 'true', collapse near-duplicate media into dupe sets at ingest.",
+            "type": "string"
+          },
           "name": {
             "minLength": 1,
             "type": "string"

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -96,6 +96,22 @@ class TestDatasetEndpoints:
         # response carries ``error`` not ``message``.
         assert "error" in data
 
+    def test_load_demo_accepts_merge_near_duplicates(self, client):
+        """POST /api/dataset/load-demo accepts the ``merge_near_duplicates`` flag.
+
+        Regression for a 422 "Unknown field" on ``merge_near_duplicates``:
+        the handler always read the flag, but the request schema never
+        declared it, so marshmallow rejected the body before the handler
+        ran. With the field declared, an unknown demo name should now reach
+        the handler and fail with 400 "Invalid dataset name" instead.
+        """
+        resp = client.post(
+            "/api/dataset/load-demo",
+            json={"name": "nonexistent_demo", "merge_near_duplicates": "true"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid dataset" in resp.get_json()["message"]
+
     def test_browse_media_files_unknown_source(self, client):
         """GET /api/browse-media-files with unknown source returns 404."""
         resp = client.get("/api/browse-media-files?source=demo:nonexistent_xyz&path=")

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -368,6 +368,10 @@ class DatasetLoadDemoRequestSchema(Schema):
         load_default="false",
         metadata={"description": "When 'true', compute + persist the 2-D Browse projection at ingest."},
     )
+    merge_near_duplicates = fields.String(
+        load_default="false",
+        metadata={"description": "When 'true', collapse near-duplicate media into dupe sets at ingest."},
+    )
 
 
 class DatasetLoadFolderRequestSchema(Schema):


### PR DESCRIPTION
## Summary

`POST /api/dataset/load-demo` was returning `422 UNPROCESSABLE ENTITY` with `{"merge_near_duplicates": ["Unknown field."]}` whenever the "merge near-duplicates" option was enabled.

The handler in `vtsearch/routes/datasets/load.py` already read and acted on `merge_near_duplicates` (lines 385–386), but the request schema `DatasetLoadDemoRequestSchema` never declared the field. With marshmallow's default `unknown=RAISE`, the body was rejected before the handler ever ran.

## Changes

- **`vtsearch/schemas/datasets.py`** — declare `merge_near_duplicates` on `DatasetLoadDemoRequestSchema` as a string flag (`load_default="false"`), mirroring the existing `build_projection` field. The frontend already sends `'true'`/`'false'` strings, and the handler parses it via `_form_flag`.
- **`frontend/openapi.json`** — regenerated snapshot (`python scripts/dump_openapi.py`) picking up the new field.
- **`tests/datasets/test_datasets.py`** — regression test asserting the endpoint accepts `merge_near_duplicates` and reaches the handler (400 "Invalid dataset name" for an unknown demo) instead of failing schema validation with 422.

## Testing

- `./run-tests.sh` — all backend tests pass (5262 passed).
- `./run-tests.sh frontend` — Angular build, npm audit, and Vitest (895 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJMdPD2Sj7DuuDsyXFvCmt)_