### PR TITLE
Comprehensive interface audit: fix 20+ cross-boundary bugs with regression tests

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,0 +1,226 @@
+# Comprehensive interface audit — July 2026
+
+**Status: fix pass shipped; open follow-ups below.**
+
+A full-codebase audit focused on interface boundaries: frontend ↔ backend
+API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
+IO subsystems, concurrency, and frontend TypeScript logic.  Six parallel
+audit passes produced ~40 findings; the confirmed, well-scoped ones were
+fixed with regression tests in the same pass.  This document records what
+shipped and what is deliberately deferred, so the next contributor picking
+up any of these areas sees the known-weak spots.
+
+## What shipped
+
+### Backend — state / settings / jobs
+
+- **Detector-state wipe via the request-missing sentinel** (high).
+  `ensure_votes_match_active_dataset` guarded on `if not ds_ctx.dataset_id`,
+  but inside a request with no `X-Dataset-Id` the dataset context is the
+  request-missing sentinel whose id is the *truthy* string
+  `"__request_missing__"`.  Any request naming a detector but no dataset
+  wiped the detector's in-memory session (votes, label history, the whole
+  Find-verification session) against the sentinel's frozen-empty medias.
+  Fixed in `vtscore/detectors/dataset_sync.py`; regression test in
+  `tests/detectors/test_detectors.py`.
+- **Settings-import code injection surface** (high in multi-user).
+  `_get_setter_map()` scanned the whole `vtsearch.settings` namespace for
+  `set_*` callables, so an imported or synced settings dict could invoke
+  process-level setters (`set_settings_path`, `set_user_data_dir_override`,
+  CLI knobs) and repoint storage for the whole process.  The map is now
+  restricted to real schema keys.  Tests in `tests/io/test_sync_sources.py`.
+- **JobManager pending-slot coalescing across requesters** (high).
+  The single pending slot coalesced *any* new `start()` into the parked
+  job, so a poller of that job id could receive another user's / another
+  (dataset, detector) pair's results.  Coalescing now requires the same
+  requester context; anything else supersedes the parked pending with a
+  visible `cancelled` status.  A pending job cancelled while parked is no
+  longer promoted and run.  Tests in `tests_lib/integration/test_async_jobs.py`.
+- **Cross-detector label application in labelset sync** (medium).
+  `sync_from_labelset_source(detector_id)` wrote `detector_meta` to the
+  *named* detector but applied the imported votes to the request's *active*
+  detector.  The apply pass now runs under `override_detector_context(ctx)`.
+  Test in `tests/io/test_sync_sources.py`.
+- **Detector-JSON lost update** (low-medium). `sync_labels_to_loaded_detector`
+  did an unlocked read→merge→write of the detector JSON; concurrent syncs
+  from different dataset contexts dropped each other's cross-dataset
+  entries.  Now serialised under a module lock.
+
+### Backend — ML / thresholds
+
+- **`find_optimal_threshold` search-space bugs** (medium).  The candidate
+  set was only the observed scores, so "predict nothing" (threshold above
+  max; FPR=0, FNR=1) was unreachable even when it minimised the weighted
+  cost — under a precision-biased inclusion the calibrated cutoff came out
+  far too permissive.  Tied scores also produced infeasible mid-tie cut
+  positions.  Both fixed; the function can now return `NO_GOOD_THRESHOLD`
+  when abstaining is strictly cheaper.  Tests in
+  `tests_lib/sorting/test_find_optimal_threshold.py`.
+- **Stale calibration cache below the ramp floor** (medium).  The <6-label
+  training path left `det_ctx.calibration_cache` stale, so an inclusion
+  slide re-thresholded against fold orderings computed for the old label
+  set/model.  The cache is now cleared on that path.  Tests in
+  `tests_lib/detectors/test_calibration_cache_invalidation.py`.
+- **NaN-threshold guard** (low).  Fold calibration scores are now sanitised
+  (`sigmoid_to_finite_scores`) so a destabilised fold model can't put NaN
+  on `DetectorContext.threshold` when safe-thresholds is off.
+- **DiversityTree `inertia=None` crash path** (low).  The k-means backend
+  contract allows `inertia=None`; `_build_node` now keeps such labels as a
+  fallback candidate instead of crashing on `labels == ci` with
+  `best_labels is None`.
+- Docstring drift fixes: GMM <2-scores fallback wording, `n_labels <= 6`
+  pure-GMM boundary, stale `"embedding"`-key wording in `train_and_score`
+  and the eval harness docs.
+
+### Backend — IO / downloads
+
+- **Whole-archive RAM read** (high).  `_validate_archive` read the entire
+  (multi-GB) archive into memory to inspect 4 magic bytes; now reads 4 bytes.
+- **Duplicate-media re-ingest** (medium).  `_ingest_via_source` inserted
+  entries into the live `medias` dict as it went, then returned -1 mid-loop
+  on a later failure; the fallback re-ingested the whole group, duplicating
+  the already-inserted entries.  Partial inserts are now rolled back before
+  the fallback signal.  Test in `tests/datasets/test_media_sources.py`.
+- **HTTP-archive cache collision** (medium).  The resolve cache was keyed on
+  the URL *basename*, so two archives sharing a final path segment silently
+  served each other's bytes.  Now keyed on a hash of the full URL.
+  *Note: existing caches under the old naming are orphaned and will be
+  re-downloaded once.*
+- **Demo-download cache poisoning** (medium).  Oxford Flowers labels,
+  ROxford ground truth, and UCSF PDFs were downloaded straight to their
+  final paths; a failed run left a truncated file that the `exists()` gate
+  treated as cached forever.  Added `download_file_atomic` (temp + rename)
+  and used it at all three sites.  Tests in
+  `tests_lib/downloads/test_download_and_extract.py`.
+- **Zip-slip prefix check** (low).  The downloader's inline
+  `startswith` traversal check lacked a trailing separator; it now shares
+  `archive.py`'s strict `_reject_traversal`.  Tests added.
+- Small hardening: dataset-container writes fsync before the publishing
+  rename; `video2image` no longer leaks its temp file on a failed write;
+  the settings per-path lock is keyed on the resolved path for the file's
+  whole lifetime.
+
+### Frontend
+
+- **Stuck optimistic vote on failed POST** (high).  A failed vote POST left
+  `pendingOptimistic`/`pendingVerified`/`pendingRegionBoxes` entries that
+  re-imposed the phantom vote over every `/api/votes` poll forever — silent
+  label loss with a lying UI.  The error path now rolls the entries back and
+  re-reads server state; undo/redo error paths fixed the same way.
+- **Dropped `onComplete` in dashboard loading-task polling** (medium-high).
+  `startProgressPolling`/`startDetectorProgressPolling` discarded the
+  completion callback when the polling loop was already active (common:
+  the loop auto-starts on any non-idle SSE snapshot), so
+  `loadDataset`/`loadDetector` never promoted the pair via `setActivePair`.
+  Callbacks are now registered on the service and fired when the loop
+  settles, gated per-task so an unrelated task's failure doesn't suppress
+  promotion.  New spec: `dashboard-loading-tasks.service.spec.ts`.
+- **Context-switch failure handling** (medium).  A failed load kick-off or
+  an errored background load task was treated as success and promoted the
+  unloaded pair to active (re-opening the H25 409 cascade).  Failed
+  switches now roll intent back and complete without emitting; the route
+  guard maps the empty completion to a clean navigation denial via
+  `defaultIfEmpty` instead of the router's `EmptyError`.  Cancel-and-replace
+  now cancels only the superseded switch's own loading tasks instead of
+  every non-idle task (it used to kill unrelated imports).
+- **Inline error-message parsing** (low, systematic).  ~15 inline handlers
+  read only `err.error?.error`, but many routes emit the flask_smorest
+  `{message}` envelope; they degraded to generic fallbacks.  Added
+  `utils/api-error.ts` (`apiErrorMessage`) reading both envelopes and
+  converted every site.
+- `uploadServerMediaFile` no longer drops `media_type` when `cropParams`
+  is absent.
+
+## Open follow-ups
+
+Ordered roughly by severity.  Each was found and verified during the audit
+but deferred as needing a design decision or a larger change.
+
+1. **SSE `/api/events` pins a gthread worker thread per connection.**
+   With `workers = 1, threads = 8`, eight open tabs starve the whole app;
+   stalled requests plus a live heartbeat read as an app hang.  Needs a
+   design decision: bound SSE connections, size the pool against them, or
+   move the stream off the request-thread pool.
+2. **Registry dataset/detector load: check-then-act double-start and
+   half-loaded context visibility.**  Two concurrent `POST .../load` both
+   pass the `is_loaded` check and spawn twin loads sharing a truncated
+   `task_id`; `register_context(ctx)` runs before the loader populates
+   `ctx.medias`, so concurrent requests can see a torn, partially-loaded
+   dataset (or hit `RuntimeError: dictionary changed size during
+   iteration`).  Same pattern for detector loads
+   (`routes/detectors/registry.py`).
+3. **JobManager cancellation is advisory only.**  No job target reads
+   `AsyncJob.is_cancelled`, so cancelling a *running* learned-sort/eval
+   job never stops the GIL-bound training (the cancelled-pending half was
+   fixed in this pass).  Wiring `is_cancelled` into the training loop's
+   epoch boundary would make cancel real.
+4. **Staging imports publish through the global `dataset_progress`
+   singleton** (`load_pipeline.py:_stage_importer_in_background`): two
+   concurrent staging imports interleave one channel and the terminal
+   `staging_result` is last-writer-wins, orphaning the loser's staged pkl.
+   Needs per-task trackers like `_run_origin_load_in_background`.
+5. **Eval progress is a global singleton keyed to no job**
+   (`routes/eval.py`): overlapping evals decorrelate the progress bar from
+   job identity.
+6. **Learned-sort signature/data decorrelation** (`routes/sorting.py`):
+   the background job copies the live vote dicts at *run* time but caches
+   the result under the *request-time* signature; a vote change (or an
+   `ensure_votes_match_active_dataset` rehydrate) in between poisons the
+   `_last_done` cache for later identical-signature requests.
+7. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
+   dataset where only some media carry `patch_regions`
+   (`embedding/matrix.py:_build_region_arrays`): region rows are in the
+   patch embedder's space, fallback rows in the primary's.  Needs either an
+   ingest guarantee (all-or-nothing patch_regions per dataset) or space
+   checking here.
+8. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+   don't force the full-data `hidden_dim`, always calibrate below 6 labels
+   (production uses 0.5), and thread the split RNG into calibration - so
+   reported eval costs measure a pipeline production doesn't run in exactly
+   the small-label regime the eval characterises.
+9. **Inclusion slide drops the safe-threshold GMM blend**
+   (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
+   `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
+   inclusion to a value and back changes the threshold semantics relative
+   to a fresh retrain.  Decide whether the blend applies on slides.
+10. **`update_cache_for_cid` is a dead API with a latent bug**
+    (`detectors/labelset_training.py`): it writes the media's *primary*
+    vector into the detector-space label-embedding cache and stamps
+    `region=None` even when the element has a region box.  No runtime
+    callers today - fix or remove before wiring it up.
+11. **Two training entry points disagree at 4-5 labels** with
+    safe-thresholds off: `train_and_threshold` runs real cross-calibration,
+    `_train_and_score_xy` hard-codes 0.5.  Same user state, different
+    cutoff depending on route.
+12. **Dataset registry is not multi-process safe**
+    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
+    name; a concurrent CLI autodetect run against the same data dir can
+    silently erase the server's registrations.  Fine under the documented
+    single-worker model; needs flock if that changes.
+13. **`http_archive` cache never invalidates** when the remote archive
+    changes (fixed collision, not staleness); `extract_archive_cached`'s
+    mtime/size keying is the model.
+14. **Streaming exporters use a fixed `.tmp` sibling**, so two concurrent
+    exports to the same path clobber each other's temp file.
+15. **Threshold averaging with the abstain sentinel**: a fold returning
+    `NO_GOOD_THRESHOLD` (2.0) now raises the fold mean, possibly above 1.0
+    (= abstain overall).  This is the intended lean but the blend weight is
+    crude; revisit if precision-biased small-label behaviour looks off.
+16. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+    rather than clean): browse-canvas/minimap coordinate math and rAF
+    lifecycles, modal/player component lifecycle sweep, left/right-panel
+    virtualization, and a full route-blueprint sweep of
+    `routes/datasets|media|detectors|labels|processors|projection`.
+
+## Behaviour changes shipped (backwards compatibility notes)
+
+- `find_optimal_threshold` can now return `NO_GOOD_THRESHOLD` (2.0); fold
+  means can exceed 1.0 where abstaining is strictly cheaper.
+- `_apply_settings` no longer applies non-schema keys (previously reachable:
+  `settings_path`, `user_data_dir_override`, `settings_source_config`,
+  CLI knobs).
+- `http_archive` resolve caches move to hash-keyed directory names; old
+  cache dirs are orphaned and re-downloaded once.
+- `JobManager.start()` from a different (user, dataset, detector) than the
+  parked pending now supersedes it (pollers of the old job id see
+  `cancelled`) instead of silently rebinding their job to the new request.

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -40,6 +40,7 @@ import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
+import { apiErrorMessage } from '../../utils/api-error';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -826,7 +827,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
         error: (err) => {
           this.status.set('error');
           this.errorMessage.set(
-            err?.error?.message || err?.error?.error || 'Failed to build the map',
+            apiErrorMessage(err, 'Failed to build the map'),
           );
         },
       });
@@ -870,7 +871,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
         this.selection.consumeSurviveProjectionChange();
         this.status.set('error');
         this.errorMessage.set(
-          err?.error?.message || err?.error?.error || 'Failed to build the map',
+          apiErrorMessage(err, 'Failed to build the map'),
         );
       },
     });
@@ -1020,7 +1021,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
           } else {
             this.status.set('error');
             this.errorMessage.set(
-              err?.error?.message || err?.error?.error || 'Failed to build the map',
+              apiErrorMessage(err, 'Failed to build the map'),
             );
           }
         },

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -6,6 +6,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { DatasetsCrudApiService } from '../../../services/datasets-crud-api.service';
 import { DatasetsListingsApiService } from '../../../services/datasets-listings-api.service';
 import { DatasetRegistryEntry, MediaTypeInfo } from '../../../models/api.models';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 interface CombineRow {
   id: string;
@@ -121,7 +122,7 @@ export class CombineDatasetsModalComponent implements OnInit {
       },
       error: (err) => {
         this.submitting.set(false);
-        this.error.set((err?.error?.error as string) || 'Combine failed');
+        this.error.set(apiErrorMessage(err, 'Combine failed'));
       },
     });
   }

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -6,6 +6,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
 import type { DetectorCombineResponse } from '../../../generated/api-client/models/detector-combine-response';
 import { DetectorRegistryEntry } from '../../../models/api.models';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 interface SourceRow {
   name: string;
@@ -93,7 +94,7 @@ export class CombineDetectorsModalComponent implements OnInit {
       error: (err) => {
         this.submitting = false;
         const status = err?.status;
-        const serverMsg = err?.error?.error || '';
+        const serverMsg = apiErrorMessage(err, '');
         if (status === 422) {
           this.error =
             serverMsg ||

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -17,6 +17,7 @@ import { SettingsStateService } from '../../../services/settings-state.service';
 import { ToastService } from '../../../services/toast.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec, ImportDefaultsForMediaType } from '../../../models/api.models';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -877,7 +878,7 @@ export class DatasetImporterModalComponent implements OnInit {
         },
         error: (err) => {
           this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
-          this.dynamicFieldError.update((m) => ({ ...m, [key]: err?.error?.error || 'Could not load options' }));
+          this.dynamicFieldError.update((m) => ({ ...m, [key]: apiErrorMessage(err, 'Could not load options') }));
           this.dynamicFieldOptions.update((m) => ({ ...m, [key]: [] }));
         },
       });
@@ -1573,7 +1574,7 @@ export class DatasetImporterModalComponent implements OnInit {
       },
       error: (err) => {
         this.lfSubmitting.set(false);
-        this.lfError.set(err.error?.error || 'Upload failed');
+        this.lfError.set(apiErrorMessage(err, 'Upload failed'));
       },
     });
   }
@@ -1599,7 +1600,7 @@ export class DatasetImporterModalComponent implements OnInit {
       },
       error: (err) => {
         this.lfSubmitting.set(false);
-        this.lfError.set(err.error?.error || 'Upload failed');
+        this.lfError.set(apiErrorMessage(err, 'Upload failed'));
       },
     });
   }
@@ -2146,7 +2147,7 @@ export class DatasetImporterModalComponent implements OnInit {
       },
       error: (err) => {
         this.sfSubmitting.set(false);
-        this.sfBrowseError.set(err.error?.error || 'Import failed');
+        this.sfBrowseError.set(apiErrorMessage(err, 'Import failed'));
       },
     });
   }
@@ -2233,7 +2234,7 @@ export class DatasetImporterModalComponent implements OnInit {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.error.set(err.error?.error || 'Import failed');
+          this.error.set(apiErrorMessage(err, 'Import failed'));
         },
       });
     } else {
@@ -2245,7 +2246,7 @@ export class DatasetImporterModalComponent implements OnInit {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.error.set(err.error?.error || 'Import failed');
+          this.error.set(apiErrorMessage(err, 'Import failed'));
         },
       });
     }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -35,6 +35,7 @@ import {
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { SourcePickerComponent } from '../dataset-importer-modal/source-picker/source-picker.component';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 type ModalView = 'main' | 'media-picker';
 type ModalTab = 'blank' | 'trained';
@@ -1001,7 +1002,7 @@ export class NewDetectorModalComponent implements OnInit {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.error.set(err.error?.error || 'Failed to create detector from labelset');
+          this.error.set(apiErrorMessage(err, 'Failed to create detector from labelset'));
         },
       });
   }
@@ -1058,7 +1059,7 @@ export class NewDetectorModalComponent implements OnInit {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.error.set(err.error?.error || 'Failed to create detector');
+          this.error.set(apiErrorMessage(err, 'Failed to create detector'));
         },
       });
   }

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, output } from '@angular/cor
 
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
+import { apiErrorMessage } from '../../utils/api-error';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -35,7 +36,7 @@ export class LoginComponent {
       },
       error: (err) => {
         this.busy = false;
-        this.error = err.error?.error || 'Login failed.';
+        this.error = apiErrorMessage(err, 'Login failed.');
       },
     });
   }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -4,6 +4,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
 import type { DatasetRegistryStatsResponse } from '../../../generated/api-client/models/dataset-registry-stats-response';
 import { formatTimestamp as formatTs } from '../../../utils/format-date';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -33,7 +34,7 @@ export class DatasetStatsModalComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err.error?.error || 'Failed to load stats');
+        this.error.set(apiErrorMessage(err, 'Failed to load stats'));
         this.loading.set(false);
       },
     });

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.ts
@@ -4,6 +4,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsRegistryApiService } from '../../../services/detectors-registry-api.service';
 import type { DetectorRegistryStatsResponse } from '../../../generated/api-client/models/detector-registry-stats-response';
 import { formatTimestamp as formatTs } from '../../../utils/format-date';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 /** Read-only stats for a registered detector. Mirrors the dataset stats
  *  modal: labelset composition (positives / negatives / total, plus how
@@ -38,7 +39,7 @@ export class DetectorStatsModalComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err.error?.error || err.error?.message || 'Failed to load stats');
+        this.error.set(apiErrorMessage(err, 'Failed to load stats'));
         this.loading.set(false);
       },
     });

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 interface Example {
   type: 'good' | 'bad';
@@ -83,7 +84,7 @@ export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.saving.set(false);
-        this.error.set(err.error?.error || 'Failed to save');
+        this.error.set(apiErrorMessage(err, 'Failed to save'));
       },
     });
   }

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsFindApiService } from '../../../services/detectors-find-api.service';
 import type { FindStatsResponse } from '../../../generated/api-client/models/find-stats-response';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 /** A scaled point on the FP/FN-vs-inclusion chart. */
 interface ChartPoint {
@@ -53,7 +54,7 @@ export class FindStatsModalComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err?.error?.error || err?.error?.message || 'Failed to load stats');
+        this.error.set(apiErrorMessage(err, 'Failed to load stats'));
         this.loading.set(false);
       },
     });

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -21,6 +21,7 @@ import { MediasApiService } from '../../../services/medias-api.service';
 import { VoteStateService } from '../../../services/vote-state.service';
 import { ImporterField } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 type ModalView = 'picker' | 'form';
 
@@ -173,7 +174,7 @@ export class LabelImporterModalComponent implements OnDestroy {
           this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
           this.dynamicFieldError.update((m) => ({
             ...m,
-            [key]: err?.error?.error || 'Could not load options',
+            [key]: apiErrorMessage(err, 'Could not load options'),
           }));
           this.dynamicFieldOptions.update((m) => ({ ...m, [key]: [] }));
         },
@@ -243,7 +244,7 @@ export class LabelImporterModalComponent implements OnDestroy {
       },
       error: (err) => {
         this.submitting.set(false);
-        this.importError.set(err.error?.error || 'Import failed');
+        this.importError.set(apiErrorMessage(err, 'Import failed'));
       },
     });
   }
@@ -284,7 +285,7 @@ export class LabelImporterModalComponent implements OnDestroy {
         }
       },
       error: (err) => {
-        this.importError.set(err.error?.error || `Failed to add media to ${label} pile`);
+        this.importError.set(apiErrorMessage(err, `Failed to add media to ${label} pile`));
         if (label === 'good') {
           this.addingGood.set(false);
         } else {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -9,6 +9,7 @@ import { SettingsIoApiService } from '../../../services/settings-io-api.service'
 import { ImporterField } from '../../../models/api.models';
 import type { SettingsExporterEntry } from '../../../generated/api-client/models/settings-exporter-entry';
 import type { RunSettingsExportResponse } from '../../../generated/api-client/models/run-settings-export-response';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 type ModalView = 'picker' | 'form';
 
@@ -127,7 +128,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
       },
       error: (err) => {
         this.submitting.set(false);
-        this.exportError.set(err.error?.error || 'Export failed');
+        this.exportError.set(apiErrorMessage(err, 'Export failed'));
       },
     });
   }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -8,6 +8,7 @@ import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.co
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
 import type { SettingsImporterEntry } from '../../../generated/api-client/models/settings-importer-entry';
+import { apiErrorMessage } from '../../../utils/api-error';
 
 type ModalView = 'picker' | 'form';
 
@@ -128,7 +129,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.importError.set(err.error?.error || 'Import failed');
+          this.importError.set(apiErrorMessage(err, 'Import failed'));
         },
       });
   }

--- a/frontend/src/app/guards/active-context.guard.ts
+++ b/frontend/src/app/guards/active-context.guard.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router, UrlTree } from '@angular/router';
 import { Observable, combineLatest, of } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { defaultIfEmpty, filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { ActiveContextService } from '../services/active-context.service';
 import { ContextSwitchService } from '../services/context-switch.service';
 import { DatasetStateService } from '../services/dataset-state.service';
@@ -85,11 +85,14 @@ export const activeContextGuard: CanActivateFn = (route) => {
       // is a valid UI state (the explainer renders against the new
       // pair), so we don't fast-fail on it here.
       return contextSwitch.applyActivePair(datasetId, detectorId).pipe(
-        // `applyActivePair` returns an Observable that completes (no
-        // value) on success. `combineLatest`-ing with an of(true) ensures
-        // the guard emits `true` once prep settles.
+        // `applyActivePair` emits once on success. When the switch is
+        // superseded by a competing one, or a required load fails, its
+        // completion completes WITHOUT emitting - `defaultIfEmpty` turns
+        // that into a clean navigation denial instead of the router's
+        // EmptyError (failed navigation with no feedback).
         tap(() => recentSessions.bump(datasetId, detectorId)),
         switchMap(() => of(true as const)),
+        defaultIfEmpty(false as const),
       );
     }),
   );

--- a/frontend/src/app/guards/active-context.guard.ts
+++ b/frontend/src/app/guards/active-context.guard.ts
@@ -51,7 +51,7 @@ export const activeContextGuard: CanActivateFn = (route) => {
   return datasetState.loaded$.pipe(
     filter((loaded) => loaded),
     take(1),
-    switchMap((): Observable<true | UrlTree> => {
+    switchMap((): Observable<boolean | UrlTree> => {
       const dataset = datasetState.datasets.find((d) => d.id === datasetId);
       const detector = datasetState.detectors.find((d) => d.id === detectorId);
 

--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -43,6 +43,8 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
   let loadDetectorSubjects: Map<string, Subject<unknown>>;
   let loadingTasks$: BehaviorSubject<LoadingTask[]>;
   let detectorLoadingTasks$: BehaviorSubject<LoadingTask[]>;
+  let cancelledTaskIds: string[];
+  let cancelledDetectorTaskIds: string[];
 
   function makeDataset(
     id: string,
@@ -84,6 +86,8 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
     loadDetectorSubjects = new Map();
     loadingTasks$ = new BehaviorSubject<LoadingTask[]>([]);
     detectorLoadingTasks$ = new BehaviorSubject<LoadingTask[]>([]);
+    cancelledTaskIds = [];
+    cancelledDetectorTaskIds = [];
 
     const datasetStateStub = {
       get datasets(): DatasetRegistryEntry[] {
@@ -106,7 +110,10 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
         loadRegisteredSubjects.set(id, s);
         return s;
       },
-      cancelTask: (_taskId: string): Subject<unknown> => new Subject<unknown>(),
+      cancelTask: (taskId: string): Subject<unknown> => {
+        cancelledTaskIds.push(taskId);
+        return new Subject<unknown>();
+      },
     };
 
     const detectorsRegistryApiStub = {
@@ -115,8 +122,10 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
         loadDetectorSubjects.set(id, s);
         return s;
       },
-      cancelDetectorLoadingTask: (_taskId: string): Subject<unknown> =>
-        new Subject<unknown>(),
+      cancelDetectorLoadingTask: (taskId: string): Subject<unknown> => {
+        cancelledDetectorTaskIds.push(taskId);
+        return new Subject<unknown>();
+      },
     };
 
     const progressEventsStub = {
@@ -304,6 +313,85 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
 
     expect(activeContext.datasetId).toBe('d2');
     expect(activeContext.modelId).toBe('m2');
+  });
+
+  it('does not promote the pair when the dataset load kick-off fails', () => {
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1', { loaded: false })];
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+
+    let emitted = false;
+    let completed = false;
+    switcher.applyActivePair('d1', 'm1').subscribe({
+      next: () => (emitted = true),
+      complete: () => (completed = true),
+    });
+
+    // The load POST fails (e.g. 500). Regression: this used to count as a
+    // completed load and promote the unloaded pair to active, re-opening
+    // the H25 cascade of 409 dataset_not_loaded from the very view the
+    // guard was about to activate.
+    loadRegisteredSubjects.get('d1')!.error(new Error('500'));
+
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+    // The pulldown highlight rolls back to the still-active pair.
+    expect(activeContext.intentDatasetId).toBe('old-ds');
+    // Completion completes WITHOUT emitting → the guard's defaultIfEmpty
+    // denies navigation cleanly.
+    expect(emitted).toBe(false);
+    expect(completed).toBe(true);
+    expect(switcher.switching).toBe(false);
+  });
+
+  it('does not promote the pair when the background load task errors', () => {
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1', { loaded: false })];
+    detectors = [makeDetector('m1', { detector_loaded: true })];
+
+    let emitted = false;
+    switcher.applyActivePair('d1', 'm1').subscribe({ next: () => (emitted = true) });
+
+    loadRegisteredSubjects.get('d1')!.next({ ok: true, message: '', task_id: 'task-d1' });
+    loadRegisteredSubjects.get('d1')!.complete();
+    loadingTasks$.next([
+      makeLoadingTask({ dataset_id: 'd1', task_id: 'task-d1', status: 'loading' }),
+    ]);
+
+    // The background load dies (OOM, bad pickle, …): the task settles
+    // idle WITH an error. The pair must not be promoted.
+    loadingTasks$.next([
+      makeLoadingTask({ dataset_id: 'd1', task_id: 'task-d1', status: 'idle', error: 'boom' }),
+    ]);
+
+    expect(activeContext.datasetId).toBe('old-ds');
+    expect(activeContext.modelId).toBe('old-det');
+    expect(emitted).toBe(false);
+    expect(switcher.switching).toBe(false);
+  });
+
+  it('cancels only the superseded switch\'s own loading tasks on cancel-and-replace', () => {
+    activeContext.setActivePair('old-ds', 'old-det');
+    datasets = [makeDataset('d1'), makeDataset('d2', { loaded: true }), makeDataset('d3')];
+    detectors = [
+      makeDetector('m1', { detector_loaded: true }),
+      makeDetector('m2', { detector_loaded: true }),
+    ];
+    // d1's load task (owned by the switch about to be superseded) plus an
+    // unrelated in-flight load of d3 (e.g. a dashboard-initiated import).
+    loadingTasks$.next([
+      makeLoadingTask({ dataset_id: 'd1', task_id: 'task-d1', status: 'loading' }),
+      makeLoadingTask({ dataset_id: 'd3', task_id: 'task-d3', status: 'loading' }),
+    ]);
+
+    switcher.applyActivePair('d1', 'm1').subscribe();
+    // Rapid re-click: replace d1/m1 with d2/m2.
+    switcher.applyActivePair('d2', 'm2').subscribe();
+
+    // Regression: cancel-and-replace used to POST a cancel for EVERY
+    // non-idle task, killing the unrelated d3 load mid-flight.
+    expect(cancelledTaskIds).toEqual(['task-d1']);
+    expect(cancelledDetectorTaskIds).toEqual([]);
   });
 
   it('promotes intent to active via the completion observable returned to the route guard', () => {

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -14,10 +14,17 @@ interface ActiveSwitch {
   datasetId: string;
   detectorId: string;
   cancelled: boolean;
+  /** Set when a required load's kick-off POST failed or its background
+   *  task errored.  A failed switch must NOT promote the pair to active:
+   *  the backend hasn't loaded it, so promotion would re-open the H25
+   *  cascade of 409 `dataset_not_loaded` this service exists to prevent. */
+  failed: boolean;
   cancellable: Subject<void>;
   /** ReplaySubject(1) so late subscribers (e.g. the route guard
    *  attaching after a synchronous fast-path completion) still see the
-   *  completion signal. */
+   *  completion signal.  Completes WITHOUT emitting when the switch is
+   *  superseded or fails; consumers must handle the empty completion
+   *  (the guard uses `defaultIfEmpty`, browse-prep a `complete` handler). */
   completion: ReplaySubject<void>;
 }
 
@@ -127,7 +134,7 @@ export class ContextSwitchService {
       previous.cancellable.next();
       previous.cancellable.complete();
       previous.completion.complete();
-      this.cancelInFlightLoads();
+      this.cancelInFlightLoads(previous);
     }
 
     const requestId = this.activeContext.nextRequestId();
@@ -136,6 +143,7 @@ export class ContextSwitchService {
       datasetId,
       detectorId,
       cancelled: false,
+      failed: false,
       cancellable: new Subject<void>(),
       completion: new ReplaySubject<void>(1),
     };
@@ -206,6 +214,10 @@ export class ContextSwitchService {
         .pipe(
           takeUntil(current.cancellable),
           catchError(() => {
+            // The load kick-off failed: still tick so the switch settles,
+            // but mark it failed so finishIfCurrent doesn't promote an
+            // unloaded pair (which would 409 every subsequent request).
+            current.failed = true;
             sub.next();
             sub.complete();
             return EMPTY;
@@ -231,6 +243,8 @@ export class ContextSwitchService {
         .pipe(
           takeUntil(current.cancellable),
           catchError(() => {
+            // See runDatasetLoad: settle the switch but don't promote.
+            current.failed = true;
             sub.next();
             sub.complete();
             return EMPTY;
@@ -282,7 +296,14 @@ export class ContextSwitchService {
               return !tasks.some((t) => t.dataset_id === datasetId && t.status !== 'idle');
             }
             const task = tasks.find((t) => t.task_id === taskId);
-            if (task) seen = true;
+            if (task) {
+              seen = true;
+              // A load that settled WITH an error must not promote the
+              // pair; the dataset never loaded.
+              if (task.status === 'idle' && task.error) {
+                current.failed = true;
+              }
+            }
             // Settled only once we've seen the task and it's no longer
             // running (gone idle, or dropped from the stream entirely).
             return seen && !(task && task.status !== 'idle');
@@ -316,7 +337,12 @@ export class ContextSwitchService {
               return !tasks.some((t) => t.detector_id === detectorId && t.status !== 'idle');
             }
             const task = tasks.find((t) => t.task_id === taskId);
-            if (task) seen = true;
+            if (task) {
+              seen = true;
+              if (task.status === 'idle' && task.error) {
+                current.failed = true;
+              }
+            }
             return seen && !(task && task.status !== 'idle');
           }),
           take(1),
@@ -334,22 +360,38 @@ export class ContextSwitchService {
   private finishIfCurrent(current: ActiveSwitch): void {
     if (this.active !== current || current.cancelled) return;
     if (current.requestId !== this.activeContext.currentRequestId) return;
+    this.switchingSubject.next(false);
+    this.datasetState.setLoading(false);
+    this.active = null;
+    if (current.failed) {
+      // A required load failed: the backend does NOT have the pair loaded,
+      // so promoting it would tag every request with ids that 409. Roll
+      // the intent back to the still-active pair (pulldown highlight) and
+      // complete without emitting - the guard's `defaultIfEmpty` turns
+      // that into a clean navigation denial, and the SSE error row /
+      // global toast already surface the failure itself.
+      this.activeContext.setIntent(this.activeContext.datasetId, this.activeContext.modelId);
+      current.completion.complete();
+      return;
+    }
     // Loads have settled; promote intent to active now so the HTTP
     // interceptor starts tagging requests with the new ids (and not
     // before, per H25).
     this.activeContext.setActive(current.datasetId, current.detectorId);
-    this.switchingSubject.next(false);
-    this.datasetState.setLoading(false);
-    this.active = null;
     current.completion.next();
     current.completion.complete();
   }
 
-  private cancelInFlightLoads(): void {
-    // Best-effort: cancel any active dataset/detector loading tasks so
-    // we don't waste CPU on a load whose result will be discarded. The
-    // request-id check is the actual correctness guarantee.
-    const datasetTasks = this.progressEvents.loadingTasks().filter((t) => t.status !== 'idle');
+  private cancelInFlightLoads(previous: ActiveSwitch): void {
+    // Best-effort: cancel the superseded switch's own dataset/detector
+    // loading tasks so we don't waste CPU on a load whose result will be
+    // discarded. The request-id check is the actual correctness guarantee.
+    // Scoped to the previous switch's ids: an unrelated import or a
+    // dashboard-initiated load of a third dataset must not be blown away
+    // by a rapid pulldown double-click.
+    const datasetTasks = this.progressEvents
+      .loadingTasks()
+      .filter((t) => t.status !== 'idle' && !!t.dataset_id && t.dataset_id === previous.datasetId);
     for (const t of datasetTasks) {
       this.datasetsRegistryApi.cancelTask(t.task_id).subscribe({
         error: () => {
@@ -357,7 +399,9 @@ export class ContextSwitchService {
         },
       });
     }
-    const detectorTasks = this.progressEvents.detectorLoadingTasks().filter((t) => t.status !== 'idle');
+    const detectorTasks = this.progressEvents
+      .detectorLoadingTasks()
+      .filter((t) => t.status !== 'idle' && !!t.detector_id && t.detector_id === previous.detectorId);
     for (const t of detectorTasks) {
       this.detectorsRegistryApi.cancelDetectorLoadingTask(t.task_id).subscribe({
         error: () => {

--- a/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { DashboardLoadingTasksService } from './dashboard-loading-tasks.service';
+import { AchievementsService } from './achievements.service';
+import { DatasetStateService } from './dataset-state.service';
+import { DatasetsRegistryApiService } from './datasets-registry-api.service';
+import { DetectorsRegistryApiService } from './detectors-registry-api.service';
+import { ProgressEventsService } from './progress-events.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import { LoadingTask } from '../models/api.models';
+
+/**
+ * The dashboard promotes a loaded dataset/detector to the active pair via the
+ * `onComplete` callback it hands to `startProgressPolling` /
+ * `startDetectorProgressPolling`. These tests pin the callback contract:
+ * a callback registered while the polling loop is ALREADY active (an import
+ * or another load in flight - the constructor auto-starts polling on any
+ * non-idle SSE snapshot) must still fire when the loop settles, and only a
+ * failure of the callback's own task suppresses it.
+ */
+describe('DashboardLoadingTasksService', () => {
+  let service: DashboardLoadingTasksService;
+  let loadingTasks$: Subject<LoadingTask[]>;
+  let detectorLoadingTasks$: Subject<LoadingTask[]>;
+  let serverReset$: Subject<void>;
+
+  function task(overrides: Partial<LoadingTask>): LoadingTask {
+    return {
+      status: 'idle',
+      message: '',
+      current: 0,
+      total: 0,
+      task_id: 't',
+      name: 'n',
+      created_at: 0,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    loadingTasks$ = new Subject<LoadingTask[]>();
+    detectorLoadingTasks$ = new Subject<LoadingTask[]>();
+    serverReset$ = new Subject<void>();
+
+    const progressEventsStub = {
+      loadingTasks$,
+      detectorLoadingTasks$,
+      serverReset$,
+    };
+    const datasetStateStub = {
+      datasets: [],
+      refresh: vi.fn(),
+      setLoading: vi.fn(),
+    };
+    const achievementsStub = { refresh: vi.fn() };
+    const datasetsRegistryApiStub = { cancelTask: vi.fn() };
+    const detectorsRegistryApiStub = { cancelDetectorLoadingTask: vi.fn() };
+
+    configureZoneless({
+      providers: [
+        { provide: ProgressEventsService, useValue: progressEventsStub },
+        { provide: DatasetStateService, useValue: datasetStateStub },
+        { provide: AchievementsService, useValue: achievementsStub },
+        { provide: DatasetsRegistryApiService, useValue: datasetsRegistryApiStub },
+        { provide: DetectorsRegistryApiService, useValue: detectorsRegistryApiStub },
+      ],
+    });
+
+    service = TestBed.inject(DashboardLoadingTasksService);
+  });
+
+  it('fires onComplete registered while polling is already active (regression)', () => {
+    // An unrelated import is running → the constructor subscription
+    // auto-starts the polling loop with NO callback.
+    loadingTasks$.next([task({ task_id: 'import-1', status: 'running' })]);
+
+    // The user clicks Load on a dataset; polling is already active, so the
+    // early-return branch is taken. The callback used to be silently
+    // dropped here, leaving setActivePair never called.
+    const onComplete = vi.fn();
+    service.startProgressPolling('load-1', onComplete);
+
+    // The awaited load shows up in the stream, then everything settles.
+    loadingTasks$.next([
+      task({ task_id: 'import-1', status: 'running' }),
+      task({ task_id: 'load-1', status: 'running' }),
+    ]);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    loadingTasks$.next([task({ task_id: 'import-1' }), task({ task_id: 'load-1' })]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses onComplete when its own task failed', () => {
+    const onComplete = vi.fn();
+    service.startProgressPolling('load-1', onComplete);
+
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+    loadingTasks$.next([task({ task_id: 'load-1', error: 'exploded' })]);
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('fires onComplete when only an unrelated task failed', () => {
+    loadingTasks$.next([task({ task_id: 'import-1', status: 'running' })]);
+
+    const onComplete = vi.fn();
+    service.startProgressPolling('load-1', onComplete);
+
+    loadingTasks$.next([
+      task({ task_id: 'import-1', status: 'running' }),
+      task({ task_id: 'load-1', status: 'running' }),
+    ]);
+    // The unrelated import fails; the dataset load succeeds. Promotion of
+    // the successfully loaded dataset must not be held hostage.
+    loadingTasks$.next([task({ task_id: 'import-1', error: 'disk full' }), task({ task_id: 'load-1' })]);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires each registered dataset callback exactly once', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    service.startProgressPolling('load-1', first);
+    service.startProgressPolling('load-2', second);
+
+    loadingTasks$.next([
+      task({ task_id: 'load-1', status: 'running' }),
+      task({ task_id: 'load-2', status: 'running' }),
+    ]);
+    loadingTasks$.next([task({ task_id: 'load-1' }), task({ task_id: 'load-2' })]);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    // A later settle must not re-fire consumed callbacks.
+    loadingTasks$.next([task({ task_id: 'other', status: 'running' })]);
+    loadingTasks$.next([task({ task_id: 'other' })]);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires detector onComplete registered while detector polling is already active (regression)', () => {
+    // A detector load is in flight → constructor auto-starts the loop.
+    detectorLoadingTasks$.next([task({ task_id: 'det-other', status: 'running' })]);
+
+    const onComplete = vi.fn();
+    service.startDetectorProgressPolling(onComplete);
+
+    detectorLoadingTasks$.next([task({ task_id: 'det-other' })]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears pending callbacks on backend restart', () => {
+    const onComplete = vi.fn();
+    service.startProgressPolling('load-1', onComplete);
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+
+    serverReset$.next();
+
+    // The restarted backend knows nothing about load-1; a fresh settle
+    // must not fire the stale callback.
+    loadingTasks$.next([task({ task_id: 'new-task', status: 'running' })]);
+    loadingTasks$.next([task({ task_id: 'new-task' })]);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -53,6 +53,20 @@ export class DashboardLoadingTasksService {
   private datasetPollingActive = false;
   private detectorPollingActive = false;
 
+  /**
+   * Completion callbacks registered by `startProgressPolling` /
+   * `startDetectorProgressPolling` callers, fired (and cleared) when the
+   * polling loop settles.  Kept as lists on the service (not closure
+   * parameters of the loop) so a caller whose `startProgressPolling` call
+   * early-returns because polling is already active still gets its
+   * callback invoked - dropping it silently left `setActivePair` never
+   * firing when a dataset was loaded while another import was running.
+   * Each dataset callback carries the task id it belongs to (when known)
+   * so an *unrelated* task's failure doesn't suppress it.
+   */
+  private datasetPollCallbacks: Array<{ taskId: string; cb: () => void }> = [];
+  private detectorPollCallbacks: Array<() => void> = [];
+
   constructor() {
     // SSE pushes the initial snapshot on connect, so the first event on
     // each channel tells us whether there's anything in flight; auto-
@@ -78,6 +92,8 @@ export class DashboardLoadingTasksService {
     this.awaitedTaskIds.clear();
     this.completedTaskIds.clear();
     this.completedModelTaskIds.clear();
+    this.datasetPollCallbacks = [];
+    this.detectorPollCallbacks = [];
     this.datasetPollingActive = false;
     this.detectorPollingActive = false;
     this._loadingTasks.set([]);
@@ -124,6 +140,11 @@ export class DashboardLoadingTasksService {
     // comment on `awaitedTaskIds` for why this is needed.
     if (awaitTaskId) {
       this.awaitedTaskIds.add(awaitTaskId);
+    }
+    // Registered on the service (not captured by the loop) so it fires
+    // even when the early-return below is taken - see the field comment.
+    if (onComplete) {
+      this.datasetPollCallbacks.push({ taskId: awaitTaskId ?? '', cb: onComplete });
     }
     // If polling is already active, don't restart; the existing loop
     // already covers all tasks.  This avoids clearing completedTaskIds
@@ -179,8 +200,17 @@ export class DashboardLoadingTasksService {
             if (justFinished.length === 0) {
               this.datasetState.refresh();
             }
-            if (onComplete && failed.length === 0) {
-              onComplete();
+            // Fire every registered completion callback whose own task
+            // didn't fail.  Callbacks without a task id (legacy callers)
+            // keep the old "any failure suppresses" gate.
+            const callbacks = this.datasetPollCallbacks;
+            this.datasetPollCallbacks = [];
+            const failedIds = new Set(failed.map((t) => t.task_id));
+            for (const entry of callbacks) {
+              const suppressed = entry.taskId ? failedIds.has(entry.taskId) : failed.length > 0;
+              if (!suppressed) {
+                entry.cb();
+              }
             }
           }
         },
@@ -188,6 +218,11 @@ export class DashboardLoadingTasksService {
   }
 
   startDetectorProgressPolling(onComplete?: () => void): void {
+    // Registered on the service so it fires even when polling is already
+    // active - see the field comment on `detectorPollCallbacks`.
+    if (onComplete) {
+      this.detectorPollCallbacks.push(onComplete);
+    }
     if (this.detectorPollingActive) {
       return;
     }
@@ -222,8 +257,12 @@ export class DashboardLoadingTasksService {
             if (justFinished.length === 0) {
               this.datasetState.refresh();
             }
-            if (onComplete && failed.length === 0) {
-              onComplete();
+            const callbacks = this.detectorPollCallbacks;
+            this.detectorPollCallbacks = [];
+            if (failed.length === 0) {
+              for (const cb of callbacks) {
+                cb();
+              }
             }
           }
         },

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -224,9 +224,12 @@ export class SortingApiService {
     formData.append('file', file);
     if (options?.cropParams) {
       formData.append('crop_params', JSON.stringify(options.cropParams));
-      if (options.mediaType) {
-        formData.append('media_type', options.mediaType);
-      }
+    }
+    // Appended independently of cropParams: the backend only *requires*
+    // media_type alongside crop_params, but a caller passing mediaType
+    // alone shouldn't have it silently dropped.
+    if (options?.mediaType) {
+      formData.append('media_type', options.mediaType);
     }
     return this.http.post<ServerMediaUploadResponse>('/api/server-media-files/upload', formData);
   }

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -580,6 +580,10 @@ describe('VoteStateService', () => {
       });
       const req = httpMock.expectOne('/api/medias/5/vote');
       req.flush(null, { status: 500, statusText: 'Server Error' });
+      // The failed POST triggers the optimistic rollback's server re-read.
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
 
       // The failed POST must not leave a phantom undo entry; Cmd-Z next
       // would otherwise post a "reversal" of a vote that never happened.
@@ -624,6 +628,10 @@ describe('VoteStateService', () => {
       httpMock
         .expectOne('/api/medias/2/vote')
         .flush(null, { status: 500, statusText: 'Server Error' });
+      // Drain the rollback's server re-read.
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
       expect(service.canRedo()).toBe(true);
 
       // A new vote whose POST succeeds wipes the redo stack as expected.

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -373,6 +373,81 @@ describe('VoteStateService', () => {
     });
   });
 
+  describe('failed vote POST rollback', () => {
+    it('rolls back the optimistic vote when the POST fails, so polls show server truth', () => {
+      service.submitToggleVote(10, 'good').subscribe({ next: () => {}, error: () => {} });
+      expect(service.goodVotes.has(10)).toBe(true); // optimistic
+
+      // The POST fails (transient 502 below the offline-breaker threshold).
+      httpMock
+        .expectOne('/api/medias/10/vote')
+        .flush(null, { status: 502, statusText: 'Bad Gateway' });
+
+      // The rollback re-reads server state; the server never saw the vote.
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      expect(service.goodVotes.has(10)).toBe(false);
+
+      // Regression: the pending entry used to survive the failed POST and
+      // re-impose the phantom vote over EVERY subsequent poll.
+      service.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      expect(service.goodVotes.has(10)).toBe(false);
+      expect(service.clickTimes['10']).toBeUndefined();
+    });
+
+    it('rolls back an optimistic region box when the POST fails', () => {
+      service
+        .submitToggleVote(11, 'good', [0.1, 0.2, 0.3, 0.4])
+        .subscribe({ next: () => {}, error: () => {} });
+      expect(service.goodRegionBoxes['11']).toEqual([0.1, 0.2, 0.3, 0.4]);
+
+      httpMock
+        .expectOne('/api/medias/11/vote')
+        .flush(null, { status: 500, statusText: 'Server Error' });
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {}, good_region_boxes: {} });
+
+      expect(service.goodRegionBoxes['11']).toBeUndefined();
+
+      // A later poll must not resurrect the crop either.
+      service.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [], bad: [], click_times: {}, learned_scores: {}, good_region_boxes: {} });
+      expect(service.goodRegionBoxes['11']).toBeUndefined();
+    });
+
+    it('a failed undo POST repairs local state from the server', () => {
+      service.recordVote(5, 'good', 'foo.wav');
+      service.applyOptimisticState(5, 'good');
+
+      service.undo(); // posts target=none optimistically
+      expect(service.goodVotes.has(5)).toBe(false);
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush(null, { status: 500, statusText: 'Server Error' });
+
+      // The rollback's loadVotes reflects the server (vote still good).
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [5], bad: [], click_times: { '5': 3 }, learned_scores: {} });
+      expect(service.goodVotes.has(5)).toBe(true);
+
+      // Regression: the pendingOptimistic entry from the undo's optimistic
+      // apply used to override this reload on every later poll.
+      service.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [5], bad: [], click_times: { '5': 3 }, learned_scores: {} });
+      expect(service.goodVotes.has(5)).toBe(true);
+    });
+  });
+
   describe('undo / redo stack', () => {
     it('records the previous polarity at click time and POSTs the inverse target on undo', () => {
       // Pretend a vote landed: media 5 is now good.

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -97,10 +97,12 @@ export class VoteStateService implements OnDestroy {
   /**
    * Optimistic post-vote state per media, used to preserve the user's click
    * across a polling response that raced ahead of the vote POST.  Cleared
-   * deterministically on every vote POST response; the server's reply IS
-   * the authoritative state, so there is no longer a "permanently stuck"
-   * desync if our prediction disagreed with the server (the persistent-desync
-   * half of logical-bug-audit H1).
+   * deterministically on every vote POST *resolution*: on success the
+   * server's reply is the authoritative state ({@link reconcileVoteResponse});
+   * on failure the entry is rolled back and server state re-read
+   * ({@link rollbackOptimistic}).  Either way there is no "permanently
+   * stuck" desync if our prediction disagreed with the server (the
+   * persistent-desync half of logical-bug-audit H1).
    */
   private pendingOptimistic = new Map<number, { state: VoteState; clickTime: number | null }>();
 
@@ -269,8 +271,28 @@ export class VoteStateService implements OnDestroy {
     const effectiveBox = target === 'good' && regionBox && regionBox.length === 4 ? regionBox : null;
     this.applyOptimisticRegionBox(id, effectiveBox);
     return this.mediasApi.vote(id, target, effectiveBox).pipe(
-      tap((resp) => this.reconcileVoteResponse(id, resp)),
+      tap({
+        next: (resp) => this.reconcileVoteResponse(id, resp),
+        // A failed POST means the server never saw the vote. Without the
+        // rollback, the pending entries pin the optimistic state over every
+        // subsequent /api/votes poll forever: the item shows as voted while
+        // the server (and training) never has it.
+        error: () => this.rollbackOptimistic(id),
+      }),
     );
+  }
+
+  /**
+   * Discard every pending optimistic entry for *id* and re-read the server's
+   * vote state.  Called when a vote POST fails: the prediction never became
+   * server truth, so leaving the entries in place would have
+   * {@link applyVotes} re-impose the phantom vote on every poll.
+   */
+  private rollbackOptimistic(id: number): void {
+    this.pendingOptimistic.delete(id);
+    this.pendingVerified.delete(id);
+    this.pendingRegionBoxes.delete(id);
+    this.loadVotes();
   }
 
   /**
@@ -536,7 +558,10 @@ export class VoteStateService implements OnDestroy {
     this.applyOptimisticRegionBox(entry.mediaId, box);
     this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
-      error: () => this.loadVotes(),
+      // rollbackOptimistic (not a bare loadVotes): the pending entries set
+      // by the optimistic apply above would override the reloaded server
+      // state in applyVotes, so they must be dropped first.
+      error: () => this.rollbackOptimistic(entry.mediaId),
     });
     this.toastSubject.next({ action: 'undo', mediaName: entry.mediaName });
   }
@@ -557,7 +582,8 @@ export class VoteStateService implements OnDestroy {
     this.applyOptimisticRegionBox(entry.mediaId, box);
     this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
-      error: () => this.loadVotes(),
+      // See undo(): drop the pending entries before reloading server state.
+      error: () => this.rollbackOptimistic(entry.mediaId),
     });
     this.toastSubject.next({ action: 'redo', mediaName: entry.mediaName });
   }

--- a/frontend/src/app/utils/api-error.spec.ts
+++ b/frontend/src/app/utils/api-error.spec.ts
@@ -1,0 +1,35 @@
+import { apiErrorMessage } from './api-error';
+
+describe('apiErrorMessage', () => {
+  it('reads the error_response envelope ({error: ...})', () => {
+    expect(apiErrorMessage({ error: { error: 'No files uploaded' } }, 'fallback')).toBe(
+      'No files uploaded',
+    );
+  });
+
+  it('reads the flask_smorest envelope ({message: ...})', () => {
+    // Regression: inline handlers used to read only err.error?.error, so
+    // every abort(400, message=...) route degraded to the generic fallback.
+    expect(
+      apiErrorMessage({ error: { code: 400, status: 'Bad Request', message: 'Missing field' } }, 'fallback'),
+    ).toBe('Missing field');
+  });
+
+  it('prefers the error key when both are present', () => {
+    expect(apiErrorMessage({ error: { error: 'specific', message: 'generic' } }, 'fb')).toBe(
+      'specific',
+    );
+  });
+
+  it('falls back for empty, missing, or non-string payloads', () => {
+    expect(apiErrorMessage({ error: { error: '' } }, 'fb')).toBe('fb');
+    expect(apiErrorMessage({ error: {} }, 'fb')).toBe('fb');
+    expect(apiErrorMessage({}, 'fb')).toBe('fb');
+    expect(apiErrorMessage(null, 'fb')).toBe('fb');
+    expect(apiErrorMessage(undefined, 'fb')).toBe('fb');
+    expect(apiErrorMessage({ error: { errors: { field: ['bad'] } } }, 'fb')).toBe('fb');
+    expect(apiErrorMessage({ error: { message: 42 } }, 'fb')).toBe('fb');
+    // ProgressEvent bodies (network failure) have no keys at all.
+    expect(apiErrorMessage({ error: new ProgressEvent('error') }, 'fb')).toBe('fb');
+  });
+});

--- a/frontend/src/app/utils/api-error.ts
+++ b/frontend/src/app/utils/api-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract a human-readable message from an HTTP error response body.
+ *
+ * The backend deliberately emits two error envelope shapes:
+ *
+ *  - `error_response()` (vtsearch/routes/_shared.py):
+ *    `{ "error": ..., "detail": ..., "request_id": ... }`
+ *  - `flask_smorest.abort()`:
+ *    `{ "code", "status", "message", "errors" }`
+ *
+ * The global error toast interceptor already reads both keys; inline
+ * component handlers must too, or every `abort(400, message=...)` route
+ * degrades to the component's generic fallback string.  Funnel all inline
+ * error-message extraction through here.
+ */
+export function apiErrorMessage(err: unknown, fallback: string): string {
+  const body = (err as { error?: { error?: unknown; message?: unknown } } | null | undefined)
+    ?.error;
+  const message = body?.error ?? body?.message;
+  return typeof message === 'string' && message ? message : fallback;
+}

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -195,13 +195,22 @@ class TestHttpArchiveSource:
         # Before any access, _inner should be None
         assert source._inner is None
 
+    @staticmethod
+    def _cached_dir_for(url: str):
+        import hashlib
+
+        from vtscore.config import DATA_DIR
+
+        url_filename = url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "archive"
+        url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+        return DATA_DIR / f"http_archive_resolve_{url_hash}_{url_filename}"
+
     def test_uses_cached_dir(self, tmp_path):
         """When a cached extraction directory exists, it's reused."""
-        from vtscore.config import DATA_DIR
         from vtscore.datasets.sources.http_archive import HttpArchiveSource
 
         # Create a fake cached extraction dir
-        cached = DATA_DIR / "http_archive_resolve_test.zip"
+        cached = self._cached_dir_for("https://example.com/test.zip")
         cached.mkdir(parents=True, exist_ok=True)
         (cached / "clip.wav").write_bytes(b"audio")
 
@@ -214,6 +223,39 @@ class TestHttpArchiveSource:
             import shutil
 
             shutil.rmtree(cached, ignore_errors=True)
+
+    def test_cache_not_shared_across_urls_with_same_basename(self, tmp_path):
+        """Two URLs sharing a final path segment must not share a cache.
+
+        Regression: the cache dir was keyed on the URL basename only, so
+        ``siteA/v1/images.zip`` silently served ``siteB/images.zip``'s bytes
+        (and vice versa) on any re-resolve.
+        """
+        from vtscore.datasets.sources.http_archive import HttpArchiveSource
+
+        url_a = "https://site-a.example.com/v1/images.zip"
+        url_b = "https://site-b.example.com/images.zip"
+        cached_a = self._cached_dir_for(url_a)
+        cached_b = self._cached_dir_for(url_b)
+        assert cached_a != cached_b
+
+        cached_a.mkdir(parents=True, exist_ok=True)
+        (cached_a / "a_only.wav").write_bytes(b"audio_a")
+        try:
+            # Source B must not pick up A's cached extraction: resolving via
+            # B hits the download path (which we haven't stubbed), so just
+            # verify the fast-path check.  A's source resolves fine.
+            source_a = HttpArchiveSource(url_a)
+            item = source_a.resolve_path(origin_name="a_only.wav")
+            assert item.path is not None
+
+            source_b = HttpArchiveSource(url_b)
+            assert not cached_b.is_dir(), "B's cache dir must be distinct and absent"
+            assert source_b._inner is None
+        finally:
+            import shutil
+
+            shutil.rmtree(cached_a, ignore_errors=True)
 
     def test_delegates_to_local_folder(self, tmp_path):
         """After extraction, fetch_item delegates to LocalFolderSource."""
@@ -437,6 +479,44 @@ class TestIngestViaSource:
 
         assert result == -1
         assert len(medias) == 0  # Nothing ingested, caller should use legacy
+
+    def test_ingest_rolls_back_partial_inserts_on_mid_loop_failure(self, tmp_path):
+        """A failure on a *later* entry must undo earlier inserts before
+        signalling fallback.
+
+        Regression: the fast path inserted each resolved entry into the live
+        ``medias`` dict as it went, then returned -1 when a later entry's
+        embed failed.  ``ingest_missing_medias`` re-ran the whole group
+        through the fallback path, so the already-inserted entries landed in
+        the dataset twice under fresh ids (and a label import then applied
+        the label to both copies).
+        """
+        import numpy as np
+
+        from vtscore.datasets.ingest import _ingest_via_source
+
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "first.wav").write_bytes(b"first_audio")
+        (folder / "second.wav").write_bytes(b"second_audio")
+
+        origin = {"importer": "server_folder", "params": {"path": str(folder), "media_type": "audio"}}
+        entries = [
+            {"origin": origin, "origin_name": "first.wav", "md5": "", "label": "good", "filename": "first.wav"},
+            {"origin": origin, "origin_name": "second.wav", "md5": "", "label": "bad", "filename": "second.wav"},
+        ]
+
+        medias: dict = {}
+        fake_emb = np.zeros(512, dtype=np.float32)
+        # First entry embeds fine, second entry's embed fails.
+        with patch("vtscore.detectors.resolver.embed_file", side_effect=[fake_emb, None]):
+            result = _ingest_via_source(origin, entries, medias, lambda *a: None)
+
+        assert result == -1
+        assert len(medias) == 0, (
+            "partial inserts must be rolled back before falling back, "
+            "or the fallback path re-ingests them as duplicates"
+        )
 
     def test_ingest_uses_precomputed_embedding_from_source(self, tmp_path):
         """When resolve_paths returns a FetchedItem with an embedding, the

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1417,15 +1417,10 @@ class TestRequestMissingDatasetPreservesDetectorState:
         finally:
             set_thread_dataset_context(saved)
 
-        assert good_cid in det_ctx.good_votes, (
-            "dataset-less request wiped the detector's good votes"
-        )
-        assert bad_cid in det_ctx.bad_votes, (
-            "dataset-less request wiped the detector's bad votes"
-        )
+        assert good_cid in det_ctx.good_votes, "dataset-less request wiped the detector's good votes"
+        assert bad_cid in det_ctx.bad_votes, "dataset-less request wiped the detector's bad votes"
         assert det_ctx.votes_dataset_id == prior_votes_dataset_id, (
-            "dataset-less request restamped votes_dataset_id "
-            f"({det_ctx.votes_dataset_id!r})"
+            f"dataset-less request restamped votes_dataset_id ({det_ctx.votes_dataset_id!r})"
         )
 
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1359,6 +1359,76 @@ class TestValidatedVoteSnapshot:
         )
 
 
+class TestRequestMissingDatasetPreservesDetectorState:
+    """A request that identifies a detector but no dataset must not wipe the
+    detector's in-memory session state.
+
+    Regression test: ``get_active_context()`` inside a Flask request with no
+    ``X-Dataset-Id`` returns the request-missing sentinel, whose
+    ``dataset_id`` is the *truthy* string ``"__request_missing__"``.  The
+    "no active dataset; preserve state" guard in
+    ``ensure_votes_match_active_dataset`` only checked emptiness, so such a
+    request fell through to the rehydrate path, cleared good/bad votes,
+    label history, and the whole Find-verification session against the
+    sentinel's frozen-empty medias, then stamped ``votes_dataset_id`` with
+    the sentinel id.
+    """
+
+    def test_detector_header_without_dataset_does_not_wipe_votes(self, client):
+        from vtscore.state.core import (
+            get_detector_context,
+            get_thread_dataset_context,
+            set_thread_dataset_context,
+        )
+        from vtsearch.state import medias
+
+        if len(medias) < 2:
+            pytest.skip("Need at least 2 medias")
+        ids = list(medias.keys())
+        good_cid, bad_cid = ids[0], ids[1]
+
+        client.post(
+            "/api/detectors",
+            json={"name": "NoDatasetHeaderTest", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "NoDatasetHeaderTest", "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, detector_id)
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
+
+        det_ctx = get_detector_context(detector_id)
+        assert det_ctx is not None
+        assert good_cid in det_ctx.good_votes
+        prior_votes_dataset_id = det_ctx.votes_dataset_id
+
+        # Simulate a browser/API request that carries X-Detector-Id but no
+        # dataset id: clear the test fixture's thread-local dataset context so
+        # the request resolves the dataset side to the request-missing
+        # sentinel (exactly what happens in production request threads).
+        saved = get_thread_dataset_context()
+        set_thread_dataset_context(None)
+        try:
+            resp = client.get("/api/health", headers={"X-Detector-Id": detector_id})
+            assert resp.status_code == 200
+        finally:
+            set_thread_dataset_context(saved)
+
+        assert good_cid in det_ctx.good_votes, (
+            "dataset-less request wiped the detector's good votes"
+        )
+        assert bad_cid in det_ctx.bad_votes, (
+            "dataset-less request wiped the detector's bad votes"
+        )
+        assert det_ctx.votes_dataset_id == prior_votes_dataset_id, (
+            "dataset-less request restamped votes_dataset_id "
+            f"({det_ctx.votes_dataset_id!r})"
+        )
+
+
 class TestVoteSyncsToLoadedModel:
     """Voting while a detector is loaded should auto-update the model's labelset."""
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1412,7 +1412,7 @@ class TestRequestMissingDatasetPreservesDetectorState:
         saved = get_thread_dataset_context()
         set_thread_dataset_context(None)
         try:
-            resp = client.get("/api/health", headers={"X-Detector-Id": detector_id})
+            resp = client.get("/healthz", headers={"X-Detector-Id": detector_id})
             assert resp.status_code == 200
         finally:
             set_thread_dataset_context(saved)

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -627,6 +627,41 @@ class TestApplySettings:
 
         assert _apply_settings is canonical
 
+    def test_apply_settings_ignores_infra_setters(self, isolated_settings, tmp_path):
+        """Imported/synced settings dicts are file content, not trusted code.
+
+        The settings module's namespace also holds process-level ``set_*``
+        helpers (``set_settings_path``, ``set_user_data_dir_override``, CLI
+        knobs).  A dict pulled from a settings source or import must not be
+        able to invoke them - that would let a synced file repoint the server
+        settings file or every user's data dir for the process lifetime.
+        """
+        from vtsearch import settings
+
+        orig_path = settings.SETTINGS_PATH
+        orig_override = settings._USER_DATA_DIR_OVERRIDE
+        settings._apply_settings(
+            {
+                "settings_path": str(tmp_path / "evil-settings.json"),
+                "user_data_dir_override": str(tmp_path / "evil-users"),
+                "settings_source_config": {
+                    "source_name": "server_json_file",
+                    "field_values": {"filepath": str(tmp_path / "evil-source.json")},
+                },
+            }
+        )
+        assert settings.SETTINGS_PATH == orig_path
+        assert settings._USER_DATA_DIR_OVERRIDE == orig_override
+        assert settings.get_settings_source_config() is None
+
+    def test_setter_map_contains_only_schema_keys(self):
+        """Every applyable key must be a real server/user-tier schema key."""
+        from vtsearch import settings
+
+        schema_keys = set(settings._all_defaults())
+        setter_keys = set(settings._get_setter_map())
+        assert setter_keys <= schema_keys, sorted(setter_keys - schema_keys)
+
 
 # ---------------------------------------------------------------------------
 # Startup auto-import from settings source

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -1095,6 +1095,59 @@ class TestLabelsetSync:
             set_thread_detector_context(None)
             unregister_detector_context("test_import")
 
+    def test_sync_from_source_targets_named_detector_not_active(self, tmp_path):
+        """Votes must land on the detector the sync names, not the active one.
+
+        Regression: ``sync_from_labelset_source(detector_id)`` resolved the
+        *named* context for the source config and detector_meta, but applied
+        the imported labels via ``apply_label`` → ``get_active_detector_context()``.
+        The manual sync route takes the detector as a path param, so when it
+        differed from the request's active detector, votes landed on the
+        wrong detector while the meta went to the right one.
+        """
+        from vtscore.labels.sync import sync_from_labelset_source
+        from vtscore.state.core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No test medias available")
+        first_id = next(iter(medias))
+        first_md5 = medias[first_id].get("md5", "")
+        if not first_md5:
+            pytest.skip("Test media has no md5")
+
+        filepath = tmp_path / "labels.json"
+        filepath.write_text(json.dumps({"labels": [{"md5": first_md5, "label": "good"}]}))
+
+        target = DetectorContext("sync_target", name="sync_target")
+        target.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(filepath)},
+        }
+        other = DetectorContext("sync_other", name="sync_other")
+        register_detector_context(target)
+        register_detector_context(other)
+        # A *different* detector is active when the sync fires.
+        set_thread_detector_context(other)
+
+        try:
+            result = sync_from_labelset_source("sync_target")
+            assert result is not None and len(result) == 1
+
+            assert first_id in target.good_votes, "vote must land on the named detector"
+            assert first_id not in other.good_votes, (
+                "vote leaked onto the request's active detector"
+            )
+        finally:
+            set_thread_detector_context(None)
+            unregister_detector_context("sync_target")
+            unregister_detector_context("sync_other")
+
     def test_sync_to_source_emits_detector_meta(self, tmp_path):
         """sync_to_labelset_source writes the detector's input_spec / threshold."""
         from vtscore.detectors.store import _detector_path, _write_detector

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -655,7 +655,7 @@ class TestApplySettings:
         assert settings.get_settings_source_config() is None
 
     def test_setter_map_contains_only_schema_keys(self):
-        """Every applyable key must be a real server/user-tier schema key."""
+        """Every importable key must be a real server/user-tier schema key."""
         from vtsearch import settings
 
         schema_keys = set(settings._all_defaults())

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -1140,9 +1140,7 @@ class TestLabelsetSync:
             assert result is not None and len(result) == 1
 
             assert first_id in target.good_votes, "vote must land on the named detector"
-            assert first_id not in other.good_votes, (
-                "vote leaked onto the request's active detector"
-            )
+            assert first_id not in other.good_votes, "vote leaked onto the request's active detector"
         finally:
             set_thread_detector_context(None)
             unregister_detector_context("sync_target")

--- a/tests_lib/detectors/test_calibration_cache_invalidation.py
+++ b/tests_lib/detectors/test_calibration_cache_invalidation.py
@@ -61,6 +61,4 @@ class TestCalibrationCacheClearedBelowRampFloor:
         _, _, model = train_and_score(clips, good, bad, det_ctx=det_ctx)
 
         assert model is not None
-        assert det_ctx.calibration_cache is not None, (
-            "the ≥6-label path caches fold orderings for the inclusion slide"
-        )
+        assert det_ctx.calibration_cache is not None, "the ≥6-label path caches fold orderings for the inclusion slide"

--- a/tests_lib/detectors/test_calibration_cache_invalidation.py
+++ b/tests_lib/detectors/test_calibration_cache_invalidation.py
@@ -1,0 +1,66 @@
+"""The <6-label training path must drop a stale fold-ordering cache.
+
+Regression: ``_train_and_score_xy`` skips k-fold calibration below the
+safe-threshold ramp floor (threshold = 0.5) but used to leave
+``det_ctx.calibration_cache`` untouched.  After un-voting from ≥6 labels
+down to ≤5 and retraining, a subsequent inclusion slide
+(``recompute_detector_thresholds_for_inclusion``) trusted the stale cache
+and re-thresholded against fold orderings computed for the *old* label
+set and model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.detectors.training import train_and_score
+from vtscore.state.core import DetectorContext
+
+DIM = 8
+
+
+def _clips(rng: np.random.Generator, cids: range) -> dict[int, dict]:
+    return {
+        cid: {
+            "embeddings": {"test": rng.standard_normal(DIM).astype(np.float32)},
+            "embedder": "test",
+            "media_type": "audio",
+            "md5": f"m{cid:031d}",
+        }
+        for cid in cids
+    }
+
+
+class TestCalibrationCacheClearedBelowRampFloor:
+    def test_small_label_training_clears_stale_fold_cache(self):
+        rng = np.random.default_rng(42)
+        clips = _clips(rng, range(100, 104))
+        det_ctx = DetectorContext(detector_id="det-cache-test", media_type="audio")
+        stale_orderings = [([0.9, 0.1], [1.0, 0.0])]
+        det_ctx.calibration_cache = ("stale-key", (stale_orderings, None))
+
+        good = {100: None, 101: None}
+        bad = {102: None, 103: None}
+        results, threshold, model = train_and_score(clips, good, bad, det_ctx=det_ctx)
+
+        assert model is not None
+        assert threshold == 0.5
+        assert det_ctx.calibration_cache is None, (
+            "stale fold orderings must not survive a below-ramp-floor "
+            "training; the inclusion slide re-thresholds from any non-None cache"
+        )
+        assert len(results) == len(clips)
+
+    def test_large_label_training_repopulates_cache(self):
+        rng = np.random.default_rng(43)
+        clips = _clips(rng, range(200, 208))
+        det_ctx = DetectorContext(detector_id="det-cache-test-2", media_type="audio")
+
+        good = {cid: None for cid in range(200, 204)}
+        bad = {cid: None for cid in range(204, 208)}
+        _, _, model = train_and_score(clips, good, bad, det_ctx=det_ctx)
+
+        assert model is not None
+        assert det_ctx.calibration_cache is not None, (
+            "the ≥6-label path caches fold orderings for the inclusion slide"
+        )

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -303,6 +303,79 @@ class TestDownloadAndExtract:
         assert last_cur == last_tot, "Final progress should show completion"
 
 
+class TestZipTraversalRejection:
+    """_extract_archive's zip branch must reject traversal members with the
+    same strict check as archive.py.
+
+    Regression: the previous inline ``startswith`` prefix test lacked a
+    trailing separator, so a member resolving to a *sibling* directory whose
+    name merely starts with the destination path (``/x/dest-evil`` vs
+    ``/x/dest``) passed validation.
+    """
+
+    def test_dotdot_member_rejected(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        zip_path = tmp_path / "evil.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("../escape.txt", "gotcha")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with pytest.raises(ValueError, match="Path traversal"):
+            dl_core._extract_archive(zip_path, "evil.zip", dest, "Test", lambda *a: None)
+        assert not (tmp_path / "escape.txt").exists()
+
+    def test_prefix_sibling_member_rejected(self, tmp_path):
+        """A member escaping to a sibling dir sharing the dest's name prefix."""
+        from vtscore.datasets.downloader import core as dl_core
+
+        zip_path = tmp_path / "evil.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("../dest-evil/escape.txt", "gotcha")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with pytest.raises(ValueError, match="Path traversal"):
+            dl_core._extract_archive(zip_path, "evil.zip", dest, "Test", lambda *a: None)
+        assert not (tmp_path / "dest-evil").exists()
+
+    def test_benign_zip_still_extracts(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        zip_path = _make_zip(tmp_path, arcname="ok")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        dl_core._extract_archive(zip_path, "test.zip", dest, "Test", lambda *a: None)
+        assert (dest / "ok" / "file.txt").read_text() == "hello"
+
+
+class TestValidateArchiveHeaderRead:
+    """_validate_archive must read only the archive's magic bytes.
+
+    The memory regression (read_bytes() materialising a multi-GB archive to
+    inspect 4 bytes) can't be asserted directly, but the behaviour contract
+    can: validation decisions are identical and made from the first 4 bytes.
+    """
+
+    def test_valid_zip_header_passes(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        zip_path = _make_zip(tmp_path)
+        dl_core._validate_archive(zip_path, "test.zip", "Test")
+        assert zip_path.exists()
+
+    def test_html_error_page_rejected_and_deleted(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        bad = tmp_path / "fake.zip"
+        bad.write_bytes(b"<html>503 Service Unavailable</html>")
+        with pytest.raises(RuntimeError, match="invalid file"):
+            dl_core._validate_archive(bad, "fake.zip", "Test")
+        assert not bad.exists()
+
+
 class TestCorruptArchiveValidation:
     """Corrupt or non-archive downloads are detected and cleaned up."""
 

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -376,6 +376,61 @@ class TestValidateArchiveHeaderRead:
         assert not bad.exists()
 
 
+class TestDownloadFileAtomic:
+    """download_file_atomic must never leave partial bytes at the final path.
+
+    download_file_with_progress deliberately leaves partial bytes at its
+    destination on failure (resume support), so exists()-gated callers that
+    downloaded straight to the final path cached truncated files forever.
+    """
+
+    def test_success_publishes_final_path(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        final = tmp_path / "labels.mat"
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"complete-content")
+
+        with patch.object(dl_core, "download_file_with_progress", fake_download):
+            dl_core.download_file_atomic("http://example.com/labels.mat", final, 0, lambda *a: None)
+
+        assert final.read_bytes() == b"complete-content"
+        # No temp litter.
+        assert [p.name for p in tmp_path.iterdir()] == ["labels.mat"]
+
+    def test_failure_leaves_no_file_at_final_path(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        final = tmp_path / "labels.mat"
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"partial")  # simulate bytes written before the failure
+            raise ConnectionError("network died")
+
+        with patch.object(dl_core, "download_file_with_progress", fake_download):
+            with pytest.raises(ConnectionError):
+                dl_core.download_file_atomic("http://example.com/labels.mat", final, 0, lambda *a: None)
+
+        assert not final.exists(), "a truncated file at the final path poisons the exists() cache gate"
+        assert list(tmp_path.iterdir()) == [], "temp file must be cleaned up"
+
+    def test_concurrent_winner_is_preserved(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        final = tmp_path / "labels.mat"
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"mine")
+            final.write_bytes(b"other-download-won")  # a rival completed first
+
+        with patch.object(dl_core, "download_file_with_progress", fake_download):
+            dl_core.download_file_atomic("http://example.com/labels.mat", final, 0, lambda *a: None)
+
+        assert final.read_bytes() == b"other-download-won"
+        assert [p.name for p in tmp_path.iterdir()] == ["labels.mat"]
+
+
 class TestCorruptArchiveValidation:
     """Corrupt or non-archive downloads are detected and cleaned up."""
 

--- a/tests_lib/downloads/test_ucsf_documents_download.py
+++ b/tests_lib/downloads/test_ucsf_documents_download.py
@@ -174,22 +174,26 @@ class TestDownloadUcsfDocuments:
 
         def fake_download(url, dest, size, cb):
             dest.write_bytes(b"%PDF-1.0 stub")
-            downloads.append(dest.name)
+            downloads.append(url)
 
         with (
             patch.object(dl_module.core, "DATA_DIR", tmp_path),
             patch.object(dl_module.core, "download_file_with_progress", fake_download),
             patch("requests.get", return_value=mock_response),
         ):
-            dl_module.download_ucsf_documents(
+            result = dl_module.download_ucsf_documents(
                 categories=["Tobacco"],
                 docs_per_category=5,
                 on_progress=lambda *a: None,
             )
 
-        # Only the valid 4+ char ID should be downloaded.
+        # Only the valid 4+ char ID should be downloaded.  The stubbed
+        # downloader sees a temp path (the atomic temp+rename wrapper), so
+        # assert on the URL and the published file instead of the dest name.
         assert len(downloads) == 1
-        assert "abcd0001.pdf" in downloads
+        assert downloads[0].endswith("/abcd0001.pdf")
+        published = list(result.rglob("abcd0001.pdf"))
+        assert published, "the downloaded PDF must be published at its final path"
 
     def test_handles_api_failure_gracefully(self, tmp_path):
         """If the Solr API request fails, the category is skipped."""

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -250,6 +250,126 @@ class TestCoalescing:
         assert max_active == 1
 
 
+class TestPendingIsolation:
+    """The pending slot must not blend requests from different (dataset,
+    detector) pairs or users.
+
+    Regression tests: the coalescing branch used to update the parked
+    pending in place for *any* new ``start()``, so a poller holding the
+    pending's job_id could receive results trained for a different
+    dataset/detector (and a different user).  And a pending job that was
+    cancelled while parked was still promoted and ran to completion.
+    """
+
+    def test_start_for_different_pair_supersedes_pending(self):
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        mgr.start(
+            "sig-A",
+            _make_target(first_release, first_started, ran),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        assert first_started.wait(timeout=5)
+
+        release_bc = threading.Event()
+        release_bc.set()
+        second = mgr.start(
+            "sig-B",
+            _make_target(release_bc, threading.Event(), ran),
+            dataset_id="ds-2",
+            detector_id="det-2",
+        )
+        assert second.status == "pending"
+
+        third = mgr.start(
+            "sig-C",
+            _make_target(release_bc, threading.Event(), ran),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        # Different pair → must NOT coalesce into second's job object.
+        assert third.job_id != second.job_id
+        # Second's pollers see a terminal state, not sig-C's results.
+        assert second.done_event.is_set()
+        assert second.status == "cancelled"
+        assert second.signature == "sig-B"
+        assert second.dataset_id == "ds-2"
+
+        first_release.set()
+        assert third.done_event.wait(timeout=5)
+        assert third.status == "done"
+        assert third.result == {"signature": "sig-C"}
+        # sig-B never executed.
+        assert ran == ["sig-A", "sig-C"]
+
+    def test_same_pair_still_coalesces(self):
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        mgr.start(
+            "sig-A",
+            _make_target(first_release, first_started, ran),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        assert first_started.wait(timeout=5)
+
+        release = threading.Event()
+        release.set()
+        second = mgr.start(
+            "sig-B",
+            _make_target(release, threading.Event(), ran),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        third = mgr.start(
+            "sig-C",
+            _make_target(release, threading.Event(), ran),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        assert third.job_id == second.job_id
+        assert second.signature == "sig-C"
+
+        first_release.set()
+        assert third.done_event.wait(timeout=5)
+        assert ran == ["sig-A", "sig-C"]
+
+    def test_cancelled_pending_is_not_promoted(self):
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        first = mgr.start("sig-A", _make_target(first_release, first_started, ran))
+        assert first_started.wait(timeout=5)
+
+        pending_started = threading.Event()
+        pending = mgr.start("sig-B", _make_target(threading.Event(), pending_started, ran))
+        assert pending.status == "pending"
+        pending.cancel()
+
+        first_release.set()
+        assert first.done_event.wait(timeout=5)
+        assert pending.done_event.wait(timeout=5)
+        assert pending.status == "cancelled"
+        assert not pending_started.is_set(), "cancelled pending job must not run"
+        assert ran == ["sig-A"]
+        # The manager is idle again: a fresh start spawns immediately.
+        release = threading.Event()
+        release.set()
+        job = mgr.start("sig-D", _make_target(release, threading.Event(), ran))
+        assert job.status in ("running", "done")
+        assert job.done_event.wait(timeout=5)
+        assert ran == ["sig-A", "sig-D"]
+
+
 class TestThreadContextPropagation:
     """``_run()`` must resolve and set the dataset/detector thread-local
     contexts from ``job.dataset_id`` / ``job.detector_id`` so the target's

--- a/tests_lib/sorting/test_find_optimal_threshold.py
+++ b/tests_lib/sorting/test_find_optimal_threshold.py
@@ -1,0 +1,105 @@
+"""Unit tests for ``find_optimal_threshold``.
+
+Regression coverage for two search-space bugs:
+
+* The candidate set was only the observed scores, so "predict nothing
+  positive" (threshold above the max score; FPR=0, FNR=1) was unreachable
+  even when it minimised the weighted cost - under a precision-biased
+  inclusion the calibrated cutoff came out far too permissive.
+* Tied scores produced infeasible cut positions: the cumsum at a mid-tie
+  index corresponds to predicting only *some* of the items at that score,
+  which ``score >= threshold`` cannot realize, so ``argmin`` could report
+  a cost the returned threshold doesn't achieve.
+"""
+
+from __future__ import annotations
+
+from vtscore.training.thresholds import NO_GOOD_THRESHOLD, find_optimal_threshold
+
+
+class TestBasics:
+    def test_empty_scores_returns_default(self):
+        assert find_optimal_threshold([], []) == 0.5
+
+    def test_single_class_returns_default(self):
+        assert find_optimal_threshold([0.2, 0.8], [1.0, 1.0]) == 0.5
+        assert find_optimal_threshold([0.2, 0.8], [0.0, 0.0]) == 0.5
+
+    def test_perfect_separation_picks_boundary(self):
+        scores = [0.9, 0.8, 0.2, 0.1]
+        labels = [1.0, 1.0, 0.0, 0.0]
+        t = find_optimal_threshold(scores, labels)
+        # Any threshold in (0.2, 0.8] classifies perfectly; the search
+        # returns an observed score, so it must be 0.8.
+        assert t == 0.8
+
+    def test_balanced_inclusion_prefers_low_cost_cut(self):
+        # One inversion: threshold at 0.6 gives fp=0, fn=1 (cost 1/2 + 0);
+        # cutting deeper at 0.4 gives fp=1, fn=0 (cost 1/2).  Equal cost -
+        # argmin picks the first (higher) cut.
+        scores = [0.9, 0.6, 0.5, 0.4, 0.2]
+        labels = [1.0, 1.0, 0.0, 1.0, 0.0]
+        t = find_optimal_threshold(scores, labels, 0)
+        assert 0.0 < t <= 1.0
+
+
+class TestPredictNothingCandidate:
+    def test_precision_biased_abstains_on_top_scored_negative(self):
+        """A lone top-scored negative under inclusion=-3 must abstain.
+
+        Observed candidates: t=0.9 → cost 8*1 + 1*1 = 9; t=0.1 → cost
+        8*1 + 0 = 8.  Predicting nothing costs fnr_weight = 1, strictly
+        cheaper, so the sentinel must be returned.
+        """
+        t = find_optimal_threshold([0.9, 0.1], [0.0, 1.0], inclusion_value=-3)
+        assert t == NO_GOOD_THRESHOLD
+
+    def test_observed_threshold_wins_ties_with_abstain(self):
+        """When abstaining merely ties the best observed cut, keep the cut."""
+        # Perfect separation: best observed cost is 0, abstain costs 1.
+        t = find_optimal_threshold([0.9, 0.1], [1.0, 0.0], inclusion_value=-3)
+        assert t == 0.9
+
+    def test_recall_biased_never_abstains(self):
+        # With inclusion >= 0, fnr_weight >= 1 and the full-inclusion cut
+        # costs at most fpr_weight = 1 <= fnr_weight, so abstaining is
+        # never strictly cheaper... unless every cut includes a negative
+        # AND misses a positive.  Sanity-check the common case.
+        t = find_optimal_threshold([0.9, 0.1], [0.0, 1.0], inclusion_value=3)
+        assert t == 0.1
+
+
+class TestTiedScores:
+    def test_mid_tie_cut_not_reported(self):
+        """All-tied scores admit exactly one cut: include everything.
+
+        With scores all 0.7, ``score >= 0.7`` includes every item, so
+        fp=2, fn=0 → cost = fpr_weight.  A mid-tie argmin used to report
+        an infeasible fp=0/fn=1 split.  Under inclusion=-2 (fpr_weight=4)
+        the true choice is between including all (cost 4) and abstaining
+        (cost 1): abstain wins.
+        """
+        scores = [0.7, 0.7, 0.7, 0.7]
+        labels = [1.0, 0.0, 1.0, 0.0]
+        t = find_optimal_threshold(scores, labels, inclusion_value=-2)
+        assert t == NO_GOOD_THRESHOLD
+
+    def test_tie_run_uses_last_position_counts(self):
+        """A tie run's feasible cut counts every tied item.
+
+        scores: pos 1.0, then a tied run [0.5, 0.5] with one of each class,
+        then neg 0.1.  Cutting at 0.5 includes both tied items (fp=1, fn=0);
+        cutting at 1.0 gives fp=0, fn=1.  At inclusion=0 both cost 0.5;
+        the first (higher) cut wins the argmin tie.
+        """
+        scores = [1.0, 0.5, 0.5, 0.1]
+        labels = [1.0, 1.0, 0.0, 0.0]
+        t = find_optimal_threshold(scores, labels, inclusion_value=0)
+        assert t == 1.0
+
+    def test_saturated_sigmoid_scores(self):
+        """Exact 1.0/0.0 sigmoid saturation must yield a usable threshold."""
+        scores = [1.0, 1.0, 1.0, 0.0, 0.0]
+        labels = [1.0, 1.0, 1.0, 0.0, 0.0]
+        t = find_optimal_threshold(scores, labels, inclusion_value=0)
+        assert t == 1.0

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -10,10 +10,15 @@ the worker thread to serve other requests while training runs.
 Each :class:`JobManager` runs **one** background job at a time and keeps a
 single coalescing pending slot.  When a new ``start()`` arrives while a job
 is running, its target+signature are stashed as *pending*; if another
-``start()`` arrives before the runner picks the pending slot up, the
-pending slot is updated in place (latest wins) and the same job object is
-returned.  When the running job finishes, the pending job is promoted and
-spawned automatically.  This avoids the previous design's failure mode
+``start()`` from the **same requester context** (user + dataset + detector)
+arrives before the runner picks the pending slot up, the pending slot is
+updated in place (latest wins) and the same job object is returned.  A
+``start()`` from a *different* requester context instead supersedes the
+parked pending (marking it ``cancelled`` so its pollers see a terminal
+state rather than another request's results) and parks a fresh job.  When
+the running job finishes, the pending job is promoted and spawned
+automatically - unless it was cancelled while parked, in which case it is
+terminated without running.  This avoids the previous design's failure mode
 where rapid-fire requests spawned parallel training threads that fought
 for CPU/GPU - cancellation was cooperative-only and never honoured inside
 the training loop.
@@ -77,9 +82,12 @@ class JobManager:
 
     Only one job runs at a time.  A second ``start()`` while a job is in
     flight stashes the new target+signature in a pending slot; further
-    ``start()`` calls update the pending slot in place (latest wins) and
-    return the same pending job object.  When the running job finishes,
-    the pending job is promoted and spawned.
+    ``start()`` calls from the same requester context (user + dataset +
+    detector pair) update the pending slot in place (latest wins) and
+    return the same pending job object, while a call from a different
+    requester context supersedes the parked pending with a fresh job.
+    When the running job finishes, the pending job is promoted and spawned
+    (unless it was cancelled while parked).
 
     Results from the most recently completed job are cached by *signature*
     so a follow-up call with an unchanged signature reuses the previous
@@ -157,15 +165,32 @@ class JobManager:
         with self._lock:
             prev = self._jobs.get(self._current_id) if self._current_id else None
             if prev is not None and prev.status == "running":
-                if self._pending is not None:
-                    # Coalesce: update the existing pending in place so all
-                    # callers waiting on this job_id receive the latest run.
-                    self._pending.signature = signature
-                    self._pending_target = target
-                    self._pending.user = current_user
-                    self._pending.dataset_id = dataset_id
-                    self._pending.detector_id = detector_id
-                    return self._pending
+                pend = self._pending
+                if pend is not None:
+                    if (
+                        pend.user == current_user
+                        and pend.dataset_id == dataset_id
+                        and pend.detector_id == detector_id
+                        and not pend.is_cancelled
+                    ):
+                        # Coalesce: same requester context (user + pair), so
+                        # update the existing pending in place and every
+                        # caller waiting on this job_id receives the latest
+                        # run.  This is the rapid vote→re-sort burst path.
+                        pend.signature = signature
+                        self._pending_target = target
+                        return pend
+                    # Different (user, dataset, detector) - or a pending that
+                    # was cancelled while parked.  Updating it in place would
+                    # serve its pollers *another request's* results (wrong
+                    # dataset/detector, wrong user) under their job_id, so
+                    # supersede: terminate the old pending visibly and park a
+                    # fresh job for the new requester.
+                    pend.status = "cancelled"
+                    pend.error = pend.error or "superseded by a newer request"
+                    pend.done_event.set()
+                    self._pending = None
+                    self._pending_target = None
                 job = AsyncJob(
                     job_id=uuid.uuid4().hex,
                     signature=signature,
@@ -250,17 +275,35 @@ class JobManager:
                 self._last_done = job
             job.done_event.set()
 
-            if self._pending is not None:
-                next_job = self._pending
-                next_target = self._pending_target
-                self._pending = None
-                self._pending_target = None
-                next_job.status = "running"
-                next_job.started_at = time.time()
-                self._current_id = next_job.job_id
+            promoted = self._take_pending_locked()
+            if promoted is not None:
+                next_job, next_target = promoted
 
         if next_job is not None and next_target is not None:
             self._spawn_thread(next_job, next_target)
+
+    def _take_pending_locked(self) -> tuple[AsyncJob, Callable[[AsyncJob], Any]] | None:
+        """Pop the pending slot for promotion, honouring cancellation.
+
+        A cancel that arrived while the job was parked in the pending slot
+        must terminate it, not let it run to completion anyway; such a job
+        is marked ``cancelled`` and dropped.  Returns the ``(job, target)``
+        to spawn, or ``None``.  Caller must hold ``self._lock``.
+        """
+        job = self._pending
+        target = self._pending_target
+        self._pending = None
+        self._pending_target = None
+        if job is None or target is None:
+            return None
+        if job.is_cancelled:
+            job.status = "cancelled"
+            job.done_event.set()
+            return None
+        job.status = "running"
+        job.started_at = time.time()
+        self._current_id = job.job_id
+        return job, target
 
     def _promote_pending_if_any(self) -> None:
         """Promote the pending slot to running and spawn it, if present.
@@ -271,14 +314,9 @@ class JobManager:
         next_job: AsyncJob | None = None
         next_target: Callable[[AsyncJob], Any] | None = None
         with self._lock:
-            if self._pending is not None:
-                next_job = self._pending
-                next_target = self._pending_target
-                self._pending = None
-                self._pending_target = None
-                next_job.status = "running"
-                next_job.started_at = time.time()
-                self._current_id = next_job.job_id
+            promoted = self._take_pending_locked()
+            if promoted is not None:
+                next_job, next_target = promoted
         if next_job is not None and next_target is not None:
             self._spawn_thread(next_job, next_target)
 

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -136,8 +136,15 @@ class Video2ImageMediaConverter(MediaConverter):
         elif media_bytes:
             ext = Path(filename).suffix or ".mp4"
             tmp_file = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
-            tmp_file.write(media_bytes)
-            tmp_file.close()
+            try:
+                tmp_file.write(media_bytes)
+                tmp_file.close()
+            except BaseException:
+                # A failed write (e.g. ENOSPC) happens before the try/finally
+                # below owns the temp file; clean it up here or it leaks.
+                tmp_file.close()
+                Path(tmp_file.name).unlink(missing_ok=True)
+                raise
             video_path = tmp_file.name
         else:
             return []

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -82,6 +82,11 @@ def write_container(
             with zipfile.ZipFile(raw, "w", compression=zipfile.ZIP_STORED) as zf:
                 zf.writestr("medias.pkl", medias_pickle_bytes)
                 zf.writestr("meta.json", json.dumps(meta, indent=2))
+            # Flush to stable storage before the rename publishes the file:
+            # without the fsync a crash/power loss shortly after os.replace
+            # can leave a zero-length/truncated dataset at the final path.
+            raw.flush()
+            os.fsync(raw.fileno())
         os.replace(tmp, str(p))
     except BaseException:
         try:
@@ -246,6 +251,8 @@ def _rewrite_without(path: Path, entry_name: str) -> None:
                 for item in src.infolist():
                     if item.filename != entry_name:
                         dst.writestr(item, src.read(item.filename))
+            raw.flush()
+            os.fsync(raw.fileno())
         os.replace(tmp, str(path))
     except BaseException:
         try:

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -407,7 +407,10 @@ def _validate_archive(archive_path: Path, archive_name: str, dataset_name: str) 
     """
     suffix = archive_name.lower()
     try:
-        header = archive_path.read_bytes()[:4]
+        # Read only the magic bytes - read_bytes() would materialise the
+        # whole (potentially multi-GB) archive in memory to inspect 4 bytes.
+        with open(archive_path, "rb") as f:
+            header = f.read(4)
     except OSError:
         return  # file vanished – let the caller deal with it
 
@@ -475,16 +478,20 @@ def _extract_archive(
                     tar_ref.extract(member, dest_dir, filter="data")
         on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
     elif suffix.endswith(".zip"):
+        from vtscore.datasets.archive import _reject_traversal
+
+        dest_resolved = Path(dest_dir).resolve()
         with zipfile.ZipFile(archive_path, "r") as zip_ref:
             members = zip_ref.namelist()
             total = len(members)
             for i, member in enumerate(members):
                 if i % 100 == 0 or i == total - 1:
                     on_progress("downloading", f"Extracting {dataset_name}...", i + 1, total)
-                # Guard against path traversal in zip entries
-                member_path = Path(dest_dir) / member
-                if not str(member_path.resolve()).startswith(str(Path(dest_dir).resolve())):
-                    raise ValueError(f"Path traversal detected in archive: {member}")
+                # Guard against path traversal in zip entries.  Shares the
+                # strict check with archive.py: the previous inline
+                # startswith() prefix test lacked a trailing separator, so
+                # a sibling dir with the dest as a name prefix passed.
+                _reject_traversal(dest_resolved, member)
                 zip_ref.extract(member, dest_dir)
     else:
         raise ValueError(f"Unsupported archive format: {archive_name}")

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -391,6 +391,37 @@ def download_file_with_progress(  # noqa: C901
                 response.close()
 
 
+def download_file_atomic(
+    url: str,
+    final_path: Path,
+    expected_size: int,
+    on_progress: ProgressCallback,
+) -> None:
+    """Download *url* to *final_path* via a unique temp file + atomic rename.
+
+    :func:`download_file_with_progress` deliberately leaves partial bytes at
+    its destination when every retry fails (its resume feature depends on
+    that), so callers that gate the download on ``final_path.exists()`` must
+    never point it at the final path directly - a failed run would leave a
+    truncated file that every subsequent run treats as a complete cached
+    copy.  This wrapper downloads to a sibling temp file and only publishes
+    the final path once the stream completed cleanly.  A concurrent
+    completed download wins; the temp file is always removed.
+    """
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    unique_id = uuid.uuid4().hex[:8]
+    temp_path = final_path.parent / f".dl_{unique_id}_{final_path.name}"
+    try:
+        download_file_with_progress(url, temp_path, expected_size, on_progress)
+        if not final_path.exists():
+            try:
+                os.rename(temp_path, final_path)
+            except OSError:
+                pass  # Another download finished first
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 _GZIP_MAGIC = b"\x1f\x8b"
 _ZIP_MAGIC = b"PK"
 # Uncompressed tar: first 257 bytes contain "ustar" at offset 257,

--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -104,7 +104,9 @@ def download_ucsf_documents(  # noqa: C901
             url = f"{_core.UCSF_IDL_DOWNLOAD_URL}/{doc_id[0]}/{doc_id[1]}/{doc_id[2]}/{doc_id[3]}/{doc_id}/{doc_id}.pdf"
 
             try:
-                _core.download_file_with_progress(url, pdf_path, 0, on_progress)
+                # Atomic (temp + rename): a partial PDF left at pdf_path by a
+                # hard kill would pass the exists() cache gate forever.
+                _core.download_file_atomic(url, pdf_path, 0, on_progress)
                 downloaded += 1
                 on_progress("downloading", f"Downloaded {doc_id}.pdf", downloaded, total_docs)
             except Exception:

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -225,12 +225,13 @@ def download_oxford_flowers(on_progress: Optional[ProgressCallback] = None) -> P
         on_progress=on_progress,
     )
 
-    # Download labels file if not present.
+    # Download labels file if not present.  Atomic (temp + rename): a
+    # partial file left at labels_path would pass the exists() gate forever.
     labels_path = extract_dir / "imagelabels.mat"
     if not labels_path.exists():
         _core.DATA_DIR.mkdir(exist_ok=True)
         on_progress("downloading", "Downloading Oxford Flowers labels...", 0, 0)
-        _core.download_file_with_progress(_core.OXFORD_FLOWERS_LABELS_URL, labels_path, 1024 * 1024, on_progress)
+        _core.download_file_atomic(_core.OXFORD_FLOWERS_LABELS_URL, labels_path, 1024 * 1024, on_progress)
 
     return extract_dir
 
@@ -385,11 +386,13 @@ def download_roxford5k(on_progress: Optional[ProgressCallback] = None) -> Path:
     )
 
     # Pull the (small) revisited ground-truth pickle alongside the images.
+    # Atomic (temp + rename): a partial file left at gnd_path would pass the
+    # exists() gate forever.
     gnd_path = extract_dir / "gnd_roxford5k.pkl"
     if not gnd_path.exists():
         extract_dir.mkdir(parents=True, exist_ok=True)
         on_progress("downloading", "Downloading ROxford5k ground truth...", 0, 0)
-        _core.download_file_with_progress(_core.ROXFORD_GND_URL, gnd_path, 1024 * 1024, on_progress)
+        _core.download_file_atomic(_core.ROXFORD_GND_URL, gnd_path, 1024 * 1024, on_progress)
 
     return extract_dir
 

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -250,9 +250,17 @@ def _ingest_via_source(
         return -1
 
     media_type_id = _media_type_from_origin(origin_dict)
-    embedder_name = _embedder_name_for_type(medias, media_type_id) if media_type_id else ""
+    if not media_type_id:
+        source.cleanup()
+        return -1
+    embedder_name = _embedder_name_for_type(medias, media_type_id)
 
     ingested = 0
+    # cids inserted so far, so a mid-loop fallback (-1) can roll them back.
+    # Without the rollback, the caller re-runs the *entire* entry group
+    # through the resolver/importer path and the entries this loop already
+    # inserted end up in the dataset twice under fresh ids.
+    inserted_cids: list[int] = []
 
     try:
         pairs = [(e.get("origin_name", ""), e.get("filename", "")) for e in entries]
@@ -265,10 +273,6 @@ def _ingest_via_source(
             if item.path is None:
                 continue
 
-            if not media_type_id:
-                source.cleanup()
-                return -1
-
             # When the source returns a pre-computed embedding (and there are
             # no clip params that would require re-embedding a sub-segment),
             # skip the local embed step entirely.
@@ -280,11 +284,15 @@ def _ingest_via_source(
             else:
                 # Resolve embedding + clip-aware bytes/md5 - if any step fails,
                 # fall back to the legacy full-import path so we don't produce
-                # medias with mismatched embedding/MD5/bytes triples.
+                # medias with mismatched embedding/MD5/bytes triples.  Undo
+                # this group's partial inserts first: the fallback re-ingests
+                # the whole group.
                 effective_embedder = embedder_name
                 resolved = _resolve_clip_content_and_embedding(item.path, media_type_id, origin_dict, embedder_name)
                 if resolved is None:
-                    source.cleanup()
+                    with _state_lock:
+                        for cid in inserted_cids:
+                            medias.pop(cid, None)
                     return -1  # Signal caller to use legacy full-import path
                 embedding, file_bytes, md5 = resolved
 
@@ -312,6 +320,7 @@ def _ingest_via_source(
                 cid = next_media_id(medias)
                 media_data["id"] = cid
                 medias[cid] = media_data
+                inserted_cids.append(cid)
             ingested += 1
 
             on_progress(

--- a/vtscore/datasets/sources/http_archive.py
+++ b/vtscore/datasets/sources/http_archive.py
@@ -57,10 +57,17 @@ class HttpArchiveSource(MediaSource):
         if self._inner is not None:
             return self._inner
 
+        import hashlib
+
         from vtscore.datasets.sources.local_folder import LocalFolderSource
 
         url_filename = self._url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "archive"
-        cached_dir = DATA_DIR / f"http_archive_resolve_{url_filename}"
+        # Key the cache on the *full* URL, not just its basename: two archives
+        # whose URLs share a final segment (siteA/images.zip vs siteB/images.zip)
+        # must not silently serve each other's extraction.  The basename is
+        # kept in the dir name purely for human readability.
+        url_hash = hashlib.sha256(self._url.encode("utf-8")).hexdigest()[:16]
+        cached_dir = DATA_DIR / f"http_archive_resolve_{url_hash}_{url_filename}"
 
         # Fast path: a previous run already published a cached extraction.
         if cached_dir.is_dir():

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -58,15 +58,20 @@ def ensure_votes_match_active_dataset() -> None:
         _state_lock,
         get_active_context,
         get_active_detector_context,
+        is_request_missing_dataset_context,
     )
 
     det_ctx = get_active_detector_context()
     if not det_ctx.detector_id:
         return
     ds_ctx = get_active_context()
-    if not ds_ctx.dataset_id:
+    if not ds_ctx.dataset_id or is_request_missing_dataset_context(ds_ctx):
         # No active dataset; preserve whatever the detector last saw so a
         # request that happens to omit the dataset header doesn't wipe state.
+        # The request-missing sentinel carries the truthy id
+        # "__request_missing__", so the emptiness check alone would fall
+        # through and wipe the detector's in-memory session (find scores,
+        # verified ids, label history) against an empty medias dict.
         return
 
     from vtscore.detectors.registry import get_detector

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -13,11 +13,22 @@ label, or removed when the user has untoggled the vote.
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
 from vtscore.datasets.labelset import LabelSet
 from vtscore.state.core import DetectorContext
+
+# Serialises the read → merge → write pass in
+# :func:`sync_labels_to_loaded_detector`.  Two concurrent syncs on the same
+# detector from *different dataset contexts* each merge against a stale base
+# and the last writer drops the other dataset's just-written cross-dataset
+# entries (lost update).  The write itself is atomic (os.replace), but
+# atomicity doesn't serialise the read-modify-write.  Acquired *before*
+# ``_state_lock`` (via ``validated_vote_snapshot`` inside the body); no other
+# code takes this lock, so no ordering cycle is possible.
+_label_sync_write_lock = threading.Lock()
 
 
 def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], DetectorContext] | None:
@@ -117,6 +128,12 @@ def sync_labels_to_loaded_detector() -> None:
     because the global votes reflect scoring results on a different dataset,
     not the detector's original training labels.
     """
+    with _label_sync_write_lock:
+        _sync_labels_to_loaded_detector_locked()
+
+
+def _sync_labels_to_loaded_detector_locked() -> None:
+    """Body of :func:`sync_labels_to_loaded_detector`; caller holds the lock."""
     state = _get_loaded_detector_state()
     if state is None:
         return

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -505,6 +505,13 @@ def _train_and_score_xy(
     # GMM) or unreliable.  0.5 is a sensible neutral mid-point.
     if len(X_list) < 6:
         threshold = 0.5
+        # Drop any fold-ordering cache from a previous ≥6-label training:
+        # this path neither reads nor rewrites it, and a later inclusion
+        # slide (`recompute_detector_thresholds_for_inclusion`) trusts any
+        # non-None cache - re-thresholding against orderings computed for
+        # the *old* label set/model.
+        if det_ctx is not None:
+            det_ctx.calibration_cache = None
     else:
         threshold = cross_calibration_threshold_cached(
             X_list,
@@ -548,8 +555,9 @@ def train_and_score(
     ``clips_dict``.
 
     Args:
-        clips_dict: Mapping of media ID to media data dict. Each value must contain
-            an ``"embedding"`` key with a ``numpy.ndarray`` embedding vector.
+        clips_dict: Mapping of media ID to media data dict. Each value must carry
+            a resolvable embedding vector in its per-embedder ``"embeddings"``
+            dict store (read via ``media_embedding``).
         good_votes: Dict whose keys are media IDs labelled as good (values are ``None``).
         bad_votes: Dict whose keys are media IDs labelled as bad (values are ``None``).
         inclusion_value: Integer in ``[-10, 10]`` passed to the training and

--- a/vtscore/eval/label_curve.py
+++ b/vtscore/eval/label_curve.py
@@ -479,8 +479,8 @@ def run_label_curve_eval(  # noqa: C901
 
     Args:
         dataset_clips: Mapping of dataset name to a preloaded medias dict.
-            Each media must carry an ``"embedding"`` (np.ndarray) and a
-            ``"category"`` (str).
+            Each media must carry a resolvable embedding in the per-embedder
+            ``"embeddings"`` store and a ``"category"`` (str).
         trainers: Trainer names to compare (keys of :data:`TRAINERS`).
         label_counts: How many training labels to feed each trainer.
         seeds: Random seeds.  The split/sample is fully determined by the

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -370,7 +370,8 @@ def run_voting_iterations_eval(
     Args:
         dataset_clips: Mapping of dataset name to a pre-loaded medias dict.
             Each medias dict maps ``int`` media IDs to media data dicts
-            (must include ``"embedding"`` and ``"category"`` keys).
+            (must carry a resolvable embedding in the per-embedder
+            ``"embeddings"`` store and a ``"category"`` key).
         seeds: List of random seeds to iterate over.
         categories: Optional mapping of dataset name to list of target
             categories.  If ``None`` or a dataset is missing from the dict,

--- a/vtscore/labels/sync.py
+++ b/vtscore/labels/sync.py
@@ -321,26 +321,34 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
     with _sync_lock:
         _syncing = True
         try:
-            from vtscore.state.core import get_active_context
+            from vtscore.state.core import get_active_context, override_detector_context
             from vtscore.state.votes import apply_label
 
             ds_medias = get_active_context().medias
-            for entry in labels:
-                label = entry.get("label")
-                md5 = entry.get("md5")
-                if label not in ("good", "bad") or not md5:
-                    continue
+            # Apply the votes to *ctx* - the detector this sync was invoked
+            # for - not whatever detector the surrounding request happens to
+            # have active.  The manual sync route takes the detector as a
+            # path param, so the request's X-Detector-Id can legitimately
+            # name a different detector; without the override the imported
+            # votes landed on that one while detector_meta (above) went to
+            # ctx.
+            with override_detector_context(ctx):
+                for entry in labels:
+                    label = entry.get("label")
+                    md5 = entry.get("md5")
+                    if label not in ("good", "bad") or not md5:
+                        continue
 
-                # Find media by md5
-                for mid, media in ds_medias.items():
-                    if media.get("md5") == md5:
-                        # System-driven auto-import on detector load; the
-                        # ``record_detector_import`` call below covers the
-                        # achievement credit instead of crediting each
-                        # imported label as a user vote.
-                        apply_label(mid, label, record_achievement=False)
-                        applied_any = True
-                        break
+                    # Find media by md5
+                    for mid, media in ds_medias.items():
+                        if media.get("md5") == md5:
+                            # System-driven auto-import on detector load; the
+                            # ``record_detector_import`` call below covers the
+                            # achievement credit instead of crediting each
+                            # imported label as a user vote.
+                            apply_label(mid, label, record_achievement=False)
+                            applied_any = True
+                            break
         finally:
             _syncing = False
 

--- a/vtscore/state/diversity_tree.py
+++ b/vtscore/state/diversity_tree.py
@@ -207,6 +207,13 @@ class DiversityTree:
             if inertia is not None and inertia < best_inertia:
                 best_inertia = inertia
                 best_labels = candidate_labels
+            elif best_labels is None:
+                # The backend contract allows ``inertia=None`` (a backend
+                # that doesn't report it).  Keep the labels as a fallback
+                # candidate so ``best_labels`` can't stay None and crash the
+                # ``labels == ci`` mask below; a later init with a real
+                # inertia still wins.
+                best_labels = candidate_labels
 
             # Report progress after each init, weighted by vector count
             # (k-means cost is proportional to the number of vectors).

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -46,8 +46,8 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
 
     Returns:
         A float threshold. Scores at or above this value are classified as Good.
-        Falls back to the median of scores if GMM fitting fails or fewer than 2 scores
-        are provided.
+        Returns ``0.5`` when fewer than 2 scores are provided; falls back to
+        the median of scores if GMM fitting fails.
     """
     if len(scores) < 2:
         return 0.5
@@ -192,7 +192,10 @@ def find_optimal_threshold(
               precision, i.e., exclude more items).
 
     Returns:
-        The float threshold that achieves the lowest weighted cost.
+        The float threshold that achieves the lowest weighted cost, or
+        :data:`NO_GOOD_THRESHOLD` when predicting nothing positive is
+        strictly cheaper than every realizable cut (e.g. a top-scored
+        negative under a precision-biased inclusion).
         Defaults to 0.5 if the score list is empty.
     """
     if not scores:
@@ -235,7 +238,24 @@ def find_optimal_threshold(
 
     costs = fpr_weight * fpr + fnr_weight * fnr
 
+    # Only positions where the score strictly drops afterwards are feasible
+    # cut points: ``score >= threshold`` includes *every* item tied with the
+    # threshold, so a mid-tie position advertises a TP/FP split the returned
+    # threshold cannot realize (common with a saturated MLP emitting exact
+    # 1.0/0.0 sigmoids).  The last position is always a feasible cut.
+    feasible = np.append(sorted_scores[:-1] > sorted_scores[1:], True)
+    costs = np.where(feasible, costs, np.inf)
+
     best_idx = int(np.argmin(costs))
+    best_cost = float(costs[best_idx])
+
+    # "Predict nothing positive" (a threshold above every observed score) is
+    # a legitimate candidate the observed scores can't express: FP=0, FN=all
+    # positives, so its cost is exactly ``fnr_weight``.  Observed thresholds
+    # win ties so behaviour only changes when abstaining is strictly better.
+    if fnr_weight < best_cost:
+        return NO_GOOD_THRESHOLD
+
     return float(sorted_scores[best_idx])
 
 
@@ -308,8 +328,15 @@ def compute_fold_orderings(
         model = train_model(X_train, y_train, input_dim, hidden_dim=hidden_dim)
 
         with torch.no_grad():
+            from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
+
             X_cal = X_cal.to(next(model.parameters()).device)
-            scores = torch.sigmoid(model(X_cal)).squeeze(1).cpu().tolist()
+            # Sanitize non-finite sigmoids (destabilised fold model): the
+            # orderings are cached, swept for the Stats chart, and averaged
+            # into ``DetectorContext.threshold`` - a NaN here would silently
+            # break every downstream ``score >= threshold`` comparison and
+            # leak NaN into JSON responses.
+            scores = sigmoid_to_finite_scores(model(X_cal))
         orderings.append((scores, y_np[cal_idx].tolist()))
 
     return orderings, None
@@ -416,7 +443,8 @@ def calculate_safe_threshold(
     linearly with the number of labels.
 
     Blending rules:
-        * ``n_labels < 6``  → pure GMM threshold.
+        * ``n_labels <= 6``  → pure GMM threshold (the x-cal weight
+          ``(n_labels - 6) / 14`` is 0 at exactly 6).
         * ``n_labels >= 20`` → pure x-cal threshold.
         * In between → linear interpolation.
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -1295,16 +1295,27 @@ _SETTER_MAP: dict[str, Any] | None = None
 
 
 def _get_setter_map() -> dict:
-    """Build a map of setting-key → setter-function by introspecting this module."""
+    """Build a map of setting-key → setter-function by introspecting this module.
+
+    Restricted to actual settings-schema keys (the server + user tier
+    pydantic fields).  The module also exposes process-level ``set_*``
+    helpers - ``set_settings_path``, ``set_user_data_dir_override``, the
+    CLI knobs - and an unrestricted scan would let an imported or synced
+    settings dict (file content, not trusted code) invoke them, e.g.
+    repointing the server settings file or every user's data dir for the
+    rest of the process lifetime.
+    """
     global _SETTER_MAP
     if _SETTER_MAP is not None:
         return _SETTER_MAP
     import vtsearch.settings as _self
 
+    schema_keys = set(_all_defaults())
     _SETTER_MAP = {}
     for attr_name in dir(_self):
-        if attr_name.startswith("set_") and callable(getattr(_self, attr_name)):
-            _SETTER_MAP[attr_name[4:]] = getattr(_self, attr_name)
+        key = attr_name[4:]
+        if attr_name.startswith("set_") and key in schema_keys and callable(getattr(_self, attr_name)):
+            _SETTER_MAP[key] = getattr(_self, attr_name)
     return _SETTER_MAP
 
 

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -99,7 +99,11 @@ _path_locks_guard = threading.Lock()
 
 
 def _path_lock_for(path: Path) -> threading.Lock:
-    key = str(path.resolve()) if path.exists() else str(path)
+    # resolve() is non-strict (works for not-yet-created files), so the same
+    # settings path maps to one lock across its whole lifetime.  Keying on
+    # the raw string pre-creation and the resolved string post-creation gave
+    # a relative/symlinked path two different locks.
+    key = str(path.resolve())
     with _path_locks_guard:
         lock = _path_locks.get(key)
         if lock is None:


### PR DESCRIPTION
## Summary

A full-codebase audit focused on interface boundaries — frontend ↔ backend, routes ↔ state system, app tier ↔ `vtscore`, IO, concurrency, and frontend TS logic — followed by a fix pass with regression tests for every confirmed finding. The complete findings list (fixed + deferred) lives in **`docs/plans/comprehensive-audit-2026-07.md`**.

### Highest-severity fixes

- **Detector-state wipe via the request-missing sentinel**: any request carrying `X-Detector-Id` but no dataset id wiped the detector's in-memory session (votes, label history, the whole Find-verification session) because the sentinel's truthy `"__request_missing__"` id defeated the `if not ds_ctx.dataset_id` guard in `ensure_votes_match_active_dataset`.
- **Settings-import setter injection**: `_apply_settings` dispatched to *every* module-level `set_*`, letting an imported/synced settings dict repoint `settings_path`, every user's data dir, and storage directories for the process lifetime. Now restricted to schema keys.
- **JobManager cross-requester coalescing**: the single pending slot coalesced jobs across different users and (dataset, detector) pairs, so a poller could receive another request's training results under its own job id. Coalescing is now keyed to the requester context; cancelled pending jobs are no longer promoted and run.
- **Stuck optimistic votes (frontend)**: a failed vote POST left pending-optimistic entries that re-imposed the phantom vote over every `/api/votes` poll forever — silent label loss with a lying UI. Error paths now roll back and re-read server state.
- **Whole-archive RAM read**: `_validate_archive` read multi-GB demo archives fully into memory to check 4 magic bytes.

### Other backend fixes

- Duplicate-media re-ingest on partial `_ingest_via_source` failure (rollback before fallback)
- HTTP-archive resolve cache keyed on URL basename (cross-host collisions) → full-URL hash
- Demo-download cache poisoning (truncated labels/ground-truth cached forever) → new `download_file_atomic` temp+rename helper
- `find_optimal_threshold`: unreachable "predict nothing" candidate + infeasible tied-score cuts
- Stale `calibration_cache` when labels drop below 6 (inclusion slide re-thresholded against obsolete fold orderings)
- Cross-detector label application in `sync_from_labelset_source` (votes landed on the request's active detector, meta on the named one)
- Detector-JSON read-merge-write lost update (now serialised); NaN-threshold guard; DiversityTree `inertia=None` crash path; zip-slip prefix check; container fsync; converter temp-file leak; settings lock keying; docstring drift

### Other frontend fixes

- Dashboard `onComplete` callbacks dropped when loading-task polling was already active (dataset/detector promotion silently never fired), with per-task failure gating
- Context switches: failed loads no longer promote an unloaded pair to active (H25 409 cascade); superseded switches deny navigation cleanly (`defaultIfEmpty`) instead of raising `EmptyError`; cancel-and-replace no longer cancels unrelated in-flight loads
- New `apiErrorMessage()` util reading both backend error envelopes (`{error}` and flask_smorest `{message}`), applied at ~15 inline handler sites
- `uploadServerMediaFile` no longer drops `media_type` without `cropParams`

### Behaviour changes (backwards compatibility)

- `find_optimal_threshold` can now return `NO_GOOD_THRESHOLD` (2.0) when abstaining is strictly cheaper
- `_apply_settings` ignores non-schema keys
- `http_archive` caches move to hash-keyed dir names (old caches re-download once)
- Superseded pending jobs report `cancelled` to their pollers instead of silently rebinding

## Tests

- `./run-tests.sh` (full suite): **ALL 5425 TESTS PASSED** (baseline before this PR: 5389) — includes ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, frontend `build:prod` + audit + Vitest (993 specs)
- ~36 new regression tests across `tests/detectors`, `tests/io`, `tests/datasets`, `tests_lib/integration`, `tests_lib/downloads`, `tests_lib/sorting`, `tests_lib/detectors`, plus new/extended Vitest specs (`vote-state`, `dashboard-loading-tasks`, `context-switch`, `api-error`)

## Deferred (recorded in the plan doc)

16 verified-but-deferred findings needing design decisions, including: SSE `/api/events` thread-pool starvation under multi-tab use, dataset/detector load double-start + half-loaded context visibility, advisory-only job cancellation, staging-progress singleton clobbering, learned-sort signature/data decorrelation, and audit coverage gaps (browse-canvas math, modal lifecycles, full route-blueprint sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmipNL7SJ96vW5xTV6AFHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmipNL7SJ96vW5xTV6AFHz)_