### PR TITLE
Fix stray scrollbar on single-row bin popup grid

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -428,7 +428,12 @@
   flex-shrink: 0;
 }
 
-// The name stacks under the thumbnail, truncated to the cell width.
+// The name stacks under the thumbnail, truncated to the cell width. Its
+// line-height is pinned (not left at the font's ``normal``, which varies by
+// platform font) so the rendered row height is deterministic and matches the
+// space reserved for it in ``rowSize`` (GRID_LABEL_HEIGHT). Without this the name
+// renders a couple px taller than its slot, forcing a stray scrollbar even on a
+// single row. 12px (``--font-xs``) × 1.25 = 15px == GRID_LABEL_HEIGHT.
 .bin-popup-name {
   flex: 0 0 auto;
   width: 100%;
@@ -437,6 +442,7 @@
   text-align: center;
   font-weight: var(--weight-normal);
   font-size: var(--font-xs);
+  line-height: 1.25;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -15,8 +15,21 @@ import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
-/** Vertical room (px) reserved under a grid thumbnail for its truncated name. */
-const GRID_LABEL_HEIGHT = 18;
+/** Height (px) of the name's line box under a grid thumbnail. Mirrors the pinned
+ *  ``line-height`` on ``.bin-popup-name`` (``--font-xs`` = 12px × 1.25 = 15px);
+ *  kept in sync so {@link rowSize} reserves exactly the space the name renders in.
+ *  The name's line-height is pinned (rather than left at the font's ``normal``,
+ *  which varies ~1.15–1.35 by platform font) precisely so this stays exact — an
+ *  unpinned name renders a couple px taller than its slot, which is enough to
+ *  force a stray scrollbar on even a single row. */
+const GRID_LABEL_HEIGHT = 15;
+/** Gap (px) between the thumbnail and its name inside a cell (``.bin-popup-entry``
+ *  flex ``gap``); present only when the name shows. */
+const GRID_THUMB_NAME_GAP = 2;
+/** Vertical padding (px) inside every grid cell (``.bin-popup-entry`` 2px top +
+ *  2px bottom), always present regardless of icon size. Reserved in {@link
+ *  rowSize} so the cell's real rendered height never exceeds its virtual slot. */
+const GRID_CELL_PADDING = 4;
 /** Goal width (px) at/above which grid thumbnails still show their name. Below
  *  this (the XS/S icon sizes) the name truncates to a useless "a…", so the SCSS
  *  hides it (``@container … (max-width: 60px)``) and {@link rowSize} drops the
@@ -512,12 +525,18 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual grid row (a row of cells plus its labels). At
-   *  the smallest icon sizes the name is hidden (see {@link GRID_NAME_MIN_WIDTH}),
-   *  so its reserved height is dropped to keep rows flush. */
+  /** Pixel stride of one virtual grid row: the cell's real rendered height (the
+   *  thumbnail, its always-present vertical padding, and — when shown — the
+   *  thumb→name gap and name line box) plus an inter-row gap. Accounting for the
+   *  cell padding and pinned name line box keeps the row's rendered content from
+   *  overflowing its virtual slot by a sub-pixel, which would otherwise force a
+   *  stray scrollbar on even a single row. At the smallest icon sizes the name is
+   *  hidden (see {@link GRID_NAME_MIN_WIDTH}), so its gap + label height are
+   *  dropped to keep rows flush. */
   get rowSize(): number {
-    const labelHeight = this.gridGoalWidth >= GRID_NAME_MIN_WIDTH ? GRID_LABEL_HEIGHT : 0;
-    return this.gridGoalWidth + labelHeight + GRID_GAP;
+    const nameShown = this.gridGoalWidth >= GRID_NAME_MIN_WIDTH;
+    const nameHeight = nameShown ? GRID_THUMB_NAME_GAP + GRID_LABEL_HEIGHT : 0;
+    return this.gridGoalWidth + GRID_CELL_PADDING + nameHeight + GRID_GAP;
   }
 
   /** Height (px) the grid takes: just enough for its rows, capped (to the room


### PR DESCRIPTION
## Problem

When viewing an audio (or any) bin's details in the browse bin popup, the member thumbnail grid showed a vertical scrollbar even when there was only a single row of items. Resizing the thumbnails changed the popup size but the grid stayed *slightly* too short to fit that one row, so the scrollbar never went away.

## Root cause

The virtual grid's row stride (`rowSize`, used both as the cdk `itemSize` and as the basis for the grid's total content height) **undercounted each cell's real rendered height**:

- It reserved nothing for `.bin-popup-entry`'s 4px vertical padding (2px top + 2px bottom).
- `.bin-popup-name` had **no explicit `line-height`**, so it rendered at the platform font's `normal` (~15–16px at 12px), not the ~12px the reserved label height implicitly assumed.

The rendered cell ended up a couple pixels taller than its virtual slot. Because that overshoot is a **per-row constant independent of thumbnail size**, the grid content was always a hair taller than the viewport → a scrollbar on even a single row, and changing the thumbnail size never fixed it.

## Fix

- `rowSize` now accounts for the cell's always-present vertical padding and the thumb→name gap, in addition to the name label height and inter-row gap.
- `.bin-popup-name` gets a pinned `line-height: 1.25` (12px × 1.25 = 15px) so the rendered row height is deterministic across platform fonts and exactly matches the space `rowSize` reserves for it (`GRID_LABEL_HEIGHT = 15`).

Both the name-shown and name-hidden (XS/S icon) paths now carry a consistent margin, so a single row fits without a scrollbar at every thumbnail size.

## Testing

- `./run-tests.sh frontend` — ruff/pyright/build/audit all pass; Vitest 966 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYP6UvMBuXcFmsis2kfcAY)_