### PR TITLE
WebDataset tar import Phase B: sub-file clip windows + cross-dataset re-derivation

### DIFF
--- a/docs/plans/webdataset-tar-import.md
+++ b/docs/plans/webdataset-tar-import.md
@@ -1,6 +1,8 @@
 # WebDataset-style tar-sharded import (microvent / multivent-raw)
 
-**Status:** Phase A shipped; Phase B planned (see Open follow-ups).
+**Status:** Phase A shipped; Phase B shipped (sub-file clip windows, windowed
+manifest import, archive-member `MediaSource`, audio-mimetype nuances); only the
+GUI/docs-polish follow-up (item 5) remains — see Open follow-ups.
 
 ## Problem
 
@@ -48,46 +50,60 @@ What landed:
 Net effect: a filtered subset of either corpus imports with **zero disk growth**
 and plays back whole chunks by streaming single members.
 
-## Open follow-ups (Phase B — sub-file clip windows + full re-derivation)
+## Phase B — shipped (sub-file clip windows + cross-dataset re-derivation)
+
+What landed:
+
+- **Sub-file clip windows (gap 3).** One member can yield multiple media
+  carrying `clip_start` / `clip_end`. Both players now seek/loop within the
+  window **display-only**: the video player already did
+  (`video-player.component.ts`); the audio player gained the same logic
+  (`audio-player.component.ts`, `(loadedmetadata)` + a 100 ms boundary poll).
+  We never byte-slice these AAC/MP4 members — `clip_recipe`
+  (`vtscore/media/lazy_clip.py`) now returns `None` for any archive-member
+  media, so the byte routes serve the **whole** member and the player handles
+  the window. `batch_medias` already passes `clip_start` / `clip_end` through.
+
+- **Windowed precomputed-embedding import (gap 4).** The manifest schema gained
+  optional `clip_start` / `clip_end` / `window_id` columns
+  (`_npz_vectors.read_npz_archive_member_rows`, broadcast like `archives`; a
+  `NaN`/blank extent means "whole-member row"). The importer fans one member
+  into N windowed media, each its own searchable item with its own precomputed
+  vector, carrying the clip fields top-level (player) **and** in `origin.params`
+  (survives the pickle + feeds the source). The synthesized md5 + `origin_name`
+  fold in a per-window suffix (`window_suffix`: `#<window_id>`, else
+  `@<clip_start>`) so dedup / voting / display stay unique per window.
+
+- **Archive-member `MediaSource` (gap, cross-dataset re-derivation).**
+  `vtscore/datasets/sources/local_archive_member.py` is a manifest-backed
+  source that re-supplies a member's (or a specific *window's*) precomputed
+  vector by `(archive, member[, window])`, returning a `FetchedItem` with
+  `path=None` + `embedding` set. `example_sort_origin`
+  (`vtsearch/routes/media/server.py`) now sorts directly on that vector when a
+  source returns no path (cropping is rejected — it needs bytes this path never
+  materialises). This closes the last unsupported flow (per-media cross-dataset
+  "Find" used to 400 with "no media source").
+
+- **Audio mimetype + container nuances (gap 4).** The `/audio` route now picks
+  an **audio** `Content-Type` per the member container
+  (`_audio_member_mimetype`): `.aac` → `audio/aac`, an MP4-container audio chunk
+  (`.mp4` / `.m4a`, which `mimetypes` would call `video/mp4`) → `audio/mp4`,
+  `audio/x-wav` normalised to `audio/wav`, unknown → `audio/wav`. multivent-raw
+  audio that rides inside the video MP4 is served (as today) through the
+  **video** element's audio track.
+
+## Open follow-ups
 
 Tracked here, not in the PR body.
 
-1. **Sub-file clip windows (gap 3).** Let one member yield multiple media items
-   carrying `clip_start` / `clip_end`. The serving + frontend side is largely
-   already present: the video player seeks/loops on `clip_*`
-   (`video-player.component.ts`) and `batch_medias` passes the fields through.
-   Audio should use the **same display-only seek** (serve the whole member, seek
-   in the player) rather than byte-slicing — the existing `lazy_clip` audio path
-   is WAV-only (`_wav_slice`) and these corpora are AAC/MP4, which we do not want
-   to decode server-side. Wire `lazy_clip._read_source_bytes` to an archive
-   member only if a future windowing recipe needs sliced bytes; for display-only
-   windowing nothing more than the clip fields is required.
+1. **GUI / docs polish (Phase B item 5).** The importer registers in the
+   server-tab picker with a `.npz` manifest field; add a short user-docs section
+   covering the windowed-manifest schema and the no-extraction import flow, and
+   (if a screenshot ever frames the importer picker) queue a reshoot in
+   `docs/user/screenshots-reshoot-queue.md`. No existing doc screenshot frames
+   this importer's form today, so nothing is queued.
 
-2. **Windowed precomputed-embedding import (gap 4).** Extend the manifest schema
-   with `clip_start` / `clip_end` (and optional `window_id`) so one member fans
-   out into N windowed items (≈14 × 10 s CLAP windows per chunk), each its own
-   searchable media with its own precomputed vector. The Phase A importer already
-   emits one row → one item; windowing is "many rows per member" + carrying the
-   clip fields onto each media. Keep md5 unique per *window* (fold the window id
-   into the synthesized hash).
-
-3. **Archive-member `MediaSource` for cross-dataset re-derivation.** The
-   `MediaSource` / `FetchedItem` contract is path-based, so archive members
-   (which have no on-disk path) currently have no source factory. Bytes already
-   re-derive via the origin (the byte routes), and a full pickle persists
-   embeddings, and the importer's `reload_from_origin` rebuilds the whole dataset
-   from the manifest — so the only unsupported flow is **per-media** cross-dataset
-   "Find" / example-sort-from-origin (`example_sort_origin` returns 400 "no media
-   source"). Closing it needs either a bytes-returning `FetchedItem` extension or
-   a manifest-backed source that re-supplies vectors by `(archive, member)`.
-
-4. **Audio mimetype + container nuances.** The `/audio` route now derives the
-   mimetype from the member extension (defaulting to `audio/wav`). microvent ships
-   demuxed AAC; multivent-raw audio rides in the video MP4 (no separate audio
-   dir), so most "audio events" are served through the **video** element's audio
-   track. Validate AAC/`audio/mp4` playback across browsers when wiring the GUI.
-
-5. **GUI / docs polish.** The importer registers in the server-tab picker with a
-   `.npz` manifest field; add a short user-docs section and (if a screenshot
-   frames the importer picker) queue a reshoot in
-   `docs/user/screenshots-reshoot-queue.md`.
+2. **Cross-browser AAC / `audio/mp4` validation.** The `/audio` route emits the
+   right mimetype, but actual AAC / MP4-audio-track playback across browsers
+   still needs a manual pass once the corpora are wired into a live GUI session
+   (no browser in the standard cloud container).

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -15,6 +15,7 @@
   loop
   [src]="audioSrc"
   [attr.aria-label]="media.filename || 'Audio media'"
+  (loadedmetadata)="onLoadedMetadata()"
   (volumechange)="onVolumeChange()"
   (play)="onPlay()"
   (pause)="onPause()"

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -1,3 +1,4 @@
+import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -51,5 +52,42 @@ describe('AudioPlayerComponent', () => {
     const audio = fixture.nativeElement.querySelector('audio');
     expect(audio.hasAttribute('controls')).toBe(true);
     expect(audio.hasAttribute('loop')).toBe(true);
+  });
+
+  it('seeks into the clip window when clip extents arrive after the audio loaded', () => {
+    // Mirrors the video player: a windowed archive-member clip first renders as
+    // a stub (no clip_start/clip_end), so (loadedmetadata) fires before the
+    // extents are known. Batch hydration then enriches the same media id with
+    // clip_start/clip_end on a later ngOnChanges; the player must snap into the
+    // window (display-only seek; the whole member is served).
+    const fakeAudio = {
+      volume: 0,
+      currentTime: 0,
+      paused: true,
+      play: () => Promise.resolve(),
+      pause: () => {},
+      removeAttribute: () => {},
+      load: () => {},
+    } as unknown as HTMLAudioElement;
+    component.audioRef = { nativeElement: fakeAudio } as ElementRef<HTMLAudioElement>;
+
+    const stub: Media = { id: 9, media_type: 'audio', filename: 'clip.aac', md5: 'abc', custom_metadata: {} };
+    component.media = stub;
+    component.ngOnChanges({
+      media: { currentValue: stub, previousValue: null, firstChange: true, isFirstChange: () => true },
+    });
+    // Audio loads against the stub: no clip window yet, so no seek.
+    component.onLoadedMetadata();
+    expect(fakeAudio.currentTime).toBe(0);
+
+    // Batch hydration delivers the clip extents for the same id.
+    const hydrated: Media = { ...stub, clip_start: 12, clip_end: 22 };
+    component.media = hydrated;
+    component.ngOnChanges({
+      media: { currentValue: hydrated, previousValue: stub, firstChange: false, isFirstChange: () => false },
+    });
+    expect(fakeAudio.currentTime).toBe(12);
+
+    component.ngOnDestroy();
   });
 });

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -30,6 +30,14 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   // whenever the metadata cache hydrates; without this guard, every cache
   // refresh would re-`loadAudio()` and snap playback back to t=0.
   private lastMediaId: number | null = null;
+  private clipCheckInterval: ReturnType<typeof setInterval> | null = null;
+  // Whether (loadedmetadata) has fired for the current audioSrc. Clip bounds
+  // (clip_start/clip_end) often arrive via batch hydration *after* the audio
+  // has already loaded, on a later ngOnChanges with the same media id; in that
+  // case (loadedmetadata) does not fire again, so we (re)apply the bounds here.
+  // Mirrors VideoPlayerComponent: archive-member audio windows serve the whole
+  // member and seek/loop within [clip_start, clip_end] (display-only).
+  private metadataLoaded = false;
 
   ngAfterViewInit(): void {
     this.viewReady = true;
@@ -38,11 +46,20 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
-      this.lastMediaId = this.media.id;
-      this.audioSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/audio`);
-      if (this.viewReady) {
-        this.loadAudio();
+    if (changes['media'] && this.media) {
+      if (this.media.id !== this.lastMediaId) {
+        this.lastMediaId = this.media.id;
+        this.metadataLoaded = false;
+        this.stopClipEnforcement();
+        this.audioSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/audio`);
+        if (this.viewReady) {
+          this.loadAudio();
+        }
+      } else if (this.metadataLoaded) {
+        // Same media id, but metadata (e.g. clip_start/clip_end) may have just
+        // arrived via batch hydration. The audio already loaded, so
+        // (loadedmetadata) won't fire again; apply the clip window now.
+        this.applyClipBounds();
       }
     }
     if (changes['volume'] && this.audioRef?.nativeElement) {
@@ -54,6 +71,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   ngOnDestroy(): void {
+    this.stopClipEnforcement();
     this.waveformAbort?.abort();
     this.waveformAbort = null;
     const audio = this.audioRef?.nativeElement;
@@ -61,6 +79,61 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
       audio.pause();
       audio.removeAttribute('src');
       audio.load();
+    }
+  }
+
+  onLoadedMetadata(): void {
+    const audio = this.audioRef?.nativeElement;
+    if (!audio) return;
+    this.metadataLoaded = true;
+    audio.volume = this.volume;
+    this.applyClipBounds();
+    this.syncPlaybackState();
+  }
+
+  // Seek into the clip window and (re)start boundary enforcement when the media
+  // carries clip extents; otherwise tear enforcement down. Safe to call both on
+  // (loadedmetadata) and on later metadata-enrichment ngOnChanges cycles.
+  private applyClipBounds(): void {
+    const audio = this.audioRef?.nativeElement;
+    if (!audio) return;
+
+    if (this.media?.clip_start != null) {
+      const clipStart = this.media.clip_start;
+      const clipEnd = this.media.clip_end;
+      // Snap into the window only when currently outside it, so we don't yank
+      // audio already looping correctly within its window.
+      if (audio.currentTime < clipStart || (clipEnd != null && audio.currentTime >= clipEnd)) {
+        audio.currentTime = clipStart;
+      }
+      this.startClipEnforcement();
+    } else {
+      this.stopClipEnforcement();
+    }
+  }
+
+  private startClipEnforcement(): void {
+    this.stopClipEnforcement();
+    if (this.media?.clip_start == null || this.media?.clip_end == null) return;
+
+    const clipStart = this.media.clip_start;
+    const clipEnd = this.media.clip_end;
+
+    // Poll every 100ms to enforce clip boundaries. When the audio reaches
+    // clip_end, loop back to clip_start instead of continuing.
+    this.clipCheckInterval = setInterval(() => {
+      const audio = this.audioRef?.nativeElement;
+      if (!audio || audio.paused) return;
+      if (audio.currentTime >= clipEnd || audio.currentTime < clipStart) {
+        audio.currentTime = clipStart;
+      }
+    }, 100);
+  }
+
+  private stopClipEnforcement(): void {
+    if (this.clipCheckInterval != null) {
+      clearInterval(this.clipCheckInterval);
+      this.clipCheckInterval = null;
     }
   }
 

--- a/tests/core/test_archive_member_routes.py
+++ b/tests/core/test_archive_member_routes.py
@@ -97,3 +97,71 @@ class TestArchiveMemberAudio:
         resp = client.get(f"/api/medias/{_MEDIA_ID}/audio", headers={"Range": "bytes=3-10"})
         assert resp.status_code == 206
         assert resp.data == AUDIO_BYTES[3:11]
+
+
+class TestArchiveMemberExampleSortOrigin:
+    """Cross-dataset Find re-supplies the member's precomputed vector (no path)."""
+
+    def _make_manifest(self, tmp_path, archive, member):
+        rng = np.random.default_rng(5)
+        manifest = tmp_path / "manifest.npz"
+        np.savez(
+            manifest,
+            vectors=rng.standard_normal((1, 512)).astype(np.float32),
+            members=np.array([member]),
+            archives=np.array(str(archive)),
+            embedder_name=np.array("clap"),
+        )
+        return manifest
+
+    def _origin(self, tmp_path):
+        from vtscore.datasets.importers.local_archive_member import IMPORTER
+
+        archive = _make_shard(tmp_path)
+        manifest = self._make_manifest(tmp_path, archive, "clip.aac")
+        scratch: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "audio"}, scratch)
+        return next(iter(scratch.values()))["origin"]
+
+    def test_origin_sort_uses_precomputed_vector(self, client, tmp_path):
+        origin = self._origin(tmp_path)
+        resp = client.post(
+            "/api/example-sort-origin",
+            json={"origin": origin, "key": "clip.aac"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "results" in data
+        assert "threshold" in data
+
+    def test_crop_on_archive_member_returns_400(self, client, tmp_path):
+        origin = self._origin(tmp_path)
+        resp = client.post(
+            "/api/example-sort-origin",
+            json={"origin": origin, "key": "clip.aac", "crop_params": {"start": 0, "end": 1}},
+        )
+        assert resp.status_code == 400
+
+
+class TestArchiveMemberAudioMimetype:
+    """The /audio route picks an audio Content-Type per the member's container."""
+
+    def test_aac_member_serves_audio_aac(self, client, tmp_path):
+        archive = _make_shard(tmp_path)
+        _inject(archive, "clip.aac", "audio", "clip.aac")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/audio")
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == "audio/aac"
+
+    def test_mp4_audio_member_serves_audio_mp4(self, client, tmp_path):
+        # multivent-raw audio rides in an MP4 container; mimetypes would call
+        # that video/mp4, but the <audio> element needs an audio/* type.
+        archive = _make_shard(tmp_path)
+        with tarfile.open(archive, "a") as tf:
+            info = tarfile.TarInfo("clip_audio.mp4")
+            info.size = len(AUDIO_BYTES)
+            tf.addfile(info, io.BytesIO(AUDIO_BYTES))
+        _inject(archive, "clip_audio.mp4", "audio", "clip_audio.mp4")
+        resp = client.get(f"/api/medias/{_MEDIA_ID}/audio")
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == "audio/mp4"

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -265,6 +265,7 @@ class TestLocalArchiveMemberSource:
         media = next(m for m in medias.values() if m["archive_member"]["member"] == "chunk_a.mp4")
 
         source = get_source_for_origin(media["origin"])
+        assert source is not None
         fetched = source.fetch_item("chunk_a.mp4")
         assert fetched.path is None
         assert fetched.embedding is not None
@@ -285,6 +286,7 @@ class TestLocalArchiveMemberSource:
         )
 
         source = get_source_for_origin(window["origin"])
+        assert source is not None
         # The window key is "member@start"; fetch by it returns that window's vector.
         fetched = source.fetch_item("chunk_a.mp4@10")
         assert fetched.embedding is not None
@@ -298,6 +300,7 @@ class TestLocalArchiveMemberSource:
         medias: dict[int, dict] = {}
         IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
         source = get_source_for_origin(next(iter(medias.values()))["origin"])
+        assert source is not None
         fetched = source.fetch_item("does/not/exist.mp4")
         assert fetched.path is None
         assert fetched.embedding is None

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -281,9 +281,7 @@ class TestLocalArchiveMemberSource:
         medias: dict[int, dict] = {}
         IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
         window = next(
-            m
-            for m in medias.values()
-            if m["archive_member"]["member"] == "chunk_a.mp4" and m.get("clip_start") == 10.0
+            m for m in medias.values() if m["archive_member"]["member"] == "chunk_a.mp4" and m.get("clip_start") == 10.0
         )
 
         source = get_source_for_origin(window["origin"])

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -46,6 +46,31 @@ def _make_manifest(tmp_path: Path, archive: Path, *, scalar_archive: bool = True
     return manifest
 
 
+def _make_windowed_manifest(tmp_path: Path, archive: Path) -> Path:
+    """One member fanned into three 10 s windows, plus a second whole-member row."""
+    rows = [
+        ("chunk_a.mp4", 0.0, 10.0),
+        ("chunk_a.mp4", 10.0, 20.0),
+        ("chunk_a.mp4", 20.0, 30.0),
+    ]
+    members = [m for m, _, _ in rows] + ["sub/chunk_b.mp4"]
+    clip_starts = [s for _, s, _ in rows] + [float("nan")]  # NaN: whole-member row, no window
+    clip_ends = [e for _, _, e in rows] + [float("nan")]
+    rng = np.random.default_rng(11)
+    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    manifest = tmp_path / "windowed.npz"
+    np.savez(
+        manifest,
+        vectors=vectors,
+        members=np.array(members),
+        archives=np.array(str(archive)),
+        clip_start=np.array(clip_starts, dtype=np.float32),
+        clip_end=np.array(clip_ends, dtype=np.float32),
+        embedder_name=np.array("largerclapgeneral"),
+    )
+    return manifest
+
+
 class TestManifestReader:
     def test_reads_rows_with_scalar_archive(self, tmp_path):
         archive = _make_tar(tmp_path)
@@ -141,3 +166,140 @@ class TestImporter:
         assert IMPORTER.can_reload_from_origin(origin)
         reloaded = IMPORTER.reload_from_origin(origin)
         assert reloaded == {"manifest": str(manifest.resolve()), "media_type": "video"}
+
+
+class TestWindowedManifest:
+    def test_reader_emits_clip_fields(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_windowed_manifest(tmp_path, archive)
+        rows = read_npz_archive_member_rows(manifest)
+        assert len(rows) == 4
+        windows = [r for r in rows if r["member"] == "chunk_a.mp4"]
+        assert {(r["clip_start"], r["clip_end"]) for r in windows} == {(0.0, 10.0), (10.0, 20.0), (20.0, 30.0)}
+        # The NaN-sentinel whole-member row carries no window.
+        whole = next(r for r in rows if r["member"] == "sub/chunk_b.mp4")
+        assert whole["clip_start"] is None
+        assert whole["clip_end"] is None
+
+    def test_importer_fans_member_into_windows(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_windowed_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+
+        # 3 windows of chunk_a + 1 whole chunk_b.
+        assert len(medias) == 4
+        windows = [m for m in medias.values() if m["archive_member"]["member"] == "chunk_a.mp4"]
+        assert len(windows) == 3
+        for m in windows:
+            assert m["clip_start"] is not None and m["clip_end"] is not None
+            # Display-only window persisted in origin.params too.
+            assert m["origin"]["params"]["clip_start"] == m["clip_start"]
+            assert m["origin"]["params"]["clip_end"] == m["clip_end"]
+        # Each window's synthesized md5 is unique despite sharing one member.
+        assert len({m["md5"] for m in windows}) == 3
+        # The whole-member row carries no clip fields.
+        whole = next(m for m in medias.values() if m["archive_member"]["member"] == "sub/chunk_b.mp4")
+        assert "clip_start" not in whole
+        assert "clip_start" not in whole["origin"]["params"]
+
+    def test_window_id_disambiguates_md5(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        rng = np.random.default_rng(3)
+        manifest = tmp_path / "wid.npz"
+        np.savez(
+            manifest,
+            vectors=rng.standard_normal((2, DIM)).astype(np.float32),
+            members=np.array(["chunk_a.mp4", "chunk_a.mp4"]),
+            archives=np.array(str(archive)),
+            window_id=np.array(["w0", "w1"]),
+            embedder_name=np.array("largerclapgeneral"),
+        )
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        assert len(medias) == 2
+        assert len({m["md5"] for m in medias.values()}) == 2
+        assert {m["origin"]["params"]["window_id"] for m in medias.values()} == {"w0", "w1"}
+
+
+class TestArchiveMemberClipRecipe:
+    def test_archive_member_audio_never_lazy_slices(self, tmp_path):
+        """A windowed audio archive member must not trigger WAV byte-slicing."""
+        from vtscore.media.lazy_clip import clip_recipe
+
+        archive = _make_tar(tmp_path)
+        media = {
+            "media_type": "audio",
+            "archive_member": {"path": str(archive), "member": "chunk_a.mp4"},
+            "origin": {
+                "importer": "local_archive_member",
+                "params": {"archive_path": str(archive), "member": "chunk_a.mp4", "clip_start": 0.0, "clip_end": 10.0},
+            },
+            "clip_start": 0.0,
+            "clip_end": 10.0,
+        }
+        assert clip_recipe(media) is None
+
+
+class TestLocalArchiveMemberSource:
+    def test_factory_resolves_origin(self, tmp_path):
+        from vtscore.datasets.sources import get_source_for_origin
+
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        origin = next(iter(medias.values()))["origin"]
+
+        source = get_source_for_origin(origin)
+        assert source is not None
+        assert source.name == "local_archive_member"
+
+    def test_fetch_item_resupplies_vector_no_path(self, tmp_path):
+        from vtscore.datasets.sources import get_source_for_origin
+
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        media = next(m for m in medias.values() if m["archive_member"]["member"] == "chunk_a.mp4")
+
+        source = get_source_for_origin(media["origin"])
+        fetched = source.fetch_item("chunk_a.mp4")
+        assert fetched.path is None
+        assert fetched.embedding is not None
+        assert fetched.embedding.shape == (DIM,)
+        assert fetched.embedder_name == "largerclapgeneral"
+        # Re-supplied vector matches the in-memory embedding from import.
+        np.testing.assert_array_equal(fetched.embedding, media["embeddings"]["largerclapgeneral"])
+
+    def test_fetch_item_resolves_windowed_member(self, tmp_path):
+        from vtscore.datasets.sources import get_source_for_origin
+
+        archive = _make_tar(tmp_path)
+        manifest = _make_windowed_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        window = next(
+            m
+            for m in medias.values()
+            if m["archive_member"]["member"] == "chunk_a.mp4" and m.get("clip_start") == 10.0
+        )
+
+        source = get_source_for_origin(window["origin"])
+        # The window key is "member@start"; fetch by it returns that window's vector.
+        fetched = source.fetch_item("chunk_a.mp4@10")
+        assert fetched.embedding is not None
+        np.testing.assert_array_equal(fetched.embedding, window["embeddings"]["largerclapgeneral"])
+
+    def test_fetch_item_unknown_key_returns_pathless_empty(self, tmp_path):
+        from vtscore.datasets.sources import get_source_for_origin
+
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        source = get_source_for_origin(next(iter(medias.values()))["origin"])
+        fetched = source.fetch_item("does/not/exist.mp4")
+        assert fetched.path is None
+        assert fetched.embedding is None

--- a/tests_lib/io/test_importer_loading.py
+++ b/tests_lib/io/test_importer_loading.py
@@ -684,10 +684,11 @@ class TestImporterResolveFileContract:
     #   `server_folder` importer, so resolution for those medias goes
     #   through `server_folder.resolve_file`.
     # - local_archive_member: media have no on-disk path by design (their
-    #   bytes stream from a tar/zip member, never extracted); resolution goes
-    #   through the archive-member byte path (``archive_member_ref``), not a
-    #   disk Path. Cross-dataset re-derivation is a tracked Phase B follow-up
-    #   (docs/plans/webdataset-tar-import.md).
+    #   bytes stream from a tar/zip member, never extracted); byte resolution
+    #   goes through the archive-member byte path (``archive_member_ref``), not
+    #   a disk Path, and cross-dataset re-derivation goes through the
+    #   manifest-backed ``LocalArchiveMemberSource`` (which re-supplies the
+    #   precomputed vector), not ``resolve_file``.
     _DELEGATE_IMPORTERS = {
         "pickle",
         "combine_datasets",

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -154,11 +154,7 @@ def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
     base_dir = p.resolve().parent
     with np.load(p, allow_pickle=False) as data:
         cols = _manifest_columns(data, p)
-        rows = [
-            row
-            for i in range(len(cols["members"]))
-            if (row := _manifest_row(i, cols, base_dir)) is not None
-        ]
+        rows = [row for i in range(len(cols["members"])) if (row := _manifest_row(i, cols, base_dir)) is not None]
         if not rows:
             raise ValueError(f"NPZ manifest {p} produced no rows")
         return rows

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -27,6 +27,7 @@ loading arbitrary Python objects from untrusted archives.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import numpy as np
@@ -37,6 +38,9 @@ _VECTORS_KEYS = ("vectors", "embeddings", "vecs", "embedding")
 _EMBEDDER_NAME_KEYS = ("embedder_name", "embedder")
 _MEMBERS_KEYS = ("members", "member")
 _ARCHIVES_KEYS = ("archives", "archive", "shards", "shard")
+_CLIP_START_KEYS = ("clip_start", "clip_starts", "starts", "start")
+_CLIP_END_KEYS = ("clip_end", "clip_ends", "ends", "end")
+_WINDOW_ID_KEYS = ("window_id", "window_ids", "windows", "window")
 
 
 def read_npz_embedder_name(npz_path: Path) -> str:
@@ -127,12 +131,21 @@ def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
       resolved against the manifest's directory.
     * ``filenames`` *(optional)* - ``(N,)`` display names; defaults to the
       member's basename.
+    * ``clip_start`` / ``clip_end`` *(optional)* - ``(N,)`` window extents in
+      seconds.  When present, one member can appear in several rows, each a
+      distinct **sub-file clip window** (e.g. ≈14 × 10 s CLAP windows per
+      chunk); the importer fans them out into separate windowed media that the
+      player seeks/loops within (display-only, no byte slicing).
+    * ``window_id`` *(optional)* - ``(N,)`` per-window identifiers used to keep
+      each window's synthesized content-id unique; defaults to the clip start.
     * ``embedder_name`` *(optional)* - scalar embedder name (see
       :func:`read_npz_embedder_name`).
 
-    Returns a list of ``{"archive", "member", "filename", "vector"}`` dicts
-    (archive paths resolved to absolute strings).  Raises ``ValueError`` for a
-    malformed manifest and ``FileNotFoundError`` if the file is missing.
+    Returns a list of ``{"archive", "member", "filename", "vector",
+    "clip_start", "clip_end", "window_id"}`` dicts (the three clip fields are
+    ``None`` for an un-windowed manifest; archive paths resolved to absolute
+    strings).  Raises ``ValueError`` for a malformed manifest and
+    ``FileNotFoundError`` if the file is missing.
     """
     p = Path(npz_path)
     if not p.is_file():
@@ -140,24 +153,30 @@ def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
 
     base_dir = p.resolve().parent
     with np.load(p, allow_pickle=False) as data:
-        vecs_arr, members_arr, archives_arr, filenames_arr = _manifest_columns(data, p)
+        cols = _manifest_columns(data, p)
         rows = [
             row
-            for i in range(len(members_arr))
-            if (row := _manifest_row(i, members_arr, archives_arr, filenames_arr, vecs_arr, base_dir)) is not None
+            for i in range(len(cols["members"]))
+            if (row := _manifest_row(i, cols, base_dir)) is not None
         ]
         if not rows:
             raise ValueError(f"NPZ manifest {p} produced no rows")
         return rows
 
 
-def _manifest_columns(data, p: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None]:
-    """Resolve and validate the ``(vectors, members, archives, filenames?)`` columns."""
+def _manifest_columns(data, p: Path) -> dict[str, np.ndarray | None]:
+    """Resolve and validate every manifest column.
+
+    Returns a dict with the required ``vectors`` / ``members`` / ``archives``
+    columns and the optional ``filenames`` / ``clip_start`` / ``clip_end`` /
+    ``window_id`` columns (``None`` when the manifest omits them).  Every
+    optional column is broadcast to length *N* so a scalar can stand in for a
+    whole-manifest constant.
+    """
     key_set = set(data.files)
     vectors_key = next((k for k in _VECTORS_KEYS if k in key_set), None)
     members_key = next((k for k in _MEMBERS_KEYS if k in key_set), None)
     archives_key = next((k for k in _ARCHIVES_KEYS if k in key_set), None)
-    filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
 
     if vectors_key is None or members_key is None:
         raise ValueError(
@@ -174,29 +193,92 @@ def _manifest_columns(data, p: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray
         raise ValueError(f"NPZ '{members_key}' and '{vectors_key}' have mismatched lengths ({n} vs {len(vecs_arr)})")
     if archives_key is None:
         raise ValueError(f"NPZ manifest {p} must contain an archives array (one of {_ARCHIVES_KEYS})")
-    archives_arr = _broadcast_column(data[archives_key], n, "archives")
-    filenames_arr = _broadcast_column(data[filenames_key], n, "filenames") if filenames_key is not None else None
-    return vecs_arr, members_arr, archives_arr, filenames_arr
+
+    return {
+        "vectors": vecs_arr,
+        "members": members_arr,
+        "archives": _broadcast_column(data[archives_key], n, "archives"),
+        "filenames": _optional_column(data, key_set, _FILENAMES_KEYS, n, "filenames"),
+        "clip_start": _optional_column(data, key_set, _CLIP_START_KEYS, n, "clip_start"),
+        "clip_end": _optional_column(data, key_set, _CLIP_END_KEYS, n, "clip_end"),
+        "window_id": _optional_column(data, key_set, _WINDOW_ID_KEYS, n, "window_id"),
+    }
 
 
-def _manifest_row(i, members_arr, archives_arr, filenames_arr, vecs_arr, base_dir: Path) -> dict | None:
-    """Build one ``{archive, member, filename, vector}`` row, or ``None`` to skip."""
-    member = str(members_arr[i]).strip()
+def _optional_column(data, key_set: set, keys: tuple, n: int, label: str) -> np.ndarray | None:
+    """Return a length-*n* broadcast of the first present *keys* column, else ``None``."""
+    key = next((k for k in keys if k in key_set), None)
+    if key is None:
+        return None
+    return _broadcast_column(data[key], n, label)
+
+
+def _manifest_row(i: int, cols: dict, base_dir: Path) -> dict | None:
+    """Build one window/member row, or ``None`` to skip an empty member."""
+    member = str(cols["members"][i]).strip()
     if not member:
         return None
-    archive = str(archives_arr[i]).strip()
+    archive = str(cols["archives"][i]).strip()
     if not archive:
         raise ValueError(f"manifest row {i} has an empty archive path")
     archive_path = Path(archive)
     if not archive_path.is_absolute():
         archive_path = (base_dir / archive_path).resolve()
+    filenames_arr = cols["filenames"]
     display = str(filenames_arr[i]).strip() if filenames_arr is not None else ""
     return {
         "archive": str(archive_path),
         "member": member,
         "filename": display or Path(member).name,
-        "vector": np.asarray(vecs_arr[i]),
+        "vector": np.asarray(cols["vectors"][i]),
+        "clip_start": _row_float(cols["clip_start"], i),
+        "clip_end": _row_float(cols["clip_end"], i),
+        "window_id": _row_window_id(cols["window_id"], i),
     }
+
+
+def _row_float(arr: np.ndarray | None, i: int) -> float | None:
+    """Return ``arr[i]`` as a float, or ``None`` when the column is absent/blank.
+
+    ``None`` covers three "no window for this row" encodings so a manifest can
+    mix windowed and whole-member rows in one float column: an absent column, a
+    blank string entry, and a ``NaN`` entry.
+    """
+    if arr is None:
+        return None
+    raw = arr[i]
+    if isinstance(raw, (bytes, np.bytes_, str, np.str_)) and not str(raw).strip():
+        return None
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(val) else val
+
+
+def _row_window_id(arr: np.ndarray | None, i: int) -> str | None:
+    """Return ``arr[i]`` as a trimmed string id, or ``None`` when absent/blank."""
+    if arr is None:
+        return None
+    val = str(arr[i]).strip()
+    return val or None
+
+
+def window_suffix(window_id: str | None, clip_start: float | None) -> str:
+    """Return the per-window discriminator appended to a member's identity.
+
+    A windowed import fans one member into several media, so the member name
+    alone is no longer unique.  Prefer an explicit ``window_id``; otherwise key
+    on the window's start time; an un-windowed (whole-member) row contributes
+    the empty string.  Shared by the importer (synthesized md5 + ``origin_name``)
+    and the manifest-backed media source (re-supplying a specific window's
+    vector) so the two agree on a window's identity.
+    """
+    if window_id:
+        return f"#{window_id}"
+    if clip_start is not None:
+        return f"@{clip_start:g}"
+    return ""
 
 
 def _broadcast_column(arr: np.ndarray, n: int, label: str) -> np.ndarray:

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -154,13 +155,14 @@ def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:
     base_dir = p.resolve().parent
     with np.load(p, allow_pickle=False) as data:
         cols = _manifest_columns(data, p)
-        rows = [row for i in range(len(cols["members"])) if (row := _manifest_row(i, cols, base_dir)) is not None]
+        n = len(cols["members"])  # always present (validated in _manifest_columns)
+        rows = [row for i in range(n) if (row := _manifest_row(i, cols, base_dir)) is not None]
         if not rows:
             raise ValueError(f"NPZ manifest {p} produced no rows")
         return rows
 
 
-def _manifest_columns(data, p: Path) -> dict[str, np.ndarray | None]:
+def _manifest_columns(data, p: Path) -> dict[str, Any]:
     """Resolve and validate every manifest column.
 
     Returns a dict with the required ``vectors`` / ``members`` / ``archives``

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -62,7 +62,7 @@ def _synthetic_md5(archive: str, member: str, suffix: str = "") -> str:
     is *content*-based label transfer across unrelated datasets, which these
     precomputed-embedding corpora don't use.
     """
-    return hashlib.md5(f"{archive}::{member}{window_suffix}".encode()).hexdigest()
+    return hashlib.md5(f"{archive}::{member}{suffix}".encode()).hexdigest()
 
 
 class LocalArchiveMemberImporter(ImporterBase):

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -16,9 +16,15 @@ Because the embeddings are supplied, the framework embed stage is skipped: the
 import needs no GPU and reads no member bytes (it only walks each referenced
 shard's tar headers to confirm the member exists and record its size).
 
-Each row becomes one whole-member media.  Sub-file *windowing* (multiple 10 s
-clip items per member, carrying ``clip_start`` / ``clip_end``) is the planned
-Phase B extension -- see ``docs/plans/webdataset-tar-import.md``.
+Each manifest row becomes one media.  When a row carries ``clip_start`` /
+``clip_end``, the same member can appear in several rows as distinct **sub-file
+clip windows** (e.g. ≈14 × 10 s CLAP windows per chunk), each its own
+searchable media with its own pre-computed vector.  Windowed media are
+*display-only*: the byte routes serve the **whole** member and the player seeks
+/ loops within ``[clip_start, clip_end]`` -- we never byte-slice an AAC/MP4
+member server-side (see :func:`~vtscore.media.lazy_clip.clip_recipe`, which
+refuses to lazy-slice archive members).  Each window's synthesized content-id
+folds in the window so dedup / voting stay per-window unique.
 """
 
 from __future__ import annotations
@@ -33,25 +39,30 @@ from vtscore.datasets.archive_stream import (
     LOCAL_ARCHIVE_MEMBER_IMPORTER,
     member_size,
 )
-from vtscore.datasets.importers._npz_vectors import read_npz_archive_member_rows, read_npz_embedder_name
+from vtscore.datasets.importers._npz_vectors import (
+    read_npz_archive_member_rows,
+    read_npz_embedder_name,
+    window_suffix,
+)
 from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.embedding.media_vectors import init_embeddings
 
 logger = logging.getLogger(__name__)
 
 
-def _synthetic_md5(archive: str, member: str) -> str:
-    """Return a stable content-id for a member without reading its bytes.
+def _synthetic_md5(archive: str, member: str, suffix: str = "") -> str:
+    """Return a stable content-id for a member/window without reading its bytes.
 
     The real point of this importer is to avoid touching member *data* (the
     corpora are far too large to hash in full), so the dedup/label key is
-    derived from the globally-unique ``archive::member`` pair instead of the
-    member's content.  This keeps in-dataset dedup, voting, and label
-    persistence working; the one thing it gives up is *content*-based label
-    transfer across unrelated datasets, which these precomputed-embedding
-    corpora don't use.
+    derived from the globally-unique ``archive::member`` pair (plus a
+    per-window suffix) instead of the member's content.  This keeps in-dataset
+    dedup, voting, and label persistence working -- and unique **per window**
+    when a member fans out into several clip windows; the one thing it gives up
+    is *content*-based label transfer across unrelated datasets, which these
+    precomputed-embedding corpora don't use.
     """
-    return hashlib.md5(f"{archive}::{member}".encode()).hexdigest()
+    return hashlib.md5(f"{archive}::{member}{window_suffix}".encode()).hexdigest()
 
 
 class LocalArchiveMemberImporter(ImporterBase):
@@ -95,6 +106,9 @@ class LocalArchiveMemberImporter(ImporterBase):
                 " • archives - (N,) archive paths (or a single value for one shard);\n"
                 "   relative paths resolve against the manifest's directory.\n"
                 " • filenames (optional) - (N,) display names.\n"
+                " • clip_start / clip_end (optional) - (N,) window extents in seconds;\n"
+                "   one member may repeat across rows as separate clip windows.\n"
+                " • window_id (optional) - (N,) per-window ids (default: the clip start).\n"
                 " • embedder_name (optional) - the embedder that produced the vectors.\n"
                 "Members are streamed on demand; the archives are never extracted."
             ),
@@ -124,45 +138,75 @@ class LocalArchiveMemberImporter(ImporterBase):
 
         next_id = max(medias.keys(), default=0) + 1
         skipped = 0
+        # Member sizes are read once per shard member (a tar-header lookup), not
+        # once per window: a heavily-windowed manifest references the same member
+        # ~14 times, and the size is identical for every window of it.
+        size_cache: dict[tuple[str, str], int] = {}
         for row in rows:
             archive = row["archive"]
             member = row["member"]
-            try:
-                size = member_size(archive, member)
-            except (ArchiveMemberError, OSError) as exc:
-                # The manifest references a member we can't locate in its shard
-                # (missing archive, renamed member). Skip it rather than import
-                # a media whose bytes will never resolve.
-                logger.warning("local_archive_member: skipping %s::%s (%s)", archive, member, exc)
+            cache_key = (archive, member)
+            if cache_key not in size_cache:
+                try:
+                    size_cache[cache_key] = member_size(archive, member)
+                except (ArchiveMemberError, OSError) as exc:
+                    # The manifest references a member we can't locate in its
+                    # shard (missing archive, renamed member). Skip it rather
+                    # than import a media whose bytes will never resolve.
+                    logger.warning("local_archive_member: skipping %s::%s (%s)", archive, member, exc)
+                    size_cache[cache_key] = -1
+            size = size_cache[cache_key]
+            if size < 0:
                 skipped += 1
                 continue
 
-            origin = {
-                "importer": self.name,
-                "params": {
-                    "archive_path": archive,
-                    "member": member,
-                    "media_type": output_type,
-                    "manifest": str(manifest.resolve()),
-                    "embedder_name": embedder_name,
-                },
+            clip_start = row.get("clip_start")
+            clip_end = row.get("clip_end")
+            window_id = row.get("window_id")
+            suffix = window_suffix(window_id, clip_start)
+
+            params: dict[str, Any] = {
+                "archive_path": archive,
+                "member": member,
+                "media_type": output_type,
+                "manifest": str(manifest.resolve()),
+                "embedder_name": embedder_name,
             }
-            medias[next_id] = {
+            # Persist the window in origin.params (the channel that survives the
+            # pickle round-trip and re-derivation) so the manifest-backed source
+            # can re-supply *this* window's vector. clip_recipe() refuses to
+            # lazy-slice archive members, so carrying clip extents here never
+            # triggers server-side byte slicing.
+            if clip_start is not None:
+                params["clip_start"] = clip_start
+            if clip_end is not None:
+                params["clip_end"] = clip_end
+            if window_id:
+                params["window_id"] = window_id
+
+            media: dict[str, Any] = {
                 "id": next_id,
                 "media_type": output_type,
                 "embedder": embedder_name,
                 "file_size": size,
-                "md5": _synthetic_md5(archive, member),
+                "md5": _synthetic_md5(archive, member, suffix),
                 "embeddings": init_embeddings(embedder_name, row["vector"]),
                 "filename": row["filename"],
                 "category": "custom",
-                "origin": origin,
-                "origin_name": f"{archive}::{member}",
+                "origin": {"importer": self.name, "params": params},
+                "origin_name": f"{archive}::{member}{suffix}",
                 "media_bytes": None,
                 "media_string": None,
                 "duration": 0,
                 "archive_member": {"path": archive, "member": member},
             }
+            # Top-level clip extents drive the player's display-only seek/loop
+            # (passed through by /api/medias/batch).
+            if clip_start is not None:
+                media["clip_start"] = clip_start
+            if clip_end is not None:
+                media["clip_end"] = clip_end
+            medias[next_id] = media
             next_id += 1
 
         if not medias:

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -135,6 +135,7 @@ class LocalArchiveMemberImporter(ImporterBase):
 
         rows = read_npz_archive_member_rows(manifest)
         embedder_name = read_npz_embedder_name(manifest)
+        manifest_path = str(manifest.resolve())
 
         next_id = max(medias.keys(), default=0) + 1
         skipped = 0
@@ -143,70 +144,11 @@ class LocalArchiveMemberImporter(ImporterBase):
         # ~14 times, and the size is identical for every window of it.
         size_cache: dict[tuple[str, str], int] = {}
         for row in rows:
-            archive = row["archive"]
-            member = row["member"]
-            cache_key = (archive, member)
-            if cache_key not in size_cache:
-                try:
-                    size_cache[cache_key] = member_size(archive, member)
-                except (ArchiveMemberError, OSError) as exc:
-                    # The manifest references a member we can't locate in its
-                    # shard (missing archive, renamed member). Skip it rather
-                    # than import a media whose bytes will never resolve.
-                    logger.warning("local_archive_member: skipping %s::%s (%s)", archive, member, exc)
-                    size_cache[cache_key] = -1
-            size = size_cache[cache_key]
+            size = self._member_size_cached(size_cache, row["archive"], row["member"])
             if size < 0:
                 skipped += 1
                 continue
-
-            clip_start = row.get("clip_start")
-            clip_end = row.get("clip_end")
-            window_id = row.get("window_id")
-            suffix = window_suffix(window_id, clip_start)
-
-            params: dict[str, Any] = {
-                "archive_path": archive,
-                "member": member,
-                "media_type": output_type,
-                "manifest": str(manifest.resolve()),
-                "embedder_name": embedder_name,
-            }
-            # Persist the window in origin.params (the channel that survives the
-            # pickle round-trip and re-derivation) so the manifest-backed source
-            # can re-supply *this* window's vector. clip_recipe() refuses to
-            # lazy-slice archive members, so carrying clip extents here never
-            # triggers server-side byte slicing.
-            if clip_start is not None:
-                params["clip_start"] = clip_start
-            if clip_end is not None:
-                params["clip_end"] = clip_end
-            if window_id:
-                params["window_id"] = window_id
-
-            media: dict[str, Any] = {
-                "id": next_id,
-                "media_type": output_type,
-                "embedder": embedder_name,
-                "file_size": size,
-                "md5": _synthetic_md5(archive, member, suffix),
-                "embeddings": init_embeddings(embedder_name, row["vector"]),
-                "filename": row["filename"],
-                "category": "custom",
-                "origin": {"importer": self.name, "params": params},
-                "origin_name": f"{archive}::{member}{suffix}",
-                "media_bytes": None,
-                "media_string": None,
-                "duration": 0,
-                "archive_member": {"path": archive, "member": member},
-            }
-            # Top-level clip extents drive the player's display-only seek/loop
-            # (passed through by /api/medias/batch).
-            if clip_start is not None:
-                media["clip_start"] = clip_start
-            if clip_end is not None:
-                media["clip_end"] = clip_end
-            medias[next_id] = media
+            medias[next_id] = self._build_media(next_id, row, size, output_type, embedder_name, manifest_path)
             next_id += 1
 
         if not medias:
@@ -214,6 +156,75 @@ class LocalArchiveMemberImporter(ImporterBase):
                 f"No importable members in {manifest}"
                 + (f" ({skipped} referenced member(s) could not be located)" if skipped else "")
             )
+
+    @staticmethod
+    def _member_size_cached(size_cache: dict[tuple[str, str], int], archive: str, member: str) -> int:
+        """Return *member*'s size (cached per shard member), or ``-1`` if unlocatable."""
+        cache_key = (archive, member)
+        if cache_key not in size_cache:
+            try:
+                size_cache[cache_key] = member_size(archive, member)
+            except (ArchiveMemberError, OSError) as exc:
+                # The manifest references a member we can't locate in its shard
+                # (missing archive, renamed member). Skip it rather than import a
+                # media whose bytes will never resolve.
+                logger.warning("local_archive_member: skipping %s::%s (%s)", archive, member, exc)
+                size_cache[cache_key] = -1
+        return size_cache[cache_key]
+
+    def _build_media(
+        self, media_id: int, row: dict, size: int, output_type: str, embedder_name: str, manifest_path: str
+    ) -> dict[str, Any]:
+        """Build one media dict from a manifest row (one whole member or one window)."""
+        archive = row["archive"]
+        member = row["member"]
+        clip_start = row.get("clip_start")
+        clip_end = row.get("clip_end")
+        window_id = row.get("window_id")
+        suffix = window_suffix(window_id, clip_start)
+
+        params: dict[str, Any] = {
+            "archive_path": archive,
+            "member": member,
+            "media_type": output_type,
+            "manifest": manifest_path,
+            "embedder_name": embedder_name,
+        }
+        # Persist the window in origin.params (the channel that survives the
+        # pickle round-trip and re-derivation) so the manifest-backed source can
+        # re-supply *this* window's vector. clip_recipe() refuses to lazy-slice
+        # archive members, so carrying clip extents here never triggers
+        # server-side byte slicing.
+        if clip_start is not None:
+            params["clip_start"] = clip_start
+        if clip_end is not None:
+            params["clip_end"] = clip_end
+        if window_id:
+            params["window_id"] = window_id
+
+        media: dict[str, Any] = {
+            "id": media_id,
+            "media_type": output_type,
+            "embedder": embedder_name,
+            "file_size": size,
+            "md5": _synthetic_md5(archive, member, suffix),
+            "embeddings": init_embeddings(embedder_name, row["vector"]),
+            "filename": row["filename"],
+            "category": "custom",
+            "origin": {"importer": self.name, "params": params},
+            "origin_name": f"{archive}::{member}{suffix}",
+            "media_bytes": None,
+            "media_string": None,
+            "duration": 0,
+            "archive_member": {"path": archive, "member": member},
+        }
+        # Top-level clip extents drive the player's display-only seek/loop
+        # (passed through by /api/medias/batch).
+        if clip_start is not None:
+            media["clip_start"] = clip_start
+        if clip_end is not None:
+            media["clip_end"] = clip_end
+        return media
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         manifest = Path(field_values["manifest"])

--- a/vtscore/datasets/sources/local_archive_member.py
+++ b/vtscore/datasets/sources/local_archive_member.py
@@ -1,0 +1,141 @@
+"""Manifest-backed media source for no-extraction archive members.
+
+The ``local_archive_member`` importer records only ``{archive path, member}``
+(plus an optional clip window) and re-derives a media's *bytes* through
+:mod:`vtscore.datasets.archive_stream`.  That covers playback, but the
+:class:`~vtscore.datasets.sources.base.MediaSource` contract the cross-dataset
+resolver / example-sort uses is **path-based**, and an archive member has no
+on-disk path -- so without a source factory, per-media "Find from origin"
+(:func:`vtsearch.routes.media.server.example_sort_origin`) returns 400.
+
+This source closes that gap without re-deriving bytes: the embeddings are
+already precomputed in the ``.npz`` manifest, so it re-supplies a member's (or a
+specific *window's*) vector straight out of the manifest.  A
+:class:`~vtscore.datasets.sources.base.FetchedItem` returned here has
+``path=None`` and ``embedding`` set; the route sorts directly on that vector
+(no fetch, no re-embed), exactly as :func:`example_sort_by_id` reuses an
+in-memory embedding.  Per the no-persisted-vectors rule nothing here writes the
+vectors anywhere; they are read from the manifest on demand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+
+from vtscore.datasets.importers._npz_vectors import (
+    read_npz_archive_member_rows,
+    read_npz_embedder_name,
+    window_suffix,
+)
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
+
+__all__ = ["LocalArchiveMemberSource"]
+
+
+class LocalArchiveMemberSource(MediaSource):
+    """A media source that re-supplies precomputed vectors from an NPZ manifest.
+
+    Each manifest row is indexed under its **window key** -- the member name plus
+    the same per-window suffix the importer folds into a media's identity (see
+    :func:`~vtscore.datasets.importers._npz_vectors.window_suffix`) -- and, as a
+    fallback, under its bare member name (resolving to that member's first
+    window).  Fetches return the row's embedding, never a file path.
+
+    Args:
+        manifest: Path to the ``.npz`` manifest the import used.
+        embedder_name: The embedder that produced the vectors; falls back to the
+            name recorded in the manifest when blank.
+    """
+
+    name = "local_archive_member"
+
+    def __init__(self, manifest: str | Path, embedder_name: str = "") -> None:
+        self._manifest = Path(manifest)
+        self._embedder_name = embedder_name or read_npz_embedder_name(self._manifest)
+        self._index: dict[str, dict] | None = None
+
+    def _rows_by_key(self) -> dict[str, dict]:
+        """Build (once) the ``{window_key | member: row}`` lookup for the manifest."""
+        if self._index is not None:
+            return self._index
+        index: dict[str, dict] = {}
+        for row in read_npz_archive_member_rows(self._manifest):
+            member = row["member"]
+            key = member + window_suffix(row.get("window_id"), row.get("clip_start"))
+            index[key] = row
+            # Bare-member fallback resolves to the member's first window.
+            index.setdefault(member, row)
+        self._index = index
+        return index
+
+    def _lookup(self, key: str) -> dict | None:
+        """Resolve *key* to a manifest row, tolerating an ``archive::member`` form."""
+        key = (key or "").strip()
+        if not key:
+            return None
+        index = self._rows_by_key()
+        row = index.get(key)
+        if row is not None:
+            return row
+        # ``origin_name`` is stored as ``"<archive>::<member><suffix>"``; accept it.
+        if "::" in key:
+            return index.get(key.split("::", 1)[1])
+        return None
+
+    def _fetched(self, row: dict | None) -> FetchedItem:
+        if row is None:
+            return FetchedItem(path=None)
+        return FetchedItem(
+            path=None,
+            embedding=np.asarray(row["vector"]),
+            embedder_name=self._embedder_name,
+        )
+
+    def list_items(self, extensions: list[str] | None = None) -> Iterator[MediaItem]:
+        exts = {e.lower() for e in extensions} if extensions else None
+        seen: set[str] = set()
+        for row in read_npz_archive_member_rows(self._manifest):
+            member = row["member"]
+            key = member + window_suffix(row.get("window_id"), row.get("clip_start"))
+            if key in seen:
+                continue
+            seen.add(key)
+            if exts is not None and Path(member).suffix.lower() not in exts:
+                continue
+            yield MediaItem(key=key, filename=row["filename"], source_name=self.name)
+
+    def fetch_item(self, key: str) -> FetchedItem:
+        return self._fetched(self._lookup(key))
+
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
+        row = self._lookup(origin_name)
+        if row is None and filename:
+            target = Path(filename).name
+            row = next(
+                (r for r in read_npz_archive_member_rows(self._manifest) if r["filename"] == target),
+                None,
+            )
+        return self._fetched(row)
+
+
+class _LocalArchiveMemberSourceFactory:
+    """Factory for auto-discovery by :class:`~vtscore.plugins.PluginRegistry`.
+
+    Resolves the ``local_archive_member`` origins emitted by
+    :class:`~vtscore.datasets.importers.local_archive_member.LocalArchiveMemberImporter`.
+    """
+
+    name = "local_archive_member"
+
+    def create_from_origin(self, origin: dict) -> LocalArchiveMemberSource | None:
+        params = origin.get("params", {})
+        manifest = params.get("manifest", "")
+        if not manifest:
+            return None
+        return LocalArchiveMemberSource(manifest, embedder_name=params.get("embedder_name", ""))
+
+
+SOURCE = _LocalArchiveMemberSourceFactory()

--- a/vtscore/media/lazy_clip.py
+++ b/vtscore/media/lazy_clip.py
@@ -189,7 +189,20 @@ def clip_recipe(media: dict[str, Any]) -> tuple | None:
     The converter branch is checked first and is keyed by the ``converter``
     param, not the target media type: a ``document2image`` output has
     ``media_type == "image"`` but is a converter output, not an image *clip*.
+
+    **Archive members never lazy-slice.** A ``local_archive_member`` media may
+    carry ``clip_start`` / ``clip_end`` (a windowed import), but its window is
+    *display-only*: the byte routes serve the whole member and the player seeks
+    within the window.  These corpora are AAC/MP4, which the WAV-only audio
+    slicer cannot cut and which we deliberately do not decode server-side, so we
+    return ``None`` here and let the caller fall through to whole-member byte
+    serving.
     """
+    from vtscore.datasets.archive_stream import archive_member_ref  # noqa: PLC0415
+
+    if archive_member_ref(media) is not None:
+        return None
+
     origin = media.get("origin")
     params = origin.get("params", {}) if isinstance(origin, dict) else {}
 

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -242,6 +242,34 @@ def _member_mimetype(filename: str, default: str) -> str:
     return guessed or default
 
 
+def _audio_member_mimetype(filename: str) -> str:
+    """Pick the ``Content-Type`` for an archive-member served via ``/audio``.
+
+    WebDataset-style audio events ship in a few container shapes:
+
+    * **demuxed AAC** (microvent) - ``.aac`` -> ``audio/aac``.
+    * **audio in an MP4 container** (multivent-raw rides the audio in the video
+      MP4; ``.m4a`` audio chunks) - ``mimetypes`` reports ``.mp4`` as
+      *``video/mp4``*, but when an ``<audio>`` element requests it we want the
+      audio mimetype so the browser plays the audio track.  Map any ``video/*``
+      container (mp4 / quicktime) to ``audio/mp4``.
+
+    Anything else keeps its guessed ``audio/*`` type, normalising the legacy
+    ``audio/x-wav`` to ``audio/wav``, and falls back to ``audio/wav`` when the
+    extension is unknown (the on-the-fly serving format).
+    """
+    import mimetypes  # noqa: PLC0415
+
+    guessed, _ = mimetypes.guess_type(filename)
+    if not guessed:
+        return "audio/wav"
+    if guessed == "audio/x-wav":
+        return "audio/wav"
+    if guessed.startswith("video/"):
+        return "audio/mp4"
+    return guessed
+
+
 def _send_streamed_range(total, read_slice, mimetype: str, download_name: str) -> Response:
     """Serve *total* bytes with HTTP Range support, reading only what's asked.
 
@@ -286,7 +314,9 @@ def _send_streamed_range(total, read_slice, mimetype: str, download_name: str) -
     return resp
 
 
-def _archive_member_response(media: dict, download_name: str, default_mimetype: str) -> Response | None:
+def _archive_member_response(
+    media: dict, download_name: str, default_mimetype: str, mimetype: str | None = None
+) -> Response | None:
     """Serve an archive-member media by streaming a single member, or ``None``.
 
     Returns ``None`` for media that aren't archive-member-backed (the caller
@@ -294,6 +324,11 @@ def _archive_member_response(media: dict, download_name: str, default_mimetype: 
     located in its shard.  Otherwise returns a Range-capable response that
     reads only the requested bytes straight out of the tar/zip, never
     extracting or fully buffering the member.
+
+    *mimetype*, when given, is used verbatim; otherwise it is guessed from the
+    member name (falling back to *default_mimetype*).  The audio route passes an
+    explicit value because audio events ride in containers ``mimetypes`` would
+    label ``video/*`` (see :func:`_audio_member_mimetype`).
     """
     from vtscore.datasets.archive_stream import (  # noqa: PLC0415
         ArchiveMemberError,
@@ -314,8 +349,8 @@ def _archive_member_response(media: dict, download_name: str, default_mimetype: 
     def read_slice(start, length):
         return read_member_range(archive_path, member, start, length)
 
-    mimetype = _member_mimetype(media.get("filename") or member, default_mimetype)
-    return _send_streamed_range(total, read_slice, mimetype, download_name)
+    resolved = mimetype or _member_mimetype(media.get("filename") or member, default_mimetype)
+    return _send_streamed_range(total, read_slice, resolved, download_name)
 
 
 def _send_video_bytes(data: bytes, mimetype: str, download_name: str) -> Response:
@@ -490,8 +525,11 @@ def media_audio(media_id: int):
     c = get_media(media_id)
     if not c:
         abort(404, message="not found")
-    ext = Path(c.get("filename", "")).suffix or ".wav"
-    streamed = _archive_member_response(c, f"media_{media_id}{ext}", "audio/wav")
+    filename = c.get("filename", "")
+    ext = Path(filename).suffix or ".wav"
+    streamed = _archive_member_response(
+        c, f"media_{media_id}{ext}", "audio/wav", mimetype=_audio_member_mimetype(filename or ext)
+    )
     if streamed is not None:
         return streamed
     media_bytes = _resolve_bytes(c)

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -314,7 +314,21 @@ def example_sort_origin(body: dict):
     crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
 
     try:
-        file_path = source.fetch_item(key).path
+        fetched = source.fetch_item(key)
+
+        # Pathless sources (archive members) re-supply the item's precomputed
+        # vector instead of bytes; sort directly on it, exactly as
+        # ``example_sort_by_id`` reuses an in-memory embedding. Cropping needs
+        # the actual bytes, which this path deliberately never materialises.
+        if fetched.path is None and fetched.embedding is not None:
+            if crop_params:
+                abort(400, message="Cannot crop an archive-member example (no extracted bytes)")
+            from vtsearch.routes.sorting import _cosine_sort
+
+            results, thresh = _cosine_sort(fetched.embedding)
+            return {"results": results, "threshold": thresh}
+
+        file_path = fetched.path
         if file_path is None:
             abort(404, message=f"File not found: {key}")
 


### PR DESCRIPTION
Implements Phase B of the no-extraction WebDataset-style tar import (`docs/plans/webdataset-tar-import.md`). Builds on Phase A's single-member streaming + whole-member importer.

## What landed

- **Sub-file 10 s clip windows (display-only seek).** The audio player now seeks/loops within `[clip_start, clip_end]` mirroring the video player (`(loadedmetadata)` + a 100 ms boundary poll, re-applied when extents arrive via batch hydration). `clip_recipe()` (`vtscore/media/lazy_clip.py`) now returns `None` for any archive-member media, so the byte routes serve the **whole** member and the player handles the window — we never byte-slice these AAC/MP4 members server-side.

- **Windowed precomputed-embedding import.** The `.npz` manifest gained optional `clip_start` / `clip_end` / `window_id` columns (broadcast like `archives`; a `NaN`/blank extent marks a whole-member row). The `local_archive_member` importer fans one member into N windowed media, each its own searchable item with its own precomputed vector. The synthesized md5 + `origin_name` fold in a per-window suffix (`#<window_id>`, else `@<clip_start>`) so dedup / voting / display stay unique per window. Clip extents are carried both top-level (player) and in `origin.params` (survives the pickle + feeds the source).

- **Archive-member `MediaSource` for cross-dataset re-derivation.** New manifest-backed `LocalArchiveMemberSource` (`vtscore/datasets/sources/local_archive_member.py`) re-supplies a member's (or a specific window's) precomputed vector by `(archive, member[, window])`, returning a `FetchedItem` with `path=None` + `embedding` set. `example_sort_origin` now sorts directly on that vector when a source returns no path (cropping is rejected — it needs bytes this path never materialises). Closes the last unsupported flow: per-media cross-dataset "Find" used to 400 with "no media source".

- **Audio mimetype + container nuances.** The `/audio` route now picks an audio `Content-Type` per the member container (`_audio_member_mimetype`): `.aac` → `audio/aac`; an MP4-container audio chunk (`.mp4` / `.m4a`, which `mimetypes` would call `video/mp4`) → `audio/mp4`; `audio/x-wav` normalised to `audio/wav`; unknown → `audio/wav`.

## Tests

- `tests_lib/io/test_archive_member_import.py` — windowed manifest reader, importer fan-out + per-window unique md5, `window_id` disambiguation, `clip_recipe` guard, and the new `MediaSource` (vector re-supply, windowed lookup, unknown-key empty).
- `tests/core/test_archive_member_routes.py` — `/audio` mimetype per container, and `example-sort-origin` on an archive-member origin (200 sort on the precomputed vector; 400 on crop).
- `audio-player.component.spec.ts` — seek-into-window-on-late-hydration, mirroring the video spec.

Full `./run-tests.sh` green (5317 Python passed; frontend build + audit + Vitest 911 passed; ruff/pyright/deptry/pip-audit clean).

## Follow-ups (deferred, tracked in the plan)

GUI/docs-polish (user-docs section for the windowed-manifest schema) and a manual cross-browser AAC/`audio/mp4` playback pass — both recorded under "Open follow-ups" in `docs/plans/webdataset-tar-import.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhuNrB5BkkLrXxf7KTGWQB)_