### PR TITLE
Fix residual bin-popup flash: reveal only after the measured clamp

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -152,11 +152,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   /** Clamped on-screen position; starts at the anchor and is nudged inward. */
   left = 0;
   top = 0;
-  /** False until the popup has been clamped to its on-screen spot; the panel is
-   *  kept ``visibility: hidden`` until then so the user never sees it flash at the
-   *  raw summon point (which may be half off-screen) before it's placed. Reset on
-   *  every genuine re-summon so the move to a new bin also stays hidden until
-   *  re-clamped. */
+  /** False until the popup has been clamped *and* measured at its on-screen spot;
+   *  the panel is kept ``visibility: hidden`` until then so the user never sees it
+   *  flash at the raw summon point (which may be half off-screen) or at a computed
+   *  clamp that the post-render measurement then corrects. Flipped true only in
+   *  {@link nudgeOnScreen} (the rAF after {@link place}), once the rendered panel
+   *  has been measured and any residual overflow removed, and only once settings
+   *  have loaded so the size is final. Reset on every genuine re-summon so the
+   *  move to a new bin also stays hidden until re-placed. */
   placed = false;
   /** Max width (px) the popup may take; shrunk to fit a narrow visible region. */
   maxWidthPx = GRID_COLUMN_WIDTH;
@@ -920,9 +923,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     // unplaced keeps the popup hidden until then rather than showing it unclamped.
     if (!this.panelRef?.nativeElement) return;
     this.clampInto(this.left, this.top);
-    // The clamp has settled the on-screen position, so reveal the popup now; the
-    // rAF nudge below is only a sub-pixel correction that won't visibly move it.
-    this.placed = true;
+    // Flush the freshly-clamped position and the size caps clampInto just set
+    // (bodyCapPx/previewCapPx/maxWidthPx) to the DOM. This runs in a bare
+    // setTimeout, so under zoneless change detection nothing else schedules a
+    // render; without this markForCheck the clamp would never reach the DOM
+    // until some unrelated event happened to tick CD. The popup stays hidden
+    // (``placed`` is still false) — the actual reveal happens in nudgeOnScreen,
+    // on the next frame, once the *rendered* panel has been measured and any
+    // residual overflow corrected. Revealing here, before that measurement, was
+    // what let the popup flash at the computed clamp and then jump to the
+    // corrected spot.
+    this.cdr.markForCheck();
     requestAnimationFrame(() => this.nudgeOnScreen());
   }
 
@@ -939,17 +950,43 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     const regionTop = Math.max(b ? b.top : 0, 0);
     const regionRight = Math.min(b ? b.right : window.innerWidth, window.innerWidth);
     const regionBottom = Math.min(b ? b.bottom : window.innerHeight, window.innerHeight);
+    // Correct off the panel's measured *size* applied to its intended position
+    // (this.left/this.top), not the panel's currently-rendered absolute rect: the
+    // clamp from place() may not have painted yet, so rect.right/rect.bottom can
+    // still describe the previous spot. Using this.left + width keeps the
+    // correction right regardless of paint timing.
+    const width = rect.width;
+    const height = rect.height;
     let l = this.left;
     let t = this.top;
     // Pull in from the far edges first, then guarantee the near edges, so a popup
     // larger than the region pins to top-left (losing the far edge, not the near).
-    if (rect.right > regionRight - EDGE_MARGIN) l -= rect.right - (regionRight - EDGE_MARGIN);
-    if (rect.bottom > regionBottom - EDGE_MARGIN) t -= rect.bottom - (regionBottom - EDGE_MARGIN);
+    if (this.left + width > regionRight - EDGE_MARGIN) {
+      l -= this.left + width - (regionRight - EDGE_MARGIN);
+    }
+    if (this.top + height > regionBottom - EDGE_MARGIN) {
+      t -= this.top + height - (regionBottom - EDGE_MARGIN);
+    }
     l = Math.max(regionLeft + EDGE_MARGIN, l);
     t = Math.max(regionTop + EDGE_MARGIN, t);
-    if (l !== this.left || t !== this.top) {
-      this.left = l;
-      this.top = t;
+    const moved = l !== this.left || t !== this.top;
+    this.left = l;
+    this.top = t;
+    // Reveal now that the panel is measured and corrected, so the first painted
+    // frame is already at the final on-screen spot. Gate the first reveal on the
+    // settings being loaded: the popup's size (grid thumbnail size, whether the
+    // metadata column shows, the preview-pane size) all come from settings, so
+    // revealing before they arrive would show the popup at default sizes and then
+    // re-clamp/move it when they land. The settings effect calls place() again
+    // once settings resolve, which reveals then. Browse only ever mounts with
+    // settings present, so this never strands the popup permanently hidden.
+    const settingsReady = this.settingsState.settingsSignal() != null;
+    if (!this.placed) {
+      if (settingsReady) {
+        this.placed = true;
+        this.cdr.markForCheck();
+      }
+    } else if (moved) {
       this.cdr.markForCheck();
     }
   }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -12,6 +12,17 @@ import { configureZoneless } from '../../testing/zoneless-testbed';
 import { settleZoneless } from '../../testing/settle-resource';
 
 /**
+ * Drain several zoneless settle passes. The popup places itself across a chain
+ * of `setTimeout(place)` → `requestAnimationFrame(nudge)` → `markForCheck`, and
+ * the `setTimeout` is itself scheduled by the async CD tick that runs *after*
+ * the first settle's own macrotask — so a single `settleZoneless` can return
+ * before the reveal chain has run. A few passes flush it deterministically.
+ */
+async function settlePasses(fixture: ComponentFixture<unknown>, passes = 3): Promise<void> {
+  for (let i = 0; i < passes; i++) await settleZoneless(fixture);
+}
+
+/**
  * Zoneless positioning guard for the VTSBrowse bin detail popup.
  *
  * The popup opens hidden and reveals itself only after its position has been
@@ -94,7 +105,7 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
 
   it('reveals the popup at its clamped spot once measured, no manual detectChanges', async () => {
     const fixture = makeFixture();
-    await settleZoneless(fixture);
+    await settlePasses(fixture);
 
     const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
     expect(panel).not.toBeNull();
@@ -116,7 +127,7 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // reveal at default sizes and then re-clamp when they arrive.
     settings.set(null);
     const fixture = makeFixture();
-    await settleZoneless(fixture);
+    await settlePasses(fixture);
 
     const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
     expect(panel.style.visibility).toBe('hidden');
@@ -124,7 +135,7 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // Settings resolve through the same signal the app writes; the popup's
     // settings effect re-places and reveals.
     settings.set({});
-    await settleZoneless(fixture);
+    await settlePasses(fixture);
     expect(panel.style.visibility).toBe('visible');
 
     fixture.destroy();

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BrowseBinPopupComponent } from './browse-bin-popup.component';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
+import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
+import { ActiveContextService } from '../../services/active-context.service';
+import { SettingsStateService } from '../../services/settings-state.service';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+/**
+ * Zoneless positioning guard for the VTSBrowse bin detail popup.
+ *
+ * The popup opens hidden and reveals itself only after its position has been
+ * clamped on-screen and the rendered panel measured (see `place()` /
+ * `nudgeOnScreen()`). Under zoneless change detection those steps run in a bare
+ * `setTimeout` + `requestAnimationFrame`, with no change detection attached, so
+ * the reveal must schedule its own `markForCheck()` or the `visibility` binding
+ * silently goes stale — the popup would stay invisible, or (before the reveal
+ * was moved past the measurement) flash at the un-corrected spot. This spec
+ * drives the real component through the production channel and asserts on the
+ * rendered DOM, with NO manual `detectChanges()`, so a missing notification
+ * surfaces as a stale style rather than being papered over.
+ */
+describe('BrowseBinPopupComponent (zoneless positioning)', () => {
+  let settings: ReturnType<typeof signal<Record<string, unknown> | null>>;
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+
+  function makeFixture(): ComponentFixture<BrowseBinPopupComponent> {
+    const selectionStub: Partial<BrowseSelectionService> = {
+      version: signal(0) as unknown as BrowseSelectionService['version'],
+      has: () => false,
+      selectedCountIn: () => 0,
+      addAll: () => {},
+      removeAll: () => {},
+      remove: () => {},
+    };
+    const metadataStub: Partial<MediaMetadataCacheService> = {
+      version$: of(0),
+      get: () => undefined,
+      ensureLoaded: () => {},
+    };
+    const activeContextStub: Partial<ActiveContextService> = {
+      mediaUrl: (p: string) => p,
+    };
+    const settingsStub: Partial<SettingsStateService> = {
+      settingsSignal: settings as unknown as SettingsStateService['settingsSignal'],
+      load: () => {},
+      update: () => of({}) as ReturnType<SettingsStateService['update']>,
+    };
+
+    TestBed.resetTestingModule();
+    configureZoneless({
+      imports: [BrowseBinPopupComponent],
+      providers: [
+        { provide: BrowseSelectionService, useValue: selectionStub },
+        { provide: MediaMetadataCacheService, useValue: metadataStub },
+        { provide: ActiveContextService, useValue: activeContextStub },
+        { provide: SettingsStateService, useValue: settingsStub },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(BrowseBinPopupComponent);
+    // A singleton bin summoned far off the right/bottom edge of a small canvas:
+    // the raw anchor (5000, 5000) is well outside the 400×400 region, so a
+    // correct placement must pull the popup back inside it.
+    fixture.componentRef.setInput('memberIds', [1]);
+    fixture.componentRef.setInput('repId', 1);
+    fixture.componentRef.setInput('mediaType', 'image');
+    fixture.componentRef.setInput('bounds', new DOMRect(0, 0, 400, 400));
+    fixture.componentRef.setInput('x', 5000);
+    fixture.componentRef.setInput('y', 5000);
+    return fixture;
+  }
+
+  beforeEach(() => {
+    settings = signal<Record<string, unknown> | null>({});
+    // Run requestAnimationFrame callbacks on a microtask so `settleZoneless`'s
+    // macrotask + `whenStable` drain them deterministically (jsdom's real rAF
+    // fires on a ~16ms timer that would race the settle). Deferring rather than
+    // running synchronously avoids re-entrancy if a callback re-schedules rAF.
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      void Promise.resolve().then(() => cb(0));
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
+  it('reveals the popup at its clamped spot once measured, no manual detectChanges', async () => {
+    const fixture = makeFixture();
+    await settleZoneless(fixture);
+
+    const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
+    expect(panel).not.toBeNull();
+    // The reveal must have reached the DOM through scheduled change detection
+    // alone: this is the zoneless staleness guard for the reveal's markForCheck.
+    expect(panel.style.visibility).toBe('visible');
+    // …and it must sit inside the visible region, not at the raw off-screen
+    // anchor it was summoned from. A revealed-but-unclamped popup would still
+    // read 5000px here.
+    expect(parseFloat(panel.style.left)).toBeLessThan(400);
+    expect(parseFloat(panel.style.top)).toBeLessThan(400);
+
+    fixture.destroy();
+  });
+
+  it('stays hidden until settings load, then reveals', async () => {
+    // Cold open: settings not yet resolved. The popup's size (thumbnail size,
+    // metadata column, preview pane) all come from settings, so it must not
+    // reveal at default sizes and then re-clamp when they arrive.
+    settings.set(null);
+    const fixture = makeFixture();
+    await settleZoneless(fixture);
+
+    const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
+    expect(panel.style.visibility).toBe('hidden');
+
+    // Settings resolve through the same signal the app writes; the popup's
+    // settings effect re-places and reveals.
+    settings.set({});
+    await settleZoneless(fixture);
+    expect(panel.style.visibility).toBe('visible');
+
+    fixture.destroy();
+  });
+});


### PR DESCRIPTION
## What was wrong

The VTSBrowse bin detail popup still flashed at the wrong spot despite the earlier `visibility: hidden`-until-placed guard (PR #2149). Two zoneless-specific defects were behind it:

1. **Reveal happened before measurement.** `place()` clamped the popup with *computed* sizes, immediately set `placed = true`, and only *then* scheduled the rAF `nudgeOnScreen()` that measures the rendered panel and corrects residual overflow. So the popup could appear at the computed clamp and then jump when the measured correction landed.
2. **Reveal never scheduled change detection.** The app is zoneless (`provideZonelessChangeDetection()`). `place()` runs in a bare `setTimeout`, mutated the plain `placed`/`left`/`top` fields, and never called `markForCheck()` — so the reveal rode a later, unrelated CD tick, making its timing (and paint position) nondeterministic.

## The fix

- Move the reveal into `nudgeOnScreen()` (the post-render rAF), so `placed` flips true only once the panel has been measured and corrected — the first painted frame is already at the final spot.
- Base the overflow correction on the intended position plus the *measured size* (`this.left + width`) rather than the panel's currently-rendered absolute rect, so it's robust to paint timing.
- Call `markForCheck()` when revealing (and when the corrective nudge moves the panel), so the reveal reliably reaches the DOM under zoneless.
- Gate the first reveal on settings being loaded, so a cold open doesn't reveal at default sizes and then re-clamp when the real view prefs (thumbnail size, metadata column, preview-pane size) arrive.

## Tests

New `browse-bin-popup.zoneless.spec.ts` drives the real component through the production channel (no manual `detectChanges()`) and asserts on the rendered DOM:
- reveals at its clamped spot (not the raw off-screen anchor) via scheduled CD alone — guards the reveal's `markForCheck()`;
- stays hidden until settings resolve, then reveals.

Full suite green: `ALL 5366 TESTS PASSED`; frontend gate (build:prod + 957 Vitest tests) clean.

No screenshot reshoot needed — this changes *when* the popup appears, not how it looks once placed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fdXRxZzP5qGR1Hc38zUnC)_