### PR TITLE
Hide grid thumbnail names at the smallest icon sizes

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -343,6 +343,9 @@
   padding: 2px;
   border-radius: var(--radius-sm);
   width: var(--popup-cell, 80px);
+  // Query container so the name can hide itself at small icon sizes (below).
+  container-type: inline-size;
+  container-name: bin-cell;
   // Animate the "viewed" enlarge (below) so items grow/settle smoothly rather
   // than popping as focus walks the grid.
   transition: transform var(--transition-base);
@@ -431,6 +434,16 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+// At the two smallest icon sizes (XS/S, ~46px content-box) the name truncates to
+// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
+// The reserved row height (GRID_LABEL_HEIGHT in the .ts) is dropped in lockstep
+// so hidden names don't leave an empty gap under each thumbnail.
+@container bin-cell (max-width: 60px) {
+  .bin-popup-name {
+    display: none;
+  }
 }
 
 .sr-only {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -17,6 +17,11 @@ import type { MediaBatchResponse } from '../../generated/api-client/models/media
 
 /** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
 const GRID_LABEL_HEIGHT = 18;
+/** Goal width (px) at/above which grid thumbnails still show their name. Below
+ *  this (the XS/S icon sizes) the name truncates to a useless "a…", so the SCSS
+ *  hides it (``@container … (max-width: 60px)``) and {@link rowSize} drops the
+ *  reserved label height to match, keeping the grid gap-free. */
+const GRID_NAME_MIN_WIDTH = 65;
 /** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
 const GRID_GAP = 4;
 /** Width (px) available to lay out cells inside the popup's scroll column (≈ its
@@ -494,9 +499,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual grid row (a row of cells plus its labels). */
+  /** Pixel stride of one virtual grid row (a row of cells plus its labels). At
+   *  the smallest icon sizes the name is hidden (see {@link GRID_NAME_MIN_WIDTH}),
+   *  so its reserved height is dropped to keep rows flush. */
   get rowSize(): number {
-    return this.gridGoalWidth + GRID_LABEL_HEIGHT + GRID_GAP;
+    const labelHeight = this.gridGoalWidth >= GRID_NAME_MIN_WIDTH ? GRID_LABEL_HEIGHT : 0;
+    return this.gridGoalWidth + labelHeight + GRID_GAP;
   }
 
   /** Height (px) the grid takes: just enough for its rows, capped (to the room

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -184,6 +184,9 @@
   cursor: pointer;
   color: var(--text-vote);
   line-height: 1.3;
+  // Query container so the name can hide itself at small icon sizes (below).
+  container-type: inline-size;
+  container-name: bsp-cell;
 
   &:hover {
     color: var(--text-primary);
@@ -241,4 +244,12 @@
   text-align: center;
   line-height: 1.2;
   flex-shrink: 0;
+}
+
+// At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
+// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
+@container bsp-cell (max-width: 60px) {
+  .bsp-name-grid {
+    display: none;
+  }
 }

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.scss
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.scss
@@ -9,6 +9,9 @@
   transition: background var(--transition-fast);
   min-width: 0;
   overflow: hidden;
+  // Query container so the name can hide itself at small icon sizes (below).
+  container-type: inline-size;
+  container-name: media-cell;
 
   &:hover {
     background: var(--bg-hover);
@@ -82,6 +85,15 @@
   width: 100%;
   text-align: center;
   line-height: 1.2;
+}
+
+// At the two smallest icon sizes (XS/S, whose cells resolve to a content-box
+// width of ~42-46px) the name truncates to a useless "a…", so hide it and let
+// the grid pack more thumbnails per row. M and up (content-box ≥72px) keep it.
+@container media-cell (max-width: 60px) {
+  .media-name-grid {
+    display: none;
+  }
 }
 
 .media-score {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -81,6 +81,9 @@ h3 {
   cursor: pointer;
   color: var(--text-vote);
   line-height: 1.3;
+  // Query container so the name can hide itself at small icon sizes (below).
+  container-type: inline-size;
+  container-name: vote-cell;
 
   &:hover {
     color: var(--text-primary);
@@ -144,4 +147,12 @@ h3 {
   text-align: center;
   line-height: 1.2;
   flex-shrink: 0;
+}
+
+// At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
+// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
+@container vote-cell (max-width: 60px) {
+  .vote-name-grid {
+    display: none;
+  }
 }


### PR DESCRIPTION
## What & why

At the two smallest thumbnail sizes (XS/S), the name label under each thumbnail truncates to a useless `a…` and eats vertical space a user is trying to reclaim to fit *more* thumbnails on screen. This hides the name below a small cell threshold and reclaims that space.

## Approach

The name is hidden with a **per-cell container query** rather than a JS flag, so it self-adjusts to the actual rendered cell width and needs no new component inputs. Each grid cell already gets its width from the `--grid-goal-width` (`--popup-cell`) variable driven by the XS/S/M/L/XL size control, so a uniform `@container … (max-width: 60px)` cleanly separates XS/S (content-box ≤ ~46px) from M and up (≥ ~72px).

Applied to all four thumbnail grids that render a name under a thumbnail:
- Left media list (`.media-name-grid`)
- Right vote list (`.vote-name-grid`)
- Browse Selection panel (`.bsp-name-grid`)
- Bin popup (`.bin-popup-name`)

## Row-height packing

- **Left media list** measures its virtual row stride from a real rendered card, so the tighter card auto-packs with no code change.
- **Bin popup** computes its row stride, so `rowSize` now drops the reserved 18px label height (`GRID_LABEL_HEIGHT`) below `GRID_NAME_MIN_WIDTH` so hidden names leave no empty gap.

On the original heuristic ("hide when text is ⅔ the thumbnail height"): it would essentially never fire, since the name text is only ~13px tall vs the 25px minimum thumbnail. The real trigger is width-based truncation, which is what this uses. Per discussion, names are hidden at XS and S; M and up keep them.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright/build all pass; frontend build OK; 955 Vitest tests pass.

No doc screenshots frame a small-icon grid (the `results-grid` shot uses the default M size), so there's no screenshot drift to reshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD1qhu3qXKaMD3Q2SBjWwM)_