### PR TITLE
Auto-load datasets when browsing instead of 409-ing the load

### DIFF
--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -135,6 +135,46 @@ class TestRequestScopedDataset:
         resp = client.get("/api/datasets/registry", headers={"X-Dataset-Id": "nope"})
         assert resp.status_code == 200
 
+    def test_registry_load_succeeds_with_stale_unloaded_header(self, client, tmp_path):
+        """Loading a dataset must not 409 because the active-context header
+        still points at a since-evicted dataset.
+
+        Reproduces the "browse an unloaded dataset" failure: the browse
+        flow fires ``POST /api/datasets/registry/<target>/load`` while the
+        active ``X-Dataset-Id`` header still names a previously-active
+        dataset that has since been unloaded. The load handler spawns a
+        background thread, and ``spawn`` snapshots the active context to
+        replay it on the new thread. That snapshot must tolerate the
+        unloaded header (snapshot ``None`` for that half) rather than
+        raising ``DatasetNotLoadedError`` and 409-ing the very request
+        whose job is to recover from the unloaded state.
+        """
+        import pickle
+
+        from vtscore.datasets.registry import register_dataset
+
+        pkl = tmp_path / "target.pkl"
+        with open(pkl, "wb") as f:
+            pickle.dump(
+                {1: {"id": 1, "media_type": "audio", "embedding": np.zeros(4, dtype=np.float32)}},
+                f,
+            )
+        entry = register_dataset(
+            name="Target",
+            media_type="audio",
+            num_items=1,
+            pkl_path=str(pkl),
+            embedder="",
+            created_by="default",
+        )
+
+        resp = client.post(
+            f"/api/datasets/registry/{entry['id']}/load",
+            headers={"X-Dataset-Id": "ghost_unloaded"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+
     def test_no_header_uses_global_active(self, client):
         """Without the header, behaviour is identical to before (global active)."""
         _make_dataset("req_global", [400])

--- a/vtsearch/threading.py
+++ b/vtsearch/threading.py
@@ -104,13 +104,38 @@ def _install_user(user: str | None) -> None:
 
 def _snapshot_state_contexts() -> tuple[Any, Any]:
     """Capture the active dataset + detector context as resolved on the
-    calling thread."""
-    # Library-tier import; keep deferred so the helper stays importable
+    calling thread.
+
+    When the current request named an *unloaded* dataset / detector via
+    ``X-Dataset-Id`` / ``X-Detector-Id`` (e.g. the active-context header
+    still points at a since-evicted id), the proxy resolver raises
+    ``DatasetNotLoadedError`` / ``DetectorNotLoadedError`` (the H16/H34
+    contract for data-serving routes). Snapshotting context to hand off
+    to a background thread is *not* a data-serving read, so that raise
+    must not 409 the request that called :func:`spawn` — most notably the
+    registry-load handler, whose whole job is to *recover* from an
+    unloaded dataset. Fall back to ``None`` for the offending half; the
+    spawned body either sets its own context (the load task creates a
+    fresh one) or harmlessly resolves to the empty fallback.
+    """
+    # Library-tier imports; keep deferred so the helper stays importable
     # in environments where ``vtscore.state`` hasn't been initialised
     # (notably the lib-clean test runner).
+    from vtscore.state.core import (  # noqa: PLC0415
+        DatasetNotLoadedError,
+        DetectorNotLoadedError,
+    )
     from vtsearch.state import get_active_context, get_active_detector_context  # noqa: PLC0415
 
-    return get_active_context(), get_active_detector_context()
+    try:
+        ds_ctx = get_active_context()
+    except DatasetNotLoadedError:
+        ds_ctx = None
+    try:
+        det_ctx = get_active_detector_context()
+    except DetectorNotLoadedError:
+        det_ctx = None
+    return ds_ctx, det_ctx
 
 
 def _install_state_contexts(ds_ctx: Any, det_ctx: Any) -> None:


### PR DESCRIPTION
## Problem

Browsing an unloaded dataset could fail with an error modal instead of just loading it:

> **Message:** Dataset is not loaded — **Status:** 409 CONFLICT
> **Endpoint:** `POST /api/datasets/registry/<target>/load`

The 409 came from the *load* request itself — the one action meant to recover from the unloaded state.

## Root cause

The browse flow fires `POST /api/datasets/registry/<target>/load` while the active-context `X-Dataset-Id` header still names a *previously-active dataset that has since been unloaded* (evicted/expired but still registered).

The load handler spawns a background thread via `spawn()`, which snapshots the active dataset/detector context so it can be replayed on the new thread. That snapshot calls `get_active_context()`, which hits the H16/H34 proxy resolver — and because the header names an unloaded id, it raises `DatasetNotLoadedError`. This raise happens *outside* any try/except in the request path, so it propagates as a 409 and the load never starts.

## Fix

`vtsearch/threading.py::_snapshot_state_contexts` now tolerates an unloaded `X-Dataset-Id` / `X-Detector-Id` header: snapshotting context to hand off to a thread is **not** a data-serving read, so the H16/H34 409 contract shouldn't apply. When the resolver raises, we snapshot `None` for that half. The spawned body either sets its own context (the load task creates a fresh one) or harmlessly resolves to the empty fallback.

With this, browsing an unloaded dataset loads it cleanly and no error modal appears.

## Tests

- New regression test in `tests/datasets/test_request_context.py`: `POST /api/datasets/registry/<target>/load` with a stale unloaded `X-Dataset-Id` header now returns 200 instead of 409.
- Full `./run-tests.sh` green (5306 passed), including ruff/codespell/deptry and the frontend build gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGZGdkMq7rgR75XeoUouoq)_