### PR TITLE
Handle RHEL modular cuda-drivers in install.sh driver auto-install

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -678,6 +678,17 @@ CPU arch) and retries. It also enables **EPEL** best-effort first, since `dkms`
 Note this is *not* something a reboot fixes — until the repo is enabled the
 package simply doesn't exist, so nothing got installed to take effect on boot.
 
+There is a **second** RHEL failure mode, hit on RHEL 8/9 (and Rocky / Alma /
+CentOS Stream) once the repo *is* enabled: the CUDA repo packages the driver as
+a **DNF module**, so `dnf install cuda-drivers` is rejected with `All matches
+were filtered out by modular filtering for argument: cuda-drivers`. The package
+exists but is hidden behind a module stream that has to be enabled first. The
+installer handles this too: after the plain `cuda-drivers` install is filtered
+out, it falls back to `dnf module install nvidia-driver:latest-dkms`
+(proprietary DKMS — covers Turing/Ampere/Ada like the g4dn's T4), and if that
+stream is unavailable it retries with `nvidia-driver:open-dkms` (the open kernel
+module, which newer datacenter GPUs such as Hopper and Blackwell require).
+
 You can also do it by hand:
 
 ```bash
@@ -688,7 +699,9 @@ sudo apt-get update && sudo apt-get install -y nvidia-driver-535   # or newer
 sudo dnf install -y epel-release                                   # for dkms
 sudo dnf config-manager --add-repo \
   https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-sudo dnf install -y cuda-drivers                                   # builds via DKMS
+# The driver is a DNF module on RHEL 8/9, so `dnf install cuda-drivers` is
+# rejected with "filtered out by modular filtering" -- install the module:
+sudo dnf module install -y nvidia-driver:latest-dkms              # builds via DKMS
 
 sudo reboot                                                        # if needed
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -167,6 +167,45 @@ vts_enable_nvidia_cuda_repo() {
     return 0
 }
 
+# Install the NVIDIA driver packages on the RHEL/Fedora/Amazon-Linux family,
+# coping with the two ways `cuda-drivers` can be unavailable:
+#
+#   1. The plain meta-package. On Fedora, Amazon Linux, and RHEL once the CUDA
+#      repo is enabled and NOT modular, `dnf install cuda-drivers` just works.
+#   2. The DNF *module*. On RHEL 8/9 (and Rocky/Alma/CentOS Stream) NVIDIA's CUDA
+#      repo ships the driver as a module stream, so a bare `dnf install
+#      cuda-drivers` is REJECTED with "All matches were filtered out by modular
+#      filtering for argument: cuda-drivers" -- the package exists but is hidden
+#      behind a module that must be enabled first. This is the failure on a fresh
+#      RHEL 9 GPU box (e.g. an AWS g4dn) even after the repo is enabled. The fix
+#      is `dnf module install nvidia-driver:<stream>`: latest-dkms (proprietary,
+#      covers Turing/Ampere/Ada like the T4) first, then open-dkms as a fallback
+#      for newer datacenter GPUs (Hopper, Blackwell) that ONLY have an open
+#      kernel module. Both build via DKMS, so they need the kernel-devel/dkms
+#      packages the caller installs beforehand.
+#   $1 = sudo prefix ("" or "sudo");  $2 = the dnf/yum command name.
+vts_rhel_install_driver_pkgs() {
+    local sudo_cmd="$1" dnf="$2"
+    if $sudo_cmd "$dnf" install -y cuda-drivers; then
+        return 0
+    fi
+    # `dnf module` doesn't exist under plain yum (RHEL 7), but there cuda-drivers
+    # is a plain package and the line above already succeeded, so we only reach
+    # here on dnf-based RHEL 8/9 where the modular path is the right one.
+    echo "  'cuda-drivers' is hidden behind a dnf module (RHEL 8/9 modular repo);" >&2
+    echo "  installing the nvidia-driver module stream instead." >&2
+    local stream
+    for stream in latest-dkms open-dkms; do
+        $sudo_cmd "$dnf" module reset -y nvidia-driver >/dev/null 2>&1 || true
+        if $sudo_cmd "$dnf" module install -y "nvidia-driver:${stream}"; then
+            echo "  Installed nvidia-driver:${stream}." >&2
+            return 0
+        fi
+        echo "  nvidia-driver:${stream} stream failed; trying the next stream." >&2
+    done
+    return 1
+}
+
 # Best-effort, distro-aware NVIDIA driver install so we can fix the missing
 # driver FOR the user instead of just telling them how. It's a privileged,
 # system-mutating step (kernel driver), so it only runs on an explicit choice
@@ -239,15 +278,18 @@ vts_install_nvidia_driver() {
             # A base AMI doesn't have NVIDIA's CUDA repo (which provides
             # cuda-drivers), so the first install attempt typically fails with
             # "No match for argument: cuda-drivers". Enable the repo and retry;
-            # this is the fix for the common fresh-RHEL-GPU-box failure.
-            if ! $sudo_cmd "$dnf" install -y cuda-drivers; then
+            # this is the fix for the common fresh-RHEL-GPU-box failure. The
+            # retry goes through vts_rhel_install_driver_pkgs, which ALSO handles
+            # the second RHEL failure mode -- "All matches were filtered out by
+            # modular filtering" -- by installing the nvidia-driver module stream.
+            if ! vts_rhel_install_driver_pkgs "$sudo_cmd" "$dnf"; then
                 echo "  cuda-drivers not available yet -- enabling NVIDIA's CUDA repo and retrying." >&2
                 if ! vts_enable_nvidia_cuda_repo "$sudo_cmd" "$dnf"; then
                     echo "  Could not enable NVIDIA's CUDA repo automatically; see AWS's guide:" >&2
                     echo "    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html" >&2
                     return 1
                 fi
-                if ! $sudo_cmd "$dnf" install -y cuda-drivers; then
+                if ! vts_rhel_install_driver_pkgs "$sudo_cmd" "$dnf"; then
                     echo "  cuda-drivers install still failed after enabling NVIDIA's CUDA repo." >&2
                     echo "  See AWS's GPU-driver guide:" >&2
                     echo "    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html" >&2


### PR DESCRIPTION
## What & why

The GPU driver auto-installer in `scripts/install.sh` dead-ended on a fresh **RHEL 9** GPU box (AWS `g4dn.4xlarge` / Tesla T4). It got as far as enabling NVIDIA's CUDA repo, but the retry failed with:

```
All matches were filtered out by modular filtering for argument: cuda-drivers
Error: Unable to find a match: cuda-drivers
```

On RHEL 8/9 (and Rocky / Alma / CentOS Stream) NVIDIA's CUDA repo ships the driver as a **DNF module**, so a bare `dnf install cuda-drivers` is rejected even once the repo is enabled — the package exists but is hidden behind a module stream. The installer only knew the *first* RHEL failure mode (`No match for argument: cuda-drivers`, repo not enabled) and kept retrying the same plain install, which can never succeed on a modular repo.

## Changes

- **`scripts/install.sh`**: new `vts_rhel_install_driver_pkgs` helper that:
  1. tries the plain `cuda-drivers` meta-package (Fedora / Amazon Linux / non-modular RHEL), then
  2. on the modular-filtering rejection, falls back to `dnf module install nvidia-driver:<stream>` — `latest-dkms` (proprietary DKMS; covers Turing/Ampere/Ada like the T4) first, then `open-dkms` (open kernel module, required by newer datacenter GPUs such as Hopper/Blackwell).

  Wired into both call sites in the RHEL branch (before and after enabling the CUDA repo). Both streams build via DKMS, which the surrounding code already provisions (kernel-devel/headers/gcc/make/dkms).
- **`docs/DEPLOYMENT.md`**: document the second RHEL failure mode and update the manual-install snippet to use `dnf module install -y nvidia-driver:latest-dkms`.

## Testing

- `bash -n scripts/install.sh` — syntax OK
- `codespell` clean on both changed files

The driver path can't be meaningfully exercised in the CPU-only test container (no GPU, no sudo driver install), so this is a best-effort shell change verified by syntax/spell checks; the existing pytest suite does not cover `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar6P3cfJpsteDa9NDfUpFt)_