### PR TITLE
docs: fix Batch A correctness bugs from 2026-07-07 docs audit

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,8 @@ unless otherwise noted. File uploads use `multipart/form-data`.
 | [Datasets](api/datasets.md) | Loading, importers, demos, staging, registry, media types, embedders, clippers, converters, file browsing |
 | [Import & Export](api/io.md) | Result exporters, label importers, pregen processors, autorun extractors/localizers |
 | [Settings](api/settings.md) | App settings, autorun processors, settings sources, labelset sources |
-| [Dashboard & Lookup](api/dashboard.md) | Dashboard info (incl. disk/RAM usage), multi-dataset find (incl. cancel/stats/corrections), find progress |
+| [Dashboard](api/dashboard.md) | Dashboard dataset info/rename, disk/RAM usage probes |
+| [Find, Auto-Detect & Scoring](api/find.md) | Multi-dataset find (+ cancel/check-labels), Find Label, Auto-Detect, find stats/corrections, find progress |
 | [File Browser](api/file-browser.md) | Server filesystem browsing |
 
 ### Not yet documented in depth
@@ -27,10 +28,44 @@ in full. Use Swagger (`GET /api/docs`) for these:
 - **Projection / VTSBrowse** — `GET/POST /api/projection/*` (UMAP projection + hex-tile pyramid).
 - **Sessions** — session lifecycle endpoints.
 - **Jobs** — async job listing/status (backed by `vtscore.concurrency.async_jobs`).
-- **Find** — `cancel`, `stats`, and `corrections` companions to multi-dataset find.
-- **Dashboard usage** — disk-usage / RAM-usage probes.
 - **Health probes** — `GET /healthz`, `GET /readyz` (liveness / readiness).
 - **Version** — `GET /api/version` (returns the running build's version string).
+
+## Context headers (`X-Dataset-Id` / `X-Detector-Id`)
+
+VTSearch holds **multiple loaded datasets and detectors at once**, one context
+each. Most endpoints operate on "the active context", and the active context is
+chosen **per request** by two HTTP headers:
+
+| Header | Selects | Sent by |
+|--------|---------|---------|
+| `X-Dataset-Id` | Which loaded `DatasetContext` the request's `medias` / diversity / dataset-scoped votes resolve to | Angular's `HttpClient` interceptor on every API call |
+| `X-Detector-Id` | Which loaded `DetectorContext` the request's `good_votes` / `bad_votes` / MLP / labelset resolve to | Same interceptor |
+
+Key semantics (`app.py` `before_request`, `vtsearch/routes/_shared.py`):
+
+- **Per-request, not global.** The headers stash the chosen context on
+  `flask.g` for the lifetime of the request; they do **not** mutate any global
+  "currently active" state, so concurrent requests for different datasets don't
+  interfere.
+- **Query-param fallback.** Browser-native requests that bypass the Angular
+  interceptor (`<img src>`, `<audio src>`, `<video src>`) may pass
+  `?dataset_id=` / `?detector_id=` instead; the header takes priority when both
+  are present.
+- **Required on context-mutating endpoints.** Endpoints that mutate dataset or
+  detector state (votes, label imports, media insertion, learned sort, …) are
+  guarded by `require_dataset_header` / `require_detector_header` and return
+  **400** with a message like `X-Dataset-Id header (or ?dataset_id= query param)
+  is required for this endpoint` when the id can't be determined. Pure reads,
+  registry listings, auth, and file-browser routes don't require them.
+- **Unloaded id → 409.** If a header names an id that isn't currently loaded,
+  the request proceeds until it touches a context proxy, then fails **409**
+  (`DatasetNotLoadedError` / `DetectorNotLoadedError`) rather than silently
+  falling back to stale data. Routes that never touch the proxies still respond
+  normally.
+
+Per-endpoint pages note where these headers are required; when in doubt, send
+both for any dataset- or detector-scoped call.
 
 ## Conventions
 
@@ -40,6 +75,7 @@ in full. Use Swagger (`GET /api/docs`) for these:
 | **Body** | JSON request body (Content-Type `application/json`) |
 | **Form** | `multipart/form-data` |
 | `→` | Response body |
+| `X-Dataset-Id` / `X-Detector-Id` | [Context headers](#context-headers-x-dataset-id--x-detector-id) selecting the active dataset / detector |
 | Async endpoints | Return immediately; subscribe to the `dataset` channel on `GET /api/events` (SSE) for progress |
 
 **Common error shape:**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,10 +69,11 @@ VTSearch/
 │   │   ├── embedder.py             MediaEmbedder shared helpers (media_from_path, etc.)
 │   │   ├── clipper.py              Shared clipper logic
 │   │   ├── audio/                  Audio media type, embedders (CLAP, CLAP-Music, CLAP-General,
-│   │   │                           AST, Whisper), clippers, SpeechExtractor
+│   │   │                           ParaSpeechCLAP, AST, Whisper), clippers, SpeechExtractor
 │   │   ├── image/                  Image media type, embedders (SigLIP default; SigLIP2, CLIP,
-│   │   │                           DINOv2, DINOv3, EUPE; each with single + patch variants),
-│   │   │                           clippers, ImageClassExtractor, FaceLocalizer, OCRExtractor
+│   │   │                           Face, SIFT-VLAD single-vector; DINOv2, DINOv3, EUPE each with
+│   │   │                           single + patch variants), clippers, ImageClassExtractor,
+│   │   │                           FaceLocalizer, OCRExtractor
 │   │   ├── text/                   Text media type, embedders (E5 default, BGE), clippers
 │   │   ├── video/                  Video media type, embedders (X-CLIP default, LanguageBind,
 │   │   │                           VideoMAE), clippers
@@ -186,8 +187,9 @@ VTSearch/
 │
 ├── vtsearch/                       Flask app tier (imports Flask; not library-safe)
 │   ├── settings.py                 Persistent settings (server tier + per-user tier)
-│   ├── settings_factory.py         Accessor factories for settings.py
+│   ├── settings_store.py           Two-tier persistence engine (file locking, caches) for settings.py
 │   ├── settings_models.py          Marshmallow schema helpers for settings
+│   ├── threading.py                Context-carrying thread helper (user + dataset + detector locals)
 │   ├── achievements.py             Achievement state management
 │   ├── autorun_processors.py       autorun_extractors / autorun_localizers CRUD
 │   ├── logging_config.py           Logging setup
@@ -218,7 +220,8 @@ VTSearch/
 │   │
 │   └── routes/                     Flask blueprints; all HTTP request handling
 │       ├── _shared.py              Shared route helpers (request parsing, JSON safety)
-│       ├── auth.py                 /api/auth/status
+│       ├── auth.py                 /api/auth/status, login, logout
+│       ├── auth_huggingface.py     HuggingFace OAuth (/api/auth/huggingface/*)
 │       ├── main.py                 Root route, favicon, logo
 │       ├── sorting.py              Text/learned/example sort, diversity
 │       ├── eval.py                 Evaluation and labeling progress routes

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,7 +12,7 @@ installation and getting started, see [SETUP.md](SETUP.md).
 4. [Offline deployment](#offline-deployment)
 5. [Data directory layout](#data-directory-layout)
 6. [Docker production notes](#docker-production-notes)
-7. [Requirements file structure](#requirements-file-structure)
+7. [Dependency structure](#dependency-structure)
 8. [Troubleshooting](#troubleshooting)
 
 ---
@@ -328,9 +328,10 @@ It is created automatically on first startup.
 
 ```
 data/
-├── models/                           # HuggingFace model cache (~3.2 GB total)
+├── models/                           # HuggingFace model cache (~3.8 GB total)
 │   ├── models--laion--clap-htsat-unfused/
 │   ├── models--google--siglip-base-patch16-224/
+│   ├── models--openai--clip-vit-base-patch32/
 │   ├── models--microsoft--xclip-base-patch32/
 │   └── models--intfloat--e5-base-v2/
 ├── embeddings/                       # Cached dataset embeddings (.pkl files)
@@ -347,7 +348,7 @@ data/
 
 | Path | Preserve? | Why |
 |------|-----------|-----|
-| `data/models/` | **Yes** | Re-downloading is slow (~3.2 GB) |
+| `data/models/` | **Yes** | Re-downloading is slow (~3.8 GB) |
 | `data/embeddings/` | **Yes** | Contains cached embeddings; losing them means recomputing |
 | `data/settings.json` | **Yes** | User preferences, trained detectors, autorun processors |
 | `data/detectors/` | **Yes** | Persistent detector definitions with labelsets |
@@ -367,7 +368,7 @@ and auto-saved on every change. Schema:
   "theme": "dark",
   "enrich_descriptions": false,
   "safe_thresholds": false,
-  "calibrate_count": 2,
+  "calibrate_count": 1,
   "calibration_fraction": 0.5,
   "audio_playing": true,
   "show_animations": "show",
@@ -494,7 +495,7 @@ docker run -p 5000:5000 -v /path/on/host:/app/data vtsearch
   With all four loaded simultaneously, expect ~4–6 GB total application
   memory. Models are loaded lazily; only the media types actually used are
   loaded.
-- **Disk**: The `data/models/` directory uses ~3.2 GB. Dataset embeddings
+- **Disk**: The `data/models/` directory uses ~3.8 GB. Dataset embeddings
   and media files vary by dataset size.
 - **CPU**: `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` are set to reduce
   per-operation memory. This trades single-operation throughput for lower

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -192,7 +192,7 @@ changes to `vtscore/media/__init__.py` are needed.
 
 | Method                      | Signature                      | Description                              |
 |-----------------------------|--------------------------------|------------------------------------------|
-| `load_media_data(file_path)`| `(Path) -> dict`               | Must include `"duration"` key            |
+| `load_media_data(file_path, media_bytes=None)`| `(Path, bytes \| None) -> dict` | Must include `"duration"` key. The optional `media_bytes` lets callers (e.g. the folder loader) pass already-read bytes to avoid a second disk read. |
 | `media_response(media)`     | `(dict) -> MediaResponse`      | HTTP response for a media item           |
 
 **Optional overridable properties (with defaults):**
@@ -201,7 +201,6 @@ changes to `vtscore/media/__init__.py` are needed.
 |----------------------|-------------|--------------------|-------------------------------------------|
 | `folder_import_name` | `str`       | `type_id`          | Alias for folder imports (matches `type_id`) |
 | `dir_key`            | `str`       | `type_id + "_dir"` | Key in pickle files for external dir       |
-| `legacy_bytes_keys`  | `list[str]` | `[]`               | Legacy keys for inline bytes in old pickles |
 | `pickle_extra_fields`| `list[str]` | `[]`               | Extra fields to preserve in pickle round-trips (e.g. `["width", "height"]`) |
 
 **Optional overridable methods:**
@@ -266,6 +265,9 @@ embedder per media type should override the `is_default` property to return
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image | ✅ |
 | `image/embedder_siglip2.py` | `ImageSiglip2Embedder` | image | |
 | `image/embedder_clip.py` | `ImageClipEmbedder` | image | |
+| `image/embedder_dinov2_single.py` / `_patch.py` | `ImageDinov2SingleEmbedder` / `ImageDinov2PatchEmbedder` | image | |
+| `image/embedder_dinov3_single.py` / `_patch.py` | `ImageDinov3SingleEmbedder` / `ImageDinov3PatchEmbedder` | image | |
+| `image/embedder_eupe_single.py` / `_patch.py` | `ImageEupeSingleEmbedder` / `ImageEupePatchEmbedder` | image | |
 | `image/embedder_sift_vlad.py` | `ImageSiftVladEmbedder` | image | |
 | `image/embedder_face.py` | `ImageFaceEmbedder` | image | |
 | `text/embedder_e5.py` | `TextE5Embedder` | text | ✅ |

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -43,7 +43,7 @@ families share this one field type; each family's base module re-exports
 |---------------|-------------|----------|---------------------------------------------------------|
 | `key`         | `str`       |:        | Field identifier (dict key in `field_values`)           |
 | `label`       | `str`       |:        | Display label in the UI                                 |
-| `field_type`  | `FieldType` |:        | `"text"`, `"url"`, `"folder"`, `"file"`, `"password"`, `"email"`, `"select"`, or `"server_path"` |
+| `field_type`  | `FieldType` |:        | `"text"`, `"url"`, `"folder"`, `"file"`, `"password"`, `"email"`, `"number"`, `"select"`, `"server_path"`, or `"checkbox"` |
 | `description` | `str`       | `""`     | Helper text shown below the field                       |
 | `accept`      | `str`       | `""`     | For `"file"` fields: comma-separated extensions (e.g. `".pkl"`) |
 | `options`     | `list[str]` | `[]`     | For `"select"` fields: allowed dropdown values          |
@@ -1276,14 +1276,18 @@ class S3SettingsSource(SettingsSource):
         PluginField("key", "Object Key", "text"),
     ]
 
-    def load(self, field_values: dict) -> dict:
+    # Override the underscored template methods, NOT load() / save().
+    # The public load() / save() are framework wrappers that normalize
+    # field_values before dispatching here (see vtscore/sync/__init__.py).
+
+    def _do_load(self, field_values: dict) -> dict:
         """Read settings from S3. Return a settings dict."""
         import boto3, json
         s3 = boto3.client("s3")
         obj = s3.get_object(Bucket=field_values["bucket"], Key=field_values["key"])
         return json.loads(obj["Body"].read())
 
-    def save(self, settings_data: dict, field_values: dict) -> None:
+    def _do_save(self, settings_data: dict, field_values: dict) -> None:
         """Write settings to S3."""
         import boto3, json
         s3 = boto3.client("s3")
@@ -1298,6 +1302,9 @@ SETTINGS_SOURCE = S3SettingsSource()
 ```
 
 The sentinel `SETTINGS_SOURCE` at module level is required for auto-discovery.
+Override `_do_load` / `_do_save` (not `load` / `save`): `SyncSource`'s public
+`load` / `save` normalize `field_values` and then dispatch to the underscored
+hooks, so a subclass that overrides `load` / `save` directly is never called.
 
 ### Template variables
 
@@ -1389,12 +1396,14 @@ class DatabaseLabelsetSource(LabelsetSource):
         PluginField("table", "Table Name", "text", default="labels"),
     ]
 
-    def load(self, field_values: dict) -> list[dict]:
+    # Override the underscored template methods, NOT load() / save().
+
+    def _do_load(self, field_values: dict) -> list[dict]:
         """Read labels from database. Return list of label dicts."""
         # Each dict should have: "name" (media name/hash), "label" ("Good"/"Bad")
         ...
 
-    def save(self, labelset: LabelSet, field_values: dict) -> None:
+    def _do_save(self, labelset: LabelSet, field_values: dict) -> None:
         """Write labelset to database."""
         for elem in labelset.elements:
             # Upsert each element...
@@ -1405,6 +1414,9 @@ LABELSET_SOURCE = DatabaseLabelsetSource()
 ```
 
 The sentinel `LABELSET_SOURCE` at module level is required for auto-discovery.
+As with settings sources, override `_do_load` / `_do_save` (not `load` /
+`save`): the public methods normalize `field_values` before dispatching to
+these hooks, so a direct `load` / `save` override never runs.
 
 ### Template variables
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -162,8 +162,8 @@ See [EXTENDING-plugins.md § Adding a Settings Source](EXTENDING-plugins.md#addi
 
 - [ ] Create `vtsearch/settings_io/sources/<name>/__init__.py`
 - [ ] Subclass `SettingsSource`, set `name`, `display_name`, `description`, `fields`
-- [ ] Implement `load(self, field_values)`: return a settings dict
-- [ ] Implement `save(self, settings_data, field_values)`: persist settings
+- [ ] Implement `_do_load(self, field_values)`: return a settings dict (override the underscored hook, not `load`)
+- [ ] Implement `_do_save(self, settings_data, field_values)`: persist settings (override the underscored hook, not `save`)
 - [ ] Expose `SETTINGS_SOURCE = YourSource()` at module level
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install
 - [ ] Test: start the app and check `GET /api/settings-sources` includes your source
@@ -174,8 +174,8 @@ See [EXTENDING-plugins.md § Adding a Labelset Source](EXTENDING-plugins.md#addi
 
 - [ ] Create `vtscore/labels/sources/<name>/__init__.py`
 - [ ] Subclass `LabelsetSource`, set `name`, `display_name`, `description`, `fields`
-- [ ] Implement `load(self, field_values)`: return a list of label dicts
-- [ ] Implement `save(self, labelset, field_values)`: persist a `LabelSet`
+- [ ] Implement `_do_load(self, field_values)`: return a list of label dicts (override the underscored hook, not `load`)
+- [ ] Implement `_do_save(self, labelset, field_values)`: persist a `LabelSet` (override the underscored hook, not `save`)
 - [ ] Expose `LABELSET_SOURCE = YourSource()` at module level
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install
 - [ ] Test: start the app and check `GET /api/labelset-sources` includes your source

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -64,7 +64,7 @@ deployments. Runs locally or in Docker.
 | [demos.md](demos.md) | Available demo datasets |
 | [plans/README.md](plans/README.md) | Filename index of open design plans (multi-media import, patch embedders, clipper chain, etc.) |
 | [../vtscore/docs/README.md](../vtscore/docs/README.md) | Developer documentation for the `vtscore` library (the Flask-free reusable core extracted from VTSearch) |
-| [design/cli-detector-converter.md](design/cli-detector-converter.md) | CLI autodetect with converters/clippers (**Design proposal**, not yet implemented) |
+| [plans/cli-detector-converter.md](plans/cli-detector-converter.md) | CLI autodetect with converters/clippers (**Design proposal**, not yet implemented) |
 
 ---
 

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -24,7 +24,7 @@ The model outputs raw logits (not probabilities) during training. This allows th
 | **Optimizer** | Adam | `lr=0.001`, `weight_decay=1e-4` |
 | **Epochs (cap)** | 200 | Configurable via `TRAIN_EPOCHS` in `config.py` or the `VTSEARCH_TRAIN_EPOCHS` env var |
 | **Early-stop patience** | 10 | Training halts when the loss fails to improve for this many consecutive epochs (configurable via `TRAIN_PATIENCE` / `VTSEARCH_TRAIN_PATIENCE`; set 0 to disable) |
-| **Hidden layer** | 4–32 neurons | `max(4, min(32, n_train // 3))` via `_auto_hidden_dim()` |
+| **Hidden layer** | 8–32 neurons | `max(MLP_HIDDEN_MIN, min(MLP_HIDDEN_MAX, n_train // 3))` (i.e. `max(8, min(32, n_train // 3))`) via `_auto_hidden_dim()` |
 | **Dropout** | 0.5 | Applied after ReLU, active only during training |
 | **Batching** | Full-batch | All labeled data in every forward pass |
 | **Reproducibility** | Local `torch.Generator` | Per-model seed (default 42) for thread-safe deterministic init |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -610,8 +610,9 @@ dependencies automatically and supports grouped test subsets:
 ```
 
 Available groups: `core`, `api`, `sorting`, `datasets`, `io`, `detectors`,
-`downloads`, `integration`, `cli`, `converters`. See [`CLAUDE.md`](../CLAUDE.md) for the
-full group-to-file mapping.
+`downloads`, `integration`, `cli`, `converters`, `projection`, `frontend`
+(plus `gpu` and `vtscore-clean`, which run separately). See
+[`CLAUDE.md`](../CLAUDE.md) for the full group-to-file mapping.
 
 You can also run pytest directly:
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -2,9 +2,33 @@
 
 [← Back to API index](../API.md)
 
+VTSearch has **two independent auth systems**, easy to confuse:
+
+1. **VTSearch user auth** (`/api/auth/*`) — who the *VTSearch user* is. Governs
+   per-user data directories and the login gate. Configured by the server's
+   **login provider**.
+2. **HuggingFace OAuth** (`/api/auth/huggingface/*`) — hands the *server* a
+   HuggingFace Hub token so it can download gated demo datasets and gated model
+   weights. It does **not** change who the VTSearch user is.
+
 ---
 
-## Authentication
+## VTSearch user auth
+
+### Login providers
+
+The active provider is chosen once at server start via the `--login` CLI flag
+(see [CLI.md](../CLI.md)); with no flag the app runs single-user. The provider
+determines what `/api/auth/*` does and whether the SPA shows a login screen.
+
+| Provider | `--login` | `provider` name | `login_required` | Behaviour |
+|----------|-----------|-----------------|------------------|-----------|
+| `DefaultLoginProvider` | *(none, default)* | `"default"` | `false` | Single-user. Every request is authenticated as `"default"`; `data/` used directly (no per-user subdir). Login/logout return 400. |
+| `TrivialLoginProvider` | `--login trivial` | `"trivial"` | `true` | Cookie-based, **no password** (dev/testing multi-user). Username sent to `POST /api/auth/login`, stored in a signed session cookie; per-user data dir `data/<username>/`. |
+| `ApiKeyLoginProvider` | `--login api_key` | `"api_key"` | `false` | Bearer-token for headless clients. Reads `Authorization: Bearer <key>`, hashes it (SHA-256), looks it up in `data/api_keys.json`. No login UI; no `/api/auth/login` support (send the header directly). |
+
+The SPA switches on `login_required` from `GET /api/auth/status`: when `true`
+it shows a login screen at startup, otherwise it goes straight to the app.
 
 ### Auth status
 
@@ -21,9 +45,9 @@ GET /api/auth/status
 }
 ```
 
-Returns the active login provider name, current user, whether the request
-is authenticated, and whether the frontend should show a login screen.
-With `DefaultLoginProvider`, every request is authenticated as `"default"`.
+Returns the active login provider name, current user, whether the request is
+authenticated, and whether the frontend should show a login screen. With
+`DefaultLoginProvider`, every request is authenticated as `"default"`.
 
 ### Login
 
@@ -33,10 +57,12 @@ POST /api/auth/login
 
 **Body:** `{"username": "..."}`
 
-→ Provider-specific response. With `DefaultLoginProvider`, returns 400
-(`{"error": "Login/logout not supported by the active provider"}`).
-With `TrivialLoginProvider`, authenticates and returns the auth status dict
-(same shape as `GET /api/auth/status`).
+Only the `trivial` provider supports login.
+
+→ **`trivial`**: sets the session username and returns the auth status dict
+(same shape as `GET /api/auth/status`, now `authenticated: true`).
+→ **`default` / `api_key`**: **400** `{"error": "Login/logout not supported by
+the active provider"}`.
 
 ### Logout
 
@@ -44,9 +70,75 @@ With `TrivialLoginProvider`, authenticates and returns the auth status dict
 POST /api/auth/logout
 ```
 
-→ Provider-specific response. With `DefaultLoginProvider`, returns 400
-(`{"error": "Login/logout not supported by the active provider"}`).
-With `TrivialLoginProvider`, clears the session and returns the auth status dict.
+Only the `trivial` provider supports logout.
+
+→ **`trivial`**: clears the session username and returns the auth status dict.
+→ **`default` / `api_key`**: **400** `{"error": "Login/logout not supported by
+the active provider"}`.
+
+---
+
+## HuggingFace OAuth ("Sign in with HuggingFace")
+
+Authenticates VTSearch's **outbound** requests to the HuggingFace Hub so gated
+demo datasets and gated model weights download successfully. The obtained token
+lives only in a process-scoped in-memory store (`vtscore.security.hf_auth`);
+nothing is written to disk. This is **server-side auth, not VTSearch user
+auth** — signing in here gives the server a Hub token, it doesn't log a user in.
+
+The flow is **available only when configured** — the server operator registers
+a HuggingFace OAuth app and sets `HF_OAUTH_CLIENT_ID` (plus optional
+`HF_OAUTH_CLIENT_SECRET`, `HF_OAUTH_REDIRECT_URI`, `HF_OAUTH_SCOPES`). When
+unconfigured, the endpoints return `configured: false` so the UI can show setup
+guidance instead of a dead button.
+
+These are plain Flask routes (browser redirects), so they are **not** on the
+OpenAPI surface.
+
+### HuggingFace status
+
+```
+GET /api/auth/huggingface/status
+```
+
+→ ```json
+{"configured": true, "authenticated": false, "username": "", "scopes": ""}
+```
+
+`configured` reflects whether an OAuth client id is set; the rest reflect the
+current sign-in state (`authenticated`, `username`, `scopes`).
+
+### HuggingFace login
+
+```
+GET /api/auth/huggingface/login
+```
+
+Begins the PKCE OAuth handshake.
+
+→ Configured: `{"configured": true, "authorize_url": "https://huggingface.co/oauth/authorize?..."}`
+— the frontend navigates the browser to `authorize_url`.
+→ Unconfigured: `{"configured": false}`.
+
+### HuggingFace callback
+
+```
+GET /api/auth/huggingface/callback
+```
+
+OAuth redirect target (not called directly). Exchanges the authorization code
+for a token, stores it in memory, then **302-redirects** back to `/?hf_auth=success`
+(or `/?hf_auth=error&hf_auth_reason=...` on failure). Not a JSON endpoint.
+
+### HuggingFace logout
+
+```
+POST /api/auth/huggingface/logout
+```
+
+Forgets the stored Hub credential (sign out).
+
+→ `{"ok": true}`
 
 ---
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -34,7 +34,7 @@ POST /api/auth/login
 **Body:** `{"username": "..."}`
 
 → Provider-specific response. With `DefaultLoginProvider`, returns 400
-(`{"error": "Login not supported by the active provider"}`).
+(`{"error": "Login/logout not supported by the active provider"}`).
 With `TrivialLoginProvider`, authenticates and returns the auth status dict
 (same shape as `GET /api/auth/status`).
 
@@ -45,7 +45,7 @@ POST /api/auth/logout
 ```
 
 → Provider-specific response. With `DefaultLoginProvider`, returns 400
-(`{"error": "Logout not supported by the active provider"}`).
+(`{"error": "Login/logout not supported by the active provider"}`).
 With `TrivialLoginProvider`, clears the session and returns the auth status dict.
 
 ---

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -1,16 +1,20 @@
-# Dashboard & Lookup
+# Dashboard
 
 [← Back to API index](../API.md)
 
----
+Metadata and resource-usage probes for the Dashboard view. For running
+detectors against data (multi-dataset Find, Find Label, Auto-Detect), see
+[Find, Auto-Detect & Scoring](find.md).
 
-## Dashboard
+---
 
 ### Dataset info
 
 ```
 GET /api/dashboard/dataset-info
 ```
+
+Metadata about the currently loaded dataset.
 
 → ```json
 {
@@ -23,6 +27,8 @@ GET /api/dashboard/dataset-info
 }
 ```
 
+**404** if no dataset is loaded.
+
 ### Rename dataset
 
 ```
@@ -31,105 +37,29 @@ PUT /api/dashboard/dataset-rename
 
 **Body:** `{"name": "My Custom Name"}`
 
+Sets a custom display name for the currently loaded dataset.
+
 → `{"success": true, "name": "My Custom Name"}`
 
----
+**400** if the name is empty after trimming.
 
-## Multi-dataset Find
-
-### Check label resolution (pre-flight)
+### Disk usage
 
 ```
-POST /api/find/check-labels
+GET /api/dashboard/disk-usage
 ```
 
-**Body:** `{"dataset_ids": ["id1", "id2"], "detector_ids": ["m1"]}`
+Free/used/total bytes for the partition holding `DATA_DIR`.
 
-Pre-flight check that reports how many detector labels can be resolved
-for the given detectors and datasets. Call this before starting a Find to
-warn the user about unresolved labels.
+→ `{"total": 500107862016, "used": 210000000000, "free": 290107862016, "path": "/app/data"}`
 
-→ ```json
-{
-  "warnings": [
-    {
-      "detector_name": "Mammals",
-      "total_labels": 82,
-      "resolved_labels": 60,
-      "failed_labels": 22
-    }
-  ]
-}
-```
-
-`warnings` only contains entries for detectors with at least one unresolved
-label. An empty `warnings` list means everything is fine.
-
-### Run find
+### RAM usage
 
 ```
-POST /api/find
+GET /api/dashboard/ram-usage
 ```
 
-**Body:** `{"dataset_ids": ["id1", "id2"], "detector_ids": ["m1"]}`
+System RAM total/used/free in bytes, read from `/proc/meminfo` (Linux). `free`
+is `MemAvailable`; `used` is `total − free`. (No `path` key, unlike disk usage.)
 
-→ ```json
-{
-  "results": [...],
-  "negative_results": [...],
-  "datasets": ["ESC-50", "Speech Commands"],
-  "detectors": ["Dog Barks"],
-  "media_type": "audio",
-  "multiple_datasets": true,
-  "multiple_detectors": false,
-  "total_hits": 42
-}
-```
-
-### Find progress (SSE)
-
-Find progress streams on the `find` channel of
-[`/api/events`](events.md):
-
-```json
-{
-  "status": "running",
-  "message": "Scoring with \"ModelName\" on \"DatasetName\"...",
-  "current": 150,
-  "total": 300,
-  "step": 2,
-  "total_steps": 3,
-  "error": null
-}
-```
-
-`status` is `"idle"` or `"running"`. `step` / `total_steps` track the
-high-level Find phases (prepare detectors, load data, score), and `overall`
-(0..1) plus `eta_seconds` give a single whole-job progress fraction and ETA
-across all phases (see [Events](events.md#progress-object-shape)).
-
-### Apply labels from detector (Find Label)
-
-```
-POST /api/find-label
-```
-
-**Body:** `{"detector_id": "abc123"}` (optionally include `"dataset_id"`
-to override the request-scoped dataset context).
-
-Resolves the detector from the registry, scores every loaded media using
-the detector's MLP, and applies Good/Bad labels for **all** elements
-based on the threshold. If no trained MLP is cached in the detector's
-context, trains on-the-fly from the detector's labelset (resolving label
-origins as needed).
-
-→ ```json
-{
-  "results": [{"id": 0, "score": 0.9812}, ...],
-  "threshold": 0.5,
-  "applied": 42,
-  "total_scored": 500
-}
-```
-
-404 if detector not found. 400 if `detector_id` is missing.
+→ `{"total": 16777216000, "used": 8388608000, "free": 8388608000}`

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -2,6 +2,10 @@
 
 [← Back to API index](../API.md)
 
+> Endpoints that act on "the loaded dataset" resolve it via the
+> [`X-Dataset-Id` context header](../API.md#context-headers-x-dataset-id--x-detector-id)
+> (registry routes take the id in the path instead).
+
 ---
 
 ## Media Types, Embedders, Clippers & Converters
@@ -198,6 +202,47 @@ Lists `.pkl` files in the embeddings directory.
 
 → `{"files": [{"name": "esc50", "path": "/abs/path/esc50.pkl", "size_mb": 12.3}]}`
 
+### Importer field options (dynamic dropdowns)
+
+```
+POST /api/dataset/import/{importer_name}/options
+```
+
+**Body:** `{"field_key": "collection", "values": {...}}` (`values` is the
+current form snapshot, optional).
+
+Calls the importer's `get_field_options(field_key, values)` and returns
+dropdown options for a [dynamic-options field](../EXTENDING-plugins.md#dynamic-field-options).
+
+→ `{"options": ["a", "b", "c"]}`
+
+400 (unknown / non-dynamic field), 404 (unknown importer), 501 (not
+implemented), 502 (remote error).
+
+### Detect media type
+
+```
+GET /api/dataset/detect-media-type
+```
+
+**Query:** `source` (default `"folder"`), `path` (default `""`), `recursive`
+(default `true`), `limit` (default 50, clamped to 1–500).
+
+Samples a folder's files by extension to pre-fill the import modal's
+media-type dropdown.
+
+→ ```json
+{
+  "sample_size": 50,
+  "counts_by_type": {"audio": 48, "image": 2},
+  "extensions": {".wav": 48, ".png": 2},
+  "dominant": "audio",
+  "truncated": false
+}
+```
+
+400 (path escapes root), 404 (source/dir not found).
+
 ---
 
 ## Loading Datasets
@@ -259,6 +304,35 @@ POST /api/dataset/load-source
 **Body:** `{"source": {"importer": "demo", "params": {"name": "esc50"}}}`
 
 → `{"ok": true, "message": "Loading started"}`
+
+**From a browser folder upload:**
+
+```
+POST /api/dataset/import-local-folder
+```
+
+**Form (`multipart/form-data`):** `files` (repeated — one file field per file,
+each multipart filename set to its `webkitRelativePath`), `media_type`
+(required); optional `dataset_name` (default `"Local folder upload"`),
+`embedder`, `clipper_params` (JSON string), `build_projection`,
+`merge_near_duplicates`, and clipper-chain fields. Streams the uploaded folder
+to a server temp dir and runs the `server_folder` importer in the background.
+
+→ `{"ok": true, "message": "...", "task_id": "..."}`
+
+**From a browser paths-file upload:**
+
+```
+POST /api/dataset/import-local-files
+```
+
+**Form (`multipart/form-data`):** `paths_file` (a single `.txt` / `.list` /
+`.npz` of media paths, required), `media_type` (required); optional
+`dataset_name` (default `"Local files upload"`), `embedder`, `clipper`,
+`clipper_params` (JSON string), `source_specs`. Runs the `server_files`
+importer in the background. Same response shape as `import-local-folder`.
+
+→ `{"ok": true, "message": "...", "task_id": "..."}`
 
 All load endpoints are async; subscribe to the `dataset` and
 `loading-tasks` channels on [`/api/events`](events.md) (SSE) for progress.
@@ -381,6 +455,20 @@ Requires at least two paths.
 
 → `{"ok": true, "message": "Combining datasets..."}`
 
+### Promote a selection to a new dataset
+
+```
+POST /api/dataset/promote
+```
+
+**Body:** `{"name": "My subset", "media_ids": [0, 3, 7]}` — ids from the active
+dataset (both fields required, non-empty).
+
+Snapshots the selected media (preserving origins and embeddings) into a brand-
+new saved, registered dataset.
+
+→ `{"ok": true, "dataset_id": "abc123", "name": "My subset", "num_items": 3}`
+
 ---
 
 ## Export & Clear
@@ -494,3 +582,29 @@ Sets which users can access a dataset (multi-user deployments). Only the
 dataset owner or an admin can modify readers.
 
 → `{"ok": true, "readers": ["user1", "user2"]}`
+
+### Preload dataset embedder
+
+```
+POST /api/datasets/registry/{dataset_id}/preload-embedder
+```
+
+Warms the dataset's embedder in a background daemon thread (idempotent) so it's
+ready before training. No body.
+
+→ `{"ok": true, "embedder": "clap"}` (`embedder` is `""` if the dataset has none)
+
+403 if access is denied; 404 if the dataset does not exist.
+
+### Build diversity tree
+
+```
+POST /api/datasets/registry/{dataset_id}/diversity-tree
+```
+
+Kicks off a cancellable background build of the diversity index for an
+already-loaded dataset. Progress streams on `/api/progress`. No body.
+
+→ `{"ok": true, "message": "...", "task_id": "_divtree_abc12345"}`
+
+400 if the dataset isn't loaded; 403 if access is denied; 404 if it doesn't exist.

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -96,7 +96,10 @@ When the detector context **is** loaded, the new labels are also resolved
 against the loaded dataset's medias, applied to the detector's votes, and
 a fresh MLP is trained with a cross-validated threshold.
 
-→ `{"success": true, "applied": 12, "skipped": 3, "num_labels": 62, "message": "..."}`
+→ `{"applied": 12, "skipped": 3, "resolved": 12, "trained": true, "num_labels": 62, "message": "..."}`
+
+`resolved` counts labels resolved into the loaded detector context (0 when no
+context is loaded); `trained` is `true` when a fresh MLP was retrained.
 
 404 if detector or importer not found. 400 on validation errors.
 

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -2,6 +2,11 @@
 
 [← Back to API index](../API.md)
 
+> Detector-scoped endpoints resolve the active detector (and, where scoring is
+> involved, the active dataset) via the
+> [`X-Dataset-Id` / `X-Detector-Id` context headers](../API.md#context-headers-x-dataset-id--x-detector-id).
+> Requirements are noted per endpoint.
+
 ---
 
 ## Detectors
@@ -117,6 +122,66 @@ supported policy) removes any element that appears with disagreeing
 labels across sources.
 
 → `{"success": true, "name": "A+B", "media_type": "audio", "num_labels": 73, "combined_from": ["A", "B"], "source_label_counts": [50, 30], "examples": [...]}` (201)
+
+### Labels detail
+
+```
+GET /api/detectors/{name}/labels-detail
+```
+
+Returns the detector's saved labelset split into good/bad lists with right-pane
+render data. Not gated on a loaded dataset (but when one is loaded, each item's
+`cid` / `time` / `score` resolve against it).
+
+→ ```json
+{
+  "media_type": "audio",
+  "good": [
+    {"id": "...", "label": "good", "media_type": "audio", "name": "...",
+     "filename": "dog.wav", "origin_name": "...", "md5": "...", "cid": 12,
+     "time": 1234567890.0, "score": 0.97, "region_box": null}
+  ],
+  "bad": [...]
+}
+```
+
+404 if the detector is not found.
+
+### Label preview / thumbnail
+
+```
+GET /api/detectors/{name}/labels/{element_id}/preview
+GET /api/detectors/{name}/labels/{element_id}/thumbnail
+```
+
+Serve one saved labelset element, resolved via its origin:
+
+- **`/preview`** — the full underlying media file bytes (mimetype by type), or,
+  for text, JSON `{"content", "word_count", "character_count"}`.
+- **`/thumbnail`** — a small image: resized image (cropped to `region_box` for
+  region votes), audio waveform PNG, or video mid-frame PNG. Much smaller than
+  `/preview`.
+
+404 if the detector, element, or file is missing; 500 if a thumbnail can't be
+generated.
+
+### Export portable bundle
+
+```
+POST /api/detectors/{detector_id}/portable-bundle
+```
+
+**Requires** [`X-Dataset-Id`](../API.md#context-headers-x-dataset-id--x-detector-id).
+No body.
+
+Retrains the detector from its on-disk labelset in the **active dataset's**
+embedder space and streams a zipped, standalone scoring bundle (ONNX model +
+manifest + README).
+
+→ Binary `.zip` download (`<detector>-detector.zip`).
+
+400 (no medias loaded, or no labels to score), 404 (detector not found), 409
+(active dataset can't supply the detector's embedder type).
 
 ---
 
@@ -243,6 +308,21 @@ PUT /api/detectors/registry/{detector_id}/rename
 **Body:** `{"name": "New Name"}`
 
 → `{"ok": true, "name": "New Name"}`
+
+### Set detector readers
+
+```
+PUT /api/detectors/registry/{detector_id}/readers
+```
+
+**Body:** `{"readers": ["user1", "user2"]}` (`["*"]` makes it public).
+
+Replaces the detector's reader access list (multi-user deployments). Only the
+detector's creator may call it.
+
+→ `{"ok": true, "readers": ["user1", "user2"]}`
+
+403 if the caller is not the creator; 404 if the detector does not exist.
 
 ### Detector statistics
 

--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -1,0 +1,228 @@
+# Find, Auto-Detect & Scoring
+
+[← Back to API index](../API.md)
+
+Endpoints for running detectors against data: multi-dataset **Find**, the
+active-dataset **Find Label** / **Auto-Detect** flows, and their evaluation
+stats and cancel companions.
+
+Several endpoints here read or mutate the active dataset / detector context via
+the [`X-Dataset-Id` / `X-Detector-Id` headers](../API.md#context-headers-x-dataset-id--x-detector-id);
+the required ones are marked below.
+
+---
+
+## Multi-dataset Find
+
+Runs each selected detector against each selected dataset (loaded from its
+pickle) and returns a merged table. Detector and dataset ids come from the
+request **body**, so these routes do not require context headers.
+
+### Check label resolution (pre-flight)
+
+```
+POST /api/find/check-labels
+```
+
+**Body:** `{"dataset_ids": ["id1", "id2"], "detector_ids": ["m1"]}`
+
+Reports, per detector, how many labels can be resolved against the chosen
+datasets so the UI can warn before an expensive Find. Call before `POST
+/api/find`.
+
+→ ```json
+{
+  "warnings": [
+    {
+      "detector_name": "Mammals",
+      "total_labels": 82,
+      "resolved_labels": 60,
+      "failed_labels": 22
+    }
+  ]
+}
+```
+
+`warnings` only contains entries for detectors with at least one unresolved
+label; an empty list means everything resolves.
+
+### Run find
+
+```
+POST /api/find
+```
+
+**Body:** `{"dataset_ids": ["id1", "id2"], "detector_ids": ["m1"]}`
+
+→ ```json
+{
+  "results": [
+    {
+      "id": 0,
+      "filename": "dog.wav",
+      "md5": "...",
+      "origin_name": "...",
+      "origin": {"...": "..."},
+      "dataset_name": "ESC-50",
+      "detector_verdicts": {"Dog Barks": {"verdict": "Good"}}
+    }
+  ],
+  "negative_results": [...],
+  "datasets": ["ESC-50", "Speech Commands"],
+  "detectors": ["Dog Barks"],
+  "media_type": "audio",
+  "multiple_datasets": true,
+  "multiple_detectors": false,
+  "total_hits": 42
+}
+```
+
+Each verdict is one of `Good`, `Bad`, `Error`, `N/A`. Errors: **400** (empty
+id lists, or a detector has no labels), **404** (unknown dataset/detector id),
+**500** (pickle load failed).
+
+### Cancel find
+
+```
+POST /api/find/cancel
+```
+
+Sets the shared `find_progress` cancel flag so any in-flight scoring path
+(find / find-label / auto-detect) stops cooperatively. Always **200**, no-op
+when idle.
+
+→ `{"ok": true}`
+
+### Find progress (SSE)
+
+Find progress streams on the `find` channel of [`/api/events`](events.md):
+
+```json
+{
+  "status": "running",
+  "message": "Scoring with \"ModelName\" on \"DatasetName\"...",
+  "current": 150,
+  "total": 300,
+  "step": 2,
+  "total_steps": 3,
+  "error": null
+}
+```
+
+`status` is `"idle"` or `"running"`. `step` / `total_steps` track the high-level
+Find phases (prepare detectors, load data, score); `overall` (0..1) and
+`eta_seconds` give a single whole-job progress fraction and ETA (see
+[Events](events.md#progress-object-shape)).
+
+---
+
+## Active-dataset scoring
+
+These operate on the **loaded** dataset (the in-memory snapshot), not pickles.
+
+### Find Label (score + label the active dataset)
+
+```
+POST /api/find-label
+```
+
+**Requires** `X-Dataset-Id` **and** `X-Detector-Id`.
+**Body:** `{"detector_id": "abc123"}`
+
+Scores every loaded media with the given detector and applies Good/Bad labels
+to **all** elements by threshold, freezing scores and initial labels for the
+Find verification workflow. If no trained MLP is cached in the detector
+context, it trains on the fly from the detector's labelset (resolving label
+origins as needed).
+
+→ ```json
+{
+  "ok": true,
+  "results": [{"id": 0, "score": 0.9812}, ...],
+  "threshold": 0.5,
+  "good_count": 42,
+  "bad_count": 458,
+  "detector_name": "Dog Barks"
+}
+```
+
+On patch-region-aware datasets each result additionally carries `best_region`.
+Errors: **400** (no medias loaded, or detector has no labels), **404**
+(detector not found), **409** (active dataset can't supply the detector's
+embedder type).
+
+### Auto-Detect
+
+```
+POST /api/auto-detect
+```
+
+**Body:** `{"detector_name": ""}` — omit / empty to run **every** detector
+flagged for Auto-Find on the active dataset's media type, or name a single one.
+
+Scores the active dataset with each Auto-Find detector, training each MLP on
+demand, and returns one result column per detector.
+
+→ ```json
+{
+  "media_type": "audio",
+  "detectors_run": 2,
+  "results": {
+    "Dog Barks": {
+      "detector_name": "Dog Barks",
+      "threshold": 0.5,
+      "total_hits": 42,
+      "hits": [{"id": 0, "score": 0.98}, ...],
+      "negative_hits": [{"id": 7, "score": 0.02}, ...]
+    }
+  },
+  "missing_detectors": []
+}
+```
+
+When an exporter is configured for Auto-Find, an `auto_export` object
+(`{exporter, success, message?/error?}`) is added. Errors: **400** (no medias
+loaded, or no Auto-Find detectors for the media type), **404** (named detector
+not flagged for Auto-Find).
+
+### Find stats (detector evaluation)
+
+```
+GET /api/find/stats
+```
+
+Pure-read detector-evaluation stats over the adopted Find label set: a 2×2
+confusion of the adopted label vs. the detector's original call, plus an FP/FN
+threshold sweep.
+
+→ ```json
+{
+  "total_good": 42, "total_bad": 458,
+  "verified_count": 30,
+  "confirmed_good": 25, "confirmed_bad": 3,
+  "culled_false_pos": 3, "rescued_false_neg": 2,
+  "agreements": 28, "corrections": 2,
+  "agreement_rate": 0.93, "precision": 0.89,
+  "inclusion": 0, "threshold": 0.5, "stale": false,
+  "sweep": [{"inclusion": -10, "threshold": 0.7, "false_pos": 1, "false_neg": 9}, ...]
+}
+```
+
+`sweep` covers inclusion −10..10.
+
+### Fold corrections into the detector
+
+```
+POST /api/find/corrections-to-detector
+```
+
+**Requires** `X-Dataset-Id` **and** `X-Detector-Id`.
+
+Writes the Find corrections (adopted labels that differ from the detector's
+original call) into the active detector's on-disk labelset for future scoring,
+leaving the current Find session frozen and marking it stale.
+
+→ `{"ok": true, "name": "Dog Barks", "corrections_added": 2, "num_labels": 84}`
+
+Errors: **400** (no Find run yet), **404** (no active detector), **409**
+(detector vote state not aligned with the active dataset).

--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -2,6 +2,9 @@
 
 [← Back to API index](../API.md)
 
+> These endpoints read/mutate the active dataset and detector via the
+> [`X-Dataset-Id` / `X-Detector-Id` context headers](../API.md#context-headers-x-dataset-id--x-detector-id).
+
 ---
 
 ## Inclusion & Thresholds

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -233,7 +233,47 @@ POST /api/learned-sort
 Trains an MLP on the current good/bad votes and scores all medias. Requires at
 least one good and one bad vote.
 
+**Asynchronous by default.** Training is GIL-bound, so the endpoint hands the
+work to a background thread and returns immediately:
+
+→ `{"job_id": "…", "status": "running", "current": 0, "total": 1}`
+
+Poll [`GET /api/learned-sort/result`](#learned-sort-result-poll) with that
+`job_id` until `status == "done"` to receive the results. A no-op call (votes,
+detector, inclusion, and threshold settings unchanged from the most recent
+successful run) short-circuits and returns the cached `done` payload directly.
+
+Pass `{"wait": true}` in the body to block until the job finishes and receive
+the result inline (used by tests; the frontend leaves it `false`):
+
 → `{"results": [{"id": 0, "score": 0.9234}], "threshold": 0.5123}`
+
+The `done` payload — whether returned inline (`wait=true`) or via the result
+poll — carries `results` and `threshold`.
+
+#### Learned sort result (poll)
+
+```
+GET /api/learned-sort/result?job_id=<id>
+```
+
+Polls a background learned-sort job.
+
+- Running: `{"job_id": "…", "status": "running", "current": N, "total": M}`
+- Done: `{"results": [{"id": 0, "score": 0.9234}], "threshold": 0.5123}`
+- Cancelled: `{"job_id": "…", "status": "cancelled"}`
+- Job failed: HTTP 500.
+- Unknown `job_id`: HTTP 404.
+
+#### Cancel learned sort
+
+```
+POST /api/learned-sort/cancel/<job_id>
+```
+
+Sets the cancel flag on the job; the training loop polls it cooperatively.
+Returns `{"ok": true}` (HTTP 200) even when the job has already finished — the
+contract is "make sure it's no longer running". Unknown `job_id`: HTTP 404.
 
 On patch-region-aware datasets the MLP is max-pooled over each
 image's region tree, and each result carries `"best_region": [x0,

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -2,6 +2,10 @@
 
 [← Back to API index](../API.md)
 
+> Media, vote, and sort endpoints are scoped to the active dataset/detector via
+> the [`X-Dataset-Id` / `X-Detector-Id` context headers](../API.md#context-headers-x-dataset-id--x-detector-id).
+> Vote- and label-mutating routes **require** them (400 otherwise).
+
 ---
 
 ## Medias
@@ -359,6 +363,34 @@ POST /api/server-media-files/upload
 **Form:** `file`: media file to upload.
 
 → `{"filename": "abc123.wav", "original_name": "dog_bark.wav"}` (201)
+
+### Save loaded media as a server example file
+
+```
+POST /api/server-media-files/from-media-id
+```
+
+**Body:** `{"media_id": 42}` (optionally `{"media_id": 42, "crop_params": {...}}`
+— e.g. audio `{"start", "end"}` or image `{"box": [...]}`).
+
+Materialises a loaded media's bytes (optionally cropped) into the per-user
+`example_media/` dir so the new-detector form can reference it as a seed.
+
+→ `{"filename": "abc123.wav", "original_name": "dog_bark.wav"}` (201)
+
+400 (media not loaded, or invalid `crop_params`), 404 (media bytes unavailable).
+
+### Server media file thumbnail
+
+```
+GET /api/server-media-files/{filename}/thumbnail
+```
+
+Small preview image of an example file in the user's `example_media/` dir:
+image bytes, an audio waveform PNG, or a video mid-frame PNG (binary, not JSON).
+
+400 (filename escapes the media dir), 404 (not found / no thumbnail for the
+type), 500 (generation failed).
 
 ### Seed votes from examples
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -119,6 +119,6 @@ Datasets are grouped by media type below. Each demo comes in size variants — *
 | **kth_l** | Simple human-action recordings across 6 KTH categories (large) |
 | **kth_a** | Simple human-action recordings across 6 KTH categories (all) |
 
-> **Note:** Video demos are downloaded from HuggingFace Datasets. On some networks or air-gapped systems this may require manual setup; see [DEPLOYMENT.md](DEPLOYMENT.md) for offline deployment instructions.
+> **Note:** Video demos are downloaded from a mix of sources: the UCF-101 subset from HuggingFace Datasets, the full UCF-101 categories from YouTube, HMDB51 from `serre-lab.clps.brown.edu`, and KTH from `csc.kth.se`. On some networks or air-gapped systems this may require manual setup; see [DEPLOYMENT.md](DEPLOYMENT.md) for offline deployment instructions.
 
 You can also load your own data from pickle files or folders via the same dialog.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -110,6 +110,7 @@ All three resolve through `--shadow-dropdown` so they auto-tint per theme.
 | `--z-modal-backdrop` | 1000   | Modal overlay |
 | `--z-modal`          | 1001   | Modal content |
 | `--z-burger-menu`    | 2000   | Dropdown menus that must clear modals |
+| `--z-offline-banner` | 4500   | Offline / connection-lost banner |
 | `--z-toast`          | 5000   | Toast notifications |
 | `--z-login`          | 9999   | Login gate |
 

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -601,7 +601,7 @@ overrides the CLI value for themselves.
 
 ## Settings tabs
 
-The Settings modal (gear icon) is organised into seven tabs:
+The Settings modal (gear icon) is organised into eight tabs:
 
 - **Appearance** - theme, animations, the metadata panel, the
   **Enable achievements** toggle, and per-media-type Scroll Style
@@ -612,6 +612,8 @@ The Settings modal (gear icon) is organised into seven tabs:
   [Configuring Autopilot](#configuring-autopilot).
 - **Browser** - per-media-type look of the spatial Browse view (tile
   shape, colour scheme, cell size).
+- **HuggingFace** - sign in with HuggingFace to download gated demo
+  datasets and gated AI models.
 - **Import Defaults** - default embedder, clipper, and converters per
   media type, plus the **Solo media type** picker.
 - **Server** - read-only settings fixed when the server started and

--- a/vtscore/docs/extending/media-types.md
+++ b/vtscore/docs/extending/media-types.md
@@ -87,7 +87,6 @@ Optional overrides:
 |--------|---------|---------|
 | `folder_import_name` | `type_id` | Alias used by folder-style importers |
 | `dir_key` | `type_id + "_dir"` | Key in pickle files for external directories |
-| `legacy_bytes_keys` | `[]` | Legacy keys to honour when unpickling old datasets |
 | `pickle_extra_fields` | `[]` | Custom clip-dict keys to preserve through pickle round-trip |
 | `display_metadata(media)` | base fields | Extra fields surfaced in the labeling UI |
 
@@ -162,8 +161,8 @@ class Mesh3DMediaType(MediaType):
         # Preserve our custom vertex / face counts across pickle round-trip.
         return ["vertex_count", "face_count"]
 
-    def load_media_data(self, file_path: Path) -> dict:
-        raw = file_path.read_bytes()
+    def load_media_data(self, file_path: Path, media_bytes: bytes | None = None) -> dict:
+        raw = media_bytes if media_bytes is not None else file_path.read_bytes()
         # Toy counts; a real impl would parse properly.
         text = raw.decode("ascii", errors="replace")
         vertex_count = text.count("\nv ") + text.count("\nvertex ")


### PR DESCRIPTION
## What this is

Batch A of the concrete-edits queue from `docs/reviews/2026-07-07-docs-audit.md` — the correctness bugs that actively mislead readers. Every claim was re-verified against `origin/dev` code before editing (the audit was a day old); one flagged item did not survive verification and was intentionally left as-is (see below).

## Fixes

**ML / config values**
- `ML.md`: hidden-layer sizing `4–32` → `8–32` (`MLP_HIDDEN_MIN = 8` in `vtscore/config.py`).
- `DEPLOYMENT.md`: `calibrate_count` default `2` → `1`; reconcile the model-cache size to `~3.8 GB` in all three places; add the missing CLIP dir to the `data/models/` tree; fix the TOC anchor (`Requirements file structure` → `Dependency structure`).

**Architecture map**
- `ARCHITECTURE.md`: `settings_factory.py` → `settings_store.py`; add `threading.py` and `routes/auth_huggingface.py`; refresh the audio inventory (add ParaSpeechCLAP) and image inventory (Face, SIFT-VLAD single-vector; DINOv2/DINOv3/EUPE single+patch, no phantom SigLIP/CLIP patch split).

**User- and ops-facing**
- `USER_GUIDE.md`: Settings modal `seven` → `eight` tabs; add the **HuggingFace** tab.
- `SETUP.md`: add `projection` and `frontend` to the test-group list.
- `HANDOFF.md`: repoint the dead `design/cli-detector-converter.md` link to the real `plans/cli-detector-converter.md`.

**Extension docs (dead-code-path bugs)**
- `EXTENDING-media.md` (and the `vtscore/docs/extending/media-types.md` mirror): drop the phantom `legacy_bytes_keys` property; fix the `load_media_data` signature to `(file_path, media_bytes=None)`; add the missing DINOv2/DINOv3/EUPE image embedders to the inventory table.
- `EXTENDING-plugins.md`: add `number`/`checkbox` to the FieldType list; rewrite the Settings-Source and Labelset-Source examples to override `_do_load` / `_do_save` (overriding `load` / `save` directly is never called).
- `EXTENDING.md`: source checklists now say `_do_load` / `_do_save`.

**API docs**
- `api/medias.md`: document `POST /api/learned-sort` as **async by default** (returns a `job_id`), plus the previously-undocumented `GET /api/learned-sort/result` and `POST /api/learned-sort/cancel/{job_id}`. A client written from the old doc would hang waiting for `results`.
- `api/detectors.md`: correct the import-labels response shape (`applied, skipped, resolved, trained, num_labels, message` — no `success`).
- `api/auth.md`: correct the 400 message string to `"Login/logout not supported by the active provider"`.

**Style**
- `style-guide.md`: add the missing `--z-offline-banner: 4500` z-index row.
- `demos.md`: correct the oversimplified "video demos come from HuggingFace" note (mixed HF / YouTube / serre-lab.clps.brown.edu / csc.kth.se).

## Not changed (finding didn't hold up)

Audit item S1.4.23 (`EXTENDING-plugins.md` L1076, `POST /api/detectors` "wrong" for the registry context): verified against `vtsearch/routes/detectors/crud.py` — `POST /api/detectors` genuinely creates the `data/detectors/<name>.json` file, and the parenthetical `POST /api/detectors/registry/from-labelset/<importer>` also exists. The existing text is accurate, so it was left unchanged.

## Testing

`./run-tests.sh` — **ALL 5396 TESTS PASSED** (1 skipped). codespell clean on the changed files. Doc-only markdown change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSjTgW88MtBhLcmrnRMKXt)_