### PR TITLE
Parallelize OpenLogo download across its ~27k loose files

### DIFF
--- a/tests_lib/downloads/test_openlogo_download.py
+++ b/tests_lib/downloads/test_openlogo_download.py
@@ -19,7 +19,7 @@ class TestDownloadOpenlogo:
         """download_openlogo pulls the snapshot and returns the openlogo/ directory."""
         from vtscore.datasets import downloader as dl_module
 
-        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class=None):
+        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class=None, max_workers=8):
             d = Path(local_dir)
             (d / "data").mkdir(parents=True, exist_ok=True)
             (d / "data" / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -36,6 +36,34 @@ class TestDownloadOpenlogo:
         assert (result / "data").is_dir()
         assert (result / "samples.json").exists()
 
+    def test_forwards_widened_worker_count(self, tmp_path):
+        """The download parallelizes across OpenLogo's ~27k tiny files.
+
+        With no single archive to stream, wall-clock is dominated by per-file
+        request latency, so we widen snapshot_download's default of 8 workers.
+        Assert the configured count is forwarded rather than left at the default.
+        """
+        from vtscore.datasets import downloader as dl_module
+
+        captured: dict = {}
+
+        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class=None, max_workers=8):
+            captured["max_workers"] = max_workers
+            d = Path(local_dir)
+            (d / "data").mkdir(parents=True, exist_ok=True)
+            (d / "data" / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+            (d / "samples.json").write_text('{"samples": []}')
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch("huggingface_hub.snapshot_download", fake_snapshot),
+        ):
+            dl_module.download_openlogo(on_progress=lambda *a: None)
+
+        assert captured["max_workers"] == dl_module.core.OPENLOGO_DOWNLOAD_WORKERS
+        assert captured["max_workers"] > 8
+
     def test_reports_measurable_file_progress(self, tmp_path):
         """The tqdm_class handed to snapshot_download forwards a live file count.
 
@@ -48,7 +76,7 @@ class TestDownloadOpenlogo:
 
         events: list = []
 
-        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class):
+        def fake_snapshot(*, repo_id, repo_type, local_dir, ignore_patterns, token, tqdm_class, max_workers=8):
             d = Path(local_dir)
             (d / "data").mkdir(parents=True, exist_ok=True)
             (d / "data" / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -129,6 +129,10 @@ ROXFORD_GND_URL = "https://cmp.felk.cvut.cz/revisitop/data/datasets/roxford5k/gn
 # with ``huggingface_hub.snapshot_download`` rather than the single-URL helper,
 # and parsed from ``samples.json`` with the stdlib (no ``fiftyone`` dependency).
 OPENLOGO_REPO_ID = "Voxel51/OpenLogo"
+# Parallel workers for the OpenLogo snapshot. With ~27k tiny files the download is
+# latency-bound on per-file round trips, so we widen snapshot_download's default of
+# 8 to fetch many concurrently. Kept modest to stay under HF's public rate limits.
+OPENLOGO_DOWNLOAD_WORKERS = 16
 
 # Visual Genome (v1.4): a multi-label scene dataset of ~108k dense-annotated
 # photos.  Images ship as two zips (the historical VG_100K / VG_100K_2 splits);

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -463,6 +463,11 @@ def download_openlogo(on_progress: Optional[ProgressCallback] = None) -> Path:
                 on_progress("downloading", "Downloading OpenLogo logos", int(self.n), total)
             return displayed
 
+    # ~27k loose files means the wall-clock cost is dominated by per-file request
+    # latency (resolve -> 302 -> CDN GET), not bandwidth, so fetch many at once.
+    # snapshot_download defaults to 8 workers; widen it to parallelize across the
+    # round trips. The dataset is public, so this is bounded by HF rate limits
+    # rather than auth — 16 is a comfortable margin below where those bite.
     snapshot_download(
         repo_id=_core.OPENLOGO_REPO_ID,
         repo_type="dataset",
@@ -470,6 +475,7 @@ def download_openlogo(on_progress: Optional[ProgressCallback] = None) -> Path:
         ignore_patterns=["*.gif"],
         token=get_token(),
         tqdm_class=_OpenlogoProgress,
+        max_workers=_core.OPENLOGO_DOWNLOAD_WORKERS,
     )
     return extract_dir
 


### PR DESCRIPTION
## What & why

Investigating a report that the **OpenLogo** demo dataset downloads very slowly ("is it not using my HF auth?"). Two findings:

1. **Auth is wired correctly and is not the problem.** `download_openlogo` already passes `token=get_token()` to `snapshot_download`, so a signed-in user's HF token is attached. But OpenLogo (`Voxel51/OpenLogo`) is a **public** dataset — HF auth only governs gated-repo access and rate-limit headroom, never per-file throughput. Signing in cannot make it faster.

2. **The slowness is structural.** OpenLogo ships as **~27,000 loose JPEGs (~4.6 GB)** with no single archive, so `snapshot_download` fetches file-by-file. Wall-clock is dominated by per-file request latency (`resolve/` → 302 → CDN GET), not bandwidth — the classic HuggingFace "lots of tiny files" pathology. The call left `max_workers` at `snapshot_download`'s default of **8**.

## Change

Widen the OpenLogo snapshot to **16** parallel workers (new `OPENLOGO_DOWNLOAD_WORKERS` constant in `core.py`), so the 27k round trips run concurrently — the single biggest lever for a many-small-files repo. Kept modest to stay comfortably under HF's public rate limits. (`hf_transfer` was considered but barely helps here, since it accelerates *large* single files, not many small ones.)

## Tests

- New `test_forwards_widened_worker_count` asserts the configured count is forwarded and exceeds the old default of 8.
- Existing `fake_snapshot` mocks updated to accept the new `max_workers` kwarg.
- `./run-tests.sh downloads` → all 186 pass (ruff/format/codespell/deptry/wiring gates green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLQr53WXDen8NnX2jzvmrC)_