### PR TITLE
Browse canvas: double-right-click empty space zooms out

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -258,6 +258,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private pendingToggleX = 0;
   private pendingToggleY = 0;
   private static readonly DBLCLICK_MS = 250;
+  // `event.timeStamp` of the last right-click that landed on empty canvas (no
+  // bin under the cursor), used to detect a double-right-click there; see
+  // {@link onContextMenu}. Reset to 0 whenever a right-click lands on a bin
+  // or a double is consumed, so only two *consecutive empty* right-clicks
+  // within DBLCLICK_MS pair up.
+  private lastEmptyContextMenuAt = 0;
   // Per-notch wheel zoom factor. A pyramid level spans a full 2x of zoom, so the
   // {@link zoomsPerLevel} setting (n) sets how many notches cross a bin layer:
   // the factor is 2 ** (1 / n). At the default n=2 that is exactly √2, so two
@@ -2179,7 +2185,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /** Right-click: suppress the native menu and ask the view to open the bin
-   *  popup, carrying the cursor anchor and the bin (if any) under it. */
+   *  popup, carrying the cursor anchor and the bin (if any) under it. A
+   *  second right-click on empty canvas (no bin under the cursor) within the
+   *  double-click window zooms out about the cursor instead, mirroring
+   *  double-click-to-zoom-in. Landing on a bin at either click breaks the
+   *  pair, so it never fires while browsing bin popups. */
   private onContextMenu(event: MouseEvent): void {
     event.preventDefault();
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
@@ -2188,6 +2198,19 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // Close any hover preview so it doesn't sit under the popup.
     this.clearHover();
     const cell = this.hitTest(mx, my);
+
+    if (!cell) {
+      const now = event.timeStamp;
+      const isDoubleRightClick = now - this.lastEmptyContextMenuAt < BrowseCanvasComponent.DBLCLICK_MS;
+      this.lastEmptyContextMenuAt = isDoubleRightClick ? 0 : now;
+      if (isDoubleRightClick) {
+        this.zoomBy(1 / BrowseCanvasComponent.DOUBLE_CLICK_ZOOM, mx, my);
+        return;
+      }
+    } else {
+      this.lastEmptyContextMenuAt = 0;
+    }
+
     const members = cell ? this.cellMembers(cell) : [];
     this.contextMenu.emit({
       clientX: event.clientX,


### PR DESCRIPTION
## Summary
- Double-clicking the VTSBrowse canvas already zooms in about the cursor; right-clicking a bin already opens its details popup.
- Adds the missing mirror gesture: double-right-clicking empty canvas (no bin under the cursor on either click) now zooms out about the cursor instead.
- A right-click that lands on a bin (either click of the pair) breaks the sequence, so the gesture never fires while browsing bin popups — only two consecutive empty-canvas right-clicks within the existing double-click window pair up.

## Test plan
- [x] `cd frontend && npm run build:prod` — clean build, no warnings
- [x] `./run-tests.sh` — full suite: 5480 passed, 1 skipped (frontend build + audit + Vitest all green)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhP7N3F3DtfYTMPTc95rh7)_