### PR TITLE
Fix stray scrollbar on audio bin popup from unaccounted body padding

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -61,7 +61,7 @@
     </button>
   </div>
 
-  <div class="bin-popup-body" [style.height.px]="bodyHeight">
+  <div class="bin-popup-body" [style.height.px]="bodyOuterHeight">
     @if (showMetadataColumn) {
       <div class="bin-popup-meta-col" [style.width.px]="metadataColWidth">
         <div class="bin-popup-meta-grid">

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -78,6 +78,15 @@ const PREVIEW_OVERSIZE = 2.0;
 const HOVER_EXTENT_PER_RADIUS = 3;
 /** Vertical room (px) the member-count label takes above the scrolling grid. */
 const COUNT_LABEL_HEIGHT = 22;
+/** Vertical padding (px) inside ``.bin-popup-body`` (``var(--space-sm)`` = 6px,
+ *  top + bottom). The body's bound ``height`` is a *border-box* height (the app
+ *  sets ``box-sizing: border-box`` globally), so this padding must be added on
+ *  top of the content the flex columns need ({@link bodyHeight}); otherwise the
+ *  padding eats into the content area and each column's ``height: 100%`` resolves
+ *  to 12px less than {@link bodyHeight}. For audio (where the member grid is the
+ *  exact-fit element) that shortfall forces a stray scrollbar on even a single
+ *  row; for the square preview pane it renders the box 12px non-square. */
+const BODY_PADDING_Y = 12;
 /**
  * Discrete ladder (px) of detail-canvas sizes the top-left size buttons step
  * through. Each click moves to the next rung past the current size in the click
@@ -637,6 +646,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     return Math.max(this.gridColHeight, this.previewSize);
   }
 
+  /** Border-box height (px) bound to ``.bin-popup-body``: the content the flex
+   *  columns need ({@link bodyHeight}) plus the body's own vertical padding. Since
+   *  the body is ``box-sizing: border-box``, the bound ``height`` has to include
+   *  that padding for the content area to actually equal {@link bodyHeight};
+   *  without it every column's ``height: 100%`` comes up {@link BODY_PADDING_Y}px
+   *  short, which shows as a stray scrollbar on the audio member grid and a
+   *  slightly non-square preview pane. */
+  get bodyOuterHeight(): number {
+    return this.bodyHeight + BODY_PADDING_Y;
+  }
+
   /** Side (px) of the *rendered* square preview pane. {@link previewSize} is the
    *  pane's target/minimum side; here we grow it to the full body height so the
    *  pane is always square and the image scales to the largest size that fits.
@@ -1090,7 +1110,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     // plus a gap when shown.
     const metaW = this.showMetadataColumn ? METADATA_COLUMN_WIDTH + PREVIEW_GAP : 0;
     const width = Math.min(metaW + previewW + gridW, this.maxWidthPx);
-    const height = headerH + this.bodyHeight;
+    const height = headerH + this.bodyOuterHeight;
     let l = desiredLeft;
     let t = desiredTop;
     if (l + width + EDGE_MARGIN > regionRight) {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -147,6 +147,27 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     fixture.destroy();
   });
 
+  it('reserves the body padding so a small audio bin grid does not scroll', async () => {
+    // The body is ``box-sizing: border-box`` with 12px of vertical padding, so its
+    // bound height must exceed the flex content it holds by that padding — else the
+    // grid column's ``height: 100%`` content box comes up 12px short and the member
+    // grid gets a stray scrollbar even on a single row (the bug this guards). Audio
+    // has no preview pane, so the grid is the exact-fit element that reveals it.
+    const fixture = makeFixture();
+    fixture.componentRef.setInput('mediaType', 'audio');
+    fixture.componentRef.setInput('memberIds', [1, 2]);
+    fixture.componentRef.setInput('repId', 1);
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    const body = fixture.nativeElement.querySelector('.bin-popup-body') as HTMLElement;
+    // The bound (border-box) height carries the grid column's full content height
+    // (count label + rows) plus the body's own 12px vertical padding on top.
+    expect(parseFloat(body.style.height)).toBe(cmp.gridColHeight + 12);
+
+    fixture.destroy();
+  });
+
   it('stays hidden until settings load, then reveals', async () => {
     // Cold open: settings not yet resolved. The popup's size (thumbnail size,
     // metadata column, preview pane) all come from settings, so it must not


### PR DESCRIPTION
## Problem

The VTSBrowse bin detail popup was still showing a stray scrollbar on small audio bins — the window looked *slightly* too short and forced an unnecessary scrollbar even on a single row of items. The previous fix (PR #2175) tuned the per-row `rowSize` by a couple pixels, which never reached the real, larger shortfall, so it kept recurring.

## Root cause

`.bin-popup-body` is `box-sizing: border-box` (set globally) **and** has `padding: var(--space-sm)` (6px top + 6px bottom = 12px). Its height was bound to `bodyHeight` — the height the flex columns' *content* needs (the grid column, or the preview pane). Because of border-box, that 12px of padding is subtracted from the content area, so every column's `height: 100%` resolved to `bodyHeight − 12px`.

For **audio**, where the member grid is the exact-fit element, the CDK virtual-scroll viewport ended up ~12px shorter than its single row of content → stray scrollbar. On image/video the same shortfall just letterboxed the preview pane by 12px (and rendered it slightly non-square), so it went unnoticed — which is why the report was audio-specific.

## Fix

- Add `BODY_PADDING_Y` (12px) and a `bodyOuterHeight` getter that adds the body's own vertical padding on top of `bodyHeight`.
- Bind `.bin-popup-body`'s (border-box) `height` to `bodyOuterHeight`, so the content area actually equals `bodyHeight` and each column's `height: 100%` gets the full space it needs.
- Clamp the popup's on-screen position against `bodyOuterHeight` too, so the reserved padding is reflected in the vertical fit.

## Test

Added a regression test (`browse-bin-popup.zoneless.spec.ts`) asserting the bound body height carries the grid column's full content height **plus** the 12px body padding, for a small audio bin. Full `./run-tests.sh frontend` gate passes (build + audit + 968 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tBLjhvFoESrpKD5LEquJW)_