### PR TITLE
VTSBrowse: right-click opens & pins the bin detail view, autoplays its rep

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -305,6 +305,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
       // right-clicked) so the pane is never blank and the detail view starts on
       // the same image — not the 1-D list's first item, which differs.
       this.previewId = this.representativeId();
+      // Auto-play the representative's clip on open (audio) so the detail window
+      // is an "intense hover": opening it hears the rep, just like resting on the
+      // bin on the canvas. This is the only way to hear a singleton audio bin,
+      // whose member grid (and its hover-to-hear) is dropped (see previewOnly).
+      if (this.previewId != null) this.playAudio(this.previewId);
       // A fresh bin is a fresh popup: forget any drag from the previous one so
       // it re-anchors to the new summon point.
       this.dragged = false;
@@ -908,19 +913,32 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnChanges, OnDest
     // media type, so audio/text/document read metadata for the item under the
     // cursor even without a preview pane).
     this.previewId = id;
+    this.playAudio(id);
+  }
+
+  /**
+   * Audition ``id`` in the popup's audio element (audio media only), updating
+   * the shared now-playing indicator. Shared by the open-time autoplay and the
+   * grid-row hover; a no-op when the same clip is already playing so re-entering
+   * a row (or a redundant re-summon) doesn't restart it.
+   */
+  private playAudio(id: number): void {
     if (this.mediaType() !== 'audio') return;
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
     this.audioSrc = src;
+    // The autoplay-on-open path may fire before prefetchVisible has hydrated the
+    // representative's metadata, so make sure its clip extents are loading (the
+    // clip-window handlers read them lazily as they land).
+    this.metadataCache.ensureLoaded([id]);
     this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id) });
     setTimeout(() => {
       const el = this.audioRef?.nativeElement;
       if (!el) return;
       el.volume = this.volume();
       // Windowed archive-member clips serve the whole file: seek to clip_start
-      // and loop within [clip_start, clip_end]. The hovered item's metadata is
-      // already hydrated (prefetchVisible loads the visible window), and is read
-      // lazily inside the handlers regardless.
+      // and loop within [clip_start, clip_end]. Metadata is read lazily inside
+      // the handlers regardless.
       applyClipWindow(el, () => this.metadataCache.get(id));
       el.load();
       el.play().catch(() => {});

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BrowseBinPopupComponent } from './browse-bin-popup.component';
+import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -166,6 +167,36 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // (count label + rows) plus the body's own 12px vertical padding on top.
     expect(parseFloat(body.style.height)).toBe(cmp.gridColHeight + 12);
 
+    fixture.destroy();
+  });
+
+  it('auto-plays the representative clip when an audio bin opens', async () => {
+    // Opening the detail popup is an "intense hover": for audio it should start
+    // auditioning the bin's representative straight away, with no grid-row hover
+    // — the behavior a singleton audio bin (no member grid) relies on entirely.
+    // jsdom doesn't implement the media element's play/load, so stub them; the
+    // now-playing emit happens before the deferred play() regardless.
+    const playStub = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined);
+    const loadStub = vi
+      .spyOn(HTMLMediaElement.prototype, 'load')
+      .mockImplementation(() => {});
+
+    const fixture = makeFixture();
+    fixture.componentRef.setInput('mediaType', 'audio');
+    fixture.componentRef.setInput('memberIds', [7, 8, 9]);
+    fixture.componentRef.setInput('repId', 8);
+    const played: (NowPlaying | null)[] = [];
+    fixture.componentInstance.nowPlaying.subscribe((v) => played.push(v));
+    await settlePasses(fixture);
+
+    // The window opened auditioning the representative (id 8), not the list's
+    // first member (id 7), and surfaced it on the shared now-playing indicator.
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail' });
+
+    playStub.mockRestore();
+    loadStub.mockRestore();
     fixture.destroy();
   });
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -293,6 +293,16 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private selAccent = '#4f9dff';
 
   private hoveredCell: HexCellPayload | null = null;
+  /**
+   * A bin "pinned" enlarged because its detail popup (right-click) is open.
+   * Independent of the live hover: it stays enlarged as long as the popup is up,
+   * so the user can tell which bin the details belong to. While a cell is pinned,
+   * hover on other bins is suppressed — the detail popup has precedence — until
+   * the popup is dismissed ({@link unpinCell}) or right-clicking another bin
+   * pins that one instead. Rendered enlarged via the same {@link drawHoveredHex}
+   * path as a hover; see the ``pinnedCell ?? hoveredCell`` pick in {@link draw}.
+   */
+  private pinnedCell: HexCellPayload | null = null;
   private hoverDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   // Last known cursor position over the canvas (canvas-relative mx/my plus the
   // viewport clientX/clientY) and whether the pointer is currently inside.
@@ -1361,19 +1371,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.selAccent = this.themeColor('--accent-color') || '#4f9dff';
     const selectionActive = this.selection.size > 0;
 
-    // The hovered cell is deferred and redrawn last (enlarged, on top of its
-    // neighbours) so the hover read-out is a size bump rather than a border —
-    // leaving the border free to encode selection state.
+    // The enlarged cell is deferred and redrawn last (on top of its neighbours)
+    // so the read-out is a size bump rather than a border — leaving the border
+    // free to encode selection state. A pinned cell (its detail popup is open)
+    // wins over the live hover, so the bin whose details are showing stays
+    // enlarged even as the cursor moves off it.
+    const enlargedCell = this.pinnedCell ?? this.hoveredCell;
     let hovered: { cell: HexCellPayload; sx: number; sy: number } | null = null;
     for (const cell of allCells) {
       const [sx, sy] = this.projToScreen(cell.cx, cell.cy);
       if (sx < -screenRadius * 2 || sx > this.width + screenRadius * 2) continue;
       if (sy < -screenRadius * 2 || sy > this.height + screenRadius * 2) continue;
-      if (
-        this.hoveredCell &&
-        this.hoveredCell.q === cell.q &&
-        this.hoveredCell.r === cell.r
-      ) {
+      if (enlargedCell && enlargedCell.q === cell.q && enlargedCell.r === cell.r) {
         hovered = { cell, sx, sy };
         continue;
       }
@@ -2184,22 +2193,33 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.zoomBy(BrowseCanvasComponent.DOUBLE_CLICK_ZOOM, mx, my);
   }
 
-  /** Right-click: suppress the native menu and ask the view to open the bin
-   *  popup, carrying the cursor anchor and the bin (if any) under it. A
-   *  second right-click on empty canvas (no bin under the cursor) within the
+  /** Right-click: suppress the native menu, pin the bin under the cursor so it
+   *  stays enlarged, and ask the view to open its detail popup. A second
+   *  right-click on empty canvas (no bin under the cursor) within the
    *  double-click window zooms out about the cursor instead, mirroring
-   *  double-click-to-zoom-in. Landing on a bin at either click breaks the
-   *  pair, so it never fires while browsing bin popups. */
+   *  double-click-to-zoom-in. Landing on a bin at either click breaks the pair,
+   *  so it never fires while browsing bin popups. */
   private onContextMenu(event: MouseEvent): void {
     event.preventDefault();
     const rect = this.canvasRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
-    // Close any hover preview so it doesn't sit under the popup.
+    // Target the bin the cursor is already hovering first, falling back to a
+    // hit-test only when nothing is hovered (the pointer only just arrived, or a
+    // different bin is currently pinned). This is what makes the *first*
+    // right-click open the detail view: a hovered thumbnail breaks out well past
+    // its true hex, so a raw hit-test at the cursor can land outside the true
+    // silhouette and find nothing — which used to shrink the bin and take a
+    // second click. The hovered cell is unambiguously what the user is aiming at.
+    const cell = this.hoveredCell ?? this.hitTest(mx, my);
+    // Stop the transient hover audition and drop the hover highlight; from here
+    // the pinned cell drives the enlarge and the popup drives the audio.
     this.clearHover();
-    const cell = this.hitTest(mx, my);
 
     if (!cell) {
+      // Empty canvas: a second right-click within the double-click window zooms
+      // out about the cursor (mirrors double-click-to-zoom-in). A bin under
+      // either click breaks the pair.
       const now = event.timeStamp;
       const isDoubleRightClick = now - this.lastEmptyContextMenuAt < BrowseCanvasComponent.DBLCLICK_MS;
       this.lastEmptyContextMenuAt = isDoubleRightClick ? 0 : now;
@@ -2211,14 +2231,33 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.lastEmptyContextMenuAt = 0;
     }
 
-    const members = cell ? this.cellMembers(cell) : [];
+    // Pin the bin so it stays enlarged while its detail popup is open (right-
+    // clicking another bin re-pins to it; dismissing the popup unpins via the
+    // view calling {@link unpinCell}). Blank space clears any pin.
+    this.pinnedCell = cell;
+    this.requestRedraw();
     this.contextMenu.emit({
       clientX: event.clientX,
       clientY: event.clientY,
-      members,
+      members: cell ? this.cellMembers(cell) : [],
       repId: cell ? cell.rep_id : null,
       bounds: rect,
     });
+  }
+
+  /**
+   * Release the pinned bin — called by the browse view when the detail popup is
+   * dismissed — and resume live hover at the current cursor position, so the bin
+   * now under the cursor lifts (and, for audio, plays) again. No-op when nothing
+   * is pinned.
+   */
+  unpinCell(): void {
+    if (!this.pinnedCell) return;
+    this.pinnedCell = null;
+    this.requestRedraw();
+    if (this.pointerInside) {
+      this.emitHoverHit(this.lastMouseX, this.lastMouseY, this.lastClientX, this.lastClientY);
+    }
   }
 
   /** Canvas-relative ``[x, y]`` for a mouse event. */
@@ -2615,6 +2654,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.lastClientY = event.clientY;
     this.pointerInside = true;
 
+    // A pinned bin (its detail popup is open) has precedence: suppress hover on
+    // other bins so the popup keeps its enlarge and audition. Keep tracking the
+    // cursor above, so hover resolves correctly the moment the popup is closed.
+    if (this.pinnedCell) return;
+
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
     this.hoverDebounceTimer = setTimeout(() => {
       this.emitHoverHit(mx, my, event.clientX, event.clientY);
@@ -2629,6 +2673,9 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * post-zoom refresh.
    */
   private emitHoverHit(mx: number, my: number, clientX: number, clientY: number): void {
+    // Hover is suppressed while a bin's detail popup is pinned (also guards the
+    // post-zoom refresh path, which calls this directly).
+    if (this.pinnedCell) return;
     const hit = this.hitTest(mx, my);
     const prevQ = this.hoveredCell?.q;
     const prevR = this.hoveredCell?.r;

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -796,6 +796,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   dismissContextMenu(): void {
     this.contextMenuOpen = false;
+    // Release the canvas's pinned enlarge so live hover resumes on the bin now
+    // under the cursor.
+    this.canvas?.unpinCell();
   }
 
   /**


### PR DESCRIPTION
## Summary

Reworks the VTSBrowse canvas so right-clicking a bin behaves like an "intense hover": it opens the bin detail popup **on the first click**, keeps that bin **enlarged for as long as the popup is open**, and (for audio) **auto-plays the bin's representative** just like resting on the bin does.

Previously, right-clicking a hovered (enlarged) bin would shrink it back down and open nothing — a second right-click was needed to actually open the detail view. The detail popup also never played anything until you separately hovered a member row, and a singleton audio bin (whose member grid is dropped) could never be heard at all.

## What changed

- **First-click open (double-click bug fix).** `onContextMenu` now targets the bin already under the cursor's hover, falling back to a hit-test only when nothing is hovered. A hovered thumbnail breaks out well past its true hex, so a raw hit-test at the cursor could land outside the true silhouette and find nothing — which shrank the bin and swallowed the click. The hovered cell is unambiguously what the user is aiming at.
- **Pinned enlarge with popup precedence.** Added a `pinnedCell` on the canvas, independent of live hover. It renders enlarged (`pinnedCell ?? hoveredCell`) and suppresses hover on *other* bins while set, so the bin whose details are showing stays enlarged and mousing over neighbors is ignored. Right-clicking another bin re-pins to it (switches the popup); dismissing the popup unpins and resumes live hover.
- **Autoplay on open.** The bin popup now auditions the representative clip when it opens or switches bins (audio), covering singleton audio bins that have no member grid to hover.
- **Unpin on dismiss.** The browse view releases the canvas's pin when the popup closes.

## Tests

- Added a bin-popup unit test asserting the representative auto-plays on open and surfaces on the shared now-playing indicator.
- `./run-tests.sh frontend` green (build + audit + 994 Vitest tests).

## Notes

- No doc screenshots frame the bin detail popup or a hovered/enlarged bin (the only browse shot captures the map's resting state), so no reshoot-queue entry was needed.
- Switching from bin A to bin B while A's popup is open replaces the detail view with B (A shrinks, B enlarges + opens + autoplays), per the chosen behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR1rGcyHNLeoCozuNqKXnF)_