### PR TITLE
Add Info metadata toggle to bin popup for non-preview media (audio)

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -12,7 +12,7 @@
     class="bin-popup-header"
     [class.dragging]="dragging"
     (pointerdown)="onHeaderPointerDown($event)">
-    @if (showPreview) {
+    @if (canToggleMetadata) {
       <button
         type="button"
         class="bin-popup-meta-toggle"
@@ -23,6 +23,8 @@
         [attr.aria-label]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'">
         <vt-icon type="info" [size]="15" />
       </button>
+    }
+    @if (showPreview) {
       <div class="bin-popup-size-group" role="group" aria-label="Detail image size">
         <button
           type="button"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -86,9 +86,10 @@
   }
 }
 
-// Metadata-column toggle: a single square button beside the size group that
-// shows/hides the metadata column left of the preview. Active (column shown)
-// reads as a filled accent chip; inactive is a muted outline like the size buttons.
+// Metadata-column toggle: a single square button in the header that shows/hides
+// the metadata column (left of the preview for thumbnail media, left of the grid
+// otherwise). Active (column shown) reads as a filled accent chip; inactive is a
+// muted outline like the size buttons.
 .bin-popup-meta-toggle {
   display: inline-flex;
   align-items: center;
@@ -153,8 +154,9 @@
 
 // The metadata column: a fixed-width, vertically-scrolling stack of the focused
 // item's Train/Find fields (name, media type, custom-metadata categories, MD5),
-// sitting left of the preview pane. Its width is bound per render; it fills the
-// body height and scrolls internally when the fields overflow.
+// sitting left of the preview pane (thumbnail media) or the member grid (audio /
+// text / document). Its width is bound per render; it fills the body height and
+// scrolls internally when the fields overflow.
 .bin-popup-meta-col {
   height: 100%;
   flex-shrink: 0;

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -332,10 +332,20 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   }
 
   // --- Metadata column ------------------------------------------------------
-  // A column left of the detail-canvas preview carrying the same fields the
-  // Train/Find center panel shows for the focused item (name, media type, custom
-  // metadata, MD5). It attaches to the preview pane — the popup's focused item —
-  // so it only exists for media types that have a preview (image / video).
+  // A column carrying the same fields the Train/Find center panel shows for the
+  // focused item (name, media type, custom metadata, MD5). For thumbnail media
+  // (image / video) it sits left of the detail-canvas preview; for non-preview
+  // media (audio / text / document) it sits left of the member grid and tracks
+  // the hovered/arrowed item, so the user can still read metadata for the item
+  // under the cursor even without a preview pane. It is offered for every media
+  // type, since the fields are media-agnostic.
+
+  /** Whether the metadata toggle (the Info button) is offered. The panel is
+   *  media-agnostic, so it's available for every media type — audio and the
+   *  other non-preview types included — as long as there's an active type. */
+  get canToggleMetadata(): boolean {
+    return !!this.mediaType();
+  }
 
   /** Whether the user has the metadata column shown for the active media type.
    *  Absent entries default to shown, mirroring the center panel's metadata
@@ -346,10 +356,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return value !== false;
   }
 
-  /** Whether the metadata column actually renders: only when there is a preview
-   *  pane (the focused item it sits beside) and the user hasn't hidden it. */
+  /** Whether the metadata column actually renders: the metadata feature is
+   *  offered for this media type and the user hasn't hidden it. */
   get showMetadataColumn(): boolean {
-    return this.showPreview && this.metadataShown;
+    return this.canToggleMetadata && this.metadataShown;
   }
 
   /** Fixed width (px) of the metadata column when shown. */
@@ -363,7 +373,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  settings effect re-clamps the popup, since the width changed. */
   toggleMetadata(): void {
     const mediaType = this.mediaType();
-    if (!this.showPreview || !mediaType) return;
+    if (!mediaType) return;
     const dict = { ...this.metadataShownDict, [mediaType]: !this.metadataShown };
     this.settingsState.update({ popup_metadata_shown: dict } as SettingsUpdate).subscribe();
   }
@@ -825,8 +835,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   // --- Hover: preview the full-res original (image/video) + hear (audio) ----
 
   onEntryEnter(id: number): void {
-    // Thumbnail media: paint the hovered item's full-res original into the pane.
-    if (this.showPreview) this.previewId = id;
+    // Follow the hover: paint the hovered item's full-res original into the pane
+    // (thumbnail media) and drive the metadata column + focus ring to it (every
+    // media type, so audio/text/document read metadata for the item under the
+    // cursor even without a preview pane).
+    this.previewId = id;
     if (this.mediaType() !== 'audio') return;
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
@@ -844,7 +857,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  bin's representative so the pane stays populated. */
   onGridLeave(): void {
     this.stopAudio();
-    if (this.showPreview) this.previewId = this.representativeId();
+    // Fall the focus back to the bin's representative so the pane and metadata
+    // column stay populated (every media type, matching the hover-follow above).
+    this.previewId = this.representativeId();
+    this.cdr.markForCheck();
   }
 
   private stopAudio(): void {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -89,6 +89,13 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
 
   beforeEach(() => {
     settings = signal<Record<string, unknown> | null>({});
+    // jsdom doesn't implement Element.scrollTo; the CDK virtual viewport calls it
+    // when a grid-bearing popup (any multi-item bin, or a non-preview media type
+    // like audio, which always renders the member grid) scrolls to the
+    // representative. Stub it so those popups don't throw during placement.
+    if (!Element.prototype.scrollTo) {
+      (Element.prototype as unknown as { scrollTo: () => void }).scrollTo = () => {};
+    }
     // Run requestAnimationFrame callbacks on a microtask so `settleZoneless`'s
     // macrotask + `whenStable` drain them deterministically (jsdom's real rAF
     // fires on a ~16ms timer that would race the settle). Deferring rather than
@@ -117,6 +124,25 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // read 5000px here.
     expect(parseFloat(panel.style.left)).toBeLessThan(400);
     expect(parseFloat(panel.style.top)).toBeLessThan(400);
+
+    fixture.destroy();
+  });
+
+  it('offers the metadata toggle and column for audio (no preview pane)', async () => {
+    // Audio is a non-thumbnailed type: no magnified preview pane on the canvas or
+    // in the popup. The metadata panel is media-agnostic, though, so the Info
+    // button and the (default-shown) metadata column must still be offered, so
+    // hovering a bin member surfaces its metadata just like it does for images.
+    const fixture = makeFixture();
+    fixture.componentRef.setInput('mediaType', 'audio');
+    fixture.componentRef.setInput('memberIds', [1, 2]);
+    fixture.componentRef.setInput('repId', 1);
+    await settlePasses(fixture);
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('.bin-popup-preview')).toBeNull();
+    expect(root.querySelector('.bin-popup-meta-toggle')).not.toBeNull();
+    expect(root.querySelector('.bin-popup-meta-col')).not.toBeNull();
 
     fixture.destroy();
   });


### PR DESCRIPTION
## What & why

When browsing a non-thumbnailed media type (e.g. audio), right-clicking a bin on the Browse canvas opens the detail popup with a member grid you can hover through. The popup's **Info** button and its metadata column were gated on `showPreview` (image / video only), so audio popups let you *hear* each hovered item but gave you no way to *see* its metadata.

This decouples the metadata panel from the preview pane. The panel is media-agnostic (name, media type, custom-metadata categories, MD5), so it's now offered for every media type — the same Info toggle and default-shown metadata column you already get for images.

## What changed

- **`showMetadataColumn` no longer requires `showPreview`.** New `canToggleMetadata` getter (true for any active media type) drives both the Info button and the column. `toggleMetadata()` is likewise no longer gated on `showPreview`.
- **Layout:** for thumbnail media the column still sits left of the detail-canvas preview; for audio / text / document it sits left of the member grid. The existing `clampInto` gap accounting already handles the no-preview case (one flex gap between column and grid).
- **Hover / arrow focus drives `previewId` for all media types**, so the metadata column and the grid focus ring follow the item under the cursor even when there's no preview pane. `onGridLeave` falls focus back to the bin's representative for every type.
- **Test:** added a zoneless spec asserting audio popups render the Info toggle and the (default-shown) metadata column but no preview pane. Polyfilled `Element.scrollTo` in the spec's `beforeEach` — jsdom lacks it, and the audio path exercises the CDK virtual grid's scroll-to-representative that image-singleton tests never hit.

## Testing

`./run-tests.sh frontend` passes: `build:prod` clean, `npm audit` clean, Vitest 958 passing, plus the ruff/codespell/deptry preamble.

No doc screenshots frame the bin popup metadata surface, so nothing was added to the reshoot queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwTMwipqNmxr94hk7NMufd)_