### PR TITLE
Color console progress bar fill by completion (red/yellow/green)

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -158,6 +158,66 @@ class TestMakeConsoleProgress:
         for seg in renders:
             assert seg.index("s)") > seg.index("%")
 
+    def test_bar_fill_is_colored_red_at_or_below_half(self, capsys):
+        """A bar at ≤50% colors its fill red (between the brackets only)."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 30, 100)
+        cb("loading", "model.safetensors", 50, 100)
+
+        out = capsys.readouterr().out
+        # Every render's bracketed fill opens with the red code and resets
+        # before the closing bracket; the percentage stays uncolored.
+        for seg in (s for s in out.split("\r") if "[" in s):
+            assert "[\033[31m" in seg
+            assert "\033[0m]" in seg
+
+    def test_bar_fill_is_colored_yellow_past_half(self, capsys):
+        """A bar in (50%, 100%) colors its fill yellow."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 75, 100)
+
+        out = capsys.readouterr().out
+        assert "[\033[33m" in out
+        assert "\033[0m]" in out
+
+    def test_bar_fill_is_colored_green_at_completion(self, capsys):
+        """A 100% bar colors its fill green."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 100, 100)
+
+        out = capsys.readouterr().out
+        assert "[\033[32m" in out
+        assert "\033[0m]" in out
+
+    def test_completed_bar_via_flush_is_green(self, capsys):
+        """The flush-finalized bar (snap to 100%) colors its fill green."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 40, 100)
+        cb.flush()
+
+        out = capsys.readouterr().out
+        # The final overwrite is the full green bar at 100%.
+        assert "[\033[32m" + "#" * 30 + "\033[0m] 100%" in out
+
+    def test_color_codes_do_not_shift_bar_alignment(self, capsys):
+        """ANSI color codes live *inside* the brackets, so the open-bracket
+        column (and thus vertical alignment) is unaffected."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Importing torch…", 10, 100)
+        cb("loading", "Importing transformers…", 90, 100)
+        cb.flush()
+
+        out = capsys.readouterr().out
+        renders = [seg for seg in out.replace("\033[K", "").split("\r") if "[" in seg]
+        # The first "[" in each render is the bar's open bracket, not a code.
+        cols = {seg.index("[") for seg in renders}
+        assert len(cols) == 1, f"color codes shifted bars: columns were {cols}"
+
     def test_phase_after_progress_starts_new_line(self, capsys):
         """A phase message arriving mid-progress-bar should start a new line."""
         cb = _make_console_progress(lambda *a, **kw: None)

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -26,6 +26,27 @@ _TIME_SUFFIX_RE = re.compile(r"\s*\(\d+s(?:,\s*\d+\s+modules)?\)$")
 #: push their own bar right rather than being truncated.
 _LABEL_WIDTH = 32
 
+#: ANSI colors for the bar fill *between* the brackets (the rest of the line
+#: keeps its default color).  Red while at or below the half-way mark, yellow
+#: past it, green only at completion.  ``_ANSI_RESET`` restores the default so
+#: the closing bracket and trailing percentage are uncolored.
+_ANSI_RED = "\033[31m"
+_ANSI_YELLOW = "\033[33m"
+_ANSI_GREEN = "\033[32m"
+_ANSI_RESET = "\033[0m"
+
+
+def _bar_color(pct: int) -> str:
+    """Return the ANSI color for a bar at *pct* percent (0-100).
+
+    Red for ``pct <= 50``, yellow for ``50 < pct < 100``, green at ``100``.
+    """
+    if pct >= 100:
+        return _ANSI_GREEN
+    if pct > 50:
+        return _ANSI_YELLOW
+    return _ANSI_RED
+
 
 def _strip_time_suffix(msg: str) -> str:
     return _TIME_SUFFIX_RE.sub("", msg) if msg else msg
@@ -314,7 +335,7 @@ def _make_console_progress(original_callback):
         """Overwrite the current progress line with a 100% bar."""
         if _last_base[0]:
             label = f"{_last_base[0]:<{_LABEL_WIDTH}}"
-            sys.stdout.write(f"\r    {label} [{_FULL_BAR}] 100%\033[K")
+            sys.stdout.write(f"\r    {label} [{_ANSI_GREEN}{_FULL_BAR}{_ANSI_RESET}] 100%\033[K")
 
     def _flush() -> None:
         if _on_progress_line[0]:
@@ -337,7 +358,9 @@ def _make_console_progress(original_callback):
                 sys.stdout.write("\n")
             pct = min(100, current * 100 // total)
             filled = pct * 30 // 100
-            bar = "#" * filled + "." * (30 - filled)
+            # Color only the fill between the brackets: red ≤50%, yellow >50%,
+            # green at 100%.  The rest of the line keeps its default color.
+            bar = f"{_bar_color(pct)}{'#' * filled}{'.' * (30 - filled)}{_ANSI_RESET}"
             # Pad the base label to a fixed width so every bar starts at the
             # same column and the bars line up vertically.  The elapsed-time /
             # status suffix (e.g. "(3s, 247 modules)") goes *after* the


### PR DESCRIPTION
## What

The console progress bar painted during startup preloading (`_make_console_progress` in `vtscore/embedding/loader.py`) now colors the bar fill *between the brackets* by completion, leaving the rest of the line in its default color:

- **Red** at or below the half-way mark (`pct <= 50`)
- **Yellow** past half (`50 < pct < 100`)
- **Green** at completion (`pct == 100`), including the flush-finalized snap-to-100% bar

So `[##########....................]  33%` → red fill, `[##################............]  60%` → yellow fill, `[##############################] 100%` → green fill.

## How

- Added `_ANSI_RED/_YELLOW/_GREEN/_RESET` constants and a `_bar_color(pct)` helper.
- Wrapped only the `#`/`.` fill in the color code + reset, so the open bracket's column is unchanged and bars still align vertically. The percentage and brackets stay uncolored.

## Tests

Added cases under `TestMakeConsoleProgress` covering the red/yellow/green thresholds, the flush-finalized green bar, and that the color codes don't shift bar alignment. Full suite green (`./run-tests.sh`: 5275 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Ma5YCFin723V1qDszCB4)_