### PR TITLE
Pool open archive handles to fix fd-exhaustion leak

### DIFF
--- a/tests_lib/datasets/test_archive_stream.py
+++ b/tests_lib/datasets/test_archive_stream.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import io
 import tarfile
+import threading
 import zipfile
 from pathlib import Path
 
 import pytest
 
+from vtscore.datasets import archive_stream
 from vtscore.datasets.archive_stream import (
     LOCAL_ARCHIVE_MEMBER_IMPORTER,
     ArchiveMemberError,
@@ -92,6 +94,96 @@ class TestReadMember:
             info.size = len(new_payload)
             tf.addfile(info, io.BytesIO(new_payload))
         assert read_member(archive, "chunk_a.mp4") == new_payload
+
+
+def _make_one_member_tar(path: Path, payload: bytes = MEMBER_A, name: str = "m.bin") -> Path:
+    with tarfile.open(path, "w") as tf:
+        info = tarfile.TarInfo(name)
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+    return path
+
+
+class TestHandlePool:
+    def test_repeated_reads_reuse_one_handle(self, tmp_path):
+        archive_stream._reset_pool()
+        archive = _make_tar(tmp_path)
+        for _ in range(50):
+            assert read_member_range(archive, "chunk_a.mp4", 0, 5) == MEMBER_A[:5]
+        # A single pooled handle serves every request -- no fd-per-read leak.
+        assert len(archive_stream._handle_cache) == 1
+        pooled = archive_stream._handle_cache[archive_stream._cache_key(archive)]
+        assert pooled._handle is not None
+
+    def test_zip_reads_reuse_one_handle(self, tmp_path):
+        archive_stream._reset_pool()
+        archive = _make_zip(tmp_path)
+        for _ in range(20):
+            assert read_member(archive, "chunk_a.mp4") == MEMBER_A
+        assert len(archive_stream._handle_cache) == 1
+
+    def test_pool_bounds_open_handles_and_closes_evicted(self, tmp_path):
+        archive_stream._reset_pool()
+        first = _make_one_member_tar(tmp_path / "shard_0.tar")
+        assert read_member(first, "m.bin") == MEMBER_A
+        pooled_first = archive_stream._handle_cache[archive_stream._cache_key(first)]
+        assert pooled_first._handle is not None
+
+        # Fill the pool past its bound; the LRU archive (the first) is evicted.
+        for i in range(1, archive_stream._MAX_OPEN_ARCHIVES + 1):
+            a = _make_one_member_tar(tmp_path / f"shard_{i}.tar")
+            assert read_member(a, "m.bin") == MEMBER_A
+
+        assert len(archive_stream._handle_cache) == archive_stream._MAX_OPEN_ARCHIVES
+        assert archive_stream._cache_key(first) not in archive_stream._handle_cache
+        assert pooled_first._handle is None  # closed on eviction, fd released
+        # Re-reading an evicted archive transparently re-pools it.
+        assert read_member(first, "m.bin") == MEMBER_A
+
+    def test_read_through_closed_handle_falls_back(self, tmp_path):
+        archive_stream._reset_pool()
+        archive = _make_tar(tmp_path)
+        read_member(archive, "chunk_a.mp4")
+        pooled = archive_stream._handle_cache[archive_stream._cache_key(archive)]
+        pooled.close()  # simulate eviction under a stale reference
+        _path, info, _is_zip = archive_stream._resolve(archive, "chunk_a.mp4")
+        # A stale reference still returns correct bytes via a one-shot open.
+        assert pooled.read(info, 0, None) == MEMBER_A
+
+    def test_concurrent_range_reads_same_archive(self, tmp_path):
+        archive_stream._reset_pool()
+        archive = _make_tar(tmp_path)
+        results: dict[int, bytes] = {}
+        errors: list[Exception] = []
+
+        def worker(i: int) -> None:
+            try:
+                start = i % 10
+                results[i] = read_member_range(archive, "chunk_a.mp4", start, 12)
+            except Exception as exc:  # noqa: BLE001 - surfaced via `errors`
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(40)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        for i, got in results.items():
+            start = i % 10
+            assert got == MEMBER_A[start : start + 12]
+        # Serialised reads share the single pooled handle.
+        assert len(archive_stream._handle_cache) == 1
+
+    def test_reset_pool_closes_handles(self, tmp_path):
+        archive_stream._reset_pool()
+        archive = _make_tar(tmp_path)
+        read_member(archive, "chunk_a.mp4")
+        pooled = archive_stream._handle_cache[archive_stream._cache_key(archive)]
+        archive_stream._reset_pool()
+        assert len(archive_stream._handle_cache) == 0
+        assert pooled._handle is None
 
 
 class TestArchiveMemberRef:

--- a/vtscore/datasets/archive_stream.py
+++ b/vtscore/datasets/archive_stream.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import tarfile
 import threading
 import zipfile
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,126 @@ _index_lock = threading.Lock()
 def _cache_key(path: Path) -> tuple[str, int, int]:
     st = path.stat()
     return (str(path), st.st_size, st.st_mtime_ns)
+
+
+#: Upper bound on simultaneously-open archive handles.  Reads seek within a
+#: reused handle instead of reopening the archive on every HTTP Range request,
+#: so a windowed-audio corpus no longer exhausts the process fd limit.  The
+#: least-recently-used archive is closed once the pool exceeds this size.
+_MAX_OPEN_ARCHIVES = 32
+
+
+class _PooledArchive:
+    """A reusable open handle to one tar/zip archive.
+
+    Holds a single ``tarfile.TarFile`` / ``zipfile.ZipFile`` open across many
+    range reads.  Reads on the same archive are serialised by ``_lock`` because
+    ``TarFile`` (and, pre-parallel, ``ZipFile``) share one underlying file
+    position across member file objects, so concurrent seeks would corrupt each
+    other.  Different archives use different instances and read in parallel.
+    """
+
+    def __init__(self, path: Path, is_zip: bool) -> None:
+        self.path = path
+        self.is_zip = is_zip
+        self._lock = threading.Lock()
+        self._handle: Any = _open_archive(path, is_zip)
+
+    def read(self, info: Any, start: int, length: int | None) -> bytes:
+        with self._lock:
+            handle = self._handle
+            if handle is not None:
+                return _read_from(handle, info, start, length, self.is_zip)
+            # Evicted/closed out from under a stale reference: fall back to a
+            # one-shot open/close for just this read so no fd is retained.
+            handle = _open_archive(self.path, self.is_zip)
+            try:
+                return _read_from(handle, info, start, length, self.is_zip)
+            finally:
+                handle.close()
+
+    def close(self) -> None:
+        """Close the underlying handle, waiting for any in-flight read first."""
+        with self._lock:
+            handle, self._handle = self._handle, None
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception:  # noqa: BLE001 - best-effort fd release
+                pass
+
+
+# Process-scoped pool of open archive handles, keyed like ``_index_cache`` and
+# ordered least-recently-used first for eviction.
+_handle_cache: OrderedDict[tuple[str, int, int], _PooledArchive] = OrderedDict()
+_handle_lock = threading.Lock()
+
+
+def _open_archive(path: Path, is_zip: bool) -> Any:
+    if is_zip:
+        return zipfile.ZipFile(path, "r")
+    try:
+        return tarfile.open(path, "r:*")
+    except tarfile.TarError as exc:
+        raise ArchiveMemberError(f"Not a readable tar/zip archive: {path} ({exc})") from exc
+
+
+def _read_from(handle: Any, info: Any, start: int, length: int | None, is_zip: bool) -> bytes:
+    if is_zip:
+        with handle.open(info, "r") as f:
+            if start:
+                f.seek(start)
+            return f.read() if length is None else f.read(length)
+    extracted = handle.extractfile(info)
+    if extracted is None:
+        raise ArchiveMemberError(f"Member {info.name!r} is not a regular file")
+    with extracted as f:
+        if start:
+            f.seek(start)
+        return f.read() if length is None else f.read(length)
+
+
+def _pooled_archive(path: Path, is_zip: bool) -> _PooledArchive:
+    """Return the pooled handle for *path*, opening and caching it on first use.
+
+    Insertion may evict the least-recently-used archive; evictions are closed
+    outside ``_handle_lock`` (each ``close`` waits on its own read lock) so the
+    pool never blocks on a slow ``close`` and locks are never nested.
+    """
+    key = _cache_key(path)
+    with _handle_lock:
+        pooled = _handle_cache.get(key)
+        if pooled is not None:
+            _handle_cache.move_to_end(key)
+            return pooled
+
+    # Open outside the pool lock; another thread may race us to the same key.
+    opened = _PooledArchive(path, is_zip)
+    to_close: list[_PooledArchive] = []
+    with _handle_lock:
+        existing = _handle_cache.get(key)
+        if existing is not None:
+            _handle_cache.move_to_end(key)
+            pooled = existing
+            to_close.append(opened)
+        else:
+            _handle_cache[key] = opened
+            pooled = opened
+            while len(_handle_cache) > _MAX_OPEN_ARCHIVES:
+                _, evicted = _handle_cache.popitem(last=False)
+                to_close.append(evicted)
+    for handle in to_close:
+        handle.close()
+    return pooled
+
+
+def _reset_pool() -> None:
+    """Close and drop all pooled archive handles (test/shutdown hook)."""
+    with _handle_lock:
+        handles = list(_handle_cache.values())
+        _handle_cache.clear()
+    for handle in handles:
+        handle.close()
 
 
 def _is_zip(path: Path) -> bool:
@@ -137,30 +258,16 @@ def read_member_range(
     """Read *length* bytes of *member* starting at byte offset *start*.
 
     ``length=None`` reads to the end of the member.  The archive handle is
-    opened and closed within the call (each call gets its own handle, so
-    concurrent range requests don't share mutable archive state), and the
+    drawn from a bounded process-scoped pool (see :func:`_pooled_archive`) and
+    left open for reuse, so a burst of HTTP Range requests over a windowed-audio
+    corpus reuses a handful of fds instead of opening one per request.  The
     member's file object is *seeked* to *start* so only the requested slice is
     read -- the whole member is never materialised for a partial request.
     """
     path, info, is_zip = _resolve(archive_path, member)
     if start < 0:
         start = 0
-
-    if is_zip:
-        with zipfile.ZipFile(path, "r") as zf:
-            with zf.open(info, "r") as f:
-                if start:
-                    f.seek(start)
-                return f.read() if length is None else f.read(length)
-
-    with tarfile.open(path, "r:*") as tf:
-        extracted = tf.extractfile(info)
-        if extracted is None:
-            raise ArchiveMemberError(f"Member {member!r} is not a regular file in {path}")
-        with extracted as f:
-            if start:
-                f.seek(start)
-            return f.read() if length is None else f.read(length)
+    return _pooled_archive(path, is_zip).read(info, start, length)
 
 
 def archive_member_ref(media: dict[str, Any]) -> tuple[str, str] | None:


### PR DESCRIPTION
## Problem

Importing a large WebDataset-style corpus (~12,500 windowed audio media across ~950 tar shards) and actively playing/training crashed the server with a continuous stream of `accept: Too many open files`, after which the process became unresponsive and had to be killed — losing all in-memory dataset state.

**Root cause:** `archive_stream.read_member_range()` opened a *new* file descriptor to the tar/zip archive on every call. The member *index* was cached correctly (metadata only, no bytes), but the archive file handle itself was opened and closed per request. With windowed audio the browser issues several HTTP Range requests per clip (probe, seek-to-clip-start, playback); across 12k+ items clicked through quickly, fds accumulated faster than the OS reclaimed them and exhausted the default per-process limit (~1024) within minutes.

## Fix

Added a bounded, process-scoped **LRU pool of open archive handles** in `vtscore/datasets/archive_stream.py`, keyed the same way as the member index (`path` / `size` / `mtime_ns`):

- `read_member_range()` now draws a handle from the pool and **seeks within the reused handle** instead of reopening the archive on every request.
- Reads on the *same* archive are serialised by a per-handle lock, because a `TarFile` (and pre-3.7 `ZipFile`) shares one underlying file position across its member file objects, so concurrent seeks would corrupt each other. Reads on *different* archives use different handles and proceed in parallel.
- The pool caps at 32 open archives (`_MAX_OPEN_ARCHIVES`) and **closes the least-recently-used handle on overflow**. `close()` waits on the in-flight read lock first, and a stale-reference read transparently falls back to a one-shot open/close — so no fd is ever leaked or closed mid-read.
- Cache key folds in `size`/`mtime_ns`, so a replaced-on-disk archive naturally pools a fresh handle.

Zip archives get the same pooling as tar.

## Tests

Added a `TestHandlePool` suite in `tests_lib/datasets/test_archive_stream.py` covering: single-handle reuse across many reads (tar + zip), the 32-handle bound with LRU eviction closing the evicted fd, the stale-reference fallback, concurrent range reads on one archive, and pool reset. Full suite green (5384 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YTXgJFABFQNZ7vUFUC76p

---
_Generated by [Claude Code](https://claude.ai/code/session_015YTXgJFABFQNZ7vUFUC76p)_