### PR TITLE
Measured, n-aware progress-load weights (affine cost model)

### DIFF
--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -193,15 +193,18 @@ would cover those too.
   `total` (e.g. model load) sits the bar at its weighted floor until the next
   phase. That's honest but static; per-step weights (now shipped) mitigate it,
   but a phase with no `total` still can't animate within itself.
-- **Weights are static guesses.** The per-step weights are fixed ballparks, not
-  learned. A future refinement could record real per-phase durations per
-  media-type/embedder and feed measured weights back in. **Specified in
-  `docs/plans/progress-weight-calibration.md`** — including making the weights
-  depend on dataset size `n` via an affine per-phase cost model (the fixed
-  model-load cost is why one static vector can't serve both small and large
-  datasets). Not yet run (needs a GPU host). A CPU **image** profile
-  (`_LOAD_STEP_WEIGHTS_CPU_IMAGE`) shipped as a stopgap: images embed cheaply, so
-  the generic 55%-embed CPU profile mispaced image imports.
+- **Weights are static guesses.** *(Largely resolved.)* The per-step weights are
+  now fit to measured per-phase durations via an affine `n`-aware cost model —
+  see `docs/plans/progress-weight-calibration.md` (executed 2026-07 for
+  `{cpu,cuda} × {image,audio}`, default embedder; coefficients in
+  `vtscore/datasets/stages/_load_cost_model.py`). The fixed model-load cost is why
+  one static vector can't serve both small and large datasets, so
+  `load_step_weights(media_type, *, n, download_size_mb, embedder)` computes the
+  vector from the cost model when `n` is known and a coefficient row exists, and
+  otherwise returns the static per-(device, media) profile (the large-`n`
+  asymptote). Remaining media/embedders/cuML cells are uncalibrated and keep the
+  static profiles (incl. the CPU **image** stopgap
+  `_LOAD_STEP_WEIGHTS_CPU_IMAGE`).
 - **Dead dashboard fields.** `progressValue` / `progressTotal` /
   `progressIndeterminate` on `DashboardComponent` are set by the Find polling
   but never rendered; safe to remove in a cleanup pass.

--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -1,14 +1,16 @@
 # Progress-weight calibration
 
-**Status: planned (not yet run).** This doc specifies how to replace the
-hand-guessed dataset-load progress weights with *measured* ones, and how to make
-the weights depend on dataset size `n` rather than being a single fixed vector
-per device. It is the concrete follow-up to the "Weights are static guesses"
-item in `docs/plans/progress-bar-consolidation.md`.
+**Status: executed for image + audio × CPU + GPU (2026-07).** This doc specifies
+how to replace the hand-guessed dataset-load progress weights with *measured*
+ones, and how to make the weights depend on dataset size `n` rather than being a
+single fixed vector per device. It is the concrete follow-up to the "Weights are
+static guesses" item in `docs/plans/progress-bar-consolidation.md`. The
+instrumentation, driver, affine fit, and `n`-aware wiring shipped; fitted
+coefficients for the image/audio × CPU/GPU cells are in `_load_cost_model.py`.
+See **Results** for the runs; the sections above are the design/method.
 
-It is written to be run **locally / on a CUDA box** — the Claude Cloud container
-has no GPU and is not the right place to gather GPU timings. Nothing here has
-been executed yet; the numbers below the line are the target schema, not results.
+It is written to be run **on a CUDA box** — the Claude Cloud container has no GPU.
+The runs below were done on the HLTCOE Grid (a100).
 
 ## Background: what the weights do (and don't do)
 
@@ -183,8 +185,11 @@ it.
 
 ## Open follow-ups
 
-- This plan is **specified but not executed** — needs a GPU host and a few hours
-  of load runs. Until then the static image-CPU profile (shipped) is the stopgap.
+- **Executed** for `{cpu, cuda} × {image, audio}`, default embedder — see
+  Results below. Remaining media types (`video / text / document`), non-default
+  embedders, and the cuML-on/off split are still uncalibrated and fall back to
+  the static profiles; re-run `scripts/profiling/calibrate_load_weights.py` for
+  those cells when needed.
 - Once coefficients exist, revisit the **finalize sub-slot shares** (the
   `FinalizeProgress._SLOTS` ballparks) with the same measured data — they have
   the same "static guess" problem one level down.
@@ -196,5 +201,70 @@ it.
 
 ## Results
 
-*(empty — populate with the fitted coefficient table and fit diagnostics after
-running the harness on a GPU box.)*
+Ran on the HLTCOE Grid (a100 for the GPU cells) via
+`scripts/profiling/calibrate_load_weights.py` with the env-gated recorder, then
+`scripts/profiling/fit_load_weights.py` over the JSONL. 242 phase rows across the
+four cells. Coefficients are checked into `_load_cost_model.py`.
+
+**What ran.** `{cpu, cuda} × {image (caltech101 / siglip), audio (esc50 / clap)}`,
+default embedder only. Sizes `caltech101_{s,m,l,a}` (n = 412/838/1704/2954) and
+`esc50_{s,m,l,a}` (n = 245/588/1127/1960); ≥2 reps on the fast cells. Each cell's
+first load pays the cold model + cold archive download; the driver clears only the
+*embeddings* cache between loads, so the source stays warm and every load
+re-embeds. **Skipped, logged not silent:** media `video/text/document`; all
+non-default embedders (image: siglip2, eupe_\*, face, sift_vlad; audio:
+whisper_encoder…); cuML on/off. Uncalibrated cells fall back to the static
+per-(device, media) profile — unchanged behaviour.
+
+**Model-load is warm-≈0 by construction.** A warm load *skips the model phase
+entirely* (the encoder is resident, so no `loading model` status fires), so there
+is no warm row to fit — `a_model` is floored to 0.5 s and the model slice stays
+deliberately tiny. The cold first-load model cost (below) is recorded as a note,
+not paced against (per the plan).
+
+### Fitted coefficients (seconds; `n` = item count)
+
+| device | media | embedder | a_model (cold) | embed `a + b·n` | R² | finalize `a + b·n` | R² | n pts |
+|--------|-------|----------|---------------|-----------------|----|--------------------|----|------|
+| cpu  | image | siglip | 0.5 (39.9) | 1.97 + 0.2927·n | 1.00 | 0.47 + 0.00212·n | 0.90 | 5 |
+| cpu  | audio | clap   | 0.5 (4.5)  | 0.00 + 0.1846·n | 1.00 | 0.00 + 0.00253·n | 1.00 | 5 |
+| cuda | image | siglip | 0.5 (119.7)| 2.12 + 0.00678·n | 0.89 | 8.01 (fixed, b≈0) | 0.00 | 12 |
+| cuda | audio | clap   | 0.5 (40.1) | 0.69 + 0.03663·n | 1.00 | 0.00 + 0.00362·n | 1.00 | 12 |
+
+Download bandwidth ≈ **10.05 MB/s** (device-pooled; cuda 9.5 / cpu 10.6 agreed
+within ~10%), so `T_download ≈ download_size_mb / 10.05`.
+
+Physically sensible: per-item embed is **5–43× slower on CPU** than GPU (image
+0.293 vs 0.0068 s/item; audio 0.185 vs 0.0366) — SigLIP's ViT benefits from the
+GPU far more than CLAP. Audio finalize scales with `n` (diversity-tree k-means);
+GPU-image finalize is a ~8 s fixed overhead at these sizes (b≈0).
+
+### Sample resulting weights `[download, model, embed, finalize]`
+
+| device | media | n | archive | weights |
+|--------|-------|---|---------|---------|
+| cuda | image | 400   | 131 MB (cold) | [0.49, 0.02, 0.18, 0.31] |
+| cuda | image | 2000  | 0 (warm)      | [0.00, 0.02, 0.64, 0.34] |
+| cuda | image | 20000 | 0 (warm)      | [0.00, 0.00, 0.92, 0.08] |
+| cuda | audio | 400   | 600 MB (cold) | [0.78, 0.01, 0.20, 0.02] |
+| cuda | audio | 2000  | 0 (warm)      | [0.00, 0.01, 0.91, 0.09] |
+| cpu  | image | 400   | 131 MB (cold) | [0.10, 0.00, 0.89, 0.01] |
+| cpu  | audio | 2000  | 0 (warm)      | [0.00, 0.00, 0.99, 0.01] |
+
+The n-awareness a single static vector can't give: small `n` weighs
+model/finalize/download heavier, large `n` lets embed dominate; the download
+slice collapses when there is no archive (local imports, cached re-adds — which
+also take the static path since they don't know `n`). Cross-checks an independent
+scout run: warm large-`n` GPU-image `≈ [0, 0.02, 0.64, 0.34]` vs the scout's
+`[0, 0.01, 0.68, 0.31]` — the model and the raw data agree.
+
+### Reproduce
+
+```
+# per device (device is fixed at process start):
+CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl
+CUDA_VISIBLE_DEVICES=  python scripts/profiling/calibrate_load_weights.py --out cpu.jsonl --sizes s,m,l
+python scripts/profiling/fit_load_weights.py gpu.jsonl cpu.jsonl   # prints the table above
+```
+(Needs `VTSEARCH_MODELS_DIR` pointed at a warm model cache so the model phase is
+a load, not a cold HuggingFace download.)

--- a/scripts/profiling/calibrate_load_weights.py
+++ b/scripts/profiling/calibrate_load_weights.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Calibration driver for the dataset-load progress weights.
+
+Iterates the ``device × media_type × embedder × size`` matrix from
+``docs/plans/progress-weight-calibration.md``, invoking the real demo-load path
+per cell with the env-gated per-phase recorder armed
+(``vtscore.datasets.stages._load_profiler``, ``VTSEARCH_PROFILE_LOAD``). Each run
+appends per-phase JSONL rows to ``--out``; the fitting step
+(``fit_load_weights.py``) reads them and emits the affine cost-model table.
+
+Device is fixed at process start (``CUDA_VISIBLE_DEVICES`` must be set before
+torch imports), so run this **once per device**:
+
+    python scripts/profiling/calibrate_load_weights.py --out cpu.jsonl               # CPU: CUDA_VISIBLE_DEVICES=""
+    CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl
+
+Within one process the encoder is loaded once (first load per embedder is
+``cold_model``, the rest warm) and the source archive is downloaded/extracted
+once (first load per source is ``cold_download``, the rest warm) — the recorder
+self-detects both. Between loads the demo **embeddings** cache is cleared so
+embed always re-runs, giving fresh embed/finalize timings at each ``n``.
+
+Isolation: a scratch ``VTSEARCH_DATA_DIR`` is used so nothing touches a real
+data dir; ``VTSEARCH_MODELS_DIR`` should point at a warm model cache (else the
+model-load phase measures a cold HuggingFace download instead of a load).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+# media_type -> demo source id stem (size suffix appended: _s/_m/_l/_a).
+_SOURCE_BY_MEDIA = {
+    "image": "caltech101",
+    "audio": "esc50",
+}
+# Media types we deliberately do NOT calibrate in this run (logged as skipped).
+_SKIPPED_MEDIA = ("video", "text", "document")
+
+
+def _eprint(*a):
+    print(*a, file=sys.stderr, flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True, help="JSONL output path (appended)")
+    ap.add_argument("--media", default="image,audio", help="comma list of media types")
+    ap.add_argument("--sizes", default="s,m,l,a", help="comma list of size suffixes")
+    ap.add_argument("--reps", type=int, default=2, help="repetitions per cell (median later)")
+    ap.add_argument(
+        "--max-cpu-reps-size",
+        default="m",
+        help="on CPU, sizes larger than this get 1 rep (they are slow)",
+    )
+    args = ap.parse_args()
+
+    # Arm the recorder + isolate the data dir BEFORE importing the app.
+    os.environ["VTSEARCH_PROFILE_LOAD"] = os.path.abspath(args.out)
+    scratch = tempfile.mkdtemp(prefix="calib_data_")
+    os.environ["VTSEARCH_DATA_DIR"] = scratch
+    os.environ.pop("VTSEARCH_SERVER_INIT", None)
+
+    import app  # noqa: F401  wires Flask app + all plugins (media/importers/embedders)
+    from vtscore.config import EMBEDDINGS_DIR, resolve_device  # noqa: PLC0415
+    from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
+    from vtscore.datasets.importers import get_importer  # noqa: PLC0415
+    from vtscore.datasets.load_pipeline import (  # noqa: PLC0415
+        _run_importer_in_background,
+        loading_tasks,
+    )
+    from vtscore.media import embedders_for_type  # noqa: PLC0415
+
+    device = resolve_device()
+    _eprint(f"[calib] device={device} data_dir={scratch} out={args.out}")
+
+    # Wait on completion via mark_finished (the success path never sets status
+    # to 'idle'; it only calls mark_finished — see _load_profiler / scout notes).
+    finished: dict[str, float] = {}
+    _orig_mark = loading_tasks.mark_finished
+
+    def _mark(tid, *a, **k):
+        finished.setdefault(tid, time.monotonic())
+        return _orig_mark(tid, *a, **k)
+
+    loading_tasks.mark_finished = _mark  # type: ignore[method-assign]
+
+    def _clear_embeddings():
+        try:
+            shutil.rmtree(EMBEDDINGS_DIR, ignore_errors=True)
+        except OSError:
+            pass
+
+    def _load_and_wait(dataset_id: str, media_type: str, embedder: str) -> bool:
+        info = DEMO_DATASETS.get(dataset_id)
+        if info is None:
+            _eprint(f"[calib] SKIP unknown dataset {dataset_id}")
+            return False
+        os.environ["VTSEARCH_PROFILE_DATASET_ID"] = dataset_id
+        importer = get_importer("demo")
+        fv = {"name": dataset_id, "media_type": media_type, "embedder": embedder}
+        t0 = time.monotonic()
+        tid = _run_importer_in_background(importer, fv)
+        deadline = t0 + 3600
+        while tid not in finished:
+            if time.monotonic() > deadline:
+                _eprint(f"[calib] TIMEOUT {dataset_id}")
+                return False
+            time.sleep(0.25)
+        tr = loading_tasks.get_tracker(tid)
+        snap = tr.get() if tr else {}
+        if snap.get("error"):
+            _eprint(f"[calib] FAILED {dataset_id}: {snap.get('error')}")
+            return False
+        _eprint(f"[calib] ok {dataset_id} ({time.monotonic() - t0:.1f}s)")
+        return True
+
+    media_types = [m.strip() for m in args.media.split(",") if m.strip()]
+    sizes = [s.strip() for s in args.sizes.split(",") if s.strip()]
+    size_order = ["s", "m", "l", "a"]
+    on_cpu = not device.startswith("cuda")
+    cap_idx = size_order.index(args.max_cpu_reps_size) if args.max_cpu_reps_size in size_order else 1
+
+    for m in _SKIPPED_MEDIA:
+        _eprint(f"[calib] SKIPPED media={m} (out of scope for this run)")
+
+    for media_type in media_types:
+        stem = _SOURCE_BY_MEDIA.get(media_type)
+        if stem is None:
+            _eprint(f"[calib] SKIPPED media={media_type} (no source mapped)")
+            continue
+        embs = embedders_for_type(media_type)
+        if not embs:
+            _eprint(f"[calib] SKIPPED media={media_type} (no embedder)")
+            continue
+        embedder = embs[0].name  # is_default sorted first
+        for other in embs[1:]:
+            _eprint(f"[calib] SKIPPED embedder={other.name} media={media_type} (non-default)")
+        for size in sizes:
+            dataset_id = f"{stem}_{size}"
+            reps = args.reps
+            if on_cpu and size in size_order and size_order.index(size) > cap_idx:
+                reps = 1  # large CPU cells are slow; one rep
+            for r in range(reps):
+                _clear_embeddings()  # force a fresh embed (keep the extracted source)
+                _eprint(f"[calib] === {media_type}/{embedder}/{dataset_id} rep {r + 1}/{reps} ===")
+                _load_and_wait(dataset_id, media_type, embedder)
+
+    _eprint("[calib] DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profiling/calibrate_load_weights.py
+++ b/scripts/profiling/calibrate_load_weights.py
@@ -33,6 +33,13 @@ import shutil
 import sys
 import tempfile
 import time
+from pathlib import Path
+
+# Ensure the repo root (where app.py lives) is importable no matter the cwd:
+# ``python scripts/profiling/x.py`` only puts the script's own dir on sys.path.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 # media_type -> demo source id stem (size suffix appended: _s/_m/_l/_a).
 _SOURCE_BY_MEDIA = {

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -24,6 +24,13 @@ import statistics
 import sys
 from collections import defaultdict
 
+# Warm model-load floor (seconds). Warm loads skip the model-load phase (the
+# encoder is already resident, so no "loading model" status fires), so there is
+# usually no warm row to fit; a small floor keeps the model slice present but
+# tiny — matching the "model kept deliberately small" pacing design. The cold
+# first-load model cost is recorded separately as a note, not paced against.
+_WARM_MODEL_FLOOR_S = 0.5
+
 
 def _load_rows(paths: list[str]) -> list[dict]:
     rows: list[dict] = []
@@ -65,9 +72,7 @@ def main() -> int:
     rows = _load_rows(sys.argv[1:])
 
     # Group phase-seconds by (device, media, embedder).
-    groups: dict[tuple[str, str, str], dict[str, list[tuple[float, float]]]] = defaultdict(
-        lambda: defaultdict(list)
-    )
+    groups: dict[tuple[str, str, str], dict[str, list[tuple[float, float]]]] = defaultdict(lambda: defaultdict(list))
     dl_by_device: dict[str, list[tuple[float, float]]] = defaultdict(list)  # (size_mb, seconds)
     for r in rows:
         key = (r["device"], r["media_type"], r["embedder"])
@@ -99,9 +104,12 @@ def main() -> int:
     for key in sorted(groups):
         dev, media, emb = key
         g = groups[key]
-        warm = g.get("model_warm") or g.get("model_cold") or [(0, 0.0)]
-        a_model = statistics.median([s for _, s in warm])
-        cold_model = statistics.median([s for _, s in g.get("model_cold", [(0, a_model)])])
+        # Warm loads skip the model phase, so a warm row is rare; floor when
+        # absent. Never fall back to the (large) cold value for pacing.
+        warm = g.get("model_warm")
+        a_model = statistics.median([s for _, s in warm]) if warm else _WARM_MODEL_FLOOR_S
+        cold_rows = g.get("model_cold")
+        cold_model = statistics.median([s for _, s in cold_rows]) if cold_rows else a_model
         e_xs = [n for n, _ in g.get("embed", [])]
         e_ys = [s for _, s in g.get("embed", [])]
         a_e, b_e, r2_e = _affine_fit(e_xs, e_ys)

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fit the affine per-phase load-cost model from calibration JSONL.
+
+Reads the per-phase rows emitted by ``calibrate_load_weights.py`` (via the
+``VTSEARCH_PROFILE_LOAD`` recorder) and, per ``(device, media_type, embedder)``,
+fits:
+
+    T_model    ≈ a_model                      (median warm model-load seconds)
+    T_embed    ≈ a_embed + b_embed · n        (least-squares vs n)
+    T_finalize ≈ a_fin   + b_fin   · n        (least-squares vs n)
+    bandwidth  ≈ download_size_mb / seconds   (cold-download rows, device-pooled)
+
+and prints (a) a checked-in ``_load_cost_model.py`` body and (b) a human-readable
+summary table for docs/plans/progress-weight-calibration.md. See that plan.
+
+Usage:
+    python scripts/profiling/fit_load_weights.py calib.gpu.jsonl calib.cpu.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import defaultdict
+
+
+def _load_rows(paths: list[str]) -> list[dict]:
+    rows: list[dict] = []
+    for p in paths:
+        with open(p, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    return rows
+
+
+def _affine_fit(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
+    """Ordinary least squares y ≈ a + b·x. Returns (a, b, r2).
+
+    Falls back to (mean, 0, 0) when x has no spread (can't estimate a slope).
+    """
+    n = len(xs)
+    if n == 0:
+        return 0.0, 0.0, 0.0
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    sxx = sum((x - mx) ** 2 for x in xs)
+    if sxx <= 1e-9 or n < 2:
+        return my, 0.0, 0.0
+    sxy = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    b = sxy / sxx
+    a = my - b * mx
+    ss_tot = sum((y - my) ** 2 for y in ys)
+    ss_res = sum((y - (a + b * x)) ** 2 for x, y in zip(xs, ys))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 1e-9 else 1.0
+    return a, b, r2
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: fit_load_weights.py <jsonl> [<jsonl> ...]", file=sys.stderr)
+        return 2
+    rows = _load_rows(sys.argv[1:])
+
+    # Group phase-seconds by (device, media, embedder).
+    groups: dict[tuple[str, str, str], dict[str, list[tuple[float, float]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    dl_by_device: dict[str, list[tuple[float, float]]] = defaultdict(list)  # (size_mb, seconds)
+    for r in rows:
+        key = (r["device"], r["media_type"], r["embedder"])
+        phase = r["phase"]
+        n = float(r.get("n") or 0)
+        secs = float(r.get("seconds") or 0)
+        if phase == "download":
+            if r.get("cold_download") and r.get("download_size_mb"):
+                dl_by_device[r["device"]].append((float(r["download_size_mb"]), secs))
+            continue
+        if phase.startswith("finalize:"):
+            continue  # sub-slots: deferred (see plan follow-ups)
+        if phase == "model_load":
+            # warm rows only; fall back to all if none warm
+            groups[key]["model_warm" if not r.get("cold_model") else "model_cold"].append((n, secs))
+        elif phase in ("embed", "finalize"):
+            groups[key][phase].append((n, secs))
+
+    # Bandwidth (MB/s), device-pooled then collapsed if similar.
+    bw: dict[str, float] = {}
+    for dev, pts in dl_by_device.items():
+        # seconds ≈ size / bw  ->  bw = median(size/seconds)
+        rates = [size / s for size, s in pts if s > 0]
+        if rates:
+            bw[dev] = statistics.median(rates)
+
+    model = {}
+    summary_lines = []
+    for key in sorted(groups):
+        dev, media, emb = key
+        g = groups[key]
+        warm = g.get("model_warm") or g.get("model_cold") or [(0, 0.0)]
+        a_model = statistics.median([s for _, s in warm])
+        cold_model = statistics.median([s for _, s in g.get("model_cold", [(0, a_model)])])
+        e_xs = [n for n, _ in g.get("embed", [])]
+        e_ys = [s for _, s in g.get("embed", [])]
+        a_e, b_e, r2_e = _affine_fit(e_xs, e_ys)
+        f_xs = [n for n, _ in g.get("finalize", [])]
+        f_ys = [s for _, s in g.get("finalize", [])]
+        a_f, b_f, r2_f = _affine_fit(f_xs, f_ys)
+        model[key] = {
+            "a_model": round(a_model, 4),
+            "a_embed": round(max(0.0, a_e), 4),
+            "b_embed": round(max(0.0, b_e), 6),
+            "a_fin": round(max(0.0, a_f), 4),
+            "b_fin": round(max(0.0, b_f), 6),
+        }
+        summary_lines.append(
+            f"| {dev} | {media} | {emb} | {a_model:.2f} (cold {cold_model:.1f}) | "
+            f"{a_e:.2f}+{b_e * 1000:.2f}m·n | {r2_e:.2f} | {a_f:.2f}+{b_f * 1000:.2f}m·n | {r2_f:.2f} | "
+            f"{len(e_xs)} |"
+        )
+
+    # ---- emit the checked-in module body ----
+    print("# ===== _load_cost_model.py body =====")
+    print("LOAD_COST_MODEL = {")
+    for key in sorted(model):
+        print(f"    {key!r}: {model[key]!r},")
+    print("}")
+    bw_val = statistics.median(list(bw.values())) if bw else 0.0
+    print(f"DOWNLOAD_MB_PER_S = {round(bw_val, 3)}  # per-device: {bw}")
+    print()
+    # ---- human-readable summary (paste under Results) ----
+    print("# ===== summary =====")
+    print("| device | media | embedder | a_model s (cold) | embed a+b·n | R² | finalize a+b·n | R² | pts |")
+    print("|--------|-------|----------|------------------|-------------|----|----------------|----|----|")
+    for line in summary_lines:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -144,7 +144,11 @@ def test_unknown_n_returns_static_profile(monkeypatch):
 
 def test_no_matching_cost_model_row_returns_static(monkeypatch):
     monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cpu")
-    _inject_row(monkeypatch, ("cuda", "image", "siglip"), {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002})
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+    )
     # device cpu -> no ("cpu", image, x) row -> static image-CPU profile.
     assert load_step_weights("image", n=1000, download_size_mb=100.0, embedder="siglip") == _LOAD_STEP_WEIGHTS_CPU_IMAGE
 

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -77,3 +77,86 @@ def test_falls_back_to_cpu_when_device_resolution_raises(monkeypatch):
 
     monkeypatch.setattr("vtscore.config.resolve_device", _boom)
     assert load_step_weights() == _LOAD_STEP_WEIGHTS_CPU
+
+
+# --- n-aware affine cost model -------------------------------------------------
+
+import pytest  # noqa: E402
+
+from vtscore.datasets.stages import _load_cost_model as _cm  # noqa: E402
+
+
+def _inject_row(monkeypatch, key, coeffs, *, bandwidth=10.0):
+    monkeypatch.setattr(_cm, "LOAD_COST_MODEL", {key: coeffs})
+    monkeypatch.setattr(_cm, "DOWNLOAD_MB_PER_S", bandwidth)
+
+
+def test_n_aware_weights_come_from_cost_model(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+        bandwidth=10.0,
+    )
+    w = load_step_weights("image", n=1000, download_size_mb=100.0, embedder="siglip")
+    # T = [download 100/10=10, model 0.3, embed 1+10=11, finalize 1+2=3] -> /24.3
+    assert w == pytest.approx([10 / 24.3, 0.3 / 24.3, 11 / 24.3, 3 / 24.3])
+    assert sum(w) == pytest.approx(1.0)
+
+
+def test_small_n_weights_model_heavier_and_large_n_weights_embed_heavier(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 5.0, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.001},
+    )
+    small = load_step_weights("image", n=100, download_size_mb=0, embedder="siglip")
+    large = load_step_weights("image", n=10000, download_size_mb=0, embedder="siglip")
+    # model (index 1) is a fixed cost -> a larger *fraction* at small n.
+    assert small[1] > large[1]
+    # embed (index 2) grows with n -> a larger fraction at large n.
+    assert large[2] > small[2]
+
+
+def test_download_slice_collapses_when_size_zero(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+    )
+    w = load_step_weights("image", n=1000, download_size_mb=0, embedder="siglip")
+    assert w[0] == 0.0  # no archive fetched (local import / cached re-add)
+
+
+def test_unknown_n_returns_static_profile(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+    )
+    # n unknown (folder importer) -> static asymptote, not the affine model.
+    assert load_step_weights("image", embedder="siglip") == _LOAD_STEP_WEIGHTS_GPU
+
+
+def test_no_matching_cost_model_row_returns_static(monkeypatch):
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cpu")
+    _inject_row(monkeypatch, ("cuda", "image", "siglip"), {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002})
+    # device cpu -> no ("cpu", image, x) row -> static image-CPU profile.
+    assert load_step_weights("image", n=1000, download_size_mb=100.0, embedder="siglip") == _LOAD_STEP_WEIGHTS_CPU_IMAGE
+
+
+def test_shipped_cost_model_table_is_well_formed():
+    # Every checked-in coefficient row has the affine keys and yields a
+    # normalized weight vector; empty table (pre-calibration) trivially passes.
+    for key, coeffs in _cm.LOAD_COST_MODEL.items():
+        assert set(coeffs) >= {"a_model", "a_embed", "b_embed", "a_fin", "b_fin"}
+        device, media, embedder = key
+        w = _cm.cost_model_weights(device, media, embedder, n=1000, download_size_mb=100.0)
+        assert w is not None
+        assert len(w) == _TOTAL_LOAD_STEPS
+        assert all(x >= 0 for x in w)
+        assert sum(w) == pytest.approx(1.0)

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -419,9 +419,7 @@ def _run_origin_load_in_background(
         name or _origin_to_str(origin),
         media_type=media_type,
         embedder=embedder,
-        step_weights=load_step_weights(
-            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder
-        ),
+        step_weights=load_step_weights(media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder),
     )
     # Env-gated per-phase timing recorder (VTSEARCH_PROFILE_LOAD); ``None`` and
     # zero-cost when off. Subscribed before the first phase fires. See

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -373,6 +373,8 @@ def _run_origin_load_in_background(
     media_type: str = "",
     build_projection: bool = False,
     merge_near_duplicates: bool = False,
+    n_hint: int | None = None,
+    download_size_mb_hint: float | None = None,
 ) -> str:
     """Run a dataset load in a background thread with standard error handling.
 
@@ -417,7 +419,9 @@ def _run_origin_load_in_background(
         name or _origin_to_str(origin),
         media_type=media_type,
         embedder=embedder,
-        step_weights=load_step_weights(media_type),
+        step_weights=load_step_weights(
+            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder
+        ),
     )
     # Env-gated per-phase timing recorder (VTSEARCH_PROFILE_LOAD); ``None`` and
     # zero-cost when off. Subscribed before the first phase fires. See
@@ -656,6 +660,11 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         else:
             importer.run(field_values, target_medias, thin=reference_files)
 
+    # For demo datasets we know the expected item count + archive size up front,
+    # which lets load_step_weights pace by the measured n-aware cost model rather
+    # than the static asymptote. Unknown for streaming folder imports -> None.
+    n_hint, download_size_mb_hint = _demo_load_hints(importer, field_values)
+
     return _run_origin_load_in_background(
         _load,
         origin,
@@ -669,7 +678,31 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         media_type=media_type_hint,
         build_projection=build_projection,
         merge_near_duplicates=merge_near_duplicates,
+        n_hint=n_hint,
+        download_size_mb_hint=download_size_mb_hint,
     )
+
+
+def _demo_load_hints(importer, field_values: dict) -> tuple[int | None, float | None]:
+    """Expected item count and archive size for a demo load, else ``(None, None)``.
+
+    Enables the ``n``-aware cost-model weights (see
+    :func:`vtscore.datasets.stages._common.load_step_weights`). Only the demo
+    importer knows ``n`` up front; folder importers stream, so they fall back to
+    the static weight profile.
+    """
+    if getattr(importer, "name", "") != "demo":
+        return None, None
+    dataset_id = field_values.get("name", "")
+    if not dataset_id:
+        return None, None
+    from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
+    from vtscore.datasets.demo_counts import exact_demo_count  # noqa: PLC0415
+
+    n = exact_demo_count(dataset_id)
+    info = DEMO_DATASETS.get(dataset_id) or {}
+    dl = info.get("download_size_mb")
+    return n, (float(dl) if dl is not None else None)
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -43,6 +43,7 @@ from vtscore.datasets.stages._common import (
     _origin_to_str,
     load_step_weights,
 )
+from vtscore.datasets.stages._load_profiler import start_profiler
 from vtscore.datasets.stages.clipper import _apply_clipper_stage, _relazify_reference_clips_stage
 from vtscore.datasets.stages.embedding import embed_missing, _embed_missing_stage
 from vtscore.datasets.stages.finalize import (
@@ -418,6 +419,10 @@ def _run_origin_load_in_background(
         embedder=embedder,
         step_weights=load_step_weights(media_type),
     )
+    # Env-gated per-phase timing recorder (VTSEARCH_PROFILE_LOAD); ``None`` and
+    # zero-cost when off. Subscribed before the first phase fires. See
+    # docs/plans/progress-weight-calibration.md.
+    profiler = start_profiler(tracker, media_type, embedder)
     tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
 
     # Snapshot the user that triggered the load so background per-user
@@ -450,6 +455,7 @@ def _run_origin_load_in_background(
         registry_entry_id: str | None = None
         controller = _LoadGateController(tracker)
         stepped = _make_stepped_progress(controller, tracker)
+        profiler.bind_thread()  # so FinalizeProgress.begin stamps land here (no-op when off)
 
         try:
             with thread_user(request_user), thread_dataset_context(ctx):
@@ -536,6 +542,7 @@ def _run_origin_load_in_background(
                     controller.release()
                     clear_thread_progress()
         finally:
+            profiler.finish(len(ctx.medias))  # writes JSONL + unbinds (no-op when off)
             loading_tasks.mark_finished(task_id)
 
     threading.Thread(target=task, daemon=True).start()

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -7,6 +7,8 @@ individual stage modules can depend on it without forming an import cycle.
 
 from __future__ import annotations
 
+from typing import Optional
+
 # Maps the status strings emitted by inner functions to step numbers.
 # "downloading" covers both download and extraction.
 # "loading"/"converting" cover model loading, pickle loading, and source→media
@@ -79,28 +81,63 @@ _LOAD_STEP_WEIGHTS_GPU = [0.20, 0.10, 0.30, 0.40]
 _LOAD_STEP_WEIGHTS = _LOAD_STEP_WEIGHTS_CPU
 
 
-def load_step_weights(media_type: str = "") -> list[float]:
-    """Return the dataset-load step weights for the active device and media type.
-
-    GPU hosts embed several times faster, so the un-accelerated finalize phase
-    (registry serialize/write, and CPU k-means when cuML is absent) becomes the
-    dominant cost and earns a larger slice of the unified bar. Falls back to the
-    CPU profile whenever the device can't be resolved (e.g. torch missing), so a
-    library-only caller never crashes here.
-
-    On a CPU host the split also depends on *media_type*: an image embed is a
-    single cheap ViT forward per item, so embedding no longer dominates the way
-    it does for audio/video, and ``image`` gets a profile with weight shifted off
-    embed and onto download + finalize. The GPU profile is media-agnostic — a
-    fast embed phase already shrinks embed's slice for every media type.
-    """
+def _resolve_device_name() -> str:
+    """Return "cuda"/"cpu" for the active device, defaulting to "cpu" when torch
+    can't be resolved (library-only callers must never crash here)."""
     try:
         from vtscore.config import resolve_device  # noqa: PLC0415
 
-        if resolve_device().startswith("cuda"):
-            return list(_LOAD_STEP_WEIGHTS_GPU)
+        return "cuda" if resolve_device().startswith("cuda") else "cpu"
     except Exception:
-        pass
+        return "cpu"
+
+
+def _default_embedder_name(media_type: str) -> str:
+    """Name of the default embedder for *media_type* (empty if none/unknown)."""
+    try:
+        from vtscore.media import embedders_for_type  # noqa: PLC0415
+
+        embs = embedders_for_type(media_type)
+        return embs[0].name if embs else ""
+    except Exception:
+        return ""
+
+
+def load_step_weights(
+    media_type: str = "",
+    *,
+    n: Optional[int] = None,
+    download_size_mb: Optional[float] = None,
+    embedder: Optional[str] = None,
+) -> list[float]:
+    """Return the dataset-load step weights for the active device and media type.
+
+    When the item count *n* is known (demo datasets know it up front) and a
+    measured affine cost-model row exists for (device, media_type, embedder), the
+    weights are computed from that model (see ``_load_cost_model``), so they adapt
+    to dataset size — model-load weighs heavier for small ``n``, embed dominates
+    for large ``n``. Otherwise it returns the static per-(device, media_type)
+    profile below — the large-``n`` asymptote — so callers without a known ``n``
+    (folder importers that stream) keep today's behaviour unchanged.
+
+    Static fallback rationale: GPU hosts embed several times faster, so the
+    un-accelerated finalize phase earns a larger slice; on a CPU host an image
+    embed is a single cheap ViT forward per item, so ``image`` shifts weight off
+    embed onto download + finalize. Falls back to the CPU profile whenever the
+    device can't be resolved, so a library-only caller never crashes here.
+    """
+    device = _resolve_device_name()
+
+    if n is not None and n > 0:
+        from vtscore.datasets.stages._load_cost_model import cost_model_weights  # noqa: PLC0415
+
+        emb = embedder or _default_embedder_name(media_type)
+        weights = cost_model_weights(device, media_type, emb, n, download_size_mb)
+        if weights is not None:
+            return weights
+
+    if device == "cuda":
+        return list(_LOAD_STEP_WEIGHTS_GPU)
     if media_type == "image":
         return list(_LOAD_STEP_WEIGHTS_CPU_IMAGE)
     return list(_LOAD_STEP_WEIGHTS_CPU)

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -166,6 +166,11 @@ class FinalizeProgress:
     def begin(self, slot: str) -> None:
         """Activate *slot*; subsequent :meth:`update` calls map into its range."""
         self._base, self._span = self._ranges[slot]
+        # Stamp the sub-slot boundary for the env-gated load profiler (no-op when
+        # profiling is off). See docs/plans/progress-weight-calibration.md.
+        from vtscore.datasets.stages._load_profiler import note_finalize_slot  # noqa: PLC0415
+
+        note_finalize_slot(slot)
 
     def check_cancelled(self) -> None:
         self._tracker.check_cancelled()

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -1,0 +1,72 @@
+"""Affine per-phase load-cost coefficients, fit from measured GRID timings.
+
+The dataset-load progress bar paces itself with a per-phase weight vector
+(download, model, embed, finalize). A single static vector can't be right at
+both small and large ``n``, because the phases scale with ``n`` differently:
+model-load is a fixed cost, embed and finalize grow with ``n``, and download
+tracks archive bytes. This module holds the measured affine coefficients so
+:func:`vtscore.datasets.stages._common.load_step_weights` can compute an
+``n``-aware weight vector.
+
+    T_download ≈ download_size_mb / DOWNLOAD_MB_PER_S
+    T_model    ≈ a_model                         (warm steady-state; cold noted in the plan)
+    T_embed    ≈ a_embed + b_embed · n
+    T_finalize ≈ a_fin   + b_fin   · n
+    weight_phase = T_phase / Σ T_phase
+
+The numbers below are produced by ``scripts/profiling/fit_load_weights.py`` from
+the calibration harness (``scripts/profiling/calibrate_load_weights.py``); see
+``docs/plans/progress-weight-calibration.md`` (Results) for the runs and fit
+diagnostics. Re-run that harness to refresh — do not hand-tune. Cells with no
+measured row fall back to the static per-device/media profiles in ``_common``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# key: (device, media_type, embedder) -> affine coefficients (seconds).
+# ``device`` is normalized to "cuda" / "cpu"; ``embedder`` is the encoder name.
+# POPULATED FROM CALIBRATION (see module docstring). Empty => always fall back.
+LOAD_COST_MODEL: dict[tuple[str, str, str], dict[str, float]] = {}
+
+# Cold-download bandwidth (archive MB per second) over the measured hosts.
+# 0 disables the download term (weights then reflect only model+embed+finalize).
+DOWNLOAD_MB_PER_S: float = 0.0
+
+
+def normalize_device(device: str) -> str:
+    """Collapse ``resolve_device()`` output ("cuda:0", "cuda", "cpu", "mps"…) to
+    the coarse key used by :data:`LOAD_COST_MODEL` ("cuda" / "cpu")."""
+    return "cuda" if device.startswith("cuda") else "cpu"
+
+
+def cost_model_weights(
+    device: str,
+    media_type: str,
+    embedder: str,
+    n: int,
+    download_size_mb: Optional[float] = None,
+) -> Optional[list[float]]:
+    """Return normalized ``[download, model, embed, finalize]`` weights from the
+    affine cost model, or ``None`` when no coefficient row matches (so the caller
+    can fall back to the static profile).
+
+    ``download_size_mb`` of 0/``None`` collapses the download slice — which is
+    exactly right for local-folder imports and cache-backed re-adds, where no
+    archive is fetched.
+    """
+    row = LOAD_COST_MODEL.get((normalize_device(device), media_type, embedder))
+    if row is None or n <= 0:
+        return None
+    t_download = 0.0
+    if download_size_mb and DOWNLOAD_MB_PER_S > 0:
+        t_download = download_size_mb / DOWNLOAD_MB_PER_S
+    t_model = row.get("a_model", 0.0)
+    t_embed = row.get("a_embed", 0.0) + row.get("b_embed", 0.0) * n
+    t_finalize = row.get("a_fin", 0.0) + row.get("b_fin", 0.0) * n
+    parts = [max(0.0, t_download), max(0.0, t_model), max(0.0, t_embed), max(0.0, t_finalize)]
+    total = sum(parts)
+    if total <= 0:
+        return None
+    return [p / total for p in parts]

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -27,12 +27,37 @@ from typing import Optional
 
 # key: (device, media_type, embedder) -> affine coefficients (seconds).
 # ``device`` is normalized to "cuda" / "cpu"; ``embedder`` is the encoder name.
-# POPULATED FROM CALIBRATION (see module docstring). Empty => always fall back.
-LOAD_COST_MODEL: dict[tuple[str, str, str], dict[str, float]] = {}
+# POPULATED FROM CALIBRATION (HLTCOE Grid, a100; see plan Results). Cells with no
+# row fall back to the static per-(device, media) profiles in ``_common``.
+LOAD_COST_MODEL: dict[tuple[str, str, str], dict[str, float]] = {
+    ("cpu", "image", "siglip"): {
+        "a_model": 0.5,
+        "a_embed": 1.971,
+        "b_embed": 0.292716,
+        "a_fin": 0.4663,
+        "b_fin": 0.002124,
+    },
+    ("cpu", "audio", "clap"): {"a_model": 0.5, "a_embed": 0.0, "b_embed": 0.184566, "a_fin": 0.0, "b_fin": 0.002525},
+    ("cuda", "image", "siglip"): {
+        "a_model": 0.5,
+        "a_embed": 2.1194,
+        "b_embed": 0.006784,
+        "a_fin": 8.0066,
+        "b_fin": 0.000195,
+    },
+    ("cuda", "audio", "clap"): {
+        "a_model": 0.5,
+        "a_embed": 0.6868,
+        "b_embed": 0.036626,
+        "a_fin": 0.0,
+        "b_fin": 0.003618,
+    },
+}
 
-# Cold-download bandwidth (archive MB per second) over the measured hosts.
-# 0 disables the download term (weights then reflect only model+embed+finalize).
-DOWNLOAD_MB_PER_S: float = 0.0
+# Cold-download bandwidth (archive MB per second) over the measured hosts
+# (device-pooled; the two devices agreed within ~10%). 0 disables the download
+# term (weights then reflect only model+embed+finalize).
+DOWNLOAD_MB_PER_S: float = 10.05
 
 
 def normalize_device(device: str) -> str:

--- a/vtscore/datasets/stages/_load_profiler.py
+++ b/vtscore/datasets/stages/_load_profiler.py
@@ -1,0 +1,226 @@
+"""Env-gated per-phase load-timing recorder (library tier).
+
+When ``VTSEARCH_PROFILE_LOAD=<path>`` is set, the dataset-load pipeline records
+one JSONL row per phase boundary to ``<path>`` (append mode), e.g.::
+
+    {"device": "cuda", "media_type": "image", "embedder": "siglip",
+     "dataset_id": "caltech101_s", "n": 1240, "download_size_mb": 131.0,
+     "phase": "embed", "seconds": 3.21, "cold_model": false,
+     "cold_download": true}
+
+This is the measurement instrument behind
+``docs/plans/progress-weight-calibration.md``: the rows are fit to an affine
+per-phase cost model ``T_phase ≈ a + b·n`` whose coefficients drive the
+``n``-aware :func:`load_step_weights`. It is **off by default and has no
+behaviour effect when off** — the pipeline only pays a single ``os.environ``
+lookup per load and, when profiling, a lightweight tracker subscription.
+
+Kept in ``vtscore`` (no Flask) so it works from a plain CLI/library load, not
+just the app.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any, Optional
+
+# step number (see _common._STATUS_TO_STEP / _TOTAL_LOAD_STEPS) -> phase label.
+_STEP_PHASE = {1: "download", 2: "model_load", 3: "embed", 4: "finalize"}
+
+# Embedders whose model has already been loaded in THIS process. First load of a
+# given embedder pays the cold model-load cost; later loads reuse the resident
+# model (warm). Self-detecting this is more robust than a caller-supplied flag,
+# and lets the driver measure cold+warm in one process.
+_seen_embedders: set[str] = set()
+_seen_lock = threading.Lock()
+
+# Active profiler for the current worker thread, so ``FinalizeProgress.begin``
+# can stamp finalize sub-slot boundaries without threading a profiler argument
+# through the whole finalize block.
+_active = threading.local()
+
+
+def profiling_enabled() -> bool:
+    """True when the ``VTSEARCH_PROFILE_LOAD`` recorder is armed."""
+    return bool(os.environ.get("VTSEARCH_PROFILE_LOAD"))
+
+
+def _active_profiler() -> Optional["LoadProfiler"]:
+    return getattr(_active, "profiler", None)
+
+
+def note_finalize_slot(slot: str) -> None:
+    """Record a finalize sub-slot boundary on the active profiler (no-op when
+    profiling is off). Called from ``FinalizeProgress.begin``."""
+    prof = _active_profiler()
+    if prof is not None:
+        prof._mark_finalize_slot(slot)
+
+
+def _resolve_device() -> str:
+    try:
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        return resolve_device()
+    except Exception:
+        return "unknown"
+
+
+def _download_size_mb_for(dataset_id: str) -> Optional[float]:
+    try:
+        from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
+
+        info = DEMO_DATASETS.get(dataset_id)
+        if info and info.get("download_size_mb") is not None:
+            return float(info["download_size_mb"])
+    except Exception:
+        pass
+    return None
+
+
+class LoadProfiler:
+    """Records phase-boundary timestamps for a single dataset load.
+
+    Subscribe :meth:`on_update` to the load's :class:`ProgressTracker` before the
+    first phase fires; call :meth:`bind_thread` at the start of the worker thread
+    (so finalize sub-slots land on this profiler); call :meth:`finish` with the
+    final item count when the load completes. Timings between consecutive phase
+    starts (and start→finish for the last phase) are written to the JSONL path.
+    """
+
+    def __init__(self, tracker: Any, media_type: str, embedder: str) -> None:
+        self._tracker = tracker
+        self._media_type = media_type or ""
+        self._embedder = embedder or ""
+        self._path = os.environ.get("VTSEARCH_PROFILE_LOAD", "")
+        self._lock = threading.Lock()
+        self._phase_start: dict[str, float] = {}
+        self._phase_order: list[str] = []
+        self._last_step: Any = None
+        # finalize sub-slots: ordered (slot, monotonic-start)
+        self._slot_start: list[tuple[str, float]] = []
+        self._t0 = time.monotonic()
+
+    # -- capture ------------------------------------------------------------
+    def on_update(self, snapshot: dict[str, Any]) -> None:
+        """Tracker subscriber: stamp the first time each step becomes active."""
+        step = snapshot.get("step")
+        if step == self._last_step:
+            return
+        self._last_step = step
+        phase = _STEP_PHASE.get(step) if isinstance(step, int) else None
+        if phase is None:
+            return
+        now = time.monotonic()
+        with self._lock:
+            if phase not in self._phase_start:
+                self._phase_start[phase] = now
+                self._phase_order.append(phase)
+
+    def _mark_finalize_slot(self, slot: str) -> None:
+        with self._lock:
+            self._slot_start.append((slot, time.monotonic()))
+
+    def bind_thread(self) -> None:
+        _active.profiler = self
+
+    def _unbind_thread(self) -> None:
+        if getattr(_active, "profiler", None) is self:
+            _active.profiler = None
+
+    # -- emit ---------------------------------------------------------------
+    def finish(self, n: int, dataset_id: str = "") -> None:
+        """Write one JSONL row per phase (and per finalize sub-slot), then
+        release the thread binding."""
+        try:
+            self._emit(n, dataset_id)
+        finally:
+            self._unbind_thread()
+
+    def _emit(self, n: int, dataset_id: str) -> None:
+        end = time.monotonic()
+        if not self._path:
+            return
+        dataset_id = dataset_id or os.environ.get("VTSEARCH_PROFILE_DATASET_ID", "")
+        dl_mb_env = os.environ.get("VTSEARCH_PROFILE_DOWNLOAD_MB")
+        download_size_mb = float(dl_mb_env) if dl_mb_env else _download_size_mb_for(dataset_id)
+
+        with self._lock:
+            order = list(self._phase_order)
+            starts = dict(self._phase_start)
+            slots = list(self._slot_start)
+
+        # Main-phase durations: consecutive phase starts, last phase → end.
+        durations: dict[str, float] = {}
+        for i, phase in enumerate(order):
+            t_start = starts[phase]
+            t_end = starts[order[i + 1]] if i + 1 < len(order) else end
+            durations[phase] = max(0.0, t_end - t_start)
+
+        with _seen_lock:
+            cold_model = self._embedder not in _seen_embedders
+            _seen_embedders.add(self._embedder)
+        # A download slice that actually ran (not a cached/absent archive).
+        cold_download = durations.get("download", 0.0) > 1.0
+
+        device = _resolve_device()
+        base = {
+            "device": device,
+            "media_type": self._media_type,
+            "embedder": self._embedder,
+            "dataset_id": dataset_id,
+            "n": int(n),
+            "download_size_mb": download_size_mb,
+            "cold_model": cold_model,
+            "cold_download": cold_download,
+        }
+        rows = [{**base, "phase": phase, "seconds": round(secs, 4)} for phase, secs in durations.items()]
+
+        # Finalize sub-slot durations (partition the finalize phase); recorded
+        # as phase="finalize:<slot>" for the deferred sub-share calibration.
+        fin_end = end
+        for i, (slot, t_start) in enumerate(slots):
+            t_end = slots[i + 1][1] if i + 1 < len(slots) else fin_end
+            rows.append({**base, "phase": f"finalize:{slot}", "seconds": round(max(0.0, t_end - t_start), 4)})
+
+        line = "".join(json.dumps(r) + "\n" for r in rows)
+        try:
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(line)
+        except OSError:
+            pass
+
+
+class _NullProfiler:
+    """No-op stand-in returned when profiling is off, so callers never branch on
+    ``None`` (keeps the load pipeline's cyclomatic complexity down). Deliberately
+    does NOT bind the thread-local, so :func:`note_finalize_slot` short-circuits
+    and the off path pays nothing beyond a couple of no-op method calls."""
+
+    def bind_thread(self) -> None:  # noqa: D401
+        pass
+
+    def finish(self, n: int, dataset_id: str = "") -> None:
+        pass
+
+
+_NULL_PROFILER = _NullProfiler()
+
+
+def start_profiler(tracker: Any, media_type: str, embedder: str):
+    """Create + subscribe a profiler when armed; else return a no-op stand-in.
+
+    Always returns an object with ``bind_thread`` / ``finish`` so callers invoke
+    it unconditionally.
+    """
+    if not profiling_enabled():
+        return _NULL_PROFILER
+    prof = LoadProfiler(tracker, media_type, embedder)
+    try:
+        tracker.subscribe(prof.on_update)
+    except Exception:
+        return _NULL_PROFILER
+    return prof


### PR DESCRIPTION
Executes `docs/plans/progress-weight-calibration.md`: replaces the hand-guessed
dataset-load progress weights with **measured, `n`-aware** ones fit to real
per-phase timings gathered on the HLTCOE Grid (a100).

### Why
The unified load bar paces four phases (download, model, embed, finalize) with a
weight vector. A single static vector can't be right at both small and large `n`,
because model-load is a fixed cost while embed/finalize scale with `n` — so small
datasets sat at the wrong floors and large ones raced/crawled. The weights only
shape *pacing* (the overall ETA already self-corrects), so this is about honest
motion, not a time oracle.

### What shipped
- **Env-gated per-phase recorder** (`vtscore/datasets/stages/_load_profiler.py`),
  gated on `VTSEARCH_PROFILE_LOAD`; no behaviour change when off. Subscribes to
  the load tracker, times the 4 phase boundaries + finalize sub-slots, writes
  JSONL. Wired into `load_pipeline` + `FinalizeProgress.begin`.
- **Driver + fitter** (`scripts/profiling/{calibrate,fit}_load_weights.py`):
  iterate the device × media × size matrix and fit the affine cost model
  `T_embed ≈ a+b·n`, `T_finalize ≈ a+b·n`, `T_model ≈ a_model`,
  `T_download ≈ mb / bandwidth`.
- **`n`-aware `load_step_weights(media_type, *, n, download_size_mb, embedder)`**
  computes the vector from the checked-in coefficients (`_load_cost_model.py`)
  when `n` is known and a cell matches, else the existing static per-(device,
  media) profile — a **strict superset**, so folder imports / uncalibrated cells
  are unchanged. The demo importer's known count + archive size are threaded to
  the call site.
- **Calibrated cells:** `{cpu, cuda} × {image (siglip), audio (clap)}`, default
  embedder, 242 measured rows (R² mostly 1.0). Per-item embed is 5–43× slower on
  CPU than GPU; audio finalize scales with `n`, GPU-image finalize is a fixed ~8s
  overhead. Cross-checks an independent scout run. Skipped cells
  (video/text/document, non-default embedders, cuML on/off) are logged and fall
  back to static.
- Tests (`test_load_step_weights.py`: n-aware behaviour + coefficient-table
  shape) and full Results in the plan doc.

Coefficients refresh by re-running the harness (`Reproduce` in the plan) — no
runtime persistence; they're source constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
