### PR TITLE
Fix backward-jolt stutter in VTSBrowser pan/settle glides

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1194,7 +1194,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    *  repaint, landing exactly on the clamped transform. */
   private readonly stepSettle = (now: number): void => {
     if (!this.settleActive) return;
-    const t = Math.min(1, (now - this.settleStartTs) / BrowseCanvasComponent.SETTLE_MS);
+    // Clamp to [0, 1]; the lower clamp guards the same frame-start vs. `performance.now()`
+    // timing skew described in {@link stepPanAnim} (here the rAF is scheduled from the
+    // mouseup/wheel-quiet handler), which would otherwise overshoot the snap-back backwards
+    // on the first frame. Matches the zoom transition's guard.
+    const t = Math.min(1, Math.max(0, (now - this.settleStartTs) / BrowseCanvasComponent.SETTLE_MS));
     const e = 1 - Math.pow(1 - t, 3);
     const from = this.settleFrom;
     const to = this.settleTo;
@@ -2205,7 +2209,15 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    *  exactly on the target. Zoom is constant across a pan, so it's left alone. */
   private readonly stepPanAnim = (now: number): void => {
     if (!this.panAnimActive) return;
-    const t = Math.min(1, (now - this.panAnimStartTs) / BrowseCanvasComponent.PAN_ANIM_MS);
+    // Clamp the elapsed fraction to [0, 1]. The lower clamp matters: `panAnimStartTs`
+    // is stamped with `performance.now()` synchronously inside the keydown handler,
+    // but the rAF callback is handed the *frame-start* timestamp. A keydown is
+    // dispatched mid-frame, so the rAF it schedules can run in that same frame with
+    // a `now` that predates the mid-frame stamp — `now - panAnimStartTs` then goes
+    // negative, and easeOutCubic turns a negative `t` into a negative `e`, kicking
+    // the view *backwards* (opposite the pan) for one frame before it glides forward
+    // — a visible "jump back" stutter. Mirror the same guard the zoom transition uses.
+    const t = Math.min(1, Math.max(0, (now - this.panAnimStartTs) / BrowseCanvasComponent.PAN_ANIM_MS));
     const e = 1 - Math.pow(1 - t, 3);
     const from = this.panAnimFrom;
     const to = this.panAnimTo;


### PR DESCRIPTION
## The stutter

The new directional (arrow-key) pan glide read as "good but not great": pressing an arrow looked like it **immediately painted the destination, then jumped back and animated forward to it**. That's a real backward kick on the first frame, not a perceptual artifact.

## Root cause

`stepPanAnim` (and the boundary snap-back `stepSettle`) computed eased progress with only an upper clamp:

```ts
const t = Math.min(1, (now - this.panAnimStartTs) / PAN_ANIM_MS); // no Math.max(0, …)
```

`panAnimStartTs` is stamped with `performance.now()` **synchronously inside the keydown handler**, but the rAF callback is handed the **frame-start timestamp**. A `keydown` is dispatched mid-frame, so the rAF it schedules can run in *that same frame* with a `now` that predates the mid-frame stamp. `now - panAnimStartTs` then goes **negative**, and easeOutCubic (`e = 1 - (1-t)³`) turns a negative `t` into a **negative `e`** — so `from + (to-from)·e` moves the view *backwards*, opposite the pan, for one frame before gliding forward. That's the visible "jump back".

The zoom transition (`stepZoomAnim`), which the pan glide was modeled on but written separately, already guards against exactly this with `Math.max(0, …)`. The pan glide and the settle omitted it.

## The fix

Add the same `Math.max(0, …)` lower clamp to `stepPanAnim` and `stepSettle`, so the first frame lands exactly on the start position and the glide is strictly monotonic toward the target. One-line change in each, plus explanatory comments. No behavior change to the zoom path.

## Verification

- `./run-tests.sh frontend` — ruff/format/codespell/deptry/pip-audit/pyright clean, OpenAPI snapshot OK, Angular `build:prod` OK, `npm audit` clean, **912 Vitest tests pass**.
- The change is a numeric clamp matching an existing, proven guard in sibling code; no GUI surface changed, so no screenshot reshoot is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS4EWUpXdbGmZqLrF9BtnE)_