### PR TITLE
Align metadata Copy button with the value, not the category label

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -64,35 +64,35 @@
       <div class="bin-popup-meta-col" [style.width.px]="metadataColWidth">
         <div class="bin-popup-meta-grid">
           <div class="bin-popup-meta-item">
-            <div class="bin-popup-meta-text">
-              <span class="bin-popup-meta-label">Name</span>
+            <span class="bin-popup-meta-label">Name</span>
+            <div class="bin-popup-meta-value-row">
               <span class="bin-popup-meta-value">{{ metadataName }}</span>
+              <vt-copy-detail-button [value]="metadataName" label="Name" />
             </div>
-            <vt-copy-detail-button [value]="metadataName" label="Name" />
           </div>
           <div class="bin-popup-meta-item">
-            <div class="bin-popup-meta-text">
-              <span class="bin-popup-meta-label">Media Type</span>
+            <span class="bin-popup-meta-label">Media Type</span>
+            <div class="bin-popup-meta-value-row">
               <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
+              <vt-copy-detail-button [value]="metadataMediaType | titlecase" label="Media Type" />
             </div>
-            <vt-copy-detail-button [value]="metadataMediaType | titlecase" label="Media Type" />
           </div>
           @for (entry of metadataCustom | keyvalue; track entry.key) {
             <div class="bin-popup-meta-item">
-              <div class="bin-popup-meta-text">
-                <span class="bin-popup-meta-label">{{ entry.key }}</span>
+              <span class="bin-popup-meta-label">{{ entry.key }}</span>
+              <div class="bin-popup-meta-value-row">
                 <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
+                <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
               </div>
-              <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
             </div>
           }
           @if (metadataMd5) {
             <div class="bin-popup-meta-item">
-              <div class="bin-popup-meta-text">
-                <span class="bin-popup-meta-label">MD5</span>
+              <span class="bin-popup-meta-label">MD5</span>
+              <div class="bin-popup-meta-value-row">
                 <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
+                <vt-copy-detail-button [value]="metadataMd5" label="MD5" />
               </div>
-              <vt-copy-detail-button [value]="metadataMd5" label="MD5" />
             </div>
           }
         </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -171,20 +171,21 @@
   gap: var(--space-2xs);
 }
 
+// Label stacked above the value + Copy button row.
 .bin-popup-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+// Value + per-item Copy button, aligned so the button sits beside the value
+// (the actual metadata) rather than the category label above it.
+.bin-popup-meta-value-row {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   gap: var(--space-2xs);
-  min-width: 0;
-}
-
-// Label + value stack, left of the per-item Copy button.
-.bin-popup-meta-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -202,6 +203,8 @@
   font-size: var(--font-xs);
   color: var(--text-primary);
   word-break: break-word;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 // MD5 is a long hex string; render it monospace so it reads as an opaque digest.

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -86,34 +86,34 @@
       @if (showMetadata()) {
         <div class="metadata-grid">
           <div class="metadata-item">
-            <div class="metadata-item-text">
-              <span class="metadata-label">Name</span>
+            <span class="metadata-label">Name</span>
+            <div class="metadata-value-row">
               <span class="metadata-value">{{ media.filename || 'Media #' + media.id }}</span>
+              <vt-copy-detail-button [value]="media.filename || 'Media #' + media.id" label="Name" />
             </div>
-            <vt-copy-detail-button [value]="media.filename || 'Media #' + media.id" label="Name" />
           </div>
           <div class="metadata-item">
-            <div class="metadata-item-text">
-              <span class="metadata-label">Media Type</span>
+            <span class="metadata-label">Media Type</span>
+            <div class="metadata-value-row">
               <span class="metadata-value">{{ mediaType | titlecase }}</span>
+              <vt-copy-detail-button [value]="mediaType | titlecase" label="Media Type" />
             </div>
-            <vt-copy-detail-button [value]="mediaType | titlecase" label="Media Type" />
           </div>
           @for (entry of customMetadata | keyvalue; track entry.key) {
             <div class="metadata-item">
-              <div class="metadata-item-text">
-                <span class="metadata-label">{{ entry.key }}</span>
+              <span class="metadata-label">{{ entry.key }}</span>
+              <div class="metadata-value-row">
                 <span class="metadata-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
+                <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
               </div>
-              <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
             </div>
           }
           <div class="metadata-item">
-            <div class="metadata-item-text">
-              <span class="metadata-label">MD5</span>
+            <span class="metadata-label">MD5</span>
+            <div class="metadata-value-row">
               <span class="metadata-value metadata-md5">{{ media.md5 }}</span>
+              <vt-copy-detail-button [value]="media.md5 || ''" label="MD5" />
             </div>
-            <vt-copy-detail-button [value]="media.md5 || ''" label="MD5" />
           </div>
         </div>
       }

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -190,19 +190,21 @@
   padding: var(--space-2xs) 0;
 }
 
+// Label stacked above the value + Copy button row.
 .metadata-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+// Value + per-item Copy button, aligned so the button sits beside the value
+// (the actual metadata) rather than the category label above it.
+.metadata-value-row {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   gap: var(--space-2xs);
-}
-
-// Label + value stack, left of the per-item Copy button.
-.metadata-item-text {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs);
-  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -217,6 +219,8 @@
   font-size: var(--font-md);
   color: var(--text-primary);
   word-break: break-all;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .metadata-md5 {


### PR DESCRIPTION
The per-item **Copy** buttons in the center-panel metadata tray and the VTSBrowse bin-popup looked a little high: they sat next to the uppercase category label rather than the actual metadata value.

## What changed

Each metadata item previously rendered the label + value as a column stack, with the Copy button as a sibling in a `flex-direction: row` container using `align-items: flex-start`. That top-aligned the button with the small uppercase label.

Now each item stacks the category label above a `*-value-row` that holds the value and its Copy button together, so the button aligns with the value line (the actual metadata):

- `center-panel.component.html` / `.scss` — `.metadata-item` is now a column; new `.metadata-value-row` wraps value + button.
- `browse-bin-popup.component.html` / `.scss` — `.bin-popup-meta-item` is now a column; new `.bin-popup-meta-value-row` wraps value + button.

The old `.metadata-item-text` / `.bin-popup-meta-text` wrapper classes are removed (no other code referenced them).

## Testing

- `./run-tests.sh frontend` — Angular `build:prod` OK, `npm audit` OK, 955 Vitest unit tests pass.
- No doc screenshots frame these surfaces, so no reshoot queue entry was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHaJxPxKK42RAe23r3qxD8)_