### PR TITLE
Fill zoom-out/pan animation ring for thumbnail-less media types

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1006,14 +1006,17 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // margin is bare background (the black border). Instead overscan: snapshot a
     // buffer larger than the viewport — the frozen centre is the already-rendered
     // canvas (free), and the extra ring is re-rendered from the source level's
-    // bins, painting the cached thumbnails the off-view prefetch already warmed.
-    // The shrunk blit then covers the canvas with real content. Zoom-in needs no
-    // overscan (the frame grows past the viewport), so it stays the cheap copy.
+    // bins, painting whatever the off-view prefetch already warmed: cached
+    // thumbnails in thumbnail mode, colour-mapped hexes in flat-density mode
+    // (audio/text). Both come straight from the tile cache, so the ring fills the
+    // margin for every media type rather than only thumbnail ones. The shrunk
+    // blit then covers the canvas with real content. Zoom-in needs no overscan
+    // (the frame grows past the viewport), so it stays the cheap copy.
     const overscan = Math.min(
       BrowseCanvasComponent.SNAP_OVERSCAN_MAX,
       this.animFrom.zoom / this.animTo.zoom,
     );
-    const doOverscan = overscan > 1.01 && this.thumbnailMode;
+    const doOverscan = overscan > 1.01;
     this.snapW = doOverscan ? Math.ceil(this.width * overscan) : this.width;
     this.snapH = doOverscan ? Math.ceil(this.height * overscan) : this.height;
 
@@ -2340,9 +2343,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const maxMarginY = (this.height * (BrowseCanvasComponent.SNAP_OVERSCAN_MAX - 1)) / 2;
     const marginX = Math.min(maxMarginX, Math.abs(target.centerX - this.panAnimFrom.centerX) * z);
     const marginY = Math.min(maxMarginY, Math.abs(target.centerY - this.panAnimFrom.centerY) * z);
-    // The overscan ring is only worth rendering in thumbnail mode (flat-density
-    // cells repaint cheaply and the real frame lands at the end either way).
-    const doBorder = this.thumbnailMode && (marginX > 1 || marginY > 1);
+    // Render the overscan ring for every media type: without it the revealed
+    // edge is bare background (a black gap) until the glide lands. The ring comes
+    // straight from the cached tiles — thumbnails in thumbnail mode, colour-mapped
+    // hexes in flat-density mode (audio/text) — so both slide in real content.
+    const doBorder = marginX > 1 || marginY > 1;
     this.panSnapW = this.width + 2 * Math.ceil(marginX);
     this.panSnapH = this.height + 2 * Math.ceil(marginY);
 


### PR DESCRIPTION
## What & why

Zooming out (or pressing an arrow key to pan) while browsing an **image/video** dataset fills the newly-revealed boundary with a cached ring of thumbnails, so there's no black gap. The same gestures on an **audio/text** dataset (colour-mapped hexes, no thumbnails) left a **black gap** at the boundary during the animation.

The browse-canvas zoom-out and directional-pan animations overscan a frozen snapshot and paint a ring of cached tiles into the revealed margin so the exposed boundary shows real content instead of background. That overscan was gated on `thumbnailMode`, so flat-density (thumbnail-less) media types fell back to a plain viewport-sized snapshot and showed the black margin.

## Fix

Drop the `thumbnailMode` gate in both animation paths:

- `startZoomAnim` — `doOverscan` no longer requires `thumbnailMode` (`browse-canvas.component.ts:1016`).
- `startPanAnim` — `doBorder` no longer requires `thumbnailMode` (`browse-canvas.component.ts:2345`).

`renderSnapshotBorder` is already media-type-agnostic: it draws each cached cell via `drawHex`, which paints a thumbnail in thumbnail mode and a colour-mapped hex in flat-density mode. Neighbour tiles are prefetched (`prefetchNeighbors`) regardless of mode, so the ring fills with colour hexes for audio/text exactly as it does with thumbnails for images/video — straight from the tile cache, no network wait. Comments in both paths were updated to reflect that the ring now covers every media type.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright clean, frontend `build:prod` OK, `npm audit` clean, Vitest 957 passed. No screenshot reshoot needed (animations aren't captured by the static screenshot harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYaMC9GmfjT3FaZhGH7PzP)_