### PR TITLE
Spacebar toggles selection of the in-view item in bin detail view

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -654,6 +654,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
         event.preventDefault();
         this.moveFocus(1, 0);
         break;
+      case ' ':
+        event.preventDefault();
+        this.onPreviewClick();
+        break;
       case '+':
       case '=':
         event.preventDefault();

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -123,6 +123,7 @@ export class KeyboardHelpModalComponent implements OnInit {
           title: 'Bin details window',
           shortcuts: [
             { keys: ['↑ ↓ ← →'], description: 'Move the viewed item within the grid' },
+            { keys: ['Space'], description: 'Select / deselect the viewed item' },
             { keys: ['+'], description: 'Make the detail image bigger' },
             { keys: ['-'], description: 'Make the detail image smaller' },
             { keys: ['Ctrl', 'A'], description: 'Select all items in this bin' },


### PR DESCRIPTION
## What changed

In the bin detail popup, you can already walk the grid with the arrow keys to change which item is in view. This adds **Space** to select/deselect that in-view item without leaving the keyboard.

- `browse-bin-popup.component.ts`: the `document:keydown` handler now treats `' '` (Space) by calling `onPreviewClick()`, which toggles the item currently shown in the preview pane. `preventDefault()` stops the page from scrolling. This reuses the exact same selection path as clicking the big detail image (and matches the existing `onPreviewKeydown`/`onEntryKeydown` handlers, which already bind Enter/Space to toggle). Works for both multi-member bins (toggles the arrow-focused item) and singleton/preview-only bins (toggles the lone member).
- `keyboard-help-modal.component.ts`: added a `Space → Select / deselect the viewed item` row to the "Bin details window" section.

## Testing

`./run-tests.sh frontend` — build OK, `npm audit` clean, Vitest 955 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLxFkQUiDAw4z3WhLsc7cJ)_