### PR TITLE
Remove tilde from ETA time estimates

### DIFF
--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -25,12 +25,12 @@ describe('JobProgressComponent', () => {
   it('renders the header, detail and eta', async () => {
     fixture.componentRef.setInput('header', 'Loading dataset · Step 2 of 4 · Downloading source');
     fixture.componentRef.setInput('detail', '012/345 FileABC.img');
-    fixture.componentRef.setInput('eta', '~5.5 min left');
+    fixture.componentRef.setInput('eta', '5.5 min left');
     await settleZoneless(fixture);
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
     expect(text).toContain('Downloading source');
     expect(text).toContain('FileABC.img');
-    expect(text).toContain('~5.5 min left');
+    expect(text).toContain('5.5 min left');
   });
 
   it('shows the info chip only when a description is provided', async () => {

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -36,7 +36,7 @@ export class JobProgressComponent {
   @Input() description = '';
   /** Per-item detail (left of the bar), e.g. "012/345 FileABC.img". */
   @Input() detail = '';
-  /** Right-justified status, e.g. "~5.5 min left" or "45%". */
+  /** Right-justified status, e.g. "5.5 min left" or "45%". */
   @Input() eta = '';
   /** Bar fill state; defaults to an indeterminate spinner. */
   @Input() bar: ProgressBarState = { value: 0, max: 1, indeterminate: true };

--- a/frontend/src/app/utils/format-progress.spec.ts
+++ b/frontend/src/app/utils/format-progress.spec.ts
@@ -138,13 +138,13 @@ describe('formatEta', () => {
     expect(formatEta(3)).toBe('< 10 sec left');
     expect(formatEta(4)).toBe('< 10 sec left');
     // Just over the floor rounds to the nearest 10s, not 5s.
-    expect(formatEta(12)).toBe('~10 sec left');
-    expect(formatEta(18)).toBe('~20 sec left');
-    expect(formatEta(34)).toBe('~30 sec left');
+    expect(formatEta(12)).toBe('10 sec left');
+    expect(formatEta(18)).toBe('20 sec left');
+    expect(formatEta(34)).toBe('30 sec left');
   });
 
   it('switches to minutes and hours for larger estimates', () => {
-    expect(formatEta(330)).toBe('~5.5 min left');
-    expect(formatEta(7200)).toBe('~2 hr left');
+    expect(formatEta(330)).toBe('5.5 min left');
+    expect(formatEta(7200)).toBe('2 hr left');
   });
 });

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -49,12 +49,12 @@ function snapEta(value: number, minStep: number): number {
 /** Render a snapped magnitude with at most one decimal and no trailing ``.0``. */
 function etaUnit(value: number, unit: string): string {
   const text = Number.isInteger(value) ? String(value) : value.toFixed(1);
-  return `~${text} ${unit} left`;
+  return `${text} ${unit} left`;
 }
 
 /**
  * Format a remaining-seconds estimate into a deliberately humble, single-unit
- * chip: ``~35 sec left`` / ``~5.5 min left`` / ``~2 hr left``. The value is
+ * chip: ``35 sec left`` / ``5.5 min left`` / ``2 hr left``. The value is
  * rounded to a nice step that scales with its magnitude (see
  * ``ETA_ROUND_RATIO``), so we never claim more precision than a noisy estimate
  * deserves and never show an over-precise ``5 min 34 sec``-style breakdown.
@@ -87,12 +87,12 @@ export function formatEta(seconds: number | null | undefined): string {
 
 /**
  * Format a `ProgressEvent` into the canonical
- * ``[Step S/T] (C/T) message · ~ETA left`` string used by every progress consumer.
+ * ``[Step S/T] (C/T) message · ETA left`` string used by every progress consumer.
  *
  * Each piece is optional:
  *   - The ``[Step S/T]`` prefix appears only when ``total_steps > 1``.
  *   - The ``(C/T)`` fraction appears only when ``total > 0``.
- *   - The ``· ~5.5 min left`` tail appears only when ``eta_seconds > 0``; the
+ *   - The ``· 5.5 min left`` tail appears only when ``eta_seconds > 0``; the
  *     backend gates this on at least 5s of elapsed work, so it stays hidden
  *     for short bars.
  *   - When none are present, returns the bare ``message`` (or
@@ -195,7 +195,7 @@ export function isProgressIndeterminate(
  *     is omitted here; it is returned separately as ``eta`` so the UI can pin it
  *     to the right of the progress bar where it stays visible even when a long
  *     file path ellipsizes the detail.
- *   - ``eta``: the bare ``~5.5 min left`` chip, or empty when no estimate is available.
+ *   - ``eta``: the bare ``5.5 min left`` chip, or empty when no estimate is available.
  */
 export interface ProgressHeader {
   header: string;


### PR DESCRIPTION
Drops the leading `~` from the progress-bar ETA chips. Everyone knows an ETA is an estimate, so the chips now read `5.5 min left` / `30 sec left` / `2 hr left` instead of `~5.5 min left` etc.

## Changes
- `formatEta` (`frontend/src/app/utils/format-progress.ts`): `etaUnit` no longer prepends `~`. The rounding/snapping logic that keeps the value deliberately coarse is unchanged — the chip is still an estimate, it just no longer says so with a tilde.
- Updated the doc-comment examples in `format-progress.ts` and `job-progress.component.ts` to match the new output.
- Updated the `format-progress.spec.ts` and `job-progress.component.spec.ts` expectations.

The `< 10 sec left` floor message was already tilde-free and is untouched. The Python side only computes `eta_seconds`; the tilde was purely a frontend rendering detail, so no backend change was needed.

Frontend gate (`./run-tests.sh frontend`) passes: build OK, 901 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M47tGcMarbd8YPnvQAreyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01M47tGcMarbd8YPnvQAreyt)_