### PR TITLE
docs: document windowed-manifest archive-member importer in user guide

### DIFF
--- a/docs/plans/webdataset-tar-import.md
+++ b/docs/plans/webdataset-tar-import.md
@@ -1,8 +1,11 @@
 # WebDataset-style tar-sharded import (microvent / multivent-raw)
 
 **Status:** Phase A shipped; Phase B shipped (sub-file clip windows, windowed
-manifest import, archive-member `MediaSource`, audio-mimetype nuances); only the
-GUI/docs-polish follow-up (item 5) remains — see Open follow-ups.
+manifest import, archive-member `MediaSource`, audio-mimetype nuances); the
+GUI/docs-polish follow-up (item 5) shipped — user-docs section for the
+windowed-manifest schema landed in `docs/user/USER_GUIDE.md`. Only the
+cross-browser AAC/`audio/mp4` validation pass (needs a live browser) remains —
+see Open follow-ups.
 
 ## Problem
 
@@ -96,12 +99,12 @@ What landed:
 
 Tracked here, not in the PR body.
 
-1. **GUI / docs polish (Phase B item 5).** The importer registers in the
-   server-tab picker with a `.npz` manifest field; add a short user-docs section
-   covering the windowed-manifest schema and the no-extraction import flow, and
-   (if a screenshot ever frames the importer picker) queue a reshoot in
-   `docs/user/screenshots-reshoot-queue.md`. No existing doc screenshot frames
-   this importer's form today, so nothing is queued.
+1. **GUI / docs polish (Phase B item 5).** *Shipped.* `docs/user/USER_GUIDE.md`
+   now carries an "Archive members, no extraction (WebDataset shards)" section
+   under "Loading a dataset" covering the windowed-manifest schema (the `.npz`
+   array table, clip windows, display-only playback) and the no-extraction
+   import flow. No existing doc screenshot frames this importer's form, so
+   nothing was queued in `docs/user/screenshots-reshoot-queue.md`.
 
 2. **Cross-browser AAC / `audio/mp4` validation.** The `/audio` route emits the
    right mimetype, but actual AAC / MP4-audio-track playback across browsers

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -174,6 +174,57 @@ is used for any file that doesn't have a pre-computed vector, and
 also acts as the model identifier recorded on each media. Pick an
 embedder that matches the vectors in your NPZ.
 
+### Archive members, no extraction (WebDataset shards)
+
+Some corpora are too large to unpack. WebDataset-style collections pack
+tens of thousands of audio/video chunks inside a handful of multi-GB
+`shard_*.tar` (or `.zip`) files - the multivent-raw `videos/` set alone
+is **4.1 TB across 667 shards** - so extracting a second on-disk copy
+is a non-starter. The **Server → Archive members (no extract)** importer
+(📦 in the importer picker) loads a chosen subset of those chunks
+**without unpacking anything**: each imported media records only
+`{archive path, member name}` and streams that single tar/zip member on
+demand (HTTP Range), so playing a clip transfers a few seconds of bytes
+rather than the whole shard. Nothing is written to disk, and no member
+data is read at import time - the importer only walks each referenced
+shard's tar headers to confirm the member exists and record its size.
+
+The importer has two fields:
+
+- **Dataset MediaType** - the kind of media the referenced members hold
+  (e.g. `video` or `audio`).
+- **Manifest (.npz)** - a server-path field pointing at a single `.npz`
+  manifest that pairs the chosen members with their **pre-computed**
+  vectors. Because the embeddings are supplied, the import needs no GPU
+  and skips the embed stage entirely.
+
+**Manifest schema.** The `.npz` holds these arrays, one entry per row:
+
+| Array | Shape | Required | Meaning |
+|-------|-------|----------|---------|
+| `vectors` (or `embeddings`) | *(N, D)* float | yes | one pre-computed vector per row |
+| `members` | *(N,)* string | yes | member name within its archive |
+| `archives` | *(N,)* string, or a single value | yes | archive path per row; a scalar is broadcast to every row (one-shard manifests). Relative paths resolve against the manifest's own directory |
+| `filenames` | *(N,)* string | no | display names (default: the member's basename) |
+| `clip_start` / `clip_end` | *(N,)* float seconds | no | sub-file **clip window** extents; a blank/`NaN` extent means a whole-member row |
+| `window_id` | *(N,)* | no | per-window id (default: the clip start) |
+| `embedder_name` | scalar string | no | the embedder that produced the vectors |
+
+**Clip windows.** When rows carry `clip_start` / `clip_end`, the *same*
+member can appear in several rows as distinct **sub-file clip windows**
+(e.g. ≈14 × 10 s CLAP windows per chunk), each becoming its own
+searchable media with its own pre-computed vector. Windowed media are
+**display-only**: the byte routes always serve the whole member and the
+player seeks/loops within `[clip_start, clip_end]` - VTSearch never
+slices an AAC/MP4 member server-side. Each window gets a content-id that
+folds in the window, so de-duplication, voting, and labels stay unique
+per window.
+
+The vector dimension and embedder must match what VTSearch uses for that
+media type, exactly as for the [`.npz` manifest importer](#pre-computed-embeddings-npz)
+above - pick an *Embedder* (or set `embedder_name` in the manifest) that
+matches the vectors you supplied.
+
 ---
 
 ## The three-panel layout


### PR DESCRIPTION
## What

Closes the last open follow-up (Phase B item 5) in `docs/plans/webdataset-tar-import.md`: the **GUI/docs polish** for the no-extraction archive-member importer.

Adds an **"Archive members, no extraction (WebDataset shards)"** subsection to `docs/user/USER_GUIDE.md`, under *Loading a dataset → Pre-computed embeddings*. It covers:

- **The no-extraction import flow** — what the 📦 *Server → Archive members (no extract)* importer does: records only `{archive path, member name}`, streams a single tar/zip member on demand via HTTP Range, writes nothing to disk and reads no member bytes at import time (only tar headers for existence + size).
- **The two importer fields** — *Dataset MediaType* and *Manifest (.npz)*.
- **The windowed `.npz` manifest schema** — a table of every array (`vectors`/`embeddings`, `members`, `archives` with scalar broadcast, optional `filenames`, `clip_start`/`clip_end`, `window_id`, `embedder_name`), each with shape, required-ness, and meaning.
- **Clip windows** — how one member fans into several sub-file windows, each its own searchable media, with display-only seek/loop playback (no server-side slicing).

Schema details were cross-checked against `read_npz_archive_member_rows` and the importer's field hints so the doc matches the code (array key names, scalar-`archives` broadcast, `filenames` defaulting to the member basename, `NaN`/blank extents meaning whole-member rows).

## Plan housekeeping

Updated `docs/plans/webdataset-tar-import.md`: status header now notes item 5 shipped, and the Open follow-ups entry is marked *Shipped* with a pointer to the new section. No doc screenshot frames this importer's form, so nothing was queued in the reshoot queue.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj4S3Cxo4xiYFehZ4XcKA7)_