### PR TITLE
Preload the top view's thumbnails before revealing the browse canvas

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1424,14 +1424,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const meta = this.meta();
     if (!meta || meta.point_count === 0) return;
 
-    const thumbs = this.thumbnailMode;
-    if (thumbs && this.firstViewTimer === null) {
+    // Arm the backstop the first time we begin waiting: a tile or thumbnail that
+    // hard-fails to load caches nothing and fires no redraw, so without this the
+    // cover could strand. The timer releases it regardless (falling back to the
+    // old show-then-fill behaviour), and reportFirstView clears it on success.
+    if (this.firstViewTimer === null) {
       this.firstViewTimer = setTimeout(
         () => this.reportFirstView(),
         BrowseCanvasComponent.FIRST_VIEW_MAX_WAIT_MS,
       );
     }
 
+    const thumbs = this.thumbnailMode;
     const level = this.activeLevel;
     const radius = meta.base_radius / Math.pow(2, level);
     const screenRadius = radius * this.effZoom;

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -141,6 +141,17 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * numbers that track pan/zoom.
    */
   readonly densityMaxChanged = output<number>();
+  /**
+   * Emitted once, after the opening view is fully painted with real content:
+   * the fit has run against the real canvas size, every density tile under the
+   * viewport is in, and — for image/video datasets — every on-screen
+   * representative thumbnail has decoded (or failed). The browse view keeps a
+   * cover over the canvas until this fires, so the user is shown the finished
+   * view rather than a thumbnail-less grey grid that then fills in. Fires
+   * exactly once per canvas instance (a later pan/zoom loads on demand as
+   * before). See {@link maybeReportFirstView}.
+   */
+  readonly firstViewReady = output<void>();
 
   /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
   private thumbCache = new Map<number, HTMLImageElement>();
@@ -212,6 +223,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // `resize()`; this flag stops later window resizes from clobbering the user's
   // pan/zoom.
   private fittedAgainstRealSize = false;
+  // Guards {@link firstViewReady} so the opening-view signal fires exactly once
+  // per canvas instance.
+  private firstViewReported = false;
+  // Backstop so a representative thumbnail that never resolves (a hung request)
+  // can't strand the reveal cover: armed the first time we begin waiting on the
+  // opening view's thumbnails, it releases the view after this long regardless.
+  private firstViewTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly FIRST_VIEW_MAX_WAIT_MS = 12000;
   // Whether the user has taken over the framing (panned, zoomed, or resized a
   // thumbnail). Until then the view stays auto-fit: applying a saved cell size
   // (which changes the bin radius and thus how far edge bins reach) re-fits so
@@ -556,6 +575,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       if (this.thumbPrefetchIsTimeout) clearTimeout(this.thumbPrefetchHandle);
       else if (typeof cancelIdleCallback === 'function') cancelIdleCallback(this.thumbPrefetchHandle);
     }
+    if (this.firstViewTimer !== null) clearTimeout(this.firstViewTimer);
     const el = this.canvasRef.nativeElement;
     el.removeEventListener('mousedown', this.boundMouseDown);
     el.removeEventListener('wheel', this.boundWheel);
@@ -1378,6 +1398,75 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     };
     this.displayedLevel = level;
     this.hasDrawn = true;
+
+    this.maybeReportFirstView();
+  }
+
+  /**
+   * Emit {@link firstViewReady} once the opening view is fully painted with real
+   * content. Called at the end of every {@link draw} until it fires. It holds
+   * until three facts are true: the fit ran against the *real* canvas size (the
+   * 800×600 fallback fit paints a framing {@link resize} immediately refits
+   * away), every tile under the viewport has loaded, and — for thumbnail media —
+   * every on-screen representative thumbnail has decoded or failed. Each pending
+   * tile / thumbnail lands with its own redraw, so a later draw re-runs this
+   * check until the view is whole; a one-shot timer, armed the first time we
+   * start waiting on thumbnails, releases the cover if an image hangs. Pure
+   * density media (audio/text) paint no thumbnails, so it fires as soon as the
+   * visible tiles are in.
+   */
+  private maybeReportFirstView(): void {
+    if (this.firstViewReported) return;
+    // Hold until the fit used the real canvas size: the fallback fit paints
+    // tiles/thumbnails for a framing the refit discards, so revealing then would
+    // flash the wrong view.
+    if (!this.fittedAgainstRealSize) return;
+    const meta = this.meta();
+    if (!meta || meta.point_count === 0) return;
+
+    const thumbs = this.thumbnailMode;
+    if (thumbs && this.firstViewTimer === null) {
+      this.firstViewTimer = setTimeout(
+        () => this.reportFirstView(),
+        BrowseCanvasComponent.FIRST_VIEW_MAX_WAIT_MS,
+      );
+    }
+
+    const level = this.activeLevel;
+    const radius = meta.base_radius / Math.pow(2, level);
+    const screenRadius = radius * this.effZoom;
+
+    for (const { tx, ty } of this.getVisibleTiles()) {
+      const tile = this.tileCache.getCached(level, tx, ty);
+      // Geometry still loading: a tileLoaded$ redraw re-runs this check.
+      if (!tile) return;
+      if (!thumbs) continue;
+      for (const cell of tile.cells) {
+        // Only cells actually on screen gate the reveal — the visible-tile set
+        // carries a one-tile margin, so mirror draw()'s per-cell cull exactly.
+        const [sx, sy] = this.projToScreen(cell.cx, cell.cy);
+        if (sx < -screenRadius * 2 || sx > this.width + screenRadius * 2) continue;
+        if (sy < -screenRadius * 2 || sy > this.height + screenRadius * 2) continue;
+        if (this.thumbFailed.has(cell.rep_id)) continue;
+        // draw() already kicked off the load for every drawn cell; here we only
+        // read whether it has decoded. A missing / still-decoding image holds
+        // the reveal (its onload fires a redraw that re-checks).
+        const img = this.thumbCache.get(cell.rep_id);
+        if (!img || !img.complete || img.naturalWidth === 0) return;
+      }
+    }
+    this.reportFirstView();
+  }
+
+  /** Fire {@link firstViewReady} once and cancel the backstop timer. */
+  private reportFirstView(): void {
+    if (this.firstViewReported) return;
+    this.firstViewReported = true;
+    if (this.firstViewTimer !== null) {
+      clearTimeout(this.firstViewTimer);
+      this.firstViewTimer = null;
+    }
+    this.firstViewReady.emit();
   }
 
   /** Selection state of a cell: 0 = none, 1 = partial, 2 = full. Memoized on

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -39,7 +39,10 @@
       </div>
     }
     @case ('ready') {
-      <div class="browse-content" #content [style.--browse-panel-width]="panelWidth() + 'px'">
+      <div
+        class="browse-content"
+        #content
+        [style.--browse-panel-width]="panelWidth() + 'px'">
         <div class="browse-main">
           <div class="browse-tools-left" vtNoFocusSteal>
             @if (subset) {
@@ -81,6 +84,7 @@
             (hexHover)="onHexHover($event)"
             (densityMaxChanged)="onDensityMaxChanged($event)"
             (contextMenu)="onCanvasContextMenu($event)"
+            (firstViewReady)="onCanvasFirstView()"
           />
           <vt-browse-hover-preview
             [hover]="hoverEvent"
@@ -192,6 +196,18 @@
             />
           </div>
         </aside>
+
+        <!-- Cover the mounted-but-loading canvas until it signals its opening
+             view is fully painted (fit + top-view thumbnails), so the user is
+             shown the finished view rather than a thumbnail-less grid. -->
+        @if (!revealed()) {
+          <div class="browse-preload-cover">
+            <div class="browse-status">
+              <p class="browse-status-message">{{ preloadMessage }}</p>
+              <vt-progress-bar [indeterminate]="true" [value]="0" [max]="1" />
+            </div>
+          </div>
+        }
       </div>
     }
   }

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -105,6 +105,20 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+  // Positioning context for the pre-reveal cover, which sits over the whole
+  // (already laid-out) grid while the canvas paints its opening view.
+  position: relative;
+}
+
+// Opaque cover over the canvas + panels until the opening view is ready. The
+// content underneath is fully laid out (so the canvas fits at its real size and
+// the reveal doesn't reflow); this just hides the mid-load grid and swallows
+// interaction until it's worth showing.
+.browse-preload-cover {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  background: var(--bg-body);
 }
 
 // Holds the canvas plus its on-canvas overlays (controls, info, hover

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -96,6 +96,16 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   densityMax = 1;
   readonly status = signal<'loading' | 'building' | 'ready' | 'error' | 'done'>('loading');
+  /**
+   * Whether the canvas content is uncovered. The canvas is mounted (so it can
+   * lay out and fetch) as soon as {@link status} is ``ready``, but a cover stays
+   * over it until the canvas signals its opening view is fully painted — the
+   * fit ran and the top view's thumbnails decoded — so the user is shown the
+   * finished view instead of a thumbnail-less grid that then fills in. Reset to
+   * ``false`` each time a *fresh* canvas mounts (see {@link enterReady}); an
+   * in-place refresh of an already-ready canvas leaves it untouched.
+   */
+  readonly revealed = signal(false);
   readonly errorMessage = signal('');
   readonly buildProgress = signal(0);
   readonly buildTotal = signal(0);
@@ -572,7 +582,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    */
   @HostListener('document:keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
-    if (this.status() !== 'ready' || this.contextMenuOpen) return;
+    if (this.status() !== 'ready' || !this.revealed() || this.contextMenuOpen) return;
     if (shortcutsBlocked()) return;
 
     // Ctrl/Cmd-A: fully select every bin whose silhouette sits entirely in view.
@@ -832,6 +842,31 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Enter the ready state, mounting the canvas. When we arrive from a non-ready
+   * status a *fresh* canvas is created, so drop the reveal cover and wait for
+   * its {@link BrowseCanvasComponent.firstViewReady}; an in-place refresh of an
+   * already-ready canvas (e.g. a subset cull re-binning in place) keeps the same
+   * canvas, so leave the cover state alone or it would strand a working view
+   * (the existing canvas won't re-emit the one-shot signal).
+   */
+  private enterReady(): void {
+    if (this.status() !== 'ready') this.revealed.set(false);
+    this.status.set('ready');
+  }
+
+  /** The canvas finished painting its opening view (fit + top-view thumbnails);
+   *  uncover it. */
+  onCanvasFirstView(): void {
+    this.revealed.set(true);
+  }
+
+  /** Message on the pre-reveal cover: names thumbnails for media that paint
+   *  them (the case this cover exists for), the projection otherwise. */
+  get preloadMessage(): string {
+    return usesThumbnails(this.mediaType()) ? 'Loading thumbnails…' : 'Loading projection…';
+  }
+
   private loadProjection(): void {
     this.status.set('loading');
     this.polling = false;
@@ -868,7 +903,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.tileCache.setContentVersion(meta.content_version ?? 0);
 
     if (meta.point_count > 0) {
-      this.status.set('ready');
+      this.enterReady();
       return;
     }
     if (meta.status === 'error') {
@@ -908,7 +943,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
             this.tileCache.setProjectionId(meta.projection_id);
             if (meta.point_count > 0) {
               this.polling = false;
-              this.status.set('ready');
+              this.enterReady();
               return;
             }
             if (meta.status === 'error') {

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -127,6 +127,22 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(errEl!.textContent).toContain('projection exploded');
   });
 
+  it('covers the canvas until it reports its opening view is painted', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+
+    // On entry the canvas is covered so the user never sees a half-loaded grid.
+    expect(component.revealed()).toBe(false);
+    // The cover names the projection for pure-density media (the canary DS is
+    // audio); image/video datasets — the case this cover exists for — would read
+    // "Loading thumbnails…" instead.
+    expect(component.preloadMessage).toBe('Loading projection…');
+
+    // The canvas signals its opening view is fully painted → uncover it.
+    component.onCanvasFirstView();
+    expect(component.revealed()).toBe(true);
+  });
+
   it('engages region-draw while Shift is held, releasing on keyup and blur', async () => {
     await settleZoneless(fixture);
     const component = fixture.componentInstance;

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -221,6 +221,12 @@ function makeHelpers(page: Page): Helpers {
       await page.waitForURL(/browse/i, { timeout: 15000 }).catch(() => {});
       // First visit builds the UMAP projection (progress bar); wait it out.
       await page.waitForSelector('.browse-content, canvas', { timeout: 180000 });
+      // The canvas mounts under an opaque cover that only lifts once the opening
+      // view's tiles + thumbnails have painted; wait for it to detach so the shot
+      // frames the finished map, not the "Loading thumbnails…" cover.
+      await page
+        .waitForSelector('.browse-preload-cover', { state: 'detached', timeout: 180000 })
+        .catch(() => {});
       await wait(3000);
     },
   };


### PR DESCRIPTION
## Problem

Opening **Browse** on a large image dataset flashed a useless intermediate view: after the projection-build progress bar, the canvas mounted and showed a thumbnail-less grey density grid, which then filled in with thumbnails as they streamed. Since *we* choose when to show the canvas, there's no reason to reveal it before the opening view — the one view we know we'll start at — is actually painted.

## Change

The browse canvas now holds a cover over itself until its opening view is genuinely ready, then reveals the finished view in one step.

- **`browse-canvas.component.ts`** — new one-shot `firstViewReady` output. After each draw, `maybeReportFirstView()` checks that (a) the fit ran against the *real* canvas size (not the 800×600 pre-layout fallback), (b) every density tile under the viewport has loaded, and (c) for image/video, every on-screen representative thumbnail has decoded or failed. Each pending tile/thumbnail lands with its own redraw, so a later draw re-runs the check until the view is whole. A 12s backstop timer (armed for all media types) releases the cover if a tile or thumbnail hard-fails, falling back to the old show-then-fill behaviour rather than stranding. Pure-density media (audio/text) reveal as soon as the visible tiles are in.
- **`browse-view.component.*`** — the canvas mounts as soon as the projection is ready (so it lays out and fetches at its true final size), but a `revealed` signal keeps an opaque cover over the whole content until `firstViewReady` fires. `enterReady()` drops the cover only when a *fresh* canvas mounts; an in-place refresh of an already-ready canvas (e.g. a subset cull) leaves it untouched so a working view is never re-covered. Keyboard shortcuts are gated on `revealed()` too.
- **`capture.ts`** (screenshot harness) — waits for the cover to detach so a future reshoot frames the finished map, not the transient loading cover.

Net time to a usable canvas is about the same; the difference is the user sees a spinner instead of a half-rendered canvas, then the finished view.

## Tests

- Added a `browse-view` zoneless unit test covering the cover/reveal surface (starts covered, message reflects media type, uncovers on `firstViewReady`).
- `./run-tests.sh frontend` green: build OK, 948 unit tests pass, audit clean, plus the Python-side linters (ruff/pyright/deptry/pip-audit/OpenAPI/wiring) that run in its preamble. Change is frontend-only, so no Python tests are affected.

No screenshot reshoot needed — the steady-state browse map the `browse-view` shot captures is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhw4iQ1kMqT47m8ctW57F)_