### PR TITLE
Fix demo-import double-clip redundancy

### DIFF
--- a/tests/datasets/test_demo_double_clip.py
+++ b/tests/datasets/test_demo_double_clip.py
@@ -1,0 +1,88 @@
+"""Characterization test: a clipped demo import runs the clipper twice.
+
+When a demo dataset is created through the importer flow, the clipper is
+dispatched into **two** places:
+
+1. The demo importer's own internal clipping inside ``load_demo_dataset``
+   (``DemoDatasetImporter.run`` forwards ``field_values['clipper']``).
+2. The shared load pipeline's ``_apply_clipper_stage``, because
+   ``_run_importer_in_background`` re-adds ``clipper`` to ``field_values``
+   *and* forwards it to ``_run_origin_load_in_background``.
+
+So for a clipped audio demo (e.g. GTZAN, whose pre-selected default is the
+real ``sound_tiling`` clipper) the clipper runs on the media, then runs again
+on the already-clipped media.  These tests pin that current behavior so the
+redundancy is verifiable; if it is fixed, they should be flipped to assert a
+single dispatch.
+"""
+
+from unittest.mock import patch
+
+
+class TestDemoImportDoubleClip:
+    def test_clipper_dispatched_to_both_importer_and_pipeline(self):
+        """One clipped demo import fans the clipper out to importer + pipeline."""
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.importers.demo import IMPORTER as demo_importer
+
+        captured: dict = {}
+
+        def fake_origin_load(load_fn, origin, **kwargs):
+            # Record the clipper the pipeline would hand to _apply_clipper_stage.
+            captured["pipeline_clipper"] = kwargs.get("clipper")
+            # Drive the importer synchronously the way the real background
+            # thread would, so we also observe the importer's own clipping.
+            load_fn({})
+            return "task-1"
+
+        demo_calls: list = []
+
+        def fake_load_demo(dataset_name, medias, **kwargs):
+            demo_calls.append(kwargs.get("clipper_name"))
+
+        with (
+            patch.object(load_pipeline, "_run_origin_load_in_background", side_effect=fake_origin_load),
+            patch("vtscore.datasets.importers.demo.load_demo_dataset", side_effect=fake_load_demo),
+        ):
+            load_pipeline._run_importer_in_background(
+                demo_importer,
+                {"name": "gtzan_a", "clipper": "sound_tiling", "media_type": "audio"},
+            )
+
+        # The demo importer clipped internally with sound_tiling...
+        assert demo_calls == ["sound_tiling"], demo_calls
+        # ...and the pipeline received the SAME clipper for _apply_clipper_stage.
+        assert captured["pipeline_clipper"] == "sound_tiling"
+
+    def test_apply_clipper_stage_reclips_already_clipped_media(self):
+        """The pipeline stage has no guard for already-clipped media."""
+        from vtscore.datasets.stages import clipper as clipper_stage
+
+        class DummyTracker:
+            def check_cancelled(self):
+                pass
+
+            def update(self, *a, **k):
+                pass
+
+        class DummyCtx:
+            def __init__(self, medias):
+                self.medias = medias
+
+        # A media that already looks like a finished clip (carries an embedding).
+        ctx = DummyCtx({1: {"id": 1, "media_type": "audio", "embeddings": {"clap": [0.0]}}})
+
+        calls: list = []
+
+        def spy_apply(clips_dict, clipper_name, clipper_params=None, on_progress=None, chain_steps=None, embedder=None):
+            calls.append(clipper_name)
+
+        with (
+            patch.object(clipper_stage, "_apply_clipper", side_effect=spy_apply),
+            patch.object(clipper_stage, "invalidate_embedding_matrix", lambda ctx: None),
+        ):
+            clipper_stage._apply_clipper_stage(ctx, DummyTracker(), "sound_tiling", None, None)
+
+        # No early-return for a non-empty clipper: the stage re-runs the clipper
+        # on media that the importer already clipped.
+        assert calls == ["sound_tiling"]

--- a/tests/datasets/test_demo_double_clip.py
+++ b/tests/datasets/test_demo_double_clip.py
@@ -94,6 +94,7 @@ class TestDemoImportSingleClip:
         only be prevented upstream at dispatch (see the suppression above).
         """
         from vtscore.datasets.stages import clipper as clipper_stage
+        from vtscore.state import DatasetContext
 
         class DummyTracker:
             def check_cancelled(self):
@@ -102,11 +103,8 @@ class TestDemoImportSingleClip:
             def update(self, *a, **k):
                 pass
 
-        class DummyCtx:
-            def __init__(self, medias):
-                self.medias = medias
-
-        ctx = DummyCtx({1: {"id": 1, "media_type": "audio", "embeddings": {"clap": [0.0]}}})
+        ctx = DatasetContext("test-double-clip")
+        ctx.medias = {1: {"id": 1, "media_type": "audio", "embeddings": {"clap": [0.0]}}}
 
         calls: list = []
 

--- a/tests/datasets/test_demo_double_clip.py
+++ b/tests/datasets/test_demo_double_clip.py
@@ -1,27 +1,22 @@
-"""Characterization test: a clipped demo import runs the clipper twice.
+"""Regression: a clipped demo import must clip exactly once.
 
-When a demo dataset is created through the importer flow, the clipper is
-dispatched into **two** places:
+A demo import runs through ``_run_importer_in_background``.  The demo importer
+clips (and embeds + caches) the dataset itself inside ``load_demo_dataset``, so
+the shared load pipeline must **not** run its ``_apply_clipper_stage`` on top —
+that would clip the already-clipped media a second time (re-decoding audio,
+re-tiling, recomputing MD5s, regenerating thumbnails).
 
-1. The demo importer's own internal clipping inside ``load_demo_dataset``
-   (``DemoDatasetImporter.run`` forwards ``field_values['clipper']``).
-2. The shared load pipeline's ``_apply_clipper_stage``, because
-   ``_run_importer_in_background`` re-adds ``clipper`` to ``field_values``
-   *and* forwards it to ``_run_origin_load_in_background``.
-
-So for a clipped audio demo (e.g. GTZAN, whose pre-selected default is the
-real ``sound_tiling`` clipper) the clipper runs on the media, then runs again
-on the already-clipped media.  These tests pin that current behavior so the
-redundancy is verifiable; if it is fixed, they should be flipped to assert a
-single dispatch.
+The fix routes clipping through the importer's ``handles_own_clipping`` flag:
+the dispatch keeps the full clipper config in ``field_values`` for the importer
+and suppresses the pipeline-level clipper.  These tests pin that contract.
 """
 
 from unittest.mock import patch
 
 
-class TestDemoImportDoubleClip:
-    def test_clipper_dispatched_to_both_importer_and_pipeline(self):
-        """One clipped demo import fans the clipper out to importer + pipeline."""
+class TestDemoImportSingleClip:
+    def test_demo_import_clips_once_via_importer_only(self):
+        """The clipper goes to the importer with its params; the pipeline is suppressed."""
         from vtscore.datasets import load_pipeline
         from vtscore.datasets.importers.demo import IMPORTER as demo_importer
 
@@ -30,15 +25,16 @@ class TestDemoImportDoubleClip:
         def fake_origin_load(load_fn, origin, **kwargs):
             # Record the clipper the pipeline would hand to _apply_clipper_stage.
             captured["pipeline_clipper"] = kwargs.get("clipper")
+            captured["pipeline_clipper_params"] = kwargs.get("clipper_params")
             # Drive the importer synchronously the way the real background
-            # thread would, so we also observe the importer's own clipping.
+            # thread would, so we observe the importer's own clipping.
             load_fn({})
             return "task-1"
 
         demo_calls: list = []
 
         def fake_load_demo(dataset_name, medias, **kwargs):
-            demo_calls.append(kwargs.get("clipper_name"))
+            demo_calls.append((kwargs.get("clipper_name"), kwargs.get("clipper_params")))
 
         with (
             patch.object(load_pipeline, "_run_origin_load_in_background", side_effect=fake_origin_load),
@@ -46,16 +42,57 @@ class TestDemoImportDoubleClip:
         ):
             load_pipeline._run_importer_in_background(
                 demo_importer,
-                {"name": "gtzan_a", "clipper": "sound_tiling", "media_type": "audio"},
+                {
+                    "name": "gtzan_a",
+                    "clipper": "sound_tiling",
+                    "clipper_params": {"duration": 5.0},
+                    "media_type": "audio",
+                },
             )
 
-        # The demo importer clipped internally with sound_tiling...
-        assert demo_calls == ["sound_tiling"], demo_calls
-        # ...and the pipeline received the SAME clipper for _apply_clipper_stage.
-        assert captured["pipeline_clipper"] == "sound_tiling"
+        # The demo importer clipped once, with the clipper AND its real params
+        # (previously the params were dropped before run(), so it silently used
+        # the clipper's defaults).
+        assert demo_calls == [("sound_tiling", {"duration": 5.0})], demo_calls
+        # The pipeline's clipper stage is suppressed: no second clip.
+        assert captured["pipeline_clipper"] == ""
+        assert captured["pipeline_clipper_params"] is None
 
-    def test_apply_clipper_stage_reclips_already_clipped_media(self):
-        """The pipeline stage has no guard for already-clipped media."""
+    def test_non_self_clipping_importer_still_uses_pipeline_clipper(self):
+        """Importers without ``handles_own_clipping`` still clip via the pipeline."""
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.importers.base import ImporterBase
+
+        class DummyImporter(ImporterBase):
+            name = "dummy_clip_test"
+            display_name = "Dummy"
+            fields: list = []
+
+            def run(self, field_values, medias, thin=False):
+                pass
+
+        captured: dict = {}
+
+        def fake_origin_load(load_fn, origin, **kwargs):
+            captured["pipeline_clipper"] = kwargs.get("clipper")
+            captured["pipeline_clipper_params"] = kwargs.get("clipper_params")
+            return "task-2"
+
+        with patch.object(load_pipeline, "_run_origin_load_in_background", side_effect=fake_origin_load):
+            load_pipeline._run_importer_in_background(
+                DummyImporter(),
+                {"clipper": "sound_tiling", "clipper_params": {"duration": 5.0}, "media_type": "audio"},
+            )
+
+        assert captured["pipeline_clipper"] == "sound_tiling"
+        assert captured["pipeline_clipper_params"] == {"duration": 5.0}
+
+    def test_apply_clipper_stage_has_no_guard_for_clipped_media(self):
+        """Rationale check: the stage clips whatever non-empty clipper it's given.
+
+        The stage itself has no "already clipped?" guard, so the double-clip can
+        only be prevented upstream at dispatch (see the suppression above).
+        """
         from vtscore.datasets.stages import clipper as clipper_stage
 
         class DummyTracker:
@@ -69,7 +106,6 @@ class TestDemoImportDoubleClip:
             def __init__(self, medias):
                 self.medias = medias
 
-        # A media that already looks like a finished clip (carries an embedding).
         ctx = DummyCtx({1: {"id": 1, "media_type": "audio", "embeddings": {"clap": [0.0]}}})
 
         calls: list = []
@@ -83,6 +119,4 @@ class TestDemoImportDoubleClip:
         ):
             clipper_stage._apply_clipper_stage(ctx, DummyTracker(), "sound_tiling", None, None)
 
-        # No early-return for a non-empty clipper: the stage re-runs the clipper
-        # on media that the importer already clipped.
         assert calls == ["sound_tiling"]

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -140,6 +140,17 @@ class ImporterBase(PluginBase):
     #: dataset-wide identifier).
     origin_suppressed: bool = False
 
+    #: When ``True``, the importer applies the clipper (and owns the
+    #: resulting clipped + embedded artifacts) inside its own :meth:`run`,
+    #: so the shared load pipeline must NOT run its ``_apply_clipper_stage``
+    #: on top — doing so would clip the already-clipped media a second time.
+    #: Set this on importers that self-clip (e.g. the demo importer, which
+    #: clips + embeds + caches the final dataset in ``load_demo_dataset``).
+    #: The dispatch (:func:`_run_importer_in_background`) keeps the full
+    #: clipper config in ``field_values`` for these importers and suppresses
+    #: the pipeline's clipper stage.
+    handles_own_clipping: bool = False
+
     def __init__(self) -> None:
         #: Mapping of filename to pre-computed embedding vector.  Importers
         #: that supply content vectors alongside media should populate this

--- a/vtscore/datasets/importers/demo/__init__.py
+++ b/vtscore/datasets/importers/demo/__init__.py
@@ -35,6 +35,9 @@ class DemoDatasetImporter(ImporterBase):
     ui_mode = "custom"
     picker_view = "demo"
     category = "demo"
+    # ``load_demo_dataset`` applies the clipper itself (and caches the
+    # clipped + embedded result), so the shared pipeline must not clip again.
+    handles_own_clipping = True
 
     fields = [
         PluginField(

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -614,6 +614,18 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # Keep clipper in field_values for importers that need it (e.g. demo
     # importer stores it in the container metadata for readiness tracking).
     field_values["clipper"] = clipper_name
+    # Importers that clip themselves (``handles_own_clipping``) own the full
+    # clip config: hand the params/chain back so their ``run`` clips with the
+    # user's real settings, and suppress the pipeline-level clipper so the
+    # media isn't clipped a second time on top of the importer's own pass.
+    if getattr(importer, "handles_own_clipping", False):
+        if clipper_params is not None:
+            field_values["clipper_params"] = clipper_params
+        if chain_steps is not None:
+            field_values["clipper_chain"] = chain_steps
+        pipeline_clipper, pipeline_clipper_params, pipeline_chain_steps = "", None, None
+    else:
+        pipeline_clipper, pipeline_clipper_params, pipeline_chain_steps = clipper_name, clipper_params, chain_steps
     embedder_name = field_values.get("embedder", "")
     embedders = _parse_embedder_list(field_values.pop("embedders", None))
     # The primary picker's choice always leads the embed order (it becomes each
@@ -641,9 +653,9 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         _load,
         origin,
         name=importer.resolve_display_name(field_values),
-        clipper=clipper_name,
-        clipper_params=clipper_params,
-        chain_steps=chain_steps,
+        clipper=pipeline_clipper,
+        clipper_params=pipeline_clipper_params,
+        chain_steps=pipeline_chain_steps,
         embedder=embedder_name,
         embedders=embedders,
         created_by=created_by,


### PR DESCRIPTION
## What this fixes

Creating an audio demo dataset that uses a clipper (e.g. GTZAN, whose pre-selected default is the real `sound_tiling` clipper) ran the clipper **twice** on the same media:

1. Inside the demo importer — `load_demo_dataset` clips + embeds + caches the dataset itself (`vtscore/datasets/loader_demo.py`).
2. Again in the shared pipeline — `_run_importer_in_background` also forwarded the clipper to `_apply_clipper_stage`, which re-ran it on the already-clipped media (`vtscore/datasets/load_pipeline.py`).

The second pass re-decoded the audio, re-tiled, recomputed MD5s, and regenerated waveform thumbnails for every clip — pure wasted CPU. (It did not re-embed in the default case, since the clips already carried embeddings.)

This is separate from — and downstream of — the full-track re-embedding that was already fixed via `skip_embedding` (PR #2054). That change stopped embedding full tracks before clipping; this one stops clipping the clips a second time.

## The fix

Add a `handles_own_clipping` capability flag on `ImporterBase` (mirroring the existing `origin_suppressed` / `supports_chunked` flags) and set it on the demo importer. When an importer declares it, `_run_importer_in_background`:

- hands the **full** clipper config (name **and** params) back into `field_values` so the importer clips with the user's real settings, and
- suppresses the pipeline-level clipper so `_apply_clipper_stage` is a no-op.

The demo importer legitimately owns clipping because it also owns the clipped+embedded pickle cache and the `skip_embedding` optimization; moving clipping to the pipeline would gut both. The staging flow (`_stage_importer_in_background`) never ran the clipper stage, so it was already single-clip and is unaffected.

### Latent bug also fixed

`clipper_params` were popped from `field_values` before the demo importer's `run()`, so its internal clip silently used the clipper's **default** params (only the discarded pipeline pass got the real ones). The importer now receives the params, so custom clipper params (e.g. `duration=5.0`) take effect on the first and only clip.

## Tests

New `tests/datasets/test_demo_double_clip.py`:
- demo import clips once, via the importer, with its real params; pipeline clipper suppressed;
- non-self-clipping importers still clip via the pipeline (unchanged);
- rationale check that `_apply_clipper_stage` has no "already clipped?" guard (so suppression must happen at dispatch).

Full suite green (`./run-tests.sh`): 5369 passed, 1 skipped.

## Backwards compatibility

No behavior change for any non-demo importer. Demo datasets built before this change are unaffected (cache format unchanged); the only user-visible difference is that clipped demo imports no longer do the redundant second clipping pass, and custom clipper params now actually apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCGqgZzb1De21eFqLcD54m)_