### PR TITLE
Fix bin detail popup flashing at un-clamped summon point

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -4,6 +4,7 @@
   [style.left.px]="left"
   [style.top.px]="top"
   [style.maxWidth.px]="maxWidthPx"
+  [style.visibility]="placed ? 'visible' : 'hidden'"
   role="dialog"
   aria-label="Bin items">
   <div

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -148,6 +148,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Clamped on-screen position; starts at the anchor and is nudged inward. */
   left = 0;
   top = 0;
+  /** False until the popup has been clamped to its on-screen spot; the panel is
+   *  kept ``visibility: hidden`` until then so the user never sees it flash at the
+   *  raw summon point (which may be half off-screen) before it's placed. Reset on
+   *  every genuine re-summon so the move to a new bin also stays hidden until
+   *  re-clamped. */
+  placed = false;
   /** Max width (px) the popup may take; shrunk to fit a narrow visible region. */
   maxWidthPx = GRID_COLUMN_WIDTH;
   /** True once the user has dragged the popup by its header. While set, the
@@ -260,6 +266,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       if (resummoned && !this.dragged) {
         this.left = this.x();
         this.top = this.y();
+        // Hide the popup until it's re-clamped at the new anchor, so it doesn't
+        // flash at the raw summon point (which may be half off-screen) first.
+        this.placed = false;
       }
       // Measure + clamp after the new content lays out.
       setTimeout(() => this.place());
@@ -789,7 +798,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  and correct any residual overflow, so the window ends up entirely on-screen
    *  even if the computed height drifts from what actually rendered. */
   private place(): void {
+    // Before the panel exists there's nothing to measure/clamp; a later place()
+    // call (e.g. from ngAfterViewInit) will run once it's in the DOM. Staying
+    // unplaced keeps the popup hidden until then rather than showing it unclamped.
+    if (!this.panelRef?.nativeElement) return;
     this.clampInto(this.left, this.top);
+    // The clamp has settled the on-screen position, so reveal the popup now; the
+    // rAF nudge below is only a sub-pixel correction that won't visibly move it.
+    this.placed = true;
     requestAnimationFrame(() => this.nudgeOnScreen());
   }
 


### PR DESCRIPTION
## Problem

When right-clicking a bin on the VTSBrowse canvas, the detail popup would briefly flash at the raw right-click point — often half off-screen — before jumping to its clamped, fully-visible location.

This happened because the popup rendered at the raw summon point (`x`/`y`) first, and only got clamped by `place()` on a subsequent `setTimeout` + `requestAnimationFrame`, leaving a visible frame at the un-clamped position.

## Fix

Find the popup's on-screen position *before* showing it instead of after:

- Added a `placed` flag (starts `false`); the panel is bound to `visibility: hidden` until the first clamp completes, so the un-clamped position is never painted.
- `place()` reveals the popup (`placed = true`) only after `clampInto` has settled the position. The trailing `requestAnimationFrame` nudge is a sub-pixel correction that won't visibly move it.
- `place()` now no-ops until the panel exists in the DOM, so the popup stays hidden rather than being shown unclamped before its view initializes.
- On a genuine re-summon (right-clicking a different bin while the popup is open), `placed` is reset to `false` so the move to the new anchor also stays hidden until re-clamped — no flash at the new spot either.

## Testing

`./run-tests.sh frontend` passes: TypeScript build OK, audit clean, 943 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QWY3B4RLt4Hy5FWJYFXX9)_