### PR TITLE
Move metadata copy buttons to the left of their values

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -68,23 +68,23 @@
           <div class="bin-popup-meta-item">
             <span class="bin-popup-meta-label">Name</span>
             <div class="bin-popup-meta-value-row">
-              <span class="bin-popup-meta-value">{{ metadataName }}</span>
               <vt-copy-detail-button [value]="metadataName" label="Name" />
+              <span class="bin-popup-meta-value">{{ metadataName }}</span>
             </div>
           </div>
           <div class="bin-popup-meta-item">
             <span class="bin-popup-meta-label">Media Type</span>
             <div class="bin-popup-meta-value-row">
-              <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
               <vt-copy-detail-button [value]="metadataMediaType | titlecase" label="Media Type" />
+              <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
             </div>
           </div>
           @for (entry of metadataCustom | keyvalue; track entry.key) {
             <div class="bin-popup-meta-item">
               <span class="bin-popup-meta-label">{{ entry.key }}</span>
               <div class="bin-popup-meta-value-row">
-                <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
                 <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
+                <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
               </div>
             </div>
           }
@@ -92,8 +92,8 @@
             <div class="bin-popup-meta-item">
               <span class="bin-popup-meta-label">MD5</span>
               <div class="bin-popup-meta-value-row">
-                <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
                 <vt-copy-detail-button [value]="metadataMd5" label="MD5" />
+                <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
               </div>
             </div>
           }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -181,8 +181,9 @@
   min-width: 0;
 }
 
-// Value + per-item Copy button, aligned so the button sits beside the value
-// (the actual metadata) rather than the category label above it.
+// Per-item Copy button + value. The button leads the row so it always hugs the
+// left edge of the value (the actual metadata) at a fixed offset, instead of
+// floating to the far right where short values leave it stranded.
 .bin-popup-meta-value-row {
   display: flex;
   flex-direction: row;

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -88,31 +88,31 @@
           <div class="metadata-item">
             <span class="metadata-label">Name</span>
             <div class="metadata-value-row">
-              <span class="metadata-value">{{ media.filename || 'Media #' + media.id }}</span>
               <vt-copy-detail-button [value]="media.filename || 'Media #' + media.id" label="Name" />
+              <span class="metadata-value">{{ media.filename || 'Media #' + media.id }}</span>
             </div>
           </div>
           <div class="metadata-item">
             <span class="metadata-label">Media Type</span>
             <div class="metadata-value-row">
-              <span class="metadata-value">{{ mediaType | titlecase }}</span>
               <vt-copy-detail-button [value]="mediaType | titlecase" label="Media Type" />
+              <span class="metadata-value">{{ mediaType | titlecase }}</span>
             </div>
           </div>
           @for (entry of customMetadata | keyvalue; track entry.key) {
             <div class="metadata-item">
               <span class="metadata-label">{{ entry.key }}</span>
               <div class="metadata-value-row">
-                <span class="metadata-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
                 <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
+                <span class="metadata-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
               </div>
             </div>
           }
           <div class="metadata-item">
             <span class="metadata-label">MD5</span>
             <div class="metadata-value-row">
-              <span class="metadata-value metadata-md5">{{ media.md5 }}</span>
               <vt-copy-detail-button [value]="media.md5 || ''" label="MD5" />
+              <span class="metadata-value metadata-md5">{{ media.md5 }}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -198,8 +198,9 @@
   min-width: 0;
 }
 
-// Value + per-item Copy button, aligned so the button sits beside the value
-// (the actual metadata) rather than the category label above it.
+// Per-item Copy button + value. The button leads the row so it always hugs the
+// left edge of the value (the actual metadata) at a fixed offset, instead of
+// floating to the far right of a wide cell where short values leave it stranded.
 .metadata-value-row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Problem

In the **horizontal** center-panel metadata grid, each value cell is wide (`minmax(180px, 1fr)`). Because `.metadata-value` grows with `flex: 1 1 auto`, a short value pushed its per-item copy button to the far right edge of the cell — leaving the button stranded far from the data it copies, and visually closer to the *neighboring* column's data. The same effect made the button feel oddly far from short values even in the vertical VTSBrowse bin-popup column.

## Fix

Lead each value row with the copy button instead of trailing it. The button now hugs the **left** edge of the value at a fixed offset, so it's always right next to the data it copies and the buttons line up consistently instead of scattering at variable right-edge positions.

Changes are markup-order only (plus refreshed comments); no styling or component logic changed:

- `center-panel.component.html` — Name / Media Type / custom / MD5 rows
- `browse-bin-popup.component.html` — Name / Media Type / custom / MD5 rows
- Updated the `.metadata-value-row` / `.bin-popup-meta-value-row` SCSS comments to describe the new lead-with-button layout.

## Testing

`./run-tests.sh frontend` — Angular `build:prod`, `npm audit`, and the Vitest suite (966 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvUXjt7jgYeTViJHQuFmQ4)_