### PR TITLE
install.sh: heartbeat + capture noisy driver-install fallback output

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -763,37 +763,51 @@ CPU-only torch (same as `bash scripts/install.sh cpu`); `[s]` stops. On a
 so it stops — unless you set `VTSEARCH_AUTO_DRIVER=1` (auto-install the driver)
 or `VTSEARCH_ASSUME_CPU=1` (proceed CPU-only) to choose unattended.
 
-### GPU install prints a red "dependency conflicts" report (harmless)
+**About the output.** The driver install is a *try-until-one-works* cascade, and
+on a bare cloud GPU box its early attempts are *expected* to fail (the dnf module
+is filtered, `dkms` is unreachable, etc.) before a later approach succeeds. By
+default each attempt runs under a **live heartbeat** with its output captured to
+a log, so instead of the raw `Problem 1..6 / nothing provides dkms` /
+`filtered out by modular filtering` / subscription-manager walls you see a moving
+`Installing … ` line followed by either a green `✓` or a dim *"not available
+here; trying another approach…"*. The captured output is shown only if a step
+genuinely fails. The heartbeat also keeps long, otherwise-silent steps (metadata
+refresh, the kernel-module compile, the torch import in the smoke test) visibly
+alive so they don't look frozen. To watch every command's raw, unfiltered output
+live (e.g. to debug a genuinely stuck install), re-run with
+`VTSEARCH_VERBOSE=1 bash scripts/install.sh`.
 
-**Symptom**: The cuML step of `scripts/install.sh` ends with a wall of red
-text, then keeps going and reports success:
-
-```
-ERROR: pip's dependency resolver does not currently take into account all the
-packages that are installed. This behaviour is the source of the following
-dependency conflicts.
-torch 2.6.0+cu124 requires nvidia-cublas-cu12==12.4.5.8 ... but you have
-nvidia-cublas-cu12 12.9.2.10 which is incompatible.
-... (one line per nvidia-*-cu12 lib)
-Successfully installed nvidia-cublas-cu12-12.9.2.10 ...
-  cuML installed: GPU UMAP + k-means enabled.
-```
+### GPU install's cuML step (the "dependency conflicts" report, captured by default)
 
 **Cause**: cuML (RAPIDS 25.x) depends on **newer** `nvidia-*-cu12` runtime
 wheels than the torch build pins **exactly** (e.g. `cu124` torch pins
 `==12.4.x`). Installing cuML upgrades those libs, so pip's post-install
-consistency check flags torch's now-unsatisfied `==` pins. **This is cosmetic
-and non-fatal**: pip completes the install and rolls nothing back, and CUDA
-12.x minor runtimes are ABI-compatible across versions, so torch keeps working
-on the bumped libraries.
+consistency check emits a red `ERROR: pip's dependency resolver ...` report
+flagging torch's now-unsatisfied `==` pins:
 
-**What to do**: nothing. `scripts/install.sh` prints a heads-up before the
-cuML step and runs a **GPU smoke test** at the end (a tiny torch CUDA matmul +
-a cuML import) that confirms the stack actually works — if that smoke test
-passes, the red report did not matter. Only act if the smoke test *fails*, or
-if your error is the **fatal** `cuda_fp8.hpp` / nvjitlink variant below (that
-one names `nvidia-nvjitlink-cu12 >= 12.9` and `cuml-cu12 >= 26`, and the
-install does **not** succeed) — that is a different problem with a real fix.
+```
+ERROR: pip's dependency resolver does not currently take into account all the
+packages that are installed. ... torch 2.6.0+cu124 requires
+nvidia-cublas-cu12==12.4.5.8 ... but you have nvidia-cublas-cu12 12.9.2.10
+which is incompatible. ... (one line per nvidia-*-cu12 lib)
+```
+
+**This is cosmetic and non-fatal**: pip completes the install and rolls nothing
+back, and CUDA 12.x minor runtimes are ABI-compatible across versions, so torch
+keeps working on the bumped libraries.
+
+**What you actually see**: by default `scripts/install.sh` runs the cuML step
+under a heartbeat with its output **captured to a log**, so that red wall does
+**not** scroll past — you see a live `Installing cuML/RAPIDS …` line and then a
+green `✓`. The raw report only surfaces if the step actually fails, or if you
+re-run with `VTSEARCH_VERBOSE=1` (which streams every step's raw output live).
+
+**What to do**: nothing. The installer runs a **GPU smoke test** at the end (a
+tiny torch CUDA matmul + a cuML import) that confirms the stack actually works.
+Only act if the smoke test *fails*, or if your error is the **fatal**
+`cuda_fp8.hpp` / nvjitlink variant below (that one names `nvidia-nvjitlink-cu12
+>= 12.9` and `cuml-cu12 >= 26`, and the install does **not** succeed) — that is
+a different problem with a real fix.
 
 ### cuML crashes compiling a kernel (`cuda_fp8.hpp` / nvrtc errors)
 

--- a/scripts/_progress.sh
+++ b/scripts/_progress.sh
@@ -17,12 +17,14 @@ if [ -t 1 ]; then
     _VTS_BOLD="$(printf '\033[1m')"
     _VTS_CYAN="$(printf '\033[36m')"
     _VTS_GREEN="$(printf '\033[32m')"
+    _VTS_RED="$(printf '\033[31m')"
     _VTS_DIM="$(printf '\033[2m')"
     _VTS_RESET="$(printf '\033[0m')"
 else
     _VTS_BOLD=""
     _VTS_CYAN=""
     _VTS_GREEN=""
+    _VTS_RED=""
     _VTS_DIM=""
     _VTS_RESET=""
 fi
@@ -67,4 +69,158 @@ vts_progress_done() {
     local msg="$1"
     printf '\n%s%s✓ %s (total: %s)%s\n\n' \
         "$_VTS_BOLD" "$_VTS_GREEN" "$msg" "$(_vts_elapsed)" "$_VTS_RESET"
+}
+
+# --- live "heartbeat" command runner -----------------------------------------
+# Long install steps (dnf metadata refresh, kernel-module compile, multi-GB pip
+# downloads, the GPU smoke-test import) can sit silent for 10s-several minutes,
+# which looks frozen. And the driver install is a try-until-one-works cascade
+# whose doomed early attempts dump scary-but-recoverable dnf/pip error walls
+# (the "Problem 1..6 / nothing provides dkms" tree, "filtered out by modular
+# filtering", the red "pip's dependency resolver" report, the unregistered-RHEL
+# subscription-manager noise). Users read those as the installer crashing.
+#
+# vts_run / vts_try fix both at once: they run a command with its combined
+# output captured to a temp log while an animated heartbeat (elapsed seconds)
+# shows the step is alive, then print a single ✓/✗ verdict line. The noisy
+# output stays in the log instead of scrolling past as a wall.
+#
+#   vts_run "Label" cmd args...   # on failure: print ✗ and DUMP the log
+#   vts_try "Label" cmd args...   # on failure: print a dim "trying another
+#                                 #   approach" and stay quiet -- for a
+#                                 #   best-effort step in a cascade whose
+#                                 #   failure is expected and handled by the
+#                                 #   caller's next fallback.
+#
+# Both return the command's exit status and leave the log path in $VTS_LAST_LOG.
+# Set VTSEARCH_VERBOSE=1 to stream every command's raw output live instead (no
+# capture, no spinner) -- the escape hatch for debugging a genuinely stuck run.
+#
+# Pass the command as separate args (NO shell operators / pipes / redirects).
+# For an optional sudo prefix, use an UNQUOTED variable so an empty value (the
+# already-root case) vanishes instead of becoming a literal empty argument:
+#   vts_try "Installing X" ${sudo_cmd} "$dnf" install -y x
+#
+# Used as a bare statement under `set -e`, a failing vts_try aborts the script;
+# append `|| true` when the failure is meant to be tolerated outside an `if`.
+
+VTS_LAST_LOG=""
+
+_vts_run_ok()   { printf '%s✓%s %s\n' "$_VTS_GREEN" "$_VTS_RESET" "$1"; }
+_vts_run_fail() { printf '%s✗%s %s\n' "$_VTS_RED" "$_VTS_RESET" "$1"; }
+_vts_run_soft() {
+    printf '  %s↻ %s — not available here; trying another approach…%s\n' \
+        "$_VTS_DIM" "$1" "$_VTS_RESET"
+}
+
+# Echo a captured log, indented and fenced, only if it has content.
+vts_dump_log() {
+    local log="${1:-$VTS_LAST_LOG}"
+    [ -n "$log" ] && [ -s "$log" ] || return 0
+    printf '%s    ---- captured output (set VTSEARCH_VERBOSE=1 to see this live) ----%s\n' \
+        "$_VTS_DIM" "$_VTS_RESET"
+    sed 's/^/    /' "$log"
+    printf '%s    ----------------------------------------------------------------%s\n' \
+        "$_VTS_DIM" "$_VTS_RESET"
+}
+
+# Animate a heartbeat next to $2 until background pid $1 exits. TTY: an in-place
+# spinner with elapsed seconds. Non-TTY (CI, `curl ... | bash`): a dot every few
+# seconds so piped logs still show the step is alive.
+_vts_spin() {
+    local pid="$1" label="$2"
+    local frames='|/-\' i=0 start now el
+    start=$(date +%s)
+    if [ -t 1 ]; then
+        while kill -0 "$pid" 2>/dev/null; do
+            i=$(((i + 1) % 4))
+            now=$(date +%s)
+            el=$((now - start))
+            printf '\r%s%s%s %s %s(%ds)%s\033[K' \
+                "$_VTS_CYAN" "${frames:$i:1}" "$_VTS_RESET" \
+                "$label" "$_VTS_DIM" "$el" "$_VTS_RESET"
+            sleep 0.2
+        done
+        printf '\r\033[K'
+    else
+        printf '   %s … ' "$label"
+        while kill -0 "$pid" 2>/dev/null; do
+            printf '.'
+            sleep 5
+        done
+        printf '\n'
+    fi
+}
+
+_vts_mktemp() { mktemp 2>/dev/null || printf '/tmp/vts_run.%s.%s' "$$" "${RANDOM:-0}"; }
+
+# mode: hard (print ✗ and dump the log on failure) | soft (stay quiet on failure,
+# for a best-effort cascade step the caller will fall back from).
+_vts_run_impl() {
+    local mode="$1"; shift
+    local label="$1"; shift
+    local rc=0
+
+    if [ "${VTSEARCH_VERBOSE:-0}" = "1" ]; then
+        VTS_LAST_LOG="/dev/null"
+        printf '%s ▸ %s%s\n' "$_VTS_DIM" "$label" "$_VTS_RESET"
+        if "$@"; then rc=0; else rc=$?; fi
+        if [ "$rc" -eq 0 ]; then _vts_run_ok "$label"
+        elif [ "$mode" = soft ]; then _vts_run_soft "$label"
+        else _vts_run_fail "$label"; fi
+        return "$rc"
+    fi
+
+    local log
+    log="$(_vts_mktemp)"
+    VTS_LAST_LOG="$log"
+    # stdin from /dev/null so a backgrounded command never blocks invisibly on a
+    # prompt (e.g. an un-warmed sudo); it fails fast and we dump/handle the log.
+    "$@" >"$log" 2>&1 </dev/null &
+    local pid=$!
+    _vts_spin "$pid" "$label"
+    wait "$pid" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        _vts_run_ok "$label"
+    elif [ "$mode" = soft ]; then
+        _vts_run_soft "$label"
+    else
+        _vts_run_fail "$label"
+        vts_dump_log "$log"
+    fi
+    # Keep the log only for a hard failure (already dumped, but handy for VERBOSE
+    # re-runs); drop it otherwise. Guarded so `set -e` can't fire on the test.
+    if [ "$rc" -eq 0 ] || [ "$mode" = soft ]; then
+        rm -f "$log" 2>/dev/null || true
+    fi
+    return "$rc"
+}
+
+vts_run() { local l="$1"; shift; _vts_run_impl hard "$l" "$@"; }
+vts_try() { local l="$1"; shift; _vts_run_impl soft "$l" "$@"; }
+
+# --- sudo credential keep-alive ----------------------------------------------
+# vts_run backgrounds commands with stdin from /dev/null, so a sudo step that
+# needs a password would fail fast rather than prompt. Warm the sudo timestamp
+# up front (one foreground prompt) and refresh it in the background so the whole
+# driver install runs without a mid-step password stall. $1 = sudo prefix (""
+# => already root, nothing to do). Returns non-zero if creds can't be cached
+# (no TTY and no NOPASSWD); the caller proceeds and backgrounded sudo fails fast.
+VTS_SUDO_KEEPALIVE_PID=""
+vts_sudo_keepalive() {
+    local sudo_cmd="$1"
+    [ -n "$sudo_cmd" ] || return 0
+    $sudo_cmd -v || return 1
+    ( while true; do
+          sleep 50
+          $sudo_cmd -n -v >/dev/null 2>&1 || exit 0
+      done ) &
+    VTS_SUDO_KEEPALIVE_PID=$!
+    return 0
+}
+vts_sudo_keepalive_stop() {
+    [ -n "$VTS_SUDO_KEEPALIVE_PID" ] && kill "$VTS_SUDO_KEEPALIVE_PID" 2>/dev/null
+    VTS_SUDO_KEEPALIVE_PID=""
+    return 0
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,14 @@ set -euo pipefail
 # (VTSearch also smoke-tests CUDA at runtime and falls back to CPU if the
 # installed wheel can't run on the GPU, so a mismatch degrades instead of
 # crashing - but you only get GPU acceleration with a matching wheel.)
+#
+# OUTPUT / QUIET MODE: the driver install is a try-until-one-works cascade, and
+# its doomed early attempts (on a bare cloud GPU box) print scary-but-recoverable
+# dnf/pip error walls. By default those attempts run under a live heartbeat with
+# their output captured to a log, so you see "trying X… not available here, trying
+# the next approach" instead of a wall of red, and the raw output only surfaces if
+# a step actually fails. Set VTSEARCH_VERBOSE=1 to stream every command's raw
+# output live (no capture, no spinner) when debugging a genuinely stuck install.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -154,10 +162,12 @@ vts_enable_nvidia_cuda_repo() {
     # .repo file directly -- tool-agnostic and works under yum too.
     local repo_file="/etc/yum.repos.d/cuda-${slug}.repo"
     if command -v curl >/dev/null 2>&1; then
-        $sudo_cmd curl -fsSL -o "$repo_file" "$url" \
+        vts_run "Adding NVIDIA's CUDA repo (${slug})" \
+            ${sudo_cmd} curl -fsSL -o "$repo_file" "$url" \
             || { echo "  Failed to download the CUDA .repo file (network/proxy/404?)." >&2; return 1; }
     elif command -v wget >/dev/null 2>&1; then
-        $sudo_cmd wget -qO "$repo_file" "$url" \
+        vts_run "Adding NVIDIA's CUDA repo (${slug})" \
+            ${sudo_cmd} wget -qO "$repo_file" "$url" \
             || { echo "  Failed to download the CUDA .repo file (network/proxy/404?)." >&2; return 1; }
     else
         echo "  Neither curl nor wget is available to fetch the CUDA .repo file." >&2
@@ -165,7 +175,7 @@ vts_enable_nvidia_cuda_repo() {
     fi
 
     # Refresh metadata so the newly added repo is visible to the installer.
-    $sudo_cmd "$dnf" makecache >/dev/null 2>&1 || true
+    vts_try "Refreshing package metadata" ${sudo_cmd} "$dnf" makecache || true
     return 0
 }
 
@@ -202,14 +212,14 @@ vts_enable_nvidia_cuda_repo() {
 #   $1 = sudo prefix ("" or "sudo");  $2 = the dnf/yum command name.
 vts_rhel_install_driver_pkgs() {
     local sudo_cmd="$1" dnf="$2"
-    if $sudo_cmd "$dnf" install -y cuda-drivers; then
+    if vts_try "Installing NVIDIA driver (cuda-drivers package)" \
+        ${sudo_cmd} "$dnf" install -y cuda-drivers; then
         return 0
     fi
     # `dnf module` doesn't exist under plain yum (RHEL 7), but there cuda-drivers
     # is a plain package and the line above already succeeded, so we only reach
     # here on dnf-based RHEL 8/9 where the modular path is the right one.
-    echo "  'cuda-drivers' is hidden behind a dnf module (RHEL 8/9 modular repo);" >&2
-    echo "  installing the nvidia-driver module stream instead." >&2
+    echo "  (cuda-drivers is a dnf module here; using a driver module stream instead.)" >&2
 
     # The -dkms streams need `dkms` (from EPEL). Make it present before trying
     # them; if it can't be installed, skip straight to the precompiled streams
@@ -218,19 +228,17 @@ vts_rhel_install_driver_pkgs() {
     if vts_rhel_ensure_dkms "$sudo_cmd" "$dnf"; then
         streams="latest-dkms open-dkms latest open"
     else
-        echo "  dkms is unavailable -- skipping the DKMS streams and trying the" >&2
-        echo "  precompiled (kABI-tracking) streams, which need no dkms." >&2
+        echo "  (dkms unavailable; trying the precompiled kABI-tracking streams.)" >&2
         streams="latest open"
     fi
 
     local stream
     for stream in $streams; do
         $sudo_cmd "$dnf" module reset -y nvidia-driver >/dev/null 2>&1 || true
-        if $sudo_cmd "$dnf" module install -y "nvidia-driver:${stream}"; then
-            echo "  Installed nvidia-driver:${stream}." >&2
+        if vts_try "Installing NVIDIA driver module stream: ${stream}" \
+            ${sudo_cmd} "$dnf" module install -y "nvidia-driver:${stream}"; then
             return 0
         fi
-        echo "  nvidia-driver:${stream} stream failed; trying the next stream." >&2
     done
     return 1
 }
@@ -252,8 +260,8 @@ vts_rhel_ensure_dkms() {
     if command -v dkms >/dev/null 2>&1 || rpm -q dkms >/dev/null 2>&1; then
         return 0
     fi
-    $sudo_cmd "$dnf" install -y epel-release >/dev/null 2>&1 || true
-    $sudo_cmd "$dnf" install -y dkms >/dev/null 2>&1 || true
+    vts_try "Enabling EPEL (for dkms)" ${sudo_cmd} "$dnf" install -y epel-release || true
+    vts_try "Installing dkms" ${sudo_cmd} "$dnf" install -y dkms || true
     if command -v dkms >/dev/null 2>&1 || rpm -q dkms >/dev/null 2>&1; then
         return 0
     fi
@@ -269,9 +277,9 @@ vts_rhel_ensure_dkms() {
     case "$rhelver" in
         [0-9]*)
             local epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${rhelver}.noarch.rpm"
-            echo "  Bootstrapping EPEL from ${epel_url} to satisfy dkms." >&2
-            $sudo_cmd "$dnf" install -y "$epel_url" >/dev/null 2>&1 || true
-            $sudo_cmd "$dnf" install -y dkms >/dev/null 2>&1 || true
+            vts_try "Bootstrapping EPEL from ${epel_url}" \
+                ${sudo_cmd} "$dnf" install -y "$epel_url" || true
+            vts_try "Installing dkms" ${sudo_cmd} "$dnf" install -y dkms || true
             ;;
     esac
     command -v dkms >/dev/null 2>&1 || rpm -q dkms >/dev/null 2>&1
@@ -308,10 +316,11 @@ vts_install_driver_runfile() {
     if command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
         local dnf="dnf"
         command -v dnf >/dev/null 2>&1 || dnf="yum"
-        $sudo_cmd "$dnf" install -y "kernel-devel-$(uname -r)" kernel-headers gcc make tar \
-            >/dev/null 2>&1 || true
+        vts_try "Installing kernel headers + build tools" \
+            ${sudo_cmd} "$dnf" install -y "kernel-devel-$(uname -r)" kernel-headers gcc make tar || true
     elif command -v apt-get >/dev/null 2>&1; then
-        $sudo_cmd apt-get install -y "linux-headers-$(uname -r)" gcc make >/dev/null 2>&1 || true
+        vts_try "Installing kernel headers + build tools" \
+            ${sudo_cmd} apt-get install -y "linux-headers-$(uname -r)" gcc make || true
     fi
 
     local url="${VTSEARCH_NVIDIA_RUNFILE_URL:-}"
@@ -358,13 +367,12 @@ vts_install_driver_runfile() {
         return 1
     fi
 
-    echo "  Running the NVIDIA installer (silent; compiles the kernel module against" >&2
-    echo "  kernel $(uname -r)). This takes a few minutes and disables nouveau." >&2
     # --silent implies --no-questions/--ui=none. --disable-nouveau blacklists the
     # conflicting OSS driver (a reboot then loads nvidia). --no-cc-version-check
     # tolerates a gcc that differs from the one the kernel was built with.
-    $sudo_cmd sh "$runfile" --silent --disable-nouveau --no-cc-version-check
-    local rc=$?
+    local rc=0
+    vts_run "Compiling the NVIDIA kernel module (a few minutes; kernel $(uname -r))" \
+        ${sudo_cmd} sh "$runfile" --silent --disable-nouveau --no-cc-version-check || rc=$?
     rm -f "$runfile"
     if [ "$rc" -ne 0 ]; then
         echo "  The NVIDIA .run installer exited non-zero (see /var/log/nvidia-installer.log)." >&2
@@ -407,6 +415,12 @@ vts_install_nvidia_driver() {
     echo "  Installing the NVIDIA driver (distro: ${distro:-unknown}). This needs" >&2
     echo "  network access and a few minutes; you may be prompted for your password." >&2
 
+    # Cache sudo credentials now (one prompt) and keep them warm for the duration,
+    # so the backgrounded heartbeat-wrapped steps below never stall invisibly on a
+    # password prompt. The RETURN trap stops the refresher on every exit path.
+    vts_sudo_keepalive "$sudo_cmd" || true
+    trap 'vts_sudo_keepalive_stop' RETURN
+
     # Set to 1 by any branch that gets the driver packages installed. When it
     # stays 0, we fall through to the universal `.run` installer fallback below
     # rather than giving up -- this is what saves a bare RHEL 9 box where every
@@ -414,17 +428,19 @@ vts_install_nvidia_driver() {
     local pkg_ok=0
     case "$distro" in
         *ubuntu* | *debian*)
-            if $sudo_cmd apt-get update; then
+            if vts_try "Refreshing apt package lists" ${sudo_cmd} apt-get update; then
                 # ubuntu-drivers picks the recommended driver for THIS GPU; fall
                 # back to a recent fixed branch if the helper isn't installed.
                 if ! command -v ubuntu-drivers >/dev/null 2>&1; then
-                    $sudo_cmd apt-get install -y ubuntu-drivers-common >/dev/null 2>&1 || true
+                    vts_try "Installing ubuntu-drivers-common" \
+                        ${sudo_cmd} apt-get install -y ubuntu-drivers-common || true
                 fi
                 if command -v ubuntu-drivers >/dev/null 2>&1; then
-                    if $sudo_cmd ubuntu-drivers install || $sudo_cmd apt-get install -y nvidia-driver-535; then
+                    if vts_try "Installing the recommended NVIDIA driver (ubuntu-drivers)" ${sudo_cmd} ubuntu-drivers install \
+                        || vts_try "Installing NVIDIA driver (nvidia-driver-535)" ${sudo_cmd} apt-get install -y nvidia-driver-535; then
                         pkg_ok=1
                     fi
-                elif $sudo_cmd apt-get install -y nvidia-driver-535; then
+                elif vts_try "Installing NVIDIA driver (nvidia-driver-535)" ${sudo_cmd} apt-get install -y nvidia-driver-535; then
                     pkg_ok=1
                 fi
                 [ "$pkg_ok" -eq 1 ] || echo "  driver package install failed." >&2
@@ -444,8 +460,8 @@ vts_install_nvidia_driver() {
                 # (The `dkms` package itself comes from EPEL and is handled inside
                 # vts_rhel_install_driver_pkgs -> vts_rhel_ensure_dkms, which knows
                 # how to bootstrap EPEL when the packaged epel-release isn't found.)
-                $sudo_cmd "$dnf" install -y "kernel-devel-$(uname -r)" kernel-headers gcc make \
-                    >/dev/null 2>&1 || true
+                vts_try "Installing kernel headers + build tools" \
+                    ${sudo_cmd} "$dnf" install -y "kernel-devel-$(uname -r)" kernel-headers gcc make || true
                 # A base AMI doesn't have NVIDIA's CUDA repo (which provides
                 # cuda-drivers), so the first install attempt typically fails with
                 # "No match for argument: cuda-drivers". Enable the repo and retry;
@@ -590,6 +606,9 @@ vts_install_precommit() {
 # `--extra-index-url <cpu wheel index>` + `-e .[dev]`.
 vts_install_cpu() {
     vts_progress_init 4 "Installing VTSearch CPU dependencies"
+    echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
+    echo "for 10-30s at a time while it resolves dependency versions. That silence is"
+    echo "normal -- it is working, not frozen."
 
     vts_progress_step "Checking Python version (>= 3.10)"
     # shellcheck source=_check-python.sh
@@ -652,23 +671,23 @@ vts_install_cuml() {
 
     # Heads-up: cuML depends on NEWER nvidia-*-cu12 runtime wheels than the torch
     # build pins exactly (e.g. cu124 torch pins ==12.4.x), so installing it upgrades
-    # those libs and pip prints a red "dependency conflicts" report naming torch's
+    # those libs and pip emits a red "dependency conflicts" report naming torch's
     # now-unsatisfied pins. This is distinct from the FATAL RAPIDS-26 nvjitlink/fp8
     # break the cuml-cu12<26 cap above prevents -- this one is cosmetic. That is
     # EXPECTED and non-fatal -- pip still completes the install and does not roll
     # anything back, and CUDA 12.x runtimes are compatible across minor versions.
-    # The GPU smoke test at the end of this install confirms torch + cuML actually
-    # work together, so you don't have to guess whether the red text mattered.
-    echo "  Note: pip may print a red 'dependency conflicts' report below (torch pins"
-    echo "        older CUDA runtime libs than cuML wants). It is expected and"
-    echo "        non-fatal; the final GPU smoke test verifies they coexist."
+    # vts_run captures that report into a log instead of letting it scroll past as
+    # a scary red wall (it surfaces only if the install actually fails); the GPU
+    # smoke test below then confirms torch + cuML coexist. This is a multi-GB
+    # RAPIDS download, so the heartbeat's elapsed-time counter is the liveness cue.
+    echo "  (cuML is a large multi-GB download; the heartbeat below shows progress."
+    echo "   A cosmetic pip 'dependency conflicts' report is captured, not shown.)"
 
-    # Isolated pass against the NVIDIA index. Guarded so `set -e` can't abort the
-    # install on failure; the runtime cuML detection degrades to CPU either way.
-    if pip install --extra-index-url https://pypi.nvidia.com \
-        --prefer-binary \
-        "$cuml_pkg" \
-        --progress-bar on; then
+    # Isolated pass against the NVIDIA index. vts_run is guarded so `set -e` can't
+    # abort the install on failure; the runtime cuML detection degrades to CPU.
+    if vts_run "Installing cuML/RAPIDS (${cuml_pkg})" \
+        pip install --extra-index-url https://pypi.nvidia.com \
+            --prefer-binary "$cuml_pkg"; then
         echo "  cuML installed: GPU UMAP + k-means enabled."
     else
         echo "warning: cuML (${cuml_pkg}) install failed; GPU UMAP/k-means will fall" >&2
@@ -694,8 +713,12 @@ vts_smoke_test_gpu() {
         return 0
     fi
 
-    local rc=0
-    "$pybin" - <<'PY' || rc=$?
+    # Write the probe to a temp file so it can be run as a backgrounded command
+    # under a heartbeat (importing torch alone is a ~15s silent stretch that looks
+    # frozen); a heredoc on stdin can't be backgrounded with stdin from /dev/null.
+    local rc=0 pyfile log pid
+    pyfile="$(mktemp --suffix=.py 2>/dev/null || mktemp)"
+    cat >"$pyfile" <<'PY'
 import sys
 
 try:
@@ -730,6 +753,19 @@ except Exception:  # noqa: BLE001 - absence is fine; app uses the CPU fallback
 sys.exit(0 if gpu_ok else 1)
 PY
 
+    if [ "${VTSEARCH_VERBOSE:-0}" = "1" ]; then
+        "$pybin" "$pyfile" || rc=$?
+    else
+        log="$(_vts_mktemp)"
+        "$pybin" "$pyfile" >"$log" 2>&1 </dev/null &
+        pid=$!
+        _vts_spin "$pid" "Importing torch + exercising the GPU"
+        wait "$pid" || rc=$?
+        cat "$log"
+        rm -f "$log" 2>/dev/null || true
+    fi
+    rm -f "$pyfile" 2>/dev/null || true
+
     case "$rc" in
         0) ;;  # GPU verified end-to-end; the python output already said so.
         1) ;;  # torch fine but no usable CUDA -> CPU mode; python explained why.
@@ -753,6 +789,9 @@ vts_install_gpu() {
     local extra_index="https://download.pytorch.org/whl/${cuda_tag}"
 
     vts_progress_init 8 "Installing VTSearch GPU dependencies (CUDA tag: ${cuda_tag})"
+    echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
+    echo "for 10-30s at a time while it resolves dependency versions. That silence is"
+    echo "normal -- it is working, not frozen."
 
     vts_progress_step "Checking Python version (>= 3.10)"
     # shellcheck source=_check-python.sh
@@ -832,6 +871,8 @@ case "$MODE" in
                         echo "driver installed but its module isn't loaded yet; otherwise the" >&2
                         echo "named repo/package error), resolve it, then re-run:" >&2
                         echo "  bash scripts/install.sh" >&2
+                        echo "For the full, unfiltered output of every step, re-run with:" >&2
+                        echo "  VTSEARCH_VERBOSE=1 bash scripts/install.sh" >&2
                         exit 1
                     fi
                     ;;


### PR DESCRIPTION
## Problem

Installing GPU deps on a fresh cloud GPU box (e.g. an AWS `g4dn.xlarge`) *works*, but it's rough to watch and tempts impatient users to cancel a perfectly good install:

- **Scary-but-recoverable error walls.** The driver install is a *try-until-one-works* cascade. On a bare/unregistered RHEL box its early attempts are *expected* to fail before a later approach succeeds, and each doomed attempt dumped its raw output: the `Problem 1..6 / nothing provides dkms` dependency tree, `All matches were filtered out by modular filtering`, the repeated unregistered-RHEL `subscription-manager` notices, and the cuML step's red `ERROR: pip's dependency resolver …` report. It reads like the installer is crashing.
- **Silent ~20s "frozen" pauses.** Steps silenced with `>/dev/null 2>&1` (`dnf makecache`, `dnf install kernel-devel …`), the `.run` kernel-module compile (prints two lines then goes quiet for minutes), and the GPU smoke-test `import torch` all ran with zero output.

## What changed

**`scripts/_progress.sh` — a shared heartbeat command runner:**

- `vts_run` / `vts_try` run a command with combined output captured to a temp log behind an **animated heartbeat** (elapsed seconds on a TTY; periodic dots when piped), then print a one-line `✓`/`✗` verdict. `vts_run` dumps the log on failure; `vts_try` stays quiet on failure (a best-effort cascade step the caller falls back from) and narrates *"not available here; trying another approach…"*.
- `VTSEARCH_VERBOSE=1` streams every command's raw output live (no capture, no spinner) — the escape hatch for debugging a genuinely stuck install.
- `vts_sudo_keepalive` caches `sudo` up front and refreshes it in the background, so the backgrounded (stdin-from-`/dev/null`) steps never stall invisibly on a password prompt. A `RETURN` trap stops the refresher exactly when the driver install returns.

**`scripts/install.sh` — wire it through:**

- Driver cascade (`cuda-drivers`, `nvidia-driver:*` module streams, EPEL/`dkms` bootstrap, kernel headers, the `.run` compile) now narrates instead of dumping walls.
- The cuML step's red dependency-conflicts report is captured (shown only on failure or under `VTSEARCH_VERBOSE=1`).
- The GPU smoke test runs under a heartbeat (extracted to a temp file so it can be backgrounded), preserving its `0`/`1` exit-code semantics.
- A heads-up before the pip steps explains that the silent dependency-resolution phase is normal — those keep their native download progress bars.

**`docs/DEPLOYMENT.md`** — updated the driver-install and cuML troubleshooting sections to describe the narrated/quiet default and the `VTSEARCH_VERBOSE` escape hatch.

## Testing

- `./run-tests.sh` → **ALL 5275 TESTS PASSED** (ruff / codespell / deptry / frontend-build gates run first and passed).
- Functionally exercised the new runner helpers (success, soft-fail, hard-fail-with-dump, empty-sudo-prefix elision, `VTSEARCH_VERBOSE` live streaming) and verified `RETURN`-trap scoping fires once on the function's own return and never for nested/later functions.
- `bash -n` clean on both scripts. (No real GPU box available in this environment, so the live driver cascade wasn't exercised end-to-end.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MT6C5xc6gZPPdG7SS7F3GQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MT6C5xc6gZPPdG7SS7F3GQ)_