### PR TITLE
Fix info-icon tooltip: clicking now shows/toggles instead of blocking it

### DIFF
--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.spec.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.spec.ts
@@ -1,0 +1,112 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FieldHintIconComponent } from './field-hint-icon.component';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('FieldHintIconComponent', () => {
+  let fixture: ComponentFixture<FieldHintIconComponent>;
+  let component: FieldHintIconComponent;
+
+  const iconSpan = (): HTMLElement =>
+    fixture.nativeElement.querySelector('.field-hint-icon') as HTMLElement;
+  const tooltip = (): HTMLElement | null =>
+    fixture.nativeElement.querySelector('.field-hint-tooltip');
+
+  beforeEach(async () => {
+    await configureZoneless({ imports: [FieldHintIconComponent] }).compileComponents();
+    fixture = TestBed.createComponent(FieldHintIconComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('hint', 'Explains the field');
+    await settleZoneless(fixture);
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+    expect(tooltip()).toBeNull();
+  });
+
+  it('shows the tooltip immediately on click (no hover delay)', async () => {
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+
+    expect(component.visible()).toBe(true);
+    expect(tooltip()?.textContent).toContain('Explains the field');
+  });
+
+  it('toggles the tooltip off on a second click', async () => {
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(true);
+
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(false);
+    expect(tooltip()).toBeNull();
+  });
+
+  it('keeps a click-opened tooltip open when the pointer leaves the icon', async () => {
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(true);
+
+    iconSpan().dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    await settleZoneless(fixture);
+
+    // A click pins the tooltip; moving the mouse off the icon must not close it.
+    expect(component.visible()).toBe(true);
+    expect(tooltip()).not.toBeNull();
+  });
+
+  it('closes a click-opened tooltip when clicking elsewhere', async () => {
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(true);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settleZoneless(fixture);
+
+    expect(component.visible()).toBe(false);
+    expect(tooltip()).toBeNull();
+  });
+
+  it('shows after a delay on hover, then hides on mouse leave', async () => {
+    vi.useFakeTimers();
+    try {
+      iconSpan().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      // Not shown yet: the hover has a delay.
+      expect(component.visible()).toBe(false);
+
+      vi.advanceTimersByTime(600);
+      expect(component.visible()).toBe(true);
+
+      iconSpan().dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      expect(component.visible()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not leave the tooltip stuck open after a hover+click sequence', async () => {
+    // Hover to open, then click, then click again to dismiss, then move away.
+    iconSpan().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(true);
+
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(false);
+  });
+
+  it('closes the tooltip on Escape', async () => {
+    iconSpan().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(true);
+
+    iconSpan().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+    await settleZoneless(fixture);
+    expect(component.visible()).toBe(false);
+  });
+});

--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -1,5 +1,14 @@
 
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
 
 const HOVER_DELAY_MS = 500;
 
@@ -17,9 +26,9 @@ const HOVER_DELAY_MS = 500;
       (mouseenter)="onMouseEnter()"
       (mouseleave)="onMouseLeave()"
       (focus)="onMouseEnter()"
-      (blur)="hide()"
+      (blur)="onBlur()"
       (click)="onClick($event)"
-      (keydown.escape)="hide()"
+      (keydown.escape)="onEscape($event)"
       >
       <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true" focusable="false">
         <circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor" stroke-width="1.3" />
@@ -86,38 +95,66 @@ export class FieldHintIconComponent {
   readonly hint = input('');
   readonly ariaLabel = input('');
 
-  readonly visible = signal(false);
+  /** Sticky state set by clicking the icon; stays open until dismissed. */
+  private readonly pinned = signal(false);
+  /** Transient state driven by hover/focus; cleared as soon as you leave. */
+  private readonly hovered = signal(false);
+
+  /** The tooltip shows if it's pinned by a click OR currently hovered. */
+  readonly visible = computed(() => this.pinned() || this.hovered());
+
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
 
   onMouseEnter(): void {
+    // Already showing (pinned or hovered): nothing to schedule.
     if (this.visible()) return;
     this.clearTimer();
     this.hoverTimer = setTimeout(() => {
       this.hoverTimer = null;
-      this.visible.set(true);
+      this.hovered.set(true);
     }, HOVER_DELAY_MS);
   }
 
   onMouseLeave(): void {
+    // Only the transient hover ends here. A click-pinned tooltip stays open so
+    // the user can move the pointer off the icon to read it.
     this.clearTimer();
-    this.visible.set(false);
+    this.hovered.set(false);
   }
 
   onClick(event: MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
     this.clearTimer();
-    this.visible.set(true);
+    // Toggle immediately: show if hidden, dismiss if already showing (from
+    // either a previous click or an in-progress hover).
+    const willShow = !this.visible();
+    this.hovered.set(false);
+    this.pinned.set(willShow);
+  }
+
+  onBlur(): void {
+    this.hide();
+  }
+
+  onEscape(event: Event): void {
+    // Only consume Escape when we actually have a tooltip to close, so an
+    // Escape on an idle icon still bubbles up to close a parent modal.
+    if (this.visible()) {
+      event.stopPropagation();
+    }
+    this.hide();
   }
 
   hide(): void {
     this.clearTimer();
-    this.visible.set(false);
+    this.hovered.set(false);
+    this.pinned.set(false);
   }
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
-    if (!this.visible()) return;
+    if (!this.pinned()) return;
     if (!this.elementRef.nativeElement.contains(event.target as Node)) {
       this.hide();
     }


### PR DESCRIPTION
## Problem

The little "?" info icons (`vt-field-hint-icon`) throughout the app only worked on hover. Clicking one felt broken — it didn't reliably surface the explanation and seemed to suppress it.

The click handling had two concrete defects:

1. **Click could never dismiss the tooltip.** `onClick` always forced `visible.set(true)` (no toggle) *and* called `stopPropagation()`, so the `document:click` outside-click closer could never run for the icon you just clicked.
2. **A click-opened tooltip was destroyed the instant the pointer moved off the icon.** `onMouseLeave` unconditionally set `visible = false`, so a tooltip you clicked open vanished before you could move over to read it — reading as "clicking makes it disappear."

## Fix

Split the state into a transient **hover** signal and a sticky **click-pinned** signal, with `visible = pinned || hovered`:

- **Click** shows the tooltip immediately and pins it open; a second click toggles it closed.
- **Hover** still shows after the 500 ms delay and clears on mouse-leave — but no longer tears down a click-pinned tooltip.
- **Outside-click, Escape, and blur** all dismiss a pinned tooltip. Escape only swallows the keypress when a tooltip is actually open, so an Escape on an idle icon still bubbles up to close a parent modal.

## Tests

Added `field-hint-icon.component.spec.ts` (8 cases) covering immediate show-on-click, second-click toggle-off, persistence when the pointer leaves, outside-click / Escape dismissal, delayed hover show/hide, and the hover→click→click sequence. Full `./run-tests.sh frontend` gate is green (965 unit tests, build, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWDgf8HXfo1CPbSwsnePAC)_