### PR TITLE
Let region-box resize handles flip past the opposite edge

### DIFF
--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -385,6 +385,96 @@ describe('ImageViewerComponent', () => {
     });
   });
 
+  /**
+   * Resize handles flip past the opposite edge instead of hitting a wall, matching
+   * the draw flow: drag the west handle past the east edge and the dragged handle
+   * becomes the new east edge (and parallel logic for corners).
+   */
+  describe('resize handle crossing (flip instead of wall)', () => {
+    function setupWrap(component: ImageViewerComponent) {
+      component.renderedW.set(100);
+      component.renderedH.set(100);
+      component.wrapRef = {
+        nativeElement: {
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+            right: 100,
+            bottom: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>;
+    }
+
+    function mouseEventAt(x: number, y: number): MouseEvent {
+      return {
+        button: 0,
+        clientX: x,
+        clientY: y,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as unknown as MouseEvent;
+    }
+
+    type Internals = {
+      onWindowMouseMove: (e: MouseEvent) => void;
+      onWindowMouseUp: () => void;
+    };
+
+    it('flips the box when the west handle is dragged past the east edge', () => {
+      setupWrap(component);
+      component.regionBox.set([0.2, 0.3, 0.6, 0.7]);
+
+      let lastEmitted: RegionBox | null | undefined = undefined;
+      component.regionBoxChange.subscribe((v) => (lastEmitted = v));
+
+      component.onResizeHandleMouseDown('w', mouseEventAt(20, 30));
+      // Drag the west handle to x=0.9, well past the east edge at 0.6.
+      (component as unknown as Internals).onWindowMouseMove(mouseEventAt(90, 50));
+      (component as unknown as Internals).onWindowMouseUp();
+
+      // The dragged handle became the new east edge; the former east edge is now west.
+      expect(component.regionBox()).toEqual([0.6, 0.3, 0.9, 0.7]);
+      expect(lastEmitted).toEqual([0.6, 0.3, 0.9, 0.7]);
+    });
+
+    it('flips both axes when a corner handle is dragged past the opposite corner', () => {
+      setupWrap(component);
+      component.regionBox.set([0.2, 0.3, 0.6, 0.7]);
+
+      // nw controls (x0, y0); their anchors are the start east (0.6) and south (0.7)
+      // edges. Drag to (0.9, 0.95) past both.
+      component.onResizeHandleMouseDown('nw', mouseEventAt(20, 30));
+      (component as unknown as Internals).onWindowMouseMove(mouseEventAt(90, 95));
+      (component as unknown as Internals).onWindowMouseUp();
+
+      expect(component.regionBox()).toEqual([0.6, 0.7, 0.9, 0.95]);
+    });
+
+    it('restores the pre-resize box when a handle collapses it to zero area', () => {
+      setupWrap(component);
+      const original: RegionBox = [0.2, 0.3, 0.6, 0.7];
+      component.regionBox.set(original);
+
+      let lastEmitted: RegionBox | null | undefined = undefined;
+      component.regionBoxChange.subscribe((v) => (lastEmitted = v));
+
+      // Release the east handle exactly on the west edge (0.2): zero width.
+      component.onResizeHandleMouseDown('e', mouseEventAt(60, 50));
+      (component as unknown as Internals).onWindowMouseMove(mouseEventAt(20, 50));
+      (component as unknown as Internals).onWindowMouseUp();
+
+      expect(component.regionBox()).toEqual(original);
+      // Restored to a state the parent already knew; no emit needed.
+      expect(lastEmitted).toBeUndefined();
+    });
+  });
+
   describe('marquee mode toggle', () => {
     function setupWrap(component: ImageViewerComponent) {
       component.renderedW.set(100);

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -482,14 +482,20 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       this.regionBox.set([x0, y0, x0 + w, y0 + h]);
       return;
     }
-    // resize
-    let [x0, y0, x1, y1] = d.startBox;
+    // resize: like draw, the dragged handle may cross the opposite edge and
+    // flip the box rather than hitting a wall. The edge(s) the handle does not
+    // control stay anchored at their start position; the controlled edge follows
+    // the cursor, and per-axis min/max re-normalisation swaps which side is which
+    // when the cursor crosses over. (e.g. drag the west handle past the east edge
+    // and the dragged handle becomes the new east edge.)
+    const [sx0, sy0, sx1, sy1] = d.startBox;
     const lx = clamp01(local.x);
     const ly = clamp01(local.y);
-    if (d.handle.includes('n')) y0 = Math.min(ly, y1 - MIN_BOX_SIZE);
-    if (d.handle.includes('s')) y1 = Math.max(ly, y0 + MIN_BOX_SIZE);
-    if (d.handle.includes('w')) x0 = Math.min(lx, x1 - MIN_BOX_SIZE);
-    if (d.handle.includes('e')) x1 = Math.max(lx, x0 + MIN_BOX_SIZE);
+    let [x0, y0, x1, y1] = d.startBox;
+    if (d.handle.includes('w')) [x0, x1] = [Math.min(lx, sx1), Math.max(lx, sx1)];
+    else if (d.handle.includes('e')) [x0, x1] = [Math.min(sx0, lx), Math.max(sx0, lx)];
+    if (d.handle.includes('n')) [y0, y1] = [Math.min(ly, sy1), Math.max(ly, sy1)];
+    else if (d.handle.includes('s')) [y0, y1] = [Math.min(sy0, ly), Math.max(sy0, ly)];
     this.regionBox.set([x0, y0, x1, y1]);
   }
 
@@ -511,6 +517,13 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       // Don't emit: the parent's last-known state was already previousBox
       // (the transient zero-area draw was never emitted).
       this.regionBox.set(drag.previousBox);
+      return;
+    }
+    if (drag.kind === 'resize' && tooSmall) {
+      // The handle was released right at the flip point, collapsing the box to
+      // (near) zero area. Restore the pre-resize box; startBox was the parent's
+      // last-known state, so no emit is needed.
+      this.regionBox.set(drag.startBox);
       return;
     }
     this.regionBoxChange.emit(box);


### PR DESCRIPTION
## Summary

When editing a region-voting selection box, dragging a resize handle past its opposite edge now **flips** the box (the dragged handle becomes the new opposite edge) instead of hitting a wall. This matches the flexibility that already existed when *drawing* a box.

Previously, the resize logic in `onWindowMouseMove` clamped each dragged edge against the opposite edge with `Math.min`/`Math.max` minus `MIN_BOX_SIZE`, so e.g. the west handle could never cross the east edge — it stopped dead. The draw flow, by contrast, re-normalises with per-axis `Math.min`/`Math.max` every frame, so it flips naturally.

## Changes

- **`image-viewer.component.ts`** — Rewrote the `resize` branch of `onWindowMouseMove` to anchor the edge(s) the handle does *not* control at their start position, let the controlled edge follow the cursor, and re-normalise per axis with `Math.min`/`Math.max`. Crossing the opposite edge now swaps which side is which (handles corners automatically, since `nw`/`ne`/`sw`/`se` set both axes).
- Added a `resize`+`tooSmall` case to `onWindowMouseUp`: if a handle is released exactly at the flip point (collapsing the box to ~zero area), the pre-resize box is restored rather than emitting a degenerate box — mirroring the existing zero-area draw recovery.

## Tests

- Added a `resize handle crossing (flip instead of wall)` describe block covering single-edge flip (west past east), corner flip (both axes), and the zero-area collapse → restore recovery.
- Full frontend gate passes (`./run-tests.sh frontend`): build, audit, and 933 Vitest tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2Mzg9wvdiVbcKTxq3Ewh6)_