### PR TITLE
Add preview-audio volume control to the Browse view

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -145,6 +145,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
    *  the hovered thumbnail breaks out from. The preview pane is sized relative
    *  to this so it tracks the main-canvas thumbnail-size setting. */
   readonly hoverThumbRadius = input(28);
+  /** Preview-audio volume (0–1), driven by the Browse toolbar's volume control. */
+  readonly volume = input(1);
 
   /** Emitted when the popup should close (outside click, Escape, or the X). */
   readonly dismissed = output<void>();
@@ -215,6 +217,13 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   private scrollSub: Subscription | null = null;
 
   constructor() {
+    // Keep the hover-to-hear preview element in step with the Browse toolbar's
+    // volume slider mid-playback; ``onEntryEnter`` also seeds it when a clip
+    // starts.
+    effect(() => {
+      const el = this.audioRef?.nativeElement;
+      if (el) el.volume = this.volume();
+    });
     // Re-read the popup's thumbnail size whenever settings change (this is how
     // the in-header size buttons take effect, and how a change on one popup
     // becomes the default for every future popup of this media type).
@@ -848,6 +857,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       const el = this.audioRef?.nativeElement;
       if (!el) return;
       el.loop = true;
+      el.volume = this.volume();
       el.load();
       el.play().catch(() => {});
     });

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, inject, input, OnChanges, OnDestroy, signal, SimpleChanges, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnChanges, OnDestroy, signal, SimpleChanges, ViewChild } from '@angular/core';
 
 import { ActiveContextService } from '../../services/active-context.service';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
@@ -16,7 +16,18 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
 
   readonly hover = input<HexHoverEvent | null>(null);
   readonly mediaType = input('');
+  /** Preview-audio volume (0–1), driven by the Browse toolbar's volume control. */
+  readonly volume = input(1);
   @ViewChild('audioEl') audioRef?: ElementRef<HTMLAudioElement>;
+
+  constructor() {
+    // Keep the live element in sync when the toolbar slider moves mid-playback;
+    // ``playAudio`` also seeds it so a freshly-started clip honours the level.
+    effect(() => {
+      const el = this.audioRef?.nativeElement;
+      if (el) el.volume = this.volume();
+    });
+  }
 
   visible = false;
   left = 0;
@@ -93,6 +104,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
       const el = this.audioRef?.nativeElement;
       if (!el) return;
       el.loop = true;
+      el.volume = this.volume();
       el.load();
       el.play().catch(() => {});
     });

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -81,6 +81,7 @@
           <vt-browse-hover-preview
             [hover]="hoverEvent"
             [mediaType]="mediaType()"
+            [volume]="volume()"
           />
           @if (contextMenuOpen) {
             <vt-browse-bin-popup
@@ -90,6 +91,7 @@
               [memberIds]="contextMembers"
               [repId]="contextRepId"
               [mediaType]="mediaType()"
+              [volume]="volume()"
               [hoverThumbRadius]="thumbnailRadius"
               (dismissed)="dismissContextMenu()"
             />
@@ -153,6 +155,31 @@
                 <vt-icon type="image" [size]="18"></vt-icon>
               </button>
             </div>
+            @if (mediaType() === 'audio') {
+              <div class="browse-volume" role="group" aria-label="Preview volume">
+                <button
+                  type="button"
+                  class="browse-size-btn"
+                  (click)="toggleMute()"
+                  [attr.aria-pressed]="volume() === 0"
+                  [title]="volume() === 0 ? 'Unmute preview audio' : 'Mute preview audio'"
+                  [attr.aria-label]="volume() === 0 ? 'Unmute preview audio' : 'Mute preview audio'">
+                  <vt-icon [type]="volume() === 0 ? 'volume-mute' : 'volume'" [size]="15"></vt-icon>
+                </button>
+                <input
+                  type="range"
+                  class="browse-volume-slider"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  [value]="volume()"
+                  (input)="onVolumeInput($event)"
+                  (change)="onVolumeCommit($event)"
+                  title="Preview volume"
+                  aria-label="Preview volume"
+                />
+              </div>
+            }
           </div>
           <div class="browse-info">
             <span class="browse-info-label">{{ datasetName() }}</span>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -279,3 +279,69 @@
   box-shadow: inset 0 1px 3px var(--shadow-dropdown);
   z-index: 1;
 }
+
+// Preview-volume control (audio datasets only): a mute toggle joined to a slim
+// range slider, sharing the grouped-pill look of the zoom / hex-size clusters.
+.browse-volume {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.browse-volume-slider {
+  width: 72px;
+  height: 28px;
+  margin: 0 0 0 -1px;
+  padding: 0 var(--space-sm);
+  box-sizing: border-box;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+
+  &:hover {
+    border-color: var(--text-primary);
+    z-index: 1;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 1px;
+  }
+
+  // Blink/WebKit track + thumb.
+  &::-webkit-slider-runnable-track {
+    height: 3px;
+    border-radius: 2px;
+    background: var(--border);
+  }
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    margin-top: -4.5px; // centre the 12px thumb on the 3px track
+    border: none;
+    border-radius: 50%;
+    background: var(--accent-color);
+    cursor: pointer;
+  }
+
+  // Firefox track + thumb.
+  &::-moz-range-track {
+    height: 3px;
+    border-radius: 2px;
+    background: var(--border);
+  }
+
+  &::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border: none;
+    border-radius: 50%;
+    background: var(--accent-color);
+    cursor: pointer;
+  }
+}

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -90,6 +90,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   // build poller, settings effect), so a signal so those writes repaint the
   // canvas/minimap inputs and the info row under zoneless.
   readonly mediaType = signal('');
+  /**
+   * Preview-audio volume (0–1) for the Browse view's hover/bin-popup playback,
+   * seeded from and written back to the shared ``volume`` setting so it stays in
+   * lockstep with the Find view's player. Only surfaced (as a toolbar mute +
+   * slider) for audio datasets — the only media type Browse plays sound for.
+   */
+  readonly volume = signal(1);
+  /** Last non-zero level, so the mute toggle can restore where the user was. */
+  private preMuteVolume = 1;
   hoverEvent: HexHoverEvent | null = null;
   /**
    * Top of the density scale for the legend: the densest cell currently in
@@ -272,6 +281,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       const settingsErrored = this.settingsState.error() != null;
       if (settings) {
         this.lastSettings = settings;
+        const vol = settings.volume ?? 1;
+        this.volume.set(vol);
+        if (vol > 0) this.preMuteVolume = vol;
         if (settings.browse_panel_width != null && !this.panelWidthInitialized) {
           this.panelWidth.set(
             this.clamp(
@@ -713,6 +725,46 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   /** Choose a zoom and pan so the current data just fits in view. */
   zoomToFit(): void {
     this.canvas?.zoomToFit();
+  }
+
+  // --- Preview-audio volume (audio datasets only) -------------------------
+
+  /** Live drag of the volume slider: update the level (and the playing preview,
+   *  via the ``[volume]`` inputs) on every ``input`` without hammering the
+   *  settings API — the write is deferred to {@link onVolumeCommit} on release. */
+  onVolumeInput(event: Event): void {
+    const v = this.clampVolume(+(event.target as HTMLInputElement).value);
+    this.volume.set(v);
+    if (v > 0) this.preMuteVolume = v;
+  }
+
+  /** Slider released (``change``): persist the settled level once. */
+  onVolumeCommit(event: Event): void {
+    const v = this.clampVolume(+(event.target as HTMLInputElement).value);
+    this.setVolume(v);
+  }
+
+  /** Mute toggle: drop to 0 (remembering where we were) or restore the last
+   *  non-zero level. Persists immediately since it's a discrete action. */
+  toggleMute(): void {
+    if (this.volume() > 0) {
+      this.preMuteVolume = this.volume();
+      this.setVolume(0);
+    } else {
+      this.setVolume(this.preMuteVolume > 0 ? this.preMuteVolume : 1);
+    }
+  }
+
+  private setVolume(v: number): void {
+    const clamped = this.clampVolume(v);
+    this.volume.set(clamped);
+    if (clamped > 0) this.preMuteVolume = clamped;
+    this.settingsState.update({ volume: clamped }).subscribe();
+  }
+
+  private clampVolume(v: number): number {
+    if (!Number.isFinite(v)) return this.volume();
+    return Math.max(0, Math.min(1, v));
   }
 
   // --- Right-click bin popup ----------------------------------------------

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -171,4 +171,27 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     component.toggleMarqueeMode();
     expect(component.regionDrawActive).toBe(true);
   });
+
+  it('drives preview-audio volume from the toolbar: slider lowers the level and mute round-trips', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+
+    // Settings resolved to {} → volume defaults to full.
+    expect(component.volume()).toBe(1);
+
+    // Dragging the slider lowers the level (this signal feeds the `[volume]`
+    // inputs on the hover-preview + bin-popup, quieting a playing clip live).
+    component.onVolumeInput({ target: { value: '0.3' } } as unknown as Event);
+    expect(component.volume()).toBeCloseTo(0.3);
+
+    // Muting drops to 0; unmuting restores the pre-mute level, not full volume.
+    component.toggleMute();
+    expect(component.volume()).toBe(0);
+    component.toggleMute();
+    expect(component.volume()).toBeCloseTo(0.3);
+
+    // A committed (released) value clamps into [0, 1].
+    component.onVolumeCommit({ target: { value: '5' } } as unknown as Event);
+    expect(component.volume()).toBe(1);
+  });
 });

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -124,4 +124,10 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   // buttons in the metadata panels.
   copy:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+  // Speaker with sound waves / muted speaker, used by the Browse toolbar's
+  // preview-volume control (audio datasets only).
+  volume:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>',
+  'volume-mute':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>',
 };


### PR DESCRIPTION
## Problem

In the **Browse** (VTSBrowse) view, audio previews play through hidden, uncontrolled `<audio>` elements — the hover preview (`browse-hover-preview`) and the bin-popup grid hover (`browse-bin-popup`) both just call `loop`/`load()`/`play()` with no `controls`, no volume binding, and no read of the persisted `volume` setting. So Browse audio always played at **full volume (1.0)** with no way to lower it. Unlike Train for Find (whose `<audio controls>` player has a native slider + ArrowUp/ArrowDown), Browse had nothing.

Arrow keys can't be the answer here: in Browse all four arrows **pan the canvas** (`panByKey`). Re-binding ArrowUp/Down to volume would double-bind them and make arrows mean different things for image vs. audio datasets.

## What changed

- **Browse toolbar control (audio datasets only):** a mute toggle + volume slider in the top-right control cluster, shown via `@if (mediaType() === 'audio')`. Dragging the slider updates the level live; the value is committed (persisted) once on release; the mute button drops to 0 and restores the pre-mute level.
- **Persisted, shared level:** the control reads and writes the existing `volume` setting, so Browse stays in lockstep with the Find view's player (set it in either place, it carries everywhere).
- **Live application:** the hover-preview and bin-popup now take a `[volume]` input, seed `el.volume` when a clip starts, and keep the playing element in sync while the slider moves (a small `effect`).
- **Icons:** added `volume` / `volume-mute` glyphs to the extended icon set.
- **Test:** a zoneless unit test covering the slider, both mute branches, and `[0,1]` clamping.

## Notes

- The `browse-view` doc screenshot uses an image dataset, so the audio-only control doesn't appear in it — no reshoot needed.
- Frontend gate green: `build:prod` OK, `npm audit` clean, Vitest 967 passed; ruff/pyright/deptry/pip-audit/codespell all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPvJQ4a2rCprZjAUK6j1dA)_