### PR TITLE
Fix region-matrix fallback mixing embedding spaces on mixed patch datasets

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -7,7 +7,9 @@ shipped (per-task progress isolation — staging imports + eval jobs); fifth
 follow-up pass shipped (#5, #8 of the renumbered open list — ML threshold
 correctness); sixth follow-up pass shipped (#1 of the then-current open
 list — SSE connection cap); seventh follow-up pass shipped (http_archive
-cache staleness); remaining open follow-ups below.**
+cache staleness); eighth follow-up pass shipped (#1 of the then-current
+open list — region-matrix fallback space mixing); remaining open
+follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -292,6 +294,35 @@ up any of these areas sees the known-weak spots.
   (`test_stale_cache_invalidated_on_signature_mismatch`,
   `test_signature_probe_failure_trusts_existing_cache`).
 
+### Eighth follow-up pass (drained from the open list)
+
+- **Region-matrix fallback space mixing** (was open #1).
+  `embedding/matrix.py:_build_region_arrays` flattens every media's
+  `patch_regions` into one `(R, D)` matrix, giving a region-less media a
+  single fallback row so the segmented max-pool never sees an empty group.
+  That fallback unconditionally read the media's *primary* vector - fine
+  when every media in the dataset carries `patch_regions` (the only
+  reachable case before the v3 trio-embedder work), but on a dataset that
+  mixes patch-capable and patch-less media (a combined dataset, or a media
+  type the patch embedder can't process) the primary can be a different
+  embedder than the one that produced the region rows, silently stacking
+  vectors from two different embedding spaces into one matrix and scoring
+  the region-less media's dot-products meaninglessly.  Added
+  `_patch_embedder_for_region_snap`, which derives the patch-slot embedder
+  name from a media that actually carries `patch_regions` (role-typing its
+  bound embedder names via `derive_binding_from_names`, not just reading the
+  *first* media in the dict, which may itself be the region-less one and
+  never had a patch-embedder vector to role-type from); the fallback row now
+  reads that embedder's vector instead of the primary.  A region-less media
+  with no vector at all under the patch embedder now raises `ValueError`
+  naming the media and embedder (matching this module's existing
+  loud-failure philosophy for missing embeddings) rather than silently
+  substituting the wrong space.  Single-embedder datasets are unaffected:
+  the derived patch embedder there always equals the primary, so the
+  fallback read is byte-for-byte the same as before.  Tests in
+  `tests_lib/detectors/test_region_score_pool.py`
+  (`TestRegionMatrixFallbackSpace`).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
@@ -300,34 +331,29 @@ open items #2, #6, #10, #14 were drained in the second follow-up pass, the
 renumbered #2 "JobManager cancellation advisory" in the third pass, the
 staging + eval progress isolation (renumbered #2, #3) in the fourth, the
 re-renumbered #5/#8 "ML threshold correctness" items in the fifth, the
-re-renumbered #1 "SSE connection cap" in the sixth, and the re-renumbered
-#6 "http_archive cache staleness" in the seventh — see the follow-up-pass
-subsections under What shipped.  The list below is renumbered again after
-those drains.)
+re-renumbered #1 "SSE connection cap" in the sixth, the re-renumbered #6
+"http_archive cache staleness" in the seventh, and the re-renumbered #1
+"region-matrix fallback space mixing" in the eighth — see the
+follow-up-pass subsections under What shipped.  The list below is
+renumbered again after those drains.)
 
-1. **Region-matrix fallback can mix embedding spaces** on a multi-embedder
-   dataset where only some media carry `patch_regions`
-   (`embedding/matrix.py:_build_region_arrays`): region rows are in the
-   patch embedder's space, fallback rows in the primary's.  Needs either an
-   ingest guarantee (all-or-nothing patch_regions per dataset) or space
-   checking here.
-2. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
+1. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
    don't force the full-data `hidden_dim` and don't thread the split RNG
    into calibration - so reported eval costs measure a pipeline that differs
    from production in the small-label regime.  (The "production uses 0.5
    below 6 labels" mismatch is now narrower: with safe-thresholds off,
    production cross-calibrates below 6 too — see Fifth follow-up pass.)
-3. **Inclusion slide drops the safe-threshold GMM blend**
+2. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-4. **Dataset registry is not multi-process safe**
+3. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-5. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+4. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
    rather than clean): browse-canvas/minimap coordinate math and rAF
    lifecycles, modal/player component lifecycle sweep, left/right-panel
    virtualization, and a full route-blueprint sweep of
@@ -389,3 +415,9 @@ those drains.)
   published. A cache built before this change (no recorded signature) or a
   failed probe still trusts the existing cache, so this is additive: no
   previously-cached extraction is invalidated by upgrading alone.
+- A region-less media in a mixed patch/non-patch dataset now has its
+  region-matrix fallback row read from the dataset's patch-slot embedder
+  instead of its primary embedder, and raises `ValueError` if it has no
+  vector under the patch embedder at all.  No effect on any dataset where
+  every media shares one embedder (the only case reachable before the v3
+  trio-embedder work).

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -934,11 +934,14 @@ dataset-level score precedence for detector operations) — see
   only matters once a multi-embedder (trio) dataset can be created and
   Find-scored; wire a binding derived from those medias' own embedder names when
   the create-time three-role picker lands.
-- **Region-less media in a region matrix fall back to the primary vector.**
-  `matrix._build_region_arrays` sources a region-less media's single row from
-  `media["embedding"]` (primary), not the patch embedder's vector.  On a real
-  patch dataset every media has `patch_regions`, so this branch is unreachable
-  today; revisit if a dual dataset ever mixes patch and non-patch media.
+- ~~**Region-less media in a region matrix fall back to the primary vector.**~~
+  **Fixed** (`docs/plans/comprehensive-audit-2026-07.md` → eighth follow-up
+  pass). `matrix._build_region_arrays` now sources a region-less media's
+  fallback row from the dataset's patch-slot embedder (derived from a
+  region-bearing media via `derive_binding_from_names`), not unconditionally
+  the primary; raises `ValueError` if that media has no vector under the
+  patch embedder either. Byte-for-byte unchanged when every media shares one
+  embedder.
 
 ### Open follow-ups (from 2b.3)
 

--- a/tests_lib/detectors/test_region_score_pool.py
+++ b/tests_lib/detectors/test_region_score_pool.py
@@ -87,6 +87,87 @@ class TestRegionMaxPool:
         assert best_region[2] == 0
 
 
+class TestRegionMatrixFallbackSpace:
+    """A region-less media's fallback row must be the *patch*-space vector.
+
+    On a dataset that mixes patch-capable and patch-less media (e.g. two
+    datasets combined, or a media type the patch embedder can't process),
+    the primary embedder can differ from the one that produced the region
+    vectors.  Stacking the primary vector alongside patch-space region rows
+    in the same matrix would silently score a region-less media in the wrong
+    space; the fallback must read the patch embedder's own vector instead.
+    """
+
+    def test_fallback_row_reads_patch_embedder_not_primary(self):
+        rng = np.random.default_rng(0)
+        region_vec = rng.standard_normal(DIM).astype(np.float32)
+        region_vec /= np.linalg.norm(region_vec) + 1e-8
+        primary_vec = rng.standard_normal(DIM).astype(np.float32)
+        primary_vec /= np.linalg.norm(primary_vec) + 1e-8
+        patch_vec = rng.standard_normal(DIM).astype(np.float32)
+        patch_vec /= np.linalg.norm(patch_vec) + 1e-8
+
+        clips = {
+            1: {
+                "id": 1,
+                "media_type": "image",
+                "embedder": "dinov3_patch",
+                "embeddings": {"dinov3_patch": rng.standard_normal(DIM).astype(np.float32)},
+                "patch_regions": [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=region_vec)],
+            },
+            # Region-less media bound under a *different* primary embedder
+            # (e.g. text-capable), but also carries a vector for the patch
+            # embedder - the mixed-media-type case.
+            2: {
+                "id": 2,
+                "media_type": "image",
+                "embedder": "siglip",
+                "embeddings": {"siglip": primary_vec, "dinov3_patch": patch_vec},
+                "patch_regions": None,
+            },
+        }
+
+        _all_ids, region_matrix, media_index, _region_index = get_region_matrix_for_snap(clips)
+
+        # Media 2's single fallback row is its "dinov3_patch" vector, not its
+        # "siglip" primary vector.
+        fallback_row = region_matrix[media_index.tolist().index(1)]
+        np.testing.assert_array_equal(fallback_row, patch_vec)
+        assert not np.array_equal(fallback_row, primary_vec)
+
+    def test_fallback_row_missing_patch_vector_raises(self):
+        rng = np.random.default_rng(1)
+        region_vec = rng.standard_normal(DIM).astype(np.float32)
+        region_vec /= np.linalg.norm(region_vec) + 1e-8
+
+        clips = {
+            1: {
+                "id": 1,
+                "media_type": "image",
+                "embedder": "dinov3_patch",
+                "embeddings": {"dinov3_patch": rng.standard_normal(DIM).astype(np.float32)},
+                "patch_regions": [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=region_vec)],
+            },
+            # Region-less media with no vector at all under the patch
+            # embedder - must raise loudly rather than mix in its primary.
+            2: {
+                "id": 2,
+                "media_type": "video",
+                "embedder": "siglip",
+                "embeddings": {"siglip": rng.standard_normal(DIM).astype(np.float32)},
+                "patch_regions": None,
+            },
+        }
+
+        try:
+            get_region_matrix_for_snap(clips)
+        except ValueError as exc:
+            assert "dinov3_patch" in str(exc)
+            assert "2" in str(exc)
+        else:
+            raise AssertionError("expected ValueError for missing patch-embedder vector")
+
+
 class TestRegionMatrixCache:
     def test_matrix_cached_and_invalidated(self):
         ctx = get_active_context()

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtscore.embedding.media_vectors import media_embedding, primary_embedder_name
+from vtscore.embedding.media_vectors import media_embedder_names, media_embedding, primary_embedder_name
 from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
@@ -186,6 +186,28 @@ def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
         ctx._region_index_per_row = None
 
 
+def _patch_embedder_for_region_snap(snap: dict[int, dict[str, Any]]) -> str | None:
+    """Return the patch-slot embedder name that produced *snap*'s region rows.
+
+    Derived from a media that actually carries ``patch_regions`` (rather than
+    just the first media in the dict, which may be a region-less item that
+    never had a vector for the patch embedder at all - the mixed-media-type
+    case).  That media's own bound embedder names are role-typed via
+    :func:`~vtscore.embedding.binding.derive_binding_from_names`; the patch
+    slot is the space the region vectors live in.  Returns ``None`` when no
+    media in *snap* has regions, or when the region-bearing media's embedders
+    don't role-type to a patch slot (unexpected; the fallback path then keeps
+    the pre-fix behaviour of reading the primary vector).
+    """
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+
+    for media in snap.values():
+        if media.get("patch_regions"):
+            _text, patch, _structural = derive_binding_from_names(media_embedder_names(media))
+            return patch
+    return None
+
+
 def _build_region_arrays(
     snap: dict,
     sorted_ids: list[int],
@@ -201,10 +223,21 @@ def _build_region_arrays(
       media's ``patch_regions`` list (the winning value surfaces as the UI's
       best-match overlay).
 
-    Media that expose no ``patch_regions`` contribute a single row from their
-    image-level ``embedding`` (region index 0), so every media has at least
-    one row - keeping the downstream segmented max-pool free of empty groups.
+    Media that expose no ``patch_regions`` contribute a single row (region
+    index 0) so every media has at least one row - keeping the downstream
+    segmented max-pool free of empty groups.  That fallback row is read from
+    the *patch-slot* embedder shared by the rest of the snapshot's region rows
+    (:func:`_patch_embedder_for_region_snap`), not unconditionally the primary
+    vector: on a dataset that mixes patch-capable and patch-less media (e.g. a
+    combined dataset, or a media type the patch embedder can't process), the
+    primary can be a different embedder than the one that produced the region
+    vectors, and stacking its vector alongside them would silently mix
+    embedding spaces in one matrix.  If the region-less media has no vector
+    under that patch embedder either, :func:`_require_embedding` raises rather
+    than falling back further - a loud, locatable failure instead of a
+    silently meaningless score.
     """
+    patch_embedder_name = _patch_embedder_for_region_snap(snap)
     flat_vecs: list[np.ndarray] = []
     media_index_per_row: list[int] = []
     region_index_per_row: list[int] = []
@@ -217,7 +250,7 @@ def _build_region_arrays(
                 media_index_per_row.append(mi)
                 region_index_per_row.append(ri)
         else:
-            flat_vecs.append(np.asarray(_require_embedding(cid, media), dtype=np.float32))
+            flat_vecs.append(np.asarray(_require_embedding(cid, media, patch_embedder_name), dtype=np.float32))
             media_index_per_row.append(mi)
             region_index_per_row.append(0)
     region_matrix = np.stack(flat_vecs).astype(np.float32, copy=False)


### PR DESCRIPTION
## Summary

- Drains open follow-up #1 from `docs/plans/comprehensive-audit-2026-07.md` (the "Region-matrix fallback can mix embedding spaces" finding from the original audit).
- `embedding/matrix.py:_build_region_arrays` gave a region-less media a fallback row read from its *primary* embedder, unconditionally. On a dataset that mixes patch-capable and patch-less media (a combined dataset, or a media type the patch embedder can't process), the primary can differ from the embedder that produced the region rows — silently stacking vectors from two different embedding spaces into one matrix and scoring the region-less media meaninglessly.
- Added `_patch_embedder_for_region_snap`, which derives the patch-slot embedder name from a media that actually carries `patch_regions` (not just the first media in the dict, which may itself be the region-less one). The fallback row now reads that embedder's vector instead of the primary, and raises `ValueError` (naming the media and embedder) if no such vector exists — a loud, locatable failure instead of a silent space mismatch, matching this module's existing philosophy for missing embeddings.
- Single-embedder datasets are unaffected: the derived patch embedder there always equals the primary, so the fallback read is byte-for-byte the same as before.
- Updated `docs/plans/comprehensive-audit-2026-07.md` (renumbered the open-follow-ups list, added the "Eighth follow-up pass" section, added a behaviour-change note) and marked the related note in `docs/plans/patch-embedder.md` as fixed.

## Test plan

- [x] New regression tests in `tests_lib/detectors/test_region_score_pool.py` (`TestRegionMatrixFallbackSpace`): fallback row reads the patch embedder's vector (not the primary) on a mixed-embedder snapshot, and raises `ValueError` when the region-less media has no patch-embedder vector at all.
- [x] `ruff check` / `ruff format --check` on changed files.
- [x] `./run-tests.sh detectors` — 1348 passed.
- [x] `./run-tests.sh` (full suite incl. ruff/codespell/deptry/pyright, frontend build + audit + Vitest) — 5482 passed, 1 skipped, 2 xpassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RRmk4g4ekEjVh8cNhRTgcm)_