### PR TITLE
Add hideable metadata column to the VTSBrowse detail popup

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -336,6 +336,12 @@
             },
             "type": "object"
           },
+          "popup_metadata_shown": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object"
+          },
           "popup_preview_size": {
             "additionalProperties": {
               "type": "integer"
@@ -4587,6 +4593,7 @@
           "last_embedder_per_media_type": {},
           "panel_pct_left": {},
           "panel_pct_right": {},
+          "popup_metadata_shown": {},
           "popup_preview_size": {},
           "safe_thresholds": {
             "type": "boolean"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -33,6 +33,16 @@
           <vt-icon type="image" [size]="18" />
         </button>
       </div>
+      <button
+        type="button"
+        class="bin-popup-meta-toggle"
+        [class.active]="showMetadataColumn"
+        (click)="toggleMetadata()"
+        [attr.aria-pressed]="showMetadataColumn"
+        [title]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'"
+        [attr.aria-label]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'">
+        <vt-icon type="info" [size]="15" />
+      </button>
     }
     <vt-view-controls
       side="popup"
@@ -50,6 +60,32 @@
   </div>
 
   <div class="bin-popup-body" [style.height.px]="bodyHeight">
+    @if (showMetadataColumn) {
+      <div class="bin-popup-meta-col" [style.width.px]="metadataColWidth">
+        <div class="bin-popup-meta-grid">
+          <div class="bin-popup-meta-item">
+            <span class="bin-popup-meta-label">Name</span>
+            <span class="bin-popup-meta-value">{{ metadataName }}</span>
+          </div>
+          <div class="bin-popup-meta-item">
+            <span class="bin-popup-meta-label">Media Type</span>
+            <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
+          </div>
+          @for (entry of metadataCustom | keyvalue; track entry.key) {
+            <div class="bin-popup-meta-item">
+              <span class="bin-popup-meta-label">{{ entry.key }}</span>
+              <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
+            </div>
+          }
+          @if (metadataMd5) {
+            <div class="bin-popup-meta-item">
+              <span class="bin-popup-meta-label">MD5</span>
+              <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
+            </div>
+          }
+        </div>
+      </div>
+    }
     @if (showPreview) {
       <div
         class="bin-popup-preview"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -86,6 +86,41 @@
   }
 }
 
+// Metadata-column toggle: a single square button beside the size group that
+// shows/hides the metadata column left of the preview. Active (column shown)
+// reads as a filled accent chip; inactive is a muted outline like the size buttons.
+.bin-popup-meta-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 22px;
+  padding: 0 var(--space-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-base), color var(--transition-base),
+    border-color var(--transition-base);
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+
+  &.active {
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    border-color: var(--accent);
+    color: var(--text-primary);
+  }
+
+  vt-icon {
+    line-height: 0;
+  }
+}
+
 .bin-popup-view-controls {
   margin-left: auto;
 }
@@ -114,6 +149,57 @@
   gap: var(--space-sm);
   padding: var(--space-sm);
   overflow: hidden;
+}
+
+// The metadata column: a fixed-width, vertically-scrolling stack of the focused
+// item's Train/Find fields (name, media type, custom-metadata categories, MD5),
+// sitting left of the preview pane. Its width is bound per render; it fills the
+// body height and scrolls internally when the fields overflow.
+.bin-popup-meta-col {
+  height: 100%;
+  flex-shrink: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--bg-body);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs);
+}
+
+.bin-popup-meta-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.bin-popup-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.bin-popup-meta-label {
+  font-size: var(--font-2xs);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bin-popup-meta-value {
+  font-size: var(--font-xs);
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+// MD5 is a long hex string; render it monospace so it reads as an opaque digest.
+.bin-popup-meta-md5 {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+  word-break: break-all;
 }
 
 // The large preview: the hovered (or, by default, representative) item shown

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -12,6 +12,7 @@ import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { usesThumbnails } from '../browse-canvas/hex-render.util';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
+import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
 /** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
 const GRID_LABEL_HEIGHT = 18;
@@ -22,6 +23,8 @@ const GRID_GAP = 4;
 const GRID_CONTENT_WIDTH = 256;
 /** Width (px) of the scrolling grid column; mirrors the historic popup width. */
 const GRID_COLUMN_WIDTH = 280;
+/** Width (px) of the optional metadata column shown left of the preview pane. */
+const METADATA_COLUMN_WIDTH = 200;
 /** Tallest the scrolling body grows before it caps and scrolls internally. */
 const MAX_BODY_PX = 400;
 /** Shortest the scrolling body is ever squeezed to when the visible region is
@@ -211,12 +214,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       if (!settings) return;
       this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
       this.previewSizeDict = (settings.popup_preview_size as Record<string, number>) ?? {};
+      this.metadataShownDict = (settings.popup_metadata_shown as Record<string, boolean>) ?? {};
       this.applyViewPrefs();
       // A detail-canvas size change (the top-left buttons) resizes the preview
-      // pane, hence the whole popup, so re-clamp it back fully on-screen.
+      // pane, hence the whole popup, so re-clamp it back fully on-screen. Showing
+      // or hiding the metadata column likewise changes the popup's width, so it
+      // re-clamps too.
       const override = this.previewOverride;
-      if (override !== this.lastPreviewOverride) {
+      const metaShown = this.showMetadataColumn;
+      if (override !== this.lastPreviewOverride || metaShown !== this.lastMetadataShown) {
         this.lastPreviewOverride = override;
+        this.lastMetadataShown = metaShown;
         setTimeout(() => this.place());
       }
     });
@@ -300,11 +308,100 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Last applied preview override, so the settings effect only re-clamps the
    *  popup when the detail-canvas size actually changed. */
   private lastPreviewOverride: number | null = null;
+  /** Per-media-type memory of whether the metadata column is shown, mirrored
+   *  from the ``popup_metadata_shown`` setting. Absent entries default to shown
+   *  (mirroring the Train/Find center panel's metadata default). */
+  private metadataShownDict: Record<string, boolean> = {};
+  /** Last applied column visibility, so the settings effect only re-clamps the
+   *  popup when it actually toggled. */
+  private lastMetadataShown: boolean | null = null;
 
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
   get showPreview(): boolean {
     return usesThumbnails(this.mediaType());
+  }
+
+  // --- Metadata column ------------------------------------------------------
+  // A column left of the detail-canvas preview carrying the same fields the
+  // Train/Find center panel shows for the focused item (name, media type, custom
+  // metadata, MD5). It attaches to the preview pane — the popup's focused item —
+  // so it only exists for media types that have a preview (image / video).
+
+  /** Whether the user has the metadata column shown for the active media type.
+   *  Absent entries default to shown, mirroring the center panel's metadata
+   *  tray, which is expanded by default. */
+  get metadataShown(): boolean {
+    const mediaType = this.mediaType();
+    const value = mediaType ? this.metadataShownDict[mediaType] : undefined;
+    return value !== false;
+  }
+
+  /** Whether the metadata column actually renders: only when there is a preview
+   *  pane (the focused item it sits beside) and the user hasn't hidden it. */
+  get showMetadataColumn(): boolean {
+    return this.showPreview && this.metadataShown;
+  }
+
+  /** Fixed width (px) of the metadata column when shown. */
+  get metadataColWidth(): number {
+    return METADATA_COLUMN_WIDTH;
+  }
+
+  /** Toggle the metadata column for the active media type and persist it (per
+   *  media type, under ``popup_metadata_shown``), so it becomes the default for
+   *  future popups of this type — mirroring how the size buttons persist. The
+   *  settings effect re-clamps the popup, since the width changed. */
+  toggleMetadata(): void {
+    const mediaType = this.mediaType();
+    if (!this.showPreview || !mediaType) return;
+    const dict = { ...this.metadataShownDict, [mediaType]: !this.metadataShown };
+    this.settingsState.update({ popup_metadata_shown: dict } as SettingsUpdate).subscribe();
+  }
+
+  /** Cached metadata for the focused (previewed) item, or ``undefined`` before
+   *  it has loaded. Everything the column shows reads through this. */
+  private focusedMedia(): MediaBatchResponse | undefined {
+    return this.previewId == null ? undefined : this.metadataCache.get(this.previewId);
+  }
+
+  /** Display name of the focused item, matching the center panel's Name field. */
+  get metadataName(): string {
+    const media = this.focusedMedia();
+    if (!media) return this.previewId == null ? '' : `Media #${this.previewId}`;
+    return media.filename || `Media #${media.id}`;
+  }
+
+  /** Media type of the focused item, matching the center panel's Media Type
+   *  field. Falls back to the active dataset's media type before load. */
+  get metadataMediaType(): string {
+    return this.focusedMedia()?.media_type || this.mediaType();
+  }
+
+  /** MD5 of the focused item, matching the center panel's MD5 field. */
+  get metadataMd5(): string {
+    return this.focusedMedia()?.md5 ?? '';
+  }
+
+  /** Custom metadata of the focused item — the category name/value pairs the
+   *  center panel renders between Media Type and MD5. */
+  get metadataCustom(): Record<string, unknown> {
+    return (this.focusedMedia()?.custom_metadata as Record<string, unknown>) ?? {};
+  }
+
+  /** Format a custom-metadata value for display. Mirrors the center panel's
+   *  ``formatMetadataValue`` so the same categories read identically here. */
+  formatMetadataValue(label: string, value: unknown): string {
+    if (label === 'File Size' && typeof value === 'number') {
+      return (value / 1024).toFixed(1) + ' KB';
+    }
+    if (label === 'Duration' && typeof value === 'number') {
+      return value.toFixed(1) + 's';
+    }
+    if (label === 'Frequency' && typeof value === 'number') {
+      return value + ' Hz';
+    }
+    return String(value);
   }
 
   /** Pull the remembered thumbnail size for the active media type, rechunk the
@@ -869,7 +966,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     const gridW = this.previewOnly ? 0 : GRID_COLUMN_WIDTH;
     const paneW = this.previewPaneSize;
     const previewW = paneW ? paneW + (gridW ? PREVIEW_GAP : 0) : 0;
-    const width = Math.min(previewW + gridW, this.maxWidthPx);
+    // The optional metadata column sits left of the preview, adding its width
+    // plus a gap when shown.
+    const metaW = this.showMetadataColumn ? METADATA_COLUMN_WIDTH + PREVIEW_GAP : 0;
+    const width = Math.min(metaW + previewW + gridW, this.maxWidthPx);
     const height = headerH + this.bodyHeight;
     let l = desiredLeft;
     let t = desiredTop;

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -383,6 +383,16 @@ class TestSettingsAPI:
         assert data["popup_preview_size"]["image"] == 720
         assert data["popup_preview_size"]["video"] == 96
 
+    def test_update_popup_metadata_shown_per_type(self, client):
+        res = client.put("/api/settings", json={"popup_metadata_shown": {"image": False, "video": True}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["popup_metadata_shown"]["image"] is False
+        assert data["popup_metadata_shown"]["video"] is True
+
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["popup_metadata_shown"]["image"] is False
+
     def test_update_focus_mode_left_per_type(self, client):
         res = client.put("/api/settings", json={"focus_mode_left": {"audio": "hover", "image": "click"}})
         assert res.status_code == 200

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -108,6 +108,10 @@ class AppSettingsSchema(Schema):
     # VTSBrowse bin-popup detail-canvas (large single-item preview) size in CSS
     # px, per media type. Driven by the popup's own top-left size buttons.
     popup_preview_size = _PerMediaTypeIntDict()
+    # VTSBrowse bin-popup metadata column visibility, per media type. Driven by
+    # the popup's own metadata toggle button; when shown, a column left of the
+    # detail preview carries the focused item's Train/Find metadata fields.
+    popup_metadata_shown = _PerMediaTypeBooleanDict()
 
     # Server-tier. These are fixed at server start (config file /
     # environment / CLI flags) and shared across all users; the frontend
@@ -211,6 +215,7 @@ class SettingsUpdateSchema(Schema):
     panel_pct_right = fields.Raw()
     grid_icon_size_popup = fields.Raw()
     popup_preview_size = fields.Raw()
+    popup_metadata_shown = fields.Raw()
 
     autopilot_enabled = fields.Boolean()
     hide_autopilot = fields.Boolean()

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -315,6 +315,15 @@ class UserSettings(BaseModel):
     # derived from the main-canvas thumbnail radius. Clamped to
     # ``POPUP_PREVIEW_SIZE_PX``.
     popup_preview_size: dict[str, Annotated[int, _clamp(*POPUP_PREVIEW_SIZE_PX)]] = Field(default_factory=dict)
+    # VTSBrowse bin-popup metadata column, per media type. The popup can show a
+    # column to the left of the detail-canvas preview carrying the same
+    # name/media-type/custom-metadata/MD5 fields the Train/Find center panel
+    # shows for the focused item; this remembers whether that column is shown for
+    # each media type. Empty entries fall back on the frontend to shown (mirroring
+    # the center panel's default). Only image/video popups have a preview pane and
+    # thus a focused item to attach the column to, but the flag is stored per media
+    # type generically.
+    popup_metadata_shown: dict[str, bool] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)
 


### PR DESCRIPTION
## What

The VTSBrowse bin popup (the "Details" window in the browser — its own code calls it the detail view/canvas) now shows a metadata column to the **left of the focused preview item**, replicating the fields the Train/Find center panel shows for the focused item:

- **Name** (`filename` or `Media #<id>`)
- **Media Type** (title-cased)
- Each **custom-metadata** category name/value pair (using the same `formatMetadataValue` formatting as the center panel — File Size in KB, Duration in seconds, Frequency in Hz)
- **MD5**

The column tracks whichever item is currently focused in the preview pane, so hovering the member grid updates it live.

## Hideable + remembered per media type

A metadata toggle button (ℹ) sits in the popup header next to the detail-image size buttons. Toggling it shows/hides the column and persists the choice **per media type** under a new `popup_metadata_shown` setting, mirroring how `grid_icon_size_popup` / `popup_preview_size` are remembered. The popup re-clamps on-screen when the column's presence changes its width.

The column only renders for media types that have a preview pane (image / video) — i.e. where there is a focused item to sit beside. Absent settings default to **shown**, matching the center panel's metadata tray default. This is a visible behavior change: image/video bin popups now show the column by default (users can hide it, and the choice sticks per type).

## Changes

- **Backend**: new `popup_metadata_shown: dict[str, bool]` field on `UserSettings`, wired into `AppSettingsSchema` (dump) and `SettingsUpdateSchema` (update). Accessors and route dispatch are auto-generated from the model/schema, so no manual wiring. Regenerated `frontend/openapi.json`.
- **Frontend**: metadata column + header toggle in `browse-bin-popup` (component, template, styles); width accounting in the popup's clamp logic.
- **Tests**: added a settings-route test for `popup_metadata_shown` round-tripping per media type.

Full `./run-tests.sh` passes (5366 passed, 1 skipped); `npm run build:prod` is clean with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTKmUh8mUzLYpFmuPMKbcR)_