### PR TITLE
Distinguish bin-details "viewing" cue from "selected" with nested rings

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -253,27 +253,32 @@
     color: var(--text-primary);
   }
 
+  // Selection is the INNER ring: a solid accent ring drawn at the cell edge
+  // (not the list's inset accent bar — a ring reads better under a square thumb)
+  // plus an accent-tinted fill. The viewed item's ring (below) nests outside it.
   &.selected {
     background: color-mix(in srgb, var(--accent) 18%, transparent);
     color: var(--text-primary);
-    // A ring (not the list's inset accent bar) reads better under a square thumb.
     box-shadow: 0 0 0 2px var(--accent);
   }
 
   // The bin's representative — the pile thumbnail the user right-clicked, shown
-  // large in the preview and scrolled into view here. A softer ring marks it in
-  // the 1-D list; the solid ``.selected`` ring takes over once it's selected.
+  // large in the preview and scrolled into view here. A softer inner ring marks
+  // it; the solid ``.selected`` ring takes over once it's selected.
   &.representative:not(.selected) {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
   }
 
-  // The viewed item (the one shown in the preview pane / walked by the arrow
-  // keys). A dashed accent ring distinguishes keyboard focus from the solid
-  // ``.selected`` ring and the softer ``.representative`` one; it's the only
-  // on-grid cue for non-thumbnail media, which has no preview pane.
-  &.focused:not(.selected) {
-    outline: 2px dashed var(--accent);
-    outline-offset: -2px;
+  // The viewed item (shown in the preview pane / walked by the arrow keys) is the
+  // OUTER ring: a lighter accent ring offset just beyond the cell. Drawn with
+  // ``outline`` (independent of the selection/representative box-shadow) so it
+  // layers on top of them — a selected item you're also viewing shows both rings
+  // nested (solid accent inside, lighter accent outside), where before the cue
+  // vanished. Only one item is ever "viewing", so the wider footprint is local.
+  // It's also the only on-grid cue for non-thumbnail media, which has no preview.
+  &.focused {
+    outline: 2px solid var(--accent-light);
+    outline-offset: 2px;
   }
 
   &:focus-visible {


### PR DESCRIPTION
## Problem

In the Bin Details popup's thumbnail grid, the "currently viewing" cue and the "selected" cue were nearly identical, and there was no way to tell "selected" apart from "selected and viewing":

- **Viewing** drew a *dashed accent* ring; **selected** drew a *solid accent* ring — the same color, barely distinguishable.
- The viewing ring was gated `:not(.selected)`, so it vanished entirely whenever the item was also selected. A selected item you were viewing looked exactly like any other selected item.

## Change

Split the two cues onto distinct, layerable channels (the "nested rings" direction):

- **Selected → inner ring**: solid accent ring at the cell edge + accent-tinted fill (unchanged look, now the inner band).
- **Viewing → outer ring**: a lighter accent (`--accent-light`) ring offset just *beyond* the cell, drawn with `outline` so it's independent of the selection/representative `box-shadow` and always shows on top.

Result:
- **Viewing only** → a single offset outer light ring.
- **Selected + viewing** → both rings nested (solid accent inside, lighter accent outside) — previously indistinguishable from selected-only.
- **Representative** keeps its soft inner hint.

Only one item is ever "viewing" at a time, so the wider outer ring is localized. Both `box-shadow` and `outline` are non-layout properties, so cell sizes and positions are unchanged — no reflow.

## Scope

- Single file: `frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss`.
- No documented screenshot frames this popup, so no reshoot queue entry is needed.

## Testing

- `./run-tests.sh frontend` — Angular `build:prod` clean (0 warnings), `npm audit` clean, 912 Vitest unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNyMPwhtaf1RN6o6i2jRTu)_