### PR TITLE
Default "Show Animations" setting to "Show"

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -370,7 +370,7 @@ and auto-saved on every change. Schema:
   "calibrate_count": 2,
   "calibration_fraction": 0.5,
   "audio_playing": true,
-  "show_animations": "os",
+  "show_animations": "show",
   "show_metadata": true,
   "focus_mode_left": {},
   "focus_mode_right": {},

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -20,7 +20,7 @@ GET /api/settings
   "calibrate_count": 2,
   "calibration_fraction": 0.5,
   "audio_playing": true,
-  "show_animations": "os",
+  "show_animations": "show",
   "show_metadata": true,
   "focus_mode_left": {},
   "focus_mode_right": {},

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -193,11 +193,11 @@ class UserSettings(BaseModel):
     audio_playing: bool = True
     # Master switch for decorative motion (vote swipe, icon spins/waggles/tilts,
     # toast/banner slide-ins, smooth scrolling, projection-browser zoom tweens).
-    # ``"show"`` forces motion on even against an OS reduce-motion request,
-    # ``"hide"`` always suppresses it, and ``"os"`` (the default) follows the
+    # ``"show"`` (the default) forces motion on even against an OS reduce-motion
+    # request, ``"hide"`` always suppresses it, and ``"os"`` follows the
     # platform ``prefers-reduced-motion`` preference. See the "Show Animations"
     # pulldown in the appearance settings.
-    show_animations: AnimationMode = "os"
+    show_animations: AnimationMode = "show"
     show_metadata: bool = True
     # Set to True once the user dismisses the zero-votes "Use ← / → or click"
     # hint that overlays the Good/Bad buttons when a fresh labeling session


### PR DESCRIPTION
## Summary

Changes the default value of the `show_animations` setting from `"os"` (follow the OS `prefers-reduced-motion` preference) to `"show"` (animations on by default), so new installs get decorative motion on out of the box.

## Changes

- `vtsearch/settings_models.py`: `UserSettings.show_animations` default changed from `"os"` → `"show"`, with the docstring updated to note `"show"` is now the default.
- `docs/api/settings.md` and `docs/DEPLOYMENT.md`: updated the example default settings JSON to show `"show_animations": "show"`.

The three valid modes (`"show"` / `"hide"` / `"os"`) are unchanged; only the default differs.

## Testing

- `./run-tests.sh` — all 5362 tests pass (includes the frontend `build:prod` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015eBdtoNWyF5o4M2fDgcAsG)_