### PR TITLE
No-extraction archive-member byte serving + import (WebDataset tar shards, Phase A)

### DIFF
--- a/docs/plans/webdataset-tar-import.md
+++ b/docs/plans/webdataset-tar-import.md
@@ -1,0 +1,93 @@
+# WebDataset-style tar-sharded import (microvent / multivent-raw)
+
+**Status:** Phase A shipped; Phase B planned (see Open follow-ups).
+
+## Problem
+
+Load large WebDataset-style corpora (GRID **microvent**, **multivent-raw**) into
+VTSearch for VTSBrowse / similarity search over audio/video events, where the
+media lives inside **tar shards** (`microvent/videos/shard_000000.tar`, …), the
+embeddings are **precomputed** (512-dim CLAP), and only a **filtered subset** is
+wanted. The corpora are far too large to extract a second on-disk copy
+(multivent-raw's `videos/` alone is **4.1 TB across 667 shards**), so import and
+playback must be **no-extraction**: serve a single tar member on demand.
+
+The pre-existing `local_archive` import path (`vtscore/datasets/archive.py`)
+extracts whole archives under `DATA_DIR` — a non-starter at these sizes — and the
+byte routes only read a local file path. This plan closes that gap.
+
+## Phase A — shipped (no-extraction byte serving + whole-member import)
+
+What landed:
+
+- **`vtscore/datasets/archive_stream.py`** — streams one tar/zip member with a
+  cached `{member: info}` index (metadata only, never bytes), reading just a byte
+  *range* by seeking within the member's file object. `read_member`,
+  `read_member_range`, `member_size`, `archive_member_ref`,
+  `build_archive_member_origin`, and the `local_archive_member` origin name.
+- **Unified, archive-aware byte resolution.** `MediaType._resolve_media_bytes`
+  (`vtscore/media/base.py`) gained an archive-member branch; the route-level
+  `_resolve_bytes` (`vtsearch/routes/media/list.py`) and the crop/seed
+  `_resolve_media_bytes` (`vtsearch/routes/media/server.py`) now delegate to it,
+  so inline bytes → lazy clip → **archive member** → local path → remote URL is a
+  single chain instead of three path-only duplicates.
+- **True Range streaming for playback.** `_send_streamed_range` +
+  `_archive_member_response` serve `/video` and `/audio` for archive-member media
+  by reading only the requested slice out of the shard (a few seconds of playback
+  transfers a few seconds of bytes), never extracting or fully buffering.
+- **`local_archive_member` importer** — imports a manifest-selected subset of
+  members as **whole-member** media with their precomputed vectors, reading **no
+  member data** (only each shard's tar headers, to confirm the member exists and
+  record its size). md5 is synthesized from `archive::member` (the corpora don't
+  use content-based cross-dataset label transfer; see the importer docstring).
+- **Manifest reader** —
+  `read_npz_archive_member_rows` (`_npz_vectors.py`) reads `{vectors, members,
+  archives, filenames?, embedder_name?}`, broadcasting a scalar `archives` for
+  one-shard manifests.
+
+Net effect: a filtered subset of either corpus imports with **zero disk growth**
+and plays back whole chunks by streaming single members.
+
+## Open follow-ups (Phase B — sub-file clip windows + full re-derivation)
+
+Tracked here, not in the PR body.
+
+1. **Sub-file clip windows (gap 3).** Let one member yield multiple media items
+   carrying `clip_start` / `clip_end`. The serving + frontend side is largely
+   already present: the video player seeks/loops on `clip_*`
+   (`video-player.component.ts`) and `batch_medias` passes the fields through.
+   Audio should use the **same display-only seek** (serve the whole member, seek
+   in the player) rather than byte-slicing — the existing `lazy_clip` audio path
+   is WAV-only (`_wav_slice`) and these corpora are AAC/MP4, which we do not want
+   to decode server-side. Wire `lazy_clip._read_source_bytes` to an archive
+   member only if a future windowing recipe needs sliced bytes; for display-only
+   windowing nothing more than the clip fields is required.
+
+2. **Windowed precomputed-embedding import (gap 4).** Extend the manifest schema
+   with `clip_start` / `clip_end` (and optional `window_id`) so one member fans
+   out into N windowed items (≈14 × 10 s CLAP windows per chunk), each its own
+   searchable media with its own precomputed vector. The Phase A importer already
+   emits one row → one item; windowing is "many rows per member" + carrying the
+   clip fields onto each media. Keep md5 unique per *window* (fold the window id
+   into the synthesized hash).
+
+3. **Archive-member `MediaSource` for cross-dataset re-derivation.** The
+   `MediaSource` / `FetchedItem` contract is path-based, so archive members
+   (which have no on-disk path) currently have no source factory. Bytes already
+   re-derive via the origin (the byte routes), and a full pickle persists
+   embeddings, and the importer's `reload_from_origin` rebuilds the whole dataset
+   from the manifest — so the only unsupported flow is **per-media** cross-dataset
+   "Find" / example-sort-from-origin (`example_sort_origin` returns 400 "no media
+   source"). Closing it needs either a bytes-returning `FetchedItem` extension or
+   a manifest-backed source that re-supplies vectors by `(archive, member)`.
+
+4. **Audio mimetype + container nuances.** The `/audio` route now derives the
+   mimetype from the member extension (defaulting to `audio/wav`). microvent ships
+   demuxed AAC; multivent-raw audio rides in the video MP4 (no separate audio
+   dir), so most "audio events" are served through the **video** element's audio
+   track. Validate AAC/`audio/mp4` playback across browsers when wiring the GUI.
+
+5. **GUI / docs polish.** The importer registers in the server-tab picker with a
+   `.npz` manifest field; add a short user-docs section and (if a screenshot
+   frames the importer picker) queue a reshoot in
+   `docs/user/screenshots-reshoot-queue.md`.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5854,6 +5854,62 @@
         ],
         "type": "object"
       },
+      "import_dataset_LocalArchiveMemberImporter_Args": {
+        "additionalProperties": true,
+        "properties": {
+          "build_projection": {
+            "default": null,
+            "nullable": true
+          },
+          "clipper": {
+            "default": null,
+            "nullable": true
+          },
+          "clipper_params": {
+            "default": null,
+            "nullable": true
+          },
+          "dataset_name": {
+            "default": null,
+            "nullable": true
+          },
+          "embedder": {
+            "default": null,
+            "nullable": true
+          },
+          "embedders": {
+            "default": null,
+            "nullable": true
+          },
+          "manifest": {
+            "type": "string"
+          },
+          "media_type": {
+            "default": "video",
+            "enum": [
+              "audio",
+              "document",
+              "image",
+              "text",
+              "video",
+              ""
+            ],
+            "type": "string"
+          },
+          "merge_near_duplicates": {
+            "default": null,
+            "nullable": true
+          },
+          "source_specs": {
+            "default": null,
+            "nullable": true
+          }
+        },
+        "required": [
+          "manifest"
+        ],
+        "type": "object"
+      },
       "import_dataset_LocalFilesDatasetImporter_Args": {
         "additionalProperties": true,
         "properties": {
@@ -6471,6 +6527,38 @@
         },
         "required": [
           "url"
+        ],
+        "type": "object"
+      },
+      "stage_import_LocalArchiveMemberImporter_Args": {
+        "additionalProperties": true,
+        "properties": {
+          "dataset_name": {
+            "default": null,
+            "nullable": true
+          },
+          "manifest": {
+            "type": "string"
+          },
+          "media_type": {
+            "default": "video",
+            "enum": [
+              "audio",
+              "document",
+              "image",
+              "text",
+              "video",
+              ""
+            ],
+            "type": "string"
+          },
+          "source_specs": {
+            "default": null,
+            "nullable": true
+          }
+        },
+        "required": [
+          "manifest"
         ],
         "type": "object"
       },
@@ -8205,6 +8293,34 @@
         ]
       }
     },
+    "/api/dataset/import/local_archive_member": {
+      "post": {
+        "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "import_dataset__local_archive_member",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/import_dataset_LocalArchiveMemberImporter_Args"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Run a registered importer by name in a background thread.",
+        "tags": [
+          "datasets_staging"
+        ]
+      }
+    },
     "/api/dataset/import/local_files": {
       "post": {
         "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
@@ -8828,6 +8944,34 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/stage_import_HttpArchiveDatasetImporter_Args"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Run a registered importer in staging mode.",
+        "tags": [
+          "datasets_staging"
+        ]
+      }
+    },
+    "/api/dataset/stage-import/local_archive_member": {
+      "post": {
+        "description": "Plugin-dependent body shape: not described in the OpenAPI spec.",
+        "operationId": "stage_import__local_archive_member",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/stage_import_LocalArchiveMemberImporter_Args"
               }
             }
           },

--- a/tests/core/test_archive_member_routes.py
+++ b/tests/core/test_archive_member_routes.py
@@ -1,0 +1,101 @@
+"""End-to-end: serve archive-member media bytes via the playback routes.
+
+Exercises the no-extraction path -- a media whose bytes live inside a tar shard
+is streamed (with HTTP Range) straight out of the archive by the video/audio
+routes, never extracting or fully buffering the member.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import numpy as np
+
+from vtsearch.state import medias
+
+VIDEO_BYTES = b"FAKE-MP4-VIDEO-MEMBER-CONTENT-" * 32
+AUDIO_BYTES = b"FAKE-AAC-AUDIO-MEMBER-CONTENT-" * 16
+_MEDIA_ID = 90001
+
+
+def _make_shard(tmp_path):
+    archive = tmp_path / "shard_000000.tar"
+    with tarfile.open(archive, "w") as tf:
+        for name, payload in (("clip.mp4", VIDEO_BYTES), ("clip.aac", AUDIO_BYTES)):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    return archive
+
+
+def _inject(archive, member, media_type, filename):
+    medias[_MEDIA_ID] = {
+        "id": _MEDIA_ID,
+        "media_type": media_type,
+        "embedder": "clap",
+        "embeddings": {"clap": np.zeros(512, dtype=np.float32)},
+        "md5": "0" * 32,
+        "filename": filename,
+        "category": "custom",
+        "media_bytes": None,
+        "media_string": None,
+        "duration": 0,
+        "origin": {
+            "importer": "local_archive_member",
+            "params": {"archive_path": str(archive), "member": member, "media_type": media_type},
+        },
+        "archive_member": {"path": str(archive), "member": member},
+    }
+
+
+class TestArchiveMemberVideo:
+    def test_full_video_streams_member_bytes(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.mp4", "video", "clip.mp4")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/video")
+        assert resp.status_code == 200
+        assert resp.data == VIDEO_BYTES
+        assert resp.headers["Accept-Ranges"] == "bytes"
+        assert resp.headers["Content-Type"] == "video/mp4"
+
+    def test_range_request_returns_partial(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.mp4", "video", "clip.mp4")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/video", headers={"Range": "bytes=5-19"})
+        assert resp.status_code == 206
+        assert resp.data == VIDEO_BYTES[5:20]
+        assert resp.headers["Content-Range"] == f"bytes 5-19/{len(VIDEO_BYTES)}"
+        assert resp.headers["Content-Length"] == "15"
+
+    def test_unsatisfiable_range_returns_416(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.mp4", "video", "clip.mp4")
+        resp = client.get(
+            f"/api/medias/{_MEDIA_ID}/video", headers={"Range": f"bytes={len(VIDEO_BYTES) + 10}-"}
+        )
+        assert resp.status_code == 416
+        assert resp.headers["Content-Range"] == f"bytes */{len(VIDEO_BYTES)}"
+
+    def test_missing_member_falls_through_to_404(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "not_present.mp4", "video", "not_present.mp4")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/video")
+        assert resp.status_code == 404
+
+
+class TestArchiveMemberAudio:
+    def test_audio_streams_member_bytes(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.aac", "audio", "clip.aac")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/audio")
+        assert resp.status_code == 200
+        assert resp.data == AUDIO_BYTES
+        assert resp.headers["Accept-Ranges"] == "bytes"
+
+    def test_audio_range_request_returns_partial(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.aac", "audio", "clip.aac")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/audio", headers={"Range": "bytes=3-10"})
+        assert resp.status_code == 206
+        assert resp.data == AUDIO_BYTES[3:11]

--- a/tests/core/test_archive_member_routes.py
+++ b/tests/core/test_archive_member_routes.py
@@ -71,9 +71,7 @@ class TestArchiveMemberVideo:
     def test_unsatisfiable_range_returns_416(self, client, tmp_path):
         archive = _make_shard(tmp_path)
         _inject(archive, "clip.mp4", "video", "clip.mp4")
-        resp = client.get(
-            f"/api/medias/{_MEDIA_ID}/video", headers={"Range": f"bytes={len(VIDEO_BYTES) + 10}-"}
-        )
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/video", headers={"Range": f"bytes={len(VIDEO_BYTES) + 10}-"})
         assert resp.status_code == 416
         assert resp.headers["Content-Range"] == f"bytes */{len(VIDEO_BYTES)}"
 

--- a/tests_lib/datasets/test_archive_stream.py
+++ b/tests_lib/datasets/test_archive_stream.py
@@ -1,0 +1,123 @@
+"""Tests for no-extraction archive-member streaming (``archive_stream``)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from vtscore.datasets.archive_stream import (
+    LOCAL_ARCHIVE_MEMBER_IMPORTER,
+    ArchiveMemberError,
+    archive_member_ref,
+    build_archive_member_origin,
+    member_size,
+    read_member,
+    read_member_range,
+)
+
+MEMBER_A = b"the quick brown fox jumps over the lazy dog" * 4
+MEMBER_B = b"second member payload \x00\x01\x02 binary-ish" * 8
+
+
+def _make_tar(tmp_path: Path) -> Path:
+    archive = tmp_path / "shard_000000.tar"
+    with tarfile.open(archive, "w") as tf:
+        for name, payload in (("chunk_a.mp4", MEMBER_A), ("sub/chunk_b.aac", MEMBER_B)):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    return archive
+
+
+def _make_zip(tmp_path: Path) -> Path:
+    archive = tmp_path / "shard.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("chunk_a.mp4", MEMBER_A)
+        zf.writestr("sub/chunk_b.aac", MEMBER_B)
+    return archive
+
+
+class TestReadMember:
+    def test_member_size_tar(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        assert member_size(archive, "chunk_a.mp4") == len(MEMBER_A)
+        assert member_size(archive, "sub/chunk_b.aac") == len(MEMBER_B)
+
+    def test_read_whole_member_tar(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        assert read_member(archive, "chunk_a.mp4") == MEMBER_A
+        assert read_member(archive, "sub/chunk_b.aac") == MEMBER_B
+
+    def test_read_whole_member_zip(self, tmp_path):
+        archive = _make_zip(tmp_path)
+        assert read_member(archive, "chunk_a.mp4") == MEMBER_A
+        assert read_member(archive, "sub/chunk_b.aac") == MEMBER_B
+
+    @pytest.mark.parametrize("make", [_make_tar, _make_zip])
+    def test_partial_range_reads_only_slice(self, tmp_path, make):
+        archive = make(tmp_path)
+        # A middle slice should equal the corresponding bytes of the member.
+        start, length = 10, 17
+        got = read_member_range(archive, "chunk_a.mp4", start, length)
+        assert got == MEMBER_A[start : start + length]
+
+    @pytest.mark.parametrize("make", [_make_tar, _make_zip])
+    def test_range_to_end_when_length_none(self, tmp_path, make):
+        archive = make(tmp_path)
+        start = 25
+        got = read_member_range(archive, "chunk_a.mp4", start, None)
+        assert got == MEMBER_A[start:]
+
+    def test_missing_member_raises(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        with pytest.raises(ArchiveMemberError):
+            member_size(archive, "does_not_exist.mp4")
+
+    def test_missing_archive_raises(self, tmp_path):
+        with pytest.raises(ArchiveMemberError):
+            read_member(tmp_path / "nope.tar", "x")
+
+    def test_index_cache_busts_on_mtime(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        assert member_size(archive, "chunk_a.mp4") == len(MEMBER_A)
+        # Rewrite the archive with a differently-sized member; the cache key
+        # folds in size+mtime, so the new index must be picked up.
+        new_payload = MEMBER_A + b"EXTRA"
+        with tarfile.open(archive, "w") as tf:
+            info = tarfile.TarInfo("chunk_a.mp4")
+            info.size = len(new_payload)
+            tf.addfile(info, io.BytesIO(new_payload))
+        assert read_member(archive, "chunk_a.mp4") == new_payload
+
+
+class TestArchiveMemberRef:
+    def test_ref_from_top_level_field(self):
+        media = {"archive_member": {"path": "/a/shard.tar", "member": "m.mp4"}}
+        assert archive_member_ref(media) == ("/a/shard.tar", "m.mp4")
+
+    def test_ref_from_origin_params(self):
+        origin = build_archive_member_origin("/a/shard.tar", "m.mp4", "video")
+        ref = archive_member_ref({"origin": origin})
+        assert ref is not None
+        path, member = ref
+        assert Path(path).name == "shard.tar"
+        assert member == "m.mp4"
+
+    def test_origin_importer_name_gates_fallback(self):
+        # A non-archive-member origin must not be misread as one.
+        media = {"origin": {"importer": "server_folder", "params": {"path": "/x", "member": "m"}}}
+        assert archive_member_ref(media) is None
+
+    def test_returns_none_when_absent(self):
+        assert archive_member_ref({"media_path": "/x/y.wav"}) is None
+
+    def test_build_origin_shape(self):
+        origin = build_archive_member_origin("/a/shard.tar", "m.mp4", "video")
+        assert origin["importer"] == LOCAL_ARCHIVE_MEMBER_IMPORTER
+        assert origin["params"]["member"] == "m.mp4"
+        assert origin["params"]["media_type"] == "video"
+        assert Path(origin["params"]["archive_path"]).name == "shard.tar"

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -118,9 +118,7 @@ class TestImporter:
 
     def test_skips_missing_members(self, tmp_path):
         archive = _make_tar(tmp_path)
-        manifest = _make_manifest(
-            tmp_path, archive, members=["chunk_a.mp4", "not_in_shard.mp4"]
-        )
+        manifest = _make_manifest(tmp_path, archive, members=["chunk_a.mp4", "not_in_shard.mp4"])
         medias: dict[int, dict] = {}
         IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
         # The missing member is skipped; the real one still imports.

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -1,0 +1,145 @@
+"""Tests for the ``local_archive_member`` importer + its NPZ manifest reader."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vtscore.datasets.archive_stream import archive_member_ref, read_member
+from vtscore.datasets.importers._npz_vectors import read_npz_archive_member_rows
+from vtscore.datasets.importers.local_archive_member import IMPORTER
+
+MEMBERS = {
+    "chunk_a.mp4": b"AAAA-payload-a" * 16,
+    "sub/chunk_b.mp4": b"BBBB-payload-b" * 16,
+}
+DIM = 512
+
+
+def _make_tar(tmp_path: Path) -> Path:
+    archive = tmp_path / "shard_000000.tar"
+    with tarfile.open(archive, "w") as tf:
+        for name, payload in MEMBERS.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    return archive
+
+
+def _make_manifest(tmp_path: Path, archive: Path, *, scalar_archive: bool = True, members=None) -> Path:
+    members = members if members is not None else list(MEMBERS)
+    rng = np.random.default_rng(7)
+    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    manifest = tmp_path / "manifest.npz"
+    archives = np.array(str(archive)) if scalar_archive else np.array([str(archive)] * len(members))
+    np.savez(
+        manifest,
+        vectors=vectors,
+        members=np.array(members),
+        archives=archives,
+        embedder_name=np.array("largerclapgeneral"),
+    )
+    return manifest
+
+
+class TestManifestReader:
+    def test_reads_rows_with_scalar_archive(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive, scalar_archive=True)
+        rows = read_npz_archive_member_rows(manifest)
+        assert len(rows) == 2
+        assert {r["member"] for r in rows} == set(MEMBERS)
+        for r in rows:
+            assert Path(r["archive"]).name == "shard_000000.tar"
+            assert r["vector"].shape == (DIM,)
+        # filename defaults to the member basename.
+        by_member = {r["member"]: r for r in rows}
+        assert by_member["sub/chunk_b.mp4"]["filename"] == "chunk_b.mp4"
+
+    def test_reads_rows_with_per_row_archives(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive, scalar_archive=False)
+        rows = read_npz_archive_member_rows(manifest)
+        assert len(rows) == 2
+
+    def test_missing_required_arrays_raise(self, tmp_path):
+        bad = tmp_path / "bad.npz"
+        np.savez(bad, vectors=np.zeros((2, DIM), dtype=np.float32))
+        with pytest.raises(ValueError):
+            read_npz_archive_member_rows(bad)
+
+
+class TestImporter:
+    def test_imports_whole_members_without_bytes(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+
+        assert len(medias) == 2
+        for media in medias.values():
+            assert media["media_type"] == "video"
+            # No materialized bytes / disk path: bytes re-derive from the shard.
+            assert media["media_bytes"] is None
+            assert "media_path" not in media or media["media_path"] is None
+            # Precomputed embedding is carried, under the manifest's embedder.
+            assert media["embedder"] == "largerclapgeneral"
+            assert media["embeddings"]["largerclapgeneral"].shape == (DIM,)
+            assert len(media["md5"]) == 32
+            ref = media["archive_member"]
+            assert Path(ref["path"]).name == "shard_000000.tar"
+            assert media["origin"]["importer"] == "local_archive_member"
+            assert media["origin"]["params"]["manifest"] == str(manifest.resolve())
+
+    def test_imported_media_bytes_resolve_from_shard(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+
+        for media in medias.values():
+            ref = archive_member_ref(media)
+            assert ref is not None
+            data = read_member(ref[0], ref[1])
+            assert data == MEMBERS[ref[1]]
+
+    def test_unique_md5_per_member(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        md5s = {m["md5"] for m in medias.values()}
+        assert len(md5s) == len(medias)
+
+    def test_skips_missing_members(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(
+            tmp_path, archive, members=["chunk_a.mp4", "not_in_shard.mp4"]
+        )
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        # The missing member is skipped; the real one still imports.
+        assert len(medias) == 1
+        assert next(iter(medias.values()))["archive_member"]["member"] == "chunk_a.mp4"
+
+    def test_all_missing_raises(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive, members=["nope1.mp4", "nope2.mp4"])
+        medias: dict[int, dict] = {}
+        with pytest.raises(ValueError):
+            IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+
+    def test_reload_from_origin_round_trips(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        origin = next(iter(medias.values()))["origin"]
+        assert IMPORTER.can_reload_from_origin(origin)
+        reloaded = IMPORTER.reload_from_origin(origin)
+        assert reloaded == {"manifest": str(manifest.resolve()), "media_type": "video"}

--- a/tests_lib/io/test_importer_loading.py
+++ b/tests_lib/io/test_importer_loading.py
@@ -683,11 +683,17 @@ class TestImporterResolveFileContract:
     #   streamed to a temp directory and re-imported through the regular
     #   `server_folder` importer, so resolution for those medias goes
     #   through `server_folder.resolve_file`.
+    # - local_archive_member: media have no on-disk path by design (their
+    #   bytes stream from a tar/zip member, never extracted); resolution goes
+    #   through the archive-member byte path (``archive_member_ref``), not a
+    #   disk Path. Cross-dataset re-derivation is a tracked Phase B follow-up
+    #   (docs/plans/webdataset-tar-import.md).
     _DELEGATE_IMPORTERS = {
         "pickle",
         "combine_datasets",
         "local_folder",
         "local_files",
+        "local_archive_member",
     }
 
     def test_all_disk_importers_override_resolve_file(self):

--- a/vtscore/datasets/archive_stream.py
+++ b/vtscore/datasets/archive_stream.py
@@ -1,0 +1,207 @@
+"""Stream a single member out of a local tar/zip archive without extracting.
+
+This is the no-extraction counterpart to :mod:`vtscore.datasets.archive`,
+which extracts a whole archive to :data:`~vtscore.config.DATA_DIR`.  Here we
+serve **one member on demand**: a ``{member_name: info}`` index is built once
+per archive (cached, keyed by path/size/mtime) and a byte range of a single
+member is read by seeking within that member's file object.  So playback of a
+media stored inside a multi-GB tar shard never materialises the member on disk
+and, paired with HTTP Range, downloads only the bytes the browser actually
+plays.
+
+This is the mechanism a WebDataset-style corpus needs: tens of thousands of
+audio/video chunks live in a handful of multi-GB ``shard_*.tar`` files, far too
+large to extract a second on-disk copy of (multivent-raw's ``videos/`` alone is
+4.1 TB).  A ``local_archive_member`` media records only ``{archive path,
+member}`` and re-derives its bytes through here.
+
+Per the "no persisted vectors / bytes" rule nothing here writes member bytes
+anywhere: the only cache is the in-memory member **index** (TarInfo / ZipInfo
+metadata, not content), which is rebuilt from the archive on the next start.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import threading
+import zipfile
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "LOCAL_ARCHIVE_MEMBER_IMPORTER",
+    "ArchiveMemberError",
+    "archive_member_ref",
+    "build_archive_member_origin",
+    "member_size",
+    "read_member",
+    "read_member_range",
+]
+
+#: Origin importer name for media served straight out of an archive member
+#: (no extraction).  Resolves through
+#: :class:`~vtscore.datasets.sources.local_archive_member.LocalArchiveMemberSource`.
+LOCAL_ARCHIVE_MEMBER_IMPORTER = "local_archive_member"
+
+
+class ArchiveMemberError(Exception):
+    """Raised when an archive or one of its members cannot be read."""
+
+
+# Process-scoped index cache.  Keyed by (resolved path, size, mtime_ns) so a
+# replaced archive busts the cache; the value is a {member_name: info} map of
+# tarfile.TarInfo / zipfile.ZipInfo objects (metadata only -- never bytes).
+_index_cache: dict[tuple[str, int, int], dict[str, Any]] = {}
+_index_lock = threading.Lock()
+
+
+def _cache_key(path: Path) -> tuple[str, int, int]:
+    st = path.stat()
+    return (str(path), st.st_size, st.st_mtime_ns)
+
+
+def _is_zip(path: Path) -> bool:
+    """Return True when *path* is a zip archive (sniffed, then by suffix)."""
+    try:
+        if zipfile.is_zipfile(path):
+            return True
+    except OSError:
+        pass
+    return path.name.lower().endswith(".zip")
+
+
+def _build_index(path: Path) -> dict[str, Any]:
+    """Build a ``{member_name: info}`` index for *path* (tar or zip)."""
+    if _is_zip(path):
+        with zipfile.ZipFile(path, "r") as zf:
+            return {info.filename: info for info in zf.infolist() if not info.is_dir()}
+    try:
+        with tarfile.open(path, "r:*") as tf:
+            return {m.name: m for m in tf.getmembers() if m.isfile()}
+    except tarfile.TarError as exc:
+        raise ArchiveMemberError(f"Not a readable tar/zip archive: {path} ({exc})") from exc
+
+
+def _index(path: Path) -> dict[str, Any]:
+    """Return the cached member index for *path*, building it on first use."""
+    key = _cache_key(path)
+    with _index_lock:
+        cached = _index_cache.get(key)
+    if cached is not None:
+        return cached
+    index = _build_index(path)
+    with _index_lock:
+        _index_cache[key] = index
+    return index
+
+
+def _resolve(archive_path: str | Path, member: str) -> tuple[Path, Any, bool]:
+    """Resolve *(archive_path, member)* to ``(path, info, is_zip)``.
+
+    Raises :class:`ArchiveMemberError` if the archive is missing or the member
+    is not present in it.
+    """
+    path = Path(archive_path)
+    if not path.is_file():
+        raise ArchiveMemberError(f"Archive not found: {path}")
+    index = _index(path)
+    info = index.get(member)
+    if info is None:
+        raise ArchiveMemberError(f"Member {member!r} not found in archive {path}")
+    return path, info, isinstance(info, zipfile.ZipInfo)
+
+
+def member_size(archive_path: str | Path, member: str) -> int:
+    """Return the uncompressed size in bytes of *member* inside *archive_path*."""
+    _path, info, is_zip = _resolve(archive_path, member)
+    return int(info.file_size if is_zip else info.size)
+
+
+def read_member(archive_path: str | Path, member: str) -> bytes:
+    """Read and return the **whole** *member* from *archive_path*.
+
+    Used by callers that genuinely need every byte (computing a content hash,
+    embedding, transcoding a non-streamable container).  Range-served playback
+    should use :func:`read_member_range` so it never holds the whole member in
+    memory.
+    """
+    return read_member_range(archive_path, member, 0, None)
+
+
+def read_member_range(
+    archive_path: str | Path,
+    member: str,
+    start: int,
+    length: int | None,
+) -> bytes:
+    """Read *length* bytes of *member* starting at byte offset *start*.
+
+    ``length=None`` reads to the end of the member.  The archive handle is
+    opened and closed within the call (each call gets its own handle, so
+    concurrent range requests don't share mutable archive state), and the
+    member's file object is *seeked* to *start* so only the requested slice is
+    read -- the whole member is never materialised for a partial request.
+    """
+    path, info, is_zip = _resolve(archive_path, member)
+    if start < 0:
+        start = 0
+
+    if is_zip:
+        with zipfile.ZipFile(path, "r") as zf:
+            with zf.open(info, "r") as f:
+                if start:
+                    f.seek(start)
+                return f.read() if length is None else f.read(length)
+
+    with tarfile.open(path, "r:*") as tf:
+        extracted = tf.extractfile(info)
+        if extracted is None:
+            raise ArchiveMemberError(f"Member {member!r} is not a regular file in {path}")
+        with extracted as f:
+            if start:
+                f.seek(start)
+            return f.read() if length is None else f.read(length)
+
+
+def archive_member_ref(media: dict[str, Any]) -> tuple[str, str] | None:
+    """Return *(archive_path, member)* for an archive-member media, or ``None``.
+
+    Reads the top-level ``archive_member`` convenience field first (set at
+    import and on re-derivation) and falls back to ``origin.params`` (the
+    channel that survives the pickle round-trip), so a freshly imported media
+    and one reopened from disk resolve identically.
+    """
+    ref = media.get("archive_member")
+    if isinstance(ref, dict):
+        path = ref.get("path")
+        member = ref.get("member")
+        if path and member:
+            return str(path), str(member)
+
+    origin = media.get("origin")
+    if not isinstance(origin, dict) or origin.get("importer") != LOCAL_ARCHIVE_MEMBER_IMPORTER:
+        return None
+    params = origin.get("params", {})
+    path = params.get("archive_path") or params.get("path")
+    member = params.get("member")
+    if path and member:
+        return str(path), str(member)
+    return None
+
+
+def build_archive_member_origin(archive_path: str | Path, member: str, media_type: str) -> dict[str, Any]:
+    """Build the ``local_archive_member`` origin for a member of *archive_path*.
+
+    Records only the archive path + member name + output media type -- never
+    the member bytes -- so the media re-derives ``origin -> archive member ->
+    bytes`` on demand through
+    :class:`~vtscore.datasets.sources.local_archive_member.LocalArchiveMemberSource`.
+    """
+    return {
+        "importer": LOCAL_ARCHIVE_MEMBER_IMPORTER,
+        "params": {
+            "archive_path": str(Path(archive_path).resolve()),
+            "member": str(member),
+            "media_type": media_type,
+        },
+    }

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -35,6 +35,8 @@ import numpy as np
 _FILENAMES_KEYS = ("filenames", "names", "paths", "filename")
 _VECTORS_KEYS = ("vectors", "embeddings", "vecs", "embedding")
 _EMBEDDER_NAME_KEYS = ("embedder_name", "embedder")
+_MEMBERS_KEYS = ("members", "member")
+_ARCHIVES_KEYS = ("archives", "archive", "shards", "shard")
 
 
 def read_npz_embedder_name(npz_path: Path) -> str:
@@ -105,3 +107,103 @@ def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
         for k in keys:
             mapping[k] = np.asarray(data[k])
         return mapping
+
+
+def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
+    """Read archive-member rows from an ``.npz`` manifest.
+
+    This is the no-extraction counterpart of
+    :func:`read_npz_filenames_and_vectors`: instead of mapping a filesystem
+    path to a vector, each row references a **member inside a tar/zip shard**
+    plus its pre-computed embedding, so a filtered subset of a WebDataset-style
+    corpus imports without ever extracting the shards.
+
+    Expected arrays (NumPy ``.npz``, ``allow_pickle=False``):
+
+    * ``vectors`` / ``embeddings`` - ``(N, D)`` float embeddings, one per row.
+    * ``members`` - ``(N,)`` member names within their archive.
+    * ``archives`` - ``(N,)`` archive paths, **or** a single scalar/1-element
+      value applied to every row (one-shard manifests).  Relative paths are
+      resolved against the manifest's directory.
+    * ``filenames`` *(optional)* - ``(N,)`` display names; defaults to the
+      member's basename.
+    * ``embedder_name`` *(optional)* - scalar embedder name (see
+      :func:`read_npz_embedder_name`).
+
+    Returns a list of ``{"archive", "member", "filename", "vector"}`` dicts
+    (archive paths resolved to absolute strings).  Raises ``ValueError`` for a
+    malformed manifest and ``FileNotFoundError`` if the file is missing.
+    """
+    p = Path(npz_path)
+    if not p.is_file():
+        raise FileNotFoundError(f"NPZ file not found: {p}")
+
+    base_dir = p.resolve().parent
+    with np.load(p, allow_pickle=False) as data:
+        key_set = set(data.files)
+        vectors_key = next((k for k in _VECTORS_KEYS if k in key_set), None)
+        members_key = next((k for k in _MEMBERS_KEYS if k in key_set), None)
+        archives_key = next((k for k in _ARCHIVES_KEYS if k in key_set), None)
+        filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
+
+        if vectors_key is None or members_key is None:
+            raise ValueError(
+                f"NPZ manifest {p} must contain a vectors array (one of {_VECTORS_KEYS}) "
+                f"and a members array (one of {_MEMBERS_KEYS})"
+            )
+
+        vecs_arr = data[vectors_key]
+        members_arr = np.atleast_1d(data[members_key])
+        if members_arr.ndim != 1:
+            raise ValueError(f"NPZ '{members_key}' array must be 1-D, got shape {members_arr.shape}")
+        n = len(members_arr)
+        if len(vecs_arr) != n:
+            raise ValueError(
+                f"NPZ '{members_key}' and '{vectors_key}' have mismatched lengths ({n} vs {len(vecs_arr)})"
+            )
+
+        archives_arr = _broadcast_column(data[archives_key], n, "archives") if archives_key is not None else None
+        if archives_arr is None:
+            raise ValueError(f"NPZ manifest {p} must contain an archives array (one of {_ARCHIVES_KEYS})")
+        filenames_arr = _broadcast_column(data[filenames_key], n, "filenames") if filenames_key is not None else None
+
+        rows: list[dict] = []
+        for i in range(n):
+            member = str(members_arr[i]).strip()
+            if not member:
+                continue
+            archive = str(archives_arr[i]).strip()
+            if not archive:
+                raise ValueError(f"NPZ manifest {p} row {i} has an empty archive path")
+            archive_path = Path(archive)
+            if not archive_path.is_absolute():
+                archive_path = (base_dir / archive_path).resolve()
+            display = str(filenames_arr[i]).strip() if filenames_arr is not None else ""
+            rows.append(
+                {
+                    "archive": str(archive_path),
+                    "member": member,
+                    "filename": display or Path(member).name,
+                    "vector": np.asarray(vecs_arr[i]),
+                }
+            )
+        if not rows:
+            raise ValueError(f"NPZ manifest {p} produced no rows")
+        return rows
+
+
+def _broadcast_column(arr: np.ndarray, n: int, label: str) -> np.ndarray:
+    """Return a length-*n* 1-D view of *arr*, broadcasting a scalar/1-element.
+
+    A manifest whose every row shares one archive may store ``archives`` as a
+    single scalar (or 1-element array); this expands it to one entry per row.
+    Raises ``ValueError`` for any other length mismatch.
+    """
+    flat = np.atleast_1d(arr)
+    if flat.ndim != 1:
+        raise ValueError(f"NPZ '{label}' array must be 1-D, got shape {flat.shape}")
+    if len(flat) == n:
+        return flat
+    if len(flat) == 1:
+        return np.repeat(flat, n)
+    raise ValueError(f"NPZ '{label}' has length {len(flat)}, expected {n} or 1")

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -140,56 +140,63 @@ def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
 
     base_dir = p.resolve().parent
     with np.load(p, allow_pickle=False) as data:
-        key_set = set(data.files)
-        vectors_key = next((k for k in _VECTORS_KEYS if k in key_set), None)
-        members_key = next((k for k in _MEMBERS_KEYS if k in key_set), None)
-        archives_key = next((k for k in _ARCHIVES_KEYS if k in key_set), None)
-        filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
-
-        if vectors_key is None or members_key is None:
-            raise ValueError(
-                f"NPZ manifest {p} must contain a vectors array (one of {_VECTORS_KEYS}) "
-                f"and a members array (one of {_MEMBERS_KEYS})"
-            )
-
-        vecs_arr = data[vectors_key]
-        members_arr = np.atleast_1d(data[members_key])
-        if members_arr.ndim != 1:
-            raise ValueError(f"NPZ '{members_key}' array must be 1-D, got shape {members_arr.shape}")
-        n = len(members_arr)
-        if len(vecs_arr) != n:
-            raise ValueError(
-                f"NPZ '{members_key}' and '{vectors_key}' have mismatched lengths ({n} vs {len(vecs_arr)})"
-            )
-
-        archives_arr = _broadcast_column(data[archives_key], n, "archives") if archives_key is not None else None
-        if archives_arr is None:
-            raise ValueError(f"NPZ manifest {p} must contain an archives array (one of {_ARCHIVES_KEYS})")
-        filenames_arr = _broadcast_column(data[filenames_key], n, "filenames") if filenames_key is not None else None
-
-        rows: list[dict] = []
-        for i in range(n):
-            member = str(members_arr[i]).strip()
-            if not member:
-                continue
-            archive = str(archives_arr[i]).strip()
-            if not archive:
-                raise ValueError(f"NPZ manifest {p} row {i} has an empty archive path")
-            archive_path = Path(archive)
-            if not archive_path.is_absolute():
-                archive_path = (base_dir / archive_path).resolve()
-            display = str(filenames_arr[i]).strip() if filenames_arr is not None else ""
-            rows.append(
-                {
-                    "archive": str(archive_path),
-                    "member": member,
-                    "filename": display or Path(member).name,
-                    "vector": np.asarray(vecs_arr[i]),
-                }
-            )
+        vecs_arr, members_arr, archives_arr, filenames_arr = _manifest_columns(data, p)
+        rows = [
+            row
+            for i in range(len(members_arr))
+            if (row := _manifest_row(i, members_arr, archives_arr, filenames_arr, vecs_arr, base_dir)) is not None
+        ]
         if not rows:
             raise ValueError(f"NPZ manifest {p} produced no rows")
         return rows
+
+
+def _manifest_columns(data, p: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None]:
+    """Resolve and validate the ``(vectors, members, archives, filenames?)`` columns."""
+    key_set = set(data.files)
+    vectors_key = next((k for k in _VECTORS_KEYS if k in key_set), None)
+    members_key = next((k for k in _MEMBERS_KEYS if k in key_set), None)
+    archives_key = next((k for k in _ARCHIVES_KEYS if k in key_set), None)
+    filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
+
+    if vectors_key is None or members_key is None:
+        raise ValueError(
+            f"NPZ manifest {p} must contain a vectors array (one of {_VECTORS_KEYS}) "
+            f"and a members array (one of {_MEMBERS_KEYS})"
+        )
+
+    vecs_arr = data[vectors_key]
+    members_arr = np.atleast_1d(data[members_key])
+    if members_arr.ndim != 1:
+        raise ValueError(f"NPZ '{members_key}' array must be 1-D, got shape {members_arr.shape}")
+    n = len(members_arr)
+    if len(vecs_arr) != n:
+        raise ValueError(f"NPZ '{members_key}' and '{vectors_key}' have mismatched lengths ({n} vs {len(vecs_arr)})")
+    if archives_key is None:
+        raise ValueError(f"NPZ manifest {p} must contain an archives array (one of {_ARCHIVES_KEYS})")
+    archives_arr = _broadcast_column(data[archives_key], n, "archives")
+    filenames_arr = _broadcast_column(data[filenames_key], n, "filenames") if filenames_key is not None else None
+    return vecs_arr, members_arr, archives_arr, filenames_arr
+
+
+def _manifest_row(i, members_arr, archives_arr, filenames_arr, vecs_arr, base_dir: Path) -> dict | None:
+    """Build one ``{archive, member, filename, vector}`` row, or ``None`` to skip."""
+    member = str(members_arr[i]).strip()
+    if not member:
+        return None
+    archive = str(archives_arr[i]).strip()
+    if not archive:
+        raise ValueError(f"manifest row {i} has an empty archive path")
+    archive_path = Path(archive)
+    if not archive_path.is_absolute():
+        archive_path = (base_dir / archive_path).resolve()
+    display = str(filenames_arr[i]).strip() if filenames_arr is not None else ""
+    return {
+        "archive": str(archive_path),
+        "member": member,
+        "filename": display or Path(member).name,
+        "vector": np.asarray(vecs_arr[i]),
+    }
 
 
 def _broadcast_column(arr: np.ndarray, n: int, label: str) -> np.ndarray:

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -1,0 +1,210 @@
+"""Import a filtered subset of media straight out of tar/zip shards.
+
+This importer is the no-extraction path for WebDataset-style corpora: tens of
+thousands of audio/video chunks live inside a handful of multi-GB ``shard_*.tar``
+files, and a sidecar manifest already pairs a chosen subset of those chunks with
+**pre-computed** embedding vectors.  Rather than extract a second on-disk copy
+of the shards (multivent-raw's ``videos/`` alone is 4.1 TB), each imported media
+records only ``{archive path, member name}`` and re-derives its bytes on demand
+through :mod:`vtscore.datasets.archive_stream` -- so a media plays back by
+streaming a single tar member with HTTP Range, never persisting it.
+
+Input is a single ``.npz`` manifest holding, per row, an archive path, a member
+name within that archive, and a pre-computed vector (see
+:func:`~vtscore.datasets.importers._npz_vectors.read_npz_archive_member_rows`).
+Because the embeddings are supplied, the framework embed stage is skipped: the
+import needs no GPU and reads no member bytes (it only walks each referenced
+shard's tar headers to confirm the member exists and record its size).
+
+Each row becomes one whole-member media.  Sub-file *windowing* (multiple 10 s
+clip items per member, carrying ``clip_start`` / ``clip_end``) is the planned
+Phase B extension -- see ``docs/plans/webdataset-tar-import.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Any
+
+from vtscore.datasets.archive_stream import (
+    ArchiveMemberError,
+    LOCAL_ARCHIVE_MEMBER_IMPORTER,
+    member_size,
+)
+from vtscore.datasets.importers._npz_vectors import read_npz_archive_member_rows, read_npz_embedder_name
+from vtscore.datasets.importers.base import ImporterBase, PluginField
+from vtscore.embedding.media_vectors import init_embeddings
+
+logger = logging.getLogger(__name__)
+
+
+def _synthetic_md5(archive: str, member: str) -> str:
+    """Return a stable content-id for a member without reading its bytes.
+
+    The real point of this importer is to avoid touching member *data* (the
+    corpora are far too large to hash in full), so the dedup/label key is
+    derived from the globally-unique ``archive::member`` pair instead of the
+    member's content.  This keeps in-dataset dedup, voting, and label
+    persistence working; the one thing it gives up is *content*-based label
+    transfer across unrelated datasets, which these precomputed-embedding
+    corpora don't use.
+    """
+    return hashlib.md5(f"{archive}::{member}".encode()).hexdigest()
+
+
+class LocalArchiveMemberImporter(ImporterBase):
+    """Import a manifest-selected subset of archive members with no extraction.
+
+    The user supplies a ``.npz`` manifest pairing tar/zip members with
+    pre-computed embeddings; each row imports as one media whose bytes stream
+    from the shard on demand.  Nothing is written to disk and no member data is
+    read at import time.
+    """
+
+    name = LOCAL_ARCHIVE_MEMBER_IMPORTER
+    display_name = "Archive members (no extract)"
+    description = (
+        "Import a manifest-selected subset of media stored inside tar/zip shards, "
+        "with pre-computed embeddings, without extracting the archives. Bytes stream "
+        "a single member on demand -- built for WebDataset-style corpora too large to copy."
+    )
+    icon = "\U0001f4e6"  # 📦
+    picker_view = "form"
+    category = "server"
+
+    fields = [
+        PluginField(
+            key="media_type",
+            label="Dataset MediaType",
+            field_type="select",
+            description="Type of media the referenced members hold (e.g. video or audio).",
+            default="video",
+            required=False,
+        ),
+        PluginField(
+            key="manifest",
+            label="Manifest (.npz)",
+            field_type="server_path",
+            description="A .npz manifest pairing archive members with pre-computed embedding vectors.",
+            hint=(
+                "Expected arrays:\n"
+                " • vectors / embeddings - (N, D) float embeddings, one per row.\n"
+                " • members - (N,) member names within their archive.\n"
+                " • archives - (N,) archive paths (or a single value for one shard);\n"
+                "   relative paths resolve against the manifest's directory.\n"
+                " • filenames (optional) - (N,) display names.\n"
+                " • embedder_name (optional) - the embedder that produced the vectors.\n"
+                "Members are streamed on demand; the archives are never extracted."
+            ),
+            accept=".npz",
+        ),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        from vtscore.media import all_folder_names  # noqa: PLC0415
+
+        for f in self.fields:
+            if f.key == "media_type":
+                f.options = all_folder_names()
+                break
+
+    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        from vtscore.media import get_by_folder_name  # noqa: PLC0415
+
+        manifest = Path(field_values["manifest"])
+        if not manifest.is_file():
+            raise FileNotFoundError(f"Manifest not found: {manifest}")
+        output_type = get_by_folder_name(field_values.get("media_type", "video")).type_id
+
+        rows = read_npz_archive_member_rows(manifest)
+        embedder_name = read_npz_embedder_name(manifest)
+
+        next_id = max(medias.keys(), default=0) + 1
+        skipped = 0
+        for row in rows:
+            archive = row["archive"]
+            member = row["member"]
+            try:
+                size = member_size(archive, member)
+            except (ArchiveMemberError, OSError) as exc:
+                # The manifest references a member we can't locate in its shard
+                # (missing archive, renamed member). Skip it rather than import
+                # a media whose bytes will never resolve.
+                logger.warning("local_archive_member: skipping %s::%s (%s)", archive, member, exc)
+                skipped += 1
+                continue
+
+            origin = {
+                "importer": self.name,
+                "params": {
+                    "archive_path": archive,
+                    "member": member,
+                    "media_type": output_type,
+                    "manifest": str(manifest.resolve()),
+                    "embedder_name": embedder_name,
+                },
+            }
+            medias[next_id] = {
+                "id": next_id,
+                "media_type": output_type,
+                "embedder": embedder_name,
+                "file_size": size,
+                "md5": _synthetic_md5(archive, member),
+                "embeddings": init_embeddings(embedder_name, row["vector"]),
+                "filename": row["filename"],
+                "category": "custom",
+                "origin": origin,
+                "origin_name": f"{archive}::{member}",
+                "media_bytes": None,
+                "media_string": None,
+                "duration": 0,
+                "archive_member": {"path": archive, "member": member},
+            }
+            next_id += 1
+
+        if not medias:
+            raise ValueError(
+                f"No importable members in {manifest}"
+                + (f" ({skipped} referenced member(s) could not be located)" if skipped else "")
+            )
+
+    def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        manifest = Path(field_values["manifest"])
+        if not manifest.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest}")
+        if not manifest.is_file():
+            raise IsADirectoryError(f"Manifest must be a file: {manifest}")
+        self.run(field_values, medias, thin=thin)
+
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        manifest = (field_values.get("manifest") or "").strip()
+        if manifest:
+            stem = Path(manifest).stem
+            if stem:
+                return stem
+        return self.display_name
+
+    def origin_display(self, origin: dict[str, Any]) -> str:
+        params = origin.get("params", {})
+        member = params.get("member", "")
+        archive = params.get("archive_path", "")
+        if archive and member:
+            return f"{self.name}:{Path(archive).name}::{member}"
+        return self.name
+
+    def can_reload_from_origin(self, origin: dict[str, Any]) -> bool:
+        manifest = origin.get("params", {}).get("manifest", "")
+        return bool(manifest) and Path(manifest).is_file()
+
+    def reload_from_origin(self, origin: dict[str, Any]) -> dict[str, Any] | None:
+        params = origin.get("params", {})
+        manifest = params.get("manifest", "")
+        if not manifest or not Path(manifest).is_file():
+            return None
+        return {"manifest": manifest, "media_type": params.get("media_type", "video")}
+
+
+IMPORTER = LocalArchiveMemberImporter()

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -61,6 +61,32 @@ def _fetch_media_url(url: str) -> bytes | None:
         return None
 
 
+def _resolve_archive_member_bytes(media: dict) -> bytes | None:
+    """Return a media's bytes by streaming its archive member, or ``None``.
+
+    For ``local_archive_member`` media (whose bytes live inside a tar/zip shard
+    that we deliberately never extract) this reads the whole member on demand
+    via :mod:`vtscore.datasets.archive_stream`.  Returns ``None`` for any media
+    that is not archive-member-backed, or when the member can't be read, so the
+    caller falls through to its remaining resolution order.
+
+    Callers serving Range requests (video/audio playback) should prefer the
+    route-level partial-read path so a large member is never fully buffered;
+    this whole-member read backs the non-streaming callers (thumbnails, image,
+    transcode of non-streamable containers).
+    """
+    from vtscore.datasets.archive_stream import ArchiveMemberError, archive_member_ref, read_member  # noqa: PLC0415
+
+    ref = archive_member_ref(media)
+    if ref is None:
+        return None
+    try:
+        return read_member(ref[0], ref[1])
+    except (ArchiveMemberError, OSError):
+        logging.getLogger(__name__).warning("Failed to read archive member %s::%s", ref[0], ref[1], exc_info=True)
+        return None
+
+
 def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
     """Default no-op progress callback used when no real reporter is set."""
 
@@ -442,6 +468,9 @@ class MediaType(ABC):
         clipped = lazy_clip_bytes(media)
         if clipped is not None:
             return clipped
+        archive_bytes = _resolve_archive_member_bytes(media)
+        if archive_bytes is not None:
+            return archive_bytes
         media_path = media.get("media_path")
         if media_path:
             path = Path(media_path)

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -205,7 +205,23 @@ def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:  # noqa:
 
 
 def _resolve_bytes(media: dict) -> bytes | None:
-    """Return media bytes, lazy-loading from media_path if needed."""
+    """Return a media's full bytes via the media type's resolver.
+
+    Delegates to :meth:`MediaType._resolve_media_bytes` so every byte route
+    shares one resolution chain (inline bytes -> lazy clip -> archive member
+    -> local path -> remote URL) instead of the old path-only duplicate.  Media
+    whose type isn't registered fall back to the inline-bytes / local-path
+    pair.
+    """
+    from vtscore.media import get as get_media_type  # noqa: PLC0415
+
+    try:
+        mt = get_media_type(media.get("media_type", ""))
+    except KeyError:
+        mt = None
+    if mt is not None:
+        return mt._resolve_media_bytes(media)
+
     media_bytes = media.get("media_bytes")
     if media_bytes is not None:
         return media_bytes
@@ -216,6 +232,90 @@ def _resolve_bytes(media: dict) -> bytes | None:
             with open(p, "rb") as f:
                 return f.read()
     return None
+
+
+def _member_mimetype(filename: str, default: str) -> str:
+    """Guess a mimetype for an archive member from its name, else *default*."""
+    import mimetypes  # noqa: PLC0415
+
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed or default
+
+
+def _send_streamed_range(total, read_slice, mimetype: str, download_name: str) -> Response:
+    """Serve *total* bytes with HTTP Range support, reading only what's asked.
+
+    *read_slice(start, length)* returns the requested byte slice (``length``
+    is ``None`` for "to end").  Unlike :func:`_send_video_bytes` this never
+    buffers the whole payload for a partial request -- the backing reader
+    (an archive member) is seeked to *start* and only the served slice is
+    read, so playing a few seconds out of a large member transfers a few
+    seconds of bytes.
+    """
+    range_header = request.headers.get("Range")
+    if range_header:
+        try:
+            byte_range = range_header.replace("bytes=", "").strip()
+            parts = byte_range.split("-", 1)
+            start = int(parts[0])
+            end = int(parts[1]) if parts[1] else total - 1
+        except (ValueError, IndexError):
+            start, end = 0, total - 1
+        end = min(end, total - 1)
+        if start < 0 or start >= total or start > end:
+            resp = make_response(b"")
+            resp.status_code = 416
+            resp.headers["Content-Range"] = f"bytes */{total}"
+            resp.headers["Content-Length"] = "0"
+            resp.headers["Content-Type"] = mimetype
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        data = read_slice(start, end - start + 1)
+        resp = make_response(data)
+        resp.status_code = 206
+        resp.headers["Content-Range"] = f"bytes {start}-{end}/{total}"
+        resp.headers["Content-Length"] = str(len(data))
+    else:
+        data = read_slice(0, None)
+        resp = make_response(data)
+        resp.headers["Content-Length"] = str(total)
+
+    resp.headers["Content-Type"] = mimetype
+    resp.headers["Accept-Ranges"] = "bytes"
+    resp.headers["Content-Disposition"] = f'inline; filename="{download_name}"'
+    return resp
+
+
+def _archive_member_response(media: dict, download_name: str, default_mimetype: str) -> Response | None:
+    """Serve an archive-member media by streaming a single member, or ``None``.
+
+    Returns ``None`` for media that aren't archive-member-backed (the caller
+    then falls through to its normal resolution), or when the member can't be
+    located in its shard.  Otherwise returns a Range-capable response that
+    reads only the requested bytes straight out of the tar/zip, never
+    extracting or fully buffering the member.
+    """
+    from vtscore.datasets.archive_stream import (  # noqa: PLC0415
+        ArchiveMemberError,
+        archive_member_ref,
+        member_size,
+        read_member_range,
+    )
+
+    ref = archive_member_ref(media)
+    if ref is None:
+        return None
+    archive_path, member = ref
+    try:
+        total = member_size(archive_path, member)
+    except (ArchiveMemberError, OSError):
+        return None
+
+    def read_slice(start, length):
+        return read_member_range(archive_path, member, start, length)
+
+    mimetype = _member_mimetype(media.get("filename") or member, default_mimetype)
+    return _send_streamed_range(total, read_slice, mimetype, download_name)
 
 
 def _send_video_bytes(data: bytes, mimetype: str, download_name: str) -> Response:
@@ -390,6 +490,10 @@ def media_audio(media_id: int):
     c = get_media(media_id)
     if not c:
         abort(404, message="not found")
+    ext = Path(c.get("filename", "")).suffix or ".wav"
+    streamed = _archive_member_response(c, f"media_{media_id}{ext}", "audio/wav")
+    if streamed is not None:
+        return streamed
     media_bytes = _resolve_bytes(c)
     if media_bytes is None:
         abort(404, message="media not available")
@@ -439,6 +543,12 @@ def media_video(media_id: int):
             415,
             message=f"Cannot play {ext} videos: install ffmpeg or opencv-python-headless to enable transcoding",
         )
+
+    # Archive-member video: stream the member with Range so the browser only
+    # downloads the bytes it plays -- never extracting or fully buffering it.
+    streamed = _archive_member_response(c, f"media_{media_id}{ext}", "video/mp4")
+    if streamed is not None:
+        return streamed
 
     media_bytes = _resolve_bytes(c)
     if media_bytes is None:

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -526,23 +526,7 @@ def media_video(media_id: int):
     # For browser-incompatible formats (e.g. .avi), transcode to MP4 and
     # cache the result so subsequent requests are instant.
     if ext not in _BROWSER_VIDEO_EXTS:
-        cached = c.get("_transcoded_mp4")
-        if cached is not None:
-            return _send_video_bytes(cached, "video/mp4", f"media_{media_id}.mp4")
-
-        media_bytes = _resolve_bytes(c)
-        if media_bytes is None:
-            abort(404, message="media not available")
-
-        transcoded = _transcode_to_mp4(media_bytes, filename)
-        if transcoded is not None:
-            c["_transcoded_mp4"] = transcoded
-            return _send_video_bytes(transcoded, "video/mp4", f"media_{media_id}.mp4")
-        # ffmpeg and OpenCV both unavailable; cannot transcode
-        abort(
-            415,
-            message=f"Cannot play {ext} videos: install ffmpeg or opencv-python-headless to enable transcoding",
-        )
+        return _serve_transcoded_video(c, media_id, ext, filename)
 
     # Archive-member video: stream the member with Range so the browser only
     # downloads the bytes it plays -- never extracting or fully buffering it.
@@ -562,6 +546,31 @@ def media_video(media_id: int):
         mimetype = "video/mp4"
 
     return _send_video_bytes(media_bytes, mimetype, f"media_{media_id}{ext}")
+
+
+def _serve_transcoded_video(c: dict, media_id: int, ext: str, filename: str) -> Response:
+    """Serve a browser-incompatible video by transcoding it to MP4 (cached).
+
+    Resolves the source bytes (which may stream from an archive member),
+    transcodes to H.264 MP4, memoises the result on the in-memory media, and
+    ``abort``-s 415 when neither ffmpeg nor OpenCV is available.
+    """
+    cached = c.get("_transcoded_mp4")
+    if cached is not None:
+        return _send_video_bytes(cached, "video/mp4", f"media_{media_id}.mp4")
+
+    media_bytes = _resolve_bytes(c)
+    if media_bytes is None:
+        abort(404, message="media not available")
+
+    transcoded = _transcode_to_mp4(media_bytes, filename)
+    if transcoded is not None:
+        c["_transcoded_mp4"] = transcoded
+        return _send_video_bytes(transcoded, "video/mp4", f"media_{media_id}.mp4")
+    abort(
+        415,
+        message=f"Cannot play {ext} videos: install ffmpeg or opencv-python-headless to enable transcoding",
+    )
 
 
 def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -372,9 +372,26 @@ def _media_extension(media: dict) -> str:
 def _resolve_media_bytes(media: dict) -> bytes | None:
     """Return the raw bytes for a loaded media item.
 
-    Mirrors :func:`vtsearch.routes.media.list._resolve_bytes` but is also
-    aware of text media (which stores its content as ``media_string``).
+    Delegates to the media type's resolver (inline bytes -> lazy clip ->
+    archive member -> local path -> remote URL) so it handles every backing
+    the byte routes do, then adds a text fallback (text media stores its
+    content as ``media_string``, which the byte resolver doesn't produce).
     """
+    from vtscore.media import get as get_media_type  # noqa: PLC0415
+
+    try:
+        mt = get_media_type(media.get("media_type", ""))
+    except KeyError:
+        mt = None
+    if mt is not None:
+        data = mt._resolve_media_bytes(media)
+        if data is not None:
+            return data
+
+    media_string = media.get("media_string")
+    if media_string is not None:
+        return media_string.encode("utf-8")
+
     media_bytes = media.get("media_bytes")
     if media_bytes is not None:
         return media_bytes
@@ -383,9 +400,6 @@ def _resolve_media_bytes(media: dict) -> bytes | None:
         p = Path(media_path)
         if p.exists():
             return p.read_bytes()
-    media_string = media.get("media_string")
-    if media_string is not None:
-        return media_string.encode("utf-8")
     return None
 
 


### PR DESCRIPTION
## What & why

Loads WebDataset-style tar-sharded corpora (GRID **microvent** / **multivent-raw**) into VTSearch for VTSBrowse / similarity search **without extracting the shards**. These corpora are far too large to copy a second time (multivent-raw's `videos/` alone is **4.1 TB across 667 shards**), so selective, no-extraction import + playback is the only way they fit. Embeddings ship precomputed (512-dim CLAP), so import needs no GPU.

This is **Phase A** of the design in `docs/plans/webdataset-tar-import.md`: the critical no-extraction byte-serving path + a whole-member import. Sub-file 10 s clip windows and full cross-dataset re-derivation are scoped as Phase B in that doc.

## What landed

- **`vtscore/datasets/archive_stream.py`** — streams one tar/zip member with a cached `{member: info}` index (metadata only, never bytes), reading just a byte *range* by seeking within the member's file object. The no-extraction counterpart to `archive.py` (which extracts whole archives to `DATA_DIR`).
- **Unified, archive-aware byte resolution.** `MediaType._resolve_media_bytes` gained an archive-member branch; the route-level `_resolve_bytes` (`routes/media/list.py`) and the crop/seed `_resolve_media_bytes` (`routes/media/server.py`) now delegate to it — collapsing three path-only duplicates into one chain (inline bytes → lazy clip → **archive member** → local path → remote URL, restoring the `media_url` fallback on the routes).
- **True Range streaming for playback.** `/video` and `/audio` serve archive-member media by reading only the requested slice out of the shard (a few seconds of playback transfers a few seconds of bytes) — never extracting or fully buffering.
- **`local_archive_member` importer + `.npz` manifest reader.** Imports a manifest-selected, precomputed-embedding subset as whole-member media, reading **no member data** (only each shard's tar headers, to confirm the member exists and record its size). md5 is synthesized from `archive::member` to avoid hashing TB of content.

## No persisted vectors/bytes

No member bytes are ever written to disk: the only cache is the in-memory member *index*. Origins record `{archive path, member}` and re-derive on demand. Precomputed vectors live in memory (and in a full pickle, the existing dataset-pickle exception); the manifest path is recorded in the origin so the whole dataset re-derives via the importer's `reload_from_origin`.

## Tests

- `tests_lib/datasets/test_archive_stream.py` — member index, whole + partial-range reads (tar & zip), cache-busting, ref/origin helpers.
- `tests_lib/io/test_archive_member_import.py` — manifest reader (scalar/per-row archives), importer output shape, byte re-derivation, skip-missing-members, reload round-trip.
- `tests/core/test_archive_member_routes.py` — end-to-end `/video` + `/audio` streaming, Range 206, unsatisfiable 416, missing-member 404.
- OpenAPI snapshot regenerated for the new importer; full `./run-tests.sh` green (5305 passed).

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TupY6cyzrChGsJa9wag5V7)_