### PR TITLE
Fix crash importing WAVE_FORMAT_EXTENSIBLE audio (UrbanSound8K)

### DIFF
--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -221,6 +221,61 @@ class TestSoundTilingClipper:
             assert overlap >= 1.0 - 0.01
 
 
+def _generate_wavex(freq: float, duration: float, sr: int = 48000) -> bytes:
+    """Generate a ``WAVE_FORMAT_EXTENSIBLE`` (tag 0xFFFE) WAV byte string.
+
+    UrbanSound8K and many real-world datasets ship WAVs in this container,
+    which stdlib ``wave`` rejects with ``unknown format: 65534``.  libsndfile's
+    ``WAVEX`` major format writes exactly that, so it reproduces the crash.
+    """
+    import numpy as np  # noqa: PLC0415
+    import soundfile as sf  # noqa: PLC0415
+
+    t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+    samples = (np.sin(2 * np.pi * freq * t) * 16000).astype(np.int16)
+    buf = io.BytesIO()
+    sf.write(buf, samples, sr, format="WAVEX", subtype="PCM_16")
+    return buf.getvalue()
+
+
+class TestWaveFormatExtensible:
+    """Clippers must tolerate WAVE_FORMAT_EXTENSIBLE input (UrbanSound8K crash)."""
+
+    def test_wavex_is_not_readable_by_stdlib_wave(self):
+        # Guards the regression test below: confirm the fixture really is the
+        # extensible format that stdlib wave chokes on.
+        wavex = _generate_wavex(440, 3.0)
+        with pytest.raises(wave.Error, match="65534"):
+            wave.open(io.BytesIO(wavex), "rb")
+
+    def test_wav_duration_handles_extensible(self):
+        from vtscore.media.audio.clipper import _wav_duration
+
+        wavex = _generate_wavex(440, 3.0)
+        assert _wav_duration(wavex) == pytest.approx(3.0, abs=0.01)
+
+    def test_tiling_clipper_handles_extensible(self):
+        from vtscore.media.audio.clipper import SoundTilingClipper
+
+        wavex = _generate_wavex(440, 5.0)
+        media = {"id": 1, "media_type": "audio", "media_bytes": wavex, "duration": 5.0}
+        result = SoundTilingClipper(2.0).clip(media)
+        assert len(result) == 3
+        for tile in result:
+            # Emitted tiles are plain PCM that stdlib wave can read.
+            with wave.open(io.BytesIO(tile["media_bytes"]), "rb") as wf:
+                assert wf.getframerate() == 48000
+
+    def test_clip_clipper_handles_extensible(self):
+        from vtscore.media.audio.clipper import SoundClipClipper
+
+        wavex = _generate_wavex(440, 5.0)
+        media = {"id": 1, "media_type": "audio", "media_bytes": wavex, "duration": 5.0}
+        result = SoundClipClipper(1.0, 3.0).clip(media)
+        assert len(result) == 1
+        assert result[0]["duration"] == pytest.approx(2.0, abs=0.01)
+
+
 # ---------------------------------------------------------------------------
 # SoundClipClipper
 # ---------------------------------------------------------------------------

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -12,9 +12,37 @@ from typing import Any
 from vtscore.media.clipper import MediaClipper
 
 
+def _to_pcm_wav(wav_bytes: bytes) -> bytes:
+    """Re-encode WAV bytes into plain PCM that stdlib ``wave`` can parse.
+
+    The stdlib ``wave`` module only understands ``WAVE_FORMAT_PCM`` (tag 1);
+    it raises ``wave.Error`` on ``WAVE_FORMAT_EXTENSIBLE`` (tag 0xFFFE, 65534),
+    which is what UrbanSound8K and many other real-world WAVs use.  ``soundfile``
+    reads those fine, so decode with it and re-write as 16-bit PCM.
+    """
+    import soundfile as sf  # noqa: PLC0415
+
+    data, sr = sf.read(io.BytesIO(wav_bytes), dtype="int16", always_2d=False)
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def _open_wav(wav_bytes: bytes) -> wave.Wave_read:
+    """Open WAV bytes for reading, tolerating non-PCM formats.
+
+    Falls back to re-encoding via :func:`_to_pcm_wav` when stdlib ``wave``
+    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``).
+    """
+    try:
+        return wave.open(io.BytesIO(wav_bytes), "rb")
+    except (wave.Error, EOFError):
+        return wave.open(io.BytesIO(_to_pcm_wav(wav_bytes)), "rb")
+
+
 def _wav_duration(wav_bytes: bytes) -> float:
     """Return the duration in seconds of a WAV byte string."""
-    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+    with _open_wav(wav_bytes) as wf:
         return wf.getnframes() / wf.getframerate()
 
 
@@ -23,7 +51,7 @@ def _wav_slice(wav_bytes: bytes, start: float, end: float) -> bytes:
 
     Returns a new WAV byte string containing only the requested segment.
     """
-    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+    with _open_wav(wav_bytes) as wf:
         sr = wf.getframerate()
         n_channels = wf.getnchannels()
         sampwidth = wf.getsampwidth()


### PR DESCRIPTION
## Problem

Importing the UrbanSound8K audio demo dataset crashed during clipping:

```
File "vtscore/media/audio/clipper.py", line 17, in _wav_duration
    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
  ...
wave.Error: unknown format: 65534
```

Format tag `65534` is `0xFFFE` = `WAVE_FORMAT_EXTENSIBLE`. Python's stdlib `wave` module only understands `WAVE_FORMAT_PCM` (tag 1) and raises on the extensible container, which UrbanSound8K and many other real-world WAVs ship. The audio clippers (`SoundTilingClipper`, `SoundClipClipper`, `SoundSilenceClipper`, `SoundSpeechActivityClipper`) all read WAV bytes via `_wav_duration` / `_wav_slice`, so any of them hit the crash on such input.

## Fix

`vtscore/media/audio/clipper.py`: added `_open_wav`, which opens WAV bytes with stdlib `wave` and, on `wave.Error` / `EOFError`, falls back to re-encoding the bytes to plain 16-bit PCM via `soundfile` (already a hard dependency; it reads extensible WAVs fine). Both `_wav_duration` and `_wav_slice` now go through it. The happy path is unchanged — the fallback only triggers when stdlib `wave` can't parse the container. Emitted tiles remain standard PCM.

## Tests

Added `TestWaveFormatExtensible` in `tests/detectors/test_clippers.py`. It generates genuine `WAVE_FORMAT_EXTENSIBLE` bytes via libsndfile's `WAVEX` major format, asserts stdlib `wave` rejects them with `65534` (guarding the regression), and confirms `_wav_duration`, `SoundTilingClipper`, and `SoundClipClipper` all handle the input and emit stdlib-readable PCM tiles.

Full `./run-tests.sh` passes (5377 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL2pJCA1bskZF9J3tL66Fn)_