### PR TITLE
Fix 20 Newsgroups demo load hanging on "Downloading source"

### DIFF
--- a/tests_lib/downloads/test_20newsgroups_download.py
+++ b/tests_lib/downloads/test_20newsgroups_download.py
@@ -1,0 +1,118 @@
+"""Tests for the 20 Newsgroups archive prefetch.
+
+The regression these guard against: ``download_20newsgroups`` used to delegate
+the network fetch to ``sklearn.datasets.fetch_20newsgroups``, whose internal
+``urlretrieve`` has no timeout and whose retry loop only catches
+``URLError``/``TimeoutError``. A silently stalled connection therefore hung
+forever with no progress ("Downloading source" stuck on step 1). The fix
+pre-downloads the archive through ``download_file_with_progress`` (fail-fast
+timeout, retries, byte-level progress) into sklearn's cache dir so the fetch
+reuses the checksum-matching tar without touching the network.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _archive_meta():
+    from sklearn.datasets._twenty_newsgroups import ARCHIVE, CACHE_NAME
+
+    return ARCHIVE, CACHE_NAME
+
+
+class TestPrefetch20Newsgroups:
+    def test_downloads_archive_via_timeout_guarded_helper(self, tmp_path):
+        """A clean cache triggers download_file_with_progress into 20news_home."""
+        from vtscore.datasets.downloader import text as text_module
+
+        ARCHIVE, _ = _archive_meta()
+        calls = []
+
+        with (
+            patch("sklearn.datasets.get_data_home", return_value=str(tmp_path)),
+            patch.object(
+                text_module._core,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: calls.append((url, dest, size)),
+            ),
+        ):
+            text_module._prefetch_20newsgroups_archive(on_progress=lambda *a: None)
+
+        assert len(calls) == 1, "expected exactly one timeout-guarded download"
+        url, dest, size = calls[0]
+        assert url == ARCHIVE.url
+        assert dest == tmp_path / "20news_home" / ARCHIVE.filename
+        assert size > 0
+        # The destination directory must be created before the download runs.
+        assert (tmp_path / "20news_home").is_dir()
+
+    def test_noop_when_pickle_cache_exists(self, tmp_path):
+        """The parsed .pkz cache short-circuits the whole prefetch."""
+        from vtscore.datasets.downloader import text as text_module
+
+        _, cache_name = _archive_meta()
+        (tmp_path / cache_name).write_bytes(b"cached")
+        called = []
+
+        with (
+            patch("sklearn.datasets.get_data_home", return_value=str(tmp_path)),
+            patch.object(
+                text_module._core,
+                "download_file_with_progress",
+                lambda *a, **kw: called.append(True),
+            ),
+        ):
+            text_module._prefetch_20newsgroups_archive(on_progress=lambda *a: None)
+
+        assert not called, "download must be skipped when the pickle cache exists"
+
+    def test_noop_when_archive_already_present(self, tmp_path):
+        """An already-downloaded tar is left for sklearn to extract."""
+        from vtscore.datasets.downloader import text as text_module
+
+        ARCHIVE, _ = _archive_meta()
+        twenty_home = tmp_path / "20news_home"
+        twenty_home.mkdir()
+        (twenty_home / ARCHIVE.filename).write_bytes(b"tar")
+        called = []
+
+        with (
+            patch("sklearn.datasets.get_data_home", return_value=str(tmp_path)),
+            patch.object(
+                text_module._core,
+                "download_file_with_progress",
+                lambda *a, **kw: called.append(True),
+            ),
+        ):
+            text_module._prefetch_20newsgroups_archive(on_progress=lambda *a: None)
+
+        assert not called, "download must be skipped when the archive already exists"
+
+
+class TestDownload20Newsgroups:
+    def test_prefetch_runs_before_sklearn_fetch(self):
+        """download_20newsgroups prefetches the archive before fetching."""
+        from vtscore.datasets.downloader import text as text_module
+
+        order = []
+
+        def fake_prefetch(on_progress):
+            order.append("prefetch")
+
+        def fake_fetch(**kwargs):
+            order.append("fetch")
+            return SimpleNamespace(
+                data=["a sports article", "a science article"],
+                target=[0, 1],
+                target_names=["rec.sport.baseball", "sci.space"],
+            )
+
+        with (
+            patch.object(text_module, "_prefetch_20newsgroups_archive", fake_prefetch),
+            patch("sklearn.datasets.fetch_20newsgroups", fake_fetch),
+        ):
+            texts, labels, names = text_module.download_20newsgroups(["sports", "science"], on_progress=lambda *a: None)
+
+        assert order == ["prefetch", "fetch"], "prefetch must run before the sklearn fetch"
+        assert texts == ["a sports article", "a science article"]
+        assert names == ["sports", "science"]

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -58,6 +58,13 @@ CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 CALTECH101_URL = "https://data.caltech.edu/records/mzrjq-6wc02/files/caltech-101.zip"
 CALTECH256_URL = "https://data.caltech.edu/records/nyy15-4j048/files/256_ObjectCategories.tar?download=1"
 UCF101_SUBSET_URL = "https://huggingface.co/datasets/sayakpaul/ucf101-subset/resolve/main/UCF101_subset.tar.gz"
+# 20 Newsgroups is fetched via scikit-learn, but we pre-download its archive
+# ourselves (through download_file_with_progress) so the transfer gets a
+# fail-fast timeout, retries, and byte-level progress instead of sklearn's
+# no-timeout urlretrieve. The URL/checksum/filename themselves come from
+# sklearn's own ARCHIVE metadata at runtime to stay in lock-step; this size is
+# only the progress-bar fallback when the server omits Content-Length.
+TWENTY_NEWSGROUPS_DOWNLOAD_SIZE_MB = 14
 BBC_NEWS_URL = "http://mlg.ucd.ie/files/datasets/bbc-fulltext.zip"
 AG_NEWS_URL = "https://raw.githubusercontent.com/mhjabreel/CharCnn_Keras/master/data/ag_news_csv/train.csv"
 IMDB_URL = "https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -18,6 +18,50 @@ from vtscore.datasets.downloader import core as _core
 from vtscore.datasets.downloader.core import ProgressCallback
 
 
+def _prefetch_20newsgroups_archive(on_progress: ProgressCallback) -> None:
+    """Pre-download the 20 Newsgroups tar into sklearn's cache with a timeout.
+
+    Fetches sklearn's ``20news-bydate.tar.gz`` archive via
+    :func:`~vtscore.datasets.downloader.core.download_file_with_progress`
+    (fail-fast connect/read timeout, retry with backoff, byte-level progress)
+    and drops it where :func:`sklearn.datasets.fetch_20newsgroups` expects it,
+    so the subsequent fetch reuses the checksum-matching file instead of
+    running its own no-timeout ``urlretrieve`` (which can hang forever on an
+    unresponsive host).
+
+    No-op when the parsed pickle cache or the archive already exists. Best
+    effort: if sklearn's private archive metadata cannot be imported (a future
+    reorg) the prefetch is skipped and ``fetch_20newsgroups`` falls back to its
+    built-in download.
+    """
+    try:
+        from sklearn.datasets import get_data_home
+        from sklearn.datasets._twenty_newsgroups import ARCHIVE, CACHE_NAME
+    except ImportError:
+        return
+
+    data_home = Path(get_data_home())
+    # sklearn writes a parsed pickle (CACHE_NAME) after the first successful
+    # load; once it exists, no download or extraction happens at all.
+    if (data_home / CACHE_NAME).exists():
+        return
+
+    twenty_home = data_home / "20news_home"
+    archive_path = twenty_home / ARCHIVE.filename
+    # A tar already sitting in the cache dir is extracted (and checksum-verified)
+    # by sklearn without any network access, so leave it be.
+    if archive_path.exists():
+        return
+
+    twenty_home.mkdir(parents=True, exist_ok=True)
+    _core.download_file_with_progress(
+        ARCHIVE.url,
+        archive_path,
+        _core.TWENTY_NEWSGROUPS_DOWNLOAD_SIZE_MB * 1024 * 1024,
+        on_progress,
+    )
+
+
 def download_20newsgroups(
     categories: list[str],
     on_progress: Optional[ProgressCallback] = None,
@@ -59,7 +103,19 @@ def download_20newsgroups(
 
     from sklearn.datasets import fetch_20newsgroups
 
-    on_progress("downloading", "Downloading 20 Newsgroups dataset...", 0, 0)
+    # sklearn's fetch_20newsgroups downloads the archive with
+    # urllib.urlretrieve, which has no timeout and whose retry loop only catches
+    # URLError/TimeoutError -- a silently stalled connection hangs forever with
+    # no progress (the "Downloading source" step never advances). We instead
+    # pre-fetch the archive through download_file_with_progress (fail-fast
+    # timeout, retry/backoff, byte-level progress, SSRF-safe redirect handling)
+    # into sklearn's own cache dir. fetch_20newsgroups then finds the
+    # checksum-matching tar already present and just extracts it, without
+    # touching the network. If sklearn's private archive metadata ever moves,
+    # the prefetch degrades gracefully to sklearn's built-in download.
+    _prefetch_20newsgroups_archive(on_progress)
+
+    on_progress("downloading", "Preparing 20 Newsgroups dataset...", 0, 0)
 
     # Map our category names to 20 newsgroups categories.
     # Covers all 20 newsgroups under shorter, friendlier aliases.


### PR DESCRIPTION
## What & why

Making a "20 Newsgroups (S)" demo dataset (and its M/L/A siblings) could stick on **"Loading dataset · Step 1 of 4 · Downloading source"** forever.

**Root cause:** `download_20newsgroups` was the only demo downloader that handed its network fetch to scikit-learn's `fetch_20newsgroups`, whose internal `urlretrieve` has **no timeout** and whose retry loop only catches `URLError`/`TimeoutError`:

```python
while True:
    try:
        urlretrieve(remote.url, temp_file_path)   # no timeout
        break
    except (URLError, TimeoutError):
        ...retry...
```

A *silently stalled* connection to the archive host (`ndownloader.figshare.com`) — common under a restrictive network policy or a proxy that black-holes the connection — never raises, so it's never retried and never surfaced as an error. The socket sits open indefinitely. On top of that, `on_progress(...)` fired exactly once before the blocking call, so even a merely-slow download rendered as a frozen step with no byte progress.

Every other source (BBC, IMDB, AG News, images/video) routes through VTSearch's own `download_file_with_progress`, which has `timeout=(10, 60)`, retry/backoff, byte-level progress, and clear gated-host errors. 20 Newsgroups skipped all of it.

## The fix

Pre-download `20news-bydate.tar.gz` through `download_file_with_progress` into sklearn's cache dir, then let `fetch_20newsgroups` reuse the checksum-matching tar (sklearn ≥1.6 short-circuits `_fetch_remote` when the file is already present) — no second network hit.

- Fail-fast connect/read timeout, retries with backoff, and real byte-level progress driving the "Downloading source" step.
- No-op when the parsed `.pkz` cache or the archive already exists.
- URL/checksum/filename are read from sklearn's own `ARCHIVE` metadata at runtime to stay in lock-step; `core.py` only adds a size constant used as the progress-bar fallback when the server omits `Content-Length`.
- Degrades gracefully to sklearn's built-in download if sklearn's private archive metadata is ever moved.

## Testing

- New `tests_lib/downloads/test_20newsgroups_download.py`: verifies the prefetch downloads via the timeout-guarded helper into `20news_home/`, is a no-op when the pickle cache or archive already exists, and runs before the sklearn fetch.
- Verified end-to-end locally with the sklearn cache cleared: 1766 byte-progress events now fire during the download (vs. 0 before), and a cached re-run downloads nothing.
- Full `./run-tests.sh` suite green (5370 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbfqemUXAzHTGgkJuaso9R)_