### PR TITLE
Audit follow-ups: registry double-start, learned-sort cache, exporter temp collision, dead cache API

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -111,7 +111,6 @@ default_concurrent_embeddings  # noqa: F821
 # ---------------------------------------------------------------------------
 find_by_pkl_path  # noqa: F821 - vtscore.datasets.registry
 recreate_model_at_time  # noqa: F821 - vtscore.detectors.labeling_progress
-update_cache_for_cid  # noqa: F821 - vtscore.detectors.labelset_training
 collect_media_origins  # noqa: F821 - vtscore.detectors.training
 train_detector_from_origins  # noqa: F821 - vtscore.detectors.training
 

--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,6 +1,8 @@
 # Comprehensive interface audit — July 2026
 
-**Status: fix pass shipped; open follow-ups below.**
+**Status: initial fix pass shipped; second follow-up pass shipped
+(#2, #6, #10, #14 of the original open list); remaining open follow-ups
+below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -131,82 +133,97 @@ up any of these areas sees the known-weak spots.
 - `uploadServerMediaFile` no longer drops `media_type` when `cropParams`
   is absent.
 
+### Second follow-up pass (drained from the open list)
+
+- **Registry dataset/detector load double-start + half-loaded visibility**
+  (was open #2).  Added an atomic reserve-under-lock step
+  (`begin_load`/`end_load` in `vtscore/datasets/registry.py`,
+  `begin_detector_load`/`end_detector_load` in
+  `vtscore/detectors/registry.py`): only one loader runs per id, so two
+  concurrent `.../load` requests no longer spawn twins.  The deterministic
+  task id is now intentional poll-coalescing (a second caller attaches to
+  the in-flight load).  `register_context` / `register_detector_context`
+  moved to *after* the context is fully populated, so no torn,
+  empty-then-growing context is ever published and the loaded flag is never
+  set ahead of the context store.  Tests in
+  `tests_lib/datasets/test_registry_load_reservation.py` and
+  `tests_lib/detectors/test_detector_load_reservation.py`.
+- **Learned-sort signature/data decorrelation** (was open #6).  The route
+  now freezes the votes at request time (`good_snapshot`/`bad_snapshot`),
+  exactly as region boxes already were, and passes those snapshots to both
+  the signature builder and the background job.  Previously the job copied
+  the live vote proxy at *run* time, so an intervening vote change (or an
+  `ensure_votes_match_active_dataset` rehydrate) cached a result under the
+  wrong signature.  Test in `tests/sorting/test_sorting.py`.
+- **`update_cache_for_cid` dead API removed** (was open #10).  It wrote the
+  media's *primary* vector into the detector-space label-embedding cache and
+  stamped `region=None`; no runtime callers.  Removed the function, its
+  `labelset_ops` re-export, the vulture-whitelist entry, and two stale doc
+  references.
+- **Streaming exporter temp-file collision** (was open #14).  Both
+  `server_json_file` and `server_csv_file` used a fixed `<name>.tmp`
+  sibling; two concurrent exports to the same path clobbered each other.
+  Switched to the house-style `<name>.<pid>.<uuid>.tmp` and added an fsync
+  before the atomic replace.  Tests in `tests/io/test_exporters.py`.
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
-but deferred as needing a design decision or a larger change.
+but deferred as needing a design decision or a larger change.  (Original
+open items #2, #6, #10, #14 were drained in the second follow-up pass — see
+"Second follow-up pass" under What shipped.)
 
 1. **SSE `/api/events` pins a gthread worker thread per connection.**
    With `workers = 1, threads = 8`, eight open tabs starve the whole app;
    stalled requests plus a live heartbeat read as an app hang.  Needs a
    design decision: bound SSE connections, size the pool against them, or
    move the stream off the request-thread pool.
-2. **Registry dataset/detector load: check-then-act double-start and
-   half-loaded context visibility.**  Two concurrent `POST .../load` both
-   pass the `is_loaded` check and spawn twin loads sharing a truncated
-   `task_id`; `register_context(ctx)` runs before the loader populates
-   `ctx.medias`, so concurrent requests can see a torn, partially-loaded
-   dataset (or hit `RuntimeError: dictionary changed size during
-   iteration`).  Same pattern for detector loads
-   (`routes/detectors/registry.py`).
-3. **JobManager cancellation is advisory only.**  No job target reads
+2. **JobManager cancellation is advisory only.**  No job target reads
    `AsyncJob.is_cancelled`, so cancelling a *running* learned-sort/eval
    job never stops the GIL-bound training (the cancelled-pending half was
    fixed in this pass).  Wiring `is_cancelled` into the training loop's
    epoch boundary would make cancel real.
-4. **Staging imports publish through the global `dataset_progress`
+3. **Staging imports publish through the global `dataset_progress`
    singleton** (`load_pipeline.py:_stage_importer_in_background`): two
    concurrent staging imports interleave one channel and the terminal
    `staging_result` is last-writer-wins, orphaning the loser's staged pkl.
    Needs per-task trackers like `_run_origin_load_in_background`.
-5. **Eval progress is a global singleton keyed to no job**
+4. **Eval progress is a global singleton keyed to no job**
    (`routes/eval.py`): overlapping evals decorrelate the progress bar from
    job identity.
-6. **Learned-sort signature/data decorrelation** (`routes/sorting.py`):
-   the background job copies the live vote dicts at *run* time but caches
-   the result under the *request-time* signature; a vote change (or an
-   `ensure_votes_match_active_dataset` rehydrate) in between poisons the
-   `_last_done` cache for later identical-signature requests.
-7. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
+5. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
    dataset where only some media carry `patch_regions`
    (`embedding/matrix.py:_build_region_arrays`): region rows are in the
    patch embedder's space, fallback rows in the primary's.  Needs either an
    ingest guarantee (all-or-nothing patch_regions per dataset) or space
    checking here.
-8. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+6. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
    don't force the full-data `hidden_dim`, always calibrate below 6 labels
    (production uses 0.5), and thread the split RNG into calibration - so
    reported eval costs measure a pipeline production doesn't run in exactly
    the small-label regime the eval characterises.
-9. **Inclusion slide drops the safe-threshold GMM blend**
+7. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-10. **`update_cache_for_cid` is a dead API with a latent bug**
-    (`detectors/labelset_training.py`): it writes the media's *primary*
-    vector into the detector-space label-embedding cache and stamps
-    `region=None` even when the element has a region box.  No runtime
-    callers today - fix or remove before wiring it up.
-11. **Two training entry points disagree at 4-5 labels** with
-    safe-thresholds off: `train_and_threshold` runs real cross-calibration,
-    `_train_and_score_xy` hard-codes 0.5.  Same user state, different
-    cutoff depending on route.
-12. **Dataset registry is not multi-process safe**
-    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
-    name; a concurrent CLI autodetect run against the same data dir can
-    silently erase the server's registrations.  Fine under the documented
-    single-worker model; needs flock if that changes.
-13. **`http_archive` cache never invalidates** when the remote archive
+8. **Two training entry points disagree at 4-5 labels** with
+   safe-thresholds off: `train_and_threshold` runs real cross-calibration,
+   `_train_and_score_xy` hard-codes 0.5.  Same user state, different
+   cutoff depending on route.
+9. **Dataset registry is not multi-process safe**
+   (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
+   name; a concurrent CLI autodetect run against the same data dir can
+   silently erase the server's registrations.  Fine under the documented
+   single-worker model; needs flock if that changes.
+10. **`http_archive` cache never invalidates** when the remote archive
     changes (fixed collision, not staleness); `extract_archive_cached`'s
     mtime/size keying is the model.
-14. **Streaming exporters use a fixed `.tmp` sibling**, so two concurrent
-    exports to the same path clobber each other's temp file.
-15. **Threshold averaging with the abstain sentinel**: a fold returning
+11. **Threshold averaging with the abstain sentinel**: a fold returning
     `NO_GOOD_THRESHOLD` (2.0) now raises the fold mean, possibly above 1.0
     (= abstain overall).  This is the intended lean but the blend weight is
     crude; revisit if precision-biased small-label behaviour looks off.
-16. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+12. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
     rather than clean): browse-canvas/minimap coordinate math and rAF
     lifecycles, modal/player component lifecycle sweep, left/right-panel
     virtualization, and a full route-blueprint sweep of
@@ -224,3 +241,13 @@ but deferred as needing a design decision or a larger change.
 - `JobManager.start()` from a different (user, dataset, detector) than the
   parked pending now supersedes it (pollers of the old job id see
   `cancelled`) instead of silently rebinding their job to the new request.
+- Registry `.../load` while a load of the same id is already in flight now
+  returns `{"message": "… load already in progress"}` with the shared task
+  id (attach + poll) instead of spawning a second loader.  The load task id
+  is the full id (`_regload_<id>` / `_detload_<id>`) rather than an 8-char
+  prefix.  A registered dataset/detector context is published only once
+  fully loaded, so it is no longer briefly visible half-populated.
+- Streaming `server_json_file` / `server_csv_file` exports now write to a
+  `<name>.<pid>.<uuid>.tmp` temp sibling instead of a fixed `<name>.tmp`.
+- `update_cache_for_cid` (unused) was removed from
+  `vtscore.detectors.labelset_training` and the `labelset_ops` re-export.

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -689,9 +689,6 @@ def labelset_train_and_score(
     dataset: DatasetContext,
 ) -> dict[int, float]:
     """Like train_and_score but uses ctx.labelset, not the live vote dicts."""
-
-def update_cache_for_cid(ctx: DetectorContext, cid: int) -> None:
-    """Refresh the label embedding for one media after a vote change."""
 ```
 
 ### Labelset element identity (for cross-dataset label restore)

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -844,3 +844,68 @@ class TestGuiStreaming:
         assert "b9.wav" in captured.out
         assert "b4.wav" not in captured.out
         assert "2 hit(s)" in res["message"]
+
+
+class TestStreamingExportTempCollision:
+    """Regression (audit #14): two concurrent streaming exports to the same
+    destination path must not clobber each other's temp file.
+
+    Both exporters used to build a single fixed ``<name>.tmp`` sibling, so the
+    first export to finish renamed/deleted that shared temp out from under the
+    other — surfacing as ``FileNotFoundError`` from ``os.replace`` (or a
+    corrupted merged file). Each export now writes to a per-writer-unique
+    ``<name>.<pid>.<uuid>.tmp``.
+    """
+
+    def _run_collision(self, exporter_name: str, out: Path) -> None:
+        import threading
+
+        from vtscore.exporters import get_exporter
+
+        a_opened = threading.Event()
+        b_done = threading.Event()
+        a_result: dict[str, object] = {}
+        a_error: list[BaseException] = []
+
+        def a_records():
+            # By the time this iterator is first pulled, export A has already
+            # opened its temp file and written any header. Park here until
+            # export B has fully completed against the same path so we exercise
+            # the collision window.
+            a_opened.set()
+            b_done.wait(timeout=5)
+            yield "dog_bark", {"id": 1, "filename": "a1.wav", "category": "c", "score": 0.5, "label": "good"}
+
+        def run_a():
+            try:
+                a_result["res"] = get_exporter(exporter_name).export_cli_streaming(
+                    _STREAM_HEADER, a_records(), {"filepath": str(out)}
+                )
+            except BaseException as exc:  # noqa: BLE001 - re-raised via assertion
+                a_error.append(exc)
+
+        ta = threading.Thread(target=run_a)
+        ta.start()
+        assert a_opened.wait(timeout=5), "export A never started"
+
+        # Export B runs to completion while A is parked mid-stream.
+        b_res = get_exporter(exporter_name).export_cli_streaming(
+            _STREAM_HEADER, _stream_records(), {"filepath": str(out)}
+        )
+        b_done.set()
+        ta.join(timeout=5)
+
+        assert not a_error, f"export A failed on temp collision: {a_error[0]!r}"
+        assert "3 hit(s)" in b_res["message"]
+        assert "1 hit(s)" in a_result["res"]["message"]  # type: ignore[index]
+        # Destination is intact (last atomic replace wins) and no temp leaked.
+        assert out.exists()
+        assert list(out.parent.glob("*.tmp")) == []
+
+    def test_json_concurrent_exports_to_same_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_collision("server_json_file", Path(tmp) / "hits.ndjson")
+
+    def test_csv_concurrent_exports_to_same_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_collision("server_csv_file", Path(tmp) / "hits.csv")

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -900,3 +900,46 @@ class TestLoadEmbedderConcurrentCallback:
                 _load_embedder_with_progress("audio", 5)
 
         assert mock_emb._on_progress is original_cb
+
+
+class TestLearnedSortVoteSnapshot:
+    """Regression (audit #6): the learned-sort job must train on the votes as
+    they were at *request* time, not whatever the live vote proxy holds when
+    the background job happens to run.
+
+    The signature is computed at request time; if the job re-read the live
+    proxy at run time, a vote change (or an ``ensure_votes_match_active_dataset``
+    rehydrate) in between would cache a result trained on V2 under the key for
+    V1 — poisoning ``_last_done`` for later identical-signature requests.
+    """
+
+    def test_job_uses_request_time_snapshot_not_live_votes(self, client, monkeypatch):
+        from vtscore.concurrency.async_jobs import learned_sort_jobs
+        from vtscore.detectors import learned_sort as ls_mod
+
+        learned_sort_jobs.reset_for_tests()
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        app_module.good_votes.update({1: None, 2: None})
+        app_module.bad_votes.update({3: None})
+
+        captured: dict[str, dict] = {}
+
+        def fake_run(*, good, bad, **_kwargs):
+            # Simulate a vote landing after the request computed its signature
+            # but before/while the job runs: mutate the live proxy.
+            app_module.good_votes[99] = None
+            captured["good"] = dict(good)
+            captured["bad"] = dict(bad)
+            return {1: 0.9, 2: 0.8, 3: 0.1}, 0.5
+
+        monkeypatch.setattr(ls_mod, "run_learned_sort", fake_run)
+
+        resp = client.post("/api/learned-sort", json={"wait": True})
+        assert resp.status_code == 200
+
+        # The job trained on the frozen request-time votes, not the live proxy
+        # that gained id 99 mid-run.
+        assert captured["good"] == {1: None, 2: None}
+        assert 99 not in captured["good"]
+        assert captured["bad"] == {3: None}

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -931,7 +931,7 @@ class TestLearnedSortVoteSnapshot:
             app_module.good_votes[99] = None
             captured["good"] = dict(good)
             captured["bad"] = dict(bad)
-            return {1: 0.9, 2: 0.8, 3: 0.1}, 0.5
+            return [], 0.5
 
         monkeypatch.setattr(ls_mod, "run_learned_sort", fake_run)
 

--- a/tests_lib/datasets/test_registry_load_reservation.py
+++ b/tests_lib/datasets/test_registry_load_reservation.py
@@ -1,0 +1,60 @@
+"""Regression (audit #2): atomic load reservation for the dataset registry.
+
+The ``.../load`` handler used an unguarded check-then-act — it read
+``is_loaded()`` (the flag is only set at the *end* of the loader) and spawned a
+background load. Two concurrent requests both saw ``False`` and started twin
+loaders that shared a task id and raced to register/tear-down the same context.
+``begin_load`` closes that window: the decision and the reservation happen under
+a single lock.
+"""
+
+from __future__ import annotations
+
+from vtscore.datasets import registry
+
+
+class TestDatasetLoadReservation:
+    def test_first_caller_reserves_others_see_in_progress(self):
+        registry.reset_for_tests()
+        ds_id = "a" * 32
+
+        # The first caller wins the race and must run the load.
+        assert registry.begin_load(ds_id) == "reserved"
+        # Concurrent callers see the load already in flight and attach to it
+        # instead of spawning a twin loader.
+        assert registry.begin_load(ds_id) == "in_progress"
+        assert registry.begin_load(ds_id) == "in_progress"
+        # The loaded flag stays False until the loader completes.
+        assert registry.is_loaded(ds_id) is False
+
+    def test_reports_loaded_after_completion(self):
+        registry.reset_for_tests()
+        ds_id = "b" * 32
+
+        assert registry.begin_load(ds_id) == "reserved"
+        # Loader publishes the context, flips the loaded flag, releases the slot.
+        registry.add_loaded_id(ds_id)
+        registry.end_load(ds_id)
+        # Any later caller is told it's already loaded (no reload, no twin).
+        assert registry.begin_load(ds_id) == "loaded"
+
+    def test_failed_load_releases_reservation_for_retry(self):
+        registry.reset_for_tests()
+        ds_id = "c" * 32
+
+        assert registry.begin_load(ds_id) == "reserved"
+        # Load failed: the flag is never set; the worker's ``finally`` releases
+        # the reservation. A retry can reserve again rather than being wedged.
+        registry.end_load(ds_id)
+        assert registry.is_loaded(ds_id) is False
+        assert registry.begin_load(ds_id) == "reserved"
+
+    def test_distinct_ids_are_independent(self):
+        registry.reset_for_tests()
+        first, second = "d" * 32, "e" * 32
+
+        assert registry.begin_load(first) == "reserved"
+        # A different id is not blocked by an in-flight load of another.
+        assert registry.begin_load(second) == "reserved"
+        assert registry.begin_load(first) == "in_progress"
+        assert registry.begin_load(second) == "in_progress"

--- a/tests_lib/detectors/test_detector_load_reservation.py
+++ b/tests_lib/detectors/test_detector_load_reservation.py
@@ -1,0 +1,50 @@
+"""Regression (audit #2): atomic load reservation for the detector registry.
+
+Mirrors the dataset-registry reservation. Two concurrent
+``POST /api/detectors/registry/load`` both passed the ``is_detector_loaded``
+check (the flag is only set at the end of the loader) and spawned twin loaders
+that shared a task id and raced to register/tear-down the same context.
+``begin_detector_load`` closes that window.
+"""
+
+from __future__ import annotations
+
+from vtscore.detectors import registry
+
+
+class TestDetectorLoadReservation:
+    def test_first_caller_reserves_others_see_in_progress(self):
+        registry.reset_for_tests()
+        det_id = "a" * 32
+
+        assert registry.begin_detector_load(det_id) == "reserved"
+        assert registry.begin_detector_load(det_id) == "in_progress"
+        assert registry.begin_detector_load(det_id) == "in_progress"
+        assert registry.is_detector_loaded(det_id) is False
+
+    def test_reports_loaded_after_completion(self):
+        registry.reset_for_tests()
+        det_id = "b" * 32
+
+        assert registry.begin_detector_load(det_id) == "reserved"
+        registry.add_loaded_detector_id(det_id)
+        registry.end_detector_load(det_id)
+        assert registry.begin_detector_load(det_id) == "loaded"
+
+    def test_failed_load_releases_reservation_for_retry(self):
+        registry.reset_for_tests()
+        det_id = "c" * 32
+
+        assert registry.begin_detector_load(det_id) == "reserved"
+        registry.end_detector_load(det_id)
+        assert registry.is_detector_loaded(det_id) is False
+        assert registry.begin_detector_load(det_id) == "reserved"
+
+    def test_distinct_ids_are_independent(self):
+        registry.reset_for_tests()
+        first, second = "d" * 32, "e" * 32
+
+        assert registry.begin_detector_load(first) == "reserved"
+        assert registry.begin_detector_load(second) == "reserved"
+        assert registry.begin_detector_load(first) == "in_progress"
+        assert registry.begin_detector_load(second) == "in_progress"

--- a/vtscore/datasets/registry.py
+++ b/vtscore/datasets/registry.py
@@ -48,6 +48,12 @@ _entries: list[dict[str, Any]] | None = None
 # The set of dataset IDs that are currently loaded in memory.
 _loaded_ids: set[str] = set()
 
+# The set of dataset IDs whose background load is currently in flight.  Used
+# to gate the ``.../load`` handler's check-then-act: without it two concurrent
+# requests both pass the ``is_loaded`` check (the flag is only set at the *end*
+# of the loader) and spawn twin loaders against the same id.
+_loading_ids: set[str] = set()
+
 
 # ---------------------------------------------------------------------------
 # Persistence
@@ -257,6 +263,35 @@ def is_loaded(dataset_id: str) -> bool:
         return dataset_id in _loaded_ids
 
 
+def begin_load(dataset_id: str) -> str:
+    """Atomically claim the right to load *dataset_id*.
+
+    This closes the check-then-act race in the ``.../load`` handler: the
+    decision to load and the reservation happen under a single lock, so two
+    concurrent requests can't both start a loader.
+
+    Returns:
+        ``"loaded"`` – already resident in memory; the caller should no-op.
+        ``"in_progress"`` – another loader is already running; the caller
+            should attach to the existing task instead of spawning a twin.
+        ``"reserved"`` – the caller won the race and must run the load, then
+            call :func:`end_load` once it settles (success or failure).
+    """
+    with _lock:
+        if dataset_id in _loaded_ids:
+            return "loaded"
+        if dataset_id in _loading_ids:
+            return "in_progress"
+        _loading_ids.add(dataset_id)
+        return "reserved"
+
+
+def end_load(dataset_id: str) -> None:
+    """Release the load reservation taken by :func:`begin_load`."""
+    with _lock:
+        _loading_ids.discard(dataset_id)
+
+
 def find_by_pkl_path(pkl_path: str) -> dict[str, Any] | None:
     """Return the entry whose ``pkl_path`` matches, or ``None``."""
     with _lock:
@@ -333,3 +368,4 @@ def reset_for_tests() -> None:
     with _lock:
         _entries = None
         _loaded_ids.clear()
+        _loading_ids.clear()

--- a/vtscore/detectors/labelset_ops.py
+++ b/vtscore/detectors/labelset_ops.py
@@ -48,7 +48,6 @@ from vtscore.detectors.labelset_training import (
     labelset_train_and_score,
     populate_label_embeddings,
     train_from_labelset,
-    update_cache_for_cid,
 )
 
 __all__ = [
@@ -72,5 +71,4 @@ __all__ = [
     "labelset_train_and_score",
     "populate_label_embeddings",
     "train_from_labelset",
-    "update_cache_for_cid",
 ]

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -574,36 +574,3 @@ def labelset_train_and_score(
     # ``train_and_score``).  A no-op for every non-structural dataset.
     results, threshold = maybe_labelset_structural_rerank(det_ctx, labelset, results, threshold, clips_dict)
     return results, threshold, model
-
-
-def update_cache_for_cid(
-    det_ctx,
-    labelset: LabelSet,
-    cid: int,
-    snap: dict[int, dict[str, Any]],
-) -> None:
-    """Refresh the cache entry for whichever labelset element matches *cid*.
-
-    Called after a vote in the active dataset toggles a media item.  Looks
-    up which :class:`LabeledElement` has the same origin as ``snap[cid]``
-    and copies its embedding into the cache.  No-op if the cid isn't
-    represented in the labelset (e.g. the element was just removed).
-    """
-    from vtscore.datasets.labelset import element_key, media_element_key
-    from vtscore.detectors.labelset_elements import stable_element_id
-
-    media = snap.get(cid)
-    if not media:
-        return
-    target_key = media_element_key(media)
-    if target_key is None:
-        return
-    embedding = media_embedding(media)
-    if embedding is None:
-        return
-    for elem in labelset.elements:
-        if element_key(elem) == target_key:
-            eid = stable_element_id(elem)
-            det_ctx.label_embeddings[eid] = np.asarray(embedding)
-            det_ctx.label_embedding_regions[eid] = None
-            return

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -34,6 +34,11 @@ _entries: list[dict[str, Any]] | None = None
 # Set of detector IDs currently loaded in memory (each has a DetectorContext).
 _loaded_ids: set[str] = set()
 
+# Detector IDs whose background load is currently in flight.  Gates the
+# ``.../load`` handler's check-then-act (the loaded flag is only set at the end
+# of the loader, so two concurrent loads would otherwise both start).
+_loading_ids: set[str] = set()
+
 
 # ---------------------------------------------------------------------------
 # Persistence
@@ -308,6 +313,29 @@ def is_detector_loaded(detector_id: str) -> bool:
         return detector_id in _loaded_ids
 
 
+def begin_detector_load(detector_id: str) -> str:
+    """Atomically claim the right to load *detector_id*.
+
+    Mirrors :func:`vtscore.datasets.registry.begin_load`.  Returns ``"loaded"``
+    if the detector is already resident, ``"in_progress"`` if another loader is
+    already running (attach to its task), or ``"reserved"`` if the caller won
+    the race and must run the load then call :func:`end_detector_load`.
+    """
+    with _lock:
+        if detector_id in _loaded_ids:
+            return "loaded"
+        if detector_id in _loading_ids:
+            return "in_progress"
+        _loading_ids.add(detector_id)
+        return "reserved"
+
+
+def end_detector_load(detector_id: str) -> None:
+    """Release the load reservation taken by :func:`begin_detector_load`."""
+    with _lock:
+        _loading_ids.discard(detector_id)
+
+
 def get_loaded_detector_ids() -> set[str]:
     """Return a copy of all loaded detector IDs."""
     with _lock:
@@ -348,3 +376,4 @@ def reset_for_tests() -> None:
     with _lock:
         _entries = None
         _loaded_ids.clear()
+        _loading_ids.clear()

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -367,13 +367,6 @@ but trains on the full labelset (cross-dataset labels) and scores only
 the active `clips_dict`. Returns the same `(results, threshold, model)`
 tuple.
 
-### `update_cache_for_cid(det_ctx, labelset, cid, snap)`
-
-`vtscore/detectors/labelset_training.py:316`. Refresh the cache entry
-for whichever labelset element corresponds to one cid. Called after a
-vote toggles a media item in the active dataset, so the labelset's
-training vector tracks the live embedding.
-
 ---
 
 ## Element identity (cross-dataset label restore)

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -14,6 +14,7 @@ import csv
 import io
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -125,14 +126,18 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
 
         Uses a fixed column superset (see :attr:`_STREAM_COLUMNS`) because a
         streaming writer cannot look ahead to decide which optional clip
-        columns are present.  The file is built at a sibling ``.tmp`` path and
-        atomically renamed on success.
+        columns are present.  The file is built at a per-writer-unique sibling
+        ``.tmp`` path and atomically renamed on success, so two concurrent
+        exports to the same path can't clobber each other's temp file.
         """
         from vtscore.datasets.origin import Origin  # noqa: PLC0415
 
         filepath = Path(field_values["filepath"])
         filepath.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = filepath.with_name(filepath.name + ".tmp")
+        # Per-writer unique suffix (pid + uuid) so two threads/processes racing
+        # to export the same path can't truncate each other's in-flight tmp or
+        # chase one already renamed away.  Matches vtscore.io.atomic_write_text.
+        tmp_path = filepath.with_name(f"{filepath.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
 
         thresholds = {d.get("detector_name", ""): d.get("threshold", "") for d in header.get("detectors", [])}
 
@@ -161,6 +166,8 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                         ]
                     )
                     total_hits += 1
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, filepath)
         finally:
             if tmp_path.exists():

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -93,13 +94,17 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
         The first line is a metadata object describing the run; every
         subsequent line is a single hit with its ``detector`` name merged in.
         Lines are flushed as they stream, so the full result set is never
-        held in memory.  The file is built at a sibling ``.tmp`` path and
-        atomically renamed on success, so a crash mid-run cannot leave a
-        half-written file at the destination.
+        held in memory.  The file is built at a per-writer-unique sibling
+        ``.tmp`` path and atomically renamed on success, so a crash mid-run
+        cannot leave a half-written file at the destination and two concurrent
+        exports to the same path can't clobber each other's temp file.
         """
         filepath = Path(field_values["filepath"])
         filepath.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = filepath.with_name(filepath.name + ".tmp")
+        # Per-writer unique suffix (pid + uuid) so two threads/processes racing
+        # to export the same path can't truncate each other's in-flight tmp or
+        # chase one already renamed away.  Matches vtscore.io.atomic_write_text.
+        tmp_path = filepath.with_name(f"{filepath.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
 
         meta = {
             "format": "vtsearch-hits-ndjson/v1",
@@ -115,6 +120,8 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
                 for detector_name, hit in records:
                     f.write(json.dumps({"detector": detector_name, **hit}) + "\n")
                     total_hits += 1
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, filepath)
         finally:
             # Clean up the temp file if the rename never happened (e.g. an

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -35,7 +35,9 @@ from vtscore.datasets.load_pipeline import _warmup_embedder_async
 from vtscore.datasets.loader import load_dataset_from_pickle
 from vtscore.datasets.registry import (
     add_loaded_id as _reg_add_loaded,
+    begin_load as _reg_begin_load,
     can_user_access as _reg_can_access,
+    end_load as _reg_end_load,
     get_dataset as _reg_get,
     is_loaded as _reg_is_loaded,
     is_owner as _reg_is_owner,
@@ -158,18 +160,29 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     if not _reg_can_access(dataset_id, get_current_user()):
         abort(403, message="Access denied")
 
-    # If already loaded in memory, nothing to do.
-    if _reg_is_loaded(dataset_id):
+    # Atomically decide our role.  This closes the check-then-act race where
+    # two concurrent loads both saw ``is_loaded()`` False (the flag is only set
+    # at the *end* of the loader) and spawned twin loaders sharing one task id.
+    # The task id is a pure function of the dataset id so a second caller that
+    # finds a load already in progress can attach to the same tracker.
+    task_id = f"_regload_{dataset_id}"
+    load_role = _reg_begin_load(dataset_id)
+    if load_role == "loaded":
         return {"ok": True, "message": "Dataset already loaded", "task_id": ""}
+    if load_role == "in_progress":
+        return {"ok": True, "message": "Dataset load already in progress", "task_id": task_id}
 
+    # load_role == "reserved": we own the load.  Release the reservation on any
+    # early failure below (and in the worker's ``finally``) so a retry isn't
+    # permanently blocked.
     pkl_path = entry.get("pkl_path", "")
     if not pkl_path or not Path(pkl_path).is_file():
+        _reg_end_load(dataset_id)
         abort(404, message=f"Saved dataset file not found: {pkl_path}")
 
     _LOAD_STEPS = 2  # step 1: load items (read + dedup); step 2: diversity index
 
     # Create a per-task tracker for this load operation.
-    task_id = f"_regload_{dataset_id[:8]}"
     tracker = _loading_tasks.create_task(
         task_id,
         entry.get("name", dataset_id),
@@ -203,8 +216,12 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
             try:
                 tracker.update("loading", "Preparing…", 0, 0, step=1, total_steps=_LOAD_STEPS)
                 # Create a fresh context for this dataset (don't activate yet).
+                # It is NOT registered until fully populated below: publishing an
+                # empty-then-growing ctx into the global store lets concurrent
+                # requests observe a torn, half-loaded dataset (or hit
+                # "dictionary changed size during iteration" while the loader
+                # mutates ctx.medias unlocked).
                 ctx = DatasetContext(dataset_id)
-                register_context(ctx)
                 gc.collect()
 
                 # Set thread-local progress for the pickle loader.
@@ -268,6 +285,10 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 # bar reaches 100% cleanly instead of stalling at the step-1
                 # boundary when the tree restored without emitting any progress.
                 tracker.update("loading", "Finalizing…", current=1, total=1, step=2, total_steps=_LOAD_STEPS)
+                # Publish the fully-populated context, THEN flip the loaded flag,
+                # so there is never a moment where _loaded_ids says "loaded" but
+                # the context store lacks it (or holds a half-filled one).
+                register_context(ctx)
                 _reg_add_loaded(dataset_id)
                 # Update item count and dupe count in case they changed
                 num_dupes = sum(
@@ -302,6 +323,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
             finally:
                 clear_thread_progress()
+                _reg_end_load(dataset_id)
                 _loading_tasks.mark_finished(task_id)
 
     from vtsearch.threading import spawn

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -354,8 +354,16 @@ def _run_detector_load_task(
     values are passed explicitly.
     """
     from vtscore.concurrency.progress import CancelledError, detector_loading_tasks
-    from vtscore.detectors.registry import add_loaded_detector_id, remove_loaded_detector_id
-    from vtscore.state.core import thread_dataset_context, thread_detector_context
+    from vtscore.detectors.registry import (
+        add_loaded_detector_id,
+        end_detector_load,
+        remove_loaded_detector_id,
+    )
+    from vtscore.state.core import (
+        register_detector_context,
+        thread_dataset_context,
+        thread_detector_context,
+    )
 
     try:
         with thread_dataset_context(thread_ds_ctx), thread_detector_context(det_ctx):
@@ -445,6 +453,10 @@ def _run_detector_load_task(
                 # subsequent dataset switches and re-derive against the new
                 # dataset's medias.
                 det_ctx.votes_dataset_id = thread_ds_ctx.dataset_id
+                # Publish the fully-populated context, THEN flip the loaded flag,
+                # so there is never a window where the detector is marked loaded
+                # but its context is absent or half-filled in the global store.
+                register_detector_context(det_ctx)
                 add_loaded_detector_id(detector_id)
                 tracker.update("idle", "", 0, 0, step=None, total_steps=None)
             except CancelledError:
@@ -464,6 +476,7 @@ def _run_detector_load_task(
                 error_msg = str(e) or repr(e) or "Unknown error during detector loading"
                 tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
     finally:
+        end_detector_load(detector_id)
         detector_loading_tasks.mark_finished(task_id)
 
 
@@ -489,6 +502,29 @@ def _unload_active_detector() -> dict:
     return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
 
 
+def _reembed_or_ack_loaded_detector(detector_id: str, entry: dict) -> dict:
+    """Handle a load request for a detector already resident in memory.
+
+    Its cached label embeddings may have been built against a different embedder
+    than the currently-active dataset uses (e.g. the user switched from a SigLIP
+    image dataset to a CLIP one). Re-embed the labels in that case so MLP
+    training mixes only same-space vectors; the invalidation itself happens
+    inside ``populate_label_embeddings``, this just surfaces the work via a
+    progress task instead of letting it run lazily inside the next request.
+    Otherwise it's a no-op acknowledgement.
+    """
+    from vtscore.detectors.embedder_sync import maybe_start_label_reembed
+    from vtsearch.state import get_active_detector_context
+    from vtsearch.threading import spawn
+
+    det_ctx_existing = get_active_detector_context()
+    if det_ctx_existing.detector_id == detector_id:
+        task_id = maybe_start_label_reembed(det_ctx_existing, entry, spawn=spawn)
+        if task_id is not None:
+            return {"ok": True, "message": "Re-embedding labels", "task_id": task_id}
+    return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
+
+
 @detectors_registry_bp.route("/api/detectors/registry/load", methods=["POST"])
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
@@ -501,16 +537,14 @@ def load_detector_route(body: dict):
     detector without loading another one.
     """
     from vtscore.detectors.registry import (
+        begin_detector_load,
         can_user_access_detector,
         get_detector,
-        is_detector_loaded,
     )
     from vtsearch.state import (
         DetectorContext,
         bad_votes,
-        get_active_detector_context,
         good_votes,
-        register_detector_context,
     )
 
     detector_id = body.get("detector_id")
@@ -528,40 +562,32 @@ def load_detector_route(body: dict):
     if detector_id is None:
         return _unload_active_detector()
 
-    if is_detector_loaded(detector_id):
-        # Detector is already in memory, but its cached label embeddings may
-        # have been built against a different embedder than the one the
-        # currently-active dataset uses (e.g. user switched from an image
-        # dataset embedded with SigLIP to one embedded with CLIP). Re-embed
-        # the labels in that case so MLP training mixes only same-space
-        # vectors. The cache invalidation itself happens inside
-        # ``populate_label_embeddings``; this branch just makes the work
-        # visible via a progress task instead of letting it run lazily
-        # inside the next vote or learned-sort request.
-        from vtscore.detectors.embedder_sync import maybe_start_label_reembed
-        from vtsearch.threading import spawn
+    # Atomically decide our role, closing the check-then-act race where two
+    # concurrent loads both saw the detector unloaded (the loaded flag is only
+    # set at the end of the loader) and spawned twin loaders.
+    load_role = begin_detector_load(detector_id)
+    if load_role == "in_progress":
+        return {
+            "ok": True,
+            "message": "Detector load already in progress",
+            "task_id": f"_detload_{detector_id}",
+        }
 
-        det_ctx_existing = get_active_detector_context()
-        if det_ctx_existing.detector_id == detector_id:
-            task_id = maybe_start_label_reembed(det_ctx_existing, entry, spawn=spawn)
-            if task_id is not None:
-                return {
-                    "ok": True,
-                    "message": "Re-embedding labels",
-                    "task_id": task_id,
-                }
-        return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
+    if load_role == "loaded":
+        return _reembed_or_ack_loaded_detector(detector_id, entry)
 
     from vtscore.concurrency.progress import detector_loading_tasks
 
+    # Build the context but do NOT register it yet: the worker publishes it into
+    # the global store only after labels/embeddings/MLP are populated, so no
+    # concurrent request can observe a torn, empty-then-filling detector.
     det_ctx = DetectorContext(
         detector_id,
         name=entry.get("name", ""),
         media_type=entry.get("media_type", ""),
     )
-    register_detector_context(det_ctx)
 
-    task_id = f"_detload_{detector_id[:8]}"
+    task_id = f"_detload_{detector_id}"
     tracker = detector_loading_tasks.create_task(
         task_id,
         entry.get("name", detector_id),

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -304,7 +304,16 @@ def learned_sort(body: dict):
     ds_ctx = get_active_context()
     labelset, det_media_type = resolve_active_labelset(det_ctx)
 
-    _validate_learned_sort_inputs(labelset, good_votes, bad_votes)
+    # Freeze the votes at request time, exactly as region boxes already are.
+    # good_votes/bad_votes are lazy context proxies; if we passed them live,
+    # the signature would capture request-time membership while the background
+    # job's dict(good)/dict(bad) copy at run time could see a different set
+    # (a vote POST or an ensure_votes_match_active_dataset rehydrate in
+    # between), poisoning _last_done: key says V1, result trained on V2.
+    good_snapshot = dict(good_votes)
+    bad_snapshot = dict(bad_votes)
+
+    _validate_learned_sort_inputs(labelset, good_snapshot, bad_snapshot)
 
     inclusion_value = get_inclusion()
     safe_thresholds_value = get_safe_thresholds()
@@ -317,8 +326,8 @@ def learned_sort(body: dict):
         ds_ctx=ds_ctx,
         snap=snap,
         labelset=labelset,
-        good=good_votes,
-        bad=bad_votes,
+        good=good_snapshot,
+        bad=bad_snapshot,
         region_boxes_snapshot=region_boxes_snapshot,
         inclusion_value=inclusion_value,
         safe_thresholds_value=safe_thresholds_value,
@@ -340,8 +349,8 @@ def learned_sort(body: dict):
             snap=snap,
             labelset=labelset,
             det_media_type=det_media_type,
-            good=good_votes,
-            bad=bad_votes,
+            good=good_snapshot,
+            bad=bad_snapshot,
             region_boxes_snapshot=region_boxes_snapshot,
             inclusion_value=inclusion_value,
             safe_thresholds_value=safe_thresholds_value,


### PR DESCRIPTION
Drains four concrete open follow-ups (#2, #6, #10, #14) from `docs/plans/comprehensive-audit-2026-07.md`. Each was found and verified during the July 2026 interface audit but deferred as a well-scoped fix.

## #2 — Registry load double-start + half-loaded context visibility
`POST /api/datasets/registry/<id>/load` and `POST /api/detectors/registry/load` used an unguarded check-then-act: `is_loaded()` is only flipped at the *end* of the background loader, so two concurrent requests both saw `False`, spawned twin loaders sharing a truncated task id, and both raced to register/tear-down the same context.

- New atomic reserve-under-lock primitives: `begin_load`/`end_load` (`vtscore/datasets/registry.py`) and `begin_detector_load`/`end_detector_load` (`vtscore/detectors/registry.py`). Only one loader runs per id; a concurrent caller is told the load is already in progress and attaches to the same (now full-id) task to poll.
- `register_context` / `register_detector_context` moved to run **after** the context is fully populated, so a torn, empty-then-growing context is never published and the loaded flag is never set ahead of the context store (closes the `RuntimeError: dictionary changed size during iteration` window).

## #6 — Learned-sort signature/data decorrelation
`routes/sorting.py` computed the cache signature from the live vote proxies at request time but the background job copied them again at run time. A vote change (or an `ensure_votes_match_active_dataset` rehydrate) in between cached a result trained on the new votes under the old signature — poisoning `_last_done`. Votes are now frozen at request time (`good_snapshot`/`bad_snapshot`), mirroring the existing `region_boxes_snapshot`, and both the signature and the job use the snapshot.

## #10 — Remove dead `update_cache_for_cid`
It wrote the media's *primary* vector into the detector-space label-embedding cache and stamped `region=None` even for region-boxed elements. No runtime callers. Removed the function, its `labelset_ops` re-export, the vulture-whitelist entry, and two stale doc references.

## #14 — Streaming exporter temp-file collision
`server_json_file` and `server_csv_file` used a fixed `<name>.tmp` sibling; two concurrent exports to the same path clobbered each other (surfacing as `FileNotFoundError` from `os.replace`). Switched to the house-style `<name>.<pid>.<uuid>.tmp` and added an fsync before the atomic replace.

## Tests
- `tests_lib/datasets/test_registry_load_reservation.py`, `tests_lib/detectors/test_detector_load_reservation.py` — reservation primitives.
- `tests/sorting/test_sorting.py` — learned-sort trains on the request-time vote snapshot, not a mid-run mutation.
- `tests/io/test_exporters.py` — two concurrent same-path streaming exports both succeed and leave no stray temp.

Full `./run-tests.sh` passes (5448 passed, 1 skipped).

## Backwards compatibility
- A `.../load` while a load of the same id is in flight now returns `{"message": "… load already in progress"}` with the shared task id instead of starting a second loader; the load task id is the full id (`_regload_<id>` / `_detload_<id>`).
- Streaming exports write to a `<name>.<pid>.<uuid>.tmp` sibling instead of `<name>.tmp`.
- `update_cache_for_cid` removed from `vtscore.detectors.labelset_training` and the `labelset_ops` re-export.

The plan doc is updated: the four items move from "Open follow-ups" into "What shipped → Second follow-up pass", and the remaining open items are renumbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KKxkeZ49fpxFWbz5yfQhm

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKxkeZ49fpxFWbz5yfQhm)_