### PR TITLE
Shrink zoom-fit icon's inner square for clarity

### DIFF
--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -117,7 +117,7 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   'zoom-out':
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><line x1="7" y1="10" x2="13" y2="10"/></svg>',
   'zoom-fit':
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><path d="M6 8V6h2"/><path d="M12 6h2v2"/><path d="M14 12v2h-2"/><path d="M8 14H6v-2"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/><path d="M7.5 9V7.5h1.5"/><path d="M11 7.5h1.5V9"/><path d="M12.5 11v1.5H11"/><path d="M9 12.5H7.5V11"/></svg>',
   help:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
 };


### PR DESCRIPTION
## What changed

The "zoom fit" icon (`zoom-fit` in `frontend/src/app/components/icon/icon-svgs-extended.ts`) was hard to parse: the frame-corners square inside the magnifying glass was large enough (8 units, x/y 6→14) that it crowded the glass outline and read ambiguously.

Shrunk the inner square's corner brackets to span 5 units (x/y 7.5→12.5), keeping it centered at (10,10). The smaller frame now sits cleanly inside the glass and reads more clearly as a distinct "fit to frame" affordance.

## Notes

- No behavior change — purely the SVG path coordinates for the inner frame.
- Frontend `build:prod` passes clean (no errors or warnings).
- The `browse-view` doc screenshot (where this icon appears in the canvas zoom toolbar) is already in `docs/user/screenshots-reshoot-queue.md`, so the change will be picked up on the next reshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC3W8aHacUSzomRoYB1TQo)_