### PR TITLE
Add book emoji to "Loading ML libraries" startup line

### DIFF
--- a/app.py
+++ b/app.py
@@ -610,7 +610,7 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
                     flush=True,
                 )
 
-    print("  Loading ML libraries...", flush=True)
+    print("  \U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)
     # ``--solo-media-type`` (process-level CLI fallback) tells us which
     # mediaType's default embedder to warm even if no datasets or detectors


### PR DESCRIPTION
The startup output prefixes most status lines with an emoji, but "Loading ML libraries..." was bare, leaving it visually unaligned with the parallel progress updates below it. This adds a 📚 to match the surrounding style.

Before:
```
  Loading ML libraries...
    Importing scikit-learn…          [##############################] 100%
```

After:
```
  📚 Loading ML libraries...
    Importing scikit-learn…          [##############################] 100%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzYqqiZp5cQrVLWNSQh4mt)_