### PR TITLE
Eval harness: calibrate voting-iterations folds like production

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -8,8 +8,9 @@ follow-up pass shipped (#5, #8 of the renumbered open list — ML threshold
 correctness); sixth follow-up pass shipped (#1 of the then-current open
 list — SSE connection cap); seventh follow-up pass shipped (http_archive
 cache staleness); eighth follow-up pass shipped (#1 of the then-current
-open list — region-matrix fallback space mixing); remaining open
-follow-ups below.**
+open list — region-matrix fallback space mixing); ninth follow-up pass
+shipped (#1 of the then-current open list — eval harness calibration
+fidelity); remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -323,6 +324,29 @@ up any of these areas sees the known-weak spots.
   `tests_lib/detectors/test_region_score_pool.py`
   (`TestRegionMatrixFallbackSpace`).
 
+### Ninth follow-up pass — eval harness calibration fidelity (drained from the open list)
+
+- **Eval folds now calibrate exactly as production does** (was open #1).
+  `eval/voting_iterations.py:simulate_voting_iterations` computed its per-step
+  threshold via `calculate_cross_calibration_threshold` **without** forcing the
+  full-data `hidden_dim` (so each calibration fold auto-sized to its own
+  smaller train split) and threaded the **shared per-seed simulation RNG** into
+  the fold splits.  Production's `_train_and_score_xy` / `train_and_threshold`
+  do the opposite: they size `hidden_dim` from the full label count, force that
+  width onto the folds (via `cross_calibration_threshold_cached(...,
+  hidden_dim=...)`), and always calibrate with a fresh `RandomState(42)`.  The
+  eval therefore measured a threshold the live detector never computes in the
+  small-label regime — narrower fold nets, calibrated against splits that
+  varied with the eval seed instead of the pinned production seed.  The per-step
+  call now passes `hidden_dim=_auto_hidden_dim(n_labels)` and
+  `rng=np.random.RandomState(42)` (a fresh one per step, mirroring how
+  `cross_calibration_threshold_cached` mints one per call), and the final
+  `train_model` is handed the same `hidden_dim`.  The eval seed still varies the
+  *data* (which media are voted, in what order, and the held-out test split);
+  only the calibration folds are now pinned, exactly as in production.  Tests in
+  `tests_lib/detectors/test_eval_voting_iterations.py`
+  (`TestProductionCalibrationFidelity`).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
@@ -332,28 +356,23 @@ renumbered #2 "JobManager cancellation advisory" in the third pass, the
 staging + eval progress isolation (renumbered #2, #3) in the fourth, the
 re-renumbered #5/#8 "ML threshold correctness" items in the fifth, the
 re-renumbered #1 "SSE connection cap" in the sixth, the re-renumbered #6
-"http_archive cache staleness" in the seventh, and the re-renumbered #1
-"region-matrix fallback space mixing" in the eighth — see the
+"http_archive cache staleness" in the seventh, the re-renumbered #1
+"region-matrix fallback space mixing" in the eighth, and the re-renumbered
+#1 "eval harness calibration fidelity" in the ninth — see the
 follow-up-pass subsections under What shipped.  The list below is
 renumbered again after those drains.)
 
-1. **Eval harness fidelity** (`eval/voting_iterations.py`): fold models
-   don't force the full-data `hidden_dim` and don't thread the split RNG
-   into calibration - so reported eval costs measure a pipeline that differs
-   from production in the small-label regime.  (The "production uses 0.5
-   below 6 labels" mismatch is now narrower: with safe-thresholds off,
-   production cross-calibrates below 6 too — see Fifth follow-up pass.)
-2. **Inclusion slide drops the safe-threshold GMM blend**
+1. **Inclusion slide drops the safe-threshold GMM blend**
    (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
    `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
    inclusion to a value and back changes the threshold semantics relative
    to a fresh retrain.  Decide whether the blend applies on slides.
-3. **Dataset registry is not multi-process safe**
+2. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-4. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+3. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
    rather than clean): browse-canvas/minimap coordinate math and rAF
    lifecycles, modal/player component lifecycle sweep, left/right-panel
    virtualization, and a full route-blueprint sweep of
@@ -421,3 +440,11 @@ renumbered again after those drains.)
   vector under the patch embedder at all.  No effect on any dataset where
   every media shares one embedder (the only case reachable before the v3
   trio-embedder work).
+- `simulate_voting_iterations` / `run_voting_iterations_eval` now calibrate
+  each step's threshold with the production `hidden_dim` (full-label width,
+  forced onto the folds) and a fixed `RandomState(42)` fold split, instead of
+  auto-sizing the folds and threading the per-seed simulation RNG.  Reported
+  `cost` / `fpr` / `fnr` values shift in the small-label regime because the
+  eval now measures the exact pipeline the live detector runs; the eval seed
+  still varies the data (votes, order, test split), only the calibration folds
+  are pinned.

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -284,6 +284,103 @@ class TestSimulateVotingIterations:
 
 
 # ------------------------------------------------------------------
+# Production fidelity: the per-step calibration must match the live
+# _train_and_score_xy / train_and_threshold pipeline, or the reported
+# cost measures a pipeline the detector never runs.
+# ------------------------------------------------------------------
+
+
+def _mt_key(rng: np.random.RandomState):
+    """Return the MT19937 key array of *rng* as a tuple (pyright-narrowed).
+
+    ``get_state(legacy=True)`` returns a tuple, but the numpy stub types it as a
+    ``dict | tuple`` union; the ``isinstance`` narrows it so ``state[1]`` (the
+    624-word key array) type-checks.
+    """
+    state = rng.get_state(legacy=True)
+    assert isinstance(state, tuple)
+    return state
+
+
+class TestProductionCalibrationFidelity:
+    """The eval's per-step threshold calibration mirrors production exactly.
+
+    Production (`_train_and_score_xy` / `train_and_threshold`) sizes the hidden
+    layer from the full label count, forces that width onto the calibration
+    folds, and always calibrates with a fresh ``RandomState(42)`` (the fixed
+    seed baked into ``cross_calibration_threshold_cached``).  These tests spy on
+    the calibration call to prove the eval does the same, so overlapping the
+    fold split RNG with the per-seed simulation RNG or letting folds auto-size
+    can't silently reintroduce a production mismatch.
+    """
+
+    def _spy_calibration(self, monkeypatch):
+        from vtscore.eval import voting_iterations
+
+        real = voting_iterations.calculate_cross_calibration_threshold
+        captured: list[dict] = []
+
+        def spy(X_list, y_list, input_dim, inclusion_value=0, *, rng=None, hidden_dim=None, **kw):
+            # get_state() copies without advancing, so recording it here does
+            # not perturb the real calibration that runs on the next line.
+            captured.append(
+                {
+                    "n": len(X_list),
+                    "hidden_dim": hidden_dim,
+                    "mt_key": _mt_key(rng)[1] if rng is not None else None,
+                }
+            )
+            return real(X_list, y_list, input_dim, inclusion_value, rng=rng, hidden_dim=hidden_dim, **kw)
+
+        monkeypatch.setattr(voting_iterations, "calculate_cross_calibration_threshold", spy)
+        return captured
+
+    def test_folds_forced_to_full_data_hidden_dim(self, monkeypatch):
+        from vtscore.training.mlp import _auto_hidden_dim
+
+        captured = self._spy_calibration(monkeypatch)
+        medias = _make_separable_clips(n_per_cat=10)
+        simulate_voting_iterations(medias, "alpha", seed=42)
+
+        assert captured  # at least one calibrated step
+        for c in captured:
+            # The fold models must be sized from the full label count for the
+            # step, not auto-sized per fold (hidden_dim=None).
+            assert c["hidden_dim"] == _auto_hidden_dim(c["n"])
+
+    def test_folds_calibrate_with_fixed_random_state_42(self, monkeypatch):
+        captured = self._spy_calibration(monkeypatch)
+        medias = _make_separable_clips(n_per_cat=10)
+        simulate_voting_iterations(medias, "alpha", seed=7)
+
+        assert captured
+        ref_key = _mt_key(np.random.RandomState(42))[1]
+        for c in captured:
+            mt_key = c["mt_key"]
+            assert mt_key is not None
+            # A fresh RandomState(42), not the shared per-seed simulation RNG
+            # (which the media split + vote sequence would have advanced).
+            assert np.array_equal(mt_key, ref_key)
+
+    def test_calibration_rng_independent_of_eval_seed(self, monkeypatch):
+        """The fold split RNG is pinned, so it does not vary with the eval seed."""
+        medias = _make_separable_clips(n_per_cat=10)
+
+        captured_a = self._spy_calibration(monkeypatch)
+        simulate_voting_iterations(medias, "alpha", seed=1)
+        captured_b = self._spy_calibration(monkeypatch)
+        simulate_voting_iterations(medias, "alpha", seed=2)
+
+        # Same first-step vote count is not guaranteed across seeds, but every
+        # calibrated step in both runs must start from the identical RNG state.
+        assert captured_a and captured_b
+        ref_key = tuple(_mt_key(np.random.RandomState(42))[1].tolist())
+        states_a = {tuple(c["mt_key"].tolist()) for c in captured_a}
+        states_b = {tuple(c["mt_key"].tolist()) for c in captured_b}
+        assert states_a == states_b == {ref_key}
+
+
+# ------------------------------------------------------------------
 # Integration test: run_voting_iterations_eval
 # ------------------------------------------------------------------
 

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.eval.labels import media_is_positive, region_box_for_category
-from vtscore.training.mlp import train_model
+from vtscore.training.mlp import _auto_hidden_dim, train_model
 from vtscore.training.thresholds import (
     calculate_cross_calibration_threshold,
     calculate_safe_threshold,
@@ -309,24 +309,40 @@ def simulate_voting_iterations(
         X = torch.tensor(np.array(X_list), dtype=torch.float32)
         y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
         input_dim = X.shape[1]
+        n_labels = len(good_votes) + len(bad_votes)
 
-        # Train and find threshold (mirrors train_and_score)
+        # Train and find threshold, matching the production
+        # ``_train_and_score_xy`` / ``train_and_threshold`` pipeline exactly so
+        # the reported cost measures what the live detector computes:
+        #   * ``hidden_dim`` is sized from the *full* label count and forced onto
+        #     the calibration folds, so the fold models share the final model's
+        #     architecture (production passes this into
+        #     ``cross_calibration_threshold_cached``).  Letting each fold
+        #     auto-size to its own smaller train split would train narrower fold
+        #     nets and report a threshold the live pipeline never produces.
+        #   * the fold splits use a fresh ``RandomState(42)`` — the fixed seed
+        #     ``cross_calibration_threshold_cached`` always calibrates with —
+        #     rather than the shared per-seed simulation RNG, so the calibration
+        #     is byte-for-byte what production runs for this vote set.  The eval
+        #     seed still varies the data (which media are voted, in what order,
+        #     and the held-out test split); only the calibration folds are now
+        #     pinned, as they are in production.
+        hidden_dim = _auto_hidden_dim(n_labels)
         threshold = calculate_cross_calibration_threshold(
             X_list,
             y_list,
             input_dim,
             inclusion,
-            rng=rng,
+            rng=np.random.RandomState(42),
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
+            hidden_dim=hidden_dim,
         )
-        model = train_model(X, y, input_dim)
+        model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
 
         # Apply safe threshold blending if enabled
         if safe_thresholds:
-            threshold = _blend_safe_threshold(
-                threshold, model, region_aware, sim_clips, X_all_clips, len(good_votes) + len(bad_votes)
-            )
+            threshold = _blend_safe_threshold(threshold, model, region_aware, sim_clips, X_all_clips, n_labels)
 
         # Evaluate on held-out test set
         metrics = _evaluate_on_test(


### PR DESCRIPTION
## What

Drains open follow-up #1 ("Eval harness fidelity") from `docs/plans/comprehensive-audit-2026-07.md`.

`simulate_voting_iterations` (in `vtscore/eval/voting_iterations.py`) computed each step's decision threshold in a way that diverged from the live detector in the small-label regime:

- it called `calculate_cross_calibration_threshold` **without** forcing the full-data `hidden_dim`, so each calibration fold auto-sized to its own smaller train split (narrower fold nets than the final model); and
- it threaded the **shared per-seed simulation RNG** into the fold splits, so the calibration varied with the eval seed.

Production's `_train_and_score_xy` / `train_and_threshold` do the opposite: they size `hidden_dim` from the full label count, force that width onto the folds via `cross_calibration_threshold_cached(..., hidden_dim=...)`, and always calibrate with a fresh `RandomState(42)`. So the eval measured a threshold the live pipeline never produces.

## Change

- The per-step calibration now passes `hidden_dim=_auto_hidden_dim(n_labels)` (full-label width) and `rng=np.random.RandomState(42)` (a fresh one per step, mirroring how `cross_calibration_threshold_cached` mints one per call).
- The final `train_model` is handed the same `hidden_dim` (previously it auto-sized to the same value, so this is a no-op made explicit).
- The eval seed still varies the **data** (which media are voted, in what order, and the held-out test split); only the calibration folds are now pinned, exactly as in production.

## Behaviour change

`simulate_voting_iterations` / `run_voting_iterations_eval` reported `cost` / `fpr` / `fnr` values shift in the small-label regime, because the eval now measures the exact pipeline the live detector runs.

## Tests

New `TestProductionCalibrationFidelity` in `tests_lib/detectors/test_eval_voting_iterations.py` spies on the calibration call and asserts the folds are forced to `_auto_hidden_dim(n_labels)` and always calibrate with a fresh `RandomState(42)`, independent of the eval seed. Full `./run-tests.sh` suite passes (5485 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qa33W4BqupJYAjcKP3AZv

---
_Generated by [Claude Code](https://claude.ai/code/session_018qa33W4BqupJYAjcKP3AZv)_