### PR TITLE
Audit follow-up #1: document inclusion-slide safe-blend semantics

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -10,7 +10,9 @@ list — SSE connection cap); seventh follow-up pass shipped (http_archive
 cache staleness); eighth follow-up pass shipped (#1 of the then-current
 open list — region-matrix fallback space mixing); ninth follow-up pass
 shipped (#1 of the then-current open list — eval harness calibration
-fidelity); remaining open follow-ups below.**
+fidelity); tenth follow-up pass shipped (#1 of the then-current open list —
+inclusion-slide safe-blend semantics, resolved "skip blend on slides");
+remaining open follow-ups below.**
 
 A full-codebase audit focused on interface boundaries: frontend ↔ backend
 API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
@@ -347,6 +349,31 @@ up any of these areas sees the known-weak spots.
   `tests_lib/detectors/test_eval_voting_iterations.py`
   (`TestProductionCalibrationFidelity`).
 
+### Tenth follow-up pass — inclusion-slide safe-blend semantics (drained from the open list)
+
+- **Inclusion slide drops the safe-threshold GMM blend** (was open #1).
+  With safe-thresholds on and 6 ≤ n < 20 labels a *fresh* retrain stores the
+  cross-calibration cutoff blended with a GMM cutoff
+  (`calculate_safe_threshold`'s linear ramp), but the fold-ordering cache on
+  the detector context holds only the raw cross-calibration orderings — not the
+  GMM component — so an inclusion slide
+  (`recompute_detector_thresholds_for_inclusion`) re-derived the *raw*
+  cross-calibration aggregate and silently dropped the blend, changing the
+  threshold semantics relative to a fresh retrain.  **Decision (user): skip
+  the blend on slides.**  A slide is a cheap re-threshold over cached orderings,
+  not a re-blend; making the recompute reproduce the blend would require it to
+  carry cached GMM-threshold + label-count state, not worth it for the
+  6..19-label window (below 6 the cache is cleared and the slide is a no-op at
+  the inclusion-independent pure-GMM value; at ≥20 the blend is already pure
+  cross-calibration so a slide matches a fresh retrain exactly).  No behaviour
+  change from the pre-audit code — the divergence was already present — but it
+  was accidental and undocumented, and is now deliberate.  Documented the
+  intent on `recompute_detector_thresholds_for_inclusion` and at both blend
+  sites in `vtscore/detectors/training.py`, and pinned the semantics with tests
+  in `tests_lib/detectors/test_inclusion_slide_safe_blend.py`
+  (`TestInclusionSlideDropsSafeBlend` — a slide re-derives the raw aggregate,
+  not the blend; a below-floor slide is a no-op).
+
 ## Open follow-ups
 
 Ordered roughly by severity.  Each was found and verified during the audit
@@ -357,22 +384,18 @@ staging + eval progress isolation (renumbered #2, #3) in the fourth, the
 re-renumbered #5/#8 "ML threshold correctness" items in the fifth, the
 re-renumbered #1 "SSE connection cap" in the sixth, the re-renumbered #6
 "http_archive cache staleness" in the seventh, the re-renumbered #1
-"region-matrix fallback space mixing" in the eighth, and the re-renumbered
-#1 "eval harness calibration fidelity" in the ninth — see the
+"region-matrix fallback space mixing" in the eighth, the re-renumbered
+#1 "eval harness calibration fidelity" in the ninth, and the re-renumbered
+#1 "inclusion-slide safe-blend semantics" in the tenth — see the
 follow-up-pass subsections under What shipped.  The list below is
 renumbered again after those drains.)
 
-1. **Inclusion slide drops the safe-threshold GMM blend**
-   (`state/core.py:recompute_detector_thresholds_for_inclusion` vs
-   `training.py`): with safe-thresholds on and 6 ≤ n < 20 labels, sliding
-   inclusion to a value and back changes the threshold semantics relative
-   to a fresh retrain.  Decide whether the blend applies on slides.
-2. **Dataset registry is not multi-process safe**
+1. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
    silently erase the server's registrations.  Fine under the documented
    single-worker model; needs flock if that changes.
-3. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
+2. **Audit coverage gaps** (rate-limit casualties, treat as *not cleared*
    rather than clean): browse-canvas/minimap coordinate math and rAF
    lifecycles, modal/player component lifecycle sweep, left/right-panel
    virtualization, and a full route-blueprint sweep of
@@ -448,3 +471,10 @@ renumbered again after those drains.)
   eval now measures the exact pipeline the live detector runs; the eval seed
   still varies the data (votes, order, test split), only the calibration folds
   are pinned.
+- **No runtime change**: the inclusion-slide safe-threshold divergence
+  (`recompute_detector_thresholds_for_inclusion` re-derives the raw
+  cross-calibration cutoff and does not reapply the GMM blend, so with
+  safe-thresholds on and 6 ≤ n < 20 labels a slide yields a slightly
+  different threshold than a fresh retrain) is now documented as intentional
+  ("skip blend on slides") rather than accidental — the behaviour itself is
+  unchanged from before the audit.

--- a/tests_lib/detectors/test_inclusion_slide_safe_blend.py
+++ b/tests_lib/detectors/test_inclusion_slide_safe_blend.py
@@ -71,8 +71,7 @@ class TestInclusionSlideDropsSafeBlend:
         # The stored (fresh-retrain) cutoff is the GMM blend, distinct from the
         # raw cross-cal aggregate - otherwise this test proves nothing.
         assert abs(blended - raw) > 1e-9, (
-            "expected the GMM blend to move the threshold off the raw cross-cal value "
-            "in the 6..19 label window"
+            "expected the GMM blend to move the threshold off the raw cross-cal value in the 6..19 label window"
         )
 
         # Drive the slide path exactly as the route does: the trained threshold

--- a/tests_lib/detectors/test_inclusion_slide_safe_blend.py
+++ b/tests_lib/detectors/test_inclusion_slide_safe_blend.py
@@ -1,0 +1,111 @@
+"""An inclusion slide deliberately drops the safe-threshold GMM blend.
+
+Decision (docs/plans/comprehensive-audit-2026-07.md, open follow-up #1 -
+resolved "skip blend on slides"): with safe-thresholds ON and 6 <= n < 20
+labels, a *fresh* retrain stores a threshold blended between the
+cross-calibration cutoff and a GMM cutoff (``calculate_safe_threshold``'s linear
+ramp).  The fold-ordering cache on the detector context holds only the raw
+cross-calibration orderings - never the GMM component - so an inclusion slide
+(``recompute_detector_thresholds_for_inclusion``) re-derives the RAW
+cross-calibration aggregate and does NOT reapply the blend.
+
+That divergence is intentional: the slide is a cheap re-threshold over cached
+orderings, not a re-blend, so the recompute stays stateless (no cached GMM
+threshold / label count).  These tests pin the chosen semantics so the behaviour
+can't silently flip to "re-blend on slide" (which would need the extra state) or
+to "no-op on slide" (which would freeze the blended value and ignore the new
+inclusion).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.detectors.training import train_and_score
+from vtscore.state.core import (
+    DetectorContext,
+    recompute_detector_thresholds_for_inclusion,
+    register_detector_context,
+)
+from vtscore.training.thresholds import threshold_from_fold_orderings
+
+DIM = 8
+
+
+def _clips(rng: np.random.Generator, cids: range) -> dict[int, dict]:
+    return {
+        cid: {
+            "embeddings": {"test": rng.standard_normal(DIM).astype(np.float32)},
+            "embedder": "test",
+            "media_type": "audio",
+            "md5": f"m{cid:031d}",
+        }
+        for cid in cids
+    }
+
+
+class TestInclusionSlideDropsSafeBlend:
+    def test_slide_re_derives_raw_xcal_not_the_blend(self):
+        """Safe on, 8 labels (inside the 6..19 blend window): the fresh-retrain
+        cutoff is the GMM blend, but a slide re-derives the raw cross-cal
+        aggregate over the cached fold orderings, dropping the blend."""
+        rng = np.random.default_rng(7)
+        # 20-media haystack so the GMM has a real score distribution to fit.
+        clips = _clips(rng, range(500, 520))
+        det_ctx = DetectorContext(detector_id="det-slide-blend", media_type="audio")
+
+        good = {cid: None for cid in range(500, 504)}
+        bad = {cid: None for cid in range(504, 508)}  # 8 labels: 6 <= n < 20
+        _results, blended, model = train_and_score(
+            clips, good, bad, inclusion_value=0, safe_thresholds=True, det_ctx=det_ctx
+        )
+
+        assert model is not None
+        assert det_ctx.calibration_cache is not None, (
+            "the >=6-label safe-on path must cache raw fold orderings so a slide can move the line"
+        )
+        _key, (orderings, fallback) = det_ctx.calibration_cache
+        assert fallback is None and orderings
+
+        raw = threshold_from_fold_orderings(orderings, 0)
+        # The stored (fresh-retrain) cutoff is the GMM blend, distinct from the
+        # raw cross-cal aggregate - otherwise this test proves nothing.
+        assert abs(blended - raw) > 1e-9, (
+            "expected the GMM blend to move the threshold off the raw cross-cal value "
+            "in the 6..19 label window"
+        )
+
+        # Drive the slide path exactly as the route does: the trained threshold
+        # is stored on the (registered) context, then the slider fires recompute.
+        det_ctx.threshold = blended
+        register_detector_context(det_ctx)
+        recompute_detector_thresholds_for_inclusion(0)
+
+        # The slide re-derived the RAW cross-cal aggregate; the blend is gone.
+        assert det_ctx.threshold == raw
+        assert det_ctx.threshold != blended
+
+    def test_slide_below_ramp_floor_is_a_no_op(self):
+        """Safe on, 4 labels (below the ramp floor): the fresh retrain clears
+        the cache (pure-GMM regime), so a slide leaves the threshold untouched -
+        no raw-xcal value to fall back to, and inclusion is irrelevant there."""
+        rng = np.random.default_rng(9)
+        clips = _clips(rng, range(600, 620))
+        det_ctx = DetectorContext(detector_id="det-slide-floor", media_type="audio")
+
+        good = {600: None, 601: None}
+        bad = {602: None, 603: None}  # 4 labels < 6
+        _results, gmm_threshold, model = train_and_score(
+            clips, good, bad, inclusion_value=0, safe_thresholds=True, det_ctx=det_ctx
+        )
+
+        assert model is not None
+        assert det_ctx.calibration_cache is None, "below the ramp floor the fold cache is cleared"
+
+        det_ctx.threshold = gmm_threshold
+        register_detector_context(det_ctx)
+        recompute_detector_thresholds_for_inclusion(-10)
+
+        # No cached orderings -> recompute skips this detector; the pure-GMM
+        # value (inclusion-independent below the floor) stays put.
+        assert det_ctx.threshold == gmm_threshold

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -207,6 +207,10 @@ def train_and_threshold(
         with torch.no_grad():
             X_all = X_all.to(next(model.parameters()).device)
             all_scores = sigmoid_to_finite_scores(model(X_all))
+        # The GMM blend is applied only on a *fresh* retrain: the fold-ordering
+        # cache above stores the raw cross-cal orderings, so a later inclusion
+        # slide re-derives the unblended cutoff (intentional - see
+        # recompute_detector_thresholds_for_inclusion).
         threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))
 
     return model, threshold
@@ -543,6 +547,9 @@ def _train_and_score_xy(
     all_ids, scores, best_region = _score_all_media(model, clips_dict, score_emb)
 
     if safe_thresholds:
+        # Blend applies on this fresh retrain only; the cached fold orderings
+        # are raw cross-cal, so an inclusion slide re-derives the unblended
+        # cutoff (see recompute_detector_thresholds_for_inclusion).
         threshold = calculate_safe_threshold(threshold, scores, len(X_list))
 
     results = _format_results(all_ids, scores, best_region, clips_dict)

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -1074,6 +1074,22 @@ def recompute_detector_thresholds_for_inclusion(inclusion_value: int) -> None:
     scores.  Detectors with no cached fold orderings yet are left untouched;
     the next training pass computes the threshold under the new inclusion.
     See docs/plans/find-verification-workflow.md.
+
+    **Safe-threshold blend is deliberately NOT reapplied here.**  With
+    safe-thresholds on and 6 <= n < 20 labels, a *fresh* retrain stores the
+    cross-calibration cutoff blended with a GMM cutoff (see
+    :func:`vtscore.training.thresholds.calculate_safe_threshold`'s linear ramp).
+    The fold-ordering cache holds only the raw cross-calibration orderings - not
+    the GMM component - so a slide re-derives the **raw** cross-calibration
+    aggregate and drops the blend.  This is intentional (comprehensive-audit-
+    2026-07 open follow-up #1, resolved "skip blend on slides"): the slide is a
+    cheap re-threshold over cached orderings, not a re-blend, so the caller need
+    not carry the extra GMM/label-count state a faithful re-blend would require.
+    Consequences: below the ramp floor (n < 6) the cache is cleared and the
+    slide is a no-op (threshold stays the pure-GMM value), and at n >= 20 the
+    blend is already pure cross-calibration so the slide matches a fresh retrain
+    exactly; only the 6..19 window diverges, trading a small threshold shift on
+    the first slide for a stateless recompute.
     """
     from vtscore.training.thresholds import threshold_from_fold_orderings
 


### PR DESCRIPTION
Drains open follow-up #1 from `docs/plans/comprehensive-audit-2026-07.md` (the tenth follow-up pass).

## The finding

With safe-thresholds **on** and 6 ≤ n < 20 labels, a *fresh* retrain stores the cross-calibration cutoff blended with a GMM cutoff (`calculate_safe_threshold`'s linear ramp). But the fold-ordering cache on the detector context holds only the **raw** cross-calibration orderings — never the GMM component — so an inclusion slide (`recompute_detector_thresholds_for_inclusion`) re-derived the raw cross-calibration aggregate and silently dropped the blend. Sliding inclusion to a value and back therefore left a slightly different threshold than a fresh retrain, and the divergence was accidental and undocumented.

The `< 6` case (cache cleared → slide is a no-op at the inclusion-independent pure-GMM value) and the `≥ 20` case (blend is already pure cross-calibration → slide matches a fresh retrain) were already correct; only the 6..19 window diverged.

## The resolution

**Decision (user): skip the blend on slides.** A slide is a cheap re-threshold over cached orderings, not a re-blend; making the recompute reproduce the blend would require it to carry cached GMM-threshold + label-count state, not worth it for the narrow 6..19-label window. So there is **no runtime change** — the pre-audit behaviour is preserved — but the divergence is now deliberate and documented rather than a silent gap.

## Changes

- `vtscore/state/core.py` — documented on `recompute_detector_thresholds_for_inclusion` that the safe-threshold GMM blend is intentionally not reapplied on slides, with the reasoning and the per-regime consequences.
- `vtscore/detectors/training.py` — short cross-reference notes at both `calculate_safe_threshold` blend sites (`train_and_threshold`, `_train_and_score_xy`) so a future reader knows the blend won't survive a slide.
- `tests_lib/detectors/test_inclusion_slide_safe_blend.py` — new regression tests (`TestInclusionSlideDropsSafeBlend`): a slide re-derives the raw cross-cal aggregate (not the blend) in the 6..19 window, and a below-floor slide is a no-op that leaves the pure-GMM value.
- `docs/plans/comprehensive-audit-2026-07.md` — recorded the tenth follow-up pass, moved item #1 out of the open list (renumbered), and added a "no runtime change" note to the compatibility section.

## Testing

`./run-tests.sh` — all 5487 tests pass (1 skipped), including the two new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJqvperna6u8qzNV3etEvN)_