### PR TITLE
Simplify bin-popup thumbnail cues to selected + viewed

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -123,7 +123,6 @@
             <div
               class="bin-popup-entry"
               [class.selected]="isSelected(id)"
-              [class.representative]="isRepresentative(id)"
               [class.focused]="isFocused(id)"
               role="button"
               tabindex="0"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -247,38 +247,42 @@
   padding: 2px;
   border-radius: var(--radius-sm);
   width: var(--popup-cell, 80px);
+  // Animate the "viewed" enlarge (below) so items grow/settle smoothly rather
+  // than popping as focus walks the grid.
+  transition: transform var(--transition-base);
 
   &:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
   }
 
-  // Selection is the INNER ring: a solid accent ring drawn at the cell edge
-  // (not the list's inset accent bar — a ring reads better under a square thumb)
-  // plus an accent-tinted fill. The viewed item's ring (below) nests outside it.
+  // Two orthogonal per-thumb cues, so a thumbnail can show either or BOTH at
+  // once without them fighting. Selection is a BOUNDARY (a ring); "viewed" is a
+  // SIZE/depth cue (enlarge + lift). Different visual channels means a selected
+  // item you're also viewing reads unmistakably as ringed AND lifted.
+  //
+  // Selection: a solid accent ring at the cell edge (mirrors bin selection on
+  // the canvas) plus an accent-tinted fill.
   &.selected {
     background: color-mix(in srgb, var(--accent) 18%, transparent);
     color: var(--text-primary);
     box-shadow: 0 0 0 2px var(--accent);
   }
 
-  // The bin's representative — the pile thumbnail the user right-clicked, shown
-  // large in the preview and scrolled into view here. A softer inner ring marks
-  // it; the solid ``.selected`` ring takes over once it's selected.
-  &.representative:not(.selected) {
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
-  }
-
-  // The viewed item (shown in the preview pane / walked by the arrow keys) is the
-  // OUTER ring: a lighter accent ring offset just beyond the cell. Drawn with
-  // ``outline`` (independent of the selection/representative box-shadow) so it
-  // layers on top of them — a selected item you're also viewing shows both rings
-  // nested (solid accent inside, lighter accent outside), where before the cue
-  // vanished. Only one item is ever "viewing", so the wider footprint is local.
-  // It's also the only on-grid cue for non-thumbnail media, which has no preview.
+  // The viewed item (shown in the preview pane / walked by the arrow keys) is
+  // ENLARGED and lifted, mirroring the canvas hover-enlarge. Done with
+  // ``transform`` (painted, not laid out) so the scale never reflows the grid,
+  // shifts row heights, or resizes the popup — layout stays pixel-stable, and
+  // ``z-index`` lifts the growing thumb above its neighbours. The lift uses
+  // ``filter: drop-shadow`` rather than ``box-shadow`` so the selection ring's
+  // box-shadow survives untouched when an item is both selected and viewed. The
+  // size/depth channel is the only on-grid cue for non-thumbnail media too,
+  // which has no preview.
   &.focused {
-    outline: 2px solid var(--accent-light);
-    outline-offset: 2px;
+    position: relative;
+    z-index: 1;
+    transform: scale(1.08);
+    filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
   }
 
   &:focus-visible {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -334,12 +334,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return idx >= 0 ? idx : 0;
   }
 
-  /** True for the representative entry, so the grid can ring the item whose
-   *  thumbnail the user right-clicked (the one shown large in the preview). */
-  isRepresentative(id: number): boolean {
-    return id === this.representativeId();
-  }
-
   /** Scroll the member grid so the representative's row sits roughly centred, so
    *  the popup opens looking at the same item whose pile thumbnail was clicked
    *  rather than the 1-D list's first item. No-op for a singleton bin (no grid)


### PR DESCRIPTION
## What & why

The bin detail popup (`browse-bin-popup`) was trying to convey **three** parallel per-thumbnail states at once:

1. **selected** — in the browser-wide selection
2. **viewed** — the item painted into the popup's preview pane
3. **representative** — the bin's centroid thumbnail

State #3 is a static, open-time-only property (it just seeds which item the preview opens on and where the grid scrolls). As a persistent per-thumbnail badge it added no interactive value and, worse, its *dim inner ring* was visually confusable with the viewed item's *lighter outer ring* — a murky, hard-to-read cue set.

This removes #3 and recasts the two remaining, genuinely-interactive states onto **orthogonal visual channels** so a thumbnail can show either or **both** unambiguously:

| State | Cue | Mirrors |
|-------|-----|---------|
| **selected** | solid accent **boundary ring** + tinted fill | bin selection on the main canvas |
| **viewed** | subtle **enlarge + drop-shadow lift** | hover-enlarge on the main canvas |

Because one cue is a *boundary* and the other is *size/depth*, they never compete: a selected-and-viewed thumbnail reads as ringed **and** lifted at the same time.

## Layout stability

The enlarge uses `transform: scale()` (painted, not laid out), so it never reflows the grid, shifts virtual-scroll row heights, or resizes the popup — layout stays pixel-stable. The lift uses `filter: drop-shadow()` rather than `box-shadow`, leaving `box-shadow` free so the selection ring survives intact when an item is both selected and viewed. A `z-index` bump lifts the growing thumb above its neighbours, and a `transform` transition animates focus walking the grid.

## Changes

- `browse-bin-popup.component.html` — drop the `[class.representative]` binding
- `browse-bin-popup.component.ts` — remove the now-unused `isRepresentative()` method (`representativeId()` stays; it still seeds the preview and scroll target)
- `browse-bin-popup.component.scss` — remove the `.representative` rule; convert `.focused` from an outer outline ring to scale + drop-shadow lift; add a transform transition

## Testing

- `./run-tests.sh frontend` — build OK, `npm audit` clean, 943 Vitest tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C9jWZWHdUqstAyekt97yc

---
_Generated by [Claude Code](https://claude.ai/code/session_019C9jWZWHdUqstAyekt97yc)_