### PR TITLE
Play only the clip window in the two audio hover previews

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -10,6 +10,7 @@ import { ViewControlsComponent } from '../view-controls/view-controls.component'
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
 import { usesThumbnails } from '../browse-canvas/hex-render.util';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -909,8 +910,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     setTimeout(() => {
       const el = this.audioRef?.nativeElement;
       if (!el) return;
-      el.loop = true;
       el.volume = this.volume();
+      // Windowed archive-member clips serve the whole file: seek to clip_start
+      // and loop within [clip_start, clip_end]. The hovered item's metadata is
+      // already hydrated (prefetchVisible loads the visible window), and is read
+      // lazily inside the handlers regardless.
+      applyClipWindow(el, () => this.metadataCache.get(id));
       el.load();
       el.play().catch(() => {});
     });
@@ -929,6 +934,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
   private stopAudio(): void {
     const el = this.audioRef?.nativeElement;
     if (el) {
+      clearClipWindow(el);
       el.pause();
       el.currentTime = 0;
     }

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnChanges, OnDestroy, signal, SimpleChanges, ViewChild } from '@angular/core';
 
 import { ActiveContextService } from '../../services/active-context.service';
+import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
+import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 
 @Component({
@@ -13,6 +15,7 @@ import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 })
 export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private activeContext = inject(ActiveContextService);
+  private metadataCache = inject(MediaMetadataCacheService);
 
   readonly hover = input<HexHoverEvent | null>(null);
   readonly mediaType = input('');
@@ -100,11 +103,18 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
     if (this.audioSrc === src) return;
     this.audioSrc = src;
 
+    // Kick off metadata hydration so the clip window (clip_start/clip_end) is
+    // available by the time the audio's loadedmetadata fires; the fetch runs
+    // while the element loads.
+    this.metadataCache.ensureLoaded([mediaId]);
+
     setTimeout(() => {
       const el = this.audioRef?.nativeElement;
       if (!el) return;
-      el.loop = true;
       el.volume = this.volume();
+      // Windowed archive-member clips serve the whole file: seek to clip_start
+      // and loop within [clip_start, clip_end] instead of playing it all.
+      applyClipWindow(el, () => this.metadataCache.get(mediaId));
       el.load();
       el.play().catch(() => {});
     });
@@ -113,6 +123,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private stopAudio(): void {
     const el = this.audioRef?.nativeElement;
     if (el) {
+      clearClipWindow(el);
       el.pause();
       el.currentTime = 0;
     }

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { BrowseHoverPreviewComponent } from './browse-hover-preview.component';
 import { ActiveContextService } from '../../services/active-context.service';
+import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { settleZoneless } from '../../testing/settle-resource';
@@ -43,10 +45,21 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     const activeContextStub: Partial<ActiveContextService> = {
       mediaUrl: (p: string) => p,
     };
+    // The audio hover path reads clip extents through the metadata cache; stub it
+    // so the component constructs without pulling the real root service (and its
+    // HttpClient dependency) into the test injector.
+    const metadataStub: Partial<MediaMetadataCacheService> = {
+      version$: of(0),
+      get: () => undefined,
+      ensureLoaded: () => {},
+    };
 
     await configureZoneless({
       imports: [BrowseHoverPreviewComponent],
-      providers: [{ provide: ActiveContextService, useValue: activeContextStub }],
+      providers: [
+        { provide: ActiveContextService, useValue: activeContextStub },
+        { provide: MediaMetadataCacheService, useValue: metadataStub },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BrowseHoverPreviewComponent);

--- a/frontend/src/app/utils/clip-window.spec.ts
+++ b/frontend/src/app/utils/clip-window.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyClipWindow, clearClipWindow } from './clip-window';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+
+/**
+ * Unit coverage for the hover-preview clip-window helper (VTSearch Bug 1): the
+ * two hover players (browse canvas + bin popup) must play only a windowed
+ * clip's [clip_start, clip_end] rather than the whole archive member the server
+ * serves. Driving the element handlers directly keeps this deterministic —
+ * jsdom's HTMLMediaElement never fires real loadedmetadata/timeupdate.
+ */
+describe('applyClipWindow', () => {
+  function media(partial: Partial<MediaBatchResponse>): MediaBatchResponse {
+    return {
+      id: 1,
+      media_type: 'audio',
+      filename: 'clip.wav',
+      md5: 'x',
+      custom_metadata: {},
+      ...partial,
+    } as MediaBatchResponse;
+  }
+
+  it('seeks to clip_start and disables native loop for a windowed clip', () => {
+    const el = document.createElement('audio');
+    el.loop = true;
+    applyClipWindow(el, () => media({ clip_start: 40, clip_end: 50 }));
+
+    el.onloadedmetadata!(new Event('loadedmetadata'));
+
+    expect(el.currentTime).toBe(40);
+    expect(el.loop).toBe(false);
+  });
+
+  it('loops within the window: resets to clip_start once currentTime reaches clip_end', () => {
+    const el = document.createElement('audio');
+    applyClipWindow(el, () => media({ clip_start: 40, clip_end: 50 }));
+    el.onloadedmetadata!(new Event('loadedmetadata'));
+
+    el.currentTime = 50; // reached the end of the window
+    el.ontimeupdate!(new Event('timeupdate'));
+    expect(el.currentTime).toBe(40);
+
+    el.currentTime = 45; // inside the window — left alone
+    el.ontimeupdate!(new Event('timeupdate'));
+    expect(el.currentTime).toBe(45);
+  });
+
+  it('snaps back into the window when currentTime falls before clip_start', () => {
+    const el = document.createElement('audio');
+    applyClipWindow(el, () => media({ clip_start: 40, clip_end: 50 }));
+    el.onloadedmetadata!(new Event('loadedmetadata'));
+
+    el.currentTime = 10; // before the window
+    el.ontimeupdate!(new Event('timeupdate'));
+    expect(el.currentTime).toBe(40);
+  });
+
+  it('uses native full-file looping for non-windowed media (no clip_start)', () => {
+    const el = document.createElement('audio');
+    applyClipWindow(el, () => media({}));
+
+    el.onloadedmetadata!(new Event('loadedmetadata'));
+    expect(el.loop).toBe(true);
+    expect(el.currentTime).toBe(0);
+
+    // timeupdate is a no-op without a clip window — playback position is left be.
+    el.currentTime = 5;
+    el.ontimeupdate!(new Event('timeupdate'));
+    expect(el.currentTime).toBe(5);
+  });
+
+  it('reads the clip lazily, so extents that hydrate after wiring still take effect', () => {
+    const el = document.createElement('audio');
+    let current: MediaBatchResponse | undefined; // not yet hydrated
+    applyClipWindow(el, () => current);
+
+    // loadedmetadata before hydration: nothing to seek to, native loop stands.
+    el.onloadedmetadata!(new Event('loadedmetadata'));
+    expect(el.loop).toBe(true);
+
+    // Metadata lands; the timeupdate handler now enforces the window.
+    current = media({ clip_start: 40, clip_end: 50 });
+    el.currentTime = 55;
+    el.ontimeupdate!(new Event('timeupdate'));
+    expect(el.currentTime).toBe(40);
+  });
+
+  it('clearClipWindow detaches both handlers', () => {
+    const el = document.createElement('audio');
+    applyClipWindow(el, () => media({ clip_start: 40, clip_end: 50 }));
+    clearClipWindow(el);
+
+    expect(el.onloadedmetadata).toBeNull();
+    expect(el.ontimeupdate).toBeNull();
+  });
+});

--- a/frontend/src/app/utils/clip-window.ts
+++ b/frontend/src/app/utils/clip-window.ts
@@ -1,0 +1,47 @@
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+
+/**
+ * Wire an ``<audio>`` element to play only a media's clip window
+ * (``[clip_start, clip_end]``) when it carries one, instead of the whole
+ * archive member the server serves. For non-windowed media (``clip_start ==
+ * null``) it falls back to native full-file looping.
+ *
+ * Used by the two hover-preview players (the VTSBrowse canvas hexagons and the
+ * bin popup's member grid), which — unlike the full {@link
+ * ../components/center-panel/audio-player/audio-player.component} — drive
+ * playback off inline element handlers rather than template bindings.
+ *
+ * The clip extents are read *lazily* from ``lookup`` inside the element's
+ * ``loadedmetadata`` / ``timeupdate`` handlers rather than captured up front:
+ * batch metadata hydration for the hovered item may still be in flight when
+ * playback starts, but it will have landed by the time the audio has loaded.
+ *
+ * Call {@link clearClipWindow} on stop/cleanup to detach the handlers.
+ */
+export function applyClipWindow(
+  el: HTMLAudioElement,
+  lookup: () => MediaBatchResponse | undefined,
+): void {
+  el.onloadedmetadata = () => {
+    const clipStart = lookup()?.clip_start;
+    // Native loop only for non-windowed media; windowed clips loop manually via
+    // the timeupdate handler below so they stay within [clip_start, clip_end].
+    el.loop = clipStart == null;
+    if (clipStart != null) el.currentTime = clipStart;
+  };
+  el.ontimeupdate = () => {
+    const media = lookup();
+    const clipStart = media?.clip_start;
+    if (clipStart == null) return;
+    const clipEnd = media?.clip_end;
+    if (el.currentTime < clipStart || (clipEnd != null && el.currentTime >= clipEnd)) {
+      el.currentTime = clipStart;
+    }
+  };
+}
+
+/** Detach the clip-window handlers wired by {@link applyClipWindow}. */
+export function clearClipWindow(el: HTMLAudioElement): void {
+  el.onloadedmetadata = null;
+  el.ontimeupdate = null;
+}


### PR DESCRIPTION
## Summary

Fixes Bug 1 from the 2026-06-30 issues report: the two hover-preview audio players played the whole archive member from the start, ignoring the windowed import's `clip_start`/`clip_end`. Both now seek to `clip_start` and loop within `[clip_start, clip_end]`, matching the behavior the full center-panel `AudioPlayerComponent` already implements. Native full-file looping is kept only for non-windowed media.

## Affected components

- **`browse-hover-preview`** (VTSBrowse canvas hexagons) — now injects `MediaMetadataCacheService` and calls `ensureLoaded([mediaId])` at the start of `playAudio` so the clip extents are hydrating while the audio element loads.
- **`browse-bin-popup`** (bin popup member grid) — already injected the cache and prefetches the visible window; `onEntryEnter` now applies the clip window.

## How

A shared `frontend/src/app/utils/clip-window.ts` helper (`applyClipWindow` / `clearClipWindow`) wires the `<audio>` element's `loadedmetadata` / `timeupdate` handlers:

- `loadedmetadata`: read the clip from the cache, set `el.loop = clip_start == null`, and seek to `clip_start` when windowed.
- `timeupdate`: when windowed, reset to `clip_start` whenever `currentTime` falls outside `[clip_start, clip_end]`.
- cleanup detaches both handlers.

The clip is read *lazily* inside the handlers rather than captured up front, since batch metadata hydration may still be in flight when playback starts but has landed by the time the audio has loaded.

## Note on the reported "grey squares" breakage

The report noted that injecting `MediaMetadataCacheService` into `browse-hover-preview` broke the component. The cause is that the component's zoneless spec provided only an `ActiveContextService` stub; the real cache service transitively needs `HttpClient`, which the test injector lacks, so construction threw. The spec now provides a `MediaMetadataCacheService` stub (mirroring the bin-popup spec), and the component constructs cleanly.

## Testing

- New `frontend/src/app/utils/clip-window.spec.ts` covers seek-to-start, loop-at-end, snap-back-before-start, the non-windowed native-loop fallback, lazy clip reads, and handler detach.
- `./run-tests.sh frontend` passes (build, audit, 974 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjugkEywd8DD2FatLbtEED

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjugkEywd8DD2FatLbtEED)_