### PR TITLE
Portable (standalone) detector export — ONNX scoring bundle

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,6 +75,7 @@ from vtsearch.routes import (  # noqa: E402
     detector_find_bp,
     detector_scoring_bp,
     detectors_crud_bp,
+    detectors_export_bp,
     detectors_labels_bp,
     detectors_registry_bp,
     embed_bp,
@@ -555,6 +556,7 @@ api.register_blueprint(detectors_labels_bp)
 api.register_blueprint(detectors_registry_bp)
 api.register_blueprint(detector_scoring_bp)
 api.register_blueprint(detector_find_bp)
+api.register_blueprint(detectors_export_bp)
 api.register_blueprint(embed_bp)
 api.register_blueprint(projection_bp)
 app.register_blueprint(events_bp)

--- a/docs/plans/detector-standalone-export.md
+++ b/docs/plans/detector-standalone-export.md
@@ -1,0 +1,89 @@
+# Portable (standalone) detector export
+
+**Status:** Phase 1 shipped. See "Open follow-ups" for deferred work.
+
+## Problem
+
+Trained detectors are normally locked inside VTSearch: the MLP lives in memory
+and is re-derived from labelset origins on demand (the "No Persisted Vectors or
+MLPs" rule in `CLAUDE.md`). There was no way to hand a trained detector to
+another party so they could score their own media without running VTSearch.
+
+## What shipped
+
+A **scoring-only, portable bundle** export for any saved detector. This is the
+sanctioned exception to the no-persisted-MLP rule: it persists the trained
+classifier, but deliberately **no embeddings and no raw media**. A scoring
+detector only needs three things, all of which the bundle carries:
+
+1. the trained MLP (as ONNX),
+2. the name of the embedder to run new media through, and
+3. the decision threshold.
+
+Because none of those is a media-derived vector, the bundle does not leak the
+training set's embeddings. (A trained model can still leak *some* information
+about its training data — membership inference — which the UI warning notes.)
+
+### Format
+
+A zip with three members:
+
+- `detector.onnx` — the MLP with its sigmoid baked in. Input `embedding`
+  `[batch, dim]` → output `score` `[batch, 1]` in `[0, 1]`. The graph is
+  hand-assembled (`Gemm → ReLU → Gemm → Sigmoid`) from the trained model's
+  weights via `onnx.helper`, so it is torch-free and deterministic and avoids
+  torch 2.12's dynamo/onnxscript export machinery.
+- `manifest.json` — machine-readable embedder name/display-name/type, embedding
+  dim, threshold, scoring convention, label counts, provenance. Re-importable
+  and scriptable. `contains_media_data` is always `false`.
+- `README.md` — human-readable: which embedder to run, the threshold, and a
+  copy-paste `onnxruntime` inference snippet.
+
+### Pieces
+
+- `vtscore/detectors/portable_bundle.py` — pure, torch-free builder
+  (`mlp_weights_to_onnx`, `build_manifest`, `render_readme`, `build_bundle`).
+  Operates on the existing `serialize_weights` nested-list dict.
+- `POST /api/detectors/<detector_id>/portable-bundle`
+  (`vtsearch/routes/detectors/export.py`) — trains the detector against the
+  **active dataset** (exactly as Find does, in that dataset's embedder space),
+  then streams the zip. Requires `X-Dataset-Id`; the detector is resolved by URL
+  id, so the active *detector* need not match.
+- Frontend: a dedicated `vt-detector-portable-export-modal` opened from a new
+  **"Export model"** detector-card menu item (kept distinct from the existing
+  label "Export"). Proportional amber warning panel + Download button;
+  `DetectorsCrudApiService.exportPortableBundle()` fetches the blob.
+- Deps: `onnx` (runtime, to build the graph); `onnxruntime` (test-only, to
+  verify the emitted graph scores identically to the trained torch model).
+
+### Design decisions (settled with the user)
+
+- **Scoring-only**, not re-trainable — no embeddings/labelset in the bundle.
+- **ONNX**, not a TensorFlow file (the stack is PyTorch; ONNX runs with just
+  `onnxruntime`) and not raw JSON weights (ONNX is more portable for third
+  parties).
+- **Dedicated modal**, not a tab in the existing label-export modal (which is
+  label-centric) — the model export needs its own warning surface. The finer
+  new-tab-vs-modal choice was made by Claude because the `AskUserQuestion` tool
+  was failing in that session; revisit if the user prefers a tab.
+
+## Open follow-ups
+
+- **Exact HF model id in the README/manifest.** Today the bundle names the
+  embedder (`siglip`) and its display name (`SigLIP (general images)`) but not
+  the concrete HuggingFace repo id, because there's no uniform `model_id` on the
+  `MediaEmbedder` ABC. Surfacing it would make the README fully actionable.
+- **Exporter-plugin / CLI path.** The export is GUI-only. A `LabelsetExporter`-
+  style plugin (or a `--exporter portable_detector` autodetect destination)
+  would let CI/automation produce the bundle headlessly. The user picked the
+  dedicated modal for now; this is the deferred "both" option.
+- **Re-import.** The manifest is shaped to be re-importable, but no importer
+  reads it back yet. A "import portable detector" flow could rebuild a
+  read-only, score-only detector from a bundle.
+- **Patch / structural detectors.** The ONNX graph assumes the single-vector
+  2-layer MLP. Patch (DINOv2/v3, EUPE) and structural (SIFT/VLAD) detectors,
+  whose scoring isn't a plain MLP forward pass, are out of scope for this graph;
+  exporting them faithfully needs more than the linear stack.
+- **Screenshot.** The new modal is a GUI surface; if a doc screenshot frames it,
+  add the shot id to `docs/user/screenshots-reshoot-queue.md` (no browser in the
+  cloud container to reshoot this session).

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -10415,6 +10415,41 @@
         ]
       }
     },
+    "/api/detectors/{detector_id}/portable-bundle": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "The detector's MLP is (re)trained from its on-disk labelset in the active\ndataset's embedder space - exactly as Find does - then serialised to an ONNX\nscorer and zipped with a manifest and README.  No embeddings or raw media\nare written; only the trained classifier, the embedder name, and the\nthreshold travel in the bundle.",
+        "operationId": "export_portable_bundle",
+        "responses": {
+          "400": {
+            "description": "No medias loaded, or the detector has no labels for scoring."
+          },
+          "404": {
+            "description": "Detector not found."
+          },
+          "409": {
+            "description": "The active dataset can't supply the detector's embedder type."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Train the detector against the active dataset and stream its portable bundle.",
+        "tags": [
+          "detectors_export"
+        ]
+      }
+    },
     "/api/detectors/{detector_name}/labelset-source": {
       "get": {
         "operationId": "get_detector_labelset_source",
@@ -14372,6 +14407,10 @@
     {
       "description": "Run detectors against datasets and return merged hits / negative hits, plus a pre-flight label-resolution check.",
       "name": "detector_find"
+    },
+    {
+      "description": "Export a saved detector as a standalone, portable scoring bundle.",
+      "name": "detectors_export"
     },
     {
       "description": "On-demand embedding of a media file (multipart) or text snippet (JSON). The dispatch route is dual-mode and not described in the spec; see the module docstring.",

--- a/frontend/src/app/components/dashboard/card-context-menu-items.ts
+++ b/frontend/src/app/components/dashboard/card-context-menu-items.ts
@@ -132,6 +132,12 @@ export function buildDetectorCardMenuItems(
   items.push({ id: 'rename', label: 'Rename', title: 'Rename', iconSvg: ICON.rename });
   items.push({ id: 'add-labels', label: 'Import Labels', title: 'Import Labels', iconSvg: ICON.addLabels });
   items.push({ id: 'export', label: 'Export', title: 'Export', iconSvg: ICON.export });
+  items.push({
+    id: 'export-model',
+    label: 'Export model',
+    title: 'Export a portable, standalone scoring model (ONNX) to share with others',
+    iconSvg: ICON.export,
+  });
   items.push({ id: 'stats', label: 'Stats', title: 'Stats', iconSvg: ICON.stats });
   items.push({ id: 'delete', label: 'Delete', title: 'Delete', iconSvg: ICON.delete });
   return items;

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -276,6 +276,7 @@
                 (browse)="browseDetector(detector)"
                 (stats)="showDetectorStats(detector)"
                 (export)="openExportModal(detector)"
+                (exportModel)="openPortableExportModal(detector)"
                 (addLabels)="openAddLabelsModal(detector)"
                 (security)="editDetectorSecurity(detector)"
                 (cancelTask)="loadingTasksSvc.cancelDetectorLoadingTask($event)"
@@ -356,6 +357,14 @@
     [customTitle]="'Export Labelset: ' + modals.export.detectorName"
     (closed)="modals.closeExport()"
     (exportComplete)="modals.closeExport()"
+  />
+}
+
+@if (modals.portableExport.open) {
+  <vt-detector-portable-export-modal
+    [detectorId]="modals.portableExport.detectorId"
+    [detectorName]="modals.portableExport.detectorName"
+    (closed)="modals.closePortableExport()"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -48,6 +48,7 @@ import { LabelExporterModalComponent } from '../modals/label-exporter-modal/labe
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { DatasetStatsModalComponent } from '../modals/dataset-stats-modal/dataset-stats-modal.component';
 import { DetectorStatsModalComponent } from '../modals/detector-stats-modal/detector-stats-modal.component';
+import { DetectorPortableExportModalComponent } from '../modals/detector-portable-export-modal/detector-portable-export-modal.component';
 import { IconComponent } from '../icon/icon.component';
 import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
 
@@ -66,6 +67,7 @@ import { UsageBarComponent, UsageBytes } from './usage-bar/usage-bar.component';
     LabelImporterModalComponent,
     DatasetStatsModalComponent,
     DetectorStatsModalComponent,
+    DetectorPortableExportModalComponent,
     IconComponent,
     UsageBarComponent,
     SkeletonComponent
@@ -932,6 +934,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   openExportModal(model: DetectorRegistryEntry): void {
     this.modals.openExport(model.name);
+  }
+
+  openPortableExportModal(model: DetectorRegistryEntry): void {
+    this.modals.openPortableExport(model.id, model.name);
   }
 
   openAddLabelsModal(model: DetectorRegistryEntry): void {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -71,6 +71,7 @@ export class DetectorCardComponent {
   readonly rename = output<string>();
   readonly delete = output<void>();
   readonly export = output<void>();
+  readonly exportModel = output<void>();
   readonly addLabels = output<void>();
   readonly load = output<void>();
   readonly unload = output<void>();
@@ -155,6 +156,9 @@ export class DetectorCardComponent {
         break;
       case 'export':
         this.export.emit();
+        break;
+      case 'export-model':
+        this.exportModel.emit();
         break;
       case 'stats':
         this.stats.emit();

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.html
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.html
@@ -1,0 +1,46 @@
+<vt-modal [title]="'Export model: ' + detectorName()" [open]="true" (closed)="close()">
+  <div class="pexport">
+    <div class="pexport__warn" role="note">
+      <strong>⚠ This writes a trained model to disk.</strong>
+      <p>
+        VTSearch normally keeps trained models in memory only — this export is the
+        deliberate exception. The bundle contains <em>no raw media and no
+        embeddings</em>: just the small trained classifier, the name of the
+        embedder to use, and the threshold. (A trained model can still reveal some
+        information about its training data, so share it only with parties you'd
+        trust with the labels themselves.)
+      </p>
+    </div>
+
+    <h3>What you'll get</h3>
+    <ul class="pexport__list">
+      <li><code>detector.onnx</code> — the trained scorer (runs anywhere via onnxruntime).</li>
+      <li><code>manifest.json</code> — the embedder, embedding size, and threshold.</li>
+      <li><code>README.md</code> — which embedder to use and a copy-paste scoring snippet.</li>
+    </ul>
+
+    <p class="pexport__note">
+      The model is trained against the <strong>currently loaded dataset's</strong>
+      embedder, so a compatible dataset must be loaded.
+    </p>
+
+    @if (done()) {
+      <p class="pexport__ok">Bundle downloaded.</p>
+    }
+    @if (error()) {
+      <p class="pexport__err">{{ error() }}</p>
+    }
+  </div>
+
+  <div modal-footer>
+    <button class="btn btn--secondary" (click)="close()" title="Close without exporting">Cancel</button>
+    <button
+      class="btn btn--primary"
+      (click)="download()"
+      [disabled]="downloading()"
+      title="Download the portable detector bundle"
+    >
+      {{ downloading() ? 'Preparing…' : 'Download bundle' }}
+    </button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
@@ -1,0 +1,44 @@
+.pexport {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 34rem;
+
+  h3 {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+
+  &__warn {
+    padding: 0.75rem;
+    border: 1px solid var(--text-warning);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--text-warning) 12%, transparent);
+
+    p {
+      margin: 0.4rem 0 0;
+    }
+  }
+
+  &__list {
+    margin: 0;
+    padding-left: 1.2rem;
+  }
+
+  &__note {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    opacity: 0.75;
+  }
+
+  &__ok {
+    margin: 0;
+    color: var(--color-good);
+  }
+
+  &__err {
+    margin: 0;
+    color: var(--error-text);
+  }
+}

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DetectorPortableExportModalComponent } from './detector-portable-export-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+
+describe('DetectorPortableExportModalComponent', () => {
+  let component: DetectorPortableExportModalComponent;
+  let fixture: ComponentFixture<DetectorPortableExportModalComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DetectorPortableExportModalComponent],
+      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DetectorPortableExportModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('detectorId', 'det-123');
+    fixture.componentRef.setInput('detectorName', 'My Detector');
+    // jsdom doesn't implement the object-URL APIs the download path uses.
+    URL.createObjectURL = vi.fn(() => 'blob:mock');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('posts to the portable-bundle endpoint as a blob and marks done on success', () => {
+    component.download();
+    const req = httpMock.expectOne('/api/detectors/det-123/portable-bundle');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(new Blob(['zip-bytes'], { type: 'application/zip' }));
+
+    expect(component.done()).toBe(true);
+    expect(component.error()).toBe('');
+    expect(component.downloading()).toBe(false);
+    expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+
+  it('surfaces the server error message from the blob body', async () => {
+    component.download();
+    const req = httpMock.expectOne('/api/detectors/det-123/portable-bundle');
+    req.flush(new Blob([JSON.stringify({ message: 'No medias loaded' })], { type: 'application/json' }), {
+      status: 400,
+      statusText: 'Bad Request',
+    });
+
+    // readError reads the Blob asynchronously; let the microtask settle.
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(component.error()).toBe('No medias loaded');
+    expect(component.done()).toBe(false);
+  });
+
+  it('emits closed on cancel', () => {
+    vi.spyOn(component.closed, 'emit');
+    component.close();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.spec.ts
@@ -20,9 +20,12 @@ describe('DetectorPortableExportModalComponent', () => {
     httpMock = TestBed.inject(HttpTestingController);
     fixture.componentRef.setInput('detectorId', 'det-123');
     fixture.componentRef.setInput('detectorName', 'My Detector');
-    // jsdom doesn't implement the object-URL APIs the download path uses.
+    // jsdom doesn't implement the object-URL APIs the download path uses, and
+    // anchor.click() on a blob: href triggers a jsdom "navigation not
+    // implemented" error — stub both so the download path is inert in tests.
     URL.createObjectURL = vi.fn(() => 'blob:mock');
     URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -54,8 +57,11 @@ describe('DetectorPortableExportModalComponent', () => {
       statusText: 'Bad Request',
     });
 
-    // readError reads the Blob asynchronously; let the microtask settle.
-    await new Promise((resolve) => setTimeout(resolve));
+    // readError reads the Blob via FileReader (extra async hops); poll until
+    // the error signal settles rather than guessing a fixed delay.
+    for (let i = 0; i < 50 && component.error() === ''; i++) {
+      await new Promise((resolve) => setTimeout(resolve));
+    }
     expect(component.error()).toBe('No medias loaded');
     expect(component.done()).toBe(false);
   });

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.ts
@@ -77,14 +77,45 @@ export class DetectorPortableExportModalComponent {
   private async readError(err: unknown): Promise<string> {
     const fallback = 'Export failed. Make sure a compatible dataset is loaded, then try again.';
     const body = (err as { error?: unknown })?.error;
+
+    // Already-parsed object body (some HTTP layers/tests deliver this directly).
+    if (body && typeof body === 'object' && !(body instanceof Blob)) {
+      const obj = body as { message?: string; error?: string };
+      return obj.message || obj.error || fallback;
+    }
+
+    // The real runtime returns a Blob (the request used responseType: 'blob').
+    let text: string | undefined;
     if (body instanceof Blob) {
+      text = await this.blobText(body);
+    } else if (typeof body === 'string') {
+      text = body;
+    }
+    if (text) {
       try {
-        const parsed = JSON.parse(await body.text()) as { message?: string; error?: string };
+        const parsed = JSON.parse(text) as { message?: string; error?: string };
         return parsed.message || parsed.error || fallback;
       } catch {
         return fallback;
       }
     }
     return fallback;
+  }
+
+  /**
+   * Read a Blob to text. Prefers `Blob.text()` (browsers) and falls back to
+   * `FileReader` (jsdom, where `Blob.text` is absent), so error parsing works
+   * under unit tests too. Resolves to '' on any failure.
+   */
+  private blobText(blob: Blob): Promise<string> {
+    if (typeof blob.text === 'function') {
+      return blob.text().catch(() => '');
+    }
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result ?? ''));
+      reader.onerror = () => resolve('');
+      reader.readAsText(blob);
+    });
   }
 }

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
+import { ModalComponent } from '../../modal/modal.component';
+import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
+
+/**
+ * Exports a saved detector as a portable, standalone scoring bundle
+ * (`detector.onnx` + `manifest.json` + `README.md`). This is the deliberate
+ * exception to VTSearch's "models stay in memory" rule, so the modal leads with
+ * a proportional warning: the bundle persists the trained classifier (not raw
+ * media or embeddings) for sharing with other parties.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-detector-portable-export-modal',
+  standalone: true,
+  imports: [ModalComponent],
+  templateUrl: './detector-portable-export-modal.component.html',
+  styleUrl: './detector-portable-export-modal.component.scss',
+})
+export class DetectorPortableExportModalComponent {
+  readonly detectorId = input('');
+  readonly detectorName = input('');
+  readonly closed = output<void>();
+
+  private readonly api = inject(DetectorsCrudApiService);
+
+  readonly downloading = signal(false);
+  readonly error = signal('');
+  readonly done = signal(false);
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  download(): void {
+    if (this.downloading()) return;
+    this.downloading.set(true);
+    this.error.set('');
+    this.done.set(false);
+    this.api.exportPortableBundle(this.detectorId()).subscribe({
+      next: (blob) => {
+        this.saveBlob(blob);
+        this.downloading.set(false);
+        this.done.set(true);
+      },
+      error: (err: unknown) => {
+        this.downloading.set(false);
+        void this.readError(err).then((msg) => this.error.set(msg));
+      },
+    });
+  }
+
+  private saveBlob(blob: Blob): void {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${this.slug(this.detectorName())}-detector.zip`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  /** Mirror the server's filesystem-safe slug for the download filename. */
+  private slug(name: string): string {
+    return (
+      (name || 'detector')
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '_')
+        .replace(/^_+|_+$/g, '') || 'detector'
+    );
+  }
+
+  /**
+   * The error body is a Blob (the request used `responseType: 'blob'`), so the
+   * JSON error envelope arrives as binary. Read it back out for a useful
+   * message; fall back to a hint about the loaded-dataset requirement.
+   */
+  private async readError(err: unknown): Promise<string> {
+    const fallback = 'Export failed. Make sure a compatible dataset is loaded, then try again.';
+    const body = (err as { error?: unknown })?.error;
+    if (body instanceof Blob) {
+      try {
+        const parsed = JSON.parse(await body.text()) as { message?: string; error?: string };
+        return parsed.message || parsed.error || fallback;
+      } catch {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+}

--- a/frontend/src/app/services/dashboard-modals.service.ts
+++ b/frontend/src/app/services/dashboard-modals.service.ts
@@ -16,6 +16,12 @@ export interface ExportState {
   detectorName: string;
 }
 
+export interface PortableExportState {
+  open: boolean;
+  detectorId: string;
+  detectorName: string;
+}
+
 export interface AddLabelsState {
   open: boolean;
   detectorId: string;
@@ -63,6 +69,11 @@ export class DashboardModalsService {
     open: false,
     detectorName: '',
   });
+  private readonly portableExportSubject = new BehaviorSubject<PortableExportState>({
+    open: false,
+    detectorId: '',
+    detectorName: '',
+  });
   private readonly addLabelsSubject = new BehaviorSubject<AddLabelsState>({
     open: false,
     detectorId: '',
@@ -86,6 +97,7 @@ export class DashboardModalsService {
   readonly combineDatasets$ = this.combineDatasetsSubject.asObservable();
   readonly combineDetectors$ = this.combineDetectorsSubject.asObservable();
   readonly export$ = this.exportSubject.asObservable();
+  readonly portableExport$ = this.portableExportSubject.asObservable();
   readonly addLabels$ = this.addLabelsSubject.asObservable();
   readonly findResults$ = this.findResultsSubject.asObservable();
   readonly stats$ = this.statsSubject.asObservable();
@@ -101,6 +113,10 @@ export class DashboardModalsService {
 
   get export(): ExportState {
     return this.exportSubject.value;
+  }
+
+  get portableExport(): PortableExportState {
+    return this.portableExportSubject.value;
   }
 
   get addLabels(): AddLabelsState {
@@ -141,6 +157,14 @@ export class DashboardModalsService {
 
   closeExport(): void {
     this.exportSubject.next({ open: false, detectorName: '' });
+  }
+
+  openPortableExport(detectorId: string, detectorName: string): void {
+    this.portableExportSubject.next({ open: true, detectorId, detectorName });
+  }
+
+  closePortableExport(): void {
+    this.portableExportSubject.next({ open: false, detectorId: '', detectorName: '' });
   }
 
   openAddLabels(detectorId: string, detectorName: string): void {

--- a/frontend/src/app/services/detectors-crud-api.service.ts
+++ b/frontend/src/app/services/detectors-crud-api.service.ts
@@ -122,4 +122,17 @@ export class DetectorsCrudApiService {
       body: { names, new_name: newName, conflict_policy: conflictPolicy },
     }).pipe(map((r) => r.body));
   }
+
+  /**
+   * Download a portable, standalone scoring bundle (ONNX model + manifest +
+   * README) for a detector. Trains the detector against the active dataset
+   * server-side, so a compatible dataset must be loaded. Returns the raw zip
+   * blob; the dataset/detector headers are attached by the active-context
+   * interceptor (mirrors {@link DatasetsCrudApiService.exportDataset}).
+   */
+  exportPortableBundle(detectorId: string): Observable<Blob> {
+    return this.http.post(`/api/detectors/${encodeURIComponent(detectorId)}/portable-bundle`, null, {
+      responseType: 'blob',
+    });
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ dependencies = [
     "ultralytics",
     "opencv-python-headless",
     "imageio-ffmpeg",
+    # Portable detector export: build a standalone ONNX scorer from a trained
+    # MLP (vtscore.detectors.portable_bundle). Pure-Python protobuf builder; no
+    # torch.onnx dependency (the graph is hand-assembled via onnx.helper).
+    "onnx",
 ]
 
 [project.optional-dependencies]
@@ -63,6 +67,10 @@ dev = [
     "codespell",
     "vulture",
     "pip-audit",
+    # Used only by the portable-detector export test to load the emitted ONNX
+    # graph and confirm it scores identically to the trained torch model
+    # (imported via importorskip, so deptry sees it as declared-but-unused).
+    "onnxruntime",
     # `pyright` is the Python wrapper around the Node-based pyright CLI.
     # The wrapper lazy-downloads the binary on first invocation; the
     # exact binary version is pinned via PYRIGHT_PYTHON_FORCE_VERSION
@@ -202,6 +210,9 @@ DEP002 = [
     "gunicorn",
     "sentencepiece",
     "protobuf",
+    # Loaded via importorskip in the portable-export test; never imported
+    # statically, so deptry can't see the use.
+    "onnxruntime",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -73,6 +73,7 @@ class TestPortableExport:
         snap = snapshot_medias()
         det_data = _read_detector(_detector_path("portable-parity"))
         mlp, _threshold, _diag = resolve_or_train_detector(detector_id, det_data, "audio", snap)
+        assert mlp is not None
         live = {r["id"]: r["score"] for r in score_media_with_model(mlp, snap, embedder_name="clap")}
 
         # Re-embed the same medias and run them through the exported graph.

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -1,0 +1,113 @@
+"""Tests for POST /api/detectors/<id>/portable-bundle.
+
+Exercises the standalone-bundle export end-to-end: train a detector on the
+active dataset, stream the zip, and verify it carries a valid ONNX scorer plus a
+manifest/README describing the embedder and threshold - and nothing else.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import app as app_module
+import pytest
+from helpers import setup_trainable_model_in_registry
+from vtsearch.state import snapshot_medias
+
+
+def _export(client, detector_id):
+    return client.post(f"/api/detectors/{detector_id}/portable-bundle")
+
+
+class TestPortableExport:
+    def test_export_returns_valid_bundle(self, client):
+        import onnx  # noqa: PLC0415
+
+        detector_id = setup_trainable_model_in_registry(
+            "portable-export",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        resp = _export(client, detector_id)
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.mimetype == "application/zip"
+
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            assert sorted(zf.namelist()) == ["README.md", "detector.onnx", "manifest.json"]
+            manifest = json.loads(zf.read("manifest.json"))
+            onnx_model = onnx.load_from_string(zf.read("detector.onnx"))
+
+        onnx.checker.check_model(onnx_model)
+        assert manifest["format"] == "vtsearch-portable-detector"
+        assert manifest["detector_name"] == "portable-export"
+        # Audio test medias bind the default CLAP embedder (512-dim).
+        assert manifest["embedder"]["name"] == "clap"
+        assert manifest["embedder"]["embedding_dim"] == 512
+        assert 0.0 <= manifest["scoring"]["threshold"] <= 1.0
+        assert manifest["training_labels"] == {"good": 3, "bad": 3}
+        assert manifest["contains_media_data"] is False
+
+    def test_export_onnx_scores_match_find(self, client):
+        """The exported ONNX must score the dataset identically to the live MLP."""
+        ort = pytest.importorskip("onnxruntime")
+        import numpy as np  # noqa: PLC0415
+
+        from vtscore.detectors.model_loading import resolve_or_train_detector  # noqa: PLC0415
+        from vtscore.detectors.store import _detector_path, _read_detector  # noqa: PLC0415
+        from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
+
+        detector_id = setup_trainable_model_in_registry(
+            "portable-parity",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        resp = _export(client, detector_id)
+        assert resp.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            onnx_bytes = zf.read("detector.onnx")
+
+        snap = snapshot_medias()
+        det_data = _read_detector(_detector_path("portable-parity"))
+        mlp, _threshold, _diag = resolve_or_train_detector(detector_id, det_data, "audio", snap)
+        live = {r["id"]: r["score"] for r in score_media_with_model(mlp, snap, embedder_name="clap")}
+
+        # Re-embed the same medias and run them through the exported graph.
+        ids = sorted(live)
+        x = np.stack([np.asarray(snap[i]["embeddings"]["clap"], dtype=np.float32) for i in ids])
+        session = ort.InferenceSession(onnx_bytes)
+        onnx_scores = session.run(["score"], {"embedding": x})[0].ravel()
+        for i, s in zip(ids, onnx_scores, strict=True):
+            assert s == pytest.approx(live[i], abs=1e-4)
+
+    def test_export_unknown_detector(self, client):
+        assert _export(client, "does-not-exist").status_code == 404
+
+    def test_export_no_medias(self, client):
+        detector_id = setup_trainable_model_in_registry(
+            "portable-no-medias",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        saved = dict(app_module.medias)
+        app_module.medias.clear()
+        try:
+            assert _export(client, detector_id).status_code == 400
+        finally:
+            app_module.medias.update(saved)
+
+    def test_export_detector_without_labels(self, client):
+        from vtscore.detectors.registry import register_detector  # noqa: PLC0415
+        from vtscore.detectors.store import _detector_path, _write_detector  # noqa: PLC0415
+
+        _write_detector(
+            _detector_path("portable-empty"),
+            {"name": "portable-empty", "media_type": "audio", "examples": [], "labelset": {"labels": []}},
+        )
+        entry = register_detector(name="portable-empty", media_type="audio", num_training=0)
+        resp = _export(client, entry["id"])
+        assert resp.status_code == 400

--- a/tests_lib/detectors/test_portable_bundle.py
+++ b/tests_lib/detectors/test_portable_bundle.py
@@ -1,0 +1,142 @@
+"""Library-tier tests for the portable detector bundle builder.
+
+Covers the pure builder in :mod:`vtscore.detectors.portable_bundle`: ONNX graph
+correctness (numerically matches the trained torch model), manifest/README
+contents, and - critically - that the bundle carries *only* the classifier and
+never leaks embeddings or raw media (the scoring-only contract that makes this
+the sanctioned exception to the no-persisted-vectors rule).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import numpy as np
+import pytest
+import torch
+from vtscore.detectors import portable_bundle as pb
+from vtscore.detectors.training import serialize_weights
+from vtscore.training.mlp import build_model
+
+
+def _trained_weights(input_dim: int = 512, hidden: int = 8) -> dict:
+    """A small, deterministic 2-layer MLP serialized to the export format."""
+    gen = torch.Generator().manual_seed(0)
+    model = build_model(input_dim, hidden_dim=hidden, dropout=0.5, generator=gen)
+    model.eval()
+    return serialize_weights(model)
+
+
+def _sample_manifest(weights: dict) -> dict:
+    return pb.build_manifest(
+        detector_name="Cats",
+        media_type="image",
+        embedder="siglip",
+        embedder_display_name="SigLIP (general images)",
+        embedder_type="semantic",
+        embedding_dim=pb.embedding_dim_from_weights(weights),
+        threshold=0.6123456,
+        good_count=7,
+        bad_count=4,
+        exported_by="vtsearch test",
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+
+class TestOnnxGraph:
+    def test_embedding_dim_from_weights(self):
+        assert pb.embedding_dim_from_weights(_trained_weights(input_dim=768)) == 768
+
+    def test_split_rejects_non_two_layer(self):
+        with pytest.raises(ValueError, match="2-layer MLP"):
+            pb._split_linear_weights({"0.weight": [[1.0]], "0.bias": [0.0]})
+
+    def test_onnx_is_valid(self):
+        import onnx  # noqa: PLC0415
+
+        model = onnx.load_from_string(pb.mlp_weights_to_onnx(_trained_weights()))
+        onnx.checker.check_model(model)
+        assert {i.name for i in model.graph.input} == {pb.ONNX_INPUT_NAME}
+        assert {o.name for o in model.graph.output} == {pb.ONNX_OUTPUT_NAME}
+
+    def test_onnx_scores_match_torch(self):
+        """The emitted graph must reproduce sigmoid(model(x)) of the trained MLP."""
+        ort = pytest.importorskip("onnxruntime")
+
+        gen = torch.Generator().manual_seed(1)
+        model = build_model(512, hidden_dim=8, dropout=0.5, generator=gen)
+        model.eval()
+        weights = serialize_weights(model)
+
+        rng = np.random.default_rng(2)
+        x = rng.standard_normal((6, 512)).astype(np.float32)
+        with torch.no_grad():
+            expected = torch.sigmoid(model(torch.from_numpy(x))).numpy().ravel()
+
+        session = ort.InferenceSession(pb.mlp_weights_to_onnx(weights))
+        got = session.run([pb.ONNX_OUTPUT_NAME], {pb.ONNX_INPUT_NAME: x})[0].ravel()
+        np.testing.assert_allclose(got, expected, atol=1e-5)
+
+
+class TestManifest:
+    def test_manifest_shape(self):
+        weights = _trained_weights(input_dim=768)
+        manifest = _sample_manifest(weights)
+        assert manifest["format"] == pb.BUNDLE_FORMAT
+        assert manifest["format_version"] == pb.BUNDLE_FORMAT_VERSION
+        assert manifest["embedder"]["name"] == "siglip"
+        assert manifest["embedder"]["embedding_dim"] == 768
+        assert manifest["scoring"]["activation"] == "sigmoid"
+        # Threshold is rounded but preserved.
+        assert manifest["scoring"]["threshold"] == pytest.approx(0.612346, abs=1e-6)
+        assert manifest["training_labels"] == {"good": 7, "bad": 4}
+        assert manifest["contains_media_data"] is False
+
+    def test_readme_mentions_key_facts(self):
+        weights = _trained_weights(input_dim=768)
+        readme = pb.render_readme(_sample_manifest(weights))
+        assert "SigLIP (general images)" in readme
+        assert "siglip" in readme
+        assert "768" in readme  # embedding dim
+        assert "0.612346" in readme  # threshold
+        assert "onnxruntime" in readme  # inference snippet
+
+
+class TestBundle:
+    def test_bundle_members(self):
+        weights = _trained_weights()
+        bundle = pb.build_bundle(weights=weights, manifest=_sample_manifest(weights))
+        with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+            assert sorted(zf.namelist()) == ["README.md", "detector.onnx", "manifest.json"]
+
+    def test_bundle_is_byte_stable(self):
+        """Same inputs produce identical bytes (fixed zip timestamps)."""
+        weights = _trained_weights()
+        manifest = _sample_manifest(weights)
+        a = pb.build_bundle(weights=weights, manifest=manifest)
+        b = pb.build_bundle(weights=weights, manifest=manifest)
+        assert a == b
+
+    def test_bundle_carries_no_media_vectors(self):
+        """Scoring-only contract: nothing in the bundle leaks embeddings/media.
+
+        The only place floats legitimately appear is inside the ONNX weight
+        tensors (``detector.onnx``).  The manifest and README must not embed any
+        media-derived vector data - only counts, names, and the threshold.
+        """
+        weights = _trained_weights()
+        bundle = pb.build_bundle(weights=weights, manifest=_sample_manifest(weights))
+        with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            readme = zf.read("README.md").decode()
+
+        # No embeddings/labels payloads smuggled into the manifest.
+        forbidden = {"embeddings", "vectors", "labels", "labelset", "elements", "media"}
+        assert forbidden.isdisjoint(manifest.keys())
+        # Nothing under "embedder" or "training_labels" is a raw vector either.
+        assert isinstance(manifest["training_labels"]["good"], int)
+        assert all(not isinstance(v, list) for v in manifest["embedder"].values())
+        # The README documents new-media scoring, not stored vectors.
+        assert "no raw media" in readme.lower()

--- a/vtscore/detectors/portable_bundle.py
+++ b/vtscore/detectors/portable_bundle.py
@@ -1,0 +1,272 @@
+"""Build a standalone, portable detector bundle for transfer to other parties.
+
+CRITICAL - this is the one sanctioned exception to the "No Persisted Vectors or
+MLPs" rule (see ``CLAUDE.md``).  The bundle persists the *trained MLP* (as an
+ONNX graph) so a third party can score their own media without VTSearch.  It
+deliberately does **not** include any embeddings or raw media: a scoring
+detector only needs three things - the trained classifier, the name of the
+embedder to run new media through, and the decision threshold.  Everything in
+this module is derived from those; no media-derived vectors are ever written.
+
+The bundle is a zip with three members:
+
+* ``detector.onnx``  - the MLP with its sigmoid baked in (input ``embedding``
+  ``[batch, dim]`` -> output ``score`` ``[batch, 1]`` in ``[0, 1]``).
+* ``manifest.json``  - machine-readable embedder name/dim, threshold, scoring
+  convention, and label counts.  Lets the bundle be re-imported and scripted.
+* ``README.md``      - human-readable instructions: which embedder to run, the
+  threshold, and a copy-paste ``onnxruntime`` inference snippet.
+
+The MLP architecture is fixed (``Linear -> ReLU -> Dropout -> Linear -> 1``; see
+:func:`vtscore.training.mlp.build_model`), so the ONNX graph is hand-assembled
+via ``onnx.helper`` rather than going through ``torch.onnx``.  That keeps this
+module torch-free (it operates on the ``serialize_weights`` nested-list dict),
+avoids the dynamo/onnxscript export machinery, and is fully deterministic.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
+
+#: ``manifest.json`` format tag and version - bump the version on any
+#: backwards-incompatible change to the manifest shape or the ONNX I/O contract.
+BUNDLE_FORMAT = "vtsearch-portable-detector"
+BUNDLE_FORMAT_VERSION = 1
+
+#: ONNX graph I/O names and the op/ir versions the graph is emitted at.  Gemm,
+#: ReLU and Sigmoid are ancient ops, so a conservative opset/ir pair maximises
+#: the range of ``onnxruntime`` versions that can load the file.
+ONNX_INPUT_NAME = "embedding"
+ONNX_OUTPUT_NAME = "score"
+_ONNX_OPSET = 17
+_ONNX_IR_VERSION = 8
+
+#: Where the README points consumers for context on what produced the bundle.
+_PROJECT_URL = "https://github.com/samggreenberg/vtsearch"
+
+
+def _split_linear_weights(
+    weights: dict[str, list],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Pull the two ``Linear`` layers out of a ``serialize_weights`` dict.
+
+    Returns ``(W1, b1, W2, b2)`` as ``float32`` arrays, ordered by the
+    layer's integer prefix in the state-dict key (so the legacy ``"2."`` and
+    current ``"3."`` final-layer keys both resolve correctly).  ``W1`` is the
+    hidden layer ``[hidden, input_dim]``; ``W2`` is the output layer
+    ``[1, hidden]``.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    weight_keys = sorted((k for k in weights if k.endswith(".weight")), key=lambda k: int(k.split(".")[0]))
+    bias_keys = sorted((k for k in weights if k.endswith(".bias")), key=lambda k: int(k.split(".")[0]))
+    if len(weight_keys) != 2 or len(bias_keys) != 2:
+        raise ValueError(
+            f"Portable export expects a 2-layer MLP (2 weight + 2 bias tensors); got keys {sorted(weights)}"
+        )
+    return (
+        np.asarray(weights[weight_keys[0]], dtype=np.float32),
+        np.asarray(weights[bias_keys[0]], dtype=np.float32),
+        np.asarray(weights[weight_keys[1]], dtype=np.float32),
+        np.asarray(weights[bias_keys[1]], dtype=np.float32),
+    )
+
+
+def embedding_dim_from_weights(weights: dict[str, list]) -> int:
+    """Return the input embedding dimensionality of a serialized detector MLP."""
+    w1, _b1, _w2, _b2 = _split_linear_weights(weights)
+    return int(w1.shape[1])
+
+
+def mlp_weights_to_onnx(weights: dict[str, list]) -> bytes:
+    """Serialise a trained detector MLP to a standalone ONNX graph.
+
+    The graph computes ``sigmoid(Gemm(relu(Gemm(x, W1, b1)), W2, b2))`` - i.e.
+    the exact forward pass of the trained model with the inference-time sigmoid
+    baked in (the trained ``nn.Sequential`` emits raw logits).  Dropout is a
+    no-op at inference and is omitted.  The batch dimension is dynamic.
+    """
+    from onnx import TensorProto, checker, helper, numpy_helper  # noqa: PLC0415
+
+    w1, b1, w2, b2 = _split_linear_weights(weights)
+    input_dim = int(w1.shape[1])
+
+    initializers = [
+        numpy_helper.from_array(w1, "hidden.weight"),
+        numpy_helper.from_array(b1, "hidden.bias"),
+        numpy_helper.from_array(w2, "output.weight"),
+        numpy_helper.from_array(b2, "output.bias"),
+    ]
+    nodes = [
+        # Gemm with transB=1 computes Y = X @ W^T + b, matching nn.Linear.
+        helper.make_node(
+            "Gemm", [ONNX_INPUT_NAME, "hidden.weight", "hidden.bias"], ["hidden_pre"], name="hidden", transB=1
+        ),
+        helper.make_node("Relu", ["hidden_pre"], ["hidden"], name="relu"),
+        helper.make_node("Gemm", ["hidden", "output.weight", "output.bias"], ["logit"], name="output", transB=1),
+        helper.make_node("Sigmoid", ["logit"], [ONNX_OUTPUT_NAME], name="sigmoid"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "vtsearch_detector",
+        [helper.make_tensor_value_info(ONNX_INPUT_NAME, TensorProto.FLOAT, ["batch", input_dim])],
+        [helper.make_tensor_value_info(ONNX_OUTPUT_NAME, TensorProto.FLOAT, ["batch", 1])],
+        initializer=initializers,
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="vtsearch",
+        opset_imports=[helper.make_opsetid("", _ONNX_OPSET)],
+    )
+    model.ir_version = _ONNX_IR_VERSION
+    checker.check_model(model)
+    return model.SerializeToString()
+
+
+def build_manifest(
+    *,
+    detector_name: str,
+    media_type: str,
+    embedder: str,
+    embedder_display_name: str,
+    embedder_type: str,
+    embedding_dim: int,
+    threshold: float,
+    good_count: int,
+    bad_count: int,
+    exported_by: str,
+    exported_at: str,
+) -> dict[str, Any]:
+    """Assemble the machine-readable ``manifest.json`` payload.
+
+    Captures everything a consumer needs to score with the bundle: the embedder
+    to run new media through, the embedding dimensionality, the scoring
+    convention (sigmoid + threshold), and provenance.  ``contains_media_data``
+    is always ``False`` - the manifest documents that the bundle carries the
+    classifier only, never embeddings or raw media.
+    """
+    return {
+        "format": BUNDLE_FORMAT,
+        "format_version": BUNDLE_FORMAT_VERSION,
+        "detector_name": detector_name,
+        "media_type": media_type,
+        "model_file": "detector.onnx",
+        "embedder": {
+            "name": embedder,
+            "display_name": embedder_display_name,
+            "type": embedder_type,
+            "embedding_dim": embedding_dim,
+        },
+        "scoring": {
+            "input": ONNX_INPUT_NAME,
+            "output": ONNX_OUTPUT_NAME,
+            "activation": "sigmoid",
+            "threshold": round(float(threshold), 6),
+            "decision": "good if score >= threshold else bad",
+        },
+        "training_labels": {"good": int(good_count), "bad": int(bad_count)},
+        "exported_by": exported_by,
+        "exported_at": exported_at,
+        "contains_media_data": False,
+        "notes": (
+            "Standalone scoring model derived from labeled media. Contains the trained "
+            "classifier only - no raw media and no embeddings are included."
+        ),
+    }
+
+
+def render_readme(manifest: dict[str, Any]) -> str:
+    """Render the human-readable ``README.md`` for a bundle from its manifest."""
+    emb = manifest["embedder"]
+    scoring = manifest["scoring"]
+    dim = emb["embedding_dim"]
+    threshold = scoring["threshold"]
+    emb_label = emb["display_name"] or emb["name"]
+    return f"""# Portable detector: {manifest["detector_name"]}
+
+This is a **standalone scoring model** exported from
+[VTSearch]({_PROJECT_URL}). It ranks **{manifest["media_type"]}** items by how
+well they match the trained detector, without needing VTSearch itself.
+
+> **What's in here:** the trained classifier only. There is **no raw media and
+> there are no embeddings** in this bundle - just a small neural network and the
+> instructions to run it.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `detector.onnx` | The trained classifier. Input `{scoring["input"]}` `[batch, {dim}]`, output `{scoring["output"]}` `[batch, 1]` in `[0, 1]`. |
+| `manifest.json` | Machine-readable embedder, threshold, and scoring details. |
+| `README.md` | This file. |
+
+## How to score your own items
+
+1. **Embed** each item with the **{emb_label}** embedder
+   (VTSearch embedder id: `{emb["name"]}`, type: `{emb["type"] or "n/a"}`).
+   This must be the *same* embedder family the detector was trained on, and it
+   must produce a **{dim}-dimensional** vector. This bundle does **not** include
+   the embedder - obtain it separately.
+2. **Run** the embedding through `detector.onnx`. The model applies its sigmoid
+   internally, so the output is already a probability in `[0, 1]`.
+3. **Decide**: an item is **good** when `score >= {threshold}` and **bad**
+   otherwise. The threshold is tunable - raise it for precision, lower it for
+   recall.
+
+## Example (Python + onnxruntime)
+
+```python
+import json
+import numpy as np
+import onnxruntime as ort
+
+manifest = json.load(open("manifest.json"))
+threshold = manifest["scoring"]["threshold"]
+
+session = ort.InferenceSession("detector.onnx")
+
+# embeddings: float32 array of shape [N, {dim}] from the {emb["name"]} embedder.
+embeddings = np.zeros((1, {dim}), dtype=np.float32)  # replace with real vectors
+
+scores = session.run(["{scoring["output"]}"], {{"{scoring["input"]}": embeddings}})[0]
+labels = ["good" if float(s) >= threshold else "bad" for s in scores.ravel()]
+print(scores.ravel(), labels)
+```
+
+## Provenance
+
+- Trained on {manifest["training_labels"]["good"]} good / {manifest["training_labels"]["bad"]} bad labeled examples.
+- Exported by {manifest["exported_by"]} at {manifest["exported_at"]}.
+"""
+
+
+def build_bundle(*, weights: dict[str, list], manifest: dict[str, Any]) -> bytes:
+    """Build the full portable-detector zip (``.onnx`` + manifest + README).
+
+    *weights* is a :func:`vtscore.detectors.training.serialize_weights` dict;
+    *manifest* is the output of :func:`build_manifest`.  Returns the zip bytes,
+    ready to stream as a file download.
+    """
+    onnx_bytes = mlp_weights_to_onnx(weights)
+    readme = render_readme(manifest)
+    manifest_text = json.dumps(manifest, indent=2)
+
+    buf = io.BytesIO()
+    # Fixed entry timestamps so the same detector/dataset exports byte-stable.
+    fixed_date = (1980, 1, 1, 0, 0, 0)
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in (
+            ("detector.onnx", onnx_bytes),
+            ("manifest.json", manifest_text),
+            ("README.md", readme),
+        ):
+            info = zipfile.ZipInfo(name, date_time=fixed_date)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, data)
+    return buf.getvalue()

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -15,6 +15,7 @@ from vtsearch.routes.detectors import (
     detector_find_bp,
     detector_scoring_bp,
     detectors_crud_bp,
+    detectors_export_bp,
     detectors_labels_bp,
     detectors_registry_bp,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "detector_find_bp",
     "detector_scoring_bp",
     "detectors_crud_bp",
+    "detectors_export_bp",
     "detectors_labels_bp",
     "detectors_registry_bp",
     "embed_bp",

--- a/vtsearch/routes/detectors/__init__.py
+++ b/vtsearch/routes/detectors/__init__.py
@@ -1,6 +1,7 @@
 """Detector route blueprints."""
 
 from vtsearch.routes.detectors.crud import detectors_crud_bp
+from vtsearch.routes.detectors.export import detectors_export_bp
 from vtsearch.routes.detectors.find import detector_find_bp
 from vtsearch.routes.detectors.labels import detectors_labels_bp
 from vtsearch.routes.detectors.registry import detectors_registry_bp
@@ -10,6 +11,7 @@ __all__ = [
     "detector_find_bp",
     "detector_scoring_bp",
     "detectors_crud_bp",
+    "detectors_export_bp",
     "detectors_labels_bp",
     "detectors_registry_bp",
 ]

--- a/vtsearch/routes/detectors/export.py
+++ b/vtsearch/routes/detectors/export.py
@@ -1,0 +1,136 @@
+"""Portable detector export route.
+
+Streams a standalone, transferable scoring bundle (ONNX model + manifest +
+README) for a saved detector.  See :mod:`vtscore.detectors.portable_bundle` and
+``docs/plans/detector-standalone-export.md``.
+
+This is the sanctioned exception to the "No Persisted Vectors or MLPs" rule
+(``CLAUDE.md``): the bundle persists the trained MLP - never embeddings or raw
+media - so other parties can score their own media without VTSearch.
+
+Migrated to ``flask_smorest`` so the route is described in
+``/api/openapi.json``.  The success body is a raw ``application/zip`` download,
+so (like the dataset-export route) it is left undescribed in the spec and only
+the error responses carry schemas.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from flask import send_file
+from flask_smorest import Blueprint, abort
+
+from vtsearch.routes._shared import require_dataset_header, require_detector_header
+from vtsearch.state import snapshot_medias
+
+logger = logging.getLogger(__name__)
+
+detectors_export_bp = Blueprint(
+    "detectors_export",
+    __name__,
+    description="Export a saved detector as a standalone, portable scoring bundle.",
+)
+
+
+@detectors_export_bp.route("/api/detectors/<detector_id>/portable-bundle", methods=["POST"])
+@detectors_export_bp.alt_response(400, description="No medias loaded, or the detector has no labels for scoring.")
+@detectors_export_bp.alt_response(404, description="Detector not found.")
+@detectors_export_bp.alt_response(409, description="The active dataset can't supply the detector's embedder type.")
+@require_dataset_header
+@require_detector_header
+def export_portable_bundle(detector_id: str):
+    """Train the detector against the active dataset and stream its portable bundle.
+
+    The detector's MLP is (re)trained from its on-disk labelset in the active
+    dataset's embedder space - exactly as Find does - then serialised to an ONNX
+    scorer and zipped with a manifest and README.  No embeddings or raw media
+    are written; only the trained classifier, the embedder name, and the
+    threshold travel in the bundle.
+    """
+    import vtsearch  # noqa: PLC0415
+    from vtscore.datasets.labelset import LabelSet  # noqa: PLC0415
+    from vtscore.detectors import portable_bundle as pb  # noqa: PLC0415
+    from vtscore.detectors.model_loading import resolve_or_train_detector  # noqa: PLC0415
+    from vtscore.detectors.registry import get_detector as reg_get_detector  # noqa: PLC0415
+    from vtscore.detectors.store import _detector_path, _read_detector, _slug  # noqa: PLC0415
+    from vtscore.detectors.training import serialize_weights  # noqa: PLC0415
+    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+    from vtscore.media import get_embedder  # noqa: PLC0415
+    from vtsearch.routes.detectors.scoring import (  # noqa: PLC0415
+        _dataset_supplies_detector_type,
+        _detector_type,
+        _type_incompatible_message,
+    )
+
+    d = reg_get_detector(detector_id)
+    if d is None:
+        abort(404, message=f"Detector '{detector_id}' not found")
+
+    snap = snapshot_medias()
+    if not snap:
+        abort(400, message="No medias loaded")
+
+    media_type = d.get("media_type", "") or next(iter(snap.values())).get("media_type", "image")
+    det_data = _read_detector(_detector_path(d["name"]))
+
+    # Type gate: the active dataset must bind an embedder of the detector's
+    # locked type, else the labels would train/score in a foreign space.
+    if not _dataset_supplies_detector_type(det_data, snap):
+        abort(409, message=_type_incompatible_message(det_data))
+
+    mlp, threshold, diagnostic = resolve_or_train_detector(detector_id, det_data, media_type, snap)
+    if mlp is None:
+        if diagnostic is not None:
+            failed = diagnostic["failed_resolution"]
+            total = diagnostic["total_labels"]
+            abort(
+                400,
+                message=(
+                    f"Detector '{d['name']}' could not be trained: {failed} of {total} "
+                    "labeled items could not be resolved from their original files."
+                ),
+                resolution_diagnostic=diagnostic,
+            )
+        abort(400, message=f"Detector '{d['name']}' has no labels for scoring")
+
+    # Score-space embedder: the concrete embedder of the detector's locked type
+    # this dataset supplies (matches Find / resolve_or_train_detector's space).
+    det_type = _detector_type(det_data)
+    score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=det_type), snap)
+    embedder_display = score_emb or ""
+    if score_emb:
+        try:
+            embedder_display = get_embedder(score_emb).display_name
+        except Exception:  # noqa: BLE001 - cosmetic only; fall back to the raw name.
+            embedder_display = score_emb
+
+    weights = serialize_weights(mlp)
+    labelset = LabelSet.from_dict((det_data or {}).get("labelset") or {})
+    good_count = sum(1 for el in labelset.elements if el.label == "good")
+    bad_count = sum(1 for el in labelset.elements if el.label == "bad")
+
+    manifest = pb.build_manifest(
+        detector_name=d.get("name", ""),
+        media_type=media_type,
+        embedder=score_emb or "",
+        embedder_display_name=embedder_display,
+        embedder_type=det_type,
+        embedding_dim=pb.embedding_dim_from_weights(weights),
+        threshold=threshold,
+        good_count=good_count,
+        bad_count=bad_count,
+        exported_by=f"vtsearch {vtsearch.__version__}",
+        exported_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    bundle = pb.build_bundle(weights=weights, manifest=manifest)
+
+    return send_file(
+        io.BytesIO(bundle),
+        mimetype="application/zip",
+        download_name=f"{_slug(d['name'])}-detector.zip",
+        as_attachment=True,
+    )

--- a/vtsearch/routes/detectors/export.py
+++ b/vtsearch/routes/detectors/export.py
@@ -24,7 +24,7 @@ from types import SimpleNamespace
 from flask import send_file
 from flask_smorest import Blueprint, abort
 
-from vtsearch.routes._shared import require_dataset_header, require_detector_header
+from vtsearch.routes._shared import require_dataset_header
 from vtsearch.state import snapshot_medias
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,6 @@ detectors_export_bp = Blueprint(
 @detectors_export_bp.alt_response(404, description="Detector not found.")
 @detectors_export_bp.alt_response(409, description="The active dataset can't supply the detector's embedder type.")
 @require_dataset_header
-@require_detector_header
 def export_portable_bundle(detector_id: str):
     """Train the detector against the active dataset and stream its portable bundle.
 


### PR DESCRIPTION
## What & why

Adds a way to export a saved detector as a **portable, standalone scoring bundle** you can hand to another party so they can score their own media without running VTSearch. This is the sanctioned exception to the "No Persisted Vectors or MLPs" rule: it persists the trained classifier, but **deliberately ships no embeddings and no raw media** — a scoring detector only needs the MLP, the embedder name, and the threshold.

Design choices (settled with the user up front): **scoring-only** (not re-trainable), **ONNX** (the stack is PyTorch; ONNX runs anywhere with just `onnxruntime`), and a **dedicated modal** distinct from the existing label "Export".

## The bundle

A zip with three members:

- `detector.onnx` — the MLP with its sigmoid baked in (`embedding [batch, dim]` → `score [batch, 1]` in `[0,1]`). The graph is hand-assembled (`Gemm → ReLU → Gemm → Sigmoid`) from the trained weights via `onnx.helper`, so it's torch-free, deterministic, and sidesteps torch 2.12's dynamo/onnxscript export machinery.
- `manifest.json` — embedder name/display-name/type, embedding dim, threshold, scoring convention, label counts, provenance. `contains_media_data` is always `false`.
- `README.md` — which embedder to run, the threshold, and a copy-paste `onnxruntime` inference snippet.

## Changes

**Backend**
- `vtscore/detectors/portable_bundle.py` — pure, torch-free builder (operates on the existing `serialize_weights` dict).
- `POST /api/detectors/<detector_id>/portable-bundle` (`vtsearch/routes/detectors/export.py`) — trains the detector against the active dataset (exactly as Find does), then streams the zip. Requires `X-Dataset-Id`; resolves the detector by URL id.
- Declares `onnx` (runtime) and `onnxruntime` (test-only); refreshes the OpenAPI snapshot.

**Frontend**
- A dedicated `vt-detector-portable-export-modal`, opened from a new **"Export model"** detector-card menu item (kept separate from label "Export"). Proportional amber warning panel + Download; `DetectorsCrudApiService.exportPortableBundle()` fetches the blob.

**Docs**
- `docs/plans/detector-standalone-export.md` — what shipped + open follow-ups (exact HF model id in the README, an exporter-plugin/CLI path, re-import, patch/structural detectors).

## Testing

- Library tests (`tests_lib/detectors/test_portable_bundle.py`): ONNX validity, **ONNX↔torch score parity**, manifest/README contents, and a scoring-only-contract check that no embeddings/vectors leak.
- Route tests (`tests/detectors/test_portable_export_route.py`): success bundle, ONNX-vs-live-MLP parity, 404 / no-medias / no-labels paths.
- Frontend spec for the new modal.
- Full `./run-tests.sh` green: **5355 backend passed**, 921 frontend passed, plus ruff/format/codespell/deptry/pip-audit/pyright/OpenAPI-snapshot.

## Backwards compatibility

No breaking changes. Adds `onnx` as a new runtime dependency (small; needed to build the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoU8VYqVME6ry5EEBLbdVS)_