### PR TITLE
Align 'Loading ML libraries' emoji with sibling startup lines

### DIFF
--- a/app.py
+++ b/app.py
@@ -610,7 +610,7 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
                     flush=True,
                 )
 
-    print("  \U0001f4da Loading ML libraries...", flush=True)
+    print("\U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)
     # ``--solo-media-type`` (process-level CLI fallback) tells us which
     # mediaType's default embedder to warm even if no datasets or detectors


### PR DESCRIPTION
## Summary

The `📚 Loading ML libraries...` startup line was indented two spaces, while the other top-level status lines print at column 0:

```
⏳ Initializing VTSearch... (PID 2914929)
🚀 Running in PRODUCTION mode
  📚 Loading ML libraries...        ← misaligned
✅ VTSearch is ready!
```

The 2-space indent (a holdover from before the line had an emoji, when it sat as a bare header above the 4-space-indented import progress bars) left `📚` visibly out of line with the sibling emojis. This drops the indent so it aligns at column 0:

```
⏳ Initializing VTSearch... (PID 2914929)
🚀 Running in PRODUCTION mode
📚 Loading ML libraries...
✅ VTSearch is ready!
```

The nested `Importing scikit-learn…` / `Importing transformers…` progress bars keep their 4-space indent, so the header→sub-step hierarchy still reads correctly.

## Changes

- `app.py`: remove the leading two spaces from the `Loading ML libraries...` print.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W35qp5CF3bbo9ZpVfHj53F

---
_Generated by [Claude Code](https://claude.ai/code/session_01W35qp5CF3bbo9ZpVfHj53F)_