### PR TITLE
Fix inclusion-slide regression test broken by the MLP hidden-floor bump

### DIFF
--- a/tests/detectors/test_find_inclusion_slide.py
+++ b/tests/detectors/test_find_inclusion_slide.py
@@ -30,11 +30,21 @@ def _export_good(client):
     return sum(1 for e in resp.get_json()["labels"] if e["label"] == "good")
 
 
+# 6 good / 6 bad, leaving ids 13–20 unlabeled as the haystack an Inclusion slide
+# re-splits. The label count matters: with a tiny set (e.g. 4 good / 5 bad) the
+# calibration folds are perfectly separable — at the optimal cut both FPR and
+# FNR are 0, so no Inclusion weighting can move the threshold and the slide is a
+# genuine (correct) no-op, which this regression can't observe. This split keeps
+# the folds non-separable so tightening Inclusion demonstrably raises the cutoff.
+_GOOD_IDS = [1, 2, 3, 4, 5, 6]
+_BAD_IDS = [7, 8, 9, 10, 11, 12]
+
+
 def _run_find(client):
     detector_id = setup_trainable_model_in_registry(
         "slide-regression",
-        good_ids=[1, 2, 3, 4],
-        bad_ids=[16, 17, 18, 19, 20],
+        good_ids=_GOOD_IDS,
+        bad_ids=_BAD_IDS,
         snap=snapshot_medias(),
     )
     load_detector_and_wait(client, detector_id)


### PR DESCRIPTION
## Problem

`tests/detectors/test_find_inclusion_slide.py::test_inclusion_slide_moves_cutoff_and_resplits` fails on `dev`:

```
assert exclusive_threshold != inclusive_threshold
E   assert 0.4672418534755707 != 0.4672418534755707
```

## Root cause

The MLP hidden-floor bump (4 → 8, commit `b05836fd`) gave the calibration fold models enough capacity to **perfectly separate** the test's tiny 4-good / 5-bad fixture. When the folds are perfectly separable, the optimal cut has both FPR and FNR at 0, so no Inclusion weighting can move the threshold — the slide becomes a genuine (and *correct*) no-op. The test asserts the threshold moves, which is only observable when the folds carry some classification error.

This is a test-data artifact exposed by an intentional model change, not a product regression in the Inclusion path — the cache is still populated and the recompute still runs (verified by the sibling `test_find_label_populates_calibration_cache`, which passes).

## Fix

Use a 6-good / 6-bad label set (ids 1–12), leaving ids 13–20 unlabeled as the haystack the slide re-splits. I probed several splits: the original 4/5 was the *only* degenerate (separable) one; 6/6, 7/8, 8/12, and 10/10 all keep the folds non-separable so tightening Inclusion demonstrably raises the cutoff (e.g. 0.465 → 0.483). The larger set also keeps unlabeled items around so the test's "re-splits the unverified items" assertions exercise real work.

## Verification

Full suite green: **5395 passed, 0 failed** (this failure was the only one on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt9PU87VxcbZappWirmCoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt9PU87VxcbZappWirmCoD)_