### PR TITLE
Show live file-count progress for the OpenLogo download

### DIFF
--- a/tests_lib/downloads/test_openlogo_download.py
+++ b/tests_lib/downloads/test_openlogo_download.py
@@ -19,7 +19,7 @@ class TestDownloadOpenlogo:
         """download_openlogo pulls the snapshot and returns the openlogo/ directory."""
         from vtscore.datasets import downloader as dl_module
 
-        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token):
+        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class=None):
             d = Path(local_dir)
             (d / "data").mkdir(parents=True, exist_ok=True)
             (d / "data" / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -35,6 +35,40 @@ class TestDownloadOpenlogo:
         assert result.name == "openlogo"
         assert (result / "data").is_dir()
         assert (result / "samples.json").exists()
+
+    def test_reports_measurable_file_progress(self, tmp_path):
+        """The tqdm_class handed to snapshot_download forwards a live file count.
+
+        Every other downloader streams byte-level progress so the UI leads with a
+        count ("497/1.10GB ..."); OpenLogo is thousands of loose files, so it must
+        drive snapshot_download's over-the-files bar instead. Simulate that bar and
+        assert the callback sees a measurable (current, total), not just total=0.
+        """
+        from vtscore.datasets import downloader as dl_module
+
+        events: list = []
+
+        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class):
+            d = Path(local_dir)
+            (d / "data").mkdir(parents=True, exist_ok=True)
+            (d / "data" / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+            (d / "samples.json").write_text('{"samples": []}')
+            # Mimic how snapshot_download drives the over-the-files bar.
+            bar = tqdm_class(total=3)
+            for _ in range(3):
+                bar.update(1)
+            bar.close()
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch("huggingface_hub.snapshot_download", fake_snapshot),
+        ):
+            dl_module.download_openlogo(on_progress=lambda *a: events.append(a))
+
+        measurable = [e for e in events if e[0] == "downloading" and e[3] > 0]
+        assert measurable, f"expected a measurable download event, got {events}"
+        assert measurable[-1] == ("downloading", "Downloading OpenLogo logos", 3, 3)
 
     def test_cached_snapshot_skips_download(self, tmp_path):
         """If samples.json and data/ already exist, snapshot_download is not called."""

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -431,22 +431,42 @@ def download_openlogo(on_progress: Optional[ProgressCallback] = None) -> Path:
         return extract_dir
 
     from huggingface_hub import snapshot_download  # noqa: PLC0415
+    from huggingface_hub.utils import tqdm as _hf_tqdm  # noqa: PLC0415
 
     from vtscore.security.hf_auth import get_token  # noqa: PLC0415
 
     _core.DATA_DIR.mkdir(exist_ok=True)
+    # Brief placeholder while snapshot_download resolves the file list (a network
+    # round-trip before any file is fetched). Kept short and size-first so it
+    # stays legible in the frontend's narrow, ellipsized detail slot; real
+    # per-file progress (below) supersedes it within a second or two.
     on_progress(
         "downloading",
-        f"Downloading OpenLogo (~{_core.OPENLOGO_DOWNLOAD_SIZE_MB // 1024} GB) from HuggingFace...",
+        f"Downloading OpenLogo (~{_core.OPENLOGO_DOWNLOAD_SIZE_MB // 1024} GB)...",
         0,
         0,
     )
+
+    # OpenLogo is thousands of loose files, so there is no single byte stream to
+    # tap like download_file_with_progress does. snapshot_download drives its
+    # over-the-files progress bar through ``tqdm_class``; subclass it to forward
+    # the file count to ``on_progress`` so the UI shows a live, measurable bar
+    # ("1,234/27,000") instead of a static, ellipsized sentence.
+    class _OpenlogoProgress(_hf_tqdm):  # type: ignore[misc, valid-type]
+        def update(self, n: int = 1) -> Optional[bool]:
+            displayed = super().update(n)
+            total = int(self.total or 0)
+            if total > 0:
+                on_progress("downloading", "Downloading OpenLogo logos", int(self.n), total)
+            return displayed
+
     snapshot_download(
         repo_id=_core.OPENLOGO_REPO_ID,
         repo_type="dataset",
         local_dir=str(extract_dir),
         ignore_patterns=["*.gif"],
         token=get_token(),
+        tqdm_class=_OpenlogoProgress,
     )
     return extract_dir
 

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -431,7 +431,7 @@ def download_openlogo(on_progress: Optional[ProgressCallback] = None) -> Path:
         return extract_dir
 
     from huggingface_hub import snapshot_download  # noqa: PLC0415
-    from huggingface_hub.utils import tqdm as _hf_tqdm  # noqa: PLC0415
+    from huggingface_hub.utils.tqdm import tqdm as _hf_tqdm  # noqa: PLC0415
 
     from vtscore.security.hf_auth import get_token  # noqa: PLC0415
 


### PR DESCRIPTION
## Problem

The OpenLogo demo download's progress bar was useless. It emitted a single verbose message — `"Downloading OpenLogo (~4 GB) from HuggingFace..."` — with `total=0`, so the bar stayed **indeterminate** and the whole sentence was crammed into the frontend's fixed **16ch** detail slot (`.jp__detail { flex: 0 0 16ch }`). It ellipsized to a useless `OpenLogo (…` and never updated.

Every *other* downloader streams real progress through `download_file_with_progress`, so its detail slot leads with a count that survives truncation (e.g. `497/1.10GB EuroSAT_RGB.zip`). OpenLogo couldn't use that helper because it's thousands of loose files pulled via `huggingface_hub.snapshot_download`, so it never got a live count.

## Fix

`snapshot_download` drives its over-the-files progress bar through a `tqdm_class` parameter. `download_openlogo` now passes a small `tqdm` subclass that forwards `(current, total)` file counts to `on_progress` with status `"downloading"`, so the UI renders a live, measurable bar (`1,234/27,000 OpenLogo logos`) whose leading count survives the narrow slot — matching the counts-at-front layout every other download already uses.

The pre-resolution placeholder (shown briefly while `snapshot_download` resolves the file list) is also shortened and size-first (`Downloading OpenLogo (~4 GB)...`) so it stays legible before real progress takes over.

No frontend changes: the message flows through the existing `formatProgressHeader` / `job-progress` rendering, which already prioritizes the leading count.

## Tests

- Updated the two existing `fake_snapshot` stubs to accept the new `tqdm_class` kwarg.
- Added `test_reports_measurable_file_progress`, which simulates `snapshot_download` driving the passed `tqdm_class` and asserts the callback receives a measurable `("downloading", "Downloading OpenLogo logos", 3, 3)` rather than a `total=0` sentence.

Full `./run-tests.sh` suite is green (5409 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155Z3UM6rA13pGSaDuS7A8u)_