### PR TITLE
Speed up duplicate/dedup passes and fix their progress bars (import + reload)

### DIFF
--- a/docs/plans/near-duplicate-detection.md
+++ b/docs/plans/near-duplicate-detection.md
@@ -114,6 +114,36 @@ lists are **merged** (flattened), never nested.
 - Pipeline + route + frontend wiring for the opt-in checkbox.
 - Library-tier tests.
 
+## Performance (shipped)
+
+The hashing phase — not the collapse — dominates near-dupe wall-clock, and it
+used to report **no progress at all**: `_find_near_dup_groups` computed every
+pHash/SimHash before `collapse_near_duplicates`'s `on_progress` fired (that
+callback only ticked during the cheap `_collapse_group` loop), so the bar sat at
+its floor through the whole expensive part and then filled in a burst. Fixed:
+
+- **Progress is now driven across the hashing phase** (`_find_near_dup_groups`
+  takes an `on_progress` and ticks every `_HASH_PROGRESS_STRIDE` items); the
+  collapse tail fires one final tick. No more "dead air" on the finalize bar.
+- **Vectorised hashing (CPU, bit-identical output).** `simhash_text`'s two
+  nested Python loops (shingles × 64 bits) became a single `np.unpackbits`/vote/
+  `np.packbits` reduction; `_pack_bits` is `np.packbits` instead of a 64-iter
+  shift loop. Verified bit-for-bit against the old loops.
+- **Threaded image decode.** pHash cost is PIL thumbnail *decode* + resize (GIL
+  released), so past `_THREAD_MIN_IMAGES` images it runs on a small
+  `ThreadPoolExecutor`. Grouping is order-independent, so results are identical
+  to the inline path (test: `test_threaded_and_inline_hashing_agree`).
+
+*GPU was considered and rejected:* the per-item cost is image **decode** (no
+torch GPU path for arbitrary JPEG/PNG) and, before vectorisation, Python loops —
+the 32×32 DCT is trivially cheap, so a device round-trip per item would lose. The
+CPU wins above are the right lever.
+
+Not addressed: the **registry/pickle reload** path (`registry.py`, "Step 2 of 2
+· Removing duplicates") never runs near-dupe — its "Removing duplicates" is the
+cheap exact-MD5 `collapse_duplicates`; any real cost there is the diversity-tree
+rebuild or pickle decompress, a separate concern from this pass.
+
 ## Open follow-ups
 
 - **Audio near-dupe** via Chromaprint/AcoustID (or constellation hashing).

--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -125,6 +125,47 @@ finalize so the bar paces by real time and the overall ETA has room to
 self-correct through the diversity-tree build + registry save. Detector-load
 weights are unaffected. Tests: `tests_lib/datasets/test_load_step_weights.py`.
 
+## Registry-reload pacing + redundant rebuild (shipped)
+
+The registry/pickle **reload** path (`load_registered_dataset`,
+`vtsearch/routes/datasets/registry.py`) is its own 2-step mini-pipeline (read
+pickle → dedup + diversity), separate from the 4-step import. It had two bugs
+that made "Step 2 of 2 · Removing duplicates" appear to hang far past what the
+bar showed:
+
+1. **Frozen bar.** The reload set `total_steps=2` with **no** `set_step_weights`,
+   so step 2 was the last 50 % of the bar under equal weighting. Step 2 lumped
+   the near-instant exact-MD5 dedup with the diversity index. The dedup drove
+   step 2's within-fraction to ~1.0 in ~0.01 s, the monotonic clamp pinned the
+   overall bar at ~100 %, and it then **sat frozen there for the entire diversity
+   rebuild** (a hierarchical-k-means that measures ~45 s for 20 k items). Fixed
+   by (a) moving dedup into step 1 (it's part of loading, and a no-op on reload
+   since the pickle was already deduped at import) so it no longer pre-fills the
+   diversity slice, and (b) `set_step_weights([0.15, 0.85])` so the diversity
+   build — the only phase that can be slow — owns the bulk of the bar and paces
+   the rebuild across its whole span. A terminal `Finalizing…` update fills the
+   slice to 100 % in every branch (restore / rebuild / deferred-above-threshold).
+
+2. **Redundant rebuild.** Fresh-import datasets cache the diversity tree in their
+   pickle (`stages/registry.py`), so reload restores it in ~0 s. But **promoted**
+   datasets (`/api/dataset/promote`) omitted it, and the promote subset renumbers
+   IDs so the source tree can't be reused — so a promoted dataset rebuilt the
+   full k-means on *every* reload. Fixed by building + caching the tree at
+   promote time (`_diversity_tree_pickle_keys` +
+   `build_diversity_tree_serializable`), gated by the same
+   `should_auto_build_diversity_tree` threshold the load pipeline uses, so
+   reopening a promoted dataset restores instead of rebuilding. Measured costs
+   (20 k images): pickle read + convert ~0.7 s, dedup ~0.01 s, cache restore
+   instant, k-means rebuild ~45 s — i.e. the rebuild was ~60× everything else.
+
+Open follow-up: promote now builds the tree **synchronously** in the request
+(the app runs with `VTSEARCH_TIMEOUT=0`, so long creates are tolerated), which
+means no fine-grained progress during a large promote. If that becomes a pain,
+background the promote like the import pipeline. Other cache-miss reloads (old
+pickles predating tree caching, or a media set that shifts on load) still
+rebuild once; a "write the rebuilt tree back to the pickle on first reload" pass
+would cover those too.
+
 ## Open follow-ups
 
 - **Finalize lumps ~6 sub-stages into one step.** The finalize step (drop-none,

--- a/tests/datasets/test_promote_dataset.py
+++ b/tests/datasets/test_promote_dataset.py
@@ -47,6 +47,36 @@ class TestPromoteToDataset:
         promoted_origins = {(m.get("origin_name") or m.get("filename")) for m in roundtrip.values()}
         assert promoted_origins == original_origins
 
+    def test_caches_diversity_tree_in_pickle(self, client):
+        """The promoted pickle carries a cached diversity tree so reopening it
+        restores the tree instead of rebuilding it (hierarchical k-means) on
+        every reload. The subset's renumbered IDs must match the cache exactly.
+        """
+        from vtscore.datasets import registry as reg
+        from vtscore.datasets.loader import load_dataset_from_pickle
+        from vtscore.state import restore_diversity_tree_from_cache
+        from vtscore.state.core import DatasetContext
+        from vtsearch.state import snapshot_medias
+
+        ids = list(snapshot_medias().keys())[:3]
+        assert len(ids) >= 1
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "Cached Tree", "media_ids": ids},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        entry = reg.get_dataset(resp.get_json()["dataset_id"])
+        assert entry is not None
+
+        roundtrip: dict = {}
+        cached = load_dataset_from_pickle(entry["pkl_path"], roundtrip)
+        # A tree payload was written, and it restores cleanly onto the reloaded
+        # (renumbered) medias — i.e. no rebuild is needed on reload.
+        assert cached is not None, "promote should cache a diversity tree in the pickle"
+        ctx = DatasetContext("reload")
+        ctx.medias = roundtrip
+        assert restore_diversity_tree_from_cache(ctx, cached) is True
+
     def test_renumbers_ids_from_one(self, client):
         from vtscore.datasets import registry as reg
         from vtscore.datasets.loader import load_dataset_from_pickle

--- a/tests_lib/datasets/test_near_dupes.py
+++ b/tests_lib/datasets/test_near_dupes.py
@@ -22,7 +22,7 @@ from vtscore.state import (
     phash_image,
     simhash_text,
 )
-from vtscore.state.near_dupes import _THREAD_MIN_IMAGES, _hamming
+from vtscore.state.near_dupes import _hamming
 
 # A realistic document-length paragraph.  Near-dup text detection (tight
 # SimHash threshold) is meant to catch reformatted/re-encoded copies of a
@@ -267,20 +267,33 @@ class TestNearDupeProgress:
         # current never exceeds total within the hashing phase.
         assert all(c <= t for c, t in calls)
 
-    def test_threaded_and_inline_hashing_agree(self):
-        """The decode thread pool (>=128 images) yields the same grouping as the
-        inline path — the hash of each item is independent of completion order.
+    def test_threaded_and_inline_hashing_agree(self, monkeypatch):
+        """The decode thread pool yields the exact same grouping as the inline
+        path — each item's hash is independent of completion order.
         """
+        import copy  # noqa: PLC0415
+
+        from vtscore.state import near_dupes as nd  # noqa: PLC0415
+
         arr = _photo_arr(500)
-        # Two near-dup pairs plus filler distinct photos, padded past the thread
-        # threshold so the pooled path runs.
-        media = {1: _make_image_media(1, _img_bytes(arr)), 2: _make_image_media(2, _recompress(arr, 75))}
-        for cid in range(3, 200):
-            media[cid] = _make_image_media(cid, _photo(cid))
-        assert len(media) >= _THREAD_MIN_IMAGES
-        count = collapse_near_duplicates(media)
-        assert count == 1  # the one near-dup pair collapsed
-        assert 1 in media and 2 not in media  # larger PNG kept over the JPEG
+        base = {
+            1: _make_image_media(1, _img_bytes(arr), file_size=500),  # PNG
+            2: _make_image_media(2, _recompress(arr, 75), file_size=100),  # near-dup JPEG
+        }
+        for cid in range(3, 60):
+            base[cid] = _make_image_media(cid, _photo(cid))
+
+        inline = copy.deepcopy(base)
+        monkeypatch.setattr(nd, "_THREAD_MIN_IMAGES", 10**9)  # force the inline path
+        n_inline = collapse_near_duplicates(inline)
+
+        threaded = copy.deepcopy(base)
+        monkeypatch.setattr(nd, "_THREAD_MIN_IMAGES", 1)  # force the thread pool
+        n_threaded = collapse_near_duplicates(threaded)
+
+        assert n_inline == n_threaded
+        assert set(inline.keys()) == set(threaded.keys())
+        assert 2 not in inline  # the JPEG near-dup collapsed into the larger PNG
 
 
 # --- export expansion ----------------------------------------------------

--- a/tests_lib/datasets/test_near_dupes.py
+++ b/tests_lib/datasets/test_near_dupes.py
@@ -273,7 +273,7 @@ class TestNearDupeProgress:
         """
         import copy  # noqa: PLC0415
 
-        from vtscore.state import near_dupes as nd  # noqa: PLC0415
+        from vtscore.state import near_dupes  # noqa: PLC0415
 
         arr = _photo_arr(500)
         base = {
@@ -284,11 +284,11 @@ class TestNearDupeProgress:
             base[cid] = _make_image_media(cid, _photo(cid))
 
         inline = copy.deepcopy(base)
-        monkeypatch.setattr(nd, "_THREAD_MIN_IMAGES", 10**9)  # force the inline path
+        monkeypatch.setattr(near_dupes, "_THREAD_MIN_IMAGES", 10**9)  # force the inline path
         n_inline = collapse_near_duplicates(inline)
 
         threaded = copy.deepcopy(base)
-        monkeypatch.setattr(nd, "_THREAD_MIN_IMAGES", 1)  # force the thread pool
+        monkeypatch.setattr(near_dupes, "_THREAD_MIN_IMAGES", 1)  # force the thread pool
         n_threaded = collapse_near_duplicates(threaded)
 
         assert n_inline == n_threaded

--- a/tests_lib/datasets/test_near_dupes.py
+++ b/tests_lib/datasets/test_near_dupes.py
@@ -22,7 +22,7 @@ from vtscore.state import (
     phash_image,
     simhash_text,
 )
-from vtscore.state.near_dupes import _hamming
+from vtscore.state.near_dupes import _THREAD_MIN_IMAGES, _hamming
 
 # A realistic document-length paragraph.  Near-dup text detection (tight
 # SimHash threshold) is meant to catch reformatted/re-encoded copies of a
@@ -244,6 +244,43 @@ class TestCollapseNearDuplicates:
         assert all(
             not (isinstance(m.get("origin"), dict) and m["origin"].get("importer") == "dupe_set") for m in members
         )
+
+
+class TestNearDupeProgress:
+    def test_progress_reported_during_hashing(self):
+        """Progress advances across the (dominant) hashing phase, not just the
+        cheap collapse — the fix for the "dead air" progress bar.
+
+        Uses > _THREAD_MIN_IMAGES distinct photos so both the decode thread pool
+        and the mid-hash progress stride (every 64 items) are exercised.
+        """
+        media = {cid: _make_image_media(cid, _photo(cid)) for cid in range(1, 201)}
+        calls: list[tuple[int, int]] = []
+        collapse_near_duplicates(media, on_progress=lambda cur, tot: calls.append((cur, tot)))
+
+        # At least one tick fired *during* hashing (current > 0 against the
+        # per-item total of 200), proving the bar moves while fingerprinting
+        # rather than sitting at its floor until collapse.
+        mid_hash = [(c, t) for c, t in calls if t == 200 and c > 0]
+        assert mid_hash, f"expected mid-hash progress ticks, got {calls}"
+        assert max(c for c, _ in mid_hash) >= 128  # advanced well into the set
+        # current never exceeds total within the hashing phase.
+        assert all(c <= t for c, t in calls)
+
+    def test_threaded_and_inline_hashing_agree(self):
+        """The decode thread pool (>=128 images) yields the same grouping as the
+        inline path — the hash of each item is independent of completion order.
+        """
+        arr = _photo_arr(500)
+        # Two near-dup pairs plus filler distinct photos, padded past the thread
+        # threshold so the pooled path runs.
+        media = {1: _make_image_media(1, _img_bytes(arr)), 2: _make_image_media(2, _recompress(arr, 75))}
+        for cid in range(3, 200):
+            media[cid] = _make_image_media(cid, _photo(cid))
+        assert len(media) >= _THREAD_MIN_IMAGES
+        count = collapse_near_duplicates(media)
+        assert count == 1  # the one near-dup pair collapsed
+        assert 1 in media and 2 not in media  # larger PNG kept over the JPEG
 
 
 # --- export expansion ----------------------------------------------------

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -82,6 +82,7 @@ from vtscore.state.diversity import (  # noqa: F401
     DIVERSITY_TREE_AUTO_THRESHOLD,
     build_diversity_tree,
     build_diversity_tree_for_context,
+    build_diversity_tree_serializable,
     diversity_tree_label,
     diversity_tree_next_sample,
     diversity_tree_unlabel,

--- a/vtscore/state/diversity.py
+++ b/vtscore/state/diversity.py
@@ -143,6 +143,41 @@ def build_diversity_tree_for_context(
     # Fresh context has no votes - nothing to replay.
 
 
+def build_diversity_tree_serializable(
+    medias: dict[int, dict[str, Any]],
+    on_progress: Callable[[int, int], None] | None = None,
+) -> dict | None:
+    """Build a diversity tree over *medias* and return its cache payload.
+
+    Returns the :meth:`DiversityTree.to_serializable` dict for embedding in a
+    dataset pickle, or ``None`` when there are no usable vectors.  Unlike
+    :func:`build_diversity_tree_for_context` this touches no context and
+    replays no votes — it exists for *save* paths (e.g. dataset promote) that
+    want to cache the tree at creation so reloads restore it instead of paying
+    the hierarchical-k-means rebuild every time.
+    """
+    import numpy as np
+
+    from vtscore.state.diversity_tree import DiversityTree, auto_max_depth
+
+    vectors: dict[int, np.ndarray] = {}
+    for cid, media in medias.items():
+        emb = media_embedding(media)
+        if emb is not None:
+            vectors[cid] = np.asarray(emb, dtype=np.float32)
+
+    if not vectors:
+        return None
+
+    tree = DiversityTree(
+        vectors,
+        k=3,
+        max_depth=auto_max_depth(len(vectors), k=3),
+        on_progress=on_progress,
+    )
+    return tree.to_serializable()
+
+
 def restore_diversity_tree_from_cache(ctx: DatasetContext, cached: object) -> bool:
     """Adopt a cached diversity tree onto *ctx* when it matches the medias.
 

--- a/vtscore/state/near_dupes.py
+++ b/vtscore/state/near_dupes.py
@@ -66,11 +66,14 @@ _DCT_BASIS = _dct_basis(_DCT_N)
 
 
 def _pack_bits(flat: np.ndarray) -> int:
-    """Pack a 1-D boolean array (most-significant first) into an int."""
-    h = 0
-    for b in flat.tolist():
-        h = (h << 1) | (1 if b else 0)
-    return h
+    """Pack a 1-D boolean array of length 64 (most-significant first) into an int.
+
+    ``np.packbits`` packs MSB-first into bytes, so a big-endian
+    ``int.from_bytes`` of the 8 packed bytes reproduces the old
+    bit-by-bit shift loop exactly — but as one vectorised call instead of a
+    64-iteration Python loop per hash.
+    """
+    return int.from_bytes(np.packbits(flat).tobytes(), "big")
 
 
 def phash_image(thumbnail_bytes: bytes | None) -> int | None:
@@ -116,16 +119,17 @@ def simhash_text(text: str | None) -> int | None:
         shingles = set(words)
     if not shingles:
         return None
-    v = np.zeros(64, dtype=np.int64)
-    for sh in shingles:
-        digest = hashlib.blake2b(sh.encode("utf-8"), digest_size=8).digest()
-        hv = int.from_bytes(digest, "big")
-        for i in range(64):
-            v[i] += 1 if (hv >> i) & 1 else -1
-    h = 0
-    for i in range(63, -1, -1):
-        h = (h << 1) | (1 if v[i] > 0 else 0)
-    return h
+    # Hash every shingle to an 8-byte blake2b digest, then reduce the whole
+    # batch with numpy instead of two nested Python loops (shingles x 64 bits).
+    # ``np.unpackbits`` on the big-endian digest bytes yields, per shingle, the
+    # hash bits in most-significant-first order (bit 63 .. bit 0); mapping
+    # {0,1} -> {-1,+1}, summing across shingles, and thresholding >0 reproduces
+    # the classic SimHash bit vote bit-for-bit, and ``np.packbits`` re-packs it
+    # MSB-first into the same 64-bit integer the shift loop produced.
+    digests = b"".join(hashlib.blake2b(sh.encode("utf-8"), digest_size=8).digest() for sh in shingles)
+    bits = np.unpackbits(np.frombuffer(digests, dtype=np.uint8).reshape(len(shingles), 8), axis=1)
+    votes = (bits.astype(np.int32) * 2 - 1).sum(axis=0)  # order: bit 63 .. bit 0
+    return _pack_bits(votes > 0)
 
 
 # --- Grouping ------------------------------------------------------------
@@ -270,17 +274,84 @@ def _choose_representative(media_dict: dict[int, dict[str, Any]], comp: list[int
     return min(comp, key=sort_key)
 
 
-def _find_near_dup_groups(media_dict: dict[int, dict[str, Any]]) -> list[list[int]]:
-    """Return the near-dup groups (size >= 2) across supported media types."""
+# Report hashing progress every this many items (a whole-percent-ish stride so
+# the callback overhead stays negligible on large datasets).
+_HASH_PROGRESS_STRIDE = 64
+
+# Only spin up a decode thread pool past this many images: pool setup costs more
+# than it saves for the handful-of-items case (and the test suite's tiny groups).
+_THREAD_MIN_IMAGES = 128
+
+
+def _hash_media_items(
+    media_dict: dict[int, dict[str, Any]],
+    cids: list[int],
+    media_type: str,
+    on_tick: Callable[[], None],
+) -> dict[int, int]:
+    """Compute the 64-bit hash for every id in *cids*, calling *on_tick* per item.
+
+    Image pHash is dominated by PIL thumbnail *decode* + resize, which releases
+    the GIL, so past :data:`_THREAD_MIN_IMAGES` it runs on a small thread pool;
+    text SimHash is numpy-vectorised and cheap enough to stay inline.  The hash
+    of each item is independent, so results are order-independent and the
+    grouping stays deterministic regardless of completion order.
+    """
+    hashes: dict[int, int] = {}
+    if media_type == "image" and len(cids) >= _THREAD_MIN_IMAGES:
+        import os  # noqa: PLC0415
+        from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
+
+        workers = min(8, (os.cpu_count() or 2))
+
+        def _one(cid: int) -> tuple[int, int | None]:
+            return cid, phash_image(media_dict[cid].get("thumbnail_bytes"))
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for cid, h in pool.map(_one, cids):
+                if h is not None:
+                    hashes[cid] = h
+                on_tick()
+    else:
+        for cid in cids:
+            h = _hash_for(media_dict[cid], media_type)
+            if h is not None:
+                hashes[cid] = h
+            on_tick()
+    return hashes
+
+
+def _find_near_dup_groups(
+    media_dict: dict[int, dict[str, Any]],
+    on_progress: Callable[[int, int], None] | None = None,
+) -> list[list[int]]:
+    """Return the near-dup groups (size >= 2) across supported media types.
+
+    *on_progress* (if given) is driven across the **hashing** phase — the
+    dominant cost — so the bar advances while every image/text is fingerprinted,
+    rather than sitting at its floor until the cheap collapse phase begins.
+    """
     by_type: dict[str, list[int]] = {}
     for cid, m in media_dict.items():
         mt = m.get("media_type")
         if mt in _THRESHOLDS:
             by_type.setdefault(mt, []).append(cid)
 
+    total = sum(len(cids) for cids in by_type.values())
+    done = 0
+
+    def tick() -> None:
+        nonlocal done
+        done += 1
+        if on_progress and done % _HASH_PROGRESS_STRIDE == 0:
+            on_progress(done, total)
+
+    if on_progress:
+        on_progress(0, total)
+
     groups: list[list[int]] = []
     for mt, cids in by_type.items():
-        hashes = {cid: h for cid in cids if (h := _hash_for(media_dict[cid], mt)) is not None}
+        hashes = _hash_media_items(media_dict, cids, mt, tick)
         groups.extend(comp for comp in _connected_components(hashes, _THRESHOLDS[mt]) if len(comp) >= 2)
     return groups
 
@@ -315,13 +386,14 @@ def collapse_near_duplicates(
 
     Only ``image`` and ``text`` media are considered; other types are left
     untouched.  Returns the number of near-dup groups collapsed.
+
+    *on_progress* is driven across the dominant **hashing** phase inside
+    :func:`_find_near_dup_groups`; the subsequent collapse is cheap dict surgery,
+    so the callback only fires once more (at completion) after it finishes.
     """
-    groups = _find_near_dup_groups(media_dict)
-    total = len(groups)
-    for idx, comp in enumerate(groups):
-        if on_progress and idx % 50 == 0:
-            on_progress(idx, total)
+    groups = _find_near_dup_groups(media_dict, on_progress=on_progress)
+    for comp in groups:
         _collapse_group(media_dict, comp)
     if on_progress:
-        on_progress(total, total)
-    return total
+        on_progress(1, 1)
+    return len(groups)

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -166,7 +166,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     if not pkl_path or not Path(pkl_path).is_file():
         abort(404, message=f"Saved dataset file not found: {pkl_path}")
 
-    _LOAD_STEPS = 2  # read pickle + process items, build diversity index
+    _LOAD_STEPS = 2  # step 1: load items (read + dedup); step 2: diversity index
 
     # Create a per-task tracker for this load operation.
     task_id = f"_regload_{dataset_id[:8]}"
@@ -177,6 +177,14 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
         media_type=entry.get("media_type", ""),
         embedder=entry.get("embedder", ""),
     )
+    # Pace the unified bar against the real phase split. Step 1 (pickle read +
+    # convert + the near-instant exact-dedup) is seconds at most; step 2 is the
+    # diversity index, which is instant when the cached tree restores but a
+    # minutes-long hierarchical-k-means rebuild when it doesn't. Weighting step 2
+    # as the dominant slice keeps a rebuild advancing the bar across its whole
+    # span instead of the old equal split, where the instant dedup drove step 2
+    # to ~100% and the bar then sat frozen there through the entire rebuild.
+    tracker.set_step_weights([0.15, 0.85])
     tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):
@@ -214,6 +222,10 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
 
                 tracker.check_cancelled()
 
+                # Exact-MD5 dedup is part of loading (step 1): the pickle was
+                # already deduped at import, so on reload this is a near-instant
+                # no-op — keeping it out of step 2 stops it from pre-filling the
+                # diversity slice and freezing the bar (see set_step_weights).
                 def _dedup_progress(current: int, total: int) -> None:
                     tracker.check_cancelled()
                     tracker.update(
@@ -221,7 +233,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                         "Removing duplicates…",
                         current=current,
                         total=total,
-                        step=2,
+                        step=1,
                         total_steps=_LOAD_STEPS,
                     )
 
@@ -251,6 +263,13 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                     if should_auto_build_diversity_tree(len(ctx.medias)):
                         _diversity_progress(0, 0)
                         build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
+                # Fill the diversity slice to completion in every branch (cache
+                # restore, rebuild, or deferred-above-threshold) so the unified
+                # bar reaches 100% cleanly instead of stalling at the step-1
+                # boundary when the tree restored without emitting any progress.
+                tracker.update(
+                    "loading", "Finalizing…", current=1, total=1, step=2, total_steps=_LOAD_STEPS
+                )
                 _reg_add_loaded(dataset_id)
                 # Update item count and dupe count in case they changed
                 num_dupes = sum(

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -267,9 +267,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 # restore, rebuild, or deferred-above-threshold) so the unified
                 # bar reaches 100% cleanly instead of stalling at the step-1
                 # boundary when the tree restored without emitting any progress.
-                tracker.update(
-                    "loading", "Finalizing…", current=1, total=1, step=2, total_steps=_LOAD_STEPS
-                )
+                tracker.update("loading", "Finalizing…", current=1, total=1, step=2, total_steps=_LOAD_STEPS)
                 _reg_add_loaded(dataset_id)
                 # Update item count and dupe count in case they changed
                 num_dupes = sum(

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -108,6 +108,25 @@ def combine_datasets_route(body: dict):
     return {"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""}
 
 
+def _diversity_tree_pickle_keys(subset: dict[int, dict]) -> dict | None:
+    """Return ``{"diversity_tree": <payload>}`` to cache in a promoted pickle.
+
+    Builds the tree over *subset* at creation, exactly like a fresh import
+    does, so reopening a promoted dataset restores the tree instead of paying
+    the hierarchical-k-means rebuild on every reload (the promote save used to
+    omit it, and the subset's renumbered IDs make the source tree unusable — so
+    a promoted dataset rebuilt from scratch each time). Returns ``None`` past
+    the auto-build threshold (matching the load pipeline's deferral) or when the
+    subset carries no usable vectors.
+    """
+    from vtscore.state import build_diversity_tree_serializable, should_auto_build_diversity_tree
+
+    if not should_auto_build_diversity_tree(len(subset)):
+        return None
+    payload = build_diversity_tree_serializable(subset)
+    return {"diversity_tree": payload} if payload is not None else None
+
+
 @datasets_staging_bp.route("/api/dataset/promote", methods=["POST"])
 @datasets_staging_bp.arguments(DatasetPromoteRequestSchema)
 @datasets_staging_bp.response(200, DatasetPromoteResponseSchema)
@@ -173,20 +192,6 @@ def promote_to_dataset(body: dict):
     ds_dir.mkdir(parents=True, exist_ok=True)
     pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
 
-    # Cache the diversity tree in the pickle at creation, exactly like a fresh
-    # import does, so reopening a promoted dataset restores the tree instead of
-    # paying the hierarchical-k-means rebuild on every reload (the promote save
-    # used to omit it, and the subset's renumbered IDs make the source tree
-    # unusable — so a promoted dataset rebuilt from scratch each time). Skipped
-    # past the auto-build threshold, matching the load pipeline's deferral.
-    from vtscore.state import build_diversity_tree_serializable, should_auto_build_diversity_tree
-
-    extra_pickle_keys: dict | None = None
-    if should_auto_build_diversity_tree(len(subset)):
-        tree_payload = build_diversity_tree_serializable(subset)
-        if tree_payload is not None:
-            extra_pickle_keys = {"diversity_tree": tree_payload}
-
     try:
         data_bytes = export_dataset_to_file(
             subset,
@@ -196,7 +201,7 @@ def promote_to_dataset(body: dict):
             name=name,
             created_at=now,
             expires_at=expires_at,
-            extra_pickle_keys=extra_pickle_keys,
+            extra_pickle_keys=_diversity_tree_pickle_keys(subset),
         )
         Path(pkl_path).write_bytes(data_bytes)
         del data_bytes

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -173,6 +173,20 @@ def promote_to_dataset(body: dict):
     ds_dir.mkdir(parents=True, exist_ok=True)
     pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
 
+    # Cache the diversity tree in the pickle at creation, exactly like a fresh
+    # import does, so reopening a promoted dataset restores the tree instead of
+    # paying the hierarchical-k-means rebuild on every reload (the promote save
+    # used to omit it, and the subset's renumbered IDs make the source tree
+    # unusable — so a promoted dataset rebuilt from scratch each time). Skipped
+    # past the auto-build threshold, matching the load pipeline's deferral.
+    from vtscore.state import build_diversity_tree_serializable, should_auto_build_diversity_tree
+
+    extra_pickle_keys: dict | None = None
+    if should_auto_build_diversity_tree(len(subset)):
+        tree_payload = build_diversity_tree_serializable(subset)
+        if tree_payload is not None:
+            extra_pickle_keys = {"diversity_tree": tree_payload}
+
     try:
         data_bytes = export_dataset_to_file(
             subset,
@@ -182,6 +196,7 @@ def promote_to_dataset(body: dict):
             name=name,
             created_at=now,
             expires_at=expires_at,
+            extra_pickle_keys=extra_pickle_keys,
         )
         Path(pkl_path).write_bytes(data_bytes)
         del data_bytes


### PR DESCRIPTION
Two separate "removing duplicates" progress stalls, one per load path.

## 1. Near-duplicate merge (fresh import)

The opt-in **near-duplicate merge** spends nearly all its wall-clock computing perceptual hashes (pHash for images, SimHash for text), yet reported **no progress** during that phase — `_find_near_dup_groups` hashed every item to completion *before* `collapse_near_duplicates`'s `on_progress` ever fired (that only ticked during the cheap collapse loop). The finalize bar sat at its floor through the entire expensive part, then filled in a burst.

**Changes (`vtscore/state/near_dupes.py`):**
- **Progress across the hashing phase** — `_find_near_dup_groups` ticks every 64 items as it fingerprints; the collapse tail fires one final tick.
- **Vectorized hashing, bit-identical output** — `simhash_text`'s nested Python loops (shingles × 64 bits) collapse into a single `np.unpackbits` → ±1 vote → `np.packbits` reduction; `_pack_bits` uses `np.packbits`. Verified bit-for-bit against the old loops.
- **Threaded image decode** — pHash cost is dominated by PIL thumbnail *decode* (GIL released), so past 128 images it runs on a small `ThreadPoolExecutor`. Order-independent, so results match the inline path exactly.

**Why not GPU:** the cost is image *decode* + (formerly) Python loops, not the tiny 32×32 DCT — a device round-trip per item would lose. CPU vectorization + threading is the right lever, and the hashes stay bit-identical so the tight Hamming thresholds are unchanged.

## 2. Registry/pickle reload ("Step 2 of 2 · Removing duplicates")

The reload is a *different* 2-step pipeline (read pickle → dedup + diversity). Its "Removing duplicates" isn't slow — the exact-MD5 dedup is ~0.01s. Two bugs made it *look* stuck:

- **Frozen bar** — reload set `total_steps=2` with no step weights, so step 2 was the last 50%. The instant dedup drove step 2's fraction to ~100%, the monotonic clamp pinned the bar there, and it **sat frozen for the entire diversity-index rebuild** (~45s for 20k items). Fixed: move dedup into step 1 (a no-op on reload), and `set_step_weights([0.15, 0.85])` so the diversity build owns the bar and paces the rebuild; a terminal `Finalizing…` update completes it in every branch.
- **Redundant rebuild** — fresh-import datasets cache the diversity tree in their pickle, but **promoted** datasets omitted it (and the subset's renumbered IDs make the source tree unusable), so a promoted dataset rebuilt the full k-means on *every* reload. Fixed: build + cache the tree at promote time (`_diversity_tree_pickle_keys` + new `build_diversity_tree_serializable`), gated by the same auto-build threshold the load pipeline uses.

**Measured (20k images):** pickle read + convert ~0.7s · dedup ~0.01s · cache restore instant · k-means rebuild **~45s** (≈60× everything else).

## Tests
- `TestNearDupeProgress`: progress ticks mid-hash (not just at collapse) + threaded/inline groupings identical.
- `test_caches_diversity_tree_in_pickle`: a promoted pickle carries a tree that restores cleanly on reload (no rebuild).
- Full suite green: **5365 passed** (ruff, format, codespell, deptry, frontend build all clean).

## Notes / follow-ups (in `docs/plans/`)
- Promote now builds the tree **synchronously** (app runs with `VTSEARCH_TIMEOUT=0`, so long creates are tolerated) — no fine progress during a large promote; background it if that bites.
- Other cache-miss reloads (old pickles, media shifted on load) still rebuild once; a "write the rebuilt tree back on first reload" pass would cover those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)