### PR TITLE
Fix Browse on an unloaded dataset (big red error + frozen "Step 1 of 2")

### DIFF
--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -174,15 +174,50 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
     expect(activeContext.datasetId).toBe('old-ds');
     expect(activeContext.modelId).toBe('old-det');
 
-    // HTTP load endpoint resolves, but the loading task is still
-    // non-idle, so active must stay pinned.
-    loadRegisteredSubjects.get('d1')!.next({});
+    // HTTP load endpoint resolves (with the background task's id), but the
+    // loading task is still non-idle, so active must stay pinned.
+    loadRegisteredSubjects.get('d1')!.next({ ok: true, message: '', task_id: 't' });
     loadRegisteredSubjects.get('d1')!.complete();
     expect(activeContext.datasetId).toBe('old-ds');
     expect(activeContext.modelId).toBe('old-det');
 
     // SSE channel goes idle; only now does active flip.
     loadingTasks$.next([]);
+    expect(activeContext.datasetId).toBe('d1');
+    expect(activeContext.modelId).toBe('m1');
+  });
+
+  it('does NOT flip active before the SSE load task appears (browse-on-unloaded race)', () => {
+    // Reproduces the production race the Browse button hit: the HTTP load
+    // response lands BEFORE the `loading-tasks` SSE frame for that load
+    // arrives, so the channel is momentarily empty. The waiter must not
+    // read that empty snapshot as "load already finished" — otherwise it
+    // promotes active and the caller fires requests (e.g. the projection
+    // build) against a still-loading dataset, which 409s. Unlike the H25
+    // tests below, we deliberately do NOT pre-seed a non-idle task.
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1', { loaded: false })]; // needs load
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+
+    // HTTP load endpoint resolves with the background task's id, but the
+    // SSE channel has not reported the task yet (still empty).
+    loadRegisteredSubjects.get('d1')!.next({ ok: true, message: '', task_id: 'task-d1' });
+    loadRegisteredSubjects.get('d1')!.complete();
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+
+    // The task now appears, running. Active must still stay pinned.
+    loadingTasks$.next([
+      makeLoadingTask({ dataset_id: 'd1', task_id: 'task-d1', status: 'loading' }),
+    ]);
+    expect(activeContext.datasetId).toBe('old-ds');
+
+    // Task goes idle: only now does active flip.
+    loadingTasks$.next([
+      makeLoadingTask({ dataset_id: 'd1', task_id: 'task-d1', status: 'idle' }),
+    ]);
     expect(activeContext.datasetId).toBe('d1');
     expect(activeContext.modelId).toBe('m1');
   });
@@ -202,7 +237,7 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
     expect(activeContext.datasetId).toBe('old-ds');
     expect(activeContext.modelId).toBe('old-det');
 
-    loadDetectorSubjects.get('m1')!.next({});
+    loadDetectorSubjects.get('m1')!.next({ ok: true, task_id: 't' });
     loadDetectorSubjects.get('m1')!.complete();
     expect(activeContext.datasetId).toBe('old-ds');
     expect(activeContext.modelId).toBe('old-det');

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -212,8 +212,8 @@ export class ContextSwitchService {
           }),
         )
         .subscribe({
-          next: () => {
-            this.waitForDatasetLoad(current, datasetId).subscribe({
+          next: (resp) => {
+            this.waitForDatasetLoad(current, datasetId, resp?.task_id ?? '').subscribe({
               next: () => {
                 sub.next();
                 sub.complete();
@@ -237,8 +237,8 @@ export class ContextSwitchService {
           }),
         )
         .subscribe({
-          next: () => {
-            this.waitForDetectorLoad(current, detectorId).subscribe({
+          next: (resp) => {
+            this.waitForDetectorLoad(current, detectorId, resp?.task_id ?? '').subscribe({
               next: () => {
                 sub.next();
                 sub.complete();
@@ -249,15 +249,44 @@ export class ContextSwitchService {
     });
   }
 
-  private waitForDatasetLoad(current: ActiveSwitch, datasetId: string): Observable<void> {
+  /**
+   * Resolve once the dataset load identified by *taskId* has settled.
+   *
+   * Keying on the load's own ``task_id`` (not just ``dataset_id``) closes
+   * the SSE-lag race: ``loadRegistered`` resolves the moment the backend
+   * *kicks off* the background load, which is typically before the
+   * ``loading-tasks`` channel has reported the new task. A plain
+   * "no non-idle task for this dataset" check reads that empty window as
+   * "already finished" and promotes active early, so the next request
+   * (e.g. the projection build the Browse button fires) hits a dataset
+   * that isn't loaded yet and 409s. Instead we wait until the specific
+   * task has been *observed* in the stream and is no longer running —
+   * mirroring `DashboardLoadingTasksService`'s `awaitedTaskIds` guard.
+   *
+   * An empty ``taskId`` (the already-loaded / synchronous fast path that
+   * starts no tracked background task) falls back to the prior id-based
+   * "channel is quiet for this dataset" check, preserving that behavior.
+   */
+  private waitForDatasetLoad(
+    current: ActiveSwitch,
+    datasetId: string,
+    taskId: string,
+  ): Observable<void> {
     return new Observable<void>((sub) => {
+      let seen = false;
       this.progressEvents.loadingTasks$
         .pipe(
           takeUntil(current.cancellable),
-          filter(
-            (tasks: LoadingTask[]) =>
-              !tasks.some((t) => t.dataset_id === datasetId && t.status !== 'idle'),
-          ),
+          filter((tasks: LoadingTask[]) => {
+            if (!taskId) {
+              return !tasks.some((t) => t.dataset_id === datasetId && t.status !== 'idle');
+            }
+            const task = tasks.find((t) => t.task_id === taskId);
+            if (task) seen = true;
+            // Settled only once we've seen the task and it's no longer
+            // running (gone idle, or dropped from the stream entirely).
+            return seen && !(task && task.status !== 'idle');
+          }),
           take(1),
         )
         .subscribe({
@@ -270,15 +299,26 @@ export class ContextSwitchService {
     });
   }
 
-  private waitForDetectorLoad(current: ActiveSwitch, detectorId: string): Observable<void> {
+  /** Detector counterpart of {@link waitForDatasetLoad}; same SSE-lag race,
+   *  same task-id guard, same id-based fallback when no task is tracked. */
+  private waitForDetectorLoad(
+    current: ActiveSwitch,
+    detectorId: string,
+    taskId: string,
+  ): Observable<void> {
     return new Observable<void>((sub) => {
+      let seen = false;
       this.progressEvents.detectorLoadingTasks$
         .pipe(
           takeUntil(current.cancellable),
-          filter(
-            (tasks: LoadingTask[]) =>
-              !tasks.some((t) => t.detector_id === detectorId && t.status !== 'idle'),
-          ),
+          filter((tasks: LoadingTask[]) => {
+            if (!taskId) {
+              return !tasks.some((t) => t.detector_id === detectorId && t.status !== 'idle');
+            }
+            const task = tasks.find((t) => t.task_id === taskId);
+            if (task) seen = true;
+            return seen && !(task && task.status !== 'idle');
+          }),
           take(1),
         )
         .subscribe({


### PR DESCRIPTION
## Problem

Clicking **Browse** on an *unloaded* dataset produced a big red error toast (which the user had to acknowledge) and then left the dataset row stuck mid-load on "Step 1 of 2". Every other verb (Train/Find/Load) loads the dataset first and then runs, so Browse should too.

## Root cause

The Browse button (`BrowsePrepService.prepareAndBrowse`) loads the dataset via `ContextSwitchService.applyActivePair` and then immediately builds its projection. The load-wait declared the load **complete** as soon as *no non-idle task existed for the dataset*:

```ts
filter(tasks => !tasks.some(t => t.dataset_id === datasetId && t.status !== 'idle'))
```

That condition is trivially true in the window between `loadRegistered`'s HTTP response (which only *kicks off* the background load) and the `loading-tasks` SSE frame arriving. So the wait fired early, `setActive` promoted the not-yet-loaded dataset, and the very next call — `POST /api/projection/build` — hit a still-loading dataset and returned **409**. `build()` isn't covered by `SKIP_ERROR_TOAST`, so the global error interceptor raised the "big red error", and the row state desynced into the frozen "Step 1 of 2".

The H25 regression spec even sidesteps this exact race by pre-seeding a non-idle task before asserting, with the comment *"otherwise the empty initial BehaviorSubject value would satisfy 'no task non-idle' trivially."* Production has no such pre-seed.

The rest of the codebase already guards this SSE-lag race — `DashboardLoadingTasksService` via `awaitedTaskIds`, the Browse-detector flow via a `seenRunning` flag — but the context-switch waiters did not.

## Fix

`waitForDatasetLoad` / `waitForDetectorLoad` now key on the load's own `task_id` (returned by `loadRegistered` / `loadDetector`) and settle only once that specific task has been **observed** in the SSE stream and is no longer running (idle or dropped). An empty `task_id` (the already-loaded / synchronous fast path that starts no tracked task) falls back to the prior id-based check, so no other flow changes behavior.

With the wait corrected, Browse promotes active only after the dataset is genuinely loaded, the projection build no longer 409s, and the row tracks the real load → projection → navigate sequence — matching the other verbs.

## Tests

- New regression test in `context-switch.service.spec.ts` reproducing the production timing (HTTP response before the SSE task) and asserting active stays pinned until the task appears **and** goes idle. It fails on the old code (premature flip) and passes on the fix.
- Updated the existing H25 dataset/detector waits to emit the realistic response shape (with `task_id`).
- Frontend gate green: TypeScript build clean (no warnings), 902 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wsh9mUxhxLdrAg8rqw7ZD

---
_Generated by [Claude Code](https://claude.ai/code/session_019wsh9mUxhxLdrAg8rqw7ZD)_