### PR TITLE
Invalidate http_archive resolve cache on remote drift

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -5,8 +5,9 @@
 (JobManager cancellation now stops running jobs); fourth follow-up pass
 shipped (per-task progress isolation — staging imports + eval jobs); fifth
 follow-up pass shipped (#5, #8 of the renumbered open list — ML threshold
-correctness); sixth follow-up pass shipped (#1 of the current open list —
-SSE connection cap); remaining open follow-ups below.**
+correctness); sixth follow-up pass shipped (#1 of the then-current open
+list — SSE connection cap); seventh follow-up pass shipped (http_archive
+cache staleness); remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -270,6 +271,27 @@ up any of these areas sees the known-weak spots.
   `tests/api/test_events_sse.py` (`TestSseConnectionCapPrimitive`,
   `TestSseConnectionCapRoute`).
 
+### Seventh follow-up pass (drained from the open list)
+
+- **`http_archive` cache staleness** (was renumbered open #6).
+  `HttpArchiveSource`'s resolve cache keyed only on the URL, so once an
+  extraction was published under that key it was served forever, even after
+  the remote archive changed. Added `fetch_remote_signature()` in
+  `vtscore/datasets/downloader/core.py` — a single-byte ranged GET (more
+  universally honoured than HEAD by the flaky CDNs these archives live on)
+  that reads only `ETag` / `Last-Modified` / size from the response headers.
+  `_ensure_extracted()` now records that signature in a sidecar file next to
+  the cached extraction (kept as a *sibling*, never inside the extraction
+  tree, so it can't surface as a bogus media item to an extensionless
+  `list_items(None)`); a later access whose freshly-probed signature
+  disagrees with the recorded one busts the cache and re-downloads. A cache
+  with no recorded signature (predates this check, or its own probe failed)
+  is trusted as-is, and a probe failure (offline, flaky CDN) fails open onto
+  the existing cache rather than blocking. Tests in
+  `tests/datasets/test_media_sources.py`
+  (`test_stale_cache_invalidated_on_signature_mismatch`,
+  `test_signature_probe_failure_trusts_existing_cache`).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
@@ -277,8 +299,9 @@ but deferred as needing a design decision or a larger change.  (Original
 open items #2, #6, #10, #14 were drained in the second follow-up pass, the
 renumbered #2 "JobManager cancellation advisory" in the third pass, the
 staging + eval progress isolation (renumbered #2, #3) in the fourth, the
-re-renumbered #5/#8 "ML threshold correctness" items in the fifth, and the
-re-renumbered #1 "SSE connection cap" in the sixth — see the follow-up-pass
+re-renumbered #5/#8 "ML threshold correctness" items in the fifth, the
+re-renumbered #1 "SSE connection cap" in the sixth, and the re-renumbered
+#6 "http_archive cache staleness" in the seventh — see the follow-up-pass
 subsections under What shipped.  The list below is renumbered again after
 those drains.)
 
@@ -304,10 +327,7 @@ those drains.)
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-5. **`http_archive` cache never invalidates** when the remote archive
-   changes (fixed collision, not staleness); `extract_archive_cached`'s
-   mtime/size keying is the model.
-6. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+5. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
    rather than clean): browse-canvas/minimap coordinate math and rAF
    lifecycles, modal/player component lifecycle sweep, left/right-panel
    virtualization, and a full route-blueprint sweep of
@@ -363,3 +383,9 @@ those drains.)
   accepting an unbounded number of connections that could starve the
   gthread pool. Cap defaults to `VTSEARCH_THREADS - 2`; override with
   `VTSEARCH_SSE_MAX_CONNECTIONS`.
+- `HttpArchiveSource`'s resolve cache now checks a recorded remote signature
+  (ETag/Last-Modified/size) on each access to a cached extraction and
+  re-downloads on a mismatch, instead of trusting the cache forever once
+  published. A cache built before this change (no recorded signature) or a
+  failed probe still trusts the existing cache, so this is additive: no
+  previously-cached extraction is invalidated by upgrading alone.

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -257,6 +257,80 @@ class TestHttpArchiveSource:
 
             shutil.rmtree(cached_a, ignore_errors=True)
 
+    def test_stale_cache_invalidated_on_signature_mismatch(self, tmp_path):
+        """A cached extraction with a recorded signature that no longer
+        matches the remote is invalidated and re-downloaded.
+
+        Regression: the resolve cache never invalidated at all once
+        published, so a replaced remote archive served stale bytes forever.
+        """
+        from vtscore.datasets.sources.http_archive import HttpArchiveSource, _write_signature
+
+        url = "https://example.com/stale-sig.zip"
+        cached = self._cached_dir_for(url)
+        cached.mkdir(parents=True, exist_ok=True)
+        (cached / "old.wav").write_bytes(b"old_audio")
+        _write_signature(cached, "old-etag|old-date|100")
+
+        zip_path = tmp_path / "fresh.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("new.wav", b"new_audio")
+
+        try:
+            source = HttpArchiveSource(url)
+            with (
+                patch(
+                    "vtscore.datasets.downloader.core.fetch_remote_signature",
+                    return_value="new-etag|new-date|200",
+                ),
+                patch("vtscore.security.url_validation.validate_url"),
+                patch("vtscore.datasets.downloader.download_file_with_progress"),
+                patch(
+                    "vtscore.datasets.archive.extract_archive",
+                    side_effect=lambda _archive, dest: zipfile.ZipFile(zip_path).extractall(dest),
+                ),
+            ):
+                inner = source._ensure_extracted()
+                items = list(inner.list_items())
+                assert any(i.filename == "new.wav" for i in items)
+                assert not any(i.filename == "old.wav" for i in items)
+        finally:
+            import shutil
+
+            from vtscore.datasets.sources.http_archive import _signature_path
+
+            shutil.rmtree(cached, ignore_errors=True)
+            _signature_path(cached).unlink(missing_ok=True)
+
+    def test_signature_probe_failure_trusts_existing_cache(self, tmp_path):
+        """When the remote signature probe fails (offline/flaky CDN), a
+        cache carrying a recorded signature is still trusted rather than
+        blocking or forcing a re-download."""
+        from vtscore.datasets.sources.http_archive import HttpArchiveSource, _write_signature
+
+        url = "https://example.com/probe-fail.zip"
+        cached = self._cached_dir_for(url)
+        cached.mkdir(parents=True, exist_ok=True)
+        (cached / "clip.wav").write_bytes(b"audio")
+        _write_signature(cached, "etag|date|10")
+
+        try:
+            source = HttpArchiveSource(url)
+            with patch(
+                "vtscore.datasets.downloader.core.fetch_remote_signature",
+                return_value=None,
+            ):
+                item = source.resolve_path(origin_name="clip.wav")
+            assert item.path is not None
+            assert item.path.name == "clip.wav"
+        finally:
+            import shutil
+
+            from vtscore.datasets.sources.http_archive import _signature_path
+
+            shutil.rmtree(cached, ignore_errors=True)
+            _signature_path(cached).unlink(missing_ok=True)
+
     def test_delegates_to_local_folder(self, tmp_path):
         """After extraction, fetch_item delegates to LocalFolderSource."""
         from vtscore.datasets.sources.http_archive import HttpArchiveSource

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -407,6 +407,41 @@ def download_file_with_progress(  # noqa: C901
                 response.close()
 
 
+def fetch_remote_signature(url: str) -> Optional[str]:
+    """Fetch a lightweight signature (ETag / Last-Modified / size) for *url*.
+
+    Used to detect when a remote archive has changed so a caller's extraction
+    cache can invalidate instead of serving stale bytes forever. Issues a
+    ranged GET for a single byte (more universally honoured than HEAD by the
+    flaky third-party CDNs these archives live on) and reads only the
+    response headers.
+
+    Returns ``None`` if the probe fails outright or the server's response
+    carries none of the three signals - callers should fail open (trust an
+    existing cache) rather than block on a CDN that doesn't answer.
+    """
+    try:
+        validate_url(url)
+        session = requests.Session()
+        response = _open_validated_stream(session, url, headers={"Range": "bytes=0-0"})
+    except Exception:
+        return None
+    try:
+        if response.status_code >= 400:
+            return None
+        etag = response.headers.get("ETag", "")
+        last_modified = response.headers.get("Last-Modified", "")
+        content_range = response.headers.get("Content-Range", "")
+        total = content_range.rsplit("/", 1)[-1] if "/" in content_range else response.headers.get("Content-Length", "")
+        if not etag and not last_modified and not total:
+            return None
+        return f"{etag}|{last_modified}|{total}"
+    except Exception:
+        return None
+    finally:
+        response.close()
+
+
 def download_file_atomic(
     url: str,
     final_path: Path,

--- a/vtscore/datasets/sources/http_archive.py
+++ b/vtscore/datasets/sources/http_archive.py
@@ -27,6 +27,32 @@ log = logging.getLogger(__name__)
 _extract_lock = threading.Lock()
 
 
+def _signature_path(cached_dir: Path) -> Path:
+    """Sidecar path recording the remote signature (ETag/Last-Modified/size)
+    observed at extraction time, so a later access can detect a changed
+    remote archive and bust the cache instead of serving stale bytes forever.
+
+    Kept as a *sibling* of the extraction dir, never inside it - a file
+    inside would otherwise surface as a bogus media item to an
+    extensionless ``list_items(None)`` call.
+    """
+    return cached_dir.parent / f"{cached_dir.name}.sig"
+
+
+def _read_signature(cached_dir: Path) -> str | None:
+    try:
+        return _signature_path(cached_dir).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _write_signature(cached_dir: Path, signature: str) -> None:
+    try:
+        _signature_path(cached_dir).write_text(signature, encoding="utf-8")
+    except OSError:
+        pass
+
+
 class HttpArchiveSource(MediaSource):
     """A media source backed by a remote archive (.zip, .tar.gz, etc.).
 
@@ -59,6 +85,7 @@ class HttpArchiveSource(MediaSource):
 
         import hashlib
 
+        from vtscore.datasets.downloader.core import fetch_remote_signature
         from vtscore.datasets.sources.local_folder import LocalFolderSource
 
         url_filename = self._url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "archive"
@@ -70,10 +97,23 @@ class HttpArchiveSource(MediaSource):
         cached_dir = DATA_DIR / f"http_archive_resolve_{url_hash}_{url_filename}"
 
         # Fast path: a previous run already published a cached extraction.
+        # Only bother probing the remote when the cache carries a recorded
+        # signature to compare against - a cache with no sidecar (predates
+        # this check, or its own probe failed) is trusted as-is rather than
+        # invalidated on missing information. A probe failure (offline,
+        # flaky CDN) also fails open onto the existing cache.
+        remote_sig: str | None = None
         if cached_dir.is_dir():
-            self._extract_dir = cached_dir
-            self._inner = LocalFolderSource(cached_dir)
-            return self._inner
+            cached_sig = _read_signature(cached_dir)
+            remote_sig = fetch_remote_signature(self._url) if cached_sig else None
+            if cached_sig is None or remote_sig is None or remote_sig == cached_sig:
+                self._extract_dir = cached_dir
+                self._inner = LocalFolderSource(cached_dir)
+                return self._inner
+            log.info(
+                "Remote archive changed for %s; cached extraction is stale, re-downloading",
+                self._url,
+            )
 
         from vtscore.datasets.archive import extract_archive
         from vtscore.datasets.downloader import download_file_with_progress
@@ -97,12 +137,24 @@ class HttpArchiveSource(MediaSource):
         finally:
             archive_path.unlink(missing_ok=True)
 
+        if remote_sig is None:
+            # No signature yet (fresh download, or the pre-download probe
+            # failed) - one more attempt so a future access can detect drift.
+            remote_sig = fetch_remote_signature(self._url)
+
         # Publish the extraction as the cached dir. Re-check cached_dir under
         # the lock: two concurrent imports of the same URL can both pass the
         # earlier is_dir() check, and without this guard they'd both try to
         # rename onto the same destination (clobbering each other on POSIX,
         # raising on Windows). The loser discards its own extraction.
         with _extract_lock:
+            if cached_dir.is_dir():
+                existing_sig = _read_signature(cached_dir)
+                if remote_sig is not None and existing_sig is not None and existing_sig != remote_sig:
+                    # A concurrent run published a now-stale extraction; evict it
+                    # (and its sidecar) in favor of the fresh one we just built.
+                    shutil.rmtree(cached_dir, ignore_errors=True)
+                    _signature_path(cached_dir).unlink(missing_ok=True)
             if cached_dir.is_dir():
                 shutil.rmtree(extract_dir, ignore_errors=True)
                 final_dir = cached_dir
@@ -113,6 +165,8 @@ class HttpArchiveSource(MediaSource):
                 except OSError:
                     # e.g. cross-device rename; fall back to the unique dir.
                     final_dir = extract_dir
+                if remote_sig is not None:
+                    _write_signature(final_dir, remote_sig)
 
         self._extract_dir = final_dir
         self._inner = LocalFolderSource(final_dir)


### PR DESCRIPTION
## Summary

- Drains open follow-up #6 from `docs/plans/comprehensive-audit-2026-07.md`: `HttpArchiveSource`'s resolve cache keyed only on URL, so a published extraction was served forever even after the remote archive changed.
- Adds `fetch_remote_signature()` (`vtscore/datasets/downloader/core.py`) — a single-byte ranged GET (more universally honoured than HEAD by the flaky CDNs these archives live on) that reads `ETag` / `Last-Modified` / size from the response headers.
- `_ensure_extracted()` records that signature in a sidecar file *sibling* to the cached extraction (never inside it, so it can't surface as a bogus media item to an extensionless `list_items(None)`). A later access whose freshly-probed signature disagrees with the recorded one busts the cache and re-downloads.
- Fails open in both directions: a cache with no recorded signature (predates this change, or its own probe failed) is trusted as-is, and a probe failure (offline, flaky CDN) trusts the existing cache rather than blocking.

## Test plan

- [x] `pytest tests/datasets/test_media_sources.py -q` — 58 passed, including new regression tests `test_stale_cache_invalidated_on_signature_mismatch` and `test_signature_probe_failure_trusts_existing_cache`
- [x] `./run-tests.sh datasets` — 824 passed
- [x] `./run-tests.sh` (full suite, incl. ruff/pyright/frontend build) — 5473 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKVUiV769FBoNNfrmQGKaf)_