### PR TITLE
Engage region-select affordance while Shift held in VTSBrowse

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.html
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.html
@@ -1,3 +1,3 @@
-<div class="canvas-container" [class.marquee-active]="marqueeMode()">
+<div class="canvas-container" [class.marquee-active]="marqueeMode() || shiftHeld()">
   <canvas #canvas></canvas>
 </div>

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.scss
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.scss
@@ -19,8 +19,9 @@
     }
   }
 
-  // Region-select toggle on: a plain drag paints a marquee rather than panning,
-  // so the cursor reads as "draw a box" instead of "grab to pan".
+  // Region-select armed (toggle on, or Shift held): a drag paints a marquee
+  // rather than panning, so the cursor reads as "draw a box" instead of "grab
+  // to pan".
   &.marquee-active canvas {
     cursor: crosshair;
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -114,6 +114,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   readonly marqueeMode = input(false);
   /**
+   * Whether Shift is currently held (tracked by the parent view). Shift+drag
+   * draws a region marquee, so while Shift is down the canvas shows the same
+   * crosshair cursor as {@link marqueeMode} to preview the gesture. The actual
+   * Shift+drag is detected from `event.shiftKey` at mousedown; this input only
+   * drives the cursor affordance.
+   */
+  readonly shiftHeld = input(false);
+  /**
    * How many wheel notches cross one pyramid level (a full 2x of zoom) — the
    * per-media ``browse_mouse_zooms_per_level`` setting. The per-notch width
    * factor is ``2 ** (1 / n)``, so 1 ⇒ 2x (one notch per level), 2 ⇒ √2 (the

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -77,6 +77,7 @@
             [thumbnailBorder]="thumbnailBorder()"
             [zoomsPerLevel]="zoomsPerLevel()"
             [marqueeMode]="marqueeMode"
+            [shiftHeld]="shiftHeld()"
             (hexHover)="onHexHover($event)"
             (densityMaxChanged)="onDensityMaxChanged($event)"
             (contextMenu)="onCanvasContextMenu($event)"
@@ -102,8 +103,8 @@
               <button
                 type="button"
                 class="browse-size-btn"
-                [class.browse-size-btn--active]="marqueeMode"
-                [attr.aria-pressed]="marqueeMode"
+                [class.browse-size-btn--active]="regionDrawActive"
+                [attr.aria-pressed]="regionDrawActive"
                 (click)="toggleMarqueeMode()"
                 title="Region select: drag to select a region (Shift+drag also works)"
                 aria-label="Region select: drag to select a region">

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -145,6 +145,18 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   marqueeMode = false;
 
   /**
+   * Whether Shift is currently held. Shift+drag draws a region marquee, so while
+   * Shift is down we momentarily engage the region-select affordance — the
+   * toolbar button lights up and the canvas cursor switches to a crosshair — the
+   * same way holding Shift for region voting previews that mode. Reset on window
+   * blur so alt-tabbing away doesn't strand the view in the engaged state.
+   */
+  readonly shiftHeld = signal(false);
+  private keyDownHandler?: (e: KeyboardEvent) => void;
+  private keyUpHandler?: (e: KeyboardEvent) => void;
+  private blurHandler?: () => void;
+
+  /**
    * Subset mode: browse an ephemeral UMAP fit over just a handful of media
    * (the positives of a Find run) instead of the full dataset. Set from the
    * `?subset=1` query param plus a handoff from {@link BrowseSubsetService}.
@@ -263,6 +275,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.setupShiftListeners();
     this.settingsState.load();
 
     // Subset mode: the Find view handed off a set of positive ids to project
@@ -327,8 +340,43 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (this.pollTimer) clearTimeout(this.pollTimer);
     document.removeEventListener('mousemove', this.boundPanelMove);
     document.removeEventListener('mouseup', this.boundPanelUp);
+    this.removeShiftListeners();
     this.tileCache.clear();
     this.releaseEphemeralPositivesContext();
+  }
+
+  /**
+   * Track the Shift key at the window level so {@link regionDrawActive} reflects
+   * it. The canvas detects `event.shiftKey` directly when a drag starts, so this
+   * is purely for the affordance (button + cursor); the blur reset mirrors the
+   * image viewer's region-draw handling.
+   */
+  private setupShiftListeners(): void {
+    this.keyDownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') this.shiftHeld.set(true);
+    };
+    this.keyUpHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') this.shiftHeld.set(false);
+    };
+    this.blurHandler = () => this.shiftHeld.set(false);
+    window.addEventListener('keydown', this.keyDownHandler);
+    window.addEventListener('keyup', this.keyUpHandler);
+    window.addEventListener('blur', this.blurHandler);
+  }
+
+  private removeShiftListeners(): void {
+    if (this.keyDownHandler) window.removeEventListener('keydown', this.keyDownHandler);
+    if (this.keyUpHandler) window.removeEventListener('keyup', this.keyUpHandler);
+    if (this.blurHandler) window.removeEventListener('blur', this.blurHandler);
+  }
+
+  /**
+   * Region-select armed: either the GUI toggle is on, or Shift is held. Drives
+   * both the toolbar button's engaged state and the canvas crosshair cursor, so
+   * holding Shift previews the Shift+drag region gesture.
+   */
+  get regionDrawActive(): boolean {
+    return this.marqueeMode || this.shiftHeld();
   }
 
   /** Free a detector-positives browse context (`__detpos__<detectorId>`) when

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -126,4 +126,33 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(errEl).not.toBeNull();
     expect(errEl!.textContent).toContain('projection exploded');
   });
+
+  it('engages region-draw while Shift is held, releasing on keyup and blur', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+
+    // Idle: neither the GUI toggle nor Shift is active.
+    expect(component.shiftHeld()).toBe(false);
+    expect(component.regionDrawActive).toBe(false);
+
+    // Holding Shift previews the region-select gesture (button + cursor).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+    expect(component.shiftHeld()).toBe(true);
+    expect(component.regionDrawActive).toBe(true);
+
+    // Releasing Shift disengages it again.
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift' }));
+    expect(component.shiftHeld()).toBe(false);
+    expect(component.regionDrawActive).toBe(false);
+
+    // A window blur (alt-tab) drops a stuck Shift so the view never strands.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+    expect(component.shiftHeld()).toBe(true);
+    window.dispatchEvent(new Event('blur'));
+    expect(component.shiftHeld()).toBe(false);
+
+    // The GUI toggle keeps engaging region-draw independently of Shift.
+    component.toggleMarqueeMode();
+    expect(component.regionDrawActive).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

In VTSBrowse, holding **Shift** arms the region marquee (Shift+drag to rubber-band a selection instead of panning), but nothing previewed that mode while Shift was down: the cursor stayed a grab hand and the toolbar's region-select button looked idle. You only got the crosshair + engaged button when the GUI toggle was on.

This mirrors the image viewer's "hold Shift for region voting" behavior: while Shift is held, the region-select toolbar button lights up (engaged) and the canvas cursor switches to a crosshair, so the Shift+drag gesture previews itself.

## Changes

- **`browse-view.component.ts`** — track Shift at the window level via a `shiftHeld` signal (keydown/keyup, plus a blur reset so alt-tabbing away doesn't strand the engaged state, matching the image viewer). New `regionDrawActive` getter = `marqueeMode || shiftHeld()`.
- **`browse-view.component.html`** — the region-select button's `--active` class and `aria-pressed` now bind to `regionDrawActive`; `shiftHeld` is passed down to the canvas.
- **`browse-canvas.component.ts` / `.html` / `.scss`** — new `shiftHeld` input OR'd into the `.marquee-active` cursor class so the crosshair shows while Shift is held. The actual Shift+drag is still detected from `event.shiftKey` at mousedown; this input only drives the cursor affordance.
- **`browse-view.zoneless.spec.ts`** — added coverage for `shiftHeld`/`regionDrawActive` engaging on Shift keydown, releasing on keyup and on window blur, and the GUI toggle engaging independently.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, Vitest 903 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee8vLmj6iK819R4xKns9PT)_