### PR TITLE
Per-task progress isolation for staging imports and eval jobs

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -22,8 +22,8 @@ tracker, so clients do not need a separate REST bootstrap call.
 
 | Event name | Payload | Source |
 |---|---|---|
-| `dataset` | progress object | singleton `dataset_progress` tracker (staging, embedding) |
-| `loading-tasks` | array of task objects | `loading_tasks` (parallel dataset loads) |
+| `dataset` | progress object | singleton `dataset_progress` tracker (legacy single-op fallback) |
+| `loading-tasks` | array of task objects | `loading_tasks` (parallel dataset loads and staging imports; a staging task carries `staging_result`) |
 | `detector-loading-tasks` | array of task objects | `detector_loading_tasks` |
 | `sort` | progress object | `sort_progress` (text sort) |
 | `find` | progress object | `find_progress` (multi-dataset Find) |

--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -2,8 +2,9 @@
 
 **Status: initial fix pass shipped; second follow-up pass shipped
 (#2, #6, #10, #14 of the original open list); third follow-up pass shipped
-(JobManager cancellation now stops running jobs — was open #2 of the
-renumbered list); remaining open follow-ups below.**
+(JobManager cancellation now stops running jobs); fourth follow-up pass
+shipped (per-task progress isolation — staging imports + eval jobs);
+remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -191,61 +192,81 @@ up any of these areas sees the known-weak spots.
   (`TestCheckJobCancelledPrimitive`, `TestRunningJobCancellation`) and
   `tests_lib/detectors/test_mlp_training.py` (`TestJobCancellation`).
 
+### Fourth follow-up pass (per-task progress isolation)
+
+- **Staging imports on the global `dataset_progress` singleton** (was open
+  #3, renumbered #2 after the third pass).  `_stage_importer_in_background`
+  reported through the single global `dataset_progress` tracker, so two
+  concurrent staging imports interleaved one channel and the terminal
+  `staging_result` was last-writer-wins — orphaning the loser's staged pkl.
+  Staging now runs through a dedicated per-task `ProgressTracker` created
+  via `loading_tasks` (an `extra_fields` hook on
+  `LoadingTasksTracker.create_task` carries the `staging_result` key), keyed
+  by a returned `task_id`; the importer's own progress and the embed pass
+  route into that tracker via `set_thread_progress`.  The `stage-import` /
+  `stage-demo` routes now return the `task_id` so a poller can pick up its
+  own result off the `loading-tasks` SSE channel.  Test in
+  `tests/datasets/test_combine_datasets.py::TestStagingPerTaskIsolation`.
+- **Eval progress decorrelated from job identity** (was open #4, renumbered
+  #3 after the third pass).  The eval train-and-score route wrote progress
+  to the global `eval_progress` singleton and the `/result` poll read it
+  back, so overlapping evals (one running, one parked pending behind the
+  single-runner `eval_jobs` manager) reported each other's numbers.
+  Progress now lives on the `AsyncJob` (`job.update_progress`) and the poll
+  reads `job.current` / `job.total`; the singleton is written only from
+  inside the actually-running job's `_run` (not from the request handler for
+  a possibly-pending job), so the live `eval` SSE bar reflects the running
+  job.  Test in
+  `tests/sorting/test_sorting.py::TestEvalTrainAndScoreAsync::test_result_reports_job_progress_not_singleton`.
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
 but deferred as needing a design decision or a larger change.  (Original
-open items #2, #6, #10, #14 were drained in the second follow-up pass, and
-the renumbered #2 "JobManager cancellation advisory" in the third pass — see
+open items #2, #6, #10, #14 were drained in the second follow-up pass, the
+renumbered #2 "JobManager cancellation advisory" in the third pass, and the
+staging + eval progress isolation (renumbered #2, #3) in the fourth — see
 the follow-up-pass subsections under What shipped.  The list below is
-renumbered again after that drain.)
+renumbered again after those drains.)
 
 1. **SSE `/api/events` pins a gthread worker thread per connection.**
    With `workers = 1, threads = 8`, eight open tabs starve the whole app;
    stalled requests plus a live heartbeat read as an app hang.  Needs a
    design decision: bound SSE connections, size the pool against them, or
    move the stream off the request-thread pool.
-2. **Staging imports publish through the global `dataset_progress`
-   singleton** (`load_pipeline.py:_stage_importer_in_background`): two
-   concurrent staging imports interleave one channel and the terminal
-   `staging_result` is last-writer-wins, orphaning the loser's staged pkl.
-   Needs per-task trackers like `_run_origin_load_in_background`.
-3. **Eval progress is a global singleton keyed to no job**
-   (`routes/eval.py`): overlapping evals decorrelate the progress bar from
-   job identity.
-4. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
+2. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
    dataset where only some media carry `patch_regions`
    (`embedding/matrix.py:_build_region_arrays`): region rows are in the
    patch embedder's space, fallback rows in the primary's.  Needs either an
    ingest guarantee (all-or-nothing patch_regions per dataset) or space
    checking here.
-5. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+3. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
    don't force the full-data `hidden_dim`, always calibrate below 6 labels
    (production uses 0.5), and thread the split RNG into calibration - so
    reported eval costs measure a pipeline production doesn't run in exactly
    the small-label regime the eval characterises.
-6. **Inclusion slide drops the safe-threshold GMM blend**
+4. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-7. **Two training entry points disagree at 4-5 labels** with
+5. **Two training entry points disagree at 4-5 labels** with
    safe-thresholds off: `train_and_threshold` runs real cross-calibration,
    `_train_and_score_xy` hard-codes 0.5.  Same user state, different
    cutoff depending on route.
-8. **Dataset registry is not multi-process safe**
+6. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-9. **`http_archive` cache never invalidates** when the remote archive
+7. **`http_archive` cache never invalidates** when the remote archive
     changes (fixed collision, not staleness); `extract_archive_cached`'s
     mtime/size keying is the model.
-10. **Threshold averaging with the abstain sentinel**: a fold returning
+8. **Threshold averaging with the abstain sentinel**: a fold returning
     `NO_GOOD_THRESHOLD` (2.0) now raises the fold mean, possibly above 1.0
     (= abstain overall).  This is the intended lean but the blend weight is
     crude; revisit if precision-biased small-label behaviour looks off.
-11. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+9. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
     rather than clean): browse-canvas/minimap coordinate math and rAF
     lifecycles, modal/player component lifecycle sweep, left/right-panel
     virtualization, and a full route-blueprint sweep of
@@ -278,3 +299,12 @@ renumbered again after that drain.)
   the partial result) instead of running to completion with the cancel
   ignored.  The eval progress bar reports `"Cancelled"` on a running-job
   cancel rather than `"Error"`.
+- Staging (`POST /api/dataset/stage-import/<importer>`, `stage-demo/<name>`)
+  now returns a `task_id` and reports progress on the per-task
+  `loading-tasks` SSE channel (with its `staging_result`) instead of the
+  global `dataset` channel / `dataset_progress` singleton.
+  `_stage_importer_in_background` returns the task id.
+- Eval `GET /api/eval/train-and-score/result` reports the polled job's own
+  `current` / `total` (read from the `AsyncJob`) rather than the shared
+  `eval_progress` singleton, so overlapping evals no longer read each
+  other's progress.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1459,11 +1459,15 @@
           },
           "ok": {
             "type": "boolean"
+          },
+          "task_id": {
+            "type": "string"
           }
         },
         "required": [
           "message",
-          "ok"
+          "ok",
+          "task_id"
         ],
         "type": "object"
       },

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -664,3 +664,98 @@ class TestProgressStagingResult:
         # Clean up; explicitly clear staging_result (update has merge semantics)
         update_progress("idle", "", 0, 0, staging_result=None)
         assert get_progress()["staging_result"] is None
+
+
+class _FakeStagingImporter:
+    """Minimal importer stub for exercising ``_stage_importer_in_background``.
+
+    Populates ``temp_medias`` with pre-embedded clips whose IDs start at
+    ``_base_id`` so two concurrent stagings produce disjoint, identifiable
+    outputs.
+    """
+
+    name = "fake_stage"
+    fields: list = []
+
+    def resolve_display_name(self, field_values: dict) -> str:
+        return field_values.get("name", "fake")
+
+    def run(self, field_values: dict, temp_medias: dict, thin: bool = False) -> None:
+        base = int(field_values["_base_id"])
+        for i in range(int(field_values.get("_count", 2))):
+            mid = base + i
+            raw = _unique_bytes(mid)
+            temp_medias[mid] = {
+                "id": mid,
+                "media_type": "audio",
+                "filename": f"c{mid}.wav",
+                "md5": hashlib.md5(raw).hexdigest(),
+                "embeddings": {"clap": np.array([float(mid), 0.5], dtype=np.float32)},
+                "embedder": "clap",
+                "media_bytes": raw,
+                "media_string": None,
+                "media_path": None,
+                "origin": None,
+                "origin_name": f"c{mid}.wav",
+            }
+
+
+def _sync_thread_factory(store: list):
+    """Return a ``threading.Thread`` replacement that runs the target inline."""
+    from unittest import mock as _mock
+
+    def fake_thread(target, daemon=True, name=None):
+        store.append(target)
+        t = _mock.MagicMock()
+        t.start = target  # run synchronously on .start()
+        return t
+
+    return fake_thread
+
+
+class TestStagingPerTaskIsolation:
+    """Two concurrent staging imports must each publish their own
+    ``staging_result`` on their own per-task tracker; the terminal result is
+    no longer last-writer-wins on the global ``dataset_progress`` singleton
+    (which orphaned the loser's staged pkl)."""
+
+    def test_concurrent_stagings_keep_distinct_results(self, isolated_settings):
+        from pathlib import Path
+        from unittest import mock
+
+        from vtscore.concurrency.progress import loading_tasks
+        from vtscore.datasets.load_pipeline import _stage_importer_in_background
+
+        importer = _FakeStagingImporter()
+
+        # Patch the embedder (medias are pre-embedded) and run the daemon
+        # threads inline so both stagings complete deterministically.
+        with (
+            mock.patch("vtscore.datasets.load_pipeline.embed_missing", lambda *a, **k: None),
+            mock.patch(
+                "vtscore.datasets.load_pipeline.threading.Thread",
+                side_effect=_sync_thread_factory([]),
+            ),
+        ):
+            task_a = _stage_importer_in_background(importer, {"name": "A", "_base_id": 100, "_count": 2})
+            task_b = _stage_importer_in_background(importer, {"name": "B", "_base_id": 200, "_count": 3})
+
+        assert task_a and task_b and task_a != task_b, "each staging must get its own task id"
+
+        tasks = {t["task_id"]: t for t in loading_tasks.list_tasks()}
+        assert task_a in tasks and task_b in tasks
+
+        res_a = tasks[task_a]["staging_result"]
+        res_b = tasks[task_b]["staging_result"]
+        assert res_a is not None and res_b is not None, "both stagings must publish a staging_result"
+        assert res_a["path"] != res_b["path"], "results must not collide"
+        assert res_a["count"] == 2 and res_b["count"] == 3
+        assert res_a["name"] == "A" and res_b["name"] == "B"
+
+        # Neither staged pkl was orphaned: both exist on disk.
+        try:
+            assert Path(res_a["path"]).exists(), "staging A's pkl must not be orphaned"
+            assert Path(res_b["path"]).exists(), "staging B's pkl must not be orphaned"
+        finally:
+            Path(res_a["path"]).unlink(missing_ok=True)
+            Path(res_b["path"]).unlink(missing_ok=True)

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -684,20 +684,11 @@ class _FakeStagingImporter:
         base = int(field_values["_base_id"])
         for i in range(int(field_values.get("_count", 2))):
             mid = base + i
-            raw = _unique_bytes(mid)
-            temp_medias[mid] = {
-                "id": mid,
-                "media_type": "audio",
-                "filename": f"c{mid}.wav",
-                "md5": hashlib.md5(raw).hexdigest(),
-                "embeddings": {"clap": np.array([float(mid), 0.5], dtype=np.float32)},
-                "embedder": "clap",
-                "media_bytes": raw,
-                "media_string": None,
-                "media_path": None,
-                "origin": None,
-                "origin_name": f"c{mid}.wav",
-            }
+            clip = _make_audio_clip(mid)
+            # ``media_embedding`` reads the ``embeddings`` dict, so a
+            # pre-embedded staging clip needs it to survive the drop-none filter.
+            clip["embeddings"] = {"clap": np.array([float(mid), 0.5], dtype=np.float32)}
+            temp_medias[mid] = clip
 
 
 def _sync_thread_factory(store: list):

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -734,6 +734,49 @@ class TestEvalTrainAndScoreAsync:
         resp = client.post("/api/eval/train-and-score", json={"metric": "bogus", "wait": True})
         assert resp.status_code == 422
 
+    def test_result_reports_job_progress_not_singleton(self, client):
+        """The poll endpoint must report the polled job's own progress, not
+        the global ``eval_progress`` singleton (which an overlapping eval can
+        pollute, decorrelating the bar from job identity)."""
+        import threading
+
+        from tests.conftest import _wait_for_job
+        from vtscore.concurrency.async_jobs import eval_jobs
+        from vtscore.concurrency.progress import update_eval_progress
+
+        self._seed_history()  # 4 labels -> n_total == 3
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_stable(*args, **kwargs):
+            entered.set()
+            release.wait(timeout=10)
+            return []
+
+        with unittest.mock.patch(
+            "vtsearch.routes.eval.calculate_prediction_stability_over_time",
+            side_effect=blocking_stable,
+        ):
+            envelope = client.post("/api/eval/train-and-score", json={"metric": "stable"}).get_json()
+            assert envelope["status"] == "running"
+            assert envelope["total"] == 3
+            job_id = envelope["job_id"]
+
+            # The job thread is now inside the (blocked) computation with its
+            # own current=0 / total=3 recorded.
+            assert entered.wait(timeout=10)
+
+            # Simulate a concurrent/overlapping eval clobbering the singleton.
+            update_eval_progress("running", "other eval", 99, 12345)
+
+            result = client.get(f"/api/eval/train-and-score/result?job_id={job_id}").get_json()
+            assert result["status"] == "running"
+            assert result["total"] == 3, "must report the job's own total, not the singleton's 12345"
+            assert result["current"] == 0
+
+            release.set()
+            _wait_for_job(eval_jobs)
+
 
 class TestExampleSort:
     def test_sort_with_audio_file(self, client):

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -427,14 +427,20 @@ class LoadingTasksTracker:
         detector_id: str = "",
         embedder: str = "",
         step_weights: list[float] | None = None,
+        extra_fields: dict[str, Any] | None = None,
     ) -> ProgressTracker:
         """Create and register a new loading task.
 
         *step_weights* (one weight per step) tunes how the whole-job ``overall``
-        bar paces across phases; omit for equal weighting. Returns the per-task
-        :class:`ProgressTracker` instance.
+        bar paces across phases; omit for equal weighting. *extra_fields* adds
+        task-specific tracked keys (e.g. ``staging_result``) on top of the
+        shared progress extras. Returns the per-task :class:`ProgressTracker`
+        instance.
         """
-        tracker = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+        fields = dict(_PROGRESS_COMMON_EXTRAS)
+        if extra_fields:
+            fields.update(extra_fields)
+        tracker = ProgressTracker(extra_fields=fields)
         if step_weights is not None:
             tracker.set_step_weights(step_weights)
         tracker.subscribe(lambda _snapshot: self._notify())

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -29,7 +29,6 @@ from vtscore.concurrency.progress import (
     dataset_progress,
     loading_tasks,
     set_thread_progress,
-    update_progress,
 )
 from vtscore.datasets import export_dataset_to_file
 from vtscore.datasets.loader import apply_custom_metadata_md5
@@ -710,13 +709,24 @@ def _demo_load_hints(importer, field_values: dict) -> tuple[int | None, float | 
 STAGING_DIR = DATA_DIR / "staging"
 
 
-def _stage_importer_in_background(importer, field_values: dict, label: str = "") -> None:
+def _stage_importer_in_background(importer, field_values: dict, label: str = "") -> str:
     """Run *importer*.run() in a daemon thread, saving the result to a staging pkl.
 
     Unlike ``_run_importer_in_background``, this does **not** modify the global
-    ``medias`` dict.  Instead it writes a temporary ``.pkl`` file to
-    :data:`STAGING_DIR` and sets the ``staging_result`` field on the progress
-    tracker when finished.
+    ``medias`` dict and does **not** register a dataset.  Instead it writes a
+    temporary ``.pkl`` file to :data:`STAGING_DIR` and publishes the terminal
+    ``staging_result`` on this operation's own per-task progress tracker.
+
+    Each call gets a dedicated :class:`ProgressTracker` (via ``loading_tasks``),
+    keyed by the returned ``task_id``, mirroring
+    :func:`_run_origin_load_in_background`.  Previously every staging import
+    reported through the single global ``dataset_progress`` tracker, so two
+    concurrent stagings interleaved one channel and the terminal
+    ``staging_result`` was last-writer-wins - orphaning the loser's staged pkl.
+    With a per-task tracker the results no longer collide.
+
+    Returns the ``task_id`` a caller can poll (via the ``loading-tasks`` SSE
+    channel) for progress and the final ``staging_result``.
     """
     from vtsearch.auth import get_current_user  # noqa: PLC0415
     from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
@@ -724,21 +734,35 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     field_values = wrap_cli_file_fields(importer.fields, field_values)
     _request_user = get_current_user()
 
+    task_id = f"_staging_{uuid4().hex[:8]}"
+    display_name = label or importer.resolve_display_name(field_values)
+    tracker = loading_tasks.create_task(
+        task_id,
+        display_name,
+        media_type=_normalize_media_type(field_values.get("media_type", "")),
+        embedder=field_values.get("embedder", "") or "",
+        extra_fields={"staging_result": None},
+    )
+    tracker.update("loading", "Preparing dataset…", 0, 0)
+
     def stage_task():
-        from vtsearch.auth import thread_user
+        from vtsearch.auth import thread_user  # noqa: PLC0415
 
         with thread_user(_request_user):
+            # Route the importer's own progress calls (and embedding progress)
+            # into this task's tracker instead of the global singleton.
+            set_thread_progress(tracker.update)
             try:
                 temp_medias: dict = {}
                 importer.run(field_values, temp_medias)
                 apply_custom_metadata_md5(temp_medias)
-                embed_missing(temp_medias, field_values.get("embedder", "") or "", on_progress=update_progress)
+                embed_missing(temp_medias, field_values.get("embedder", "") or "", on_progress=tracker.update)
                 from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
 
                 temp_medias = {mid: m for mid, m in temp_medias.items() if media_embedding(m) is not None}
 
                 if not temp_medias:
-                    update_progress("idle", "", 0, 0, error="Import produced no medias.")
+                    tracker.update("idle", "", 0, 0, error="Import produced no medias.")
                     return
 
                 first = next(iter(temp_medias.values()))
@@ -756,7 +780,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 del data_bytes
                 gc.collect()
 
-                update_progress(
+                tracker.update(
                     "idle",
                     f"Staged: {name} ({count} medias)",
                     100,
@@ -766,7 +790,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
             except ImportError as e:
                 traceback.print_exc()
                 gc.collect()
-                update_progress(
+                tracker.update(
                     "idle",
                     "",
                     0,
@@ -775,7 +799,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 )
             except MemoryError:
                 gc.collect()
-                update_progress(
+                tracker.update(
                     "idle",
                     "",
                     0,
@@ -785,7 +809,11 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
             except Exception as e:
                 traceback.print_exc()
                 error_msg = str(e) or repr(e) or "Unknown error during staging"
-                update_progress("idle", "", 0, 0, error=error_msg)
+                tracker.update("idle", "", 0, 0, error=error_msg)
+            finally:
+                clear_thread_progress()
+                loading_tasks.mark_finished(task_id)
 
     thread = threading.Thread(target=stage_task, daemon=True)
     thread.start()
+    return task_id

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -181,8 +181,11 @@ _PROGRESS_COMMON_EXTRAS = {
 }
 ```
 
-`dataset_progress` additionally declares `"staging_result"` for the
-combine-datasets staging flow.
+`dataset_progress` still declares `"staging_result"` (retained for the
+legacy free-function API and its test), but the staging flow itself now
+runs through per-task trackers created via
+`LoadingTasksTracker.create_task(..., extra_fields={"staging_result": None})`,
+so two concurrent staging imports no longer collide on one channel.
 
 **ETA:** when `extra_fields` includes `"eta_seconds"`, every `update()`
 recomputes a smoothed ETA. The tracker keeps a phase key
@@ -334,9 +337,9 @@ start of each new operation so a previous cancellation doesn't
 immediately abort the next run.
 
 `cancel_dataset_progress()` is a convenience that cancels every active
-task in `loading_tasks` **and** the legacy `dataset_progress` singleton
-- staging operations write through both surfaces, so a clean abort
-needs to touch both.
+task in `loading_tasks` (which now includes staging imports) **and** the
+legacy `dataset_progress` singleton, so a clean abort touches both
+surfaces regardless of which one a given operation reports through.
 
 ---
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -325,8 +325,8 @@ def stage_import(importer_name: str):
         extra_keys=("source_specs", "dataset_name"),
     )
 
-    _stage_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Staging started"})
+    task_id = _stage_importer_in_background(importer, field_values)
+    return jsonify({"ok": True, "message": "Staging started", "task_id": str(task_id) if task_id else ""})
 
 
 @datasets_staging_bp.route("/api/dataset/stage-demo/<name>", methods=["POST"])
@@ -353,8 +353,8 @@ def stage_demo(body: dict, name: str):
         field_values["dataset_name"] = dataset_name
 
     label = dataset_name or DEMO_DATASETS[name].get("label", name)
-    _stage_importer_in_background(importer, field_values, label=label)
-    return {"ok": True, "message": "Staging demo dataset..."}
+    task_id = _stage_importer_in_background(importer, field_values, label=label)
+    return {"ok": True, "message": "Staging demo dataset...", "task_id": str(task_id) if task_id else ""}
 
 
 @datasets_staging_bp.route("/api/dataset/staging", methods=["DELETE"])

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -37,7 +37,6 @@ from vtsearch.state import (
 )
 from vtscore.concurrency.progress import (
     CancelledError,
-    get_eval_progress,
     update_eval_progress,
 )
 
@@ -192,10 +191,16 @@ def eval_train_and_score(body: dict):
         return _eval_done_payload(cached)
 
     n_total = max(len(history) - 1, 0)
-    update_eval_progress("running", f"Computing {metric}...", 0, n_total)
 
     def _run(job):
         with thread_dataset_context(ds_ctx), thread_detector_context(det_ctx):
+            # Progress lives on the job, not on the global ``eval_progress``
+            # singleton, so overlapping evals don't decorrelate the poll from
+            # job identity.  The singleton is written only from the actually-
+            # running job (here, inside ``_run``) so the live SSE ``eval`` bar
+            # reflects the running job rather than a job still parked pending.
+            job.update_progress(0, n_total, f"Computing {metric}...")
+            update_eval_progress("running", f"Computing {metric}...", 0, n_total)
             try:
                 if metric == "smart":
                     data = calculate_error_cost_over_time(clips, history, good_snap, bad_snap, inclusion)
@@ -204,6 +209,7 @@ def eval_train_and_score(body: dict):
                 else:
                     data = calculate_diversity_level_over_time(clips, history, inclusion)
                 job.result = {"metric": metric, "data": data}
+                job.update_progress(n_total, n_total, "Done")
                 update_eval_progress("idle", "Done", n_total, n_total)
             except CancelledError:
                 # User cancelled a running job: not a failure.  Clear the
@@ -221,6 +227,11 @@ def eval_train_and_score(body: dict):
         dataset_id=ds_ctx.dataset_id,
         detector_id=det_ctx.detector_id,
     )
+    # Seed this job's own total so a poll that lands before ``_run`` starts
+    # (the job may be parked pending behind another in-flight eval) still
+    # reports this job's numbers, not a global singleton shared with the
+    # currently-running job.
+    job.total = n_total
 
     if wait:
         job.done_event.wait(timeout=300)
@@ -248,12 +259,13 @@ def eval_train_and_score_result(query: dict):
         abort(404, message="Job not found", job_id=job_id, status="missing")
 
     if job.status in ("running", "pending"):
-        prog = get_eval_progress()
+        # Read progress from the job itself (not the global ``eval_progress``
+        # singleton) so overlapping evals report their own numbers.
         return {
             "job_id": job.job_id,
             "status": "running",
-            "current": prog.get("current", 0),
-            "total": prog.get("total", 0),
+            "current": job.current,
+            "total": job.total,
         }
     if job.status == "error":
         abort(500, message=job.error or "Evaluation computation failed", job_id=job.job_id)

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -497,10 +497,15 @@ class DatasetStageFileResponseSchema(Schema):
 
 class DatasetStagingStartedResponseSchema(Schema):
     """Response for ``POST /api/dataset/stage-demo/<name>`` and the
-    plugin-field staging routes that haven't migrated yet."""
+    plugin-field staging routes that haven't migrated yet.
+
+    ``task_id`` is the background staging-task tracker id (string) used by
+    the ``loading-tasks`` SSE channel to poll progress and pick up the final
+    ``staging_result``; it may be empty when no task was started."""
 
     ok = fields.Boolean(required=True)
     message = fields.String(required=True)
+    task_id = fields.String(required=True)
 
 
 class DatasetStageDemoRequestSchema(Schema):


### PR DESCRIPTION
Drains follow-ups **#3** and **#4** from `docs/plans/comprehensive-audit-2026-07.md` (per-task progress isolation).

## #3 — Staging imports off the global `dataset_progress` singleton

`_stage_importer_in_background` reported through the single global `dataset_progress` tracker, so two concurrent staging imports interleaved one channel and the terminal `staging_result` was **last-writer-wins** — orphaning the loser's staged pkl.

- Staging now runs through a dedicated per-task `ProgressTracker` created via `loading_tasks`, keyed by a returned `task_id` (mirroring `_run_origin_load_in_background`).
- Added an `extra_fields` hook to `LoadingTasksTracker.create_task` so the task tracker carries the `staging_result` key.
- The importer's own progress and the embed pass route into that tracker via `set_thread_progress`.
- `POST /api/dataset/stage-import/<importer>` and `stage-demo/<name>` now return the `task_id`; pollers pick up their own result off the `loading-tasks` SSE channel.

## #4 — Eval progress decorrelated from job identity

The eval train-and-score route wrote progress to the global `eval_progress` singleton and the `/result` poll read it back, so overlapping evals (one running, one parked pending behind the single-runner `eval_jobs` manager) reported each other's numbers.

- Progress now lives on the `AsyncJob` (`job.update_progress`); the `/result` poll reads `job.current` / `job.total`.
- The singleton is written only from inside the actually-running job's `_run` (not from the request handler for a possibly-pending job), so the live `eval` SSE bar reflects the running job.

## Tests

- `tests/datasets/test_combine_datasets.py::TestStagingPerTaskIsolation` — two concurrent stagings keep distinct `staging_result`s and neither pkl is orphaned.
- `tests/sorting/test_sorting.py::TestEvalTrainAndScoreAsync::test_result_reports_job_progress_not_singleton` — the poll reports the polled job's own total even when the singleton is clobbered by a concurrent eval.
- Full `./run-tests.sh` green (5451 passed, 1 skipped), including the OpenAPI snapshot regen (the new `task_id` field on the staging response) and the frontend build.

## Behaviour changes

- Staging routes now return a `task_id` and report progress on the `loading-tasks` SSE channel (with `staging_result`) instead of the `dataset` channel.
- `GET /api/eval/train-and-score/result` reports the polled job's own `current`/`total` instead of the shared singleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124e77XXrDM3useaBRPZfae

---
_Generated by [Claude Code](https://claude.ai/code/session_0124e77XXrDM3useaBRPZfae)_