### PR TITLE
UI style review Phase 1: broken tokens, badge contrast, focus outlines, Back-vs-Cancel

### DIFF
--- a/docs/reviews/2026-07-09-ui-style-review.md
+++ b/docs/reviews/2026-07-09-ui-style-review.md
@@ -1,10 +1,31 @@
 # UI Style Review — 2026-07-09
 
-**Status: report only — no changes made.** Comprehensive style/structure/layout review
-of the VTSearch frontend: fonts, sizing, organization, colors, contrast, component
-consistency, accessibility, and information architecture. Findings are grouped by
-severity and theme, with file:line references, and end with larger rework
-proposals plus a suggested phasing.
+**Status: Phase 1 (bug fixes) shipped; Phases 2–4 not started.** Comprehensive
+style/structure/layout review of the VTSearch frontend: fonts, sizing,
+organization, colors, contrast, component consistency, accessibility, and
+information architecture. Findings are grouped by severity and theme, with
+file:line references, and end with larger rework proposals plus a suggested
+phasing.
+
+**What shipped (Phase 1).** All of §1's verified broken/ghost tokens (incl.
+`--font-mono` and a real `--z-tooltip` defined once, and the find-stats-modal
+table styling gap); the two badge-contrast FAILs from §2
+(`badge-ready`/`badge-embedding` white-on-fill in dark theme) via a new
+`--badge-text-dark` token; the 3 focus-outline removals in §5/§8 (restored
+after confirming none were wired to a hotkey/programmatic-focus path — the
+app's `KeyboardService` already blurs `activeElement` on every shortcut); and
+the 3 Back-vs-Cancel violations in §6 (footer Cancel now calls `close()`
+instead of `back()`).
+
+**Open follow-ups (Phases 2–4, not started).** The remaining §2 light-theme
+contrast ramp (still uses the dark theme's pastel status palette — needs its
+own darkened ramp), the `zoom: 1.1` / type-scale rework (§4), token
+consolidation and alias cleanup (§3), the "one role, N implementations"
+primitives and modal polish package (§5/§6/§10.4-5), the icon system
+unification (§10.6), header/IA simplification (§7/§10.7), the remaining a11y
+sweep items (§8: modal focus trapping, heading structure, table semantics,
+`aria-sort`, fieldsets, `for=` associations), and the copy-style guide
+(§9/§10.9) are all still open — see the phasing table below for grouping.
 
 **Method.** Static audit of all 85 component SCSS files + 86 templates against
 `docs/style-guide.md` and the token system in `frontend/src/scss/_variables.scss`;

--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -36,3 +36,4 @@ An empty table means "no known-stale shots" — the desired resting state.
 
 | Shot id | Embedded in | Why it's stale | Flagged |
 |---------|-------------|----------------|---------|
+| `importer-picker` | `docs/user/USER_GUIDE.md#loading-a-dataset` | The shot's caption calls out "per-row readiness badges" (`.badge-ready`/`.badge-embedding`); the 2026-07-09 UI style review Phase 1 fix swapped their unreadable white text for a new `--badge-text-dark` token, changing the badge's rendered text color in both themes. | 2026-07-09 |

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -187,7 +187,7 @@
   justify-content: center;
   padding: var(--space-2xs) 0;
   font-size: var(--font-xs);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   border-radius: var(--radius-sm);
   background: var(--bg-hover);
   border: 1px solid var(--border);
@@ -238,7 +238,7 @@
 
 .docs-list-path {
   color: var(--text-muted);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   font-size: var(--font-xs);
 }
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -214,7 +214,7 @@
 // Match the size and color of the other values (only the fixed-width font sets
 // it apart) rather than dimming it.
 .bin-popup-meta-md5 {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-family: var(--font-mono);
   word-break: break-all;
 }
 
@@ -440,7 +440,7 @@
   max-width: var(--popup-cell, 80px);
   min-width: 0;
   text-align: center;
-  font-weight: var(--weight-normal);
+  font-weight: var(--weight-regular);
   font-size: var(--font-xs);
   line-height: 1.25;
   white-space: nowrap;

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.scss
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.scss
@@ -1,6 +1,6 @@
 .hover-popup {
   position: fixed;
-  z-index: var(--z-tooltip, 1000);
+  z-index: var(--z-tooltip);
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -165,7 +165,6 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   transition: color var(--transition-base);
-  outline: none;
 
   &:hover {
     color: var(--text-primary);

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -276,7 +276,7 @@
 .custom-select-trigger.is-locked {
   cursor: not-allowed;
   opacity: 0.6;
-  background: var(--bg-disabled, var(--bg-subtle));
+  background: var(--bg-subtle);
   color: var(--text-muted);
 }
 
@@ -287,7 +287,7 @@
   width: 100%;
   cursor: pointer;
   text-align: left;
-  background: var(--bg-input, var(--bg-subtle));
+  background: var(--bg-subtle);
 }
 
 .select-option-content {
@@ -335,7 +335,7 @@
   &:hover { background: var(--bg-hover); }
 
   &.selected {
-    background: var(--bg-active, var(--bg-hover));
+    background: var(--bg-hover);
     font-weight: var(--weight-semibold);
   }
 }

--- a/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.scss
+++ b/frontend/src/app/components/dashboard/usage-bar/usage-bar.component.scss
@@ -33,7 +33,7 @@
 
 .usage-bar-track {
   height: 8px;
-  background: var(--bg-elevated, rgba(127, 127, 127, 0.2));
+  background: var(--bg-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   overflow: hidden;

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
@@ -20,7 +20,6 @@ input[type="number"] {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   text-align: center;
-  outline: none;
 
   &:focus {
     border-color: var(--accent);

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -52,10 +52,6 @@
   font-size: var(--font-md);
   transition: background var(--transition-base), color var(--transition-base);
 
-  &:focus-visible {
-    outline: none;
-  }
-
   &:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-primary);

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -75,11 +75,11 @@
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-sm);
   font-size: var(--font-md);
-  background: var(--color-success-bg, rgba(0, 128, 0, 0.12));
-  color: var(--color-success-fg, inherit);
+  background: var(--good-bg);
+  color: var(--color-good);
 
   &--error {
-    background: var(--color-error-bg, rgba(200, 0, 0, 0.12));
-    color: var(--color-error-fg, inherit);
+    background: var(--bad-bg);
+    color: var(--color-bad);
   }
 }

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -1,7 +1,42 @@
-// `.loading-text`, `.error-text`, `.stats-table`, `.stat-label`,
-// `.stat-value`, and `.section-title` are shared utilities (see
-// dataset-stats-modal + _components.scss); only the find-specific confusion
-// grid and the inline chart are styled here.
+// `.error-text` and `.section-title` are genuinely shared (`_components.scss`).
+// `.loading-text`, `.stats-table`, `.stat-label`, `.stat-value` are NOT global -
+// each stats modal (dataset/detector/find) keeps its own view-encapsulated copy;
+// this file's copy also carries the `.stats-table th` rule since this is the
+// only one of the three whose markup uses `<thead><th>`.
+
+.loading-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-lg);
+
+  th,
+  td {
+    padding: var(--space-sm) var(--space-md);
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  th {
+    font-weight: var(--weight-semibold);
+    color: var(--text-secondary);
+    font-size: var(--font-md);
+  }
+}
+
+.stat-label {
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.stat-value {
+  color: var(--text-primary);
+}
 
 .stale-note {
   margin: 0 0 var(--space-md);
@@ -94,7 +129,7 @@
 .legend-item {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2xs, 4px);
+  gap: var(--space-2xs);
 }
 
 .swatch {

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -114,7 +114,7 @@
   justify-content: center;
   min-width: 1.75rem;
   padding: var(--space-2xs) var(--space-xs);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-mono);
   font-size: var(--font-sm);
   color: var(--text-primary);
   background: var(--bg-subtle);
@@ -165,7 +165,7 @@
 }
 
 .guide-error {
-  color: var(--danger, var(--text-primary));
+  color: var(--color-bad);
 }
 
 .guide-body {
@@ -202,7 +202,7 @@
     margin-bottom: var(--space-2xs);
   }
   ::ng-deep code {
-    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-family: var(--font-mono);
     font-size: 0.9em;
     background: var(--bg-subtle);
     padding: 0 var(--space-2xs);

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -173,7 +173,7 @@
       }
 
       <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="back()">Cancel</button>
+        <button class="btn btn--secondary" (click)="close()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
           <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting()) {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -97,7 +97,7 @@
       }
 
       <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="back()">Cancel</button>
+        <button class="btn btn--secondary" (click)="close()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
           <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
           @if (submitting()) {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -103,7 +103,7 @@
       }
 
       <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="back()">Cancel</button>
+        <button class="btn btn--secondary" (click)="close()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
           <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting()) {

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.scss
@@ -12,7 +12,7 @@
   padding: var(--space-xs) var(--space-sm);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  background: var(--bg-elevated, transparent);
+  background: var(--bg-subtle);
 }
 
 .import-defaults-footer {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -212,7 +212,7 @@
   word-break: break-word;
 
   &--mono {
-    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--font-mono);
     font-size: var(--font-sm);
     word-break: break-all;
   }
@@ -272,7 +272,7 @@
 .settings-version {
   margin-right: auto;
   font-size: var(--font-xs);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   color: var(--text-secondary);
   user-select: text;
 }
@@ -297,7 +297,7 @@
   max-width: 60ch;
 
   code {
-    font-family: var(--font-mono, monospace);
+    font-family: var(--font-mono);
     font-size: var(--font-xs);
   }
 }
@@ -308,6 +308,6 @@
   gap: var(--space-sm);
   margin-bottom: var(--space-sm);
 
-  &__icon { color: var(--success-text, var(--text-primary)); flex-shrink: 0; }
+  &__icon { color: var(--color-good); flex-shrink: 0; }
   &__label { font-size: var(--font-sm); color: var(--text-primary); }
 }

--- a/frontend/src/app/components/offline-banner/offline-banner.component.scss
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.scss
@@ -45,7 +45,7 @@
 .offline-banner__retry {
   flex: 0 0 auto;
   background: var(--accent, var(--text-primary));
-  color: var(--accent-text, var(--bg));
+  color: var(--btn-primary-text);
   border: 1px solid transparent;
   font-size: var(--font-xs);
   font-weight: var(--weight-medium);

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -126,7 +126,7 @@
 
 .toast__btn--primary {
   background: var(--accent, var(--text-primary));
-  color: var(--accent-text, var(--bg));
+  color: var(--btn-primary-text);
   border-color: transparent;
 
   &:hover {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -328,7 +328,7 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   line-height: 1.4;
   color: var(--text-muted);
   white-space: pre-wrap;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-family: var(--font-mono);
 }
 
 .required {

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -203,22 +203,23 @@
 .demo-row {
   &.ready .col-name { color: var(--color-good); }
   &.selected {
-    background: var(--bg-selected, var(--bg-hover));
+    background: var(--bg-hover);
     box-shadow: inset 3px 0 0 0 var(--accent);
-    &:hover { background: var(--bg-selected, var(--bg-hover)); }
+    &:hover { background: var(--bg-hover); }
   }
 }
 
 .badge-ready, .badge-embedding, .badge-download {
   display: inline-block;
   padding: var(--space-2xs) var(--space-sm);
-  color: var(--btn-filled-text);
   font-size: var(--font-2xs);
   border-radius: var(--radius-sm);
 }
 
-.badge-ready { background: var(--color-good); }
-.badge-embedding { background: var(--badge-embedding, var(--accent)); }
+// Dark text on these saturated fills reads far better than white
+// (--btn-filled-text): white-on-#e0a020/#4caf50 measured well under WCAG AA.
+.badge-ready { background: var(--color-good); color: var(--badge-text-dark); }
+.badge-embedding { background: var(--badge-embedding); color: var(--badge-text-dark); }
 // Neutral "needs action" pill. Uses --bg-secondary-btn (a step lighter than
 // --border) + --text-secondary so the text holds readable contrast in dark
 // mode; the previous --border + --text-muted pairing layered two near-equal

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -13,6 +13,9 @@
   --space-xl: 1rem;       // 16px
   --space-2xl: 1.5rem;    // 24px
 
+  // Monospace stack: the one place a component should reach for `monospace`.
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
   // Font-size scale
   --font-2xs: 0.7rem;
   --font-xs: 0.75rem;
@@ -69,6 +72,7 @@
   --z-sticky: 100;
   --z-modal-backdrop: 1000;
   --z-modal: 1001;
+  --z-tooltip: 1500;
   --z-burger-menu: 2000;
   --z-offline-banner: 4500;
   --z-toast: 5000;
@@ -131,6 +135,12 @@
   --tier-silver: #d9d9d9;
   --tier-gold: #f0c419;
   --tier-platinum: #f5f6fa;
+
+  // Text color for badges filled with a saturated status color
+  // (--color-good, --badge-embedding). Those fills are bright/mid-luminance
+  // in every theme by design, so dark text reads well everywhere - no need
+  // to swap per theme the way --btn-filled-text does for accent-fill buttons.
+  --badge-text-dark: #1a1a2e;
 
   // Aliases used by component SCSS files
   --border-color: var(--border);


### PR DESCRIPTION
## Summary

Phase 1 (the "low risk, small local diffs" phase) of `docs/reviews/2026-07-09-ui-style-review.md`:

- Fixed ~12 CSS custom-property references that named tokens not defined in `_variables.scss` (silently falling back or never applying): toast/offline `--accent-text`, browse-bin-popup `--weight-normal`, settings-modal `--success-text`, autodetect-results success/error bg+fg, keyboard-help `--danger`, browse-hover-preview `--z-tooltip`, usage-bar/import-defaults `--bg-elevated`, new-detector-modal `--bg-disabled`/`--bg-input`/`--bg-active`, picker-shared `--bg-selected`.
- Defined `--font-mono` once in `_variables.scss` and removed the 9 divergent fallback chains referencing it.
- Added a real `--z-tooltip` token (1500) instead of a fallback that collided with `--z-modal-backdrop`.
- `find-stats-modal`: fixed the header comment's false "shared utility" claim and added the local `.loading-text`/`.stats-table`/`.stat-label`/`.stat-value` styles the template actually needs (previously entirely unstyled).
- Fixed unreadable white text on the `badge-ready`/`badge-embedding` pills (2.28:1 and 2.78:1 contrast in dark theme) via a new `--badge-text-dark` token, matching the existing `badge-download` precedent.
- Restored 3 removed `focus-visible` outlines (left-panel tabs, center-panel metadata toggle, inclusion-slider input) after verifying none are wired to a hotkey or programmatic-focus path — the app's `KeyboardService` already blurs `activeElement` on every shortcut, so these were plain keyboard-a11y regressions, not deliberate hotkey-outline workarounds.
- Fixed the 3 Back-vs-Cancel violations (label-importer-modal, settings-importer-modal, settings-exporter-modal): footer Cancel now calls `close()` instead of `back()`, matching `dataset-importer-modal`'s existing convention.
- Updated the review doc's status header with a "what shipped" / "open follow-ups" summary, and queued the `importer-picker` screenshot for reshoot (its caption calls out the badge colors this PR changed; this container has no browser to reshoot with).

Phases 2–4 (type-scale rework, token consolidation, light-theme contrast ramp, shared-primitive consolidation, modal polish, icon system, IA/copy sweep) are unstarted — see the review doc's phasing table.

## Test plan

- [x] `cd frontend && npm run build:prod` — clean build, no warnings
- [x] `./run-tests.sh frontend` — build + audit + Vitest, 1002 tests passed
- [x] `./run-tests.sh` (full suite) — 5501 passed, 1 skipped, 2 xpassed
- [x] `python3 scripts/screenshots/wiring-check.py` — OK, 1 reshoot queued as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01UxQX9zGdSGine8iu2JTa1J)_