### PR TITLE
Exclude bulk votes from the Marathoner streak

### DIFF
--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -385,6 +385,43 @@ class TestVoteStreak:
         streak = _by_id(achievements.get_full_state(), "vote_streak")
         assert streak["counter"] == 50
 
+    def test_bulk_votes_do_not_advance_streak(self):
+        # A batch of 500 non-individual votes (count_streak=False) must not
+        # manufacture a 500-long Marathoner streak, even though it credits
+        # every other vote achievement.
+        ts = _ts(2026, 5, 13, 12, 0, 0)
+        for _ in range(500):
+            achievements.record_vote("det", "audio", now=ts, count_streak=False)
+            ts += 1
+        state = achievements.get_full_state()
+        assert _by_id(state, "vote_streak")["counter"] == 0
+        assert _by_id(state, "votes_cast")["counter"] == 500
+
+    def test_bulk_votes_are_transparent_to_an_individual_streak(self):
+        # An individual hand-click on either side of a bulk batch forms one
+        # continuous streak: the bulk votes neither extend nor reset it, and
+        # leave the gap clock alone so the two hand-clicks read as consecutive.
+        base = _ts(2026, 5, 13, 12, 0, 0)
+        achievements.record_vote("det", "audio", now=base)
+        for i in range(100):
+            achievements.record_vote("det", "audio", now=base + 30 + i, count_streak=False)
+        achievements.record_vote("det", "audio", now=base + 200)
+        assert _by_id(achievements.get_full_state(), "vote_streak")["counter"] == 2
+
+    def test_bulk_vote_does_not_reset_a_live_streak(self):
+        # A bulk batch separated from a hand-click by more than the 10-min gap
+        # still must not reset the running streak — bulk is simply invisible.
+        base = _ts(2026, 5, 13, 12, 0, 0)
+        achievements.record_vote("det", "audio", now=base)
+        achievements.record_vote("det", "audio", now=base + 60)
+        # Bulk batch an hour later: would blow the gap if it touched the clock.
+        for i in range(10):
+            achievements.record_vote("det", "audio", now=base + 3600 + i, count_streak=False)
+        # Next hand-click is within 10 min of the *second hand-click*, so the
+        # streak continues to 3 rather than resetting.
+        achievements.record_vote("det", "audio", now=base + 120)
+        assert _by_id(achievements.get_full_state(), "vote_streak")["counter"] == 3
+
 
 class TestVoteStateRoundTrip:
     def test_new_state_keys_persisted(self, isolated_settings):
@@ -787,6 +824,36 @@ class TestActionHooks:
         client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
         client.post(f"/api/medias/{media_id}/vote", json={"target": "good"})
         assert _by_id(achievements.get_full_state(), "votes_cast")["counter"] == 1
+
+    def test_bulk_vote_credits_votes_but_not_streak(self, client):
+        """Bulk "Verified Good" over a hand-selected set must not build a
+        Marathoner streak.
+
+        The user-facing action selects multiple items in the Browser and marks
+        them good/bad in one request (``/api/medias/vote-bulk``).  That is not a
+        run of consecutive *individual* hand-clicks, so it credits votes_cast
+        (the votes were cast) but leaves the vote_streak watermark at zero.
+        """
+        ids = [m["id"] for m in client.get("/api/medias/ids").get_json()][:5]
+        assert len(ids) == 5
+        resp = client.post("/api/medias/vote-bulk", json={"target": "good", "ids": ids})
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["changed"] == 5
+        state = achievements.get_full_state()
+        assert _by_id(state, "votes_cast")["counter"] == 5
+        assert _by_id(state, "vote_streak")["counter"] == 0
+
+    def test_bulk_vote_does_not_break_an_individual_streak(self, client):
+        """A single hand-click before and after a bulk batch still reads as a
+        2-long streak: the bulk votes are transparent to the streak clock."""
+        ids = [m["id"] for m in client.get("/api/medias/ids").get_json()]
+        # One real hand-click.
+        client.post(f"/api/medias/{ids[0]}/vote", json={"target": "good"})
+        # Bulk-verify a hand-selected set in between.
+        client.post("/api/medias/vote-bulk", json={"target": "good", "ids": ids[1:6]})
+        # Another real hand-click.
+        client.post(f"/api/medias/{ids[6]}/vote", json={"target": "good"})
+        assert _by_id(achievements.get_full_state(), "vote_streak")["counter"] == 2
 
     def test_find_label_does_not_credit_votes_cast(self, client):
         """Find-mode auto-labels must not count toward votes_cast or vote_streak.

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -194,7 +194,7 @@ def rethreshold_unverified_find_items() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _record_vote_locked() -> None:
+def _record_vote_locked(count_streak: bool = True) -> None:
     """Credit one vote to the active detector's achievements.
 
     Must be called while ``_state_lock`` is held so the detector context
@@ -202,11 +202,16 @@ def _record_vote_locked() -> None:
     being credited (otherwise a concurrent context switch would credit the
     wrong detector).  Establishes the lock order ``_state_lock → _settings_lock``;
     no code path takes the locks in the reverse order.
+
+    *count_streak* is forwarded to :func:`record_vote`: pass False for bulk /
+    non-individual vote applications so they credit every other achievement but
+    do not inflate the Marathoner ``vote_streak`` (which counts consecutive
+    *individual* hand-clicks).
     """
     from vtsearch.achievements import record_vote  # noqa: PLC0415
 
     det_ctx = get_active_detector_context()
-    record_vote(det_ctx.detector_id, media_type=det_ctx.media_type)
+    record_vote(det_ctx.detector_id, media_type=det_ctx.media_type, count_streak=count_streak)
 
 
 def _current_label_locked(ctx, media_id: int) -> str:
@@ -222,12 +227,18 @@ def _set_vote_locked(
     media_id: int,
     target: str,
     region_box: tuple[float, float, float, float] | None = None,
+    *,
+    count_streak: bool = True,
 ) -> tuple[str, str, int | None]:
     """Set *media_id*'s vote to *target* under an already-held ``_state_lock``.
 
     Returns ``(old_label, new_label, click_time)`` where ``click_time`` is the
     ordinal assigned to a newly-labeled media (or ``None`` when *target* is
     ``"none"`` or the call was idempotent).
+
+    *count_streak* forwards to the achievement credit: pass False for bulk
+    votes (a single batch must not build a Marathoner streak); the default True
+    is the single hand-clicked vote.
 
     Does **not** acquire ``_progress_lock``.  The public wrappers
     (:func:`set_vote`, :func:`toggle_vote`) decide whether to invalidate the
@@ -284,7 +295,7 @@ def _set_vote_locked(
     # Counter increments only on a transition that produces a labeled state.
     # Un-vote (X→none) and idempotent re-apply (handled above) credit nothing.
     if target != "none":
-        _record_vote_locked()
+        _record_vote_locked(count_streak=count_streak)
 
     return (old, target, click_time)
 
@@ -325,6 +336,8 @@ def set_vote(
     media_id: int,
     target: str,
     region_box: tuple[float, float, float, float] | None = None,
+    *,
+    count_streak: bool = True,
 ) -> tuple[str, str, int | None]:
     """Atomically set a media's vote to an absolute target state.
 
@@ -349,6 +362,12 @@ def set_vote(
         region_box: Optional normalised ``(x0, y0, x1, y1)`` good-vote region.
             Only honoured when *target* is ``"good"`` (patch-embedder v2:
             no-votes are always image-level).
+        count_streak: Pass False for bulk applications (e.g. the
+            ``/api/medias/vote-bulk`` "Verified Good/Bad" action over a
+            hand-selected set) so the batch credits every other vote
+            achievement but does not inflate the Marathoner streak, which only
+            counts consecutive *individual* hand-clicks.  Defaults to True (the
+            single-item vote path).
 
     Returns:
         ``(old_label, new_label, click_time)``.  ``click_time`` is the
@@ -356,7 +375,7 @@ def set_vote(
         idempotent calls.
     """
     with _state_lock:
-        result = _set_vote_locked(media_id, target, region_box=region_box)
+        result = _set_vote_locked(media_id, target, region_box=region_box, count_streak=count_streak)
         _mark_verified_if_find_mode(get_active_detector_context(), media_id, result[1])
     # Progress-cache invalidation runs *after* ``_state_lock`` is released so
     # we never establish a ``_state_lock → _progress_lock`` ordering across
@@ -420,6 +439,7 @@ def apply_label(
     silent: bool = False,
     region_box: tuple[float, float, float, float] | None = None,
     record_achievement: bool = True,
+    count_streak: bool = True,
 ) -> None:
     """Atomically apply a label to a media (for imports).
 
@@ -447,6 +467,11 @@ def apply_label(
             system-driven label application that isn't a user vote action
             (e.g. auto-import from a labelset source, example-media seeding
             on detector load).
+        count_streak: Forwarded to the achievement credit (only when
+            *record_achievement* is True).  Pass False for bulk applications
+            such as label import, which credit the other vote achievements but
+            must not build a Marathoner streak out of one import.  Defaults to
+            True (e.g. a single add-to-pile upload is an individual vote).
     """
     with _state_lock:
         ctx = get_active_detector_context()
@@ -470,7 +495,7 @@ def apply_label(
         if not silent:
             diversity_tree_label(media_id)
             if record_achievement and not already:
-                _record_vote_locked()
+                _record_vote_locked(count_streak=count_streak)
 
 
 def apply_label_with_click_time(media_id: int, label: str) -> None:
@@ -480,7 +505,9 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
     label appears in the frontend's click-time timeline.  Credits one vote in
     the active detector's achievement counters - bulk fill-from-sort flows
     are user vote actions and must show up in ``votes_cast`` etc. (audit
-    finding C8).
+    finding C8).  It does *not* count toward the Marathoner ``vote_streak``:
+    fill-from-sort applies a whole sort-window at once, which is not the
+    consecutive-individual-hand-click effort the streak measures.
 
     Args:
         media_id: Integer ID of the media to label.
@@ -500,7 +527,9 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
             add_label_to_history(media_id, "bad")
         assign_click_time(media_id)
         diversity_tree_label(media_id)
-        _record_vote_locked()
+        # Bulk fill-from-sort: credit votes_cast/days/hours/types but never the
+        # individual-effort Marathoner streak.
+        _record_vote_locked(count_streak=False)
 
 
 def apply_labels_bulk_with_click_time(
@@ -518,6 +547,9 @@ def apply_labels_bulk_with_click_time(
     Set *record_achievement* to ``False`` when the labels are system-generated
     (e.g. Find-mode auto-scoring) rather than explicit user votes, so those
     labels do not count toward ``votes_cast`` or ``vote_streak`` achievements.
+    When *record_achievement* is True, the credited votes still never touch the
+    Marathoner ``vote_streak``: this applies a whole batch at once, which is
+    not the consecutive-individual-hand-click effort the streak measures.
 
     When *replace_all* is True, any pre-existing votes/click-times for IDs
     outside *labels* are cleared first.  This is what ``/api/find-label``
@@ -564,4 +596,5 @@ def apply_labels_bulk_with_click_time(
             if tree is not None and media_id in tree.vector_to_leaf:
                 tree.label(media_id)
             if not already and record_achievement:
-                _record_vote_locked()
+                # Bulk batch: never contributes to the individual-effort streak.
+                _record_vote_locked(count_streak=False)

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -325,14 +325,16 @@ def record_vote(
     *,
     now: float | None = None,
     tz_offset_minutes: int | None = None,
+    count_streak: bool = True,
 ) -> None:
     """Record one user vote and credit every vote-driven achievement.
 
     Credits ``votes_cast`` always, ``detectors_trained`` on a detector's first
     vote, ``media_types_touched`` on a media type's first vote, ``days_active``
     on the first vote of each local calendar day, ``hours_voted`` on the first
-    vote within each local hour-of-day bucket, and updates the ``vote_streak``
-    watermark (longest run of consecutive votes with gaps ≤ 10 minutes).
+    vote within each local hour-of-day bucket, and (when *count_streak* is set)
+    updates the ``vote_streak`` watermark (longest run of consecutive votes
+    with gaps ≤ 10 minutes).
 
     Days and hours bucket by the voter's local wall-clock time, resolved from
     the request's timezone offset (see :func:`_user_tz_offset_minutes`), so the
@@ -349,6 +351,14 @@ def record_vote(
         tz_offset_minutes: Override the local-time offset (UTC minus local, in
             minutes) instead of reading it from the request header; only used
             by tests.  Default resolves :func:`_user_tz_offset_minutes`.
+        count_streak: When True (the default), this vote participates in the
+            Marathoner ``vote_streak`` watermark.  Bulk / non-individual vote
+            paths (Verified Good/Bad on a hand-selected set, fill-from-sort,
+            label import) pass False: they still credit every other vote
+            achievement, but a batch of N items must not manufacture an
+            N-long "consecutive individual votes" streak, and they leave the
+            running streak (and its ``last_vote_ts`` clock) untouched so a real
+            hand-clicked run on either side of them stays intact.
     """
     if _is_disabled():
         return
@@ -358,7 +368,7 @@ def record_vote(
     date_str = local_dt.strftime("%Y-%m-%d")
     hour = local_dt.hour
 
-    mutate_user(lambda cache: _credit_vote(cache, ts, detector_id, media_type, date_str, hour))
+    mutate_user(lambda cache: _credit_vote(cache, ts, detector_id, media_type, date_str, hour, count_streak))
 
 
 def _credit_vote(
@@ -368,6 +378,7 @@ def _credit_vote(
     media_type: str,
     date_str: str,
     hour: int,
+    count_streak: bool = True,
 ) -> None:
     """Apply one vote's credits to *cache* in place. See :func:`record_vote`."""
     state = _ensure_state(cache)
@@ -397,15 +408,20 @@ def _credit_vote(
         hours_seen.append(hour)
         counters["hours_voted"] += 1
 
-    last_ts = float(state.get("last_vote_ts") or 0.0)
-    if last_ts <= 0.0 or (ts - last_ts) > STREAK_GAP_SECONDS:
-        current = 1
-    else:
-        current = int(state.get("current_streak") or 0) + 1
-    state["current_streak"] = current
-    state["last_vote_ts"] = ts
-    if current > counters["vote_streak"]:
-        counters["vote_streak"] = current
+    # The Marathoner streak measures sustained *individual* hand-clicking, so
+    # bulk / non-individual votes are transparent to it: they neither advance
+    # nor reset the running streak, and they leave ``last_vote_ts`` alone so
+    # the gap is always measured between two real hand-clicks.
+    if count_streak:
+        last_ts = float(state.get("last_vote_ts") or 0.0)
+        if last_ts <= 0.0 or (ts - last_ts) > STREAK_GAP_SECONDS:
+            current = 1
+        else:
+            current = int(state.get("current_streak") or 0) + 1
+        state["current_streak"] = current
+        state["last_vote_ts"] = ts
+        if current > counters["vote_streak"]:
+            counters["vote_streak"] = current
 
 
 def record_dataset_load(importer_name: str) -> None:

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -231,7 +231,10 @@ def import_labels(body: dict):
             region_box = (float(rb_raw[0]), float(rb_raw[1]), float(rb_raw[2]), float(rb_raw[3]))
 
         for cid in cids:
-            apply_label(cid, label, region_box=region_box)
+            # Importing a labelset is a bulk action, not consecutive individual
+            # hand-clicks: credit the other vote achievements but not the
+            # Marathoner streak.
+            apply_label(cid, label, region_box=region_box, count_streak=False)
         applied += 1
 
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -885,7 +885,10 @@ def vote_media_bulk(body: dict):
         if get_media(media_id) is None:
             missing.append(media_id)
             continue
-        old, new, _click_time = set_vote(media_id, target)
+        # Bulk "Verified Good/Bad" over a hand-selected set is not an
+        # individual hand-click, so it must not build a Marathoner streak;
+        # count_streak=False still credits the other vote achievements.
+        old, new, _click_time = set_vote(media_id, target, count_streak=False)
         if old != new:
             changed += 1
 


### PR DESCRIPTION
## Problem

The **Marathoner** achievement (`vote_streak`) counts "the longest run of consecutive votes with at most a 10-minute gap" — it's meant to reward sustained *individual* hand-clicking. But every label-landing path funnels through `record_vote()`, including bulk/non-individual ones. So a single bulk action (e.g. selecting items in the Browser and clicking **Verified Good**) applied N items in microseconds and instantly manufactured an N-long streak, trivially unlocking even the Platinum (1000) tier.

## Change

`record_vote()` (and the `_record_vote_locked` → `set_vote`/`apply_label` chain) gains a `count_streak` flag, default `True`.

- **Individual hand-clicks** (`/api/medias/<id>/vote`, add-to-pile uploads, per-element label edits) keep `count_streak=True` and advance the streak as before.
- **Bulk / non-individual paths** pass `count_streak=False`:
  - `/api/medias/vote-bulk` — Verified Good/Bad over a hand-selected set (the reported case)
  - `/api/labels/fill-from-sort`
  - `/api/labels/import`
  - `apply_labels_bulk_with_click_time` (always bulk)

Bulk votes are now **transparent** to the streak: they neither advance nor reset it, and they don't touch `last_vote_ts`, so a genuine hand-clicked run on either side of a bulk action stays intact and reads as consecutive.

Scope is the streak only. Bulk votes still credit every other vote achievement — `votes_cast` (Get Out the Vote), `days_active`, `hours_voted`, `media_types_touched` — preserving audit finding C8 (bulk fill-from-sort *are* votes cast). Find-mode auto-scoring continues to credit nothing (`record_achievement=False`), unchanged.

## Tests

Added unit tests (`record_vote(count_streak=False)` doesn't advance the streak but still credits `votes_cast`; bulk batches are transparent to and don't reset a live individual streak) and route-level tests against `/api/medias/vote-bulk` (credits votes but not the streak; doesn't break an individual streak that brackets it). Full `./run-tests.sh` suite green (5360 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdjaTC8VswB1QdBkAknUna)_