### PR TITLE
Brighten stdout progress bar yellow

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -179,7 +179,7 @@ class TestMakeConsoleProgress:
         cb("loading", "model.safetensors", 75, 100)
 
         out = capsys.readouterr().out
-        assert "[\033[33m" in out
+        assert "[\033[93m" in out
         assert "\033[0m]" in out
 
     def test_bar_fill_is_colored_green_at_completion(self, capsys):

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -31,7 +31,7 @@ _LABEL_WIDTH = 32
 #: past it, green only at completion.  ``_ANSI_RESET`` restores the default so
 #: the closing bracket and trailing percentage are uncolored.
 _ANSI_RED = "\033[31m"
-_ANSI_YELLOW = "\033[33m"
+_ANSI_YELLOW = "\033[93m"  # bright yellow; the dim \033[33m renders olive/brown
 _ANSI_GREEN = "\033[32m"
 _ANSI_RESET = "\033[0m"
 


### PR DESCRIPTION
## Summary

The stdout preload progress bar's "yellow" fill (shown for 50% < pct < 100%) used the standard ANSI yellow code `\033[33m`, which most terminals render as a dim olive/brown rather than a vivid yellow. Switched it to the bright-yellow variant `\033[93m` so the mid-range bar reads as actual yellow.

## Changes

- `vtscore/embedding/loader.py`: `_ANSI_YELLOW` now `\033[93m` (bright yellow) with a clarifying comment.
- `tests_lib/cli/test_preload_progress.py`: updated the yellow-fill assertion to match the new code.

## Testing

- `./run-tests.sh cli` — all 193 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kFKUK25gXGhJSnjpj5iv9

---
_Generated by [Claude Code](https://claude.ai/code/session_012kFKUK25gXGhJSnjpj5iv9)_