### PR TITLE
Reject unroutable NPZ manifest embedder_name at import

### DIFF
--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -297,7 +297,7 @@ class TestServerFilesNpzRunsEndToEnd:
             npz,
             filenames=np.array([str(src)]),
             vectors=vec[np.newaxis],
-            embedder_name=np.array("laion-clap"),
+            embedder_name=np.array("clap"),
         )
 
         imp = ServerFilesDatasetImporter()
@@ -306,8 +306,36 @@ class TestServerFilesNpzRunsEndToEnd:
 
         assert len(medias) == 1
         media = next(iter(medias.values()))
-        assert media["embedder"] == "laion-clap"
-        assert media["origin"]["params"]["embedder_name"] == "laion-clap"
+        assert media["embedder"] == "clap"
+        assert media["origin"]["params"]["embedder_name"] == "clap"
+
+    def test_unregistered_npz_embedder_name_raises_at_import(self, tmp_path):
+        """An NPZ embedder name VTSearch can't route is rejected up front, with
+        the valid options listed, rather than silently disabling text search."""
+        from helpers import make_raw_wav_bytes
+
+        src = tmp_path / "clip.wav"
+        src.write_bytes(make_raw_wav_bytes())
+
+        rng = np.random.default_rng(0)
+        vec = rng.standard_normal(512).astype(np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src)]),
+            vectors=vec[np.newaxis],
+            embedder_name=np.array("audemb_largerclapgeneral"),
+        )
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        with pytest.raises(ValueError) as exc:
+            imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+        msg = str(exc.value)
+        assert "audemb_largerclapgeneral" in msg
+        assert "audio" in msg
+        assert "clap" in msg  # the registered options are listed
+        assert medias == {}
 
     def test_npz_per_key_layout_is_accepted(self, tmp_path):
         from helpers import make_raw_wav_bytes

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -30,19 +30,23 @@ def _make_tar(tmp_path: Path) -> Path:
     return archive
 
 
-def _make_manifest(tmp_path: Path, archive: Path, *, scalar_archive: bool = True, members=None) -> Path:
+def _make_manifest(
+    tmp_path: Path,
+    archive: Path,
+    *,
+    scalar_archive: bool = True,
+    members=None,
+    embedder_name: str | None = "xclip",
+) -> Path:
     members = members if members is not None else list(MEMBERS)
     rng = np.random.default_rng(7)
     vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
     manifest = tmp_path / "manifest.npz"
     archives = np.array(str(archive)) if scalar_archive else np.array([str(archive)] * len(members))
-    np.savez(
-        manifest,
-        vectors=vectors,
-        members=np.array(members),
-        archives=archives,
-        embedder_name=np.array("largerclapgeneral"),
-    )
+    arrays = {"vectors": vectors, "members": np.array(members), "archives": archives}
+    if embedder_name is not None:
+        arrays["embedder_name"] = np.array(embedder_name)
+    np.savez(manifest, **arrays)
     return manifest
 
 
@@ -66,7 +70,7 @@ def _make_windowed_manifest(tmp_path: Path, archive: Path) -> Path:
         archives=np.array(str(archive)),
         clip_start=np.array(clip_starts, dtype=np.float32),
         clip_end=np.array(clip_ends, dtype=np.float32),
-        embedder_name=np.array("largerclapgeneral"),
+        embedder_name=np.array("xclip"),
     )
     return manifest
 
@@ -113,8 +117,8 @@ class TestImporter:
             assert media["media_bytes"] is None
             assert "media_path" not in media or media["media_path"] is None
             # Precomputed embedding is carried, under the manifest's embedder.
-            assert media["embedder"] == "largerclapgeneral"
-            assert media["embeddings"]["largerclapgeneral"].shape == (DIM,)
+            assert media["embedder"] == "xclip"
+            assert media["embeddings"]["xclip"].shape == (DIM,)
             assert len(media["md5"]) == 32
             ref = media["archive_member"]
             assert Path(ref["path"]).name == "shard_000000.tar"
@@ -168,6 +172,54 @@ class TestImporter:
         assert reloaded == {"manifest": str(manifest.resolve()), "media_type": "video"}
 
 
+class TestEmbedderNameValidation:
+    """A manifest embedder_name that VTSearch can't route is rejected at import."""
+
+    def test_unregistered_embedder_name_raises_with_options(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        # The exact symptom from the field report: a name from an external
+        # pipeline that isn't in VTSearch's registry.
+        manifest = _make_manifest(tmp_path, archive, embedder_name="audemb_largerclapgeneral")
+        medias: dict[int, dict] = {}
+        with pytest.raises(ValueError) as exc:
+            IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        msg = str(exc.value)
+        assert "audemb_largerclapgeneral" in msg
+        # The error names the media type and lists the valid registered options.
+        assert "video" in msg
+        assert "xclip" in msg
+        # Nothing was imported.
+        assert medias == {}
+
+    def test_wrong_media_type_embedder_raises(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        # ``clap_general`` is a registered *audio* embedder, so it can't bind
+        # this ``video`` dataset's slots either.
+        manifest = _make_manifest(tmp_path, archive, embedder_name="clap_general")
+        medias: dict[int, dict] = {}
+        with pytest.raises(ValueError) as exc:
+            IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        assert "clap_general" in str(exc.value)
+        assert medias == {}
+
+    def test_registered_embedder_name_imports(self, tmp_path):
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive, embedder_name="xclip")
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        assert len(medias) == 2
+
+    def test_missing_embedder_name_is_allowed(self, tmp_path):
+        # A manifest that declares no embedder imports fine (the media just
+        # carries no embedder identity); validation only gates a *named* one.
+        archive = _make_tar(tmp_path)
+        manifest = _make_manifest(tmp_path, archive, embedder_name=None)
+        medias: dict[int, dict] = {}
+        IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
+        assert len(medias) == 2
+        assert next(iter(medias.values()))["embedder"] == ""
+
+
 class TestWindowedManifest:
     def test_reader_emits_clip_fields(self, tmp_path):
         archive = _make_tar(tmp_path)
@@ -213,7 +265,7 @@ class TestWindowedManifest:
             members=np.array(["chunk_a.mp4", "chunk_a.mp4"]),
             archives=np.array(str(archive)),
             window_id=np.array(["w0", "w1"]),
-            embedder_name=np.array("largerclapgeneral"),
+            embedder_name=np.array("xclip"),
         )
         medias: dict[int, dict] = {}
         IMPORTER.run({"manifest": str(manifest), "media_type": "video"}, medias)
@@ -270,9 +322,9 @@ class TestLocalArchiveMemberSource:
         assert fetched.path is None
         assert fetched.embedding is not None
         assert fetched.embedding.shape == (DIM,)
-        assert fetched.embedder_name == "largerclapgeneral"
+        assert fetched.embedder_name == "xclip"
         # Re-supplied vector matches the in-memory embedding from import.
-        np.testing.assert_array_equal(fetched.embedding, media["embeddings"]["largerclapgeneral"])
+        np.testing.assert_array_equal(fetched.embedding, media["embeddings"]["xclip"])
 
     def test_fetch_item_resolves_windowed_member(self, tmp_path):
         from vtscore.datasets.sources import get_source_for_origin
@@ -290,7 +342,7 @@ class TestLocalArchiveMemberSource:
         # The window key is "member@start"; fetch by it returns that window's vector.
         fetched = source.fetch_item("chunk_a.mp4@10")
         assert fetched.embedding is not None
-        np.testing.assert_array_equal(fetched.embedding, window["embeddings"]["largerclapgeneral"])
+        np.testing.assert_array_equal(fetched.embedding, window["embeddings"]["xclip"])
 
     def test_fetch_item_unknown_key_returns_pathless_empty(self, tmp_path):
         from vtscore.datasets.sources import get_source_for_origin

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -67,6 +67,42 @@ def read_npz_embedder_name(npz_path: Path) -> str:
     return ""
 
 
+def validate_manifest_embedder_name(
+    embedder_name: str, media_type_id: str, *, source_label: str = "NPZ manifest"
+) -> None:
+    """Reject a manifest *embedder_name* that VTSearch can't route to a real embedder.
+
+    An NPZ manifest may name the embedder that produced its vectors.  VTSearch
+    binds a dataset's text / region search slots by looking that name up in the
+    embedder registry (see :func:`vtscore.embedding.binding.derive_binding`), so a
+    name that is unregistered - or registered for a *different* media type - binds
+    no slot, and text queries later fail with a confusing 400 ("does not support
+    text queries").  Catch it here, at import, and point the user at the embedders
+    that are actually valid for this media type.
+
+    An empty / whitespace name is allowed: it simply means the manifest declares no
+    embedder (the importer falls back to the media type's default).  Raises
+    :class:`ValueError` for a non-empty name that is not a registered
+    *media_type_id* embedder.
+    """
+    name = (embedder_name or "").strip()
+    if not name:
+        return
+
+    from vtscore.media import embedders_for_type  # noqa: PLC0415 - avoid import cycle
+
+    valid = [e.name for e in embedders_for_type(media_type_id)]
+    if name in valid:
+        return
+    options = ", ".join(valid) if valid else "(none registered for this media type)"
+    raise ValueError(
+        f"{source_label} names embedder {name!r}, which is not a registered VTSearch "
+        f"{media_type_id} embedder. Text and region search bind by embedder name, so "
+        f"an unregistered name silently disables them. Set embedder_name to one of the "
+        f"registered {media_type_id} embedders: {options}."
+    )
+
+
 def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
     """Return a ``{filename: vector}`` mapping read from *npz_path*.
 

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -42,6 +42,7 @@ from vtscore.datasets.archive_stream import (
 from vtscore.datasets.importers._npz_vectors import (
     read_npz_archive_member_rows,
     read_npz_embedder_name,
+    validate_manifest_embedder_name,
     window_suffix,
 )
 from vtscore.datasets.importers.base import ImporterBase, PluginField
@@ -135,6 +136,7 @@ class LocalArchiveMemberImporter(ImporterBase):
 
         rows = read_npz_archive_member_rows(manifest)
         embedder_name = read_npz_embedder_name(manifest)
+        validate_manifest_embedder_name(embedder_name, output_type, source_label=f"manifest {manifest.name}")
         manifest_path = str(manifest.resolve())
 
         next_id = max(medias.keys(), default=0) + 1

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -33,7 +33,11 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-from vtscore.datasets.importers._npz_vectors import read_npz_embedder_name, read_npz_filenames_and_vectors
+from vtscore.datasets.importers._npz_vectors import (
+    read_npz_embedder_name,
+    read_npz_filenames_and_vectors,
+    validate_manifest_embedder_name,
+)
 from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 
@@ -256,7 +260,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
-    def _stage_paths(self, field_values: dict[str, Any]) -> tuple[Path, dict[str, Path], dict[str, Any], str]:
+    def _stage_paths(
+        self, field_values: dict[str, Any], media_type_id: str
+    ) -> tuple[Path, dict[str, Path], dict[str, Any], str]:
         """Read the paths file and symlink each entry into a fresh temp dir.
 
         Returns ``(staging_dir, name_to_source, content_vectors, embedder_name)`` where:
@@ -279,6 +285,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
         paths, path_to_vector, embedder_name = _read_paths_and_vectors(paths_file)
         if not paths:
             raise ValueError(f"No paths found in {paths_file}")
+        # Reject an unroutable NPZ embedder name before staging anything, so the
+        # failure is an actionable import-time error rather than a confusing
+        # "does not support text queries" 400 at search time.
+        validate_manifest_embedder_name(embedder_name, media_type_id, source_label=f"paths file {paths_file.name}")
 
         staging = Path(tempfile.mkdtemp(prefix="server_files_"))
         name_to_source = _symlink_paths(paths, staging)
@@ -365,7 +375,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
 
-        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values, output_type)
         # Merge npz-supplied vectors with any vectors set externally on
         # ``self.content_vectors``.  NPZ vectors take priority for keys
         # that overlap.
@@ -424,7 +434,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
 
-        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors, embedder_name = self._stage_paths(field_values, output_type)
         origin = self.build_origin(field_values)
         merged_vectors: dict[str, Any] = dict(self.content_vectors or {})
         merged_vectors.update(npz_vectors)


### PR DESCRIPTION
## Problem

When importing pre-computed embeddings via an NPZ manifest whose `embedder_name` comes from an external pipeline (e.g. `audemb_largerclapgeneral` from corpus tooling), VTSearch stored that name verbatim as the media's embedder. But the routing table binds a dataset's text/region search slots by looking the name up in the embedder registry — an unregistered name resolves to `(False, False, False)` capabilities, so the text slot is never bound. The import *appeared* to succeed, and the failure only surfaced much later at search time with a confusing `Embedder '...' does not support text queries` 400.

The demo loader and embedding stage already fail fast on unknown embedder names; the NPZ importers (`server_files` / `local_files` paths file, and the archive-member manifest) were the gap — they accepted any string without validation.

## Fix

Validate the manifest `embedder_name` at **import time**. A non-empty name that isn't a registered embedder *for the import's media type* now raises a `ValueError` before anything is staged/built, and — per the ask — the message **lists the valid options** for that media type:

> `manifest foo.npz names embedder 'audemb_largerclapgeneral', which is not a registered VTSearch audio embedder. Text and region search bind by embedder name, so an unregistered name silently disables them. Set embedder_name to one of the registered audio embedders: clap, clap_general, clap_music, ast, whisper_encoder, paraspeechclap.`

An empty/absent name is still allowed (the manifest simply declares no embedder). The check is shared via a new `validate_manifest_embedder_name()` helper in `_npz_vectors.py`, called from both the `server_files` importer (before staging, so no temp dirs leak on rejection) and the `local_archive_member` importer.

## Changes

- `vtscore/datasets/importers/_npz_vectors.py` — new `validate_manifest_embedder_name(embedder_name, media_type_id, *, source_label)` helper.
- `vtscore/datasets/importers/local_archive_member/__init__.py` — validate after reading the manifest embedder name.
- `vtscore/datasets/importers/server_files/__init__.py` — thread the media type into `_stage_paths` and validate before staging.
- Tests: new fail-fast cases (unregistered name lists options, wrong-media-type name rejected, registered name imports, empty name allowed) in both `tests_lib/io/test_archive_member_import.py` and `tests/io/test_npz_dataset_import.py`; existing fixtures that used placeholder unregistered names (`largerclapgeneral`, `laion-clap`) updated to registered ones.

## Backwards compatibility

This is an intentional behavior break: manifests that previously imported with an unregistered `embedder_name` now fail at import. Such datasets couldn't do text or region search anyway, so failing loudly and early (with the fix spelled out) is strictly better than the silent late failure. Datasets already imported (pickles carrying an unregistered name) reload unchanged — validation only gates the import path.

## Testing

`./run-tests.sh` — all 5389 tests pass (ruff/format/codespell/deptry gates included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrMB3E3gbgW7ar6jHwXbKp)_