### PR TITLE
Cap concurrent /api/events SSE connections to protect the gthread pool

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -144,7 +144,13 @@ A few VTSearch-specific points matter when configuring the proxy:
   SSE endpoint. Proxy response buffering breaks SSE (events arrive only when the
   buffer flushes), so disable it for the stream — `proxy_buffering off;` in nginx
   (and the equivalent elsewhere) — and ensure the same long read-timeout applies,
-  since the connection stays open for the life of the page.
+  since the connection stays open for the life of the page. Each open connection
+  pins a gthread worker thread for its lifetime, so the server caps concurrent
+  connections at `VTSEARCH_THREADS - 2` (override with
+  `VTSEARCH_SSE_MAX_CONNECTIONS`) and returns `503` once saturated instead of
+  starving the pool that serves ordinary requests; the frontend's `EventSource`
+  wrapper retries on a timer when that happens. Raising `VTSEARCH_THREADS` raises
+  the SSE cap along with it.
 - **Forwarded headers.** Pass `X-Forwarded-For`, `X-Forwarded-Proto`, and
   `X-Forwarded-Host` (and `Host`) so the app sees the real client and external
   scheme. For SSE/WebSocket-style streams also forward `Connection`/`Upgrade` if

--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -5,7 +5,8 @@
 (JobManager cancellation now stops running jobs); fourth follow-up pass
 shipped (per-task progress isolation — staging imports + eval jobs); fifth
 follow-up pass shipped (#5, #8 of the renumbered open list — ML threshold
-correctness); remaining open follow-ups below.**
+correctness); sixth follow-up pass shipped (#1 of the current open list —
+SSE connection cap); remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -246,48 +247,67 @@ up any of these areas sees the known-weak spots.
   abstaining folds and otherwise means the folds that produced a real cut.
   Tests in `tests_lib/sorting/test_find_optimal_threshold.py`.
 
+### Sixth follow-up pass — SSE connection cap (drained from the open list)
+
+- **SSE `/api/events` no longer starves the gthread pool** (was open #1).
+  Each open connection pins a worker thread for its lifetime (the generator
+  blocks in `queue.get()` between updates), so with the documented
+  `workers = 1, threads = 8` deployment, enough open tabs could exhaust the
+  pool and make ordinary requests stall while the stream's own heartbeat
+  kept the connection looking alive. Chose the "bound connections" option
+  from the three named in the original finding (bound / resize / move off
+  the pool): a hard cap, `MAX_SSE_CONNECTIONS` in
+  `vtscore/concurrency/events.py`, derived from `VTSEARCH_THREADS` minus a
+  fixed reserve of 2 (override directly with
+  `VTSEARCH_SSE_MAX_CONNECTIONS`). `acquire_sse_slot()` /
+  `release_sse_slot()` gate `/api/events` in `vtsearch/routes/events.py`;
+  once saturated, new connects get an immediate `503` with `Retry-After: 5`
+  instead of starting a stream, so the rejection itself never pins a
+  thread. The frontend's `EventSource` already schedules a manual
+  reconnect when the server closes the connection non-2xx (see
+  `progress-events.service.ts`'s `onerror`/`readyState === CLOSED` path),
+  so no frontend change was needed. Tests in
+  `tests/api/test_events_sse.py` (`TestSseConnectionCapPrimitive`,
+  `TestSseConnectionCapRoute`).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
 but deferred as needing a design decision or a larger change.  (Original
 open items #2, #6, #10, #14 were drained in the second follow-up pass, the
 renumbered #2 "JobManager cancellation advisory" in the third pass, the
-staging + eval progress isolation (renumbered #2, #3) in the fourth, and the
-re-renumbered #5/#8 "ML threshold correctness" items in the fifth — see the
-follow-up-pass subsections under What shipped.  The list below is
-renumbered again after those drains.)
+staging + eval progress isolation (renumbered #2, #3) in the fourth, the
+re-renumbered #5/#8 "ML threshold correctness" items in the fifth, and the
+re-renumbered #1 "SSE connection cap" in the sixth — see the follow-up-pass
+subsections under What shipped.  The list below is renumbered again after
+those drains.)
 
-1. **SSE `/api/events` pins a gthread worker thread per connection.**
-   With `workers = 1, threads = 8`, eight open tabs starve the whole app;
-   stalled requests plus a live heartbeat read as an app hang.  Needs a
-   design decision: bound SSE connections, size the pool against them, or
-   move the stream off the request-thread pool.
-2. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
+1. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
    dataset where only some media carry `patch_regions`
    (`embedding/matrix.py:_build_region_arrays`): region rows are in the
    patch embedder's space, fallback rows in the primary's.  Needs either an
    ingest guarantee (all-or-nothing patch_regions per dataset) or space
    checking here.
-3. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+2. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
    don't force the full-data `hidden_dim` and don't thread the split RNG
    into calibration - so reported eval costs measure a pipeline that differs
    from production in the small-label regime.  (The "production uses 0.5
    below 6 labels" mismatch is now narrower: with safe-thresholds off,
    production cross-calibrates below 6 too — see Fifth follow-up pass.)
-4. **Inclusion slide drops the safe-threshold GMM blend**
+3. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-5. **Dataset registry is not multi-process safe**
+4. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-6. **`http_archive` cache never invalidates** when the remote archive
+5. **`http_archive` cache never invalidates** when the remote archive
    changes (fixed collision, not staleness); `extract_archive_cached`'s
    mtime/size keying is the model.
-7. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+6. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
    rather than clean): browse-canvas/minimap coordinate math and rAF
    lifecycles, modal/player component lifecycle sweep, left/right-panel
    virtualization, and a full route-blueprint sweep of
@@ -338,3 +358,8 @@ renumbered again after those drains.)
   `current` / `total` (read from the `AsyncJob`) rather than the shared
   `eval_progress` singleton, so overlapping evals no longer read each
   other's progress.
+- `GET /api/events` now returns `503` (with `Retry-After: 5`) once
+  `MAX_SSE_CONNECTIONS` concurrent streams are already open, instead of
+  accepting an unbounded number of connections that could starve the
+  gthread pool. Cap defaults to `VTSEARCH_THREADS - 2`; override with
+  `VTSEARCH_SSE_MAX_CONNECTIONS`.

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -4,11 +4,15 @@ import json
 import threading
 import time
 
+import vtscore.concurrency.events as events_mod
 from vtscore.concurrency.events import (
     _TASK_CHANNELS,
     _TRACKER_CHANNELS,
     BOOT_ID,
+    acquire_sse_slot,
+    active_sse_connections,
     initial_snapshot,
+    release_sse_slot,
     stream_progress_events,
 )
 from vtscore.concurrency.progress import (
@@ -381,3 +385,86 @@ class TestEventsStateSyncExemption:
         resp = client.get("/api/version")
         assert resp.status_code == 200
         assert "votes" in calls and "embedder" in calls
+
+
+# ---------------------------------------------------------------------------
+# SSE connection cap (comprehensive-audit-2026-07 open follow-up #1)
+# ---------------------------------------------------------------------------
+
+
+class TestSseConnectionCapPrimitive:
+    def test_acquire_up_to_cap_then_rejects(self, monkeypatch):
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 2)
+        assert active_sse_connections() == 0
+        assert acquire_sse_slot() is True
+        assert acquire_sse_slot() is True
+        assert active_sse_connections() == 2
+        # Third acquire is over the cap: rejected without incrementing.
+        assert acquire_sse_slot() is False
+        assert active_sse_connections() == 2
+
+        release_sse_slot()
+        assert active_sse_connections() == 1
+        assert acquire_sse_slot() is True
+        assert active_sse_connections() == 2
+
+        release_sse_slot()
+        release_sse_slot()
+        assert active_sse_connections() == 0
+
+    def test_release_below_zero_is_clamped(self, monkeypatch):
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 2)
+        assert active_sse_connections() == 0
+        release_sse_slot()
+        assert active_sse_connections() == 0
+
+    def test_default_max_connections_derives_from_thread_pool(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_THREADS", "8")
+        assert events_mod._default_max_connections() == 6
+
+    def test_default_max_connections_floors_at_one(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_THREADS", "1")
+        assert events_mod._default_max_connections() == 1
+
+
+class TestSseConnectionCapRoute:
+    def test_route_returns_503_with_retry_after_when_saturated(self, client, monkeypatch):
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 0)
+        resp = client.get("/api/events", buffered=False)
+        try:
+            assert resp.status_code == 503
+            assert resp.headers.get("Retry-After") == "5"
+            body = resp.get_json()
+            assert "message" in body
+        finally:
+            resp.close()
+        # Rejection never touched the counter.
+        assert active_sse_connections() == 0
+
+    def test_route_rejects_when_already_saturated(self, client, monkeypatch):
+        """Simulate another connection already holding the sole slot (via the
+        primitive, not a second nested test-client request — the Werkzeug
+        test client's request-context stack isn't reentrant across two
+        concurrently-open streams on the same client)."""
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 1)
+        assert acquire_sse_slot() is True
+        try:
+            resp = client.get("/api/events", buffered=False)
+            try:
+                assert resp.status_code == 503
+            finally:
+                resp.close()
+        finally:
+            release_sse_slot()
+        assert active_sse_connections() == 0
+
+    def test_route_releases_slot_on_disconnect(self, client, monkeypatch):
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 1)
+        resp = client.get("/api/events", buffered=False)
+        try:
+            assert resp.status_code == 200
+            assert active_sse_connections() == 1
+        finally:
+            resp.close()
+        # Closing the connection frees its slot.
+        assert active_sse_connections() == 0

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -11,7 +11,9 @@ Replaces the per-tracker REST polling endpoints (``/api/dataset/progress``,
 from __future__ import annotations
 
 import json
+import os
 import queue
+import threading
 import time
 import uuid
 from typing import Any, Callable, Generator
@@ -61,6 +63,61 @@ _TASK_CHANNELS: dict[str, LoadingTasksTracker] = {
     "loading-tasks": loading_tasks,
     "detector-loading-tasks": detector_loading_tasks,
 }
+
+
+def _default_max_connections() -> int:
+    """Derive the SSE connection cap from the deployed thread pool size.
+
+    Each open ``/api/events`` connection pins a ``gthread`` worker thread
+    for its whole lifetime (the generator blocks in ``queue.get()`` between
+    updates). ``gunicorn.conf.py`` runs a single worker with
+    ``VTSEARCH_THREADS`` (default 8) threads, so an unbounded number of
+    open tabs can starve the pool of threads needed to serve ordinary REST
+    requests — a stalled request plus a live heartbeat then reads as an app
+    hang rather than a clear error (comprehensive-audit-2026-07 #1).
+    Reserve a fixed headroom so SSE can never claim every thread.
+    """
+    pool = int(os.environ.get("VTSEARCH_THREADS", "8"))
+    reserve = 2
+    return max(1, pool - reserve)
+
+
+#: Hard cap on concurrent ``/api/events`` connections this process accepts.
+#: Override directly with ``VTSEARCH_SSE_MAX_CONNECTIONS``; otherwise derived
+#: from ``VTSEARCH_THREADS`` via :func:`_default_max_connections`.
+MAX_SSE_CONNECTIONS = int(os.environ.get("VTSEARCH_SSE_MAX_CONNECTIONS", str(_default_max_connections())))
+
+_connection_lock = threading.Lock()
+_active_connections = 0
+
+
+def acquire_sse_slot() -> bool:
+    """Reserve one of the bounded SSE connection slots.
+
+    Returns ``False`` (without side effects) if the process is already at
+    :data:`MAX_SSE_CONNECTIONS`; the caller should reject the connection
+    instead of starting a stream that would pin a thread indefinitely.
+    Pair every successful call with :func:`release_sse_slot`.
+    """
+    global _active_connections
+    with _connection_lock:
+        if _active_connections >= MAX_SSE_CONNECTIONS:
+            return False
+        _active_connections += 1
+        return True
+
+
+def release_sse_slot() -> None:
+    """Release a slot reserved by :func:`acquire_sse_slot`."""
+    global _active_connections
+    with _connection_lock:
+        _active_connections = max(0, _active_connections - 1)
+
+
+def active_sse_connections() -> int:
+    """Current count of open SSE connections (test/introspection helper)."""
+    with _connection_lock:
+        return _active_connections
 
 
 def _format_sse(event: str, data: Any) -> str:

--- a/vtsearch/routes/events.py
+++ b/vtsearch/routes/events.py
@@ -6,9 +6,11 @@ Replaces per-tracker REST polling (``/api/dataset/progress``,
 
 from __future__ import annotations
 
-from flask import Blueprint, Response, stream_with_context
+from typing import Generator
 
-from vtscore.concurrency.events import stream_progress_events
+from flask import Blueprint, Response, jsonify, stream_with_context
+
+from vtscore.concurrency.events import acquire_sse_slot, release_sse_slot, stream_progress_events
 
 events_bp = Blueprint("events", __name__)
 
@@ -23,9 +25,28 @@ def progress_events() -> Response:
     ``detector-loading-tasks``, and ``heartbeat`` (periodic liveness ping)
     events. The first frame on every channel is the current snapshot; clients
     do not need a separate REST call to bootstrap state.
+
+    Each open connection pins a ``gthread`` worker thread for its lifetime,
+    so connections are capped (``MAX_SSE_CONNECTIONS``) to leave headroom for
+    ordinary requests; once the cap is hit new connects get a 503 instead of
+    starving the pool. ``EventSource`` treats a non-2xx response as a fatal
+    error and stops auto-reconnecting, so the frontend's own ``onerror``
+    handler schedules a manual reconnect (see ``progress-events.service.ts``).
     """
+    if not acquire_sse_slot():
+        response = jsonify({"message": "Too many live event streams open; retry shortly."})
+        response.status_code = 503
+        response.headers["Retry-After"] = "5"
+        return response
+
+    def generate() -> Generator[str, None, None]:
+        try:
+            yield from stream_progress_events()
+        finally:
+            release_sse_slot()
+
     response = Response(
-        stream_with_context(stream_progress_events()),
+        stream_with_context(generate()),
         mimetype="text/event-stream",
     )
     # Long-lived stream: set our own Cache-Control so the global @after_request


### PR DESCRIPTION
## Summary

Drains open follow-up #1 from `docs/plans/comprehensive-audit-2026-07.md`.

Each open `/api/events` SSE connection pins a `gthread` worker thread for its lifetime (the generator blocks in `queue.get()` between updates). Under the documented single-worker deployment (`workers = 1, threads = 8`), an unbounded number of open tabs could starve the thread pool needed to serve ordinary REST requests — a stalled request plus a live SSE heartbeat then reads as an app hang rather than a clear error.

- Added `MAX_SSE_CONNECTIONS`, `acquire_sse_slot()`/`release_sse_slot()` in `vtscore/concurrency/events.py`. The cap defaults to `VTSEARCH_THREADS - 2` (reserving headroom for normal traffic), overridable directly via `VTSEARCH_SSE_MAX_CONNECTIONS`.
- `vtsearch/routes/events.py` now checks the cap before creating the stream; once saturated, new connects get an immediate `503` with `Retry-After: 5` instead of starting a stream (so the rejection itself never pins a thread), and releases the slot when the connection closes.
- No frontend change needed: `EventSource` already treats a non-2xx response as fatal and stops auto-reconnecting, and `progress-events.service.ts`'s `onerror` handler already schedules a manual reconnect when `readyState === CLOSED`.
- Documented the cap in `docs/DEPLOYMENT.md`'s SSE/reverse-proxy section.
- Updated `docs/plans/comprehensive-audit-2026-07.md`: recorded the sixth follow-up pass, renumbered the remaining open items, and added a backwards-compatibility note.

## Test plan

- [x] `tests/api/test_events_sse.py` — new `TestSseConnectionCapPrimitive` (acquire/release/default-derivation) and `TestSseConnectionCapRoute` (503 + `Retry-After` when saturated, slot released on disconnect)
- [x] `./run-tests.sh api` — all passing
- [x] `./run-tests.sh` (full suite, after building the frontend bundle) — all 5478 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTQTPuASzDjpBMWMo1Akyn


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTQTPuASzDjpBMWMo1Akyn)_