### PR TITLE
Fix VTSBrowse button text selection and focus stealing

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -1,4 +1,4 @@
-<div class="bsp">
+<div class="bsp" vtNoFocusSteal>
   <div class="bsp-header">
     <h3 class="bsp-title" [title]="'Items you have selected on the canvas (' + count() + ')'">
       Selection ({{ count() | number }})

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -7,6 +7,7 @@ import { MediaMetadataCacheService } from '../../services/media-metadata-cache.s
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
@@ -38,7 +39,7 @@ interface SelectionEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-selection-panel',
   standalone: true,
-  imports: [CommonModule, FormsModule, ViewControlsComponent],
+  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective],
   templateUrl: './browse-selection-panel.component.html',
   styleUrl: './browse-selection-panel.component.scss',
 })

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -41,7 +41,7 @@
     @case ('ready') {
       <div class="browse-content" #content [style.--browse-panel-width]="panelWidth() + 'px'">
         <div class="browse-main">
-          <div class="browse-tools-left">
+          <div class="browse-tools-left" vtNoFocusSteal>
             @if (subset) {
               <button
                 type="button"
@@ -98,7 +98,7 @@
               (dismissed)="dismissContextMenu()"
             />
           }
-          <div class="browse-controls">
+          <div class="browse-controls" vtNoFocusSteal>
             <div class="browse-select" role="group" aria-label="Region select">
               <button
                 type="button"

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -15,6 +15,7 @@ import { BrowseSelectionPanelComponent } from '../browse-selection-panel/browse-
 import { BrowseMinimapComponent } from '../browse-minimap/browse-minimap.component';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { IconComponent } from '../icon/icon.component';
+import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { ProjectionApiService } from '../../services/projection-api.service';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -53,6 +54,7 @@ import type { SettingsUpdate } from '../../generated/api-client/models/settings-
     ProgressBarComponent,
     IconComponent,
     BrowseBinPopupComponent,
+    NoFocusStealDirective,
   ],
   // Scoped per browse view so the canvas, its minimap, and the selection panel
   // share one viewport channel and one selection set without leaking across

--- a/frontend/src/app/directives/no-focus-steal.directive.spec.ts
+++ b/frontend/src/app/directives/no-focus-steal.directive.spec.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoFocusStealDirective } from './no-focus-steal.directive';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import { settleZoneless } from '../testing/settle-resource';
+
+@Component({
+  standalone: true,
+  imports: [NoFocusStealDirective],
+  template: `
+    <div vtNoFocusSteal>
+      <button type="button" class="host-btn">Re-project</button>
+      <div role="button" tabindex="0" class="role-btn">Entry</div>
+      <input class="host-input" />
+    </div>
+  `,
+})
+class HostComponent {}
+
+describe('NoFocusStealDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await configureZoneless({ imports: [HostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    await settleZoneless(fixture);
+  });
+
+  /** Dispatch a cancelable mousedown and report whether default was prevented. */
+  function pressMouseDown(el: Element): boolean {
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    el.dispatchEvent(event);
+    return event.defaultPrevented;
+  }
+
+  it('prevents default on mousedown over a real <button> (blocks focus steal)', () => {
+    const button = fixture.nativeElement.querySelector('.host-btn') as HTMLButtonElement;
+    expect(pressMouseDown(button)).toBe(true);
+  });
+
+  it('leaves the mousedown default intact for role="button" elements that need focus', () => {
+    const roleBtn = fixture.nativeElement.querySelector('.role-btn') as HTMLElement;
+    expect(pressMouseDown(roleBtn)).toBe(false);
+  });
+
+  it('leaves other focusable controls (inputs) untouched', () => {
+    const input = fixture.nativeElement.querySelector('.host-input') as HTMLInputElement;
+    expect(pressMouseDown(input)).toBe(false);
+  });
+
+  it('keeps the click on a guarded button working (focus stays off it)', () => {
+    const button = fixture.nativeElement.querySelector('.host-btn') as HTMLButtonElement;
+    let clicked = false;
+    button.addEventListener('click', () => (clicked = true));
+    // A real click issues mousedown (prevented) then a click (not prevented).
+    pressMouseDown(button);
+    button.click();
+    expect(clicked).toBe(true);
+    expect(document.activeElement).not.toBe(button);
+  });
+});

--- a/frontend/src/app/directives/no-focus-steal.directive.ts
+++ b/frontend/src/app/directives/no-focus-steal.directive.ts
@@ -1,0 +1,38 @@
+import { Directive, ElementRef, HostListener, inject } from '@angular/core';
+
+/**
+ * Stops descendant `<button>`s from stealing keyboard focus on a mouse press.
+ *
+ * A native button focuses itself on `mousedown`. Next to a drag-interactive
+ * surface — the VTSBrowse canvas — that focus is pure nuisance: the
+ * last-clicked toolbar button keeps DOM focus, paints a focus ring the moment
+ * the user presses a modifier (Shift promotes `:focus` to `:focus-visible`),
+ * and answers a Space/Enter that was meant for the canvas. These are icon and
+ * label controls that fire an action and have nothing to keep focus *for*.
+ *
+ * Calling `preventDefault()` on the `mousedown` suppresses the focus transfer
+ * (and the start of any text selection/drag) while leaving the click itself
+ * intact — the button still fires, but focus stays where it was, over the
+ * canvas. Keyboard users are unaffected: Tab focus never routes through
+ * `mousedown`, so the buttons remain reachable and operable by keyboard.
+ *
+ * Put the directive on a container (e.g. a toolbar) rather than each button:
+ * it delegates via the event target, so buttons added later are covered too.
+ * Only presses that land on a `<button>` inside the host are intercepted.
+ */
+@Directive({
+  selector: '[vtNoFocusSteal]',
+  standalone: true,
+})
+export class NoFocusStealDirective {
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  @HostListener('mousedown', ['$event'])
+  onMouseDown(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    const button = target?.closest('button');
+    if (button && this.host.nativeElement.contains(button)) {
+      event.preventDefault();
+    }
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -10,6 +10,18 @@
   box-sizing: border-box;
 }
 
+// Buttons are controls, not prose: their labels should never be selectable.
+// Selectable button text lets a stray drag that begins on (or near) a button
+// pick up its label and hand it to the browser's native text drag-and-drop —
+// the origin of the VTSBrowse "dragging a transparent 'Re-project' layer"
+// glitch. Most UA stylesheets already set this on <button>, but app styles can
+// re-enable it by cascading `user-select` onto a shared ancestor, so pin it
+// explicitly. `[role="button"]` covers the handful of non-<button> controls.
+button,
+[role="button"] {
+  user-select: none;
+}
+
 html, body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Problem

In VTSBrowse, a click-drag on the canvas could glitch into "dragging a transparent layer with only *Re-project* written on it," and the Re-project button's label showed as highlighted. The cause is two general button misbehaviors:

1. **Button labels were selectable text.** Once a button's label got selected (a stray double-click or drag near it), a subsequent canvas drag was interpreted by the browser as a native text drag-and-drop of that selection — the "transparent Re-project layer" is the browser's drag image.
2. **Buttons stole and kept keyboard focus on mouse click.** A clicked toolbar button retained DOM focus, so it painted a focus ring the moment a modifier was pressed (Shift promotes `:focus` → `:focus-visible`) and would answer a Space/Enter that was meant for the canvas.

These are icon/label controls that fire an action and have nothing to keep focus *for*.

## Changes

- **Global `user-select: none` reset** for `button` / `[role="button"]` in `styles.scss`, so control labels can never be selected or drag-lifted anywhere in the app.
- **New shared `vtNoFocusSteal` directive** (`frontend/src/app/directives/`) that calls `preventDefault()` on `mousedown` for descendant `<button>`s. This suppresses the focus transfer (and any text-selection/drag start) while leaving the click itself intact — the button still fires, but focus stays over the canvas. It delegates via the event target, so it only touches real `<button>`s (leaving focusable `role="button"` entries and `<select>`s alone) and covers buttons added later. Keyboard Tab focus is unaffected.
- Applied the directive to the browse **toolbar** (`.browse-tools-left`), **canvas controls** (`.browse-controls`), and **selection panel** (`.bsp`).
- Added a unit spec for the directive covering the button / `role="button"` / input / click-still-fires cases.

## Verification

`./run-tests.sh frontend` passes: clean `build:prod`, `npm audit` OK, and 947 Vitest tests pass (including the 4 new directive tests). Changes are purely behavioral (focus/selection); no visual change, so no screenshots need reshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ke7q6yNgUHKuXpGbiSexa)_