### PR TITLE
Auto-scroll bin detail popup to the representative on open

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -443,15 +443,30 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Scroll the member grid so the representative's row sits roughly centred, so
    *  the popup opens looking at the same item whose pile thumbnail was clicked
    *  rather than the 1-D list's first item. No-op for a singleton bin (no grid)
-   *  or before the viewport exists. */
-  private scrollToRep(): void {
+   *  or before the viewport exists.
+   *
+   *  On open the virtual viewport may not have applied its scrollable content
+   *  size yet, so the browser clamps this first scroll back to 0 and a large bin
+   *  is left sitting at the top with the representative off-screen. When we meant
+   *  to scroll down but the offset didn't take, retry on the next frame (bounded)
+   *  until the viewport is scrollable and the target sticks. */
+  private scrollToRep(attempt = 0): void {
     const vp = this.viewport;
     if (!vp) return;
     const row = Math.floor(this.repIndex() / Math.max(1, this.columns));
     const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
-    // Centre the row in the visible window, clamped so we never scroll past 0.
-    const offset = row * this.rowSize - Math.max(0, viewportH - this.rowSize) / 2;
-    vp.scrollToOffset(Math.max(0, offset));
+    // The most we can scroll: content height (all rows) minus the visible window.
+    const maxOffset = Math.max(0, this.rows.length * this.rowSize - viewportH);
+    // Centre the row in the visible window, clamped to [0, maxOffset] so we never
+    // scroll past either end.
+    const target = Math.min(
+      maxOffset,
+      Math.max(0, row * this.rowSize - Math.max(0, viewportH - this.rowSize) / 2),
+    );
+    vp.scrollToOffset(target);
+    if (target > 0 && vp.measureScrollOffset('top') < target - 1 && attempt < 5) {
+      requestAnimationFrame(() => this.scrollToRep(attempt + 1));
+    }
   }
 
   /** Recompute the column count + row chunking for the current thumbnail size. */

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -414,9 +414,13 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     );
     if (this.gridGoalWidth !== prevGoal) {
       this.rebuildRows();
-      // The row stride changed; let the virtual viewport remeasure, then clamp.
+      // The row stride changed, so the old scroll offset now points at a
+      // different row. Let the virtual viewport remeasure, re-centre on the item
+      // being viewed (the representative until the user hovers/arrows elsewhere)
+      // so it stays in view across the size change, then clamp.
       setTimeout(() => {
         this.viewport?.checkViewportSize();
+        this.centreRowFor(this.focusIndex());
         this.place();
       });
     }
@@ -442,18 +446,24 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
 
   /** Scroll the member grid so the representative's row sits roughly centred, so
    *  the popup opens looking at the same item whose pile thumbnail was clicked
-   *  rather than the 1-D list's first item. No-op for a singleton bin (no grid)
-   *  or before the viewport exists.
+   *  rather than the 1-D list's first item. */
+  private scrollToRep(): void {
+    this.centreRowFor(this.repIndex());
+  }
+
+  /** Scroll the member grid so the row holding ``index`` sits roughly centred.
+   *  No-op for a singleton bin (no grid) or before the viewport exists.
    *
-   *  On open the virtual viewport may not have applied its scrollable content
-   *  size yet, so the browser clamps this first scroll back to 0 and a large bin
-   *  is left sitting at the top with the representative off-screen. When we meant
-   *  to scroll down but the offset didn't take, retry on the next frame (bounded)
-   *  until the viewport is scrollable and the target sticks. */
-  private scrollToRep(attempt = 0): void {
+   *  The virtual viewport may not have applied its scrollable content size yet
+   *  (on open, or right after a thumbnail-size change re-chunks the rows), so the
+   *  browser clamps this scroll back to 0 and a large bin is left sitting at the
+   *  top with the target off-screen. When we meant to scroll down but the offset
+   *  didn't take, retry on the next frame (bounded) until the viewport is
+   *  scrollable and the target sticks. */
+  private centreRowFor(index: number, attempt = 0): void {
     const vp = this.viewport;
     if (!vp) return;
-    const row = Math.floor(this.repIndex() / Math.max(1, this.columns));
+    const row = Math.floor(index / Math.max(1, this.columns));
     const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
     // The most we can scroll: content height (all rows) minus the visible window.
     const maxOffset = Math.max(0, this.rows.length * this.rowSize - viewportH);
@@ -465,7 +475,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     );
     vp.scrollToOffset(target);
     if (target > 0 && vp.measureScrollOffset('top') < target - 1 && attempt < 5) {
-      requestAnimationFrame(() => this.scrollToRep(attempt + 1));
+      requestAnimationFrame(() => this.centreRowFor(index, attempt + 1));
     }
   }
 


### PR DESCRIPTION
## Problem

When the browse view opens a bin's detail popup, it highlights the bin's representative (centroid) — but for large bins the member grid stayed scrolled to the **top**, so the highlighted item was off-screen and the user couldn't see it without scrolling.

## Cause

`scrollToRep()` fired once inside a `setTimeout` on open. At that moment the CDK virtual-scroll viewport had not yet applied its scrollable content size, so the target scroll offset was clamped back to `0` by the browser and the grid never moved.

## Fix

In `browse-bin-popup.component.ts`:

- Retry the scroll on the next animation frame (bounded to 5 attempts) whenever we meant to scroll down but the offset didn't take, so we keep trying until the viewport is actually scrollable and the target sticks.
- Clamp the target to the real max offset (`content height − viewport height`) so a representative near the *end* of a large bin scrolls fully into view without over-scrolling, and so a bin that already fits never triggers pointless retries.

The common case (default `M` popup grid size, which matches the component's default and so triggers no settings-driven row rebuild) is fully correct; the retry only guards the initial viewport-measurement race.

## Testing

- `./run-tests.sh frontend` — TypeScript build OK, 947 Vitest unit tests pass, `npm audit` clean.
- ruff / ruff format / codespell / deptry / pip-audit / pyright / OpenAPI snapshot / Dockerfile / screenshot-wiring checks all pass.

No doc screenshot frames the bin popup, and this is a scroll-position behavior change rather than a visual layout change, so no reshoot is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNof5PPkX2SpJvHXB4r6fb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNof5PPkX2SpJvHXB4r6fb)_