### PR TITLE
Align startup progress bars regardless of label length

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -271,10 +271,10 @@ class TestPreloadConsoleOutput:
             mock_emb._on_progress("loading", "Loading CLAP model weights...", 0, 0)
             mock_emb._on_progress("loading", "model.safetensors", 50, 100)
             mock_emb._on_progress("loading", "model.safetensors", 100, 100)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: importing libraries...", 1, 4)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: resampling JIT...", 2, 4)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: preprocessing...", 3, 4)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: running model...", 4, 4)
+            mock_emb._on_progress("loading", "Warming up CLAP: importing libs…", 1, 4)
+            mock_emb._on_progress("loading", "Warming up CLAP: resampling JIT…", 2, 4)
+            mock_emb._on_progress("loading", "Warming up CLAP: preprocessing…", 3, 4)
+            mock_emb._on_progress("loading", "Warming up CLAP: running model…", 4, 4)
 
         mock_emb.load_models = fake_load_models
         mock_get_embedder.return_value = mock_emb
@@ -286,7 +286,7 @@ class TestPreloadConsoleOutput:
         assert "Preloading clap embedder" in captured.out
         assert "Loading CLAP model weights..." in captured.out
         assert "model.safetensors" in captured.out
-        assert "Warming up audio pipeline: importing libraries..." in captured.out
+        assert "Warming up CLAP: importing libs…" in captured.out
 
     @patch("vtscore.embedding.loader.predict_embedders_to_preload", return_value=["clap"])
     @patch("vtscore.media.get_embedder")

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -142,6 +142,30 @@ class TestMakeConsoleProgress:
         cols = {seg.index("[") for seg in renders}
         assert len(cols) == 1, f"bars not aligned: columns were {cols}"
 
+    def test_long_labels_are_truncated_to_keep_bars_aligned(self, capsys):
+        """A label longer than _LABEL_WIDTH must not push its bar right: it is
+        truncated with an ellipsis so every bar's open bracket stays aligned."""
+        from vtscore.embedding.loader import _LABEL_WIDTH
+
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Importing torch…", 1, 2)  # short, gets padded
+        # 40 chars, well over the 32-char width; must be truncated, not overflow.
+        cb("loading", "Warming up CLAP General: resampling JIT…", 2, 3)
+        cb.flush()
+
+        captured = capsys.readouterr()
+        renders = [seg for seg in captured.out.replace("\033[K", "").split("\r") if "[" in seg]
+        cols = {seg.index("[") for seg in renders}
+        assert len(cols) == 1, f"long label shifted the bar: columns were {cols}"
+        # The long label was truncated with a trailing ellipsis before the bar.
+        long_renders = [seg for seg in renders if "Warming up CLAP General" in seg]
+        assert long_renders
+        for seg in long_renders:
+            label = seg[: seg.index("[")].strip()
+            assert len(label) == _LABEL_WIDTH
+            assert label.endswith("…")
+
     def test_elapsed_suffix_does_not_shift_bar(self, capsys):
         """A growing elapsed-time suffix ('1s' -> '10s') must not move the bar."""
         cb = _make_console_progress(lambda *a, **kw: None)

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -22,8 +22,9 @@ _TIME_SUFFIX_RE = re.compile(r"\s*\(\d+s(?:,\s*\d+\s+modules)?\)$")
 #: Fixed column width for the label printed before a console progress bar.
 #: Padding every label to this width makes the ``[####…]`` bars line up
 #: vertically.  Sized to fit the longest common preload label
-#: ("Importing sentence_transformers…", 32 chars); longer labels simply
-#: push their own bar right rather than being truncated.
+#: ("Importing sentence_transformers…", 32 chars).  Labels longer than this
+#: are truncated with an ellipsis (see :func:`_fit_label`) so the bar's open
+#: bracket always lands in the same column and the bars stay aligned.
 _LABEL_WIDTH = 32
 
 #: ANSI colors for the bar fill *between* the brackets (the rest of the line
@@ -50,6 +51,19 @@ def _bar_color(pct: int) -> str:
 
 def _strip_time_suffix(msg: str) -> str:
     return _TIME_SUFFIX_RE.sub("", msg) if msg else msg
+
+
+def _fit_label(base: str) -> str:
+    """Fit *base* to exactly :data:`_LABEL_WIDTH` columns.
+
+    Short labels are left-padded with spaces; labels longer than the width are
+    truncated and given a trailing ``…``.  Either way the result is always
+    ``_LABEL_WIDTH`` columns wide, so every bar's open bracket lands in the same
+    column and successive bars line up vertically regardless of label length.
+    """
+    if len(base) > _LABEL_WIDTH:
+        return base[: _LABEL_WIDTH - 1] + "…"
+    return f"{base:<{_LABEL_WIDTH}}"
 
 
 from vtscore.config import MODELS_CACHE_DIR, resolve_device
@@ -320,10 +334,12 @@ def _make_console_progress(original_callback):
     newline only when a different base message arrives, a phase message
     arrives, or the caller invokes ``cb.flush()``.
 
-    Every bar's label is left-padded to a fixed width (:data:`_LABEL_WIDTH`)
-    so successive bars line up vertically, and the elapsed-time/status suffix
-    is rendered after the percentage so its changing length (``1s`` → ``10s``)
-    never shifts the bar mid-progress.
+    Every bar's label is fitted to a fixed width (:data:`_LABEL_WIDTH`) via
+    :func:`_fit_label` - short labels padded, long labels truncated with an
+    ellipsis - so successive bars line up vertically regardless of label
+    length, and the elapsed-time/status suffix is rendered after the
+    percentage so its changing length (``1s`` → ``10s``) never shifts the bar
+    mid-progress.
     """
     _last_msg: list[str | None] = [None]
     _last_base: list[str | None] = [None]
@@ -334,7 +350,7 @@ def _make_console_progress(original_callback):
     def _complete_bar() -> None:
         """Overwrite the current progress line with a 100% bar."""
         if _last_base[0]:
-            label = f"{_last_base[0]:<{_LABEL_WIDTH}}"
+            label = _fit_label(_last_base[0])
             sys.stdout.write(f"\r    {label} [{_ANSI_GREEN}{_FULL_BAR}{_ANSI_RESET}] 100%\033[K")
 
     def _flush() -> None:
@@ -369,7 +385,7 @@ def _make_console_progress(original_callback):
             tail = f" {suffix}" if suffix else ""
             # \033[K clears from cursor to end of line so a shorter message
             # doesn't leave trailing chars from a longer prior render.
-            line = f"\r    {base:<{_LABEL_WIDTH}} [{bar}] {pct:>3}%{tail}\033[K"
+            line = f"\r    {_fit_label(base)} [{bar}] {pct:>3}%{tail}\033[K"
             sys.stdout.write(line)
             sys.stdout.flush()
             _on_progress_line[0] = True

--- a/vtscore/media/audio/_clap_shared.py
+++ b/vtscore/media/audio/_clap_shared.py
@@ -134,7 +134,7 @@ class _ClapBase(MediaEmbedder):
         # different sample rate.  Without this, the first embed_media()
         # call stalls for 10-30 s while numba compiles resampling kernels,
         # making the embedding progress bar appear frozen.
-        self._on_progress("loading", f"Warming up {self.label} pipeline: resampling JIT…", 1, 3)
+        self._on_progress("loading", f"Warming up {self.label}: resampling JIT…", 1, 3)
         import io  # noqa: PLC0415
 
         import soundfile as sf  # noqa: PLC0415
@@ -145,7 +145,7 @@ class _ClapBase(MediaEmbedder):
         _warmup_buf.seek(0)
         librosa.load(_warmup_buf, sr=CLAP_SAMPLE_RATE, mono=True)
 
-        self._on_progress("loading", f"Warming up {self.label} pipeline: preprocessing…", 2, 3)
+        self._on_progress("loading", f"Warming up {self.label}: preprocessing…", 2, 3)
         dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
@@ -155,7 +155,7 @@ class _ClapBase(MediaEmbedder):
             max_length=CLAP_MAX_SAMPLES,
             truncation="rand_trunc",
         )
-        self._on_progress("loading", f"Warming up {self.label} pipeline: running model…", 3, 3)
+        self._on_progress("loading", f"Warming up {self.label}: running model…", 3, 3)
         device = next(self._model.parameters()).device
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -102,10 +102,10 @@ class AudioASTEmbedder(MediaEmbedder):
 
         # Warmup: run a dummy forward pass so the first real embed_media
         # call runs at steady-state speed.
-        self._on_progress("loading", "Warming up AST pipeline: preprocessing…", 1, 2)
+        self._on_progress("loading", "Warming up AST: preprocessing…", 1, 2)
         dummy_audio = np.zeros(AST_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(dummy_audio, sampling_rate=AST_SAMPLE_RATE, return_tensors="pt")
-        self._on_progress("loading", "Warming up AST pipeline: running model…", 2, 2)
+        self._on_progress("loading", "Warming up AST: running model…", 2, 2)
         device = next(self._model.parameters()).device
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -112,10 +112,10 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
             )
 
         # Warmup: run a dummy forward pass.
-        self._on_progress("loading", "Warming up Whisper pipeline: preprocessing…", 1, 2)
+        self._on_progress("loading", "Warming up Whisper: preprocessing…", 1, 2)
         dummy_audio = np.zeros(WHISPER_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(dummy_audio, sampling_rate=WHISPER_SAMPLE_RATE, return_tensors="pt")
-        self._on_progress("loading", "Warming up Whisper pipeline: running encoder…", 2, 2)
+        self._on_progress("loading", "Warming up Whisper: running encoder…", 2, 2)
         device = next(self._model.parameters()).device
         input_features = inputs.input_features.to(device)
         with torch.no_grad():


### PR DESCRIPTION
## Problem

The startup progress bars were supposed to line up vertically, but the `Warming up CLAP pipeline: ...` lines drifted to the right — the `resampling JIT` one furthest of all:

```
    Loading weights                  [##############################] 100%
    Warming up CLAP pipeline: resampling JIT… [##############################] 100%
    Warming up CLAP pipeline: preprocessing… [##############################] 100%
    Warming up CLAP pipeline: running model… [##############################] 100%
```

## Cause

`_make_console_progress` pads each label to a fixed 32-column field with `f"{base:<32}"`. Python's `<` pad-spec only pads *short* strings — a label longer than 32 chars (the `Warming up CLAP pipeline: ...` messages are 40–41) is emitted at full length, pushing the bar's `[` to the right. The more the label overran, the further the bar shifted.

## Fix

Two parts:

1. **Guarantee alignment at the render layer.** New `_fit_label` helper fits every label to exactly `_LABEL_WIDTH` columns: short labels are padded, long labels are truncated with a trailing `…`. Used in both the live render and the completed-bar render, so the bar's open bracket always lands in the same column for *any* label — the invariant now holds regardless of label content, not just for labels that happen to fit.

2. **Shorten the warmup messages** (as suggested). Dropped the redundant `pipeline` word from the CLAP/AST/Whisper warmup lines (`Warming up CLAP pipeline: X` → `Warming up CLAP: X`), so the common labels read fully without hitting truncation. Plain `CLAP` now fits exactly; the rarer `CLAP General` / `Whisper` variants truncate cleanly but stay aligned.

Result — every bar's `[` lands in the same column:

```
    Importing torch…                 [##############################] 100%
    Loading weights                  [##############################] 100%
    Warming up CLAP: resampling JIT… [##############################] 100%
    Warming up CLAP: preprocessing…  [##############################] 100%
    Warming up CLAP: running model…  [##############################] 100%
```

## Tests

Added a regression test asserting a label longer than `_LABEL_WIDTH` keeps the bar column fixed and is truncated with an ellipsis. Updated an integration mock that used the old wording. Full suite green (5374 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01487ZTMAPHEgW2m2JHeVaAW)_