### PR TITLE
Make JobManager cancellation stop running jobs (audit follow-up)

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,8 +1,9 @@
 # Comprehensive interface audit — July 2026
 
 **Status: initial fix pass shipped; second follow-up pass shipped
-(#2, #6, #10, #14 of the original open list); remaining open follow-ups
-below.**
+(#2, #6, #10, #14 of the original open list); third follow-up pass shipped
+(JobManager cancellation now stops running jobs — was open #2 of the
+renumbered list); remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -166,64 +167,85 @@ up any of these areas sees the known-weak spots.
   Switched to the house-style `<name>.<pid>.<uuid>.tmp` and added an fsync
   before the atomic replace.  Tests in `tests/io/test_exporters.py`.
 
+### Third follow-up pass (drained from the open list)
+
+- **JobManager cancellation now stops running jobs** (was renumbered open
+  #2).  Cancelling a *running* learned-sort / eval job previously only set
+  `AsyncJob.is_cancelled`, which no job target read, so the GIL-bound
+  training kept running to completion (the cancelled-*pending* half was
+  already fixed in the initial pass; both cancel routes' docstrings already
+  *claimed* the loop "polls it cooperatively", but nothing did).  Added a
+  thread-local job binding in `vtscore/concurrency/async_jobs.py`
+  (`bind_job_cancellation` / `check_job_cancelled`, entered for the
+  worker-thread lifetime in `JobManager._run`).  The deep compute loops now
+  poll it at their natural boundaries — the MLP epoch boundary in
+  `vtscore/training/mlp.py:train_model` and the per-step retrain boundary in
+  `vtscore/detectors/labeling_progress.py:_ensure_cache`.  A poll raises the
+  existing `CancelledError`, which unwinds the training/eval stack and is
+  caught in `_run_inner` to mark the job `cancelled` (never caching its
+  half-built result via `_last_done`) and hand off to any parked pending.
+  The check is a no-op outside a bound job, so the synchronous Find flow,
+  tests, and CLI that share `train_model` are unaffected.  The eval `_run`
+  now clears the progress bar to `"Cancelled"` rather than `"Error"`.
+  Tests in `tests_lib/integration/test_async_jobs.py`
+  (`TestCheckJobCancelledPrimitive`, `TestRunningJobCancellation`) and
+  `tests_lib/detectors/test_mlp_training.py` (`TestJobCancellation`).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
 but deferred as needing a design decision or a larger change.  (Original
-open items #2, #6, #10, #14 were drained in the second follow-up pass — see
-"Second follow-up pass" under What shipped.)
+open items #2, #6, #10, #14 were drained in the second follow-up pass, and
+the renumbered #2 "JobManager cancellation advisory" in the third pass — see
+the follow-up-pass subsections under What shipped.  The list below is
+renumbered again after that drain.)
 
 1. **SSE `/api/events` pins a gthread worker thread per connection.**
    With `workers = 1, threads = 8`, eight open tabs starve the whole app;
    stalled requests plus a live heartbeat read as an app hang.  Needs a
    design decision: bound SSE connections, size the pool against them, or
    move the stream off the request-thread pool.
-2. **JobManager cancellation is advisory only.**  No job target reads
-   `AsyncJob.is_cancelled`, so cancelling a *running* learned-sort/eval
-   job never stops the GIL-bound training (the cancelled-pending half was
-   fixed in this pass).  Wiring `is_cancelled` into the training loop's
-   epoch boundary would make cancel real.
-3. **Staging imports publish through the global `dataset_progress`
+2. **Staging imports publish through the global `dataset_progress`
    singleton** (`load_pipeline.py:_stage_importer_in_background`): two
    concurrent staging imports interleave one channel and the terminal
    `staging_result` is last-writer-wins, orphaning the loser's staged pkl.
    Needs per-task trackers like `_run_origin_load_in_background`.
-4. **Eval progress is a global singleton keyed to no job**
+3. **Eval progress is a global singleton keyed to no job**
    (`routes/eval.py`): overlapping evals decorrelate the progress bar from
    job identity.
-5. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
+4. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
    dataset where only some media carry `patch_regions`
    (`embedding/matrix.py:_build_region_arrays`): region rows are in the
    patch embedder's space, fallback rows in the primary's.  Needs either an
    ingest guarantee (all-or-nothing patch_regions per dataset) or space
    checking here.
-6. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+5. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
    don't force the full-data `hidden_dim`, always calibrate below 6 labels
    (production uses 0.5), and thread the split RNG into calibration - so
    reported eval costs measure a pipeline production doesn't run in exactly
    the small-label regime the eval characterises.
-7. **Inclusion slide drops the safe-threshold GMM blend**
+6. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-8. **Two training entry points disagree at 4-5 labels** with
+7. **Two training entry points disagree at 4-5 labels** with
    safe-thresholds off: `train_and_threshold` runs real cross-calibration,
    `_train_and_score_xy` hard-codes 0.5.  Same user state, different
    cutoff depending on route.
-9. **Dataset registry is not multi-process safe**
+8. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-10. **`http_archive` cache never invalidates** when the remote archive
+9. **`http_archive` cache never invalidates** when the remote archive
     changes (fixed collision, not staleness); `extract_archive_cached`'s
     mtime/size keying is the model.
-11. **Threshold averaging with the abstain sentinel**: a fold returning
+10. **Threshold averaging with the abstain sentinel**: a fold returning
     `NO_GOOD_THRESHOLD` (2.0) now raises the fold mean, possibly above 1.0
     (= abstain overall).  This is the intended lean but the blend weight is
     crude; revisit if precision-biased small-label behaviour looks off.
-12. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+11. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
     rather than clean): browse-canvas/minimap coordinate math and rAF
     lifecycles, modal/player component lifecycle sweep, left/right-panel
     virtualization, and a full route-blueprint sweep of
@@ -251,3 +273,8 @@ open items #2, #6, #10, #14 were drained in the second follow-up pass — see
   `<name>.<pid>.<uuid>.tmp` temp sibling instead of a fixed `<name>.tmp`.
 - `update_cache_for_cid` (unused) was removed from
   `vtscore.detectors.labelset_training` and the `labelset_ops` re-export.
+- Cancelling a *running* learned-sort / eval job now actually stops it
+  (transitions to `cancelled` within one epoch / eval step and never caches
+  the partial result) instead of running to completion with the cancel
+  ignored.  The eval progress bar reports `"Cancelled"` on a running-job
+  cancel rather than `"Error"`.

--- a/tests_lib/detectors/test_mlp_training.py
+++ b/tests_lib/detectors/test_mlp_training.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import torch
 
+from vtscore.concurrency.async_jobs import AsyncJob, bind_job_cancellation
+from vtscore.concurrency.progress import CancelledError
 from vtscore.training.mlp import train_model
 
 
@@ -52,3 +54,32 @@ class TestSingleClassGuard:
         X, y = _balanced_xy()
         model = train_model(X, y, input_dim=8, hidden_dim=4)
         assert next(model.parameters()).device.type in {"cpu", "cuda", "mps"}
+
+
+class TestJobCancellation:
+    """The epoch loop must honour a cancel of the background job that owns
+    the worker thread, so cancelling a *running* learned-sort/eval job
+    actually stops the GIL-bound training instead of merely being advisory.
+    """
+
+    def test_cancelled_bound_job_aborts_at_epoch_boundary(self):
+        X, y = _balanced_xy()
+        job = AsyncJob(job_id="j1")
+        job.cancel()  # already cancelled before the first epoch runs
+        with bind_job_cancellation(job):  # noqa: SIM117
+            with pytest.raises(CancelledError):
+                train_model(X, y, input_dim=8, hidden_dim=4)
+
+    def test_uncancelled_bound_job_trains_normally(self):
+        """A bound-but-not-cancelled job must not disturb the happy path."""
+        X, y = _balanced_xy()
+        job = AsyncJob(job_id="j2")
+        with bind_job_cancellation(job):
+            model = train_model(X, y, input_dim=8, hidden_dim=4)
+        assert next(model.parameters()).device.type in {"cpu", "cuda", "mps"}
+
+    def test_no_binding_trains_normally(self):
+        """Outside any job the epoch-boundary check is a pure no-op."""
+        X, y = _balanced_xy()
+        model = train_model(X, y, input_dim=8, hidden_dim=4)
+        assert sum(p.numel() for p in model.parameters()) > 0

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -16,8 +16,18 @@ The manager must guarantee:
 from __future__ import annotations
 
 import threading
+import time
 
-from vtscore.concurrency.async_jobs import AsyncJob, JobManager
+import pytest
+
+from vtscore.concurrency.async_jobs import (
+    AsyncJob,
+    JobManager,
+    bind_job_cancellation,
+    check_job_cancelled,
+    current_job,
+)
+from vtscore.concurrency.progress import CancelledError
 from vtscore.state.core import (
     DatasetContext,
     DetectorContext,
@@ -481,3 +491,118 @@ class TestThreadContextPropagation:
         finally:
             unregister_context("ds-ctx-B")
             unregister_detector_context("det-ctx-B")
+
+
+def _cancellable_target(started: threading.Event, marker: list):
+    """Return a target that polls ``check_job_cancelled`` until cancelled.
+
+    The loop is unbounded, so it exits *only* via ``CancelledError`` (never
+    by running out of iterations before the cancel arrives) - the pattern
+    CLAUDE.md prescribes for interruptible work.
+    """
+
+    def target(job: AsyncJob) -> None:
+        started.set()
+        marker.append("start")
+        while True:  # exits only via CancelledError
+            check_job_cancelled()
+            time.sleep(0.01)
+
+    return target
+
+
+class TestCheckJobCancelledPrimitive:
+    """Unit coverage for the thread-local cancellation binding used by the
+    deep training / eval loops."""
+
+    def test_noop_without_binding(self):
+        assert current_job() is None
+        check_job_cancelled()  # must not raise when nothing is bound
+
+    def test_bound_uncancelled_job_does_not_raise(self):
+        job = AsyncJob(job_id="j")
+        with bind_job_cancellation(job):
+            assert current_job() is job
+            check_job_cancelled()  # not cancelled → no raise
+        assert current_job() is None  # binding restored on exit
+
+    def test_bound_cancelled_job_raises(self):
+        job = AsyncJob(job_id="j")
+        job.cancel()
+        with bind_job_cancellation(job):  # noqa: SIM117
+            with pytest.raises(CancelledError):
+                check_job_cancelled()
+
+    def test_binding_restored_after_exception(self):
+        job = AsyncJob(job_id="j")
+        try:
+            with bind_job_cancellation(job):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert current_job() is None
+
+    def test_nested_binding_restores_outer(self):
+        outer = AsyncJob(job_id="outer")
+        inner = AsyncJob(job_id="inner")
+        with bind_job_cancellation(outer):
+            assert current_job() is outer
+            with bind_job_cancellation(inner):
+                assert current_job() is inner
+            assert current_job() is outer
+
+
+class TestRunningJobCancellation:
+    """Cancelling a *running* job must actually stop it - the job's target
+    polls ``check_job_cancelled`` (as the real training / eval loops now do),
+    transitions to ``cancelled`` (not ``error`` or ``done``), never caches
+    its half-built result, and hands off to any parked pending.
+    """
+
+    def test_running_job_transitions_to_cancelled(self):
+        mgr = JobManager("cancel-test")
+        started = threading.Event()
+        marker: list = []
+
+        job = mgr.start("sig-A", _cancellable_target(started, marker))
+        assert started.wait(timeout=5)
+        assert job.status == "running"
+
+        job.cancel()
+        assert job.done_event.wait(timeout=5)
+        assert job.status == "cancelled"
+        # A cancelled job's partial result is never promoted to the cache.
+        assert mgr.cached_for("sig-A") is None
+
+    def test_cancelled_running_job_promotes_pending(self):
+        mgr = JobManager("cancel-test")
+        started = threading.Event()
+        marker: list = []
+
+        running = mgr.start(
+            "sig-A",
+            _cancellable_target(started, marker),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        assert started.wait(timeout=5)
+
+        # Park a pending job for the same requester context.
+        pending_release = threading.Event()
+        pending_release.set()
+        pending = mgr.start(
+            "sig-B",
+            _make_target(pending_release, threading.Event(), marker),
+            dataset_id="ds-1",
+            detector_id="det-1",
+        )
+        assert pending.status == "pending"
+
+        # Cancelling the running job must let the pending one run.
+        running.cancel()
+        assert running.done_event.wait(timeout=5)
+        assert running.status == "cancelled"
+        assert pending.done_event.wait(timeout=5)
+        assert pending.status == "done"
+        assert pending.result == {"signature": "sig-B"}
+        assert marker == ["start", "sig-B"]

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -34,8 +34,11 @@ import logging
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
+
+from vtscore.concurrency.progress import CancelledError
 
 
 @dataclass
@@ -75,6 +78,61 @@ class AsyncJob:
         self.total = total
         if message:
             self.message = message
+
+
+# ---------------------------------------------------------------------- #
+# Cooperative cancellation of *running* jobs
+# ---------------------------------------------------------------------- #
+#
+# The heavy work a job performs (MLP epoch loops in ``train_model``, eval
+# retraining over label history) is GIL-bound Python/torch, so cancelling
+# the parked pending slot - which this module already does - does nothing
+# for a job that is *already running*.  To make cancel real, the running
+# job is bound to its worker thread here and the deep compute loops poll
+# :func:`check_job_cancelled` at their natural boundaries (epoch, eval
+# step).  When the job's ``cancel_event`` is set, the next poll raises
+# :class:`CancelledError`, which unwinds the training/eval stack and is
+# caught in :meth:`JobManager._run_inner` to mark the job ``cancelled``.
+#
+# The binding is thread-local and restored on scope exit, and every job
+# runs on its own fresh daemon thread, so no cancellation state leaks
+# across jobs or into the synchronous request handlers, tests, and CLI
+# paths that share the same training code.  Outside a bound job
+# :func:`check_job_cancelled` is a no-op.
+_thread_state = threading.local()
+
+
+@contextmanager
+def bind_job_cancellation(job: AsyncJob) -> Iterator[None]:
+    """Bind *job* as the current worker thread's cancellable job.
+
+    Deep compute loops call :func:`check_job_cancelled` to observe the
+    binding.  The previous binding (normally ``None``) is restored on exit.
+    """
+    prev = getattr(_thread_state, "job", None)
+    _thread_state.job = job
+    try:
+        yield
+    finally:
+        _thread_state.job = prev
+
+
+def current_job() -> Optional[AsyncJob]:
+    """Return the :class:`AsyncJob` bound to the current thread, or ``None``."""
+    return getattr(_thread_state, "job", None)
+
+
+def check_job_cancelled() -> None:
+    """Raise :class:`CancelledError` if the current thread's job was cancelled.
+
+    A no-op when no job is bound to the calling thread (synchronous request
+    handlers, tests, the CLI), so shared library code that runs both inside
+    and outside a background job can call it unconditionally at loop
+    boundaries.
+    """
+    job = getattr(_thread_state, "job", None)
+    if job is not None and job.is_cancelled:
+        raise CancelledError("Job cancelled by user")
 
 
 class JobManager:
@@ -245,6 +303,9 @@ class JobManager:
         ds_ctx = get_context(job.dataset_id) if job.dataset_id else None
         det_ctx = get_detector_context(job.detector_id) if job.detector_id else None
         with ExitStack() as stack:
+            # Bind the job so ``check_job_cancelled`` in the deep training /
+            # eval loops can honour a cancel of this *running* job.
+            stack.enter_context(bind_job_cancellation(job))
             if job.user is not None:
                 stack.enter_context(thread_user(job.user))
             if ds_ctx is not None:
@@ -256,6 +317,17 @@ class JobManager:
     def _run_inner(self, job: AsyncJob, target: Callable[[AsyncJob], Any]) -> None:
         try:
             target(job)
+        except CancelledError:
+            # A poll of ``check_job_cancelled`` inside the training / eval
+            # loop unwound the stack: this is a user cancel of a running
+            # job, not a failure.  Mark it terminal-cancelled (never cache
+            # its half-built result) and hand off to any parked pending.
+            with self._lock:
+                if job.status == "running":
+                    job.status = "cancelled"
+                job.done_event.set()
+            self._promote_pending_if_any()
+            return
         except Exception as exc:  # noqa: BLE001
             logging.getLogger(__name__).exception("%s job failed", self._name)
             with self._lock:

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
+from vtscore.concurrency.async_jobs import check_job_cancelled
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.training.mlp import train_model
 from vtscore.training.thresholds import find_optimal_threshold
@@ -391,6 +392,12 @@ def _ensure_cache(
                     _cache_diversity_tree.label(mid)
 
     for t in range(start, len(label_history)):
+        # Each step retrains a model; honour a cancel of the owning eval job
+        # here so a long history doesn't run to completion after cancel.  The
+        # partially-built cache is a valid prefix (steps 0..t-1), so the next
+        # run resumes cleanly from ``len(_cached_steps)``.  No-op outside a
+        # job (see ``async_jobs.check_job_cancelled``).
+        check_job_cancelled()
         media_id, label, _ = label_history[t]
 
         was_labeled = _apply_label_event(media_id, label)

--- a/vtscore/training/mlp.py
+++ b/vtscore/training/mlp.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from vtscore import config
 
+from vtscore.concurrency.async_jobs import check_job_cancelled
 from vtscore.config import MLP_DROPOUT, MLP_HIDDEN_MAX, MLP_HIDDEN_MIN
 
 # ``TRAIN_EPOCHS`` and ``TRAIN_PATIENCE`` are read off ``config`` at call time
@@ -224,6 +225,10 @@ def train_model(
     with torch.random.fork_rng(), torch.enable_grad():
         torch.manual_seed(seed)
         for _ in range(epochs):
+            # Honour a cancel of the background job that owns this thread at
+            # the epoch boundary; a no-op outside a job (see
+            # ``async_jobs.check_job_cancelled``).
+            check_job_cancelled()
             optimizer.zero_grad()
             with autocast_ctx:
                 logits = model(X_train)

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -36,6 +36,7 @@ from vtsearch.state import (
     snapshot_medias,
 )
 from vtscore.concurrency.progress import (
+    CancelledError,
     get_eval_progress,
     update_eval_progress,
 )
@@ -204,6 +205,12 @@ def eval_train_and_score(body: dict):
                     data = calculate_diversity_level_over_time(clips, history, inclusion)
                 job.result = {"metric": metric, "data": data}
                 update_eval_progress("idle", "Done", n_total, n_total)
+            except CancelledError:
+                # User cancelled a running job: not a failure.  Clear the
+                # progress bar and re-raise so the JobManager marks the job
+                # ``cancelled`` rather than ``error``.
+                update_eval_progress("idle", "Cancelled", 0, 0)
+                raise
             except Exception:
                 update_eval_progress("idle", "Error", 0, 0)
                 raise


### PR DESCRIPTION
## Summary

Third follow-up pass on the July 2026 comprehensive interface audit
(`docs/plans/comprehensive-audit-2026-07.md`). Drains the renumbered open
item #2: **JobManager cancellation was advisory only.**

Cancelling a *running* learned-sort or eval job previously only set
`AsyncJob.is_cancelled`, which no job target ever read, so the GIL-bound
training kept running to completion. (The cancelled-*pending* half was
fixed in the initial pass; both cancel routes' docstrings already *claimed*
the loop "polls it cooperatively" — nothing did.)

## What changed

- **`vtscore/concurrency/async_jobs.py`** — added a thread-local job
  binding (`bind_job_cancellation` / `current_job` / `check_job_cancelled`),
  entered for the worker-thread lifetime in `JobManager._run`.
  `_run_inner` now catches the resulting `CancelledError` and marks the job
  `cancelled` (never caching its half-built result via `_last_done`), then
  promotes any parked pending.
- **`vtscore/training/mlp.py`** — `train_model` polls `check_job_cancelled()`
  at the epoch boundary.
- **`vtscore/detectors/labeling_progress.py`** — `_ensure_cache` polls at
  the per-step retrain boundary; the partially-built cache is a valid prefix
  so the next run resumes cleanly.
- **`vtsearch/routes/eval.py`** — the eval `_run` clears the progress bar to
  `"Cancelled"` (not `"Error"`) on a running-job cancel.

The check is a **no-op outside a bound job**, so the synchronous Find flow,
tests, and CLI that share `train_model` are unaffected. Reuses the existing
`vtscore.concurrency.progress.CancelledError`; no new exception type.

## Behavior change

Cancelling a running learned-sort/eval job now actually stops it
(transitions to `cancelled` within one epoch / eval step and never caches
the partial result) instead of ignoring the cancel. The eval progress bar
reports `"Cancelled"` rather than `"Error"` on a running-job cancel.

## Tests

- `tests_lib/integration/test_async_jobs.py` —
  `TestCheckJobCancelledPrimitive` (binding/no-op/nested/restore) and
  `TestRunningJobCancellation` (running job → `cancelled`, result not
  cached, pending promoted).
- `tests_lib/detectors/test_mlp_training.py` — `TestJobCancellation` proves
  the epoch-boundary check aborts a bound cancelled job and leaves the
  happy path untouched.

Full `./run-tests.sh` green (5459 passed, 1 skipped); `./run-tests.sh
vtscore-clean` green (1876 passed) confirming the library tier stays
Flask-import-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Sy7RFZWMT4PSeHVm6ZtWe

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sy7RFZWMT4PSeHVm6ZtWe)_